### PR TITLE
[v2.8] Add upgrade strategy customization and fix RKE1 snapshots

### DIFF
--- a/tests/framework/extensions/etcdsnapshot/config.go
+++ b/tests/framework/extensions/etcdsnapshot/config.go
@@ -5,6 +5,11 @@ const (
 )
 
 type Config struct {
-	UpgradeKubernetesVersion string `json:"upgradeKubernetesVersion" yaml:"upgradeKubernetesVersion"`
-	SnapshotRestore          string `json:"snapshotRestore" yaml:"snapshotRestore"`
+	UpgradeKubernetesVersion     string `json:"upgradeKubernetesVersion" yaml:"upgradeKubernetesVersion"`
+	SnapshotRestore              string `json:"snapshotRestore" yaml:"snapshotRestore"`
+	ControlPlaneConcurrencyValue string `json:"controlPlaneConcurrencyValue" yaml:"controlPlaneConcurrencyValue"`
+	ControlPlaneUnavailableValue string `json:"controlPlaneUnavailableValue" yaml:"controlPlaneUnavailableValue"`
+	WorkerConcurrencyValue       string `json:"workerConcurrencyValue" yaml:"workerConcurrencyValue"`
+	WorkerUnavailableValue       string `json:"workerUnavailableValue" yaml:"workerUnavailableValue"`
+	RecurringRestores            int    `json:"recurringRestores" yaml:"recurringRestores"`
 }

--- a/tests/framework/extensions/etcdsnapshot/etcdsnapshot.go
+++ b/tests/framework/extensions/etcdsnapshot/etcdsnapshot.go
@@ -2,6 +2,7 @@ package etcdsnapshot
 
 import (
 	"strings"
+	"time"
 
 	"github.com/rancher/norman/types"
 	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -9,8 +10,9 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -100,27 +102,36 @@ func CreateRKE1Snapshot(client *rancher.Client, clusterName string) error {
 		return err
 	}
 
-	backupConfig := clusterResp.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig
-
-	etcdBackup := &management.EtcdBackup{
-		BackupConfig: &management.BackupConfig{
-			Enabled:        backupConfig.Enabled,
-			IntervalHours:  backupConfig.IntervalHours,
-			Retention:      backupConfig.Retention,
-			S3BackupConfig: backupConfig.S3BackupConfig,
-			SafeTimestamp:  backupConfig.SafeTimestamp,
-			Timeout:        backupConfig.Timeout,
-		},
-		ClusterID: clusterID,
-		Manual:    false,
-		Name:      clusterID + "-" + namegen.AppendRandomString(""),
-		Status: &management.EtcdBackupStatus{
-			KubernetesVersion: clusterResp.RancherKubernetesEngineConfig.Version,
-		},
+	logrus.Infof("Creating snapshot...")
+	err = client.Management.Cluster.ActionBackupEtcd(clusterResp)
+	if err != nil {
+		return err
 	}
 
-	logrus.Infof("Creating snapshot...")
-	_, err = client.Management.EtcdBackup.Create(etcdBackup)
+	err = wait.Poll(1*time.Second, defaults.FiveMinuteTimeout, func() (bool, error) {
+		snapshotSteveObjList, err := client.Management.EtcdBackup.ListAll(&types.ListOpts{
+			Filters: map[string]interface{}{
+				"clusterId": clusterID,
+			},
+		})
+		if err != nil {
+			return false, nil
+		}
+
+		for _, snapshot := range snapshotSteveObjList.Data {
+			snapshotObj, err := client.Management.EtcdBackup.ByID(snapshot.ID)
+			if err != nil {
+				return false, nil
+			}
+
+			if snapshotObj.State != active {
+				return false, nil
+			}
+		}
+
+		logrus.Infof("All snapshots in the cluster are in an active state!")
+		return true, nil
+	})
 	if err != nil {
 		return err
 	}
@@ -159,11 +170,40 @@ func CreateRKE2K3SSnapshot(client *rancher.Client, clusterName string) error {
 		return err
 	}
 
+	err = wait.Poll(1*time.Second, defaults.FiveMinuteTimeout, func() (bool, error) {
+		snapshotSteveObjList, err := client.Steve.SteveType("rke.cattle.io.etcdsnapshot").List(nil)
+		if err != nil {
+			return false, nil
+		}
+
+		_, clusterSteveObject, err := clusters.GetProvisioningClusterByName(client, clusterName, fleetNamespace)
+		if err != nil {
+			return false, nil
+		}
+
+		for _, snapshot := range snapshotSteveObjList.Data {
+			snapshotObj, err := client.Steve.SteveType("rke.cattle.io.etcdsnapshot").ByID(snapshot.ID)
+			if err != nil {
+				return false, nil
+			}
+
+			if snapshotObj.ObjectMeta.State.Name == active && clusterSteveObject.ObjectMeta.State.Name == active {
+				logrus.Infof("All snapshots in the cluster are in an active state!")
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // RestoreRKE1Snapshot is a helper function to restore a snapshot on an RKE1 cluster. Returns error if any.
-func RestoreRKE1Snapshot(client *rancher.Client, clusterName string, snapshotRestore *management.RestoreFromEtcdBackupInput, kubernetesVersion string) error {
+func RestoreRKE1Snapshot(client *rancher.Client, clusterName string, snapshotRestore *management.RestoreFromEtcdBackupInput) error {
 	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
 	if err != nil {
 		return err
@@ -174,12 +214,8 @@ func RestoreRKE1Snapshot(client *rancher.Client, clusterName string, snapshotRes
 		return err
 	}
 
-	clusterResp.RancherKubernetesEngineConfig.Restore.Restore = true
-	clusterResp.RancherKubernetesEngineConfig.Restore.SnapshotName = snapshotRestore.EtcdBackupID
-	clusterResp.RancherKubernetesEngineConfig.Version = kubernetesVersion
-
 	logrus.Infof("Restoring snapshot: %v", snapshotRestore.EtcdBackupID)
-	_, err = client.Management.Cluster.Update(clusterResp, &clusterResp)
+	err = client.Management.Cluster.ActionRestoreFromEtcdBackup(clusterResp, snapshotRestore)
 	if err != nil {
 		return err
 	}
@@ -189,15 +225,15 @@ func RestoreRKE1Snapshot(client *rancher.Client, clusterName string, snapshotRes
 
 // CreateRKE2K3SSnapshot is a helper function to restore a snapshot on an RKE2 or k3s cluster. Returns error if any.
 func RestoreRKE2K3SSnapshot(client *rancher.Client, clusterName string, snapshotRestore *rkev1.ETCDSnapshotRestore) error {
-	clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clusterName, fleetNamespace)
+	clusterObject, existingSteveAPIObject, err := clusters.GetProvisioningClusterByName(client, clusterName, fleetNamespace)
 	if err != nil {
 		return err
 	}
 
-	clusterObj.Spec.RKEConfig.ETCDSnapshotRestore = snapshotRestore
+	clusterObject.Spec.RKEConfig.ETCDSnapshotRestore = snapshotRestore
 
 	logrus.Infof("Restoring snapshot: %v", snapshotRestore.Name)
-	_, err = client.Steve.SteveType(ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
+	_, err = client.Steve.SteveType(ProvisioningSteveResouceType).Update(existingSteveAPIObject, clusterObject)
 	if err != nil {
 		return err
 	}

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -97,7 +97,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
-		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, c.provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
+		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/snapshot/README.md
+++ b/tests/v2/validation/snapshot/README.md
@@ -19,6 +19,11 @@ rancher:
 snapshotInput:
   upgradeKubernetesVersion: "v1.27.6+rke2r1" # If left blank, the default version in Rancher will be used.
   snapshotRestore: "all" # Options include none, kubernetesVersion, all. Option 'none' means that only the etcd will be restored.
+  controlPlaneConcurrencyValue: "15%"
+  workerConcurrencyValue: "20%"
+  controlPlaneUnavailableValue: "1"
+  workerUnavailableValue: "10%"
+  recurringRestores: 1 # By default, this is set to 1 if this field is not included in the config.
 ```
 
 Additionally, S3 is a supported restore option. If you choose to use S3, then you must have it already enabled on the downstream cluster.
@@ -26,22 +31,13 @@ Additionally, S3 is a supported restore option. If you choose to use S3, then yo
 These tests utilize Go build tags. Due to this, see the below example on how to run the tests:
 
 ### Snapshot restore
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreTestSuite/TestRKE1SnapshotRestore"` \
-
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreTestSuite/TestRKE2K3SSnapshotRestore"` \
-
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestore"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestoreDynamicInput"`
 
 ### Snapshot restore with K8s upgrade
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreK8sUpgradeTestSuite/TestRKE1SnapshotRestoreK8sUpgrade"` \
-
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreK8sUpgradeTestSuite/TestRKE2K3SSnapshotRestoreK8sUpgrade"` \
-
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreK8sUpgradeTestSuite/TestSnapshotRestoreK8sUpgrade"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreK8sUpgradeTestSuite/TestSnapshotRestoreK8sUpgradeDynamicInput"`
 
 ### Sanpshot restore with upgrade strategy
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreUpgradeStrategyTestSuite/TestRKE1SnapshotRestoreUpgradeStrategy"` \
-
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreUpgradeStrategyTestSuite/TestRKE2K3SSnapshotRestoreUpgradeStrategy"` \
-
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreUpgradeStrategyTestSuite/TestSnapshotRestoreUpgradeStrategy"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreUpgradeStrategyTestSuite/TestSnapshotRestoreUpgradeStrategyDynamicInput"`

--- a/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -43,11 +43,13 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
 		UpgradeKubernetesVersion: s.clustersConfig.UpgradeKubernetesVersion,
 		SnapshotRestore:          "kubernetesVersion",
+		RecurringRestores:        1,
 	}
 
 	snapshotRestoreAll := &etcdsnapshot.Config{
 		UpgradeKubernetesVersion: s.clustersConfig.UpgradeKubernetesVersion,
 		SnapshotRestore:          "all",
+		RecurringRestores:        1,
 	}
 
 	tests := []struct {
@@ -61,13 +63,13 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot, false)
+			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
 		})
 	}
 }
 
 func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgradeDynamicInput() {
-	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig, false)
+	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/tests/v2/validation/snapshot/snapshot_restore_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_test.go
@@ -43,25 +43,26 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 	snapshotRestoreNone := &etcdsnapshot.Config{
 		UpgradeKubernetesVersion: "",
 		SnapshotRestore:          "none",
+		RecurringRestores:        1,
 	}
 
 	tests := []struct {
-		name        string
-		etcdRestore *etcdsnapshot.Config
-		client      *rancher.Client
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
 	}{
 		{"Restore etcd only", snapshotRestoreNone, s.client},
 	}
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdRestore, false)
+			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
 		})
 	}
 }
 
 func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnlyDynamicInput() {
-	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig, false)
+	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -41,19 +41,29 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) SetupSuite() {
 
 func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStrategy() {
 	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion: s.clustersConfig.UpgradeKubernetesVersion,
-		SnapshotRestore:          "kubernetesVersion",
+		UpgradeKubernetesVersion:     s.clustersConfig.UpgradeKubernetesVersion,
+		SnapshotRestore:              "kubernetesVersion",
+		ControlPlaneConcurrencyValue: "15%",
+		ControlPlaneUnavailableValue: "1",
+		WorkerConcurrencyValue:       "20%",
+		WorkerUnavailableValue:       "10%",
+		RecurringRestores:            1,
 	}
 
 	snapshotRestoreAll := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion: s.clustersConfig.UpgradeKubernetesVersion,
-		SnapshotRestore:          "all",
+		UpgradeKubernetesVersion:     s.clustersConfig.UpgradeKubernetesVersion,
+		SnapshotRestore:              "all",
+		ControlPlaneConcurrencyValue: "15%",
+		ControlPlaneUnavailableValue: "1",
+		WorkerConcurrencyValue:       "20%",
+		WorkerUnavailableValue:       "10%",
+		RecurringRestores:            1,
 	}
 
 	tests := []struct {
-		name        string
-		etcdRestore *etcdsnapshot.Config
-		client      *rancher.Client
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
 	}{
 		{"Restore Kubernetes version and etcd", snapshotRestoreK8sVersion, s.client},
 		{"Restore cluster config, Kubernetes version and etcd", snapshotRestoreAll, s.client},
@@ -61,13 +71,13 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig, true)
+			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
 		})
 	}
 }
 
 func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStrategyDynamicInput() {
-	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig, true)
+	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig)
 }
 
 // In order for 'go test' to run this suite, we need to create


### PR DESCRIPTION
## Issues: <!-- link the issue or issues this PR resolves here --> [Add customization to the upgrade strategy in the snapshot test suite](https://github.com/rancher/qa-tasks/issues/1037) | [Allow customization of the amount of times an etcd snapshot will restore for a downstream cluster](https://github.com/rancher/qa-tasks/issues/993)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
This PR is another entry in the overall epic issue to add to the new etcd snapshot restore test suite. The test suite, currently, does not allow for customization of values when it comes to the upgrade strategy. This is the only entry where this problem exists as Kubernetes version and snapshot restore options are customizable.

Additionally, the RKE1 snapshots were referencing the incorrect function call. This was resulting in flaky behavior when running the snapshot restore for RKE1 clusters.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Implemented customization for upgrade strategy values
- Fixed flakiness in RKE1 snapshots by calling the correct functions for etcd backup and etcd restore.
- Added customization to the amount of times the same snapshot is restored
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually tested changing the concurrency values for K3S clusters and the unavailability values for RKE1 clusters; both worked fine.

### Automated Testing
Jenkins jobs will be provided to reviewers offline.