### PR TITLE
[2.8] Expand Kubernetes Upgrade Validation Tests for Local and Imported Clusters

### DIFF
--- a/tests/framework/clients/rancher/v1/client.go
+++ b/tests/framework/clients/rancher/v1/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/rancher/apiserver/pkg/types"
@@ -406,7 +407,15 @@ func (c *NamespacedSteveClient) ListAll(params url.Values) (*SteveCollection, er
 }
 
 func (c *NamespacedSteveClient) ByID(id string) (*SteveAPIObject, error) {
-	return c.SteveClient.ByID(id)
+	var namespacedID string
+
+	if strings.Contains(id, c.namespace) {
+		namespacedID = id
+	} else {
+		namespacedID = fmt.Sprintf(c.namespace + "/" + id)
+	}
+
+	return c.SteveClient.ByID(namespacedID)
 }
 
 func (c *NamespacedSteveClient) Delete(container *SteveAPIObject) error {

--- a/tests/framework/clients/rkecli/rkecli.go
+++ b/tests/framework/clients/rkecli/rkecli.go
@@ -1,0 +1,36 @@
+package rkecli
+
+import (
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+const rkeCmd = "rke"
+
+// Up uses RKE CLI up command.
+// Cluster file path arg points to the cluster.yml file, args appended to the command.
+func Up(clusterFilePath string, args ...string) error {
+	msg, err := exec.Command(rkeCmd, "--version").CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "rke isn't executable: [%v] ", msg)
+	}
+
+	up := "up"
+
+	// Default rke up command
+	commandArgs := []string{
+		up,
+		"--config",
+		clusterFilePath,
+	}
+
+	commandArgs = append(commandArgs, args...)
+
+	msg, err = exec.Command(rkeCmd, commandArgs...).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "rke up: [%v] ", string(msg))
+	}
+
+	return nil
+}

--- a/tests/framework/clients/rkecli/state.go
+++ b/tests/framework/clients/rkecli/state.go
@@ -1,0 +1,205 @@
+package rkecli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/configmaps"
+	"github.com/rancher/rancher/tests/framework/pkg/file"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/rancher/rke/cluster"
+	rketypes "github.com/rancher/rke/types"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const filePrefix = "cluster"
+const dirName = "rke-cattle-test-dir"
+
+// NewRKEConfigs creates a new dir.
+// In that dir, it generates state and cluster files from the state configmap.
+// Returns generated state and cluster files' paths.
+func NewRKEConfigs(client *rancher.Client) (stateFilePath, clusterFilePath string, err error) {
+	err = file.NewDir(dirName)
+	if err != nil {
+		return
+	}
+
+	state, err := GetFullState(client)
+	if err != nil {
+		return
+	}
+
+	clusterFilePath, err = NewClusterFile(state, dirName)
+	if err != nil {
+		return
+	}
+
+	stateFilePath, err = NewStateFile(state, dirName)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ReadClusterFromStateFile is a function that reads the RKE config from the given state file path.
+// Returns RKE config.
+func ReadClusterFromStateFile(stateFilePath string) (*v3.RancherKubernetesEngineConfig, error) {
+	byteState, err := os.ReadFile(stateFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	//get bytes state
+	state := make(map[string]interface{})
+	err = json.Unmarshal(byteState, &state)
+	if err != nil {
+		return nil, err
+	}
+
+	//reach rke config in the current state
+	byteRkeConfig := state["currentState"].(map[string]interface{})["rkeConfig"]
+	byteTest, err := json.Marshal(byteRkeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	//final unmarshal to get the struct
+	rkeConfig := new(v3.RancherKubernetesEngineConfig)
+	err = json.Unmarshal(byteTest, rkeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return rkeConfig, nil
+}
+
+// UpdateKubernetesVersion is a function that updates kubernetes version value in cluster.yml file.
+func UpdateKubernetesVersion(kubernetesVersion, clusterFilePath string) error {
+	byteRkeConfig, err := os.ReadFile(clusterFilePath)
+	if err != nil {
+		return err
+	}
+
+	rkeConfig := new(rketypes.RancherKubernetesEngineConfig)
+	err = yaml.Unmarshal(byteRkeConfig, rkeConfig)
+	if err != nil {
+		return err
+	}
+
+	rkeConfig.Version = kubernetesVersion
+
+	byteConfig, err := yaml.Marshal(rkeConfig)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(clusterFilePath, byteConfig, 0644)
+}
+
+// NewClusterFile is a function that generates new cluster.yml file from the full state.
+// Returns the generated file's path.
+func NewClusterFile(state *cluster.FullState, dirName string) (clusterFilePath string, err error) {
+	extension := "yml"
+	rkeConfigFileName := fmt.Sprintf("%v/%v.%v", dirName, filePrefix, extension)
+
+	rkeConfig := rketypes.RancherKubernetesEngineConfig{}
+	currentRkeConfig := state.CurrentState.RancherKubernetesEngineConfig.DeepCopy()
+
+	rkeConfig.Version = currentRkeConfig.Version
+	rkeConfig.Nodes = currentRkeConfig.Nodes
+
+	rkeConfig.SSHKeyPath = appendSSHPath(currentRkeConfig.SSHKeyPath)
+	for i := range rkeConfig.Nodes {
+		rkeConfig.Nodes[i].SSHKeyPath = appendSSHPath(rkeConfig.Nodes[i].SSHKeyPath)
+	}
+
+	marshaled, err := yaml.Marshal(rkeConfig)
+	if err != nil {
+		return
+	}
+
+	fileName := file.Name(rkeConfigFileName)
+
+	clusterFilePath, err = fileName.NewFile(marshaled)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// NewStateFile is a function that generates new cluster.rkestate file from the full state.
+// Returns the generated file's path.
+func NewStateFile(state *cluster.FullState, dirName string) (stateFilePath string, err error) {
+	extension := "rkestate"
+	rkeStateFileName := fmt.Sprintf("%v/%v.%v", dirName, filePrefix, extension)
+
+	marshaled, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+
+	stateFilePath, err = file.Name(rkeStateFileName).NewFile(marshaled)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetFullState is a function that gets RKE full state from "full-cluster-state" configmap.
+// And returns the cluster full state.
+func GetFullState(client *rancher.Client) (state *cluster.FullState, err error) {
+	namespacedConfigmapClient := client.Steve.SteveType(configmaps.ConfigMapSteveType).NamespacedSteveClient(cluster.SystemNamespace)
+	if err != nil {
+		return
+	}
+
+	configmapResp, err := namespacedConfigmapClient.ByID(cluster.FullStateConfigMapName)
+	if err != nil {
+		return
+	}
+
+	configmap := &corev1.ConfigMap{}
+	err = v1.ConvertToK8sType(configmapResp.JSONResp, configmap)
+	if err != nil {
+		return
+	}
+
+	rawState, ok := configmap.Data[cluster.FullStateConfigMapName]
+	if !ok {
+		err = errors.Wrapf(err, "couldn't retrieve full state data in the configmap")
+		return
+	}
+
+	rkeFullState := &cluster.FullState{}
+	err = json.Unmarshal([]byte(rawState), rkeFullState)
+	if err != nil {
+		return
+	}
+
+	return rkeFullState, nil
+}
+
+// appendSSHPath reads sshPath input from the cattle config file.
+// If the config input has a different prefix, adds the prefix.
+func appendSSHPath(sshPath string) string {
+	sshPathPrefix := nodes.GetSSHPath().SSHPath
+
+	if strings.HasPrefix(sshPath, sshPathPrefix) {
+		return sshPath
+	}
+
+	ssh := ".ssh/"
+	sshPath = strings.TrimPrefix(sshPath, ssh)
+
+	return fmt.Sprintf(sshPathPrefix + "/" + sshPath)
+}

--- a/tests/framework/extensions/clusters/bundledclusters/list.go
+++ b/tests/framework/extensions/clusters/bundledclusters/list.go
@@ -14,9 +14,16 @@ import (
 func (bc *BundledCluster) ListAvailableVersions(client *rancher.Client) (versions []string, err error) {
 	switch bc.Meta.Provider {
 	case clusters.KubernetesProviderRKE:
-		versions, err = available.ListRKE1AvailableVersions(client, bc.V3)
-		if err != nil {
-			return
+		if bc.Meta.IsImported {
+			versions, err = available.ListRKE1ImportedAvailableVersions(client, bc.V3)
+			if err != nil {
+				return
+			}
+		} else {
+			versions, err = available.ListRKE1AvailableVersions(client, bc.V3)
+			if err != nil {
+				return
+			}
 		}
 	case clusters.KubernetesProviderRKE2:
 		if bc.Meta.IsImported {
@@ -24,7 +31,7 @@ func (bc *BundledCluster) ListAvailableVersions(client *rancher.Client) (version
 			if err != nil {
 				return
 			}
-		} else if !bc.Meta.IsImported {
+		} else {
 			versions, err = available.ListNormanRKE2AvailableVersions(client, bc.V3)
 			if err != nil {
 				return
@@ -36,7 +43,7 @@ func (bc *BundledCluster) ListAvailableVersions(client *rancher.Client) (version
 			if err != nil {
 				return
 			}
-		} else if !bc.Meta.IsImported {
+		} else {
 			versions, err = available.ListNormanK3SAvailableVersions(client, bc.V3)
 			if err != nil {
 				return

--- a/tests/framework/extensions/clusters/clustermeta.go
+++ b/tests/framework/extensions/clusters/clustermeta.go
@@ -9,6 +9,8 @@ import (
 type KubernetesProvider string
 
 const (
+	local = "local"
+
 	rke  = "rke"
 	k3s  = "k3s"
 	rke2 = "rke2"
@@ -41,6 +43,9 @@ type ClusterMeta struct {
 
 	// IsImported is used for cluster's imported information.
 	IsImported bool
+
+	// IsLocal is used for cluster's local information.
+	IsLocal bool
 }
 
 // NewClusterMeta is a function to initialize new ClusterMeta for a specific cluster.
@@ -64,6 +69,8 @@ func NewClusterMeta(client *rancher.Client, clusterName string) (clusterMeta *Cl
 	}
 
 	clusterMeta.IsHosted = IsHostedProvider(clusterMeta.Provider)
+
+	clusterMeta.IsLocal = clusterMeta.Name == local
 
 	return
 }

--- a/tests/framework/extensions/kubeapi/cluster/summary.go
+++ b/tests/framework/extensions/kubeapi/cluster/summary.go
@@ -1,0 +1,27 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/wrangler/pkg/summary"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// IsClusterActive is a helper function that uses the dynamic client to return cluster's ready state.
+func IsClusterActive(client *rancher.Client, clusterID string) (ready bool, err error) {
+	dynamic, err := client.GetRancherDynamicClient()
+	if err != nil {
+		return
+	}
+
+	unstructuredCluster, err := dynamic.Resource(schema.GroupVersionResource{Group: "management.cattle.io", Version: "v3", Resource: "clusters"}).Get(context.TODO(), clusterID, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	summarized := summary.Summarize(unstructuredCluster)
+
+	return summarized.IsReady(), nil
+}

--- a/tests/framework/pkg/config/config.go
+++ b/tests/framework/pkg/config/config.go
@@ -9,10 +9,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// ConfigEnvironmentKey is a const that stores cattle config's environment key.
+const ConfigEnvironmentKey = "CATTLE_TEST_CONFIG"
+
 // LoadConfig reads the file defined by  the `CATTLE_TEST_CONFIG` environment variable and loads the object found at the given key onto the given configuration reference.
 // The functions takes a pointer of the object.
 func LoadConfig(key string, config interface{}) {
-	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	configPath := os.Getenv(ConfigEnvironmentKey)
 
 	if configPath == "" {
 		yaml.Unmarshal([]byte("{}"), config)
@@ -49,7 +52,7 @@ func LoadConfig(key string, config interface{}) {
 
 // UpdateConfig is function that updates the CATTLE_TEST_CONFIG yaml/json that the framework uses.
 func UpdateConfig(key string, config interface{}) {
-	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	configPath := os.Getenv(ConfigEnvironmentKey)
 
 	if configPath == "" {
 		yaml.Unmarshal([]byte("{}"), config)

--- a/tests/framework/pkg/config/file.go
+++ b/tests/framework/pkg/config/file.go
@@ -2,72 +2,17 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/rancher/rancher/tests/framework/pkg/file"
 )
 
-// NewConfigurationsDir is a function that creates a directory with given directory name.
-// Ignores the returned error if the directory already exists.
-func NewConfigurationsDir(dirName string) (err error) {
-	err = os.Mkdir(dirName, 0777)
-	if err != nil {
-		if strings.Contains(err.Error(), "file exists") {
-			logrus.Info("configs dir already exists ", err)
-			return nil
-		}
-	}
-
-	return
-}
-
-type FileName string
-
 // NewConfigFileName is a constructor function that creates a configuration yaml file name
-// that returns FileName.
-func NewConfigFileName(dirName string, params ...string) FileName {
+// that returns ConfigFileName.
+func NewConfigFileName(dirName string, params ...string) file.Name {
 	fileName := strings.Join(params, "-")
 
 	fileNameFull := fmt.Sprintf("%v/%v.yaml", dirName, fileName)
 
-	return FileName(fileNameFull)
-}
-
-// NewFile is a method that creates a configuration yaml file with the received file name.
-func (cF FileName) NewFile(data []byte) (err error) {
-	err = os.WriteFile(string(cF), data, 0644)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
-// SetEnvironmentKey is a method that sets cattle config environment variable to the received file name.
-func (cF FileName) SetEnvironmentKey() (err error) {
-	configEnvironmentKey := "CATTLE_TEST_CONFIG"
-
-	configPath, err := cF.GetWDFilePath()
-	if err != nil {
-		return
-	}
-
-	os.Setenv(configEnvironmentKey, configPath)
-	logrus.Info(configEnvironmentKey, " is set to ", configPath)
-
-	return
-}
-
-// GetWDFilePath is a method that returns the received file name joined with wd path.
-func (cF FileName) GetWDFilePath() (string, error) {
-	wd, err := os.Getwd()
-	logrus.Info("wd:", wd)
-	if err != nil {
-		return "", err
-	}
-
-	path := fmt.Sprintf("%v/%v", wd, string(cF))
-
-	return path, nil
+	return file.Name(fileNameFull)
 }

--- a/tests/framework/pkg/file/file.go
+++ b/tests/framework/pkg/file/file.go
@@ -1,0 +1,64 @@
+package file
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewDir is a function that creates a directory with given directory name.
+// Ignores the returned error if the directory already exists.
+func NewDir(dirName string) (err error) {
+	err = os.Mkdir(dirName, 0777)
+	if err != nil && strings.Contains(err.Error(), "file exists") {
+		logrus.Infof("dir already exists: %v", err)
+		return nil
+	}
+
+	return
+}
+
+type Name string
+
+// NewFile is a method that creates a file with the received file name.
+func (f Name) NewFile(data []byte) (wdPath string, err error) {
+	err = os.WriteFile(string(f), data, 0644)
+	if err != nil {
+		return
+	}
+
+	wdPath, err = f.GetWDFilePath()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetWDFilePath is a method that returns the received file name joined with wd path.
+func (f Name) GetWDFilePath() (string, error) {
+	wd, err := os.Getwd()
+	logrus.Info("wd:", wd)
+	if err != nil {
+		return "", err
+	}
+
+	path := fmt.Sprintf("%v/%v", wd, string(f))
+
+	return path, nil
+}
+
+// SetEnvironmentKey is a method that sets given environment variable to the received file name.
+func (f Name) SetEnvironmentKey(envKey string) (err error) {
+	configPath, err := f.GetWDFilePath()
+	if err != nil {
+		return
+	}
+
+	err = os.Setenv(envKey, configPath)
+	logrus.Info(envKey, " is set to ", configPath)
+
+	return
+}

--- a/tests/framework/pkg/nodes/nodes.go
+++ b/tests/framework/pkg/nodes/nodes.go
@@ -124,9 +124,7 @@ func (n *Node) ExecuteCommand(command string) (string, error) {
 func GetSSHKey(sshKeyname string) ([]byte, error) {
 	var keyPath string
 
-	sshPathConfig := new(SSHPath)
-
-	config.LoadConfig(SSHPathConfigurationKey, sshPathConfig)
+	sshPathConfig := GetSSHPath()
 	if sshPathConfig.SSHPath == "" {
 		user, err := user.Current()
 		if err != nil {
@@ -143,4 +141,13 @@ func GetSSHKey(sshKeyname string) ([]byte, error) {
 	}
 
 	return content, nil
+}
+
+// GetSSHPath gets ssh path from the config
+func GetSSHPath() *SSHPath {
+	sshPathConfig := new(SSHPath)
+
+	config.LoadConfig(SSHPathConfigurationKey, sshPathConfig)
+
+	return sshPathConfig
 }

--- a/tests/v2/validation/pipeline/downstreamcleanup/main.go
+++ b/tests/v2/validation/pipeline/downstreamcleanup/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	"github.com/rancher/rancher/tests/framework/extensions/token"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/file"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/sirupsen/logrus"
@@ -28,7 +29,7 @@ var (
 	adminPassword = os.Getenv("ADMIN_PASSWORD")
 	host          = os.Getenv("HA_HOST")
 
-	configFileName = config.FileName("cattle-config.yaml")
+	configFileName = file.Name("cattle-config.yaml")
 )
 
 func main() {
@@ -64,11 +65,11 @@ func main() {
 	if err != nil {
 		logrus.Errorf("error marshaling: %v", err)
 	}
-	err = configFileName.NewFile(configData)
+	_, err = configFileName.NewFile(configData)
 	if err != nil {
 		logrus.Fatalf("error writing yaml: %v", err)
 	}
-	err = configFileName.SetEnvironmentKey()
+	err = configFileName.SetEnvironmentKey(config.ConfigEnvironmentKey)
 	if err != nil {
 		logrus.Fatalf("error while setting environment path: %v", err)
 	}

--- a/tests/v2/validation/pipeline/hapostinstall/main.go
+++ b/tests/v2/validation/pipeline/hapostinstall/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/pipeline"
 	"github.com/rancher/rancher/tests/framework/extensions/token"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/file"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -25,7 +26,7 @@ var (
 
 	clusterID = "local"
 
-	configFileName       = config.FileName("cattle-config.yaml")
+	configFileName       = file.Name("cattle-config.yaml")
 	environmentsFileName = "environments.groovy"
 
 	tokenEnvironmentKey      = "HA_TOKEN"
@@ -69,11 +70,11 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("error marshaling: %v", err)
 	}
-	err = configFileName.NewFile(configData)
+	_, err = configFileName.NewFile(configData)
 	if err != nil {
 		logrus.Fatalf("error writing yaml: %v", err)
 	}
-	err = configFileName.SetEnvironmentKey()
+	err = configFileName.SetEnvironmentKey(config.ConfigEnvironmentKey)
 	if err != nil {
 		logrus.Fatalf("error while setting environment path: %v", err)
 	}

--- a/tests/v2/validation/pipeline/releaseupgrade/main.go
+++ b/tests/v2/validation/pipeline/releaseupgrade/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
+	"github.com/rancher/rancher/tests/framework/pkg/file"
 	"github.com/rancher/rancher/tests/v2/validation/upgrade"
 	"github.com/sirupsen/logrus"
 )
@@ -89,7 +90,7 @@ func main() {
 	config.UpdateConfig(environmentflag.ConfigurationFileKey, environmentFlags)
 
 	//make cattle-configs dir
-	err := config.NewConfigurationsDir(dirName)
+	err := file.NewDir(dirName)
 	if err != nil {
 		logrus.Fatal("error while creating configs dir", err)
 	}
@@ -206,7 +207,7 @@ func main() {
 	}
 
 	for i, v := range clusters.HostedClusters {
-		var newConfigName config.FileName
+		var newConfigName file.Name
 
 		switch v.Provider {
 		case provisioninginput.AWSProviderName.String():
@@ -221,7 +222,7 @@ func main() {
 
 		newConfigName.NewFile(copiedConfig)
 
-		newConfigName.SetEnvironmentKey()
+		newConfigName.SetEnvironmentKey(config.ConfigEnvironmentKey)
 
 		pipeline.UpdateHostedKubernetesVField(v.Provider, v.KubernetesVersion)
 
@@ -252,7 +253,7 @@ func main() {
 
 		upgradeConfig := new(upgrade.Config)
 		config.LoadAndUpdateConfig(upgrade.ConfigurationFileKey, upgradeConfig, func() {
-			clusters := []upgrade.Clusters{
+			clusters := []upgrade.Cluster{
 				{
 					VersionToUpgrade: v.KubernetesVersionToUpgrade,
 					FeaturesToTest:   v.FeaturesToTest,
@@ -263,14 +264,14 @@ func main() {
 	}
 }
 
-func NewRancherClusterConfiguration(cluster pipeline.RancherCluster, newConfigName config.FileName, isCustom, isRKE1, isRKE2 bool, copiedConfig []byte, cni, provTestPackage, runCommand, tags, runFlag string) (err error) {
-	err = newConfigName.NewFile(copiedConfig)
+func NewRancherClusterConfiguration(cluster pipeline.RancherCluster, newConfigName file.Name, isCustom, isRKE1, isRKE2 bool, copiedConfig []byte, cni, provTestPackage, runCommand, tags, runFlag string) (err error) {
+	_, err = newConfigName.NewFile(copiedConfig)
 	if err != nil {
 		logrus.Info("error while writing populated config", err)
 		return err
 	}
 
-	err = newConfigName.SetEnvironmentKey()
+	err = newConfigName.SetEnvironmentKey(config.ConfigEnvironmentKey)
 	if err != nil {
 		logrus.Info("error while setting new config as env var", err)
 		return err
@@ -299,7 +300,7 @@ func NewRancherClusterConfiguration(cluster pipeline.RancherCluster, newConfigNa
 
 	upgradeConfig := new(upgrade.Config)
 	config.LoadAndUpdateConfig(upgrade.ConfigurationFileKey, upgradeConfig, func() {
-		clusters := []upgrade.Clusters{
+		clusters := []upgrade.Cluster{
 			{
 				VersionToUpgrade: cluster.KubernetesVersionToUpgrade,
 				FeaturesToTest:   cluster.FeaturesToTest,

--- a/tests/v2/validation/upgrade/config.go
+++ b/tests/v2/validation/upgrade/config.go
@@ -16,7 +16,7 @@ const (
 	latestKey            = "latest"       // latestKey is a string to determine automatically version pooling to the latest possible
 )
 
-type Clusters struct {
+type Cluster struct {
 	Name              string   `json:"name" yaml:"name" default:""`
 	VersionToUpgrade  string   `json:"versionToUpgrade" yaml:"versionToUpgrade" default:""`
 	PSACT             string   `json:"psact" yaml:"psact" default:""`
@@ -31,7 +31,7 @@ type Features struct {
 }
 
 type Config struct {
-	Clusters []Clusters `json:"clusters" yaml:"clusters" default:"[]"`
+	Clusters []Cluster `json:"clusters" yaml:"clusters" default:"[]"`
 }
 
 // loadUpgradeKubernetesConfig is a test helper function to get required slice of ClustersToUpgrade struct. Returns error if any.
@@ -40,7 +40,7 @@ type Config struct {
 //  2. An additional config field called update with slice of ClustersToUpgrade struct,
 //     for choosing some clusters to upgrade (version is optional, by default, empty string skips the test
 //     and "latest" upgrades to the latest available.)
-func loadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Clusters, err error) {
+func loadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Cluster, err error) {
 	upgradeConfig := new(Config)
 	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
 
@@ -61,7 +61,7 @@ func loadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Clusters, e
 		}
 
 		for i := range clusterList {
-			cluster := new(Clusters)
+			cluster := new(Cluster)
 
 			cluster.Name = clusterList[i]
 			cluster.isLatestVersion = true
@@ -70,7 +70,7 @@ func loadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Clusters, e
 		}
 	} else if isUpgradeSomeClusters {
 		for _, c := range upgradeConfig.Clusters {
-			cluster := new(Clusters)
+			cluster := new(Cluster)
 
 			cluster.Name = c.Name
 			cluster.VersionToUpgrade = c.VersionToUpgrade
@@ -93,7 +93,7 @@ func loadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Clusters, e
 	return
 }
 
-func loadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Clusters, err error) {
+func loadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Cluster, err error) {
 	upgradeConfig := new(Config)
 	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
 
@@ -114,7 +114,7 @@ func loadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Clusters, err
 		}
 
 		for i := range clusterList {
-			cluster := new(Clusters)
+			cluster := new(Cluster)
 
 			cluster.Name = clusterList[i]
 			ingress := false
@@ -128,7 +128,7 @@ func loadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Clusters, err
 		}
 	} else if isUpgradeSomeClusters {
 		for _, c := range upgradeConfig.Clusters {
-			cluster := new(Clusters)
+			cluster := new(Cluster)
 
 			cluster.Name = c.Name
 			cluster.FeaturesToTest = c.FeaturesToTest

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -29,7 +29,7 @@ type UpgradeWorkloadTestSuite struct {
 	suite.Suite
 	session  *session.Session
 	client   *rancher.Client
-	clusters []Clusters
+	clusters []Cluster
 }
 
 func (u *UpgradeWorkloadTestSuite) TearDownSuite() {


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/611 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently imported clusters and local cluster upgrades tests happen manually.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add local upgrade test case and expand existing upgrade Kubernetes validation test to enable testing on downstream imported clusters.

## Engineering Testing

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)


Existing / newly added automated tests that provide evidence there are no regressions: Runs will be provided offline.

Todos:
- [x] Add missing godocs
