### PR TITLE
kubectl crud for GlobalRoles

### DIFF
--- a/tests/framework/extensions/kubectl/template.go
+++ b/tests/framework/extensions/kubectl/template.go
@@ -3,6 +3,8 @@ package kubectl
 import (
 	"context"
 
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/kubeconfig"
 	batchv1 "k8s.io/api/batch/v1"
@@ -63,7 +65,7 @@ func CreateJobAndRunKubectlCommands(clusterID, jobname string, job *batchv1.Job,
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "rancher-installer2",
+			Name: namegen.AppendRandomString("rancher-installer2"),
 		},
 	}
 	_, err = downClient.Resource(corev1.SchemeGroupVersion.WithResource("serviceaccounts")).Namespace(Namespace).Create(context.TODO(), unstructured.MustToUnstructured(sa), metav1.CreateOptions{})
@@ -73,7 +75,7 @@ func CreateJobAndRunKubectlCommands(clusterID, jobname string, job *batchv1.Job,
 
 	rb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "rancher-install-cluster-admin",
+			Name: namegen.AppendRandomString("rancher-install-cluster-admin"),
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/tests/v2/validation/publicapi/crdgeneration/crd_generation.go
+++ b/tests/v2/validation/publicapi/crdgeneration/crd_generation.go
@@ -114,7 +114,8 @@ func validateRoleCreation(t *testing.T, client *rancher.Client, clusterV1 *v1.Cl
 		YAML: string(role),
 	}
 
-	podLogs, err := kubectl.Apply(client, clusterV1, yamlInput, clusterID)
+	command := []string{"kubectl", "apply", "-f", "/root/.kube/my-pod.yaml"}
+	podLogs, err := kubectl.Command(client, clusterV1, yamlInput, clusterID, command)
 	require.NoError(t, err)
 	errorLogs := "Unsupported value: \"invalid\": supported values: \"project\", \"cluster\""
 

--- a/tests/v2/validation/publicapi/globalroles/globalroles.go
+++ b/tests/v2/validation/publicapi/globalroles/globalroles.go
@@ -1,0 +1,73 @@
+package globalroles
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/kubectl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	apiVersion = "management.cattle.io/v3"
+	kind       = "GlobalRole"
+)
+
+func kubectlApplyOrDelete(t *testing.T, client *rancher.Client, clusterV1 *v1.Cluster, roleStruct interface{}, clusterID, operation, expectedLog string) {
+	roleJSON, err := json.Marshal(roleStruct)
+	require.NoError(t, err)
+
+	yamlInput := &management.ImportClusterYamlInput{
+		YAML: string(roleJSON),
+	}
+
+	command := []string{"kubectl", "", "-f", "/root/.kube/my-pod.yaml"}
+	command[1] = operation
+	podLogs, err := kubectl.Command(client, clusterV1, yamlInput, clusterID, command)
+	require.NoError(t, err)
+
+	assert.Contains(t, podLogs, expectedLog)
+}
+
+func deleteGlobalRole(t *testing.T, client *rancher.Client, clusterV1 *v1.Cluster, clusterID, roleName, expectedLog string) {
+
+	command := []string{"kubectl", "delete", "globalrole", roleName}
+	podLogs, err := kubectl.Command(client, clusterV1, nil, clusterID, command)
+	require.NoError(t, err)
+
+	assert.Contains(t, podLogs, expectedLog)
+}
+
+func readGlobalRole(t *testing.T, client *rancher.Client, clusterV1 *v1.Cluster, clusterID, roleName, expectedLog string) {
+
+	command := []string{"kubectl", "get", "globalrole", roleName}
+	podLogs, err := kubectl.Command(client, clusterV1, nil, clusterID, command)
+	require.NoError(t, err)
+
+	assert.Contains(t, podLogs, expectedLog)
+}
+
+func setupGlobalRole(name string, builtIn bool, inheritedRoles []string) *v3.GlobalRole {
+	globalRole := v3.GlobalRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		DisplayName:           name,
+		Rules:                 nil,
+		NewUserDefault:        false,
+		Builtin:               builtIn,
+		InheritedClusterRoles: inheritedRoles,
+	}
+	return &globalRole
+}

--- a/tests/v2/validation/publicapi/globalroles/globalroles_test.go
+++ b/tests/v2/validation/publicapi/globalroles/globalroles_test.go
@@ -1,0 +1,107 @@
+//go:build (validation || infra.any || cluster.any || sanity) && !stress && !extended
+
+package globalroles
+
+import (
+	"context"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"testing"
+
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	fleetLocal       = "fleet-local"
+	localCluster     = "local"
+	applyOption      = "apply"
+	deleteOption     = "delete"
+	expectCreated    = "created"
+	expectConfigured = "configured"
+	expectDeleted    = "deleted"
+	expectDenied     = "denied"
+	adminRole        = "admin"
+)
+
+type GlobalRolesTestSuite struct {
+	suite.Suite
+	client    *rancher.Client
+	session   *session.Session
+	cluster   *management.Cluster
+	clusterV1 *v1.Cluster
+}
+
+func (gr *GlobalRolesTestSuite) TearDownSuite() {
+	gr.session.Cleanup()
+}
+
+func (gr *GlobalRolesTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	gr.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(gr.T(), err)
+
+	gr.client = client
+
+	require.NoError(gr.T(), err)
+
+	kubeClient, err := gr.client.GetKubeAPIProvisioningClient()
+	require.NoError(gr.T(), err)
+
+	gr.clusterV1, err = kubeClient.Clusters(fleetLocal).Get(context.TODO(), localCluster, metav1.GetOptions{})
+	require.NoError(gr.T(), err)
+}
+
+func (gr *GlobalRolesTestSuite) crudGlobalRole() {
+
+	roles := []string{"cluster-admin"}
+	validGR := setupGlobalRole(namegen.AppendRandomString("valid"), false, roles)
+	invalidGR := setupGlobalRole(namegen.AppendRandomString("invalid"), true, roles)
+
+	gr.Run("Create GlobalRole", func() {
+		kubectlApplyOrDelete(gr.T(), gr.client, gr.clusterV1, validGR, localCluster, applyOption, expectCreated)
+	})
+
+	gr.Run("Edit GlobalRole", func() {
+		validGR.DisplayName = "changed"
+		kubectlApplyOrDelete(gr.T(), gr.client, gr.clusterV1, validGR, localCluster, applyOption, expectConfigured)
+	})
+
+	gr.Run("Invalid Edit GlobalRole Builtin", func() {
+		validGR.Builtin = true
+		kubectlApplyOrDelete(gr.T(), gr.client, gr.clusterV1, validGR, localCluster, applyOption, expectDenied)
+	})
+
+	gr.Run("Delete GlobalRole By File", func() {
+		kubectlApplyOrDelete(gr.T(), gr.client, gr.clusterV1, validGR, localCluster, deleteOption, expectDeleted)
+	})
+
+	gr.Run("Invalid Create GlobalRole", func() {
+		kubectlApplyOrDelete(gr.T(), gr.client, gr.clusterV1, invalidGR, localCluster, applyOption, expectDenied)
+	})
+
+	gr.Run("Delete Builtin GlobalRole", func() {
+		deleteGlobalRole(gr.T(), gr.client, gr.clusterV1, localCluster, adminRole, expectDenied)
+	})
+
+	gr.Run("Read GlobalRole", func() {
+		readGlobalRole(gr.T(), gr.client, gr.clusterV1, localCluster, adminRole, adminRole)
+	})
+}
+
+func (gr *GlobalRolesTestSuite) TestGlobalRoles() {
+	subSession := gr.session.NewSession()
+	defer subSession.Cleanup()
+	gr.crudGlobalRole()
+}
+
+func TestGlobalRolesTestSuite(t *testing.T) {
+	suite.Run(t, new(GlobalRolesTestSuite))
+}


### PR DESCRIPTION
remove struct

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Testing CRUD via public API via kubectl

- https://github.com/rancher/qa-tasks/issues/903
- https://github.com/rancher/qa-tasks/issues/904
- https://github.com/rancher/qa-tasks/issues/905
- https://github.com/rancher/qa-tasks/issues/906
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Found a bug within kubectl apply where it was searching using contains. Added some name generation to fix bugs with failed runs. Added tests to check crud operations via public API / kubectl.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the newly added kubectl apply function to be more flexible. It can now accept various commands, and is optional whether to pass yaml.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Local runs, and jenkins freeform run

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manual local machine runs

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)

Newly added kubectl apply function was changed to be more flexible, excepting various commands and taking in a yaml file as optional.
