### PR TITLE
Ron auth go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,6 +320,7 @@ require (
 	github.com/russellhaering/goxmldsig v1.1.1 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sclevine/agouti v3.0.0+incompatible
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/smartystreets/goconvey v1.7.2 // indirect
 	github.com/spf13/afero v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1481,6 +1481,8 @@ github.com/sanposhiho/wastedassign/v2 v2.0.6/go.mod h1:KyZ0MWTwxxBmfwn33zh3k1dms
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.1-0.20181016170032-d91630c85102 h1:WAQaHPfnpevd8SKXCcy5nk3JzEv2h5Q0kSwvoMqXiZs=
 github.com/satori/go.uuid v1.2.1-0.20181016170032-d91630c85102/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sclevine/agouti v3.0.0+incompatible h1:8IBJS6PWz3uTlMP3YBIR5f+KAldcGuOeFkFbUWfBgK4=
+github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -23,8 +23,14 @@ type OpenLDAPCredentialConfig struct {
 }
 
 type Config2 struct {
-	OpenLdapUser     string `yaml:"openLdapUser"`
-	OpenLdapUserPass string `yaml:"openLdapUserPass"`
+	OpenLdapUser                    string `yaml:"testAndEnableUser"`
+	OpenLdapUserPass                string `yaml:"testAndEnablePass"`
+	Servers                         string `yaml:"servers"`
+	ServiceAccountDistinguishedName string `yaml:"ServiceAccountDistinguishedName"`
+	ServiceAccountPassword          string `yaml:"ServiceAccountPassword"`
+	UserSearchBase                  string `yaml:"UserSearchBase"`
+	Port                            string `yaml:"389"`
+	TLS                             string `yaml:"TLS"`
 }
 
 // CreateOpenLDAPAuthConfig is a helper function that creates

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -34,7 +34,7 @@ func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthCo
 	/*	openLdapCredentialConfig := OpenLDAPCredentialConfig{
 		Servers:                         []string{"openldapqa.qa.rancher.space"},
 		ServiceAccountDistinguishedName: "cn=admin,dc=qa,dc=rancher,dc=space",
-		ServiceAccountPassword:          "<password>",
+		ServiceAccountPassword:          "<password>", map to
 		UserSearchBase:                  "dc=qa,dc=rancher,dc=space",
 		Port:                            389,
 		TLS:                             false,

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -14,7 +14,8 @@ type OpenLDAPCredentialConfig struct {
 	UserSearchBase                  string   `json:"userSearchBase"`
 	Port                            int      `json:"port"`
 	TLS                             bool     `json:"tls"`
-	// Certificate would typically be loaded from a file or another source. Commenting out for this example.
+	// Certificate would typically be loaded from a file or another source - commenting out til openldap
+	// is configured with a cert
 	// Certificate                  string `json:"certificate"`
 	TestUsername string `json:"testUsername"`
 	TestPassword string `json:"testPassword"`
@@ -48,3 +49,11 @@ func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthCo
 	}
 	return resp, nil
 }
+
+//check how the do was done for tokens - do action?
+//change it to doaction and use the config that israel sent me.
+//authprovider
+//openldap_test
+//use go freefrom job to test on jenkins to see it running
+//might have to add a build tag
+//use the jenkins job to add to go job with create cluster.

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -8,6 +8,9 @@ import (
 const openLdapConfigNameBase = "openLdapAuthConfig"
 const ConfigurationFileKey = "authProvider"
 
+//const Description = "UI session"
+//const ResponseType = "UI session"
+
 type OpenLDAPCredentialConfig struct {
 	Servers                         []string `json:"servers"`
 	ServiceAccountDistinguishedName string   `json:"serviceAccountDistinguishedName"`
@@ -23,6 +26,7 @@ type OpenLDAPCredentialConfig struct {
 }
 
 type Config2 struct {
+	Host                            string `yaml:"host"`
 	OpenLdapUser                    string `yaml:"testAndEnableUser"`
 	OpenLdapUserPass                string `yaml:"testAndEnablePass"`
 	Servers                         string `yaml:"servers"`
@@ -31,6 +35,7 @@ type Config2 struct {
 	UserSearchBase                  string `yaml:"UserSearchBase"`
 	Port                            string `yaml:"389"`
 	TLS                             string `yaml:"TLS"`
+	LoginUser                       string `yaml:"LoginUser"`
 }
 
 // CreateOpenLDAPAuthConfig is a helper function that creates

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -1,0 +1,50 @@
+package openldapauth
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+)
+
+const openLdapConfigNameBase = "openLdapAuthConfig"
+
+type OpenLDAPCredentialConfig struct {
+	Servers                         []string `json:"servers"`
+	ServiceAccountDistinguishedName string   `json:"serviceAccountDistinguishedName"`
+	ServiceAccountPassword          string   `json:"serviceAccountPassword"`
+	UserSearchBase                  string   `json:"userSearchBase"`
+	Port                            int      `json:"port"`
+	TLS                             bool     `json:"tls"`
+	// Certificate would typically be loaded from a file or another source. Commenting out for this example.
+	// Certificate                  string `json:"certificate"`
+	TestUsername string `json:"testUsername"`
+	TestPassword string `json:"testPassword"`
+}
+
+// CreateOpenLDAPAuthConfig is a helper function that creates
+// an openLDAP auth config, enables it, and returns the AuthConfig response
+func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthConfig, error) {
+	// Hardcoding the values for this config
+	openLdapCredentialConfig := OpenLDAPCredentialConfig{
+		Servers:                         []string{"openldapqa.qa.rancher.space"},
+		ServiceAccountDistinguishedName: "cn=admin,dc=qa,dc=rancher,dc=space",
+		ServiceAccountPassword:          "cattle@123",
+		UserSearchBase:                  "dc=qa,dc=rancher,dc=space",
+		Port:                            389,
+		TLS:                             false,
+		TestUsername:                    "testuser1",
+		TestPassword:                    "Tacos86!",
+	}
+
+	authConfig := management.AuthConfig{
+		Name:                     openLdapConfigNameBase,
+		OpenLDAPCredentialConfig: &openLdapCredentialConfig,
+		Enabled:                  true,
+	}
+
+	resp := &management.AuthConfig{}
+	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.AuthConfigType, authConfig, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -6,6 +6,7 @@ import (
 )
 
 const openLdapConfigNameBase = "openLdapAuthConfig"
+const ConfigurationFileKey = "authProvider"
 
 type OpenLDAPCredentialConfig struct {
 	Servers                         []string `json:"servers"`
@@ -21,11 +22,16 @@ type OpenLDAPCredentialConfig struct {
 	TestPassword string `json:"testPassword"`
 }
 
+type Config2 struct {
+	OpenLdapUser     string `yaml:"openLdapUser"`
+	OpenLdapUserPass string `yaml:"openLdapUserPass"`
+}
+
 // CreateOpenLDAPAuthConfig is a helper function that creates
 // an openLDAP auth config, enables it, and returns the AuthConfig response
 func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthConfig, error) {
 	// Hardcoding the values for this config
-	openLdapCredentialConfig := OpenLDAPCredentialConfig{
+	/*	openLdapCredentialConfig := OpenLDAPCredentialConfig{
 		Servers:                         []string{"openldapqa.qa.rancher.space"},
 		ServiceAccountDistinguishedName: "cn=admin,dc=qa,dc=rancher,dc=space",
 		ServiceAccountPassword:          "<password>",
@@ -34,12 +40,12 @@ func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthCo
 		TLS:                             false,
 		TestUsername:                    "testuser1",
 		TestPassword:                    "Tacos86!",
-	}
+	} */
 
 	authConfig := management.AuthConfig{
-		Name:                     openLdapConfigNameBase,
-		OpenLDAPCredentialConfig: &openLdapCredentialConfig,
-		Enabled:                  true,
+		Name: openLdapConfigNameBase,
+		//OpenLDAPCredentialConfig: &openLdapCredentialConfig,
+		Enabled: true,
 	}
 
 	resp := &management.AuthConfig{}

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -33,7 +33,7 @@ type Config2 struct {
 	ServiceAccountDistinguishedName string `yaml:"ServiceAccountDistinguishedName"`
 	ServiceAccountPassword          string `yaml:"ServiceAccountPassword"`
 	UserSearchBase                  string `yaml:"UserSearchBase"`
-	Port                            string `yaml:"389"`
+	Port                            string `yaml:"port"`
 	TLS                             string `yaml:"TLS"`
 	LoginUser                       string `yaml:"LoginUser"`
 }

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -8,9 +8,6 @@ import (
 const openLdapConfigNameBase = "openLdapAuthConfig"
 const ConfigurationFileKey = "authProvider"
 
-//const Description = "UI session"
-//const ResponseType = "UI session"
-
 type OpenLDAPCredentialConfig struct {
 	Servers                         []string `json:"servers"`
 	ServiceAccountDistinguishedName string   `json:"serviceAccountDistinguishedName"`
@@ -27,6 +24,7 @@ type OpenLDAPCredentialConfig struct {
 
 type Config2 struct {
 	Host                            string `yaml:"host"`
+	Token                           string `yaml:"token"`
 	OpenLdapUser                    string `yaml:"testAndEnableUser"`
 	OpenLdapUserPass                string `yaml:"testAndEnablePass"`
 	Servers                         string `yaml:"servers"`
@@ -36,26 +34,15 @@ type Config2 struct {
 	Port                            string `yaml:"port"`
 	TLS                             string `yaml:"TLS"`
 	LoginUser                       string `yaml:"LoginUser"`
+	LoginPass                       string `yaml:"LoginPass"`
 }
 
 // CreateOpenLDAPAuthConfig is a helper function that creates
 // an openLDAP auth config, enables it, and returns the AuthConfig response
 func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthConfig, error) {
-	// Hardcoding the values for this config
-	/*	openLdapCredentialConfig := OpenLDAPCredentialConfig{
-		Servers:                         []string{"openldapqa.qa.rancher.space"},
-		ServiceAccountDistinguishedName: "cn=admin,dc=qa,dc=rancher,dc=space",
-		ServiceAccountPassword:          "<password>", map to
-		UserSearchBase:                  "dc=qa,dc=rancher,dc=space",
-		Port:                            389,
-		TLS:                             false,
-		TestUsername:                    "testuser1",
-		TestPassword:                    "Tacos86!",
-	} */
 
 	authConfig := management.AuthConfig{
-		Name: openLdapConfigNameBase,
-		//OpenLDAPCredentialConfig: &openLdapCredentialConfig,
+		Name:    openLdapConfigNameBase,
 		Enabled: true,
 	}
 

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth.go
@@ -28,7 +28,7 @@ func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthCo
 	openLdapCredentialConfig := OpenLDAPCredentialConfig{
 		Servers:                         []string{"openldapqa.qa.rancher.space"},
 		ServiceAccountDistinguishedName: "cn=admin,dc=qa,dc=rancher,dc=space",
-		ServiceAccountPassword:          "cattle@123",
+		ServiceAccountPassword:          "<password>",
 		UserSearchBase:                  "dc=qa,dc=rancher,dc=space",
 		Port:                            389,
 		TLS:                             false,
@@ -49,11 +49,3 @@ func CreateOpenLDAPAuthConfig(rancherClient *rancher.Client) (*management.AuthCo
 	}
 	return resp, nil
 }
-
-//check how the do was done for tokens - do action?
-//change it to doaction and use the config that israel sent me.
-//authprovider
-//openldap_test
-//use go freefrom job to test on jenkins to see it running
-//might have to add a build tag
-//use the jenkins job to add to go job with create cluster.

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
@@ -153,7 +153,8 @@ func (d *OpenLdapTest) TestOpenLdapAPI() {
 	resp, err = d.DisableOpenLDAP(url, token)
 	require.NoError(d.T(), err)
 
-	time.Sleep(1 * time.Second) //waiting for server to be ready
+	time.Sleep(1
+		 * time.Second) //waiting for server to be ready
 
 	//try login again - this one should fail
 	resp, err = d.LoginOpenLDAP(host, token, []byte(resp.Body))

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
@@ -4,20 +4,66 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	"github.com/stretchr/testify/assert"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestCreateOpenLDAPAuthConfig(t *testing.T) {
-	rancherClient, err := rancher.NewRancherClient()
-	require.NoError(t, err)
+type openLdapTest struct {
+	suite.Suite
+	testUser *management.User
+	client   *rancher.Client
+	project  *management.Project
+	session  *session.Session
+}
 
-	authConfig, err := CreateOpenLDAPAuthConfig(rancherClient)
-	require.NoError(t, err)
+func (d *openLdapTest) SetupSuite() {
+	testSession := session.NewSession(d.T())
 
-	assert.Equal(t, openLdapConfigNameBase, authConfig.Name)
-	assert.NotNil(t, authConfig.OpenLDAPCredentialConfig)
-	assert.Equal(t, []string{"openldapqa.qa.rancher.space"}, authConfig.OpenLDAPCredentialConfig.Servers)
-	assert.Equal(t, "cn=admin,dc=qa,rancher,dc=space", authConfig.OpenLDAPCredentialConfig.ServiceAccountDistinguishedName)
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(d.T(), err)
+
+	d.client = client
+
+	projectConfig := &management.Project{
+		ClusterID: "local",
+		Name:      "TestProject",
+	}
+
+	testProject, err := client.Management.Project.Create(projectConfig)
+	require.NoError(p.T(), err)
+
+	d.project = testProject
+
+	enabled := true
+
+	user := &management.User{
+		Username: "testusername",
+		Password: "passwordpasswordd",
+		Name:     "displayname",
+		Enabled:  &enabled,
+	}
 
 }
+func (d *openLdapTest) TearDownSuite() {
+	d.session.Cleanup()
+}
+
+func TestCreateOpenLDAPAuthConfig(t *testing.T) {
+	/*
+		rancherClient, err := rancher.NewRancherClient()
+		require.NoError(t, err)
+
+		authConfig, err := CreateOpenLDAPAuthConfig(rancherClient)
+		require.NoError(t, err)
+	*/
+	/*
+		assert.Equal(t, openLdapConfigNameBase, authConfig.Name)
+		assert.NotNil(t, authConfig.OpenLDAPCredentialConfig)
+		assert.Equal(t, []string{"openldapqa.qa.rancher.space"}, authConfig.OpenLDAPCredentialConfig.Servers)
+		assert.Equal(t, "cn=admin,dc=qa,rancher,dc=space", authConfig.OpenLDAPCredentialConfig.ServiceAccountDistinguishedName)
+	*/
+}
+
+//need to add a suite a teardown and a config = somewehre?

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -153,7 +153,7 @@ func (d *OpenLdapTest) TestOpenLdapAPI() {
 	resp, err = d.DisableOpenLDAP(url, token)
 	require.NoError(d.T(), err)
 
-	time.Sleep(2 * time.Second) //waiting for server to be ready
+	time.Sleep(1 * time.Second) //waiting for server to be ready
 
 	//try login again - this one should fail
 	resp, err = d.LoginOpenLDAP(host, token, []byte(resp.Body))
@@ -300,9 +300,10 @@ func SendAPICall(url, token string, body []byte) (*APIResponse, error) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+
 	if err != nil {
-		return nil, fmt.Errorf("error reading response body: %w", err)
+		return nil, fmt.Errorf("error reading the response body: %w", err)
 	}
 
 	return &APIResponse{

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
@@ -19,10 +20,11 @@ import (
 
 type OpenLdapTest struct {
 	suite.Suite
-	testUser *management.User
-	client   *rancher.Client
-	project  *management.Project
-	session  *session.Session
+	testUser      *management.User
+	client        *rancher.Client
+	project       *management.Project
+	session       *session.Session
+	upgradeConfig *Config2
 }
 
 type APIResponse struct {
@@ -102,6 +104,10 @@ func (d *OpenLdapTest) SetupSuite() {
 	require.NoError(d.T(), err)
 
 	d.project = testProject
+
+	// Initialize the upgradeConfig field from struct
+	d.upgradeConfig = new(Config2)
+	config.LoadConfig(ConfigurationFileKey, d.upgradeConfig)
 }
 
 func (d *OpenLdapTest) TearDownSuite() {
@@ -111,18 +117,13 @@ func (d *OpenLdapTest) TearDownSuite() {
 func (d *OpenLdapTest) TestOpenLdapAPI() {
 	testSession := session.NewSession()
 	defer testSession.Cleanup()
+	host := d.upgradeConfig.Host
+	token := d.upgradeConfig.Token
+	testURI := "/v3/openLdapConfigs/openldap?action=testAndApply"
+	protocol := "https://"
+	url := protocol + host + testURI
 
-	upgradeConfig := new(Config2)
-	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
-
-	fmt.Print(d.client.RancherConfig.ClusterName)
-	fmt.Print(d.client.RancherConfig.Host)
-
-	fmt.Print(upgradeConfig.Host)
-	fmt.Print(upgradeConfig.LoginUser)
-	url := "https://ron1016.qa.rancher.space/v3/openLdapConfigs/openldap?action=testAndApply"
-	token := "token-vs9qg:pg8g9jcksx4pw6h7xh7448c6m94h8nmc45ln88q6wr9gfk57qvftp5"
-
+	//enable the openldap config
 	resp, err := d.EnableOpenLdap(url, token)
 	require.NoError(d.T(), err)
 
@@ -135,6 +136,41 @@ func (d *OpenLdapTest) TestOpenLdapAPI() {
 
 	require.True(d.T(), validStatus, errorMessage)
 
+	//attempt login with valid openldap user
+	//pass when enabled / fail when disabled
+	resp, err = d.LoginOpenLDAP(host, token, []byte(resp.Body))
+	require.NoError(d.T(), err)
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+
+		fmt.Println("login successful")
+
+	}
+	uri := "/v3-public/openLdapProviders/openldap?action=login"
+	url = d.upgradeConfig.Host + uri
+
+	//disable the openldap config
+	resp, err = d.DisableOpenLDAP(url, token)
+	require.NoError(d.T(), err)
+
+	time.Sleep(2 * time.Second) //waiting for server to be ready
+
+	//try login again - this one should fail
+	resp, err = d.LoginOpenLDAP(host, token, []byte(resp.Body))
+	require.NoError(d.T(), err)
+	if resp.StatusCode == http.StatusInternalServerError {
+		errorMessage = "openldap user can't login when openldap disabled - test passed"
+	}
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+		fmt.Println("openldap user logged in - fail")
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		errorMessage = "unauthorized login attemp"
+	}
+	if resp.StatusCode == http.StatusInternalServerError {
+		fmt.Println("openldap user login failed")
+	}
+
 }
 
 func (d *OpenLdapTest) EnableOpenLdap(url string, token string) (*APIResponse, error) {
@@ -142,7 +178,7 @@ func (d *OpenLdapTest) EnableOpenLdap(url string, token string) (*APIResponse, e
 		Enabled: true,
 		LdapConfig: LdapConfig{
 			Actions: map[string]string{
-				"testAndApply": "https://ron1016.qa.rancher.space/v3/openLdapConfigs/openldap?action=testAndApply",
+				"testAndApply": d.upgradeConfig.Host + "/v3/openLdapConfigs/openldap?action=testAndApply",
 			},
 			Annotations: map[string]string{
 				"management.cattle.io/auth-provider-cleanup": "rancher-locked",
@@ -162,8 +198,8 @@ func (d *OpenLdapTest) EnableOpenLdap(url string, token string) (*APIResponse, e
 				"cattle.io/creator": "norman",
 			},
 			Links: map[string]string{
-				"self":   "https://ron1016.qa.rancher.space/v3/openLdapConfigs/openldap",
-				"update": "https://ron1016.qa.rancher.space/v3/openLdapConfigs/openldap",
+				"self":   d.upgradeConfig.Host + "/v3/openLdapConfigs/openldap",
+				"update": d.upgradeConfig.Host + "/v3/openLdapConfigs/openldap",
 			},
 			Name:                            "openldap",
 			NestedGroupMembershipEnabled:    false,
@@ -179,16 +215,16 @@ func (d *OpenLdapTest) EnableOpenLdap(url string, token string) (*APIResponse, e
 			UserSearchAttribute:             "uid|sn|givenName",
 			UUID:                            "c30859dd-f103-446b-ad81-9633f2da0438",
 			Clone:                           true,
-			Servers:                         []string{"openldapqa.qa.rancher.space"},
+			Servers:                         []string{d.upgradeConfig.Servers},
 			AccessMode:                      "unrestricted",
 			DisabledStatusBitmask:           0,
-			ServiceAccountDistinguishedName: "cn=admin,dc=qa,dc=rancher,dc=space",
-			ServiceAccountPassword:          "cattle@123",
-			UserSearchBase:                  "dc=qa,dc=rancher,dc=space",
+			ServiceAccountDistinguishedName: d.upgradeConfig.ServiceAccountDistinguishedName,
+			ServiceAccountPassword:          d.upgradeConfig.ServiceAccountPassword,
+			UserSearchBase:                  d.upgradeConfig.UserSearchBase,
 			GroupSearchBase:                 "",
 		},
-		Username: "testuser1",
-		Password: "Tacos86!",
+		Username: d.upgradeConfig.OpenLdapUser,
+		Password: d.upgradeConfig.LoginPass,
 	}
 
 	body, err := json.MarshalIndent(payloadInstance, "", "  ")
@@ -197,8 +233,6 @@ func (d *OpenLdapTest) EnableOpenLdap(url string, token string) (*APIResponse, e
 		return nil, err
 	}
 
-	fmt.Println(string(body))
-
 	resp, err := SendAPICall(url, token, body)
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -206,7 +240,7 @@ func (d *OpenLdapTest) EnableOpenLdap(url string, token string) (*APIResponse, e
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		fmt.Println("API call was successful!")
+		fmt.Println("enable openldap was successful!")
 	} else {
 		fmt.Printf("API call failed with status code: %d\n", resp.StatusCode)
 		fmt.Println("Response Body:", resp.Body)
@@ -215,23 +249,26 @@ func (d *OpenLdapTest) EnableOpenLdap(url string, token string) (*APIResponse, e
 
 }
 func (d *OpenLdapTest) LoginOpenLDAP(host string, token string, body []byte) (*APIResponse, error) {
-	url := "https://ron1016.qa.rancher.space/v3-public/openLdapProviders/openldap?action=login"
-	token = "token-vs9qg:pg8g9jcksx4pw6h7xh7448c6m94h8nmc45ln88q6wr9gfk57qvftp5"
+	https := "https://"
+	uri := "/v3-public/openLdapProviders/openldap?action=login"
+	url := https + host + uri
 
-	body = []byte(`{
-		"description": "postman",
-		"responseType": "token",
-		"username": "testuser2",
-		"password": "Tacos86!"
-	}`)
+	// Use string formatting to replace placeholders with actual values
+	requestBody := fmt.Sprintf(`{
+        "description": "postman",
+        "responseType": "token",
+        "username": "%s",
+        "password": "%s"
+    }`, d.upgradeConfig.LoginUser, d.upgradeConfig.LoginPass)
 
-	return SendAPICall(url, token, body)
+	return SendAPICall(url, token, []byte(requestBody))
 }
 
-func (d *OpenLdapTest) DisableOpenLDAP(url string, token string) (*APIResponse, error) {
-	url = "https://ron1016.qa.rancher.space/v3/openLdapConfigs/openldap?action=disable"
+func (d *OpenLdapTest) DisableOpenLDAP(host string, token string) (*APIResponse, error) {
+	https := "https://"
+	uri := "/v3/openLdapConfigs/openldap?action=disable"
 	body := []byte(`{"action": "disable"}`)
-
+	url := https + d.upgradeConfig.Host + uri
 	resp, err := SendAPICall(url, token, body)
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -239,9 +276,9 @@ func (d *OpenLdapTest) DisableOpenLDAP(url string, token string) (*APIResponse, 
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		fmt.Println("API call was successful!")
+		fmt.Println("openldap config disabled!")
 	} else {
-		fmt.Printf("API call failed with status code: %d\n", resp.StatusCode)
+		fmt.Printf("disable api call failed with status code: %d\n", resp.StatusCode)
 		fmt.Println("Response Body:", resp.Body)
 	}
 	return resp, nil
@@ -250,9 +287,9 @@ func (d *OpenLdapTest) DisableOpenLDAP(url string, token string) (*APIResponse, 
 func SendAPICall(url, token string, body []byte) (*APIResponse, error) {
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
 	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
+		return nil, fmt.Errorf("error creating  request: %w", err)
 	}
-	fmt.Println(url, token, body)
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
@@ -1,7 +1,10 @@
 package openldapauth
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -18,6 +21,12 @@ type OpenLdapTest struct {
 	client   *rancher.Client
 	project  *management.Project
 	session  *session.Session
+}
+
+// APIResponse represents the outcome of the SendAPICall function
+type APIResponse struct {
+	StatusCode int
+	Body       string
 }
 
 func (d *OpenLdapTest) SetupSuite() {
@@ -68,6 +77,7 @@ func (d *OpenLdapTest) TestEnableOpenLDAP() {
 
 	upgradeConfig := new(Config2)
 	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
+	//MakeOpenLdapAPICALL(url, token, body)
 	fmt.Print(upgradeConfig.OpenLdapUser)
 	fmt.Print(upgradeConfig.OpenLdapUserPass)
 	fmt.Print(client)
@@ -88,6 +98,89 @@ func (d *OpenLdapTest) TestEnableOpenLDAP() {
 	*/
 }
 
+func (d *OpenLdapTest) MakeOpenLdapAPICall() {
+	host := "ron276c" // Consider fetching this from `d` if it's a property of OpenLdapTest.
+	url := fmt.Sprintf("https://%s.qa.rancher.space/v3-public/localProviders/local?action=login", host)
+	token := "token-sss6h:bsz527k7jcpr8bbjmw22wlg5w8vqzlq5w9snwpzfx7xzb8fm6hqqsp" // Similarly, fetch from `d` if required.
+
+	// Adjust the body as per your requirements. I'm using the one from the example.
+	body := []byte(`{"description": "postman", "responseType": "token", "username": "admin", "password": "N7q-*fs+Ut&Wb_Y"}`)
+
+	resp, err := MakeOpenLdapAPICALL(url, token, body)
+	if err != nil {
+		// Handle error
+		fmt.Println("Error:", err)
+		return
+	}
+
+	// Inspect the APIResponse
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("API call was successful!")
+	} else {
+		fmt.Printf("API call failed with status code: %d\n", resp.StatusCode)
+	}
+	fmt.Println("Response Body:", resp.Body)
+}
+
+// SendAPICall sends a POST request to a given URL with a provided bearer token and body.
+// It returns an APIResponse containing the status code and response body.
+func MakeOpenLdapAPICALL(url, token string, body []byte) (*APIResponse, error) {
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	// Make the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	return &APIResponse{
+		StatusCode: resp.StatusCode,
+		Body:       string(respBody),
+	}, nil
+}
+
+func APIFunction() {
+	host := "ron276c"
+	url := fmt.Sprintf("https://%s.qa.rancher.space/v3-public/localProviders/local?action=login", host)
+	token := "token-sss6h:bsz527k7jcpr8bbjmw22wlg5w8vqzlq5w9snwpzfx7xzb8fm6hqqsp"
+	body := []byte(`{"description": "postman", "responseType": "token", "username": "admin", "password": "N7q-*fs+Ut&Wb_Y"}`)
+
+	resp, err := MakeOpenLdapAPICALL(url, token, body)
+	if err != nil {
+		// Handle error
+		fmt.Println("Error:", err)
+		return
+	}
+
+	// Inspect the APIResponse
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("API call was successful!")
+	} else {
+		fmt.Printf("API call failed with status code: %d\n", resp.StatusCode)
+	}
+	fmt.Println("Response Body:", resp.Body)
+}
+
 func TestOpenLdapTestSuite(t *testing.T) {
 	suite.Run(t, new(OpenLdapTest))
 }
+
+//move credentials from code to config
+//rename/polish struct
+//check api calls for what's sent/response
+//check network and get info for structs

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
@@ -1,0 +1,23 @@
+package openldapauth
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateOpenLDAPAuthConfig(t *testing.T) {
+	rancherClient, err := rancher.NewRancherClient()
+	require.NoError(t, err)
+
+	authConfig, err := CreateOpenLDAPAuthConfig(rancherClient)
+	require.NoError(t, err)
+
+	assert.Equal(t, openLdapConfigNameBase, authConfig.Name)
+	assert.NotNil(t, authConfig.OpenLDAPCredentialConfig)
+	assert.Equal(t, []string{"openldapqa.qa.rancher.space"}, authConfig.OpenLDAPCredentialConfig.Servers)
+	assert.Equal(t, "cn=admin,dc=qa,rancher,dc=space", authConfig.OpenLDAPCredentialConfig.ServiceAccountDistinguishedName)
+
+}

--- a/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
+++ b/tests/framework/extensions/authconfigs/openldap/openldapauth_test.go
@@ -1,16 +1,18 @@
 package openldapauth
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type openLdapTest struct {
+type OpenLdapTest struct {
 	suite.Suite
 	testUser *management.User
 	client   *rancher.Client
@@ -18,8 +20,8 @@ type openLdapTest struct {
 	session  *session.Session
 }
 
-func (d *openLdapTest) SetupSuite() {
-	testSession := session.NewSession(d.T())
+func (d *OpenLdapTest) SetupSuite() {
+	testSession := session.NewSession()
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(d.T(), err)
@@ -32,25 +34,45 @@ func (d *openLdapTest) SetupSuite() {
 	}
 
 	testProject, err := client.Management.Project.Create(projectConfig)
-	require.NoError(p.T(), err)
+	require.NoError(d.T(), err)
 
 	d.project = testProject
+	/*
+		upgradeConfig := new(Config2)
+		config.LoadConfig(ConfigurationFileKey, upgradeConfig)
+		fmt.Print(upgradeConfig.OpenLdapUser)
+		fmt.Print(upgradeConfig.OpenLdapUserPass) */
 
-	enabled := true
+	//enabled := true
 
-	user := &management.User{
+	/*user := &management.User{
 		Username: "testusername",
 		Password: "passwordpasswordd",
 		Name:     "displayname",
 		Enabled:  &enabled,
-	}
+	}*/
+
+	//client.AsUser(user)
 
 }
-func (d *openLdapTest) TearDownSuite() {
+func (d *OpenLdapTest) TearDownSuite() {
 	d.session.Cleanup()
 }
 
-func TestCreateOpenLDAPAuthConfig(t *testing.T) {
+func (d *OpenLdapTest) TestEnableOpenLDAP() {
+	testSession := session.NewSession()
+	d.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(d.T(), err)
+
+	upgradeConfig := new(Config2)
+	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
+	fmt.Print(upgradeConfig.OpenLdapUser)
+	fmt.Print(upgradeConfig.OpenLdapUserPass)
+	fmt.Print(client)
+	fmt.Print(d.testUser)
+
 	/*
 		rancherClient, err := rancher.NewRancherClient()
 		require.NoError(t, err)
@@ -66,4 +88,6 @@ func TestCreateOpenLDAPAuthConfig(t *testing.T) {
 	*/
 }
 
-//need to add a suite a teardown and a config = somewehre?
+func TestOpenLdapTestSuite(t *testing.T) {
+	suite.Run(t, new(OpenLdapTest))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->https://github.com/rancher/qa-tasks/issues/874
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->automation doesn't currently have a method to enable/disable and test logins for openldap
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 added openldap extension that enables auth, verifies enabled, disables auth, verifies disabled. 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * **Validation (Go Framework)**
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 run opendapauth_test.go
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_
n/a
Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_
n/a