### PR TITLE
Updates to the following golang test framework extensions: defaults, kubeconfig, and provisioning

### DIFF
--- a/tests/framework/extensions/defaults/defaults.go
+++ b/tests/framework/extensions/defaults/defaults.go
@@ -3,8 +3,9 @@ package defaults
 import "time"
 
 var (
-	WatchTimeoutSeconds = int64(60 * 30) // 30 minutes.
-	FiveMinuteTimeout   = 5 * time.Minute
-	TenMinuteTimeout    = 10 * time.Minute
-	ThirtyMinuteTimeout = 30 * time.Minute
+	WatchTimeoutSeconds  = int64(60 * 30) // 30 minutes.
+	FiveMinuteTimeout    = 5 * time.Minute
+	TenMinuteTimeout     = 10 * time.Minute
+	FifteenMinuteTimeout = 15 * time.Minute
+	ThirtyMinuteTimeout  = 30 * time.Minute
 )

--- a/tests/framework/extensions/kubeconfig/exec.go
+++ b/tests/framework/extensions/kubeconfig/exec.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -73,7 +74,7 @@ func KubectlExec(restConfig *restclient.Config, podName, namespace string, comma
 	}
 
 	logStreamer := &LogStreamer{}
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
 		Stdin:  nil,
 		Stdout: logStreamer,
 		Stderr: os.Stderr,

--- a/tests/framework/extensions/kubeconfig/podlogs.go
+++ b/tests/framework/extensions/kubeconfig/podlogs.go
@@ -12,7 +12,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-// GetPodLogs is a helper function that resturns logs from a pod using rest client
+// GetPodLogs is a helper function that returns logs from a pod using rest client
 func GetPodLogs(client *rancher.Client, clusterID string, podName string, namespace string) (string, error) {
 	var restConfig *restclient.Config
 
@@ -52,6 +52,53 @@ func GetPodLogs(client *rancher.Client, clusterID string, podName string, namesp
 	var logs string
 	for reader.Scan() {
 		logs = logs + fmt.Sprintf("%s\n", reader.Text())
+	}
+
+	if err := reader.Err(); err != nil {
+		return "", fmt.Errorf("error reading pod logs for pod %s/%s: %v", namespace, podName, err)
+	}
+	return logs, nil
+}
+
+func GetPodLogsWithOpts(client *rancher.Client, clusterID string, podName string, namespace string, opts *corev1.PodLogOptions) (string, error) {
+	var restConfig *restclient.Config
+
+	kubeConfig, err := GetKubeconfig(client, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	restConfig, err = (*kubeConfig).ClientConfig()
+	if err != nil {
+		return "", err
+	}
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	restClient, err := restclient.RESTClientFor(restConfig)
+	if err != nil {
+		return "", err
+	}
+
+	req := restClient.Get().Resource("pods").Name(podName).Namespace(namespace).SubResource("log")
+	req.VersionedParams(
+		opts,
+		k8Scheme.ParameterCodec,
+	)
+
+	stream, err := req.Stream(context.TODO())
+	if err != nil {
+		return "", fmt.Errorf("error streaming pod logs for pod %s/%s: %v", namespace, podName, err)
+	}
+
+	defer stream.Close()
+
+	reader := bufio.NewScanner(stream)
+	var logs string
+	for reader.Scan() {
+		logs = logs + fmt.Sprintf("%s\n", reader.Text())
+		fmt.Println(reader.Text())
 	}
 
 	if err := reader.Err(); err != nil {

--- a/tests/framework/extensions/kubeconfig/pods.go
+++ b/tests/framework/extensions/kubeconfig/pods.go
@@ -1,0 +1,57 @@
+package kubeconfig
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	k8Scheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func GetPods(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]corev1.Pod, error) {
+
+	kubeConfig, err := GetKubeconfig(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), *listOptions)
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
+func GetPodNames(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]string, error) {
+	pods, err := GetPods(client, clusterID, namespace, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	if len(names) == 0 {
+		return nil, errors.New("GetPodNames: no pod names found")
+	}
+
+	return names, nil
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
- There was no function to get pod logs with customized PodOptions
- There was no function to get a []string of pod names
- The "Verify Cluster" functions all default to a 30 minute timeout that is not configurable, this limits the usage of these functions if/when provisioning/creating many clusters at once
 
## Solution
- Add  a 15 min default option
- Update deprecated Stream() call to StreamWithContext()
- Add GetPodLogsWithOpts() to `extensions/kubeconfig`
- Add GetPods() and GetPodNames() `extensions/kubeconfig`
- Add "Verify Cluster" function variants that also take a custom timeout as input (defaults to 30-minute default of the non-custom function variants)
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
