### PR TITLE
[2.8] add automation support for out-of-tree cloud provider testing with AWS RKE1

### DIFF
--- a/tests/framework/extensions/charts/awsoutoftree.go
+++ b/tests/framework/extensions/charts/awsoutoftree.go
@@ -1,0 +1,265 @@
+package charts
+
+import (
+	"time"
+
+	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
+
+	appv1 "k8s.io/api/apps/v1"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	repoType                     = "catalog.cattle.io.clusterrepo"
+	appsType                     = "catalog.cattle.io.apps"
+	awsUpstreamCloudProviderRepo = "https://github.com/kubernetes/cloud-provider-aws.git"
+	masterBranch                 = "master"
+	AwsUpstreamChartName         = "aws-cloud-controller-manager"
+	kubeSystemNamespace          = "kube-system"
+)
+
+// InstallAWSOutOfTreeChart installs the CSI chart for aws cloud provider in a given cluster.
+func InstallAWSOutOfTreeChart(client *rancher.Client, installOptions *InstallOptions, repoName, clusterID string) error {
+	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
+	if err != nil {
+		return err
+	}
+
+	registrySetting, err := client.Management.Setting.ByID(defaultRegistrySettingID)
+	if err != nil {
+		return err
+	}
+
+	awsChartInstallActionPayload := &payloadOpts{
+		InstallOptions:  *installOptions,
+		Name:            AwsUpstreamChartName,
+		Namespace:       kubeSystemNamespace,
+		Host:            serverSetting.Value,
+		DefaultRegistry: registrySetting.Value,
+	}
+
+	chartInstallAction := awsChartInstallAction(awsChartInstallActionPayload, repoName, kubeSystemNamespace, installOptions.ProjectID)
+
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	err = catalogClient.InstallChart(chartInstallAction, repoName)
+	if err != nil {
+		return err
+	}
+
+	err = VerifyChartInstall(catalogClient, kubeSystemNamespace, AwsUpstreamChartName)
+	if err != nil {
+		return err
+	}
+
+	steveclient, err := client.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return err
+	}
+
+	chartNodeSelector := map[string]string{
+		"node-role.kubernetes.io/controlplane": "true",
+	}
+	err = updateHelmNodeSelectors(steveclient, kubeSystemNamespace, AwsUpstreamChartName, chartNodeSelector)
+
+	return err
+}
+
+// awsChartInstallAction is a helper function that returns a chartInstallAction for aws out-of-tree chart.
+func awsChartInstallAction(awsChartInstallActionPayload *payloadOpts, repoName, chartNamespace, chartProject string) *types.ChartInstallAction {
+	chartValues := map[string]interface{}{
+		"args": []interface{}{
+			"--use-service-account-credentials=true",
+			"--configure-cloud-routes=false",
+			"--v=2",
+			"--cloud-provider=aws",
+		},
+		// note: order of []interface{} must match the chart's order. A union is taken in the order given (not a pure replacement of the object)
+		"clusterRoleRules": []interface{}{
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"events",
+				},
+				"verbs": []interface{}{
+					"patch",
+					"create",
+					"update",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"nodes",
+				},
+				"verbs": []interface{}{
+					"*",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"nodes/status",
+				},
+				"verbs": []interface{}{
+					"patch",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"services",
+				},
+				"verbs": []interface{}{
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"services/status",
+				},
+				"verbs": []interface{}{
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"serviceaccounts",
+				},
+				"verbs": []interface{}{
+					"get",
+					"create",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"persistentvolumes",
+				},
+				"verbs": []interface{}{
+					"get",
+					"list",
+					"update",
+					"watch",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"endpoints",
+				},
+				"verbs": []interface{}{
+					"get",
+					"create",
+					"list",
+					"watch",
+					"update",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{
+					"coordination.k8s.io",
+				},
+				"resources": []interface{}{
+					"leases",
+				},
+				"verbs": []interface{}{
+					"get",
+					"create",
+					"list",
+					"watch",
+					"update",
+				},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{""},
+				"resources": []interface{}{
+					"serviceaccounts/token",
+				},
+				"verbs": []interface{}{
+					"create",
+				},
+			},
+		},
+		"nodeSelector": map[string]interface{}{
+			"node-role.kubernetes.io/controlplane": "true",
+		},
+		"tolerations": []interface{}{
+			map[string]interface{}{
+				"effect": "NoSchedule",
+				"value":  "true",
+				"key":    "node-role.kubernetes.io/controlplane",
+			},
+			map[string]interface{}{
+				"effect": "NoSchedule",
+				"value":  "true",
+				"key":    "node.cloudprovider.kubernetes.io/uninitialized",
+			},
+			map[string]interface{}{
+				"effect": "NoSchedule",
+				"value":  "true",
+				"key":    "node-role.kubernetes.io/master",
+			},
+		},
+	}
+
+	chartInstall := newChartInstall(
+		awsChartInstallActionPayload.Name,
+		awsChartInstallActionPayload.InstallOptions.Version,
+		awsChartInstallActionPayload.InstallOptions.ClusterID,
+		awsChartInstallActionPayload.InstallOptions.ClusterName,
+		awsChartInstallActionPayload.Host,
+		repoName,
+		chartProject,
+		awsChartInstallActionPayload.DefaultRegistry,
+		chartValues)
+	chartInstalls := []types.ChartInstall{*chartInstall}
+
+	return newChartInstallAction(chartNamespace, awsChartInstallActionPayload.ProjectID, chartInstalls)
+}
+
+// updateHelmNodeSelectors is a function that updates the newNodeSelector for a given Daemonset's nodeSelector. This is required due to an
+// upstream bug in helm charts, where you can't override the nodeSelector during a deployment of an upstream chart.
+func updateHelmNodeSelectors(client *steveV1.Client, daemonsetNamespace, daemonsetName string, newNodeSelector map[string]string) error {
+	err := kwait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		_, err = client.SteveType(pods.DaemonsetSteveType).ByID(daemonsetNamespace + "/" + daemonsetName)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	steveDaemonset, err := client.SteveType(pods.DaemonsetSteveType).ByID(daemonsetNamespace + "/" + daemonsetName)
+	if err != nil {
+		return err
+	}
+
+	daemonsetObject := new(appv1.DaemonSet)
+	err = steveV1.ConvertToK8sType(steveDaemonset, &daemonsetObject)
+	if err != nil {
+		return err
+	}
+
+	daemonsetObject.Spec.Template.Spec.NodeSelector = newNodeSelector
+
+	_, err = client.SteveType(pods.DaemonsetSteveType).Update(steveDaemonset, daemonsetObject)
+	return err
+}

--- a/tests/framework/extensions/charts/payloads.go
+++ b/tests/framework/extensions/charts/payloads.go
@@ -47,10 +47,10 @@ func newChartUpgradeAction(namespace string, chartUpgrades []types.ChartUpgrade)
 }
 
 // newChartInstallAction is a private constructor that creates a chart install with given chart values that can be used for chart install action.
-func newChartInstall(name, version, clusterID, clusterName, url, defaultRegistry string, chartValues map[string]interface{}) *types.ChartInstall {
+func newChartInstall(name, version, clusterID, clusterName, url, repoName, projectID, defaultRegistry string, chartValues map[string]interface{}) *types.ChartInstall {
 	chartInstall := types.ChartInstall{
 		Annotations: map[string]string{
-			"catalog.cattle.io/ui-source-repo":      "rancher-charts",
+			"catalog.cattle.io/ui-source-repo":      repoName,
 			"catalog.cattle.io/ui-source-repo-type": "cluster",
 		},
 		ChartName:   name,
@@ -65,6 +65,7 @@ func newChartInstall(name, version, clusterID, clusterName, url, defaultRegistry
 					"rkeWindowsPathPrefix":  "",
 					"systemDefaultRegistry": defaultRegistry,
 					"url":                   url,
+					"systemProjectId":       projectID,
 				},
 				"systemDefaultRegistry": defaultRegistry,
 			},

--- a/tests/framework/extensions/charts/ranchergatekeeper.go
+++ b/tests/framework/extensions/charts/ranchergatekeeper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	kubenamespaces "github.com/rancher/rancher/tests/framework/extensions/kubeapi/namespaces"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
@@ -158,7 +159,7 @@ func InstallRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 		})
 	})
 
-	err = catalogClient.InstallChart(chartInstallAction)
+	err = catalogClient.InstallChart(chartInstallAction, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}
@@ -189,8 +190,8 @@ func InstallRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 
 // newGatekeeperChartInstallAction is a helper function that returns an array of newChartInstallActions for installing the gatekeeper and gatekeepr-crd charts
 func newGatekeeperChartInstallAction(p *payloadOpts) *types.ChartInstallAction {
-	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, nil)
-	chartInstallCRD := newChartInstall(p.Name+"-crd", p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, nil)
+	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
+	chartInstallCRD := newChartInstall(p.Name+"-crd", p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
 
 	chartInstalls := []types.ChartInstall{*chartInstallCRD, *chartInstall}
 
@@ -226,7 +227,7 @@ func UpgradeRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 		return err
 	}
 
-	err = catalogClient.UpgradeChart(chartUpgradeAction)
+	err = catalogClient.UpgradeChart(chartUpgradeAction, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}

--- a/tests/framework/extensions/charts/rancheristio.go
+++ b/tests/framework/extensions/charts/rancheristio.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	kubenamespaces "github.com/rancher/rancher/tests/framework/extensions/kubeapi/namespaces"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
@@ -123,7 +124,7 @@ func InstallRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 		})
 	})
 
-	err = catalogClient.InstallChart(chartInstallAction)
+	err = catalogClient.InstallChart(chartInstallAction, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}
@@ -177,7 +178,7 @@ func newIstioChartInstallAction(p *payloadOpts, rancherIstioOpts *RancherIstioOp
 			"enabled": rancherIstioOpts.CNI,
 		},
 	}
-	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, istioValues)
+	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, istioValues)
 	chartInstalls := []types.ChartInstall{*chartInstall}
 
 	chartInstallAction := newChartInstallAction(p.Namespace, p.InstallOptions.ProjectID, chartInstalls)
@@ -212,7 +213,7 @@ func UpgradeRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 		return err
 	}
 
-	err = catalogClient.UpgradeChart(chartUpgradeAction)
+	err = catalogClient.UpgradeChart(chartUpgradeAction, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}

--- a/tests/framework/extensions/charts/rancherlogging.go
+++ b/tests/framework/extensions/charts/rancherlogging.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	kubenamespaces "github.com/rancher/rancher/tests/framework/extensions/kubeapi/namespaces"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
@@ -153,7 +154,7 @@ func InstallRancherLoggingChart(client *rancher.Client, installOptions *InstallO
 		})
 	})
 
-	err = catalogClient.InstallChart(chartInstallAction)
+	err = catalogClient.InstallChart(chartInstallAction, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}
@@ -190,8 +191,8 @@ func newLoggingChartInstallAction(p *payloadOpts, rancherLoggingOpts *RancherLog
 		},
 	}
 
-	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, loggingValues)
-	chartInstallCRD := newChartInstall(p.Name+"-crd", p.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, nil)
+	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, loggingValues)
+	chartInstallCRD := newChartInstall(p.Name+"-crd", p.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
 	chartInstalls := []types.ChartInstall{*chartInstallCRD, *chartInstall}
 
 	chartInstallAction := newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)

--- a/tests/framework/extensions/charts/ranchermonitoring.go
+++ b/tests/framework/extensions/charts/ranchermonitoring.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	kubenamespaces "github.com/rancher/rancher/tests/framework/extensions/kubeapi/namespaces"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
@@ -155,7 +156,7 @@ func InstallRancherMonitoringChart(client *rancher.Client, installOptions *Insta
 		})
 	})
 
-	err = catalogClient.InstallChart(chartInstallAction)
+	err = catalogClient.InstallChart(chartInstallAction, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}
@@ -211,8 +212,8 @@ func newMonitoringChartInstallAction(p *payloadOpts, rancherMonitoringOpts *Ranc
 		},
 	}
 
-	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, monitoringValues)
-	chartInstallCRD := newChartInstall(p.Name+"-crd", p.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, nil)
+	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, monitoringValues)
+	chartInstallCRD := newChartInstall(p.Name+"-crd", p.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
 	chartInstalls := []types.ChartInstall{*chartInstallCRD, *chartInstall}
 
 	chartInstallAction := newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)
@@ -247,7 +248,7 @@ func UpgradeRancherMonitoringChart(client *rancher.Client, installOptions *Insta
 		return err
 	}
 
-	err = catalogClient.UpgradeChart(chartUpgradeAction)
+	err = catalogClient.UpgradeChart(chartUpgradeAction, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}

