### PR TITLE
Drone: fix s390x tag build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -705,12 +705,26 @@ clone:
   disable: true
 
 steps:
-- name: clone
+- name: clone-pr
   image: alpine/git:v2.30.2-s390x
   commands:
   - git clone $DRONE_GIT_HTTP_URL  .
   - git fetch origin $DRONE_COMMIT_REF
-  - git checkout $DRONE_COMMIT -b origin/$DRONE_TARGET_BRANCH
+  - git checkout $DRONE_COMMIT -b origin/${DRONE_TARGET_BRANCH}
+  when:
+    event:
+      - push
+      - pull_request
+
+- name: clone-tag
+  image: alpine/git:v2.30.2-s390x
+  commands:
+    - git clone $DRONE_GIT_HTTP_URL  .
+    - git fetch origin $DRONE_COMMIT_REF
+    - git checkout $DRONE_COMMIT -b origin/${DRONE_TAG}
+  when:
+    event:
+      - tag
 
 - name: build-pr
   image: rancher/dapper:v0.6.0

--- a/tests/integration/suite/conftest.py
+++ b/tests/integration/suite/conftest.py
@@ -560,7 +560,7 @@ def kubernetes_api_client(rancher_client, cluster_name):
 
 def protect_response(r):
     if r.status_code >= 300:
-        message = 'Server responded with {r.status_code}\nbody:\n{r.text}'
+        message = f'Server responded with {r.status_code}\nbody:\n{r.text}'
         raise ValueError(message)
 
 


### PR DESCRIPTION
## Issue: untracked
 
## Problem
drone-publish `clone` step build will fail when building from a tag:

```
+ git clone $DRONE_GIT_HTTP_URL  .
Cloning into '.'...
+ git fetch origin $DRONE_COMMIT_REF
From https://github.com/rancher/rancher
 * tag                   v2.7.9-debug-42864-2 -> FETCH_HEAD
+ git checkout $DRONE_COMMIT -b origin/$DRONE_TARGET_BRANCH
fatal: 'origin/' is not a valid branch name.
```

Example: https://drone-publish.rancher.io/rancher/rancher/10998/7/1

Reason is $DRONE_TARGET_BRANCH is not set for a tag build: https://docs.drone.io/pipeline/environment/reference/drone-target-branch/, but code expects it.
 
## Solution
Use $DRONE_TARGET_BRANCH for pull requests and branch pushes, $DRONE_TAG for tag builds.
 
## Testing

### Automated Testing
One build's clone step succeeded:

https://drone-publish.rancher.io/rancher/rancher/11007/7/1

Summary: covered

