### PR TITLE
Refactoring RBAC

### DIFF
--- a/tests/framework/extensions/projects/projects.go
+++ b/tests/framework/extensions/projects/projects.go
@@ -1,6 +1,8 @@
 package projects
 
 import (
+	"sort"
+
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
@@ -48,4 +50,20 @@ func GetProjectList(client *rancher.Client, clusterID string) (*management.Proje
 	}
 
 	return projectsList, nil
+}
+
+// ListProjectNames is a helper which returns a sorted list of project names
+func ListProjectNames(client *rancher.Client, clusterID string) ([]string, error) {
+	projectList, err := GetProjectList(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	projectNames := make([]string, len(projectList.Data))
+
+	for idx, project := range projectList.Data {
+		projectNames[idx] = project.Name
+	}
+	sort.Strings(projectNames)
+	return projectNames, nil
 }

--- a/tests/framework/extensions/projects/template.go
+++ b/tests/framework/extensions/projects/template.go
@@ -1,0 +1,16 @@
+package projects
+
+import (
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+)
+
+const projectName = "testproject-"
+
+// NewProjectConfig is a constructor that creates a project template
+func NewProjectConfig(clusterID string) *management.Project {
+	return &management.Project{
+		ClusterID: clusterID,
+		Name:      namegen.AppendRandomString(projectName),
+	}
+}

--- a/tests/framework/extensions/rbac/config.go
+++ b/tests/framework/extensions/rbac/config.go
@@ -1,0 +1,11 @@
+package rbac
+
+const (
+	ConfigurationFileKey = "rbacInput"
+)
+
+type Config struct {
+	Role     string `json:"role" yaml:"role"`
+	Username string `json:"username" yaml:"username"`
+	Password string `json:"password" yaml:"password"`
+}

--- a/tests/framework/extensions/rbac/verify.go
+++ b/tests/framework/extensions/rbac/verify.go
@@ -1,0 +1,255 @@
+package rbac
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	apiV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/projects"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+const (
+	roleOwner                     = "cluster-owner"
+	roleMember                    = "cluster-member"
+	roleProjectOwner              = "project-owner"
+	roleProjectMember             = "project-member"
+	roleCustomManageProjectMember = "projectroletemplatebindings-manage"
+	roleCustomCreateNS            = "create-ns"
+	roleProjectReadOnly           = "read-only"
+	restrictedAdmin               = "restricted-admin"
+	standardUser                  = "user"
+	activeStatus                  = "active"
+	forbiddenError                = "403 Forbidden"
+)
+
+var rgx = regexp.MustCompile(`\[(.*?)\]`)
+
+// VerifyGlobalRoleBindingsForUser validates that a global role bindings is created for a user when the user is created
+func VerifyGlobalRoleBindingsForUser(t *testing.T, user *management.User, adminClient *rancher.Client) {
+	query := url.Values{"filter": {"userName=" + user.ID}}
+	grbs, err := adminClient.Steve.SteveType("management.cattle.io.globalrolebinding").List(query)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(grbs.Data))
+}
+
+// VerifyUserCanListCluster validates a user with the required global permissions are able to/not able to list the clusters in rancher server
+func VerifyUserCanListCluster(t *testing.T, client, standardClient *rancher.Client, clusterID, role string) {
+	clusterList, err := standardClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
+	require.NoError(t, err)
+
+	clusterStatus := &apiV1.ClusterStatus{}
+	err = v1.ConvertToK8sType(clusterList.Data[0].Status, clusterStatus)
+	require.NoError(t, err)
+
+	if role == restrictedAdmin {
+		adminClusterList, err := client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
+		require.NoError(t, err)
+		assert.Equal(t, (len(adminClusterList.Data) - 1), len(clusterList.Data))
+	}
+	assert.Equal(t, 1, len(clusterList.Data))
+	actualClusterID := clusterStatus.ClusterName
+	assert.Equal(t, clusterID, actualClusterID)
+
+}
+
+// VerifyUserCanListProject validates a user with the required cluster permissions are able/not able to list projects in the downstream cluster
+func VerifyUserCanListProject(t *testing.T, client, standardClient *rancher.Client, clusterID, role, adminProjectName string) {
+	projectListNonAdmin, err := projects.ListProjectNames(standardClient, clusterID)
+	require.NoError(t, err)
+	projectListAdmin, err := projects.ListProjectNames(client, clusterID)
+	require.NoError(t, err)
+
+	switch role {
+	case roleOwner, restrictedAdmin:
+		assert.Equal(t, len(projectListAdmin), len(projectListNonAdmin))
+		assert.Equal(t, projectListAdmin, projectListNonAdmin)
+	case roleMember:
+		assert.Equal(t, 0, len(projectListNonAdmin))
+	case roleProjectOwner, roleProjectMember:
+		assert.Equal(t, 1, len(projectListNonAdmin))
+		assert.Equal(t, adminProjectName, projectListNonAdmin[0])
+	}
+}
+
+// VerifyUserCanCreateProjects validates a user with the required cluster permissions are able/not able to create projects in the downstream cluster
+func VerifyUserCanCreateProjects(t *testing.T, client, standardClient *rancher.Client, clusterID, role string) {
+	memberProject, err := standardClient.Management.Project.Create(projects.NewProjectConfig(clusterID))
+	switch role {
+	case roleOwner, roleMember, restrictedAdmin:
+		require.NoError(t, err)
+		log.Info("Created project as a ", role, " is ", memberProject.Name)
+		actualStatus := fmt.Sprintf("%v", memberProject.State)
+		assert.Equal(t, activeStatus, strings.ToLower(actualStatus))
+	case roleProjectOwner, roleProjectMember:
+		require.Error(t, err)
+		errStatus := strings.Split(err.Error(), ".")[1]
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(t, forbiddenError, errorMsg[1])
+	}
+}
+
+// VerifyUserCanCreateNamespace validates a user with the required cluster permissions are able/not able to create namespaces in the project they do not own
+func VerifyUserCanCreateNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID, role string) {
+	var checkErr error
+	namespaceName := namegen.AppendRandomString("testns-")
+	standardClient, err := standardClient.ReLogin()
+	require.NoError(t, err)
+
+	createdNamespace, checkErr := namespaces.CreateNamespace(standardClient, namespaceName, "{}", map[string]string{}, map[string]string{}, project)
+
+	switch role {
+	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
+		require.NoError(t, checkErr)
+		log.Info("Created a namespace as role ", role, createdNamespace.Name)
+		assert.Equal(t, namespaceName, createdNamespace.Name)
+
+		namespaceStatus := &coreV1.NamespaceStatus{}
+		err = v1.ConvertToK8sType(createdNamespace.Status, namespaceStatus)
+		require.NoError(t, err)
+		actualStatus := fmt.Sprintf("%v", namespaceStatus.Phase)
+		assert.Equal(t, activeStatus, strings.ToLower(actualStatus))
+	case roleMember:
+		require.Error(t, checkErr)
+		errStatus := strings.Split(checkErr.Error(), ".")[1]
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(t, forbiddenError, errorMsg[1])
+	}
+}
+
+// VerifyUserCanListNamespace validates a user with the required cluster permissions are able/not able to list namespaces in the project they do not own
+func VerifyUserCanListNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID, role string) {
+	log.Info("Validating if ", role, " can lists all namespaces in a cluster.")
+
+	steveAdminClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(t, err)
+	steveStandardClient, err := standardClient.Steve.ProxyDownstream(clusterID)
+	require.NoError(t, err)
+
+	namespaceListAdmin, err := steveAdminClient.SteveType(namespaces.NamespaceSteveType).List(nil)
+	require.NoError(t, err)
+	sortedNamespaceListAdmin := namespaceListAdmin.Names()
+
+	namespaceListNonAdmin, err := steveStandardClient.SteveType(namespaces.NamespaceSteveType).List(nil)
+	require.NoError(t, err)
+	sortedNamespaceListNonAdmin := namespaceListNonAdmin.Names()
+
+	switch role {
+	case roleOwner, restrictedAdmin:
+		require.NoError(t, err)
+		assert.Equal(t, len(sortedNamespaceListAdmin), len(sortedNamespaceListNonAdmin))
+		assert.Equal(t, sortedNamespaceListAdmin, sortedNamespaceListNonAdmin)
+	case roleMember:
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(sortedNamespaceListNonAdmin))
+	case roleProjectOwner, roleProjectMember:
+		require.NoError(t, err)
+		assert.NotEqual(t, len(sortedNamespaceListAdmin), len(sortedNamespaceListNonAdmin))
+		assert.Equal(t, 1, len(sortedNamespaceListNonAdmin))
+	}
+}
+
+// VerifyUserCanDeleteNamespace validates a user with the required cluster permissions are able/not able to delete namespaces in the project they do not own
+func VerifyUserCanDeleteNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID, role string) {
+
+	log.Info("Validating if ", role, " cannot delete a namespace from a project they own.")
+	steveAdminClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(t, err)
+	steveStandardClient, err := standardClient.Steve.ProxyDownstream(clusterID)
+	require.NoError(t, err)
+
+	namespaceName := namegen.AppendRandomString("testns-")
+	adminNamespace, err := namespaces.CreateNamespace(client, namespaceName+"-admin", "{}", map[string]string{}, map[string]string{}, project)
+	require.NoError(t, err)
+
+	namespaceID, err := steveAdminClient.SteveType(namespaces.NamespaceSteveType).ByID(adminNamespace.ID)
+	require.NoError(t, err)
+	err = steveStandardClient.SteveType(namespaces.NamespaceSteveType).Delete(namespaceID)
+
+	switch role {
+	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
+		require.NoError(t, err)
+	case roleMember:
+		require.Error(t, err)
+		errMessage := strings.Split(err.Error(), ":")[0]
+		assert.Equal(t, "Resource type [namespace] can not be deleted", errMessage)
+	}
+}
+
+// VerifyUserCanAddClusterRoles validates a user with the required cluster permissions are able/not able to add other users in the cluster
+func VerifyUserCanAddClusterRoles(t *testing.T, client, memberClient *rancher.Client, cluster *management.Cluster, role string) {
+	additionalClusterUser, err := users.CreateUserWithRole(client, users.UserConfig(), standardUser)
+	require.NoError(t, err)
+
+	errUserRole := users.AddClusterRoleToUser(memberClient, cluster, additionalClusterUser, roleOwner, nil)
+
+	switch role {
+	case roleProjectOwner, roleProjectMember:
+		require.Error(t, errUserRole)
+		errStatus := strings.Split(errUserRole.Error(), ".")[1]
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(t, forbiddenError, errorMsg[1])
+	case restrictedAdmin:
+		require.NoError(t, errUserRole)
+	}
+
+}
+
+// VerifyUserCanAddProjectRoles validates a user with the required cluster permissions are able/not able to add other users in a project on the downstream cluster
+func VerifyUserCanAddProjectRoles(t *testing.T, client *rancher.Client, project *management.Project, additionalUser *management.User, projectRole, clusterID, role string) {
+
+	errUserRole := users.AddProjectMember(client, project, additionalUser, projectRole, nil)
+	projectList, errProjectList := projects.ListProjectNames(client, clusterID)
+	require.NoError(t, errProjectList)
+
+	switch role {
+	case roleProjectOwner:
+		require.NoError(t, errUserRole)
+		assert.Equal(t, 1, len(projectList))
+		assert.Equal(t, project.Name, projectList[0])
+
+	case restrictedAdmin:
+		require.NoError(t, errUserRole)
+		assert.Contains(t, projectList, project.Name)
+
+	case roleProjectMember:
+		require.Error(t, errUserRole)
+	}
+
+}
+
+// VerifyUserCanDeleteProject validates a user with the required cluster/project permissions are able/not able to delete projects in the downstream cluster
+func VerifyUserCanDeleteProject(t *testing.T, client *rancher.Client, project *management.Project, role string) {
+	err := client.Management.Project.Delete(project)
+
+	switch role {
+	case roleOwner, roleProjectOwner:
+		require.NoError(t, err)
+	case roleMember:
+		require.Error(t, err)
+		errStatus := strings.Split(err.Error(), ".")[1]
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(t, forbiddenError, errorMsg[1])
+	case roleProjectMember:
+		require.Error(t, err)
+	}
+}
+
+// VerifyUserCanRemoveClusterRoles validates a user with the required cluster/project permissions are able/not able to remove cluster roles in the downstream cluster
+func VerifyUserCanRemoveClusterRoles(t *testing.T, client *rancher.Client, user *management.User) {
+	err := users.RemoveClusterRoleFromUser(client, user)
+	require.NoError(t, err)
+}

