### PR TITLE
[2.8] removing logic for 2.4 and below from docker airgap, adding 2.7+

### DIFF
--- a/tests/validation/tests/v3_api/test_airgap.py
+++ b/tests/validation/tests/v3_api/test_airgap.py
@@ -550,12 +550,7 @@ def optionally_add_cluster_to_rancher(bastion_node, ag_nodes, prep="none"):
 
 def deploy_airgap_rancher(bastion_node):
     ag_node = prepare_airgap_node(bastion_node, 1)[0]
-    if "v2.5" in RANCHER_SERVER_VERSION or \
-            "v2.6" in RANCHER_SERVER_VERSION or \
-            "master" in RANCHER_SERVER_VERSION:
-        privileged = "--privileged"
-    else:
-        privileged = ""
+    privileged = "--privileged"
     if RANCHER_HA_CERT_OPTION == 'byo-valid':
         write_cert_command = "cat <<EOT >> fullchain.pem\n{}\nEOT".format(
             base64.b64decode(RANCHER_VALID_TLS_CERT).decode("utf-8"))


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/1050

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 docker container was failing. We have to currently manually add each minor release to the job.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
remove the logic for special casing future versions. We never run airgap on 2.5 or below, so it doesn't make sense to keep that in. 

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios --> 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_