### PR TITLE
[v2.8] Fix Prime branding parameter to default instead of value

### DIFF
--- a/tests/framework/extensions/prime/primechecks.go
+++ b/tests/framework/extensions/prime/primechecks.go
@@ -15,7 +15,7 @@ const (
 
 // CheckUIBrand checks the UI brand of Rancher Prime. If the Rancher instance is not Rancher Prime, the UI brand should be blank.
 func CheckUIBrand(client *rancher.Client, isPrime bool, rancherBrand *client.Setting, brand string) error {
-	if isPrime && brand != rancherBrand.Value {
+	if isPrime && brand != rancherBrand.Default {
 		return fmt.Errorf("error: Rancher Prime UI brand %s does not match defined UI brand %s", rancherBrand.Value, brand)
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Previously, our Prime tests checked the branding value parameter to ensure that the config file value matched the response given from Prime. However, when going to the API call for `ui-brand`, the `value` parameter is now a `null` parameter in Prime setups.

This has caused our QA test to break, consequently, so we need to update where we are looking.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated value to default to ensure that this test passes.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally tested this change and the Prime test suite passed as expected.