### PR TITLE
set default useInstanceMetadataHostname true for external-aws

### DIFF
--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -1368,11 +1368,14 @@ func setInstanceMetadataHostname(data map[string]interface{}) {
 	rkeConfig, ok := values.GetValue(data, "rancherKubernetesEngineConfig")
 	if ok && rkeConfig != nil {
 		cloudProviderName := convert.ToString(values.GetValueN(data, "rancherKubernetesEngineConfig", "cloudProvider", "name"))
-		if cloudProviderName == k8s.AWSCloudProvider {
-			_, ok := values.GetValue(data, "rancherKubernetesEngineConfig", "cloudProvider", "useInstanceMetadataHostname")
-			if !ok {
-				// set default false for aws cloud provider
+		_, ok := values.GetValue(data, "rancherKubernetesEngineConfig", "cloudProvider", "useInstanceMetadataHostname")
+		if !ok {
+			if cloudProviderName == k8s.AWSCloudProvider {
+				// set default false for in-tree aws cloud provider
 				values.PutValue(data, false, "rancherKubernetesEngineConfig", "cloudProvider", "useInstanceMetadataHostname")
+			} else if cloudProviderName == k8s.ExternalAWSCloudProviderName {
+				// set default true for external-aws cloud provider
+				values.PutValue(data, true, "rancherKubernetesEngineConfig", "cloudProvider", "useInstanceMetadataHostname")
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/43175

Setting default value for the field `useInstanceMetadataHostname` when using `external-aws`. Docs and release notes would be updated to note it'll have to be disabled when users are passing custom node names for custom clusters. For all other usecases, the field will be true so that external cloud provider can find the node without `providerID`. 