### PR TITLE
[DNM] Migrate dependency of system-charts/rancher-k3s-upgrader to use charts/system-upgrade-controller

### DIFF
--- a/pkg/catalogv2/content/content.go
+++ b/pkg/catalogv2/content/content.go
@@ -44,8 +44,12 @@ import (
 
 // TODO:
 //  * CHECK IF I  CAN DO THIS WAY: there is no need for cache interface, we just need a "Get", therefore I changed the interface.
-//  * IMO is not worth to instantiate the cache of the downstream using this interface for this. We can cast the "Client" interface to use Get without options.
-//  * Check where to create this interfaces, for avoiding import cicles I also created one on catalogv2/secrets.go, should I create a package? What rules do we use?
+//  * IMO is not worth to instantiate the cache of the downstream wile installing using the upstreamcluster; I created this interfaces for this.
+//      We can cast the "Client" interface to use Get without options.
+//  * Check where to create this interfaces, for avoiding import cicles I also created one on catalogv2/secrets.go,
+//      should I create a package? What rules do we use?
+//  *  Should I have an Generic and specific interfaces or can i have directly the ones that I need (this will
+//      make more sense if we unifie this interfaces with the one from secret)
 
 // GenericNoOptionGetter  generic implementation of a "Get" this should be used to retrieve an object given a namespace
 // and name. The generic.CacheInterface[T runtime.Object] already implements it, the client interface must be changed to
@@ -72,12 +76,12 @@ type ClusterRepoNoNamespaceNoOptionGetter interface {
 // The Manager struct uses clientsets provided by the wrangler library
 // to interact with the Kubernetes API and quickly fetch instances of ConfigMaps, Secrets, and ClusterRepos.
 type Manager struct {
-	configMaps   ConfigMapNoOptionGetter              // clientset for getting ConfigMaps, this can be a cache or a client.
-	secrets      catalogv2.SecretGetterNoOption       // clientset for getting Secrets this can be a cache or a client.
-	clusterRepos ClusterRepoNoNamespaceNoOptionGetter // clientset for getting ClusterRepo custom resources this can be a cache or a client.
-	discovery    discovery.DiscoveryInterface         // An interface to the Kubernetes Discovery API. Provides information about the Kubernetes API server.
-	IndexCache   map[string]indexCache                // cache for Helm repository index files. Used to store and retrieve index files for faster access.
-	lock         sync.RWMutex                         // read-write mutex used to ensure that some Manager's operations are thread-safe.
+	configMaps   ConfigMapNoOptionGetter                // clientset for getting ConfigMaps, this can be a cache or a client.
+	secrets      catalogv2.SecretNoOptionGetterNoOption // clientset for getting Secrets this can be a cache or a client.
+	clusterRepos ClusterRepoNoNamespaceNoOptionGetter   // clientset for getting ClusterRepo custom resources this can be a cache or a client.
+	discovery    discovery.DiscoveryInterface           // An interface to the Kubernetes Discovery API. Provides information about the Kubernetes API server.
+	IndexCache   map[string]indexCache                  // cache for Helm repository index files. Used to store and retrieve index files for faster access.
+	lock         sync.RWMutex                           // read-write mutex used to ensure that some Manager's operations are thread-safe.
 }
 
 // indexCache - used to cache helm chart indexes
@@ -98,7 +102,7 @@ type repoDef struct {
 func NewManager(
 	discovery discovery.DiscoveryInterface,
 	configMaps ConfigMapNoOptionGetter,
-	secrets catalogv2.SecretGetterNoOption,
+	secrets catalogv2.SecretNoOptionGetterNoOption,
 	clusterRepos ClusterRepoNoNamespaceNoOptionGetter) *Manager {
 	return &Manager{
 		discovery:    discovery,

--- a/pkg/catalogv2/secret.go
+++ b/pkg/catalogv2/secret.go
@@ -2,12 +2,17 @@ package catalogv2
 
 import (
 	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
-	corev1controllers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
+// TODO - CHECK WHERE SHOULD I PUT THIS INTERFACES !
+
+type SecretGetterNoOption interface {
+	Get(namespace, name string) (*corev1.Secret, error)
+}
+
 // GetSecret returns the Secret from the cluster repo's clientSecret spec field
-func GetSecret(secrets corev1controllers.SecretCache, repoSpec *v1.RepoSpec, repoNamespace string) (*corev1.Secret, error) {
+func GetSecret(secrets SecretGetterNoOption, repoSpec *v1.RepoSpec, repoNamespace string) (*corev1.Secret, error) {
 	if repoSpec.ClientSecret == nil {
 		return nil, nil
 	}

--- a/pkg/catalogv2/secret.go
+++ b/pkg/catalogv2/secret.go
@@ -7,12 +7,13 @@ import (
 
 // TODO - CHECK WHERE SHOULD I PUT THIS INTERFACES !
 
-type SecretGetterNoOption interface {
+// SecretNoOptionGetterNoOption requires a Get(namespace, name string) (*corev1.Secret, error), cache implements this by default
+type SecretNoOptionGetterNoOption interface {
 	Get(namespace, name string) (*corev1.Secret, error)
 }
 
 // GetSecret returns the Secret from the cluster repo's clientSecret spec field
-func GetSecret(secrets SecretGetterNoOption, repoSpec *v1.RepoSpec, repoNamespace string) (*corev1.Secret, error) {
+func GetSecret(secrets SecretNoOptionGetterNoOption, repoSpec *v1.RepoSpec, repoNamespace string) (*corev1.Secret, error) {
 	if repoSpec.ClientSecret == nil {
 		return nil, nil
 	}

--- a/pkg/catalogv2/system/downstream_manager.go
+++ b/pkg/catalogv2/system/downstream_manager.go
@@ -1,0 +1,130 @@
+package system
+
+import (
+	"context"
+
+	v12 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	v1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
+	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/pkg/generic"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DownstreamManager is an implementation of Manager that allows the upstream cluster to interact with the downstream one.
+// It doesn't start any controller, nor loops to ensure that the charts are up-to-date.
+// Only the functions Ensure (used to install) and Manager.Uninstall should be used.
+type DownstreamManager struct {
+	Manager
+}
+
+// NewDownstreamManager can be used to create a DownstreamManager manually.
+func NewDownstreamManager(ctx context.Context,
+	contentManager ContentClient,
+	ops OperationClient,
+	pods corecontrollers.PodClient,
+	helmClient HelmClient) (*DownstreamManager, error) {
+
+	m := Manager{
+		ctx:                   ctx,
+		operation:             ops,
+		content:               contentManager,
+		pods:                  pods,
+		sync:                  nil,
+		desiredCharts:         nil,
+		refreshIntervalChange: nil,
+		settings:              nil,
+		trigger:               nil,
+		clusterRepos:          nil,
+		helmClient:            helmClient,
+	}
+
+	return &DownstreamManager{m}, nil
+}
+
+// Start this function shouldn't be used, the DownstreamManager doesn't start controllers nor have the logic to keep
+// the charts up to date. Use Ensure directly to install the charts.
+func (d *DownstreamManager) Start(_ context.Context) {
+	log.Error("The DownstreamManager shouldn't be started, calling ensure directly will ensure that the chart is installed.")
+	return
+}
+
+// Ensure differently of the Manager this function will call installCharts directly. It doesn't have any loop that
+// will keep the chart up to date.
+func (d *DownstreamManager) Ensure(namespace, name, minVersion, exactVersion string, values map[string]interface{}, forceAdopt bool, installImageOverride string) error {
+
+	return d.installCharts(
+		map[desiredKey]map[string]interface{}{
+			desiredKey{
+				namespace:            namespace,
+				name:                 name,
+				minVersion:           minVersion,
+				exactVersion:         exactVersion,
+				installImageOverride: installImageOverride,
+			}: values,
+		},
+		forceAdopt,
+	)
+}
+
+// Remove DownstreamManager don't have the concept of "required charts" therefore the remove function is useless
+func (d *DownstreamManager) Remove(_, _ string) {
+	log.Error("The DownstreamManager doesn't handle syncs, therefore we don't have a map of required maps, to uninstall use Uninstall")
+	return
+}
+
+// TODO:
+//   * Is it better to do one for each or to us generics?  If i use generics the "IDE" Complains about miss implementation, despite it working.
+//   * Where should this interfaces be declared? Do we have any rule / recommendation about it?
+
+// HelmNoNamespaceNoOptGetter allows a v1.ClusterRepoController to be used as a content.ClusterRepoNoNamespaceNoOptionGetter.
+// It does so  by using the .Get with empty Options
+type HelmNoNamespaceNoOptGetter struct {
+	v1.ClusterRepoController
+}
+
+func (n HelmNoNamespaceNoOptGetter) Get(name string) (*v12.ClusterRepo, error) {
+	return n.ClusterRepoController.Get(name, metav1.GetOptions{})
+}
+
+// ConfigMapNoOptGetter allows a ConfigMapClient to be used as a content.ConfigMapNoOptionGetter.
+// It does so  by using the .Get with empty Options
+type ConfigMapNoOptGetter struct {
+	corecontrollers.ConfigMapClient
+}
+
+func (n ConfigMapNoOptGetter) Get(namespace, name string) (*corev1.ConfigMap, error) {
+	return n.ConfigMapClient.Get(namespace, name, metav1.GetOptions{})
+}
+
+// SecretNoOptGetter allows a SecretClient to be used as a catalogv2.SecretGetterNoOption .
+// It does so  by using the .Get with empty Options
+type SecretNoOptGetter struct {
+	corecontrollers.SecretClient
+}
+
+func (n SecretNoOptGetter) Get(namespace, name string) (*corev1.Secret, error) {
+	return n.SecretClient.Get(namespace, name, metav1.GetOptions{})
+}
+
+// NoNamespaceNoOptGetter is a generic implementation that allows a NonNamespacedControllerInterface to be used as a
+// ClusterRepoNoNamespaceNoOptionGetter TODO - VAlidate if I do generic or not here.
+type NoNamespaceNoOptGetter[T generic.RuntimeMetaObject, TList runtime.Object] struct {
+	generic.NonNamespacedControllerInterface[T, TList]
+}
+
+func (n NoNamespaceNoOptGetter[T, TList]) Get(name string) (T, error) {
+	return n.NonNamespacedControllerInterface.Get(name, metav1.GetOptions{})
+}
+
+// NoOptGetter is an implementation tha allows a ClientInterface to be cast to a content.GenericNoOptionGetter
+// It does it by calling hte Get with empty GetOptions. This does not implement any cache strategy.
+type NoOptGetter[T generic.RuntimeMetaObject, TList runtime.Object] struct {
+	generic.ClientInterface[T, TList]
+}
+
+func (n NoOptGetter[T, TList]) Get(namespace, name string) (T, error) {
+	return n.ClientInterface.Get(namespace, name, metav1.GetOptions{})
+}

--- a/pkg/catalogv2/system/downstream_manager.go
+++ b/pkg/catalogv2/system/downstream_manager.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DownstreamManager is an implementation of Manager that allows the upstream cluster to interact with the downstream one.
-// It doesn't start any controller, nor loops to ensure that the charts are up-to-date.
+// It doesn't start any controller, nor loops. It DOESN'T ensure that the charts are kept up-to-date.
 // Only the functions Ensure (used to install) and Manager.Uninstall should be used.
 type DownstreamManager struct {
 	Manager
@@ -47,7 +47,7 @@ func NewDownstreamManager(ctx context.Context,
 // Start this function shouldn't be used, the DownstreamManager doesn't start controllers nor have the logic to keep
 // the charts up to date. Use Ensure directly to install the charts.
 func (d *DownstreamManager) Start(_ context.Context) {
-	log.Error("The DownstreamManager shouldn't be started, calling ensure directly will ensure that the chart is installed.")
+	log.Error("The DownstreamManager shouldn't be started, calling ensure directly will install the required chart.")
 	return
 }
 

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 	"github.com/rancher/wrangler/pkg/generated/controllers/rbac"
 	"github.com/rancher/wrangler/pkg/generic"
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/discovery/cached/memory"
@@ -155,9 +156,8 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName, updateVersion str
 	// it will only return when the deployment is done or if an error happens.
 	if err := m.Ensure("cattle-system", "system-upgrade-controller",
 		"", settings.SystemUpgradeControllerChartVersion.Get(), value, true, ""); err != nil {
-		fmt.Println("Failed to ENSURE with err %s", err.Error())
+		log.Errorf("Failed to install the system-upgrade-controller with error: %s", err.Error())
 		return err
-
 	}
 
 	return nil

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -128,7 +128,7 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName, updateVersion str
 
 	m, err := h.newDownstreamManagerFromUserContext(userCtx)
 	if err != nil {
-		panic(err.Error())
+		return err
 	}
 
 	// determine what version of Kubernetes we are updating to

--- a/pkg/controllers/management/k3sbasedupgrade/register.go
+++ b/pkg/controllers/management/k3sbasedupgrade/register.go
@@ -7,6 +7,7 @@ import (
 	manager2 "github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	wranglerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	wranglerv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	projectv3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/systemaccount"
@@ -20,6 +21,7 @@ type handler struct {
 	systemUpgradeNamespace string
 	clusterCache           wranglerv3.ClusterCache
 	clusterClient          wranglerv3.ClusterClient
+	clusterV1Cache         wranglerv1.ClusterCache
 	catalogManager         manager2.CatalogManager
 	apps                   projectv3.AppInterface
 	appLister              projectv3.AppLister
@@ -42,13 +44,14 @@ func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.M
 		systemUpgradeNamespace: systemUpgradeNS,
 		clusterCache:           wContext.Mgmt.Cluster().Cache(),
 		clusterClient:          wContext.Mgmt.Cluster(),
+		clusterV1Cache:         wContext.Provisioning.Cluster().Cache(),
 		catalogManager:         mgmtCtx.CatalogManager,
-		clusterEnqueueAfter:    wContext.Mgmt.Cluster().EnqueueAfter,
 		apps:                   mgmtCtx.Project.Apps(metav1.NamespaceAll),
 		appLister:              mgmtCtx.Project.Apps("").Controller().Lister(),
 		nodeLister:             mgmtCtx.Management.Nodes("").Controller().Lister(),
 		systemAccountManager:   systemaccount.NewManager(mgmtCtx),
 		manager:                manager,
+		clusterEnqueueAfter:    wContext.Mgmt.Cluster().EnqueueAfter,
 	}
 	wContext.Mgmt.Cluster().OnChange(ctx, "k3s-upgrade-controller", h.onClusterChange)
 }

--- a/pkg/controllers/management/k3sbasedupgrade/register.go
+++ b/pkg/controllers/management/k3sbasedupgrade/register.go
@@ -16,13 +16,13 @@ import (
 )
 
 type handler struct {
+	ctx                    context.Context
 	systemUpgradeNamespace string
 	clusterCache           wranglerv3.ClusterCache
 	clusterClient          wranglerv3.ClusterClient
 	catalogManager         manager2.CatalogManager
 	apps                   projectv3.AppInterface
 	appLister              projectv3.AppLister
-	templateLister         v3.CatalogTemplateLister
 	nodeLister             v3.NodeLister
 	systemAccountManager   *systemaccount.Manager
 	manager                *clustermanager.Manager
@@ -38,6 +38,7 @@ const (
 
 func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.ManagementContext, manager *clustermanager.Manager) {
 	h := &handler{
+		ctx:                    ctx,
 		systemUpgradeNamespace: systemUpgradeNS,
 		clusterCache:           wContext.Mgmt.Cluster().Cache(),
 		clusterClient:          wContext.Mgmt.Cluster(),
@@ -45,7 +46,6 @@ func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.M
 		clusterEnqueueAfter:    wContext.Mgmt.Cluster().EnqueueAfter,
 		apps:                   mgmtCtx.Project.Apps(metav1.NamespaceAll),
 		appLister:              mgmtCtx.Project.Apps("").Controller().Lister(),
-		templateLister:         mgmtCtx.Management.CatalogTemplates("").Controller().Lister(),
 		nodeLister:             mgmtCtx.Management.Nodes("").Controller().Lister(),
 		systemAccountManager:   systemaccount.NewManager(mgmtCtx),
 		manager:                manager,

--- a/pkg/controllers/management/k3sbasedupgrade/register.go
+++ b/pkg/controllers/management/k3sbasedupgrade/register.go
@@ -4,54 +4,34 @@ import (
 	"context"
 	"time"
 
-	manager2 "github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	wranglerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
-	wranglerv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	projectv3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/systemaccount"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type handler struct {
-	ctx                    context.Context
-	systemUpgradeNamespace string
-	clusterCache           wranglerv3.ClusterCache
-	clusterClient          wranglerv3.ClusterClient
-	clusterV1Cache         wranglerv1.ClusterCache
-	catalogManager         manager2.CatalogManager
-	apps                   projectv3.AppInterface
-	appLister              projectv3.AppLister
-	nodeLister             v3.NodeLister
-	systemAccountManager   *systemaccount.Manager
-	manager                *clustermanager.Manager
-	clusterEnqueueAfter    func(name string, duration time.Duration)
+	ctx                 context.Context
+	clusterClient       wranglerv3.ClusterClient
+	nodeLister          v3.NodeLister
+	manager             *clustermanager.Manager
+	clusterEnqueueAfter func(name string, duration time.Duration)
 }
 
 const (
 	systemUpgradeNS        = "cattle-system"
 	rancherManagedPlan     = "rancher-managed"
 	upgradeDisableLabelKey = "upgrade.cattle.io/disable"
-	k3sUpgraderCatalogName = "system-library-rancher-k3s-upgrader"
 )
 
 func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.ManagementContext, manager *clustermanager.Manager) {
 	h := &handler{
-		ctx:                    ctx,
-		systemUpgradeNamespace: systemUpgradeNS,
-		clusterCache:           wContext.Mgmt.Cluster().Cache(),
-		clusterClient:          wContext.Mgmt.Cluster(),
-		clusterV1Cache:         wContext.Provisioning.Cluster().Cache(),
-		catalogManager:         mgmtCtx.CatalogManager,
-		apps:                   mgmtCtx.Project.Apps(metav1.NamespaceAll),
-		appLister:              mgmtCtx.Project.Apps("").Controller().Lister(),
-		nodeLister:             mgmtCtx.Management.Nodes("").Controller().Lister(),
-		systemAccountManager:   systemaccount.NewManager(mgmtCtx),
-		manager:                manager,
-		clusterEnqueueAfter:    wContext.Mgmt.Cluster().EnqueueAfter,
+		ctx:                 ctx,
+		clusterClient:       wContext.Mgmt.Cluster(),
+		nodeLister:          mgmtCtx.Management.Nodes("").Controller().Lister(),
+		manager:             manager,
+		clusterEnqueueAfter: wContext.Mgmt.Cluster().EnqueueAfter,
 	}
 	wContext.Mgmt.Cluster().OnChange(ctx, "k3s-upgrade-controller", h.onClusterChange)
 }


### PR DESCRIPTION
### This is not ready to merge, is a initial draft to be validated by the team before we finish the implementation and write the tests / docs needed for this. 

## Issue: <!-- link the issue or issues this PR resolves here --> #42448 - Partial. 

<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

We want to migrate the system-upgrade-controller from system-charts to charts. 
Before doing so we need to remove the dependency of system-charts/rancher-k3s-upgrader that is used on the controller: `k3s-upgrade-controller`
 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Change the installation of the system-upgrade-controller to use the catalogV2. 

To do so I created a new handler that allows the interaction between two clusters. 

 
 
# Considerations / Validations: 
 
 There are a lot of TODOs with doubts /  things to be validated on the code.  I'll list them here too. 
 Going by the code will be "easier" to get the my doupts. 
 
## Known problems that weren't fixed:  

-   Wile upgrading from 1.24 to 1.25 on a hardened cluster. Ui let the user know about this problem: 
![image](https://github.com/rancher/rancher/assets/66074971/c50683c3-42ed-46ee-ad98-9d308f3096bf)

-   If we have any error wile installing the system-upgrade-controller the cluster seems to get "stuck" on updating. 

## Questions / Validations : 

### Changes on the catalogV2: 

- [ ] Are we Ok with the approach of creating a new handler to install charts on the downstream cluster? 

- [ ] The "Manager" only used the "Get" of the cache interfaces, as we intended to interact with the downstream cluster using the upstream one it seems that is not worth using the Cache interface (we would need to instantiate it and keep the cache on the upstream up-to-date), IMO is better to allow a new way of interacting with it without using cache. Is it Ok? 

- [ ] Is it ok to have a struct "extending" another one and overwriting the need methods? `DownstreamManager`

- [ ] To allow the upstream cluster to interact with the downstream one without any reliance on cache we had 2 options: A) Create an struct that implemented a "fake cache". B) change the required interfaces to instantiate  the Handler to require just the needed "Get", I took the 2nd approach, is it ok? 

- [ ] Were should I create the required interfaces and their implementations?  Do we have any pattern about it? 

- [ ] Should I use a "Generic" implementation for the interfaces or should I create one for each ?? 

## k3s-based-upgrade: 

- [ ] How should I aproach the uninstall of the v3.app? (For what I get this  also will be trying to upgrade the rancher-k3s-upgrader based on the old apps, therefore this whould be uninstalled, can I just delete it? do we have a better approach? )

- [ ] Is it ok to instantiate the controllers as I did?  Can we ignore cache completely  ?  (I think so as the cache should getter the data from the downstream cluster)
 
 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Just some basic tests, The idea is to validate this approach  before writing the tests and writing the doc. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_