--- a/tests/framework/extensions/charts/verify.go
+++ b/tests/framework/extensions/charts/verify.go
@@ -1,0 +1,34 @@
+package charts
+
+import (
+	"context"
+
+	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// VerifyChartInstall verifies that the app from a chart was successfully deployed
+func VerifyChartInstall(client *catalog.Client, chartNamespace, chartName string) error {
+	watchAppInterface, err := client.Apps(chartNamespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + chartName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+		app := event.Object.(*v1.App)
+
+		state := app.Status.Summary.State
+		if state == string(v1.StatusDeployed) {
+			return true, nil
+		}
+		return false, nil
+	})
+	return err
+}

--- a/tests/framework/extensions/clusters/clusterconfig.go
+++ b/tests/framework/extensions/clusters/clusterconfig.go
@@ -30,6 +30,7 @@ type ClusterConfig struct {
 	UpgradeStrategy      *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy" yaml:"upgradeStrategy"`
 	Advanced             *provisioningInput.Advanced              `json:"advanced" yaml:"advanced"`
 	ClusterSSHTests      []provisioningInput.SSHTestCase          `json:"clusterSSHTests" yaml:"clusterSSHTests"`
+	CRIDockerd           bool                                     `json:"criDockerd" yaml:"criDockerd"`
 }
 
 // ConvertConfigToClusterConfig converts the config from (user) provisioning input to a cluster config

--- a/tests/framework/extensions/defaults/defaults.go
+++ b/tests/framework/extensions/defaults/defaults.go
@@ -3,8 +3,9 @@ package defaults
 import "time"
 
 var (
-	WatchTimeoutSeconds = int64(60 * 30) // 30 minutes.
-	FiveMinuteTimeout   = 5 * time.Minute
-	TenMinuteTimeout    = 10 * time.Minute
-	ThirtyMinuteTimeout = 30 * time.Minute
+	WatchTimeoutSeconds  = int64(60 * 30) // 30 minutes.
+	FiveMinuteTimeout    = 5 * time.Minute
+	TenMinuteTimeout     = 10 * time.Minute
+	FifteenMinuteTimeout = 15 * time.Minute
+	ThirtyMinuteTimeout  = 30 * time.Minute
 )

--- a/tests/framework/extensions/provisioning/verify.go
+++ b/tests/framework/extensions/provisioning/verify.go
@@ -96,8 +96,10 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 		}
 	}
 
-	podErrors := pods.StatusPods(client, cluster.ID)
-	assert.Empty(t, podErrors)
+	if !strings.Contains(clustersConfig.CloudProvider, "external") {
+		podErrors := pods.StatusPods(client, cluster.ID)
+		assert.Empty(t, podErrors)
+	}
 }
 
 // VerifyCluster validates that a non-rke1 cluster and its resources are in a good state, matching a given config.

--- a/tests/framework/extensions/provisioninginput/config.go
+++ b/tests/framework/extensions/provisioninginput/config.go
@@ -218,4 +218,5 @@ type Config struct {
 	UpgradeStrategy        *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy,omitempty" yaml:"upgradeStrategy,omitempty"`
 	Advanced               *Advanced                                `json:"advanced,omitempty" yaml:"advanced,omitempty"`
 	ClusterSSHTests        []SSHTestCase                            `json:"clusterSSHTests,omitempty" yaml:"clusterSSHTests,omitempty"`
+	CRIDockerd             bool                                     `json:"criDockerd,omitempty" yaml:"criDockerd,omitempty"`
 }

--- a/tests/framework/extensions/workloads/pods/pod_status.go
+++ b/tests/framework/extensions/workloads/pods/pod_status.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	corev1 "k8s.io/api/core/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
@@ -25,7 +26,7 @@ func StatusPods(client *rancher.Client, clusterID string) []error {
 	var podErrors []error
 
 	steveClient := downstreamClient.SteveType(PodResourceSteveType)
-	err = kwait.Poll(5*time.Second, 15*time.Minute, func() (done bool, err error) {
+	err = kwait.Poll(5*time.Second, defaults.FifteenMinuteTimeout, func() (done bool, err error) {
 		// emptying pod errors every time we poll so that we don't return stale errors
 		podErrors = []error{}
 

--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -6,6 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"testing"
+	"time"
+
 	rv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -19,7 +23,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/repo"
-	"io"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"testing"
-	"time"
 )
 
 var propagation = metav1.DeletePropagationForeground
@@ -130,7 +131,7 @@ func (w *RancherManagedChartsTest) TestInstallChartLatestVersion() {
 	w.Require().NoError(w.updateManagementCluster())
 	app, _, err := w.waitForAksChart(rv1.StatusDeployed, "rancher-aks-operator", 0)
 	w.Require().NoError(err)
-	latest, err := w.catalogClient.GetLatestChartVersion("rancher-aks-operator")
+	latest, err := w.catalogClient.GetLatestChartVersion("rancher-aks-operator", catalog.RancherChartRepo)
 	w.Require().NoError(err)
 	w.Assert().Equal(app.Spec.Chart.Metadata.Version, latest)
 }

--- a/tests/v2/integration/catalogv2/system_charts_version_test.go
+++ b/tests/v2/integration/catalogv2/system_charts_version_test.go
@@ -67,7 +67,7 @@ func (w *SystemChartsVersionSuite) SetupSuite() {
 	w.restClientGetter, err = kubeconfig.NewRestGetter(restConfig, *kubeConfig)
 	require.NoError(w.T(), err)
 
-	w.latestWebhookVersion, err = w.catalogClient.GetLatestChartVersion(rancherWebhook)
+	w.latestWebhookVersion, err = w.catalogClient.GetLatestChartVersion(rancherWebhook, catalog.RancherChartRepo)
 	require.NoError(w.T(), err)
 
 	require.NoError(w.T(), w.updateSetting("rancher-webhook-version", w.latestWebhookVersion))
@@ -200,7 +200,7 @@ func (w *SystemChartsVersionSuite) TestInstallFleet() {
 	})
 	w.Require().NoError(err)
 
-	latest, err := w.catalogClient.GetLatestChartVersion("fleet")
+	latest, err := w.catalogClient.GetLatestChartVersion("fleet", catalog.RancherChartRepo)
 	w.Require().NoError(err)
 
 	// Ensure Rancher deployed the latest version when the minimum version is below the latest.

--- a/tests/v2/validation/charts/gatekeeper_test.go
+++ b/tests/v2/validation/charts/gatekeeper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
@@ -49,7 +50,7 @@ func (g *GateKeeperTestSuite) SetupSuite() {
 	require.NoError(g.T(), err)
 
 	// get latest version of gatekeeper chart
-	latestGatekeeperVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherGatekeeperName)
+	latestGatekeeperVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherGatekeeperName, catalog.RancherChartRepo)
 	require.NoError(g.T(), err)
 
 	// Create project
@@ -146,7 +147,7 @@ func (g *GateKeeperTestSuite) TestUpgradeGatekeeperChart() {
 	require.NoError(g.T(), err)
 
 	// Change gatekeeper install option version to previous version of the latest version
-	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherGatekeeperName)
+	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherGatekeeperName, catalog.RancherChartRepo)
 	require.NoError(g.T(), err)
 
 	if len(versionsList) < 2 {
@@ -188,7 +189,7 @@ func (g *GateKeeperTestSuite) TestUpgradeGatekeeperChart() {
 	chartVersionPreUpgrade := gatekeeperChartPreUpgrade.ChartDetails.Spec.Chart.Metadata.Version
 	require.Contains(g.T(), versionsList[1:], chartVersionPreUpgrade)
 
-	g.gatekeeperChartInstallOptions.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherGatekeeperName)
+	g.gatekeeperChartInstallOptions.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherGatekeeperName, catalog.RancherChartRepo)
 	require.NoError(g.T(), err)
 
 	g.T().Log("Upgrading gatekeeper chart to the latest version")

--- a/tests/v2/validation/charts/istio_test.go
+++ b/tests/v2/validation/charts/istio_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
@@ -61,9 +62,9 @@ func (i *IstioTestSuite) SetupSuite() {
 	}
 
 	// Get latest versions of monitoring & istio charts
-	latestIstioVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherIstioName)
+	latestIstioVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherIstioName, catalog.RancherChartRepo)
 	require.NoError(i.T(), err)
-	latestMonitoringVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName)
+	latestMonitoringVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName, catalog.RancherChartRepo)
 	require.NoError(i.T(), err)
 
 	// Create project
@@ -252,7 +253,7 @@ func (i *IstioTestSuite) TestUpgradeIstioChart() {
 	}
 
 	// Change istio install option version to previous version of the latest version
-	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherIstioName)
+	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherIstioName, catalog.RancherChartRepo)
 	require.NoError(i.T(), err)
 	require.Greaterf(i.T(), len(versionsList), 1, "There should be at least 2 versions of the istio chart")
 	versionLatest := versionsList[0]
@@ -300,7 +301,7 @@ func (i *IstioTestSuite) TestUpgradeIstioChart() {
 		require.Containsf(i.T(), imageVersion, istioVersionPreUpgrade, "Pilot & Ingressgateways images don't use the correct istio image version")
 	}
 
-	i.chartInstallOptions.istio.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherIstioName)
+	i.chartInstallOptions.istio.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherIstioName, catalog.RancherChartRepo)
 	require.NoError(i.T(), err)
 
 	i.T().Log("Upgrading istio chart with the latest version")

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
@@ -72,7 +73,7 @@ func (m *MonitoringTestSuite) SetupSuite() {
 	prometheusTargetsPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusTargetsPath)
 
 	// Get latest versions of the monitoring chart
-	latestMonitoringVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName)
+	latestMonitoringVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName, catalog.RancherChartRepo)
 	require.NoError(m.T(), err)
 
 	// Get project system projectId
@@ -261,7 +262,7 @@ func (m *MonitoringTestSuite) TestUpgradeMonitoringChart() {
 	require.NoError(m.T(), err)
 
 	// Change monitoring install option version to previous version of the latest version
-	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherMonitoringName)
+	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherMonitoringName, catalog.RancherChartRepo)
 	require.NoError(m.T(), err)
 	require.Greaterf(m.T(), len(versionsList), 1, "There should be at least 2 versions of the monitoring chart")
 	versionLatest := versionsList[0]
@@ -297,7 +298,7 @@ func (m *MonitoringTestSuite) TestUpgradeMonitoringChart() {
 	chartVersionPreUpgrade := monitoringChartPreUpgrade.ChartDetails.Spec.Chart.Metadata.Version
 	assert.Contains(m.T(), versionsList[1:], chartVersionPreUpgrade)
 
-	m.chartInstallOptions.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName)
+	m.chartInstallOptions.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName, catalog.RancherChartRepo)
 	require.NoError(m.T(), err)
 
 	m.T().Log("Upgrading monitoring chart with the latest version")

--- a/tests/v2/validation/charts/webhook_test.go
+++ b/tests/v2/validation/charts/webhook_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/kubeconfig"
@@ -44,7 +45,7 @@ func (w *WebhookTestSuite) SetupSuite() {
 
 	// Get clusterName from config yaml
 	w.clusterList = client.RancherConfig.ClusterName
-	w.chartVersion, err = client.Catalog.GetLatestChartVersion(charts.RancherWebhookName)
+	w.chartVersion, err = client.Catalog.GetLatestChartVersion(charts.RancherWebhookName, catalog.RancherChartRepo)
 	require.NoError(w.T(), err)
 
 }

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -37,6 +37,7 @@ provisioningInput:
   providers: ["linode", "aws", "do", "harvester"]
   nodeProviders: ["ec2"]
   psact: ""
+  criDockerd: false
   etcdRKE1:
     backupConfig:
       enabled: true

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
@@ -259,7 +260,7 @@ func (u *UpgradeWorkloadTestSuite) testPreUpgradeSingleCluster(clusterName strin
 		if !loggingChart.IsAlreadyInstalled {
 			clusterName, err := clusters.GetClusterNameByID(client, project.ClusterID)
 			require.NoError(u.T(), err)
-			latestLoggingVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherLoggingName)
+			latestLoggingVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherLoggingName, catalog.RancherChartRepo)
 			require.NoError(u.T(), err)
 
 			loggingChartInstallOption := &charts.InstallOptions{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/1030

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
out of tree requires chart(s) be installed post creation of a cluster. So simply setting the provider type for the cluster won't suffice. We must also add the charts repo, deploy the necessary charts, and finally do standard provider checks. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
* add logic for setting cloud provider in rke1 (This also opens the door for in-tree support, however this workflow has not been tested as thoroughly as it isn't the primary purpose of this ticket)
* add logic to install a repo and charts of a repo to the cluster as part of provisioning -- This should be considered part of provisioning because the cluster won't work properly when `external*` is set as the cloud provider, as nodes are tainted. 
* add logic to verify charts are installed
* plugin existing verification of out-of-tree provider from rke2 work
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested extensively locally when installing the charts on multiple versions of k8s for rke1. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
n/a

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

TODO: run on jenkins

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
this opens up the door for other provider related tests, both in tree and out-of-tree, as well as p1 and p2 use cases, i.e. migration from in-tree to out-of-tree. 
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
this is new functionality, unless the `if` logic is incorrect there shouldn't be room for regressions. 