--- a/tests/v2/validation/rbac/README.md
+++ b/tests/v2/validation/rbac/README.md
@@ -1,0 +1,39 @@
+# Rbac
+
+## Getting Started
+Your GO suite should be set to `-run ^Test<>TestSuite$`. For example to run the rbac_additional_test.go, set the GO suite to `-run ^TestRBACAdditionalTestSuite$` You can find specific tests by checking the test file you plan to run.
+In your config file, set the following:
+
+```json
+"rancher": { 
+  "host": "rancher_server_address",
+  "adminToken": "rancher_admin_token",
+  "clusterName": "cluster_to_run_tests_on",
+  "insecure": true/optional,
+  "cleanup": false/optional,
+}
+```
+
+For the rbac_additional_test.go run, we need the following paramters to be passed in the config file as we create an rke1 cluster
+Please use the following links to continue adding to your config for provisioning tests:
+ [Define your test](../provisioning/rke1/README.md#provisioning-input)
+(#Provisioning-Input)
+ [Configure providers to use for Node Driver Clusters](../provisioning/rke1/README.md#NodeTemplateConfigs)
+
+# RBAC input
+rbacInput is needed to the run the TestRBACDynamicInput tests, specifically username, password and a cluster/project role. role takes the following as input only. Role takes a single value. 
+Dynamic input will be executed on a single cluster. If the user is added to multiple downstream clusters, only the clusterName specified in the Rancher config will be taken into account. Some tests like VerifyListCluster may fail when the user is added in more than one downstream clusters.
+User must be already created in the rancher server. If any other format of roles is provided, the tests fail to run:
+
+`cluster-owner`
+`cluster-member`
+`project-owner`
+`project-member`
+`restricted-admin`
+
+```json
+rbacInput:
+  role: "cluster-owner"
+  username: "<userID>"
+  password: "<password>"
+```

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -3,40 +3,26 @@
 package rbac
 
 import (
-	"fmt"
-	"net/url"
-	"regexp"
 	"strings"
 	"testing"
 
-	apiV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
-	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/rbac"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
-	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	coreV1 "k8s.io/api/core/v1"
 )
 
 type RBTestSuite struct {
 	suite.Suite
-	client               *rancher.Client
-	standardUser         *management.User
-	standardUserClient   *rancher.Client
-	session              *session.Session
-	cluster              *management.Cluster
-	adminProject         *management.Project
-	steveAdminClient     *v1.Client
-	steveStdUserclient   *v1.Client
-	additionalUser       *management.User
-	additionalUserClient *rancher.Client
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
 }
 
 func (rb *RBTestSuite) TearDownSuite() {
@@ -62,221 +48,66 @@ func (rb *RBTestSuite) SetupSuite() {
 
 }
 
-func (rb *RBTestSuite) ValidateListCluster(role string) {
-
-	clusterList, err := rb.standardUserClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
-	require.NoError(rb.T(), err)
-	clusterStatus := &apiV1.ClusterStatus{}
-	err = v1.ConvertToK8sType(clusterList.Data[0].Status, clusterStatus)
+func (rb *RBTestSuite) sequentialTestRBAC(role, member string, user *management.User) {
+	standardClient, err := rb.client.AsUser(user)
 	require.NoError(rb.T(), err)
 
-	if role == restrictedAdmin {
-		adminClusterList, err := rb.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
-		require.NoError(rb.T(), err)
-		assert.Equal(rb.T(), (len(adminClusterList.Data) - 1), len(clusterList.Data))
-		return
-	}
-	assert.Equal(rb.T(), 1, len(clusterList.Data))
-	actualClusterID := clusterStatus.ClusterName
-	assert.Equal(rb.T(), rb.cluster.ID, actualClusterID)
-}
-
-func (rb *RBTestSuite) ValidateListProjects(role string) {
-
-	//Get project list as an admin
-	projectlistAdmin, err := listProjects(rb.client, rb.cluster.ID)
-	require.NoError(rb.T(), err)
-	//Get project list as a cluster owner/member, project owner/member and restricted admin
-	projectlistClusterMembers, err := listProjects(rb.standardUserClient, rb.cluster.ID)
-	require.NoError(rb.T(), err)
-	switch role {
-	case roleOwner, restrictedAdmin:
-		//assert length of projects list obtained as an admin and a cluster owner are equal
-		assert.Equal(rb.T(), len(projectlistAdmin), len(projectlistClusterMembers))
-		//assert projects values obtained as an admin and the cluster owner are the same
-		assert.Equal(rb.T(), projectlistAdmin, projectlistClusterMembers)
-	case roleMember:
-		//assert projects list obtained as a cluster member is empty
-		assert.Equal(rb.T(), 0, len(projectlistClusterMembers))
-	case roleProjectOwner, roleProjectMember:
-		//assert projects list obtained as a project owner/member is 1
-		assert.Equal(rb.T(), 1, len(projectlistClusterMembers))
-		//assert project created by admin and project obtained by project owner is same
-		assert.Equal(rb.T(), rb.adminProject.Name, projectlistClusterMembers[0])
-	}
-}
-
-func (rb *RBTestSuite) ValidateCreateProjects(role string) {
-
-	createProjectAsClusterMembers, err := createProject(rb.standardUserClient, rb.cluster.ID)
-	switch role {
-	case roleOwner, roleMember, restrictedAdmin:
-		require.NoError(rb.T(), err)
-		log.Info("Created project as a ", role, " is ", createProjectAsClusterMembers.Name)
-		require.NoError(rb.T(), err)
-		actualStatus := fmt.Sprintf("%v", createProjectAsClusterMembers.State)
-		assert.Equal(rb.T(), "active", actualStatus)
-	case roleProjectOwner, roleProjectMember:
-		require.Error(rb.T(), err)
-		errStatus := strings.Split(err.Error(), ".")[1]
-		rgx := regexp.MustCompile(`\[(.*?)\]`)
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
-	}
-}
-
-func (rb *RBTestSuite) ValidateNS(role string) {
-	var checkErr error
-
-	log.Info("Validating if ", role, " can create namespace in a project they are not owner of. ")
-	namespaceName := namegen.AppendRandomString("testns-")
-	adminNamespace, err := namespaces.CreateNamespace(rb.client, namespaceName+"-admin", "{}", map[string]string{}, map[string]string{}, rb.adminProject)
+	adminProject, err := createProject(rb.client, rb.cluster.ID)
 	require.NoError(rb.T(), err)
 
-	relogin, err := rb.standardUserClient.ReLogin()
-	require.NoError(rb.T(), err)
-	rb.standardUserClient = relogin
-
-	steveStdUserclient, err := rb.standardUserClient.Steve.ProxyDownstream(rb.cluster.ID)
-	require.NoError(rb.T(), err)
-	rb.steveStdUserclient = steveStdUserclient
-
-	createdNamespace, checkErr := namespaces.CreateNamespace(rb.standardUserClient, namespaceName, "{}", map[string]string{}, map[string]string{}, rb.adminProject)
-
-	switch role {
-	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
-		require.NoError(rb.T(), checkErr)
-		log.Info("Created a namespace as role ", role, createdNamespace.Name)
-		assert.Equal(rb.T(), namespaceName, createdNamespace.Name)
-
-		namespaceStatus := &coreV1.NamespaceStatus{}
-		err = v1.ConvertToK8sType(createdNamespace.Status, namespaceStatus)
-		require.NoError(rb.T(), err)
-		actualStatus := fmt.Sprintf("%v", namespaceStatus.Phase)
-		assert.Equal(rb.T(), "Active", actualStatus)
-	case roleMember:
-		require.Error(rb.T(), checkErr)
-		//assert cluster member gets an error when creating a namespace in a project they are not owner of
-		errStatus := strings.Split(checkErr.Error(), ".")[1]
-		rgx := regexp.MustCompile(`\[(.*?)\]`)
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
+	if member == standardUser {
+		if strings.Contains(role, "project") {
+			err := users.AddProjectMember(rb.client, adminProject, user, role, nil)
+			require.NoError(rb.T(), err)
+		} else {
+			err := users.AddClusterRoleToUser(rb.client, rb.cluster, user, role, nil)
+			require.NoError(rb.T(), err)
+		}
 	}
 
-	//Validate if cluster members/project members are able to list all the namespaces in a cluster
-	log.Info("Validating if ", role, " can lists all namespaces in a cluster.")
-
-	//Get the list of namespaces as an admin client
-	namespaceListAdmin, err := getNamespaces(rb.steveAdminClient)
+	standardClient, err = standardClient.ReLogin()
 	require.NoError(rb.T(), err)
-	//Get the list of namespaces as an admin client
-	namespaceListClusterMembers, err := getNamespaces(rb.steveStdUserclient)
 
-	switch role {
-	case roleOwner, restrictedAdmin:
-		require.NoError(rb.T(), err)
-		//Length of namespace list for admin and cluster owner should match
-		assert.Equal(rb.T(), len(namespaceListAdmin), len(namespaceListClusterMembers))
-		//Namespaces obtained as admin and cluster owner should be same
-		assert.Equal(rb.T(), namespaceListAdmin, namespaceListClusterMembers)
-	case roleMember:
-		require.NoError(rb.T(), err)
-		//Length of namespace list cluster member should be nill
-		assert.Equal(rb.T(), 0, len(namespaceListClusterMembers))
-	case roleProjectOwner, roleProjectMember:
-		require.NoError(rb.T(), err)
-		//Length of namespace list for admin and project owner/member should not match
-		assert.NotEqual(rb.T(), len(namespaceListAdmin), len(namespaceListClusterMembers))
-		assert.Equal(rb.T(), 2, len(namespaceListClusterMembers))
-	}
-
-	// Validate if cluster members are able to delete the namespace in the admin created project
-	log.Info("Validating if ", role, " cannot delete a namespace from a project they own.")
-
-	namespaceID, err := rb.steveAdminClient.SteveType(namespaces.NamespaceSteveType).ByID(adminNamespace.ID)
+	additionalUser, err := users.CreateUserWithRole(rb.client, users.UserConfig(), standardUser)
 	require.NoError(rb.T(), err)
-	err = deleteNamespace(namespaceID, rb.steveStdUserclient)
-	switch role {
-	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
-		require.NoError(rb.T(), err)
-	case roleMember:
-		require.Error(rb.T(), err)
-		errMessage := strings.Split(err.Error(), ":")[0]
-		assert.Equal(rb.T(), "Resource type [namespace] can not be deleted", errMessage)
-	}
-}
 
-func (rb *RBTestSuite) ValidateAddClusterRoles(role string) {
-
-	errUserRole := users.AddClusterRoleToUser(rb.standardUserClient, rb.cluster, rb.additionalUser, roleOwner, nil)
-
-	switch role {
-	case roleProjectOwner, roleProjectMember:
-		require.Error(rb.T(), errUserRole)
-		errStatus := strings.Split(errUserRole.Error(), ".")[1]
-		rgx := regexp.MustCompile(`\[(.*?)\]`)
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
-	case restrictedAdmin:
-		require.NoError(rb.T(), errUserRole)
-	}
-}
-
-func (rb *RBTestSuite) ValidateAddProjectRoles(role string) {
-
-	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.adminProject, rb.additionalUser, roleProjectOwner, nil)
-
-	additionalUserClient, err := rb.additionalUserClient.ReLogin()
-	require.NoError(rb.T(), err)
-	rb.additionalUserClient = additionalUserClient
-
-	projectList, errProjectList := listProjects(rb.additionalUserClient, rb.cluster.ID)
-	require.NoError(rb.T(), errProjectList)
-
-	switch role {
-	case roleProjectOwner:
-		require.NoError(rb.T(), errUserRole)
-		assert.Equal(rb.T(), 1, len(projectList))
-		assert.Equal(rb.T(), rb.adminProject.Name, projectList[0])
-
-	case restrictedAdmin:
-		require.NoError(rb.T(), errUserRole)
-		assert.Contains(rb.T(), projectList, rb.adminProject.Name)
-
-	case roleProjectMember:
-		require.Error(rb.T(), errUserRole)
-	}
-
-}
-
-func (rb *RBTestSuite) ValidateDeleteProject(role string) {
-
-	err := rb.standardUserClient.Management.Project.Delete(rb.adminProject)
-
-	switch role {
-	case roleOwner, roleProjectOwner:
-		require.NoError(rb.T(), err)
-	case roleMember:
-		require.Error(rb.T(), err)
-		errStatus := strings.Split(err.Error(), ".")[1]
-		rgx := regexp.MustCompile(`\[(.*?)\]`)
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
-	case roleProjectMember:
-		require.Error(rb.T(), err)
-	}
-}
-
-func (rb *RBTestSuite) ValidateRemoveClusterRoles() {
-
-	err := users.RemoveClusterRoleFromUser(rb.client, rb.standardUser)
-	require.NoError(rb.T(), err)
-}
-
-func (rb *RBTestSuite) ValidateRemoveProjectRoles() {
-
-	err := users.RemoveProjectMember(rb.client, rb.standardUser)
-	require.NoError(rb.T(), err)
+	rb.Run("Validating Global Role Binding is created for the user.", func() {
+		rbac.VerifyGlobalRoleBindingsForUser(rb.T(), user, rb.client)
+	})
+	rb.Run("Test case Validate if users can list any downstream clusters", func() {
+		rbac.VerifyUserCanListCluster(rb.T(), rb.client, standardClient, rb.cluster.ID, role)
+	})
+	rb.Run("Validating if members with role "+role+" are able to list all projects", func() {
+		rbac.VerifyUserCanListProject(rb.T(), rb.client, standardClient, rb.cluster.ID, role, adminProject.Name)
+	})
+	rb.Run("Validating if members with role "+role+" is able to create a project in the cluster", func() {
+		rbac.VerifyUserCanCreateProjects(rb.T(), rb.client, standardClient, rb.cluster.ID, role)
+	})
+	rb.Run("Validate namespaces checks for members with role "+role, func() {
+		rbac.VerifyUserCanCreateNamespace(rb.T(), rb.client, standardClient, adminProject, rb.cluster.ID, role)
+	})
+	rb.Run("Validating if "+role+" can lists all namespaces in a cluster.", func() {
+		rbac.VerifyUserCanListNamespace(rb.T(), rb.client, standardClient, adminProject, rb.cluster.ID, role)
+	})
+	rb.Run("Validating if "+role+" can delete a namespace from a project they own.", func() {
+		rbac.VerifyUserCanDeleteNamespace(rb.T(), rb.client, standardClient, adminProject, rb.cluster.ID, role)
+	})
+	rb.Run("Validating if member with role "+role+" can add members to the cluster", func() {
+		rbac.VerifyUserCanAddClusterRoles(rb.T(), rb.client, standardClient, rb.cluster, role)
+	})
+	rb.Run("Validating if member with role "+role+" can add members to the project", func() {
+		if strings.Contains(role, "project") {
+			rbac.VerifyUserCanAddProjectRoles(rb.T(), standardClient, adminProject, additionalUser, roleProjectOwner, rb.cluster.ID, role)
+		}
+	})
+	rb.Run("Validating if member with role "+role+" can delete a project they are not owner of ", func() {
+		rbac.VerifyUserCanDeleteProject(rb.T(), standardClient, adminProject, role)
+	})
+	rb.Run("Validating if member with role "+role+" is removed from the cluster and returns nil clusters", func() {
+		if strings.Contains(role, "cluster") {
+			rbac.VerifyUserCanRemoveClusterRoles(rb.T(), rb.client, user)
+		}
+	})
 }
 
 func (rb *RBTestSuite) TestRBAC() {
@@ -291,118 +122,54 @@ func (rb *RBTestSuite) TestRBAC() {
 		{"Project Member", roleProjectMember, standardUser},
 		{"Restricted Admin", restrictedAdmin, restrictedAdmin},
 	}
+
 	for _, tt := range tests {
 		rb.Run("Set up User with Cluster Role "+tt.name, func() {
 			newUser, err := users.CreateUserWithRole(rb.client, users.UserConfig(), tt.member)
+			require.NoError(rb.T(), err)
+			rb.T().Logf("Created user: %v", newUser.Username)
 
-			require.NoError(rb.T(), err)
-			rb.standardUser = newUser
-			rb.T().Logf("Created user: %v", rb.standardUser.Username)
-			rb.standardUserClient, err = rb.client.AsUser(newUser)
-			require.NoError(rb.T(), err)
-
-			log.Info("Validating Global Role Binding is created for the user.")
-			userId, err := users.GetUserIDByName(rb.client, rb.standardUser.Username)
-			require.NoError(rb.T(), err)
-			query := url.Values{"filter": {"userName=" + userId}}
-			grbs, err := rb.client.Steve.SteveType("management.cattle.io.globalrolebinding").List(query)
-			require.NoError(rb.T(), err)
-			assert.Equal(rb.T(), 1, len(grbs.Data))
-
+			rb.sequentialTestRBAC(tt.role, tt.member, newUser)
 			subSession := rb.session.NewSession()
 			defer subSession.Cleanup()
-
-			createProjectAsAdmin, err := createProject(rb.client, rb.cluster.ID)
-			rb.adminProject = createProjectAsAdmin
-			require.NoError(rb.T(), err)
-
-			steveAdminClient, err := rb.client.Steve.ProxyDownstream(rb.cluster.ID)
-			require.NoError(rb.T(), err)
-			rb.steveAdminClient = steveAdminClient
-		})
-
-		log.Info("Validating standard users cannot list any clusters")
-		rb.Run("Test case Validate if users can list any downstream clusters before adding the cluster role "+tt.name, func() {
-			_, err := rb.standardUserClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
-			if tt.member == standardUser {
-				require.Error(rb.T(), err)
-				assert.Contains(rb.T(), "Resource type [provisioning.cattle.io.cluster] has no method GET", err.Error())
-			}
-		})
-
-		rb.Run("Adding user as "+tt.name+" to the downstream cluster.", func() {
-			log.Info("Adding created user to the downstream clusters with the specified roles")
-
-			if tt.member == standardUser {
-				if strings.Contains(tt.role, "project") {
-					err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role, nil)
-					require.NoError(rb.T(), err)
-				} else {
-					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role, nil)
-					require.NoError(rb.T(), err)
-				}
-			}
-
-			relogin, err := rb.standardUserClient.ReLogin()
-			require.NoError(rb.T(), err)
-			rb.standardUserClient = relogin
-
-			//Create a steve user client for a standard user to get the cluster details
-			steveStdUserclient, err := rb.standardUserClient.Steve.ProxyDownstream(rb.cluster.ID)
-			require.NoError(rb.T(), err)
-			rb.steveStdUserclient = steveStdUserclient
-		})
-
-		rb.T().Logf("Starting validations for %v", tt.role)
-
-		rb.Run("Validating the cluster count obtained as the role "+tt.name, func() {
-			rb.ValidateListCluster(tt.role)
-		})
-
-		rb.Run("Validating if members with role "+tt.name+" are able to list all projects", func() {
-			rb.ValidateListProjects(tt.role)
-		})
-
-		rb.Run("Validating if members with role "+tt.name+" is able to create a project in the cluster", func() {
-			rb.ValidateCreateProjects(tt.role)
-
-		})
-
-		rb.Run("Validate namespaces checks for members with role "+tt.name, func() {
-			rb.ValidateNS(tt.role)
-		})
-
-		if !strings.Contains(tt.role, "cluster") {
-			rb.Run("Validating if member with role "+tt.name+" can add members to the cluster", func() {
-				//Set up additional user client to be added to the project
-				additionalUser, err := users.CreateUserWithRole(rb.client, users.UserConfig(), standardUser)
-				require.NoError(rb.T(), err)
-				rb.additionalUser = additionalUser
-				rb.additionalUserClient, err = rb.client.AsUser(rb.additionalUser)
-				require.NoError(rb.T(), err)
-				rb.ValidateAddClusterRoles(tt.role)
-			})
-
-			rb.Run("Validating if member with role "+tt.name+" can add members to the project", func() {
-				rb.ValidateAddProjectRoles(tt.role)
-			})
-		}
-
-		rb.Run("Validating if member with role "+tt.name+" can delete a project they are not owner of ", func() {
-			rb.ValidateDeleteProject(tt.role)
-		})
-
-		rb.Run("Validating if member with role "+tt.name+" is removed from the cluster and returns nil clusters", func() {
-			if tt.member == standardUser {
-				if strings.Contains(tt.role, "project") {
-					rb.ValidateRemoveProjectRoles()
-				} else {
-					rb.ValidateRemoveClusterRoles()
-				}
-			}
 		})
 
 	}
+}
+
+func (rb *RBTestSuite) TestRBACDynamicInput() {
+	roles := map[string]string{
+		"cluster-owner":    roleOwner,
+		"cluster-member":   roleMember,
+		"project-owner":    roleProjectOwner,
+		"project-member":   roleProjectMember,
+		"restricted-admin": restrictedAdmin,
+	}
+	var member string
+	userConfig := new(rbac.Config)
+	config.LoadConfig(rbac.ConfigurationFileKey, userConfig)
+	username := userConfig.Username
+	userByName, err := users.GetUserIDByName(rb.client, username)
+	require.NoError(rb.T(), err)
+	user, err := rb.client.Management.User.ByID(userByName)
+	require.NoError(rb.T(), err)
+
+	user.Password = userConfig.Password
+
+	role := userConfig.Role
+	val, ok := roles[role]
+	if !ok {
+		rb.FailNow("Incorrect usage of roles. Please go through the readme for correct role configurations")
+	}
+	role = val
+
+	if role == restrictedAdmin {
+		member = restrictedAdmin
+	} else {
+		member = standardUser
+	}
+	rb.sequentialTestRBAC(role, member, user)
+
 }
 
 func TestRBACTestSuite(t *testing.T) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/892
 
## Problem
RBAC test suite needs modification so it is more easily readable and avoid confusions.
 
## Solution
In this PR, we are making rbac tests run with two different input
1. Standard input: We only provide rancher server and cluster details, the tests will run for all the roles namely:
     - cluster owner
     - cluster member
     - project owner
     - project member
     - restricted admin

2. User provided input: If users want to make use of an already created user, they would need to provide a single role and the tests are run only for the role provided.
## Testing
Jenkins run

