### PR TITLE
[v2.7] Add pre-drain hook to ensure new init node is functional before remov…

### DIFF
--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -39,9 +39,10 @@ import (
 )
 
 const (
-	rkeBootstrapName                       = "rke.cattle.io/rkebootstrap-name"
-	capiMachinePreTerminateAnnotation      = "pre-terminate.delete.hook.machine.cluster.x-k8s.io/rke-bootstrap-cleanup"
-	capiMachinePreTerminateAnnotationOwner = "rke-bootstrap-controller"
+	rkeBootstrapName                   = "rke.cattle.io/rkebootstrap-name"
+	capiMachinePreDrainAnnotation      = "pre-drain.delete.hook.machine.cluster.x-k8s.io/rke-bootstrap-cleanup"
+	capiMachinePreDrainAnnotationOwner = "rke-bootstrap-controller"
+	capiMachinePreTerminateAnnotation  = "pre-terminate.delete.hook.machine.cluster.x-k8s.io/rke-bootstrap-cleanup"
 )
 
 type handler struct {
@@ -291,7 +292,7 @@ func (h *handler) OnChange(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEB
 		return h.rkeBootstrap.Update(bootstrap)
 	}
 
-	return h.reconcileMachinePreTerminateAnnotation(bootstrap)
+	return h.reconcileMachinePreDrainAnnotation(bootstrap)
 }
 
 func (h *handler) GeneratingHandler(bootstrap *rkev1.RKEBootstrap, status rkev1.RKEBootstrapStatus) ([]runtime.Object, rkev1.RKEBootstrapStatus, error) {
@@ -395,23 +396,24 @@ func getLabelsAndAnnotationsForPlanSecret(bootstrap *rkev1.RKEBootstrap, machine
 // when it is deleting and bootstrap is for an etcd node.
 func (h *handler) OnRemove(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
 	logrus.Debugf("[rkebootstrap] %s/%s: OnRemove invoked", bootstrap.Namespace, bootstrap.Name)
-	return h.reconcileMachinePreTerminateAnnotation(bootstrap)
+
+	return h.reconcileMachinePreDrainAnnotation(bootstrap)
 }
 
-// reconcileMachinePreTerminateAnnotation reconciles the machine object that owns the bootstrap. It only reconciles the machine if it is an
-// etcd machine. Its primary purpose is to manage the pre-terminate.delete.hook.machine.x-k8s.io annotation on the machine
-// object, which is used to prevent premature tear down of infrastructure before it is ready to be teared down, i.e.
-// allowing removal of an etcd member without causing quorum loss.
-// The pre-terminate hook will be set on the machine object if the machine and bootstrap are not deleting, the corresponding
+// reconcileMachinePreDrainAnnotation reconciles the machine object that owns the bootstrap. It only reconciles the machine if it is an
+// etcd machine. Its primary purpose is to manage the pre-drain.delete.hook.machine.x-k8s.io annotation on the machine
+// object, which is used to prevent draining of the corresponding downstream node, since draining may include the static
+// etcd pod which could cause a quorum loss or at worst inability to elect a new etcd member.
+// The pre-drain hook will be set on the machine object if the machine and bootstrap are not deleting, the corresponding
 // CAPI cluster and RKEControlPlane are not deleting, and the force remove annotation is not set on the bootstrap.
-// The annotation will be removed from the machine to allow infrastructure cleanup in the following cases:
-// * The machine is deleting and the "safe remove" logic has fired and removed the etcd member from the etcd cluster
+// The annotation will be removed from the machine to allow draining in the following cases:
+// * The machine is deleting and no machines are using this one's join-url
 // * The bootstrap is missing the CAPI cluster label || the CAPI cluster controlPlaneRef is nil || the machine noderef is nil
 // * Any of the following: CAPI kubeconfig secret, CAPI cluster object, RKEControlPlane object are not found
 //
-// Notably, CAPI controllers do not trigger a deletion of the RKEBootstrap object if a pre-terminate annotation exists on the corresponding machine object.
+// Notably, CAPI controllers do not trigger a deletion of the RKEBootstrap object if a pre-drain annotation exists on the corresponding machine object.
 // This means we rely on the OnChange handler to perform node safe removal, when it sees that the corresponding machine is deleting.
-func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
+func (h *handler) reconcileMachinePreDrainAnnotation(bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
 	machine, err := capr.GetMachineByOwner(h.machineCache, bootstrap)
 	if err != nil {
 		if errors.Is(err, capr.ErrNoMachineOwnerRef) || apierrors.IsNotFound(err) {
@@ -425,19 +427,19 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 
 	forceRemove, ok := bootstrap.Annotations[capr.ForceRemoveEtcdAnnotation]
 	if (ok && strings.ToLower(forceRemove) == "true") || !isEtcd {
-		// If the force remove annotation is "true" or the node is not an etcd node, then ensure the machine pre terminate annotation is removed.
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+		// If the force remove annotation is "true" or the node is not an etcd node, then ensure the machine pre drain annotation is removed.
+		return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 	}
 
-	// Only add the pre-terminate hook annotation if the corresponding machine and bootstrap are NOT deleting
+	// Only add the pre-drain hook annotation if the corresponding machine and bootstrap are NOT deleting
 	if machine.DeletionTimestamp.IsZero() && bootstrap.DeletionTimestamp.IsZero() {
-		// annotate the CAPI machine with the pre-terminate.delete.hook.machine.cluster.x-k8s.io annotation if it is an etcd machine
-		if val, ok := machine.GetAnnotations()[capiMachinePreTerminateAnnotation]; !ok || val != capiMachinePreTerminateAnnotationOwner {
+		// annotate the CAPI machine with the pre-drain.delete.hook.machine.cluster.x-k8s.io annotation if it is an etcd machine
+		if val, ok := machine.GetAnnotations()[capiMachinePreDrainAnnotation]; !ok || val != capiMachinePreDrainAnnotationOwner {
 			machine = machine.DeepCopy()
 			if machine.Annotations == nil {
 				machine.Annotations = make(map[string]string)
 			}
-			machine.Annotations[capiMachinePreTerminateAnnotation] = capiMachinePreTerminateAnnotationOwner
+			machine.Annotations[capiMachinePreDrainAnnotation] = capiMachinePreDrainAnnotationOwner
 			machine, err = h.machineClient.Update(machine)
 			if err != nil {
 				return bootstrap, err
@@ -447,40 +449,40 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if bootstrap.Spec.ClusterName == "" {
-		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster label %s was not found in bootstrap labels, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capi.ClusterLabelName)
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster label %s was not found in bootstrap labels, ensuring machine pre-drain annotation is removed", bootstrap.Namespace, bootstrap.Name, capi.ClusterLabelName)
+		return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 	}
 
 	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, bootstrap.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, bootstrap.Namespace, bootstrap.Spec.ClusterName)
-			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+			logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s was not found, ensuring machine pre-drain annotation is removed", bootstrap.Namespace, bootstrap.Name, bootstrap.Namespace, bootstrap.Spec.ClusterName)
+			return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 		}
 		return bootstrap, err
 	}
 
 	if capiCluster.Spec.ControlPlaneRef == nil {
-		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s controlplane object reference was nil, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name)
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s controlplane object reference was nil, ensuring machine pre-drain annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name)
+		return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 	}
 
 	cp, err := h.rkeControlPlanes.Get(capiCluster.Spec.ControlPlaneRef.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Warnf("[rkebootstrap] %s/%s: RKEControlPlane %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Spec.ControlPlaneRef.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
-			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+			logrus.Warnf("[rkebootstrap] %s/%s: RKEControlPlane %s/%s was not found, ensuring machine pre-drain annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Spec.ControlPlaneRef.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
+			return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 		}
 		return bootstrap, err
 	}
 
 	if !cp.DeletionTimestamp.IsZero() || !capiCluster.DeletionTimestamp.IsZero() {
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+		return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 	}
 
 	if machine.Status.NodeRef == nil {
-		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-drain annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
+		return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 	}
 
 	// If the RKEControlPlane is not deleting, then make sure this node is not being used as an init node.
@@ -512,7 +514,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+			return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 		}
 		return bootstrap, err
 	}
@@ -530,16 +532,27 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
 		return bootstrap, generic.ErrSkip
 	}
-	return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+
+	return h.ensureMachinePreDrainAnnotationRemoved(bootstrap, machine)
 }
 
-// ensureMachinePreTerminateAnnotationRemoved removes the pre-terminate annotation from a CAPI machine when we removing the rkebootstrap, indicating the infrastructure can be deleted.
-func (h *handler) ensureMachinePreTerminateAnnotationRemoved(bootstrap *rkev1.RKEBootstrap, machine *capi.Machine) (*rkev1.RKEBootstrap, error) {
+// ensureMachinePreDrainAnnotationRemoved removes the pre-drain annotation from a CAPI machine when we remove
+// the rkebootstrap, indicating the node can be drained. This also removes the legacy capiMachinePreTerminateAnnotation
+// if it exists.
+func (h *handler) ensureMachinePreDrainAnnotationRemoved(bootstrap *rkev1.RKEBootstrap, machine *capi.Machine) (*rkev1.RKEBootstrap, error) {
 	if machine == nil || machine.Annotations == nil {
 		return bootstrap, nil
 	}
 
 	var err error
+	if _, ok := machine.GetAnnotations()[capiMachinePreDrainAnnotation]; ok {
+		machine = machine.DeepCopy()
+		delete(machine.Annotations, capiMachinePreDrainAnnotation)
+		_, err = h.machineClient.Update(machine)
+	}
+	if err != nil {
+		return bootstrap, err
+	}
 	if _, ok := machine.GetAnnotations()[capiMachinePreTerminateAnnotation]; ok {
 		machine = machine.DeepCopy()
 		delete(machine.Annotations, capiMachinePreTerminateAnnotation)


### PR DESCRIPTION
## Original PR: https://github.com/rancher/rancher/pull/43230

## Issue: <!-- link the issue or issues this PR resolves here --> #43263 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

As far as I can deduce, there is a race condition between the planner updating, and CAPI draining the node. Since the etcd static pod appears to be drained (rke2 specific), if CAPI drains the node before the new init node has a chance to become a leader, there will be no etcd leaders, and the new node will constantly trying to perform leader election with a dead node, since etcd is no longer running on it. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

To mitigate this, I have added a new hook, [pre-drain.delete.hook.machine.cluster.x-k8s.io/rke-bootstrap-cleanup](http://pre-drain.delete.hook.machine.cluster.x-k8s.io/rke-bootstrap-cleanup), which is largely the same as the existing pre-terminate hook, however it prevents the node from being drained until no machines are using that server's join-url (parity with existing pre-terminate hook), but with the cavet that the controlplane must also be completely reconciled, as an update to the machine-plan secret does not guarantee the plan was successfully completed.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually scaling up and down from 3 -> 1 -> 3 etcd nodes around 5 times, no longer able to reproduce. Did see it take 10 minutes one time, but this was due to CAPI trying to continuously drain a node, and therefore not a bug in rancher, or something we can fix, and it self-corrected after 10 minutes. 

### Automated Testing

Existing PR CI tests should cover this with the scaling of etcd nodes

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Custom cluster etcd addition and removal should also be tested, to the degree of completely replacing the etcd plane 1 by 1, as well as scaling from 3 -> 1 -> 3.

Existing / newly added automated tests that provide evidence there are no regressions:
- `Test_Operation_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode`