### PR TITLE
[release/v2.8] Split provisioning-operations-tests-rke2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -159,7 +159,7 @@ trigger:
       - promote
 ---
 kind: pipeline
-name: provisioning-operations-tests-rke2
+name: provisioning-operations-test-setA-rke2
 
 platform:
   os: linux
@@ -167,7 +167,60 @@ platform:
 
 environment:
   V2PROV_TEST_DIST: "rke2"
-  V2PROV_TEST_RUN_REGEX: "^Test_Operation_.*$"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
+
+steps:
+  - name: provisioning-operations-tests-pr
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+  - name: provisioning-operations-tests-push
+    image: rancher/dapper:v0.6.0
+    failure: ignore
+    commands:
+      - dapper provisioning-tests
+    privileged: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/master"
+          - "refs/heads/release/v*"
+          - "refs/tags/v*"
+      event:
+        - push
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+      - promote
+---
+kind: pipeline
+name: provisioning-operations-test-setB-rke2
+
+platform:
+  os: linux
+  arch: amd64
+
+environment:
+  V2PROV_TEST_DIST: "rke2"
+  V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetB_.*$"
 
 steps:
   - name: provisioning-operations-tests-pr

--- a/tests/v2prov/tests/custom/operation_certificaterotation_test.go
+++ b/tests/v2prov/tests/custom/operation_certificaterotation_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_Operation_Custom_CertificateRotation(t *testing.T) {
+func Test_Operation_SetA_Custom_CertificateRotation(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/v2prov/tests/custom/operation_encryptionkeyrotation_test.go
+++ b/tests/v2prov/tests/custom/operation_encryptionkeyrotation_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_Operation_Custom_EncryptionKeyRotation(t *testing.T) {
+func Test_Operation_SetA_Custom_EncryptionKeyRotation(t *testing.T) {
 	// Encryption Key rotation is only possible with "stock configuration" on RKE2.
 	if strings.ToLower(os.Getenv("DIST")) != "rke2" {
 		t.Skip("encryption key rotation")

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
@@ -16,10 +16,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Test_Operation_Custom_EtcdSnapshotCreationRestoreInPlace creates a custom 2 node cluster with a controlplane+worker and
+// Test_Operation_SetA_Custom_EtcdSnapshotCreationRestoreInPlace creates a custom 2 node cluster with a controlplane+worker and
 // etcd node, creates a configmap, takes a snapshot of the cluster, deletes the configmap, then restores from snapshot.
 // This validates that it is possible to restore a snapshot.
-func Test_Operation_Custom_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
+func Test_Operation_SetA_Custom_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
@@ -23,11 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode creates a custom 2 node cluster with a worker and
+// Test_Operation_SetB_Custom_EtcdSnapshotOperationsOnNewCombinedNode creates a custom 2 node cluster with a worker and
 // controlplane+etcd node, creates a configmap, takes a snapshot of the cluster, deletes the configmap, then deletes the etcd machine/node
 // It then creates a new controlplane+etcd node and restores from local snapshot file. This validates that it is possible to restore
 // a snapshot on a completely new etcd node from file (without a corresponding snapshot file)
-func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T) {
+func Test_Operation_SetB_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
@@ -23,11 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// Test_Operation_Custom_EtcdSnapshotOperationsOnNewNode creates a custom 2 node cluster with a controlplane+worker and
+// Test_Operation_SetB_Custom_EtcdSnapshotOperationsOnNewNode creates a custom 2 node cluster with a controlplane+worker and
 // etcd node, creates a configmap, takes a snapshot of the cluster, deletes the configmap, then deletes the etcd machine/node
 // It then creates a new etcd node and restores from local snapshot file. This validates that it is possible to restore
 // a snapshot on a completely new etcd node from file (without a corresponding snapshot file)
-func Test_Operation_Custom_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
+func Test_Operation_SetB_Custom_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/v2prov/tests/machineprovisioning/operation_certificaterotation_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_certificaterotation_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_Operation_MP_CertificateRotation(t *testing.T) {
+func Test_Operation_SetA_MP_CertificateRotation(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/v2prov/tests/machineprovisioning/operation_encryptionkeyrotation_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_encryptionkeyrotation_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_Operation_MP_EncryptionKeyRotation(t *testing.T) {
+func Test_Operation_SetA_MP_EncryptionKeyRotation(t *testing.T) {
 	// Encryption Key rotation is only possible with "stock configuration" on RKE2.
 	if strings.ToLower(os.Getenv("DIST")) != "rke2" {
 		t.Skip("encryption key rotation")

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_Operation_MP_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
+func Test_Operation_SetA_MP_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
@@ -20,11 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Test_Operation_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode uses Minio as an object store to store S3 snapshots.
+// Test_Operation_SetB_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode uses Minio as an object store to store S3 snapshots.
 // It creates a 5 node machine provisioned cluster with 3 controlplane+etcd nodes and 2 workers, creates a configmap,
 // takes a snapshot of the cluster, deletes the configmap, then scales down the controlplane/etcd nodes.
 // It then creates a new etcd node and restores from local snapshot file, then scales the cluster back up to desired state.
-func Test_Operation_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode(t *testing.T) {
+func Test_Operation_SetB_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
@@ -19,10 +19,10 @@ import (
 	"time"
 )
 
-// Test_Operation_MP_EtcdSnapshotOperationsOnNewNode uses Minio as an object store to store S3 snapshots. It creates a 2 node machine provisioned cluster with a controlplane+worker and
+// Test_Operation_SetB_MP_EtcdSnapshotOperationsOnNewNode uses Minio as an object store to store S3 snapshots. It creates a 2 node machine provisioned cluster with a controlplane+worker and
 // etcd node, creates a configmap, takes a snapshot of the cluster, deletes the configmap, then deletes the etcd machine/node.
 // It then creates a new etcd node and restores from local snapshot file.
-func Test_Operation_MP_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
+func Test_Operation_SetB_MP_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/43560
 
## Problem
Due to bloat, the `provisioning-operations-tests-rke2` were frequently hitting the 1 hour mark for test run time.
 
## Solution
Run the provisioned and custom tests in different pipelines.
 
## Testing
Run in CI and ensure this passes within a reasonable amount of time >10 minutes, < 60 minutes

## NOTE

~Notably, until https://github.com/rancher/rancher/pull/43510 is merged, the tests will likely give "false positive" failures from the etcd operations tests. Ideally, we run the CI for this once the other PR is merged, or I can just meld the two PRs into one.~