### PR TITLE
Refactor `nodetemplates` extension of golang test framework

### DIFF
--- a/tests/framework/extensions/rke1/nodetemplates/aws/create.go
+++ b/tests/framework/extensions/rke1/nodetemplates/aws/create.go
@@ -21,8 +21,16 @@ func CreateAWSNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.NodeTe
 		AmazonEC2NodeTemplateConfig: &amazonEC2NodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/extensions/rke1/nodetemplates/aws_config.go
+++ b/tests/framework/extensions/rke1/nodetemplates/aws_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Amazon node template config
-const AmazonEC2NodeTemplateConfigurationFileKey = "awsNodeTemplate"
+const AmazonEC2NodeTemplateConfigurationFileKey = "amazonec2Config"
 
 // AmazonNodeTemplateConfig is configuration need to create a Amazon node template
 type AmazonEC2NodeTemplateConfig struct {

--- a/tests/framework/extensions/rke1/nodetemplates/azure/create.go
+++ b/tests/framework/extensions/rke1/nodetemplates/azure/create.go
@@ -21,8 +21,16 @@ func CreateAzureNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.Node
 		AzureNodeTemplateConfig: &azureNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/extensions/rke1/nodetemplates/azure_config.go
+++ b/tests/framework/extensions/rke1/nodetemplates/azure_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Azure node template config
-const AzureNodeTemplateConfigurationFileKey = "azureNodeTemplate"
+const AzureNodeTemplateConfigurationFileKey = "azureConfig"
 
 // AzureNodeTemplateConfig is configuration need to create a Azure node template
 type AzureNodeTemplateConfig struct {

--- a/tests/framework/extensions/rke1/nodetemplates/harvester/create.go
+++ b/tests/framework/extensions/rke1/nodetemplates/harvester/create.go
@@ -21,8 +21,16 @@ func CreateHarvesterNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.
 		HarvesterNodeTemplateConfig: &harvesterNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/extensions/rke1/nodetemplates/harvester_config.go
+++ b/tests/framework/extensions/rke1/nodetemplates/harvester_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Harvester node template config
-const HarvesterNodeTemplateConfigurationFileKey = "harvesterNodeTemplate"
+const HarvesterNodeTemplateConfigurationFileKey = "harvesterConfig"
 
 // HarvesterNodeTemplateConfig is configuration need to create a Harvester node template
 type HarvesterNodeTemplateConfig struct {

--- a/tests/framework/extensions/rke1/nodetemplates/linode/create.go
+++ b/tests/framework/extensions/rke1/nodetemplates/linode/create.go
@@ -21,8 +21,16 @@ func CreateLinodeNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.Nod
 		LinodeNodeTemplateConfig: &linodeNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/extensions/rke1/nodetemplates/linode_config.go
+++ b/tests/framework/extensions/rke1/nodetemplates/linode_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Linode node template config
-const LinodeNodeTemplateConfigurationFileKey = "linodeNodeTemplate"
+const LinodeNodeTemplateConfigurationFileKey = "linodeConfig"
 
 // LinodeNodeTemplateConfig is configuration need to create a Linode node template
 type LinodeNodeTemplateConfig struct {

--- a/tests/framework/extensions/rke1/nodetemplates/vsphere/create.go
+++ b/tests/framework/extensions/rke1/nodetemplates/vsphere/create.go
@@ -21,8 +21,16 @@ func CreateVSphereNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.No
 		VmwareVsphereNodeTemplateConfig: &vmwarevsphereNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/extensions/rke1/nodetemplates/vsphere_config.go
+++ b/tests/framework/extensions/rke1/nodetemplates/vsphere_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the VSphere node template config
-const VmwareVsphereNodeTemplateConfigurationFileKey = "vmwarevsphereNodeTemplate"
+const VmwareVsphereNodeTemplateConfigurationFileKey = "vmwarevsphereConfig"
 
 // VmwareVsphereNodeTemplateConfig is configuration need to create a VSphere node template
 type VmwareVsphereNodeTemplateConfig struct {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
It is currently not possible to set top-level NodeTemplate fields via configfile. The current implementation assumes defaults and is difficult to modify on the fly. Provider-specific node template configuration file keys do not match the top-level NodeTemplate struct keys.
 
## Solution
- Enable setting top-level nodetemplate fields
- Enable setting entire nodetemplate via config file
- **BREAKING** Update provider-specific configfile keys to match their top-level NodeTemplate key
- Add custom merge function for NodeTemplate
- Can still set provider-specific nodetemplate configuration separately via config file
- Should maintain backwards-compatibility if the top-level NodeTemplate configuration key is not present in the config file
- Specification of the updated provider-specific node template configuration keys should correctly overwrite the top-level NodeTemplate's provider config if specified

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Tested locally, have not tested via Jenkins

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->