### PR TITLE
Use dl.k8s.io for getting kubectl

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -9,7 +9,7 @@ ENV KUBECTL_VERSION v1.25.12
 RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+    curl -sLf https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 ENV LOGLEVEL_VERSION v0.1.5

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -9,7 +9,7 @@ ENV KUBECTL_VERSION v1.25.12
 RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+    curl -sLf https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 ENV LOGLEVEL_VERSION v0.1.5

--- a/tests/validation/Dockerfile.rke
+++ b/tests/validation/Dockerfile.rke
@@ -8,7 +8,7 @@ WORKDIR $WORKSPACE
 COPY [".", "$WORKSPACE"]
 
 RUN wget https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux-amd64 && \
-    wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
+    wget https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
     mv rke_linux-amd64 /bin/rke && \
     chmod +x /bin/rke  && \
     mv kubectl /bin/kubectl && \

--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -16,7 +16,7 @@ ARG VPN_ENCODED_LOGIN
 
 COPY [".", "$WORKSPACE"]
 
-RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
+RUN wget https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
     mv kubectl /bin/kubectl && \
     chmod +x /bin/kubectl  && \
     wget https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux-amd64 && \


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43271
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Preparing for GCS bucket deprecation at some point (https://github.com/kubernetes/k8s.io/issues/2396)
 
## Solution
Change to the currently documented source
 
## Testing
Drone CI builds the agent image, QA can test the validation files/scripts

## Engineering Testing
### Manual Testing
QA can test the validation files/scripts

### Automated Testing


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_