### PR TITLE
fix test to work with rancher envs without cert bp

### DIFF
--- a/tests/framework/clients/rancher/v1/client.go
+++ b/tests/framework/clients/rancher/v1/client.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -312,7 +313,13 @@ func (c *NamespacedSteveClient) PerformPutCaptureHeaders(host, token, name strin
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
-	var httpClient = &http.Client{}
+	// Create a custom HTTP client with custom transport settings to skip certificate verification
+	tr := &http.Transport{}
+	if c.apiClient.Opts.Insecure {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	var httpClient = &http.Client{Transport: tr}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error executing request: %v", err)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

backport of: https://github.com/rancher/rancher/pull/43277
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The problem was that when creating this test I personally only use Rancher setups with certs. However, if someone runs this on a Rancher setup without certs it doesn't execute the test
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add a step to check if we need to skip cert verification

```go
	if skipCertVerification {
		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
	}
```
 
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->

Summary: Updated the configmaps test to work with secure or insecure Rancher setups