### PR TITLE
Add charts url setting

### DIFF
--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -45,6 +45,7 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 			},
 		})
 	} else if err == nil && (repo.Spec.GitRepo != repoURL || repo.Spec.GitBranch != branchName) {
+		repo.Spec.GitRepo = repoURL
 		repo.Spec.GitBranch = branchName
 		_, err = wrangler.Catalog.ClusterRepo().Update(repo)
 	}

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -57,12 +57,12 @@ func addRepos(ctx context.Context, wrangler *wrangler.Context) error {
 	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultURL.Get(), settings.ChartDefaultBranch.Get()); err != nil {
 		return err
 	}
-	if err := addRepo(wrangler, "rancher-partner-charts", defaultURL, settings.PartnerChartDefaultBranch.Get()); err != nil {
+	if err := addRepo(wrangler, "rancher-partner-charts", settings.PartnerChartDefaultURL.Get(), settings.PartnerChartDefaultBranch.Get()); err != nil {
 		return err
 	}
 
 	if features.RKE2.Enabled() {
-		if err := addRepo(wrangler, "rancher-rke2-charts", defaultURL, settings.RKE2ChartDefaultBranch.Get()); err != nil {
+		if err := addRepo(wrangler, "rancher-rke2-charts", setings.RKE2ChartDefaultURL.Get(), settings.RKE2ChartDefaultBranch.Get()); err != nil {
 			return err
 		}
 	}

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -26,8 +26,9 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 		repoURL = defaultURL + strings.TrimPrefix(repoName, prefix)
 	} else {
 		logrus.Warnf(
-			"System charts URL set to %q, which is not the default (%q). "+
+			"Charts URL for %q set to %q, which is not the default (%q). "+
 				"If Rancher has issues finding charts, consider resetting this to the default value",
+                        repoName,
 			repoURL,
 			defaultURL,
 		)

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/rancher/rancher/pkg/features"
+	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/rancher/rancher/pkg/settings"
@@ -14,11 +15,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const defaultURL = "https://git.rancher.io/"
+
 var (
 	prefix = "rancher-"
 )
 
-func addRepo(wrangler *wrangler.Context, repoName, branchName string) error {
+func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) error {
+	if repoURL == "" || repoURL == defaultURL {
+		repoURL = defaultURL + strings.TrimPrefix(repoName, prefix)
+	} else {
+		logrus.Warnf(
+			"System charts URL set to %q, which is not the default (%q). "+
+				"If Rancher has issues finding charts, consider resetting this to the default value",
+			repoURL,
+			defaultURL,
+		)
+	}
+
 	repo, err := wrangler.Catalog.ClusterRepo().Get(repoName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = wrangler.Catalog.ClusterRepo().Create(&v1.ClusterRepo{
@@ -26,11 +40,11 @@ func addRepo(wrangler *wrangler.Context, repoName, branchName string) error {
 				Name: repoName,
 			},
 			Spec: v1.RepoSpec{
-				GitRepo:   "https://git.rancher.io/" + strings.TrimPrefix(repoName, prefix),
+				GitRepo:   repoURL,
 				GitBranch: branchName,
 			},
 		})
-	} else if err == nil && repo.Spec.GitBranch != branchName {
+	} else if err == nil && (repo.Spec.GitRepo != repoURL || repo.Spec.GitBranch != branchName) {
 		repo.Spec.GitBranch = branchName
 		_, err = wrangler.Catalog.ClusterRepo().Update(repo)
 	}
@@ -40,15 +54,15 @@ func addRepo(wrangler *wrangler.Context, repoName, branchName string) error {
 
 // addRepos upserts the rancher-charts, rancher-partner-charts and rancher-rke2-charts ClusterRepos
 func addRepos(ctx context.Context, wrangler *wrangler.Context) error {
-	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultBranch.Get()); err != nil {
+	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultURL.Get(), settings.ChartDefaultBranch.Get()); err != nil {
 		return err
 	}
-	if err := addRepo(wrangler, "rancher-partner-charts", settings.PartnerChartDefaultBranch.Get()); err != nil {
+	if err := addRepo(wrangler, "rancher-partner-charts", defaultURL, settings.PartnerChartDefaultBranch.Get()); err != nil {
 		return err
 	}
 
 	if features.RKE2.Enabled() {
-		if err := addRepo(wrangler, "rancher-rke2-charts", settings.RKE2ChartDefaultBranch.Get()); err != nil {
+		if err := addRepo(wrangler, "rancher-rke2-charts", defaultURL, settings.RKE2ChartDefaultBranch.Get()); err != nil {
 			return err
 		}
 	}

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -28,7 +28,7 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 		logrus.Warnf(
 			"Charts URL for %q set to %q, which is not the default (%q). "+
 				"If Rancher has issues finding charts, consider resetting this to the default value",
-                        repoName,
+			repoName,
 			repoURL,
 			defaultURL,
 		)

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -54,15 +54,31 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 
 // addRepos upserts the rancher-charts, rancher-partner-charts and rancher-rke2-charts ClusterRepos
 func addRepos(ctx context.Context, wrangler *wrangler.Context) error {
-	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultURL.Get(), settings.ChartDefaultBranch.Get()); err != nil {
+	if err := addRepo(
+		wrangler,
+		"rancher-charts",
+		settings.ChartDefaultURL.Get(),
+		settings.ChartDefaultBranch.Get(),
+	); err != nil {
 		return err
 	}
-	if err := addRepo(wrangler, "rancher-partner-charts", settings.PartnerChartDefaultURL.Get(), settings.PartnerChartDefaultBranch.Get()); err != nil {
+
+	if err := addRepo(
+		wrangler,
+		"rancher-partner-charts",
+		settings.PartnerChartDefaultURL.Get(),
+		settings.PartnerChartDefaultBranch.Get(),
+	); err != nil {
 		return err
 	}
 
 	if features.RKE2.Enabled() {
-		if err := addRepo(wrangler, "rancher-rke2-charts", setings.RKE2ChartDefaultURL.Get(), settings.RKE2ChartDefaultBranch.Get()); err != nil {
+		if err := addRepo(
+			wrangler,
+			"rancher-rke2-charts",
+			settings.RKE2ChartDefaultURL.Get(),
+			settings.RKE2ChartDefaultBranch.Get(),
+		); err != nil {
 			return err
 		}
 	}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -145,6 +145,10 @@ var (
 	// AuthUserSessionTTLMinutes represents the time to live for tokens used for login sessions in minutes.
 	AuthUserSessionTTLMinutes = NewSetting("auth-user-session-ttl-minutes", "960") // 16 hours
 
+	// ChartDefaultURL represents the default URL for the system charts repo. It should only be set for test or
+	// debug purposes.
+	ChartDefaultURL = NewSetting("chart-default-url", "https://git.rancher.io/")
+
 	// ConfigMapName name of the configmap that stores rancher configuration information.
 	// Deprecated: to be removed in 2.8.0
 	ConfigMapName = NewSetting("config-map-name", "rancher-config")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -181,8 +181,16 @@ var (
 	// If set to false the kubeconfig will contain a command to login to Rancher.
 	KubeconfigGenerateToken = NewSetting("kubeconfig-generate-token", "true")
 
+	// PartnerChartDefaultURL represents the default URL for the partner charts repo. It should only be set for test
+	// or debug purposes.
+	PartnerChartDefaultURL = NewSetting("partner-chart-default-url", "https://git.rancher.io/")
+
 	// RancherWebhookVersion is the exact version of the webhook that Rancher will install.
 	RancherWebhookVersion = NewSetting("rancher-webhook-version", "")
+
+	// RKE2ChartDefaultURL represents the default URL for the RKE2 charts repo. It should only be set for test or
+	// debug purposes.
+	RKE2ChartDefaultURL = NewSetting("rke2-chart-default-url", "https://git.rancher.io/")
 
 	// SystemDefaultRegistry is the default contrainer registry used for images.
 	// The environmental variable "CATTLE_BASE_REGISTRY" controls the default value of this setting.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -116,8 +116,6 @@ var (
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
 	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.9")
 	SystemManagedChartsOperationTimeout = NewSetting("system-managed-charts-operation-timeout", "300s")
-	PartnerChartDefaultBranch           = NewSetting("partner-chart-default-branch", "main")
-	RKE2ChartDefaultBranch              = NewSetting("rke2-chart-default-branch", "main")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none
 	ShellImage                          = NewSetting("shell-image", buildconfig.DefaultShellVersion)
 	IgnoreNodeName                      = NewSetting("ignore-node-name", "") // nodes to ignore when syncing v1.node to v3.node
@@ -181,12 +179,18 @@ var (
 	// If set to false the kubeconfig will contain a command to login to Rancher.
 	KubeconfigGenerateToken = NewSetting("kubeconfig-generate-token", "true")
 
+	// PartnerChartDefaultBranch represents the default branch for the partner charts repo.
+	PartnerChartDefaultBranch = NewSetting("partner-chart-default-branch", "main")
+
 	// PartnerChartDefaultURL represents the default URL for the partner charts repo. It should only be set for test
 	// or debug purposes.
 	PartnerChartDefaultURL = NewSetting("partner-chart-default-url", "https://git.rancher.io/")
 
 	// RancherWebhookVersion is the exact version of the webhook that Rancher will install.
 	RancherWebhookVersion = NewSetting("rancher-webhook-version", "")
+
+	// RKE2ChartDefaultBranch represents the default branch for the RKE2 charts repo.
+	RKE2ChartDefaultBranch = NewSetting("rke2-chart-default-branch", "main")
 
 	// RKE2ChartDefaultURL represents the default URL for the RKE2 charts repo. It should only be set for test or
 	// debug purposes.


### PR DESCRIPTION
## Issue: #43527
 
## Problem
Testing any system chart against Rancher requires following one of these methods:
* using a custom `rancher/charts` branch to be specified in `CATTLE_CHART_DEFAULT_BRANCH`, which would end up polluting `rancher/charts` with test branches
* using airgap mode ("bundled") and building a [custom repository](https://github.com/rancher/rancher/pull/41523/commits/1aaba7da2187cec6301e7fe11891571558241771) to install a specific version of a Helm chart, which in turn requires running Rancher outside of a cluster or `ADD`ing that custom repository over the [clone in the rancher/rancher image](https://github.com/rancher/rancher/blob/e5deaaf81f8af41a1219d3470a0876d384119386/package/Dockerfile#L64C1-L74)
* adding another layer to the Rancher image, which contains our bundled system chart version in the bundled repository

There should be an easier way.

## Solution
Expose new environment variables and their corresponding settings for their respective charts repositories:
| Environment variable | Setting | Repository |
|---------------------------------|------------|-----------------|
| `CATTLE_CHART_DEFAULT_URL` |  `ChartDefaultURL` | `rancher/charts`| 
| `CATTLE_PARTNER_CHART_DEFAULT_URL` |  `PartnerChartDefaultURL` | `rancher/partner-charts`| 
| `CATTLE_RKE2_CHART_DEFAULT_URL` |  `RKE2ChartDefaultURL` | `rancher/rke2-charts`| 

These options are intended for internal use only. When in use, Rancher issues a warning suggesting to unset it should any issues be encountered when fetching charts.
 
## Testing

## Engineering Testing
### Manual Testing

Having set `CATTLE_FLEET_VERSION` to `103.1.0+up0.9.0-rc.5` (no longer available in `rancher/charts` branch `dev-v2.8`, since Fleet `0.9.0` has been un-RC-ed), tested the following use cases:

1. Leaving new setting `CATTLE_CHART_DEFAULT_URL` unset: Fleet is installed in version `0.9.0` (bug fixed via #43498 ; using code from that PR leads to Rancher not installing Fleet and outputting an error instead, as expected)
2. Setting `CATTLE_CHART_DEFAULT_URL` to an empty value: same behaviour as in 1.

3. Having created a [fork](https://github.com/weyfonk/charts) of `rancher/charts`, created a `test-revert-0-9-0` branch on that fork, reverting the commit un-RC-ing Fleet 0.9.0, so that Fleet `0.9.0-rc.5` would be available on that branch. Set `CATTLE_CHART_DEFAULT_BRANCH` to `test-revert-0-9-0` and `CATTLE_CHART_DEFAULT_URL` to the fork's URL, namely `https://github.com/weyfonk/charts`. Could see Fleet installed in version `0.9.0-rc.5`.

### Automated Testing
* Test types added/modified:
    * None - unclear how to automatically test these changes: would a separate test charts repo be needed?

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
N/A