### PR TITLE
Bypass deleting cloud credential resources in validation tests

### DIFF
--- a/tests/framework/pkg/clientbase/ops.go
+++ b/tests/framework/pkg/clientbase/ops.go
@@ -230,11 +230,14 @@ func (a *APIOperations) DoCreate(schemaType string, createObj interface{}, respO
 	}
 
 	a.Session.RegisterCleanupFunc(func() error {
-		err := a.DoResourceDelete(schemaType, &resource)
-		if err != nil && (strings.Contains(err.Error(), "404 Not Found") || strings.Contains(err.Error(), "failed to find self URL of [&{  map[] map[]}]")) {
-			return nil
+		if !(schemaType == "cloudCredential") { // Skip resource deletion if resource is a cloud credential
+			err := a.DoResourceDelete(schemaType, &resource)
+			if err != nil && (strings.Contains(err.Error(), "404 Not Found") || strings.Contains(err.Error(), "failed to find self URL of [&{  map[] map[]}]")) {
+				return nil
+			}
+			return err
 		}
-		return err
+		return nil
 	})
 
 	return nil


### PR DESCRIPTION
## Issue: [#814](https://github.com/rancher/qa-tasks/issues/814)
 
## Backport
[link](https://github.com/rancher/rancher/pull/43374)

## Problem
Currently, hosted cluster tests don't properly remove clusters in cloud providers because cloud credentials are deleted before other resources that need cloud credentials are removed.

## Solution
Bypass deleting cloud credentials since they don't pose a significant load to Rancher
 
