### PR TITLE
integration test suite: unbreak f-string

### DIFF
--- a/tests/integration/suite/conftest.py
+++ b/tests/integration/suite/conftest.py
@@ -560,7 +560,7 @@ def kubernetes_api_client(rancher_client, cluster_name):
 
 def protect_response(r):
     if r.status_code >= 300:
-        message = 'Server responded with {r.status_code}\nbody:\n{r.text}'
+        message = f'Server responded with {r.status_code}\nbody:\n{r.text}'
         raise ValueError(message)
 
 


### PR DESCRIPTION
## Issue: none
 
## Problem
Integration test suite failures do not display full error messages.

eg.

```
conftest.py:216: in _create_user
    protect_response(response)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

r = <Response [500]>

    def protect_response(r):
        if r.status_code >= 300:
            message = 'Server responded with {r.status_code}\nbody:\n{r.text}'
>           raise ValueError(message)
E           ValueError: Server responded with {r.status_code}
E           body:
E           {r.text}
```

Note that ` {r.text}` is outputted verbatim.

## Solution
Use the correct f-string syntax, which was apparently accidentally broken in 2018:

https://github.com/rancher/rancher/commit/54b0c7e6cb634f53070dfca42f7e86838a8a116c#diff-8abd4f38f06b237b8f31c7b3eb83c1561ab1feea91ad89e421e161b50e2dd48fL266-R268
 
## Testing

Summary: no testing of test code fixes.

## QA Testing Considerations
No regression expected. 

### Regressions Considerations
No regression expected. 
