### PR TITLE
Remove metadata.namespace field from ClusterRoleBinding manifest for existing cluster imports

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -48,7 +48,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cattle-admin-binding
-  namespace: cattle-system
   labels:
     cattle.io/creator: "norman"
 subjects:


### PR DESCRIPTION
## Problem
One of the ClusterRoleBinding manifests generated for the import of existing clusters has a `metadata.namespace` field. This is incorrect, as [ClusterRoleBindings](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) are **not** namespaced objects.

Applying via `kubectl` does not throw an error, however other tools that do stricter validation might: for example Terraform throws an error during the `plan` phase:

```bash
15:56:55  │ Error: Cluster level resource cannot take namespace
15:56:55  │ 
15:56:55  │   with module.internal-services.kubernetes_manifest.rancher_agent_manifest["5"],
15:56:55  │   on .terraform/modules/internal-services/eks/rancher_agent_registration.tf line 7, in resource "kubernetes_manifest" "rancher_agent_manifest":
15:56:55  │    7: resource "kubernetes_manifest" "rancher_agent_manifest" {
15:56:55  │ 
15:56:55  │ Resources of type 'rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding'
15:56:55  │ cannot have a namespace
```

Note that there are two ClusterRoleBinding objects in the generated manifests, and one of them correctly omits the `metadata.namespace` field, [as seen in the template here](https://github.com/rancher/rancher/blob/release/v2.8/pkg/systemtemplate/template.go#L18-L30).
 
## Solution
Removing the offending line from the `cattle-admin-binding` ClusterRoleBinding object in [pkg/systemtemplate/template.go](https://github.com/rancher/rancher/blob/release/v2.8/pkg/systemtemplate/template.go) solves this issue.

## Testing
When applying the ClusterRoleBinding manifest with high verbosity, it is visible in the Kubernetes API's response body that the `metadata.namespace` field has been dropped/disregarded:

```bash
kubectl -v=8 apply -f $RANCHER_IMPORT_URL
``` 

Furthermore, applying the manifest without the "offending" field leads to a successful cluster import as well.