### PR TITLE
Adding automation tests for `auto-replace` feature in rke2/k3s

### DIFF
--- a/tests/v2/validation/nodescaling/auto_replace.go
+++ b/tests/v2/validation/nodescaling/auto_replace.go
@@ -1,0 +1,44 @@
+//go:build (validation || extended) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !cluster.any && !cluster.custom && !cluster.nodedriver && !sanity && !stress
+
+package nodescaling
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	shutdownCommand = "shutdown"
+	fleetNamespace  = "fleet-default"
+	deletingState   = "deleting"
+)
+
+// ReplaceNodes replaces the last node with the specified role(s) in a k3s/rke2 cluster
+func TestAutoReplace(t *testing.T, client *rancher.Client, clusterName string, nodeToReplace *nodes.Node, machineName string) error {
+	logrus.Infof("Running node auto-replace on node %s", nodeToReplace)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	// Shutdown node using ssh outside of Rancher to simulate unhealthy node
+	_, err = nodeToReplace.ExecuteCommand(shutdownCommand)
+	if err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
+		return err
+	}
+
+	// Verify node gets replaced
+	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
+	if err != nil {
+		logrus.Errorf("Rancher was unable to auto replace node %s successfully", nodeToReplace.PublicIPAddress)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
[496](https://github.com/rancher/qa-tasks/issues/496)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
We don't have the option to set the value for unhealthyNodeTimeout in our automation suite. We want to include test cases for this feature and need this option in our framework.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
We are adding the following fields to allow us to use this feature in our automation suite.
- NodeStartupTimeout
- UnhealthyNodeTimeout
- MaxUnhealthy
- UnhealthyRange
The tests being created for this feature are the following:

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manual testing was done on local setup to ensure that the field was being added correctly.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Jenkins jobs will be available upon request

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
This is for the qa team to be able to run automated tests around the node replace feature
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
There are no regressions as the feature already exists and we are just adding the field to enable the feature on the automation suite.