### PR TITLE
fix returned error when failing to decode SamlConfig `SpCert`

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -107,7 +107,7 @@ func InitializeSamlServiceProvider(configToSet *v32.SamlConfig, name string) err
 	if configToSet.SpCert != "" {
 		block, _ := pem.Decode([]byte(configToSet.SpCert))
 		if block == nil {
-			return fmt.Errorf("SAML: failed to parse PEM block containing the private key")
+			return fmt.Errorf("SAML: failed to parse PEM block containing the certificate")
 		}
 
 		cert, err = x509.ParseCertificate(block.Bytes)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/30271

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
### Summary
Upon observing the rancher deployment logs, the current error message when decoding the `SpCert` field is misleading indicating an issue with the `SamlConfig` `SpKey`, when the issue actually lies with parsing the PEM block of the certificate.

### Detailed
We had an issue that started with deploying the certificate via our IaC pipeline.

When we realised the SAML provider integration in Rancher was having issues post-deployment, we observed the error message:

> _SAML: failed to parse PEM block containing the private key_

As we saw this message, we assumed it was a formatting issue with the _private_ key, and spent hours trying to fix it. After digging into the underlying error message changed in this PR, we realised it was actually an issue with the _certificate_ being decoded and not the private key. Following that understanding it was easy to correct our mistake.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
_Change the error message as per the diff._
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
_None, semantic change._