### PR TITLE
Add script promote-release-build.sh

### DIFF
--- a/scripts/promote-release-build.sh
+++ b/scripts/promote-release-build.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+drone_cli_help() {
+    echo "Promotes build to promote-docker-image"
+    echo "and to promote-stable if destination is stable."
+    echo "Usage: $0 [-h] [-n] <tag> <destination_tag>"
+    echo "  -h  Show help information."
+    echo "  -n  Perform a dry run without making any changes."
+    echo ""
+    echo "  Requires Drone CLI and personal access token"
+    echo "  Download CLI following instructions at https://docs.drone.io/cli/install/"
+    echo "  Then configure access token: https://docs.drone.io/cli/setup/"
+    echo ""
+    echo "  To test if Drone CLI is properly configured type:"
+    echo ""
+    echo "     drone build ls rancher/rancher"
+    echo ""
+    echo "  This will show the last 25 builds"
+}
+
+drone_server="https://drone-publish.rancher.io"
+dry_run=false
+
+while getopts ":hn" opt; do
+    case $opt in
+    h)
+        drone_cli_help
+        exit 0
+        ;;
+    n)
+        dry_run=true
+        ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        drone_cli_help
+        exit 1
+        ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+source_tag=$1
+destination_tag=$2
+
+if [[ ! $destination_tag =~ ^(stable|latest|donotuse)$ ]]; then
+    echo "destination tag needs to be stable or latest (or donotuse for testing), not ${destination_tag}"
+    exit 1
+fi
+
+if [[ -z "${1}" ]]; then
+    drone_cli_help
+    exit 1
+fi
+
+if ! drone -v; then
+    drone_cli_help
+    exit 1
+fi
+
+echo "Promoting ${source_tag} to ${destination_tag}"
+
+
+# get the build number for the latest Drone build with the source tag
+build_number=""
+page=1
+until [ ${page} -gt 10 ]; do
+    build_number=$(drone -s "${drone_server}" build ls rancher/rancher --page ${page} --event tag --format "{{.Number}},{{.Ref}}" | grep "${source_tag}$" | cut -d',' -f1 | head -1)
+
+    if [ -n "${build_number}" ]; then
+        break
+    fi
+
+    page=$((page + 1))
+
+    sleep 1
+done
+
+# promote the build to promote-docker-image, 
+# and to promote-stable (which publishes the Helm chart) if destination is "stable"
+if [[ -n ${build_number} ]]; then
+    if [[ $dry_run == true ]]; then
+        echo "Dry run: drone build promote rancher/rancher ${build_number} promote-docker-image --param=SOURCE_TAG=${source_tag} --param=DESTINATION_TAG=${destination_tag}"
+        if [[ $destination_tag == "stable" ]]; then
+            echo "Dry run: drone build promote rancher/rancher ${build_number} promote-stable"
+        fi
+    else
+        drone build promote rancher/rancher "${build_number}" promote-docker-image --param=SOURCE_TAG="${source_tag}" --param=DESTINATION_TAG="${destination_tag}"
+        if [[ $destination_tag == "stable" ]]; then
+            drone build promote rancher/rancher "${build_number}" promote-stable
+        fi
+    fi
+    exit 0
+fi
+
+echo "No Build Found for source tag: ${source_tag}"
+exit 1


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/ecm-distro-tools/issues/250
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a release is promoted to stable, a release captain has to promote the same Drone build to two different environments with two different scripts, for the purpose of tagging the docker image, and for promoting the Helm chart. Also, the chart promotion script is not seeking Drone builds after the first page of results.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Creates a script named promote-release-build, which promotes a single build for a release tag to multiple drone promotion environments involved in the release process.

The script combines scripts/promote-release-build.sh and scripts/chart/promote-to-stable.sh

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -→

- run `./scripts/promote-release-build.sh -n v2.7.9 stable` and ensure `-n` is set for dry-run
- ensure the output prints two `drone build promote` commands for build 10900

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_