### PR TITLE
Global roles v2 feature tests

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -41,13 +41,15 @@ const (
 	controlPlaneRole = "control-plane-role"
 	workerRole       = "worker-role"
 
-	externalCloudProviderString = "cloud-provider=external"
-	kubeletArgKey               = "kubelet-arg"
-	kubeletAPIServerArgKey      = "kubeapi-server-arg"
-	kubeControllerManagerArgKey = "kube-controller-manager-arg"
-	cloudProviderAnnotationName = "cloud-provider-name"
-	disableCloudController      = "disable-cloud-controller"
-	protectKernelDefaults       = "protect-kernel-defaults"
+	externalCloudProviderString  = "cloud-provider=external"
+	kubeletArgKey                = "kubelet-arg"
+	kubeletAPIServerArgKey       = "kubeapi-server-arg"
+	kubeControllerManagerArgKey  = "kube-controller-manager-arg"
+	cloudProviderAnnotationName  = "cloud-provider-name"
+	disableCloudController       = "disable-cloud-controller"
+	protectKernelDefaults        = "protect-kernel-defaults"
+	localcluster                 = "fleet-local/local"
+	ErrMsgListDownstreamClusters = "Couldn't list downstream clusters"
 )
 
 // GetV1ProvisioningClusterByName is a helper function that returns the cluster ID by name
@@ -1264,4 +1266,19 @@ func WaitForActiveRKE1Cluster(client *rancher.Client, clusterID string) error {
 		return err
 	}
 	return nil
+}
+
+// ListDownstreamClusters is a helper function to get the name of the downstream clusters
+func ListDownstreamClusters(client *rancher.Client) (clusterNames []string, err error) {
+	clusterList, err := client.Steve.SteveType(ProvisioningSteveResourceType).ListAll(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, ErrMsgListDownstreamClusters)
+	}
+	for i, c := range clusterList.Data {
+		isLocalCluster := c.ID == localcluster
+		if !isLocalCluster {
+			clusterNames = append(clusterNames, clusterList.Data[i].Name)
+		}
+	}
+	return
 }

--- a/tests/framework/extensions/defaults/defaults.go
+++ b/tests/framework/extensions/defaults/defaults.go
@@ -3,9 +3,12 @@ package defaults
 import "time"
 
 var (
-	WatchTimeoutSeconds  = int64(60 * 30) // 30 minutes.
-	FiveMinuteTimeout    = 5 * time.Minute
-	TenMinuteTimeout     = 10 * time.Minute
-	FifteenMinuteTimeout = 15 * time.Minute
-	ThirtyMinuteTimeout  = 30 * time.Minute
+	WatchTimeoutSeconds           = int64(60 * 30) // 30 minutes.
+	FiveHundredMillisecondTimeout = 500 * time.Millisecond
+	TenSecondTimeout              = 10 * time.Second
+	OneMinuteTimeout              = 1 * time.Minute
+	FiveMinuteTimeout             = 5 * time.Minute
+	TenMinuteTimeout              = 10 * time.Minute
+	FifteenMinuteTimeout          = 15 * time.Minute
+	ThirtyMinuteTimeout           = 30 * time.Minute
 )

--- a/tests/framework/extensions/kubeapi/rbac/create.go
+++ b/tests/framework/extensions/kubeapi/rbac/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/rancher/rancher/pkg/api/scheme"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -67,4 +68,48 @@ func CreateRoleBinding(client *rancher.Client, clusterName, roleBindingName, nam
 	}
 
 	return newRoleBinding, nil
+}
+
+// CreateGlobalRole is a helper function that uses the dynamic client to create a global role in the local cluster.
+func CreateGlobalRole(client *rancher.Client, globalRole *v3.GlobalRole) (*v3.GlobalRole, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	globalRoleResource := dynamicClient.Resource(GlobalRoleGroupVersionResource)
+	unstructuredResp, err := globalRoleResource.Create(context.TODO(), unstructured.MustToUnstructured(globalRole), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newGlobalRole := &v3.GlobalRole{}
+	err = scheme.Scheme.Convert(unstructuredResp, newGlobalRole, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newGlobalRole, nil
+}
+
+// CreateGlobalRoleBinding is a helper function that uses the dynamic client to create a global role binding for a specific user.
+func CreateGlobalRoleBinding(client *rancher.Client, globalRoleBinding *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	globalRoleBindingResource := dynamicClient.Resource(GlobalRoleBindingGroupVersionResource)
+	unstructuredResp, err := globalRoleBindingResource.Create(context.TODO(), unstructured.MustToUnstructured(globalRoleBinding), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newGlobalRoleBinding := &v3.GlobalRoleBinding{}
+	err = scheme.Scheme.Convert(unstructuredResp, newGlobalRoleBinding, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newGlobalRoleBinding, nil
 }

--- a/tests/framework/extensions/kubeapi/rbac/delete.go
+++ b/tests/framework/extensions/kubeapi/rbac/delete.go
@@ -1,0 +1,40 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DeleteGlobalRoleBinding is a helper function that uses the dynamic client to delete a Global Role Binding by name
+func DeleteGlobalRoleBinding(client *rancher.Client, globalRoleBindingName string) error {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return err
+	}
+
+	globalRoleBindingResource := dynamicClient.Resource(GlobalRoleBindingGroupVersionResource)
+
+	err = globalRoleBindingResource.Delete(context.TODO(), globalRoleBindingName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteGlobalRole is a helper function that uses the dynamic client to delete a Global Role by name
+func DeleteGlobalRole(client *rancher.Client, globalRoleName string) error {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return err
+	}
+
+	globalRoleResource := dynamicClient.Resource(GlobalRoleGroupVersionResource)
+
+	err = globalRoleResource.Delete(context.TODO(), globalRoleName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tests/framework/extensions/kubeapi/rbac/list.go
+++ b/tests/framework/extensions/kubeapi/rbac/list.go
@@ -4,13 +4,13 @@ import (
 	"context"
 
 	"github.com/rancher/rancher/pkg/api/scheme"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ListRoleBindings is a helper function that uses the dynamic client to list rolebindings on a namespace for a specific cluster.
-// ListRoleBindings accepts ListOptions for specifying desired parameters for listed objects.
 func ListRoleBindings(client *rancher.Client, clusterName, namespace string, listOpt metav1.ListOptions) (*rbacv1.RoleBindingList, error) {
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
 	if err != nil {
@@ -37,7 +37,6 @@ func ListRoleBindings(client *rancher.Client, clusterName, namespace string, lis
 }
 
 // ListClusterRoleBindings is a helper function that uses the dynamic client to list clusterrolebindings for a specific cluster.
-// ListClusterRoleBindings accepts ListOptions for specifying desired parameters for listed objects.
 func ListClusterRoleBindings(client *rancher.Client, clusterName string, listOpt metav1.ListOptions) (*rbacv1.ClusterRoleBindingList, error) {
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
 	if err != nil {
@@ -61,4 +60,108 @@ func ListClusterRoleBindings(client *rancher.Client, clusterName string, listOpt
 	}
 
 	return crbList, nil
+}
+
+// ListGlobalRoleBindings is a helper function that uses the dynamic client to list globalrolebindings from local cluster.
+func ListGlobalRoleBindings(client *rancher.Client, listOpt metav1.ListOptions) (*v3.GlobalRoleBindingList, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredList, err := dynamicClient.Resource(GlobalRoleBindingGroupVersionResource).List(context.TODO(), listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	grbList := new(v3.GlobalRoleBindingList)
+	for _, unstructuredGRB := range unstructuredList.Items {
+		grb := &v3.GlobalRoleBinding{}
+		err := scheme.Scheme.Convert(&unstructuredGRB, grb, unstructuredGRB.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		grbList.Items = append(grbList.Items, *grb)
+	}
+
+	return grbList, nil
+}
+
+// ListClusterRoleTemplateBindings is a helper function that uses the dynamic client to list clusterroletemplatebindings from local cluster.
+func ListClusterRoleTemplateBindings(client *rancher.Client, listOpt metav1.ListOptions) (*v3.ClusterRoleTemplateBindingList, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredList, err := dynamicClient.Resource(ClusterRoleTemplateBindingGroupVersionResource).Namespace("").List(context.TODO(), listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	crtbList := new(v3.ClusterRoleTemplateBindingList)
+	for _, unstructuredCRTB := range unstructuredList.Items {
+		crtb := &v3.ClusterRoleTemplateBinding{}
+		err := scheme.Scheme.Convert(&unstructuredCRTB, crtb, unstructuredCRTB.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		crtbList.Items = append(crtbList.Items, *crtb)
+	}
+
+	return crtbList, nil
+}
+
+// ListGlobalRoles is a helper function that uses the dynamic client to list globalroles from local cluster.
+func ListGlobalRoles(client *rancher.Client, listOpt metav1.ListOptions) (*v3.GlobalRoleList, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredList, err := dynamicClient.Resource(GlobalRoleGroupVersionResource).List(context.TODO(), listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	grList := new(v3.GlobalRoleList)
+	for _, unstructuredGR := range unstructuredList.Items {
+		gr := &v3.GlobalRole{}
+		err := scheme.Scheme.Convert(&unstructuredGR, gr, unstructuredGR.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		grList.Items = append(grList.Items, *gr)
+	}
+
+	return grList, nil
+}
+
+// ListRoleTemplates is a helper function that uses the dynamic client to list role templates from local cluster.
+func ListRoleTemplates(client *rancher.Client, listOpt metav1.ListOptions) (*v3.RoleTemplateList, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredList, err := dynamicClient.Resource(RoleTemplateGroupVersionResource).List(context.TODO(), listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	rtList := new(v3.RoleTemplateList)
+	for _, unstructuredRT := range unstructuredList.Items {
+		rt := &v3.RoleTemplate{}
+		err := scheme.Scheme.Convert(&unstructuredRT, rt, unstructuredRT.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		rtList.Items = append(rtList.Items, *rt)
+	}
+
+	return rtList, nil
 }

--- a/tests/framework/extensions/kubeapi/rbac/rbac.go
+++ b/tests/framework/extensions/kubeapi/rbac/rbac.go
@@ -5,34 +5,64 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// RoleGroupVersionResource is the required Group Version Resource for accessing roles in a cluster,
-// using the dynamic client.
+const (
+	GroupName    = "management.cattle.io"
+	Version      = "v3"
+	localcluster = "local"
+)
+
+// RoleGroupVersionResource is the required Group Version Resource for accessing roles in a cluster, using the dynamic client.
 var RoleGroupVersionResource = schema.GroupVersionResource{
 	Group:    rbacv1.SchemeGroupVersion.Group,
 	Version:  rbacv1.SchemeGroupVersion.Version,
 	Resource: "roles",
 }
 
-// ClusterRoleGroupVersionResource is the required Group Version Resource for accessing clusterroles in a cluster,
-// using the dynamic client.
+// ClusterRoleGroupVersionResource is the required Group Version Resource for accessing clusterroles in a cluster, using the dynamic client.
 var ClusterRoleGroupVersionResource = schema.GroupVersionResource{
 	Group:    rbacv1.SchemeGroupVersion.Group,
 	Version:  rbacv1.SchemeGroupVersion.Version,
 	Resource: "clusterroles",
 }
 
-// RoleBindingGroupVersionResource is the required Group Version Resource for accessing rolebindings in a cluster,
-// using the dynamic client.
+// RoleBindingGroupVersionResource is the required Group Version Resource for accessing rolebindings in a cluster, using the dynamic client.
 var RoleBindingGroupVersionResource = schema.GroupVersionResource{
 	Group:    rbacv1.SchemeGroupVersion.Group,
 	Version:  rbacv1.SchemeGroupVersion.Version,
 	Resource: "rolebindings",
 }
 
-// ClusterRoleBindingGroupVersionResource is the required Group Version Resource for accessing clusterrolebindings in a cluster,
-// using the dynamic client.
+// ClusterRoleBindingGroupVersionResource is the required Group Version Resource for accessing clusterrolebindings in a cluster, using the dynamic client.
 var ClusterRoleBindingGroupVersionResource = schema.GroupVersionResource{
 	Group:    rbacv1.SchemeGroupVersion.Group,
 	Version:  rbacv1.SchemeGroupVersion.Version,
 	Resource: "clusterrolebindings",
+}
+
+// GlobalRoleGroupVersionResource is the required Group Version Resource for accessing global roles in a rancher server, using the dynamic client.
+var GlobalRoleGroupVersionResource = schema.GroupVersionResource{
+	Group:    GroupName,
+	Version:  Version,
+	Resource: "globalroles",
+}
+
+// GlobalRoleBindingGroupVersionResource is the required Group Version Resource for accessing clusterrolebindings in a cluster, using the dynamic client.
+var GlobalRoleBindingGroupVersionResource = schema.GroupVersionResource{
+	Group:    GroupName,
+	Version:  Version,
+	Resource: "globalrolebindings",
+}
+
+// ClusterRoleTemplateBindingGroupVersionResource is the required Group Version Resource for accessing clusterrolebindings in a cluster, using the dynamic client.
+var ClusterRoleTemplateBindingGroupVersionResource = schema.GroupVersionResource{
+	Group:    GroupName,
+	Version:  Version,
+	Resource: "clusterroletemplatebindings",
+}
+
+// RoleTemplateGroupVersionResource is the required Group Version Resource for accessing roletemplates in a cluster, using the dynamic client.
+var RoleTemplateGroupVersionResource = schema.GroupVersionResource{
+	Group:    GroupName,
+	Version:  Version,
+	Resource: "roletemplates",
 }

--- a/tests/framework/extensions/kubeapi/rbac/update.go
+++ b/tests/framework/extensions/kubeapi/rbac/update.go
@@ -1,0 +1,44 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// UpdateGlobalRole is a helper function that uses the dynamic client to update a Global Role
+func UpdateGlobalRole(client *rancher.Client, updatedGlobalRole *v3.GlobalRole) (*v3.GlobalRole, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(localcluster)
+	if err != nil {
+		return nil, err
+	}
+	globalRoleResource := dynamicClient.Resource(GlobalRoleGroupVersionResource)
+	globalRolesUnstructured, err := globalRoleResource.Get(context.TODO(), updatedGlobalRole.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	currentGlobalRole := &v3.GlobalRole{}
+	err = scheme.Scheme.Convert(globalRolesUnstructured, currentGlobalRole, globalRolesUnstructured.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	updatedGlobalRole.ObjectMeta.ResourceVersion = currentGlobalRole.ObjectMeta.ResourceVersion
+
+	unstructuredResp, err := globalRoleResource.Update(context.TODO(), unstructured.MustToUnstructured(updatedGlobalRole), metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newGlobalRole := &v3.GlobalRole{}
+	err = scheme.Scheme.Convert(unstructuredResp, newGlobalRole, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newGlobalRole, nil
+}

--- a/tests/v2/validation/rbac/globalrolesv2/README.md
+++ b/tests/v2/validation/rbac/globalrolesv2/README.md
@@ -1,0 +1,90 @@
+# Global Roles v2
+Global Roles v2 introduces enhanced capabilities, allowing users to define permissions across all downstream clusters. This update aims to address the limitations of predefined roles, particularly challenges associated with the Restricted Admin role. 
+
+## Pre-requisites
+- Ensure you have an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, create one first before running this test.
+- Some tests require creating additional downstream cluster. Providing the provisioningInput parameter with appropriate values is mandatory unless you are skipping those tests.
+
+## Test Setup
+Your GO suite should be set to `-run ^TestGlobalRolesV2TestSuite$`. You can find specific tests by checking the test file you plan to run.
+
+In your config file, set the following:
+```
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  userToken: "rancher_user_token"
+  insecure: True
+  cleanup: True
+  clusterName: "downstream_cluster_name"
+provisioningInput:
+  nodePools:
+  - nodeRoles:
+      etcd: true
+      quantity: 1
+  - nodeRoles:
+      controlplane: true
+      quantity: 1
+  - nodeRoles:
+      worker: true
+      quantity: 1
+  machinePools:
+  - nodeRoles:
+      etcd: true
+      quantity: 1
+  - nodeRoles:
+      controlplane: true
+      quantity: 1
+  - nodeRoles:
+      worker: true
+      quantity: 1
+  rke1KubernetesVersion:
+    - "v1.27.6-rancher1-1"
+  rke2KubernetesVersion:
+    - "v1.27.6+rke2r1"
+  k3sKubernetesVersion:
+    - "v1.27.6+k3s1"
+  cni:
+    - "canal"
+  providers: 
+    - "aws"
+  nodeProviders: 
+    - "ec2"
+  hardened: false
+
+awsCredentials:
+  secretKey: "aws_secret_key"
+  accessKey: "aws_access_key"
+  defaultRegion: "us-east-2"
+
+awsMachineConfig: 
+  region: "us-east-2"
+  instanceType: "t3a.xlarge"
+  sshUser: "ubuntu"
+  vpcId: ""
+  volumeType: "gp2"
+  zone: "a"
+  retries: 5
+  rootSize: 50
+  securityGroup: 
+    - "rancher-nodes"
+
+awsEC2Configs:
+  region: "us-east-2"
+  awsSecretAccessKey: "aws_secret_ke"
+  awsAccessKeyID: "aws_access_key"
+  awsEC2Config:
+    - instanceType: "t3a.xlarge"
+      awsRegionAZ: ""
+      awsAMI: "ami-053835e36b16f97d0"
+      awsSecurityGroups: ["sg-0e753fd5550206e55"]
+      awsSSHKeyName: "jenkins-elliptic-validation.pem"
+      awsCICDInstanceTag: "rancher-validation"
+      awsIAMProfile: "EngineeringUsersUS"
+      awsUser: "ec2-user"
+      volumeSize: 50
+      roles: ["etcd", "controlplane", "worker"]
+      isWindows: false
+sshPath: 
+  sshPath: "ssh_path"
+```

--- a/tests/v2/validation/rbac/globalrolesv2/globalroles_v2.go
+++ b/tests/v2/validation/rbac/globalrolesv2/globalroles_v2.go
@@ -1,0 +1,211 @@
+package globalrolesv2
+
+import (
+	"fmt"
+	"strings"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeapi/rbac"
+	"github.com/rancher/rancher/tests/framework/extensions/provisioning"
+	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	roleOwner          = "cluster-owner"
+	roleMember         = "cluster-member"
+	roleCrtbView       = "clusterroletemplatebindings-view"
+	roleProjectsCreate = "projects-create"
+	roleProjectsView   = "projects-view"
+	standardUser       = "user"
+	localcluster       = "local"
+	crtbOwnerLabel     = "authz.management.cattle.io/grb-owner"
+	namespace          = "fleet-default"
+	bindingLabel       = "membership-binding-owner"
+)
+
+var globalRole = v3.GlobalRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "",
+	},
+	InheritedClusterRoles: []string{},
+}
+
+var globalRoleBinding = &v3.GlobalRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "",
+	},
+	GlobalRoleName: "",
+	UserName:       "",
+}
+
+func createGlobalRoleWithInheritedClusterRoles(client *rancher.Client, inheritedRoles []string) (*v3.GlobalRole, error) {
+	globalRole.Name = namegen.AppendRandomString("testgr")
+	globalRole.InheritedClusterRoles = inheritedRoles
+	createdGlobalRole, err := rbac.CreateGlobalRole(client, &globalRole)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdGlobalRole, nil
+}
+
+func getGlobalRoleBindingForUser(client *rancher.Client, userID string) (string, error) {
+	grblist, err := rbac.ListGlobalRoleBindings(client, metav1.ListOptions{})
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, grbs := range grblist.Items {
+		if grbs.GlobalRoleName == globalRole.Name && grbs.UserName == userID {
+			return grbs.Name, nil
+		}
+	}
+
+	return "", nil
+}
+
+func listClusterRoleTemplateBindingsForInheritedClusterRoles(client *rancher.Client, grbOwner string, expectedCount int) (*v3.ClusterRoleTemplateBindingList, error) {
+	req, err := labels.NewRequirement(crtbOwnerLabel, selection.In, []string{grbOwner})
+
+	if err != nil {
+		return nil, err
+	}
+
+	selector := labels.NewSelector().Add(*req)
+
+	var crtbs *v3.ClusterRoleTemplateBindingList
+
+	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.OneMinuteTimeout, func() (done bool, pollErr error) {
+		crtbs, pollErr = rbac.ListClusterRoleTemplateBindings(client, metav1.ListOptions{
+			LabelSelector: selector.String(),
+		})
+		if pollErr != nil {
+			return false, pollErr
+		}
+		if len(crtbs.Items) == expectedCount {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return crtbs, nil
+}
+
+func getCRBsForCRTBs(client *rancher.Client, crtbs *v3.ClusterRoleTemplateBindingList) (*rbacv1.ClusterRoleBindingList, error) {
+	var downstreamCRBs rbacv1.ClusterRoleBindingList
+
+	for _, crtb := range crtbs.Items {
+		labelKey := fmt.Sprintf("%s_%s", crtb.ClusterName, crtb.Name)
+		req, err := labels.NewRequirement(labelKey, selection.In, []string{bindingLabel})
+
+		if err != nil {
+			return nil, err
+		}
+
+		selector := labels.NewSelector().Add(*req)
+		downstreamCRBsForCRTB, err := rbac.ListClusterRoleBindings(client, localcluster, metav1.ListOptions{
+			LabelSelector: selector.String(),
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		downstreamCRBs.Items = append(downstreamCRBs.Items, downstreamCRBsForCRTB.Items...)
+	}
+
+	return &downstreamCRBs, nil
+}
+
+func getRBsForCRTBs(client *rancher.Client, crtbs *v3.ClusterRoleTemplateBindingList) (*rbacv1.RoleBindingList, error) {
+	var downstreamRBs rbacv1.RoleBindingList
+
+	for _, crtb := range crtbs.Items {
+		roleTemplateName := crtb.RoleTemplateName
+
+		if strings.Contains(roleTemplateName, "rt") {
+			listOpt := metav1.ListOptions{
+				FieldSelector: "metadata.name=" + roleTemplateName,
+			}
+			roleTemplateList, err := rbac.ListRoleTemplates(client, listOpt)
+			if err != nil {
+				return nil, err
+			}
+			roleTemplateName = roleTemplateList.Items[0].RoleTemplateNames[0]
+		}
+
+		nameSelector := fmt.Sprintf("metadata.name=%s-%s", crtb.Name, roleTemplateName)
+		namespaceSelector := fmt.Sprintf("metadata.namespace=%s", crtb.ClusterName)
+		combinedSelector := fmt.Sprintf("%s,%s", nameSelector, namespaceSelector)
+		downstreamRBsForCRTB, err := rbac.ListRoleBindings(client, localcluster, "", metav1.ListOptions{
+			FieldSelector: combinedSelector,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		downstreamRBs.Items = append(downstreamRBs.Items, downstreamRBsForCRTB.Items...)
+	}
+
+	return &downstreamRBs, nil
+}
+
+func createDownstreamCluster(client *rancher.Client, clusterType string) (*management.Cluster, *v1.SteveAPIObject, *clusters.ClusterConfig, error) {
+	provisioningConfig := new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, provisioningConfig)
+	nodeProviders := provisioningConfig.NodeProviders[0]
+	externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviders)
+	testClusterConfig := clusters.ConvertConfigToClusterConfig(provisioningConfig)
+	testClusterConfig.CNI = provisioningConfig.CNIs[0]
+
+	var clusterObject *management.Cluster
+	var steveObject *v1.SteveAPIObject
+	var err error
+
+	switch clusterType {
+	case "RKE1":
+		nodeAndRoles := []provisioninginput.NodePools{
+			provisioninginput.AllRolesNodePool,
+		}
+		testClusterConfig.NodePools = nodeAndRoles
+		testClusterConfig.KubernetesVersion = provisioningConfig.RKE1KubernetesVersions[0]
+		clusterObject, _, err = provisioning.CreateProvisioningRKE1CustomCluster(client, &externalNodeProvider, testClusterConfig)
+	case "RKE2":
+		nodeAndRoles := []provisioninginput.MachinePools{
+			provisioninginput.AllRolesMachinePool,
+		}
+		testClusterConfig.MachinePools = nodeAndRoles
+		testClusterConfig.KubernetesVersion = provisioningConfig.RKE2KubernetesVersions[0]
+		steveObject, err = provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, testClusterConfig)
+	default:
+		return nil, nil, nil, fmt.Errorf("unsupported cluster type: %s", clusterType)
+	}
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return clusterObject, steveObject, testClusterConfig, nil
+}

--- a/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -1,0 +1,483 @@
+//go:build (validation || infra.any || cluster.any || stress) && !sanity && !extended
+
+package globalrolesv2
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeapi/rbac"
+	"github.com/rancher/rancher/tests/framework/extensions/provisioning"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+type GlobalRolesV2TestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (gr *GlobalRolesV2TestSuite) TearDownSuite() {
+	gr.session.Cleanup()
+}
+
+func (gr *GlobalRolesV2TestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	gr.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(gr.T(), err)
+
+	gr.client = client
+}
+
+func (gr *GlobalRolesV2TestSuite) validateRBACResources(createdUser *management.User, inheritedRoles []string) (string, int) {
+	log.Info("Verify that the global role binding is created for the user.")
+	grbOwner, err := getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+	require.NoError(gr.T(), err)
+	require.NotEmpty(gr.T(), grbOwner, "Global Role Binding not found for the user")
+	grbName := grbOwner
+
+	log.Info("Verify that the cluster role template bindings are created for the downstream clusters.")
+	clusterNames, err := clusters.ListDownstreamClusters(gr.client)
+	require.NoError(gr.T(), err)
+	clusterCount := len(clusterNames)
+	expectedCrtbCount := clusterCount * len(inheritedRoles)
+	crtbs, err := listClusterRoleTemplateBindingsForInheritedClusterRoles(gr.client, grbOwner, expectedCrtbCount)
+	require.NoError(gr.T(), err)
+	actualCrtbCount := len(crtbs.Items)
+	require.Equal(gr.T(), expectedCrtbCount, actualCrtbCount, "Unexpected number of ClusterRoleTemplateBindings: Expected %d, Actual %d", expectedCrtbCount, actualCrtbCount)
+
+	log.Info("Verify that the cluster role bindings are created for the downstream cluster.")
+	expectedCrbCount := expectedCrtbCount
+	crbs, err := getCRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualCrbCount := len(crbs.Items)
+	require.Equal(gr.T(), expectedCrbCount, actualCrbCount, "Unexpected number of ClusterRoleBindings: Expected %d, Actual %d", expectedCrbCount, actualCrbCount)
+
+	log.Info("Verify that the role bindings are created for the downstream cluster.")
+	expectedRbCount := expectedCrtbCount
+	rbs, err := getRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualRbCount := len(rbs.Items)
+	require.Equal(gr.T(), expectedRbCount, actualRbCount, "Unexpected number of RoleBindings: Expected %d, Actual %d", expectedRbCount, actualRbCount)
+	return grbName, clusterCount
+}
+
+func (gr *GlobalRolesV2TestSuite) TestCreateUserWithInheritedClusterRoles() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleOwner}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	gr.validateRBACResources(createdUser, inheritedClusterRoles)
+}
+
+func (gr *GlobalRolesV2TestSuite) TestCreateUserWithMultipleInheritedClusterRoles() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleCrtbView, roleProjectsCreate, roleProjectsView}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	gr.validateRBACResources(createdUser, inheritedClusterRoles)
+}
+
+func (gr *GlobalRolesV2TestSuite) TestCreateUserWithInheritedCustomClusterRole() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a custom role that inherits rules from the cluster-owner.")
+	inheritedRoleTemplateName := namegen.AppendRandomString("crole")
+	inheritedRoleTemplate, err := gr.client.Management.RoleTemplate.Create(&management.RoleTemplate{
+		Context:         "cluster",
+		Name:            inheritedRoleTemplateName,
+		RoleTemplateIDs: []string{roleOwner},
+	})
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{inheritedRoleTemplate.ID}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	_, expectedClusterCount := gr.validateRBACResources(createdUser, inheritedClusterRoles)
+
+	log.Info("Verify that the user can list all the downstream clusters.")
+	userClient, err := gr.client.AsUser(createdUser)
+	require.NoError(gr.T(), err)
+	clusterNames, err := clusters.ListDownstreamClusters(userClient)
+	require.NoError(gr.T(), err)
+	actualClusterCount := len(clusterNames)
+	require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", expectedClusterCount, actualClusterCount)
+}
+
+func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithInheritedClusterRoles() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleMember}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	_, expectedClusterCount := gr.validateRBACResources(createdUser, inheritedClusterRoles)
+
+	log.Info("Verify that the user can list all the downstream clusters.")
+	userClient, err := gr.client.AsUser(createdUser)
+	require.NoError(gr.T(), err)
+	clusterNames, err := clusters.ListDownstreamClusters(userClient)
+	require.NoError(gr.T(), err)
+	actualClusterCount := len(clusterNames)
+	require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", expectedClusterCount, actualClusterCount)
+
+	log.Info("As the new user, create new downstream clusters.")
+	clusterObject, _, testClusterConfig, err := createDownstreamCluster(userClient, "RKE1")
+	require.NoError(gr.T(), err)
+	provisioning.VerifyRKE1Cluster(gr.T(), userClient, testClusterConfig, clusterObject)
+	_, steveObject, testClusterConfig, err := createDownstreamCluster(userClient, "RKE2")
+	require.NoError(gr.T(), err)
+	provisioning.VerifyCluster(gr.T(), userClient, testClusterConfig, steveObject)
+
+	gr.validateRBACResources(createdUser, inheritedClusterRoles)
+}
+
+func (gr *GlobalRolesV2TestSuite) TestUpdateExistingUserWithCustomGlobalRoleInheritingClusterRoles() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleOwner}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser)
+	require.NoError(gr.T(), err)
+
+	log.Info("Add the new global role with inheritedClusterRoles to the user.")
+	globalRoleBinding.Name = namegen.AppendRandomString("testgrb")
+	globalRoleBinding.UserName = createdUser.ID
+	globalRoleBinding.GlobalRoleName = createdGlobalRole.Name
+	_, err = rbac.CreateGlobalRoleBinding(gr.client, globalRoleBinding)
+	require.NoError(gr.T(), err)
+
+	_, expectedClusterCount := gr.validateRBACResources(createdUser, inheritedClusterRoles)
+
+	log.Info("Verify that the user can list all the downstream clusters.")
+	userClient, err := gr.client.AsUser(createdUser)
+	require.NoError(gr.T(), err)
+	clusterNames, err := clusters.ListDownstreamClusters(userClient)
+	require.NoError(gr.T(), err)
+	actualClusterCount := len(clusterNames)
+	require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", expectedClusterCount, actualClusterCount)
+}
+
+func (gr *GlobalRolesV2TestSuite) TestUserDeletionAndResourceCleanupWithInheritedClusterRoles() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleOwner}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	grbName, _ := gr.validateRBACResources(createdUser, inheritedClusterRoles)
+
+	log.Infof("Delete the user: %s.", createdUser.Username)
+	err = gr.client.Management.User.Delete(createdUser)
+	require.NoError(gr.T(), err)
+
+	log.Infof("Verify that the global role %s is not deleted.", createdGlobalRole.Name)
+	listOpt := metav1.ListOptions{
+		FieldSelector: "metadata.name=" + createdGlobalRole.Name,
+	}
+	grList, err := rbac.ListGlobalRoles(gr.client, listOpt)
+	require.NoError(gr.T(), err)
+	require.NotEmpty(gr.T(), grList, "Global Role does not exist.")
+
+	log.Infof("Verify that the global role binding %s is deleted for the user.", grbName)
+	var grbOwner string
+	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.TenSecondTimeout, func() (done bool, pollErr error) {
+		grbOwner, pollErr = getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+		if pollErr != nil {
+			return false, pollErr
+		}
+		if grbOwner == "" {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(gr.T(), err)
+	require.Empty(gr.T(), grbOwner, "Global Role Binding exists for the user.")
+
+	log.Info("Verify that the cluster role template bindings are deleted for the downstream clusters.")
+	expectedCrtbCount := 0
+	crtbs, err := listClusterRoleTemplateBindingsForInheritedClusterRoles(gr.client, grbOwner, expectedCrtbCount)
+	require.NoError(gr.T(), err)
+	actualCrtbCount := len(crtbs.Items)
+	require.Equal(gr.T(), expectedCrtbCount, actualCrtbCount, "Unexpected number of ClusterRoleTemplateBindings: Expected %d, Actual %d", expectedCrtbCount, actualCrtbCount)
+
+	log.Info("Verify that the cluster role bindings are deleted for the downstream cluster.")
+	crbs, err := getCRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualCrbCount := len(crbs.Items)
+	require.Equal(gr.T(), 0, actualCrbCount, "Unexpected number of ClusterRoleBindings: Expected %d, Actual %d", 0, actualCrbCount)
+
+	log.Info("Verify that the role bindings are deleted for the downstream cluster.")
+	rbs, err := getRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualRbCount := len(rbs.Items)
+	require.Equal(gr.T(), 0, actualRbCount, "Unexpected number of RoleBindings: Expected %d, Actual %d", 0, actualRbCount)
+}
+
+func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromDeletingGlobalRoleBinding() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleOwner}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	grbName, expectedClusterCount := gr.validateRBACResources(createdUser, inheritedClusterRoles)
+
+	log.Info("Verify that the user can list all the downstream clusters.")
+	userClient, err := gr.client.AsUser(createdUser)
+	require.NoError(gr.T(), err)
+	clusterNames, err := clusters.ListDownstreamClusters(userClient)
+	require.NoError(gr.T(), err)
+	actualClusterCount := len(clusterNames)
+	require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", expectedClusterCount, actualClusterCount)
+
+	log.Info("Delete Global Role Binding.")
+	err = rbac.DeleteGlobalRoleBinding(gr.client, grbName)
+	require.NoError(gr.T(), err)
+
+	log.Info("Verify that the global role is not deleted.")
+	listOpt := metav1.ListOptions{
+		FieldSelector: "metadata.name=" + createdGlobalRole.Name,
+	}
+	grList, err := rbac.ListGlobalRoles(gr.client, listOpt)
+	require.NoError(gr.T(), err)
+	require.NotEmpty(gr.T(), grList, "Global Role does not exist.")
+
+	log.Info("Verify that the global role binding is deleted for the user.")
+	grbOwner, err := getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+	require.NoError(gr.T(), err)
+	require.Empty(gr.T(), grbOwner, "Global Role Binding exists for the user.")
+
+	log.Info("Verify that the cluster role template bindings are deleted for the downstream clusters.")
+	expectedCrtbCount := 0
+	crtbs, err := listClusterRoleTemplateBindingsForInheritedClusterRoles(gr.client, grbOwner, expectedCrtbCount)
+	require.NoError(gr.T(), err)
+	actualCrtbCount := len(crtbs.Items)
+	require.Equal(gr.T(), expectedCrtbCount, actualCrtbCount, "Unexpected number of ClusterRoleTemplateBindings: Expected %d, Actual %d", expectedCrtbCount, actualCrtbCount)
+
+	log.Info("Verify that the cluster role bindings are deleted for the downstream cluster.")
+	crbs, err := getCRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualCrbCount := len(crbs.Items)
+	require.Equal(gr.T(), 0, actualCrbCount, "Unexpected number of ClusterRoleBindings: Expected %d, Actual %d", 0, actualCrbCount)
+
+	log.Info("Verify that the role bindings are deleted for the downstream cluster.")
+	rbs, err := getRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualRbCount := len(rbs.Items)
+	require.Equal(gr.T(), 0, actualRbCount, "Unexpected number of RoleBindings: Expected %d, Actual %d", 0, actualRbCount)
+
+	log.Infof("Verify that user %s cannot list the downstream clusters.", createdUser.ID)
+	clusterNames, err = clusters.ListDownstreamClusters(userClient)
+	require.NoError(gr.T(), err)
+	actualClusterCount = len(clusterNames)
+	require.Equal(gr.T(), 0, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", 0, actualClusterCount)
+}
+
+func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromDeletingInheritedClusterRoles() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleMember}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	_, expectedClusterCount := gr.validateRBACResources(createdUser, inheritedClusterRoles)
+
+	log.Info("Create another user with global role standard user and the same global role as the first user.")
+	secondUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+	gr.validateRBACResources(secondUser, inheritedClusterRoles)
+	users := []*management.User{createdUser, secondUser}
+
+	for _, user := range users {
+		log.Infof("Verify that user %s can list all the downstream clusters.", user.ID)
+		userClient, err := gr.client.AsUser(user)
+		require.NoError(gr.T(), err)
+		clusterNames, err := clusters.ListDownstreamClusters(userClient)
+		require.NoError(gr.T(), err)
+		actualClusterCount := len(clusterNames)
+		require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters for user %s. Expected %d, Actual %d.", user.ID, expectedClusterCount, actualClusterCount)
+	}
+
+	log.Info("Remove InheritedClusterRoles from the global role.")
+	updateGlobalRole := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: createdGlobalRole.Name,
+		},
+		InheritedClusterRoles: []string{},
+	}
+	_, err = rbac.UpdateGlobalRole(gr.client, &updateGlobalRole)
+	require.NoError(gr.T(), err)
+
+	for _, user := range users {
+		log.Infof("Verify that the global role binding is not deleted for user %s.", user.ID)
+		grbOwner, err := getGlobalRoleBindingForUser(gr.client, user.ID)
+		require.NoError(gr.T(), err)
+		require.NotEmpty(gr.T(), grbOwner, "Global Role Binding does not exist for user %s", user.ID)
+
+		log.Infof("Verify that the cluster role template bindings are deleted for user %s.", user.ID)
+		crtbs, err := listClusterRoleTemplateBindingsForInheritedClusterRoles(gr.client, grbOwner, 0)
+		require.NoError(gr.T(), err)
+		actualCrtbCount := len(crtbs.Items)
+		require.Equal(gr.T(), 0, actualCrtbCount, "Unexpected number of ClusterRoleTemplateBindings for user %s: Expected %d, Actual %d", user.ID, 0, actualCrtbCount)
+
+		log.Infof("Verify that the cluster role bindings are deleted for the downstream cluster.")
+		crbs, err := getCRBsForCRTBs(gr.client, crtbs)
+		require.NoError(gr.T(), err)
+		actualCrbCount := len(crbs.Items)
+		require.Equal(gr.T(), 0, actualCrbCount, "Unexpected number of ClusterRoleBindings: Expected %d, Actual %d", 0, actualCrbCount)
+
+		log.Info("Verify that the role bindings are deleted for the downstream cluster.")
+		rbs, err := getRBsForCRTBs(gr.client, crtbs)
+		require.NoError(gr.T(), err)
+		actualRbCount := len(rbs.Items)
+		require.Equal(gr.T(), 0, actualRbCount, "Unexpected number of RoleBindings: Expected %d, Actual %d", 0, actualRbCount)
+
+		log.Infof("Verify that user %s cannot list the downstream clusters.", user.ID)
+		userClient, err := gr.client.AsUser(user)
+		require.NoError(gr.T(), err)
+		clusterNames, err := clusters.ListDownstreamClusters(userClient)
+		require.Error(gr.T(), err)
+		actualClusterCount := len(clusterNames)
+		require.Equal(gr.T(), 0, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", 0, actualClusterCount)
+	}
+}
+
+func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClusterDeletion() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a RKE2 downstream cluster.")
+	_, rke2SteveObject, testClusterConfig, err := createDownstreamCluster(gr.client, "RKE2")
+	require.NoError(gr.T(), err)
+	provisioning.VerifyCluster(gr.T(), gr.client, testClusterConfig, rke2SteveObject)
+
+	log.Info("Create a global role with inheritedClusterRoles.")
+	inheritedClusterRoles := []string{roleOwner}
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	require.NoError(gr.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(gr.client, users.UserConfig(), standardUser, createdGlobalRole.Name)
+	require.NoError(gr.T(), err)
+
+	_, expectedClusterCount := gr.validateRBACResources(createdUser, inheritedClusterRoles)
+
+	log.Info("Verify that the user can list all the downstream clusters.")
+	userClient, err := gr.client.AsUser(createdUser)
+	require.NoError(gr.T(), err)
+	clusterNames, err := clusters.ListDownstreamClusters(userClient)
+	require.NoError(gr.T(), err)
+	actualClusterCount := len(clusterNames)
+	require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", expectedClusterCount, actualClusterCount)
+
+	log.Info("Delete the RKE2 downstream cluster.")
+	clusters.DeleteK3SRKE2Cluster(userClient, rke2SteveObject.ID)
+
+	log.Info("Verify that the global role is not deleted.")
+	listOpt := metav1.ListOptions{
+		FieldSelector: "metadata.name=" + createdGlobalRole.Name,
+	}
+	grList, err := rbac.ListGlobalRoles(gr.client, listOpt)
+	require.NoError(gr.T(), err)
+	require.NotEmpty(gr.T(), grList, "Global Role does not exist.")
+
+	log.Info("Verify that the global role binding is not deleted for the user.")
+	grbOwner, err := getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+	require.NoError(gr.T(), err)
+	require.NotEmpty(gr.T(), grbOwner, "Global Role Binding does not exist for the user.")
+
+	log.Info("Verify that the cluster role template bindings are deleted for the downstream cluster.")
+	expectedCrtbCount := actualClusterCount - 1
+	crtbs, err := listClusterRoleTemplateBindingsForInheritedClusterRoles(gr.client, grbOwner, expectedCrtbCount)
+	require.NoError(gr.T(), err)
+	actualCrtbCount := len(crtbs.Items)
+	require.Equal(gr.T(), expectedCrtbCount, actualCrtbCount, "Unexpected number of ClusterRoleTemplateBindings: Expected %d, Actual %d", expectedCrtbCount, actualCrtbCount)
+
+	log.Info("Verify that the cluster role bindings are deleted for the downstream cluster.")
+	expectedCrbCount := expectedCrtbCount
+	crbs, err := getCRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualCrbCount := len(crbs.Items)
+	require.Equal(gr.T(), expectedCrbCount, actualCrbCount, "Unexpected number of ClusterRoleBindings: Expected %d, Actual %d", expectedCrbCount, actualCrbCount)
+
+	log.Info("Verify that the role bindings are deleted for the downstream cluster.")
+	expectedRbCount := expectedCrtbCount
+	rbs, err := getRBsForCRTBs(gr.client, crtbs)
+	require.NoError(gr.T(), err)
+	actualRbCount := len(rbs.Items)
+	require.Equal(gr.T(), expectedRbCount, actualRbCount, "Unexpected number of RoleBindings: Expected %d, Actual %d", expectedRbCount, actualRbCount)
+}
+
+func TestGlobalRolesV2TestSuite(t *testing.T) {
+	suite.Run(t, new(GlobalRolesV2TestSuite))
+}


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/qa-tasks/issues/930

## Problem: 
- Adding automated tests listed in the issue ^^ for **Global Roles v2** feature 
 
## Solution
- Added few helper functions to list, create, update, delete RBAC resources (global roles, global role binding, cluster role template binding etc) using kube api 
- Added the following automated tests - [rancher/qa-tasks#930](https://github.com/rancher/qa-tasks/issues/930)
  - Fresh install - Create custom roles and inherit the role[nested check]
  - Update the existing user and add the global role
  - Create a global role with multiple inheritedClusterRoles
  - Fresh Install Create downstream clusters after the global role is added to user should list the clusters for the user
  - Delete the inherited cluster role and verify all users should lose access and CRTBs should be deleted
  - Delete a downstream cluster and verify the bindings are deleted
  - Delete user and verify rbs and grbs are removed
  - Delete globalrolebinding and ensure the CRTBs are deleted for the user
- Added README
 
## Testing
- Jenkins Run