### PR TITLE
[2.8] Fix check for exact version in Helm index

### DIFF
--- a/pkg/catalogv2/system/manager_test.go
+++ b/pkg/catalogv2/system/manager_test.go
@@ -307,10 +307,13 @@ func TestInstallCharts(t *testing.T) {
 			},
 			desiredCharts: map[desiredKey]map[string]any{
 				{
-					namespace:    "cattle-fleet-system",
-					name:         "fleet",
-					minVersion:   "2.0.0",
-					exactVersion: "2.0.0",
+					namespace: "cattle-fleet-system",
+					name:      "fleet",
+					// major, minor and patch segments match a version from the index, which is
+					// where Helm could return a matching version based on those segments, but not
+					// strictly equal to the specified one
+					minVersion: "3.0.0+up1.2.3",
+					// no exact version
 				}: {},
 				{
 					namespace:    "cattle-system",
@@ -324,7 +327,7 @@ func TestInstallCharts(t *testing.T) {
 				"fleet":           false,
 				"rancher-webhook": true,
 			},
-			expectedErr: errors.New("no chart version found"),
+			expectedErr: errors.New("specified version 3.0.0+up1.2.3 doesn't exist in the index"),
 		},
 	}
 

--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -257,17 +257,25 @@ func (m *Manager) Remove(namespace, name string) {
 	}
 }
 
-// install tries to install a new version of a chart. If the exact version is provided, it will try to install it
-// otherwise it will try to install the latest version available. If a release with the version to be installed is already installed,
-// or it's pending install, upgrade or rollback this does nothing.
-// The operation created is always an upgrade, even in the case of an installation. In that case, the Install flag will be used.
+// install tries to install a new version of a chart.
+// If the exact version is provided, it will try to install it regardless of whether minVersion is provided.
+// If minVersion is provided on its own, it will try to install it only if the current version is earlier than
+// minVersion.
+// A failure to find a chart for a provided version leads to an error being thrown, without any change in state.
+// If no version is provided, it will try to install the latest version available.
+// If a release with the version to be installed is already installed, or is pending install, upgrade or rollback, this
+// does nothing.
 func (m *Manager) install(namespace, name, minVersion, exactVersion string, values map[string]interface{}, forceAdopt bool, installImageOverride string) error {
 	index, err := m.content.Index("", "rancher-charts", "", true)
 	if err != nil {
 		return err
 	}
-	v := ">=0-a" // latest - this is special syntax to match everything including pre-releases build
+
+	const latestVersionMatcher = ">=0-a" // latest - special syntax to match everything including pre-release builds
+
+	v := latestVersionMatcher
 	var isExact bool
+
 	if exactVersion != "" {
 		v = exactVersion
 		isExact = true
@@ -285,8 +293,8 @@ func (m *Manager) install(namespace, name, minVersion, exactVersion string, valu
 		return fmt.Errorf(err.Error())
 	}
 	// Because of the behavior of `index.Get`, we need this check.
-	if isExact && chart.Version != v {
-		return fmt.Errorf("specified exact version %s doesn't exist in the index", exactVersion)
+	if v != latestVersionMatcher && chart.Version != v {
+		return fmt.Errorf("specified version %s doesn't exist in the index", v)
 	}
 
 	// If the chart version is already installed, we do nothing


### PR DESCRIPTION
When installing a system chart by version, Rancher now errors if the version of the chart found in the index is not the requested one. In such a case, the chart is not installed. This previously happened only when the version to be installed would overwrite whatever other version was already installed.

Broadening the scope of this check fixes a bug whereby a system chart, eg. Fleet, would be installed in its latest available version if an invalid version number was specified in environment variables (eg. `CATTLE_FLEET_VERSION`).

## Issue:

* [fleet#1590](https://github.com/rancher/fleet/issues/1590) and [fleet#1948](https://github.com/rancher/fleet/issues/1948)
* https://github.com/rancher/fleet/issues/1948
 
## Problem

Rancher installs a version of a Helm chart which differs from the version specified in the corresponding environment variable. The installed version is not necessarily the latest available one either, which causes confusion.
 
## Solution

Expand the check for availability of the desired version to any case of a system chart installation.
 
## Testing

## Engineering Testing
### Manual Testing

Ran Rancher in VS Code, setting env var `CATTLE_FLEET_VERSION` to `102.2.0+up0.8.4` (nonexistent version in `rancher/charts`' `dev-v2.8` branch at the time of testing)

#### Before the change

Could see Rancher install Fleet 0.8.0 (screenshot by @sbulage , before I reproduced the issue on my machine):
![image](https://github.com/rancher/rancher/assets/2477066/6b90129b-ada0-4c80-8227-5f8a3a345aa4)

#### After the change

Could see Fleet not being installed by Rancher, which would emit error messages such as:
```
2023/11/06 12:15:03 [ERROR] Failed to install system chart fleet-crd: specified exact version 102.2.0+up0.8.4 doesn't exist in the index
2023/11/06 12:15:03 [ERROR] Failed to install system chart fleet: specified exact version 102.2.0+up0.8.4 doesn't exist in the index
```

## QA Testing Considerations

I have also manually tested installing an existing version (happy path), which seemed to still work as expected.
 
### Regressions Considerations
N/A