### PR TITLE
[v2.8] Backport Added CRTB create test cases by using SteveAPI

### DIFF
--- a/tests/v2/validation/rbac/crtb/README.md
+++ b/tests/v2/validation/rbac/crtb/README.md
@@ -1,0 +1,18 @@
+# ClusterRoleTemplateBinding(v1)
+This repository contains Golang automation tests for the ClusterRoleTemplateBinding functionality by SteveAPI(V1) and kubectl. This is part of Public API functionality to generate Custom Resource Definitions (CRD's) for ClusterRoleTemplateBinding. ClusterRoleTemplateBindings is allowing users to perform all the CRUD operations by using SteveAPI(V1) OR kubectl. These automation tests contains both success and error test cases to make sure the functionality is working as expected.
+
+## Pre-requisites
+- Ensure you have an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, create one first before running this test.
+
+## Test Setup
+Your GO suite should be set to `-run ^TestCRTBGenTestSuite$`. You can find specific tests by checking the test file you plan to run.
+
+In your config file, set the following:
+```
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True
+  cleanup: True
+  clusterName: "downstream_cluster_name"
+```

--- a/tests/v2/validation/rbac/crtb/crtb_create_steve_test.go
+++ b/tests/v2/validation/rbac/crtb/crtb_create_steve_test.go
@@ -1,0 +1,171 @@
+//go:build (validation || infra.any || cluster.any || sanity) && !stress && !extended
+
+package crtb
+
+import (
+	"testing"
+
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CRTBGenTestSuite struct {
+	suite.Suite
+	client    *rancher.Client
+	session   *session.Session
+	clusterID string
+	newUser   *management.User
+}
+
+func (crtb *CRTBGenTestSuite) TearDownSuite() {
+	crtb.session.Cleanup()
+}
+
+func (crtb *CRTBGenTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	crtb.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(crtb.T(), err)
+
+	crtb.client = client
+
+	crtb.clusterID, err = clusters.GetClusterIDByName(crtb.client, client.RancherConfig.ClusterName)
+	require.NoError(crtb.T(), err, "Error getting cluster ID")
+
+	crtb.newUser, err = users.CreateUserWithRole(client, users.UserConfig())
+	require.NoError(crtb.T(), err)
+}
+
+func (crtb *CRTBGenTestSuite) TestCreateCrtbWithAllRequiredInputValues() {
+	client := crtb.client
+
+	tests := []struct {
+		roleTemplateName string
+	}{
+		{clusterOwner},
+		{clusterMember},
+		{crtbManage},
+	}
+	for _, rtn := range tests {
+		crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+		clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, rtn.roleTemplateName)
+
+		resp, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+		require.NoError(crtb.T(), err)
+		assert.Contains(crtb.T(), (*resp).JSONResp["id"], crtbName)
+		assert.Contains(crtb.T(), (*resp).JSONResp["clusterName"], crtb.clusterID)
+		assert.Contains(crtb.T(), (*resp).JSONResp["userName"], crtb.newUser.ID)
+		assert.Contains(crtb.T(), (*resp).JSONResp["roleTemplateName"], rtn.roleTemplateName)
+	}
+}
+
+func (crtb *CRTBGenTestSuite) TestCreateCrtbWithUserPrincipalNameAsInput() {
+	client := crtb.client
+	crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+
+	clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, clusterMember)
+	clusterRoleTemplateBinding.UserPrincipalName = "local://" + crtb.newUser.ID
+
+	resp, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.NoError(crtb.T(), err)
+
+	assert.Contains(crtb.T(), (*resp).JSONResp["id"], crtbName)
+	assert.Contains(crtb.T(), (*resp).JSONResp["clusterName"], crtb.clusterID)
+	assert.Contains(crtb.T(), (*resp).JSONResp["userName"], crtb.newUser.ID)
+	assert.Contains(crtb.T(), (*resp).JSONResp["roleTemplateName"], clusterMember)
+	assert.Equal(crtb.T(), (*resp).JSONResp["userPrincipalName"], clusterRoleTemplateBinding.UserPrincipalName)
+}
+
+func (crtb *CRTBGenTestSuite) TestCreateCrtbAndInputLabels() {
+	client := crtb.client
+	crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+
+	clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, clusterMember)
+	clusterRoleTemplateBinding.ObjectMeta.Labels = map[string]string{"Hello": "World"}
+
+	resp, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.NoError(crtb.T(), err)
+
+	assert.Contains(crtb.T(), (*resp).JSONResp["id"], crtbName)
+	assert.Contains(crtb.T(), (*resp).JSONResp["clusterName"], crtb.clusterID)
+	assert.Contains(crtb.T(), (*resp).JSONResp["userName"], crtb.newUser.ID)
+	assert.Contains(crtb.T(), (*resp).JSONResp["roleTemplateName"], clusterMember)
+	assert.NotContains(crtb.T(), (*resp).JSONResp, clusterRoleTemplateBinding.Labels)
+}
+
+func (crtb *CRTBGenTestSuite) TestValidateErrorAlreadyCrtbExisted() {
+	client := crtb.client
+	crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+
+	clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, clusterMember)
+
+	resp, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.NoError(crtb.T(), err)
+	assert.Contains(crtb.T(), (*resp).JSONResp["id"], crtbName)
+
+	_, err = client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.Error(crtb.T(), err)
+	require.ErrorContains(crtb.T(), err, crtbConflictError)
+	require.ErrorContains(crtb.T(), err, crtbAlreadyExisted)
+}
+
+func (crtb *CRTBGenTestSuite) TestValidateErrorRoleTemplateNameDoesNotExist() {
+	client := crtb.client
+	crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+
+	clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, clusterMember)
+	clusterRoleTemplateBinding.RoleTemplateName = "roleTemplateNameNotExisted"
+
+	_, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.Error(crtb.T(), err)
+	require.ErrorContains(crtb.T(), err, badRequest)
+}
+
+func (crtb *CRTBGenTestSuite) TestValidateErrorBadRequestByPassingDifferentClusterAndNamespace() {
+	client := crtb.client
+	crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+
+	clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, clusterMember)
+	clusterRoleTemplateBinding.ClusterName = localCluster
+
+	_, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.Error(crtb.T(), err)
+	require.ErrorContains(crtb.T(), err, badRequest)
+}
+
+func (crtb *CRTBGenTestSuite) TestValidateErrorNamespaceNameDoesNotExist() {
+	client := crtb.client
+	crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+
+	clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, clusterMember)
+	clusterRoleTemplateBinding.ClusterName = "namespacenotexisted"
+
+	_, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.Error(crtb.T(), err)
+	require.ErrorContains(crtb.T(), err, badRequest)
+}
+
+func (crtb *CRTBGenTestSuite) TestValidateErrorClusterNameAndNamespaceNameDifferent() {
+	client := crtb.client
+	crtbName := namegen.RandStringLower(crtbNameWithTenChar)
+
+	clusterRoleTemplateBinding := clusterRoleTemplateBindingTemplate(crtb.clusterID, crtbName, crtb.newUser.ID, clusterMember)
+	clusterRoleTemplateBinding.ClusterName = localCluster
+
+	_, err := client.Steve.SteveType(crtbAPIEndPoint).Create(clusterRoleTemplateBinding)
+	require.Error(crtb.T(), err)
+	require.ErrorContains(crtb.T(), err, cluserNameAndNamespaceSameValue)
+}
+
+func TestCRTBGenTestSuite(t *testing.T) {
+	suite.Run(t, new(CRTBGenTestSuite))
+}

--- a/tests/v2/validation/rbac/crtb/crtb_steve.go
+++ b/tests/v2/validation/rbac/crtb/crtb_steve.go
@@ -1,0 +1,40 @@
+package crtb
+
+import (
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	crtbAPIEndPoint                 = "management.cattle.io.clusterroletemplatebinding"
+	apiVersion                      = "management.cattle.io/v3"
+	kind                            = "ClusterRoleTemplateBinding"
+	localCluster                    = "local"
+	clusterOwner                    = "cluster-owner"
+	clusterMember                   = "cluster-member"
+	crtbManage                      = "clusterroletemplatebindings-manage"
+	crtbNameWithTenChar             = 10
+	crtbConflictError               = "409 Conflict"
+	crtbAlreadyExisted              = "AlreadyExists"
+	badRequest                      = "400 Bad Request"
+	notFound                        = "404 Not Found"
+	cluserNameAndNamespaceSameValue = "Forbidden: clusterName and namespace must be the same value"
+)
+
+func clusterRoleTemplateBindingTemplate(clusterID string, crtbName string, newUser string, roleTemplateName string) v3.ClusterRoleTemplateBinding {
+	crtbTemplate := v3.ClusterRoleTemplateBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterID,
+			Name:      crtbName,
+		},
+		ClusterName:      clusterID,
+		RoleTemplateName: roleTemplateName,
+		UserName:         newUser,
+	}
+
+	return crtbTemplate
+}


### PR DESCRIPTION
## Issue: 

https://github.com/rancher/qa-tasks/issues/922
 
## Problem
Create automation tests for ClusterRoleTemplateBindings(CRTB) by using Steve endpoint, we do not have tests earlier.
 
## Solution
Create automation tests for ClusterRoleTemplateBindings(CRTB) by using Steve endpoint

Validate Test cases:
1. POST -- Success
2. POST-- Errors

 
## Testing
Validate Test cases:
1. POST -- Success
2. POST-- Errors
