### PR TITLE
bump rke to v1.5.0-rc11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.20
 // on release remove this wrangler replace and use the latest tag
 replace github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df
 
+replace github.com/rancher/rke => github.com/rancher/rke v1.5.0-rc11
+
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.22 // for compatibilty with docker 20.10.x
 	github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible // rancher-machine requires a replace is set

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d h1:Ft/iTH91TlE2oBGm
 github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d/go.mod h1:Sm2Xqai+aecgmJ86ygyEe+TdPMLkauEpykSstBAu4Ko=
 github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcpvX1sM=
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.5.0-rc9 h1:mtnpYGrTTGsMaZHmvp9dsy28fR9QpsQGSGDcJCw7gqg=
-github.com/rancher/rke v1.5.0-rc9/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
+github.com/rancher/rke v1.5.0-rc11 h1:rp5/qeuGaIpg+f3wxCHQi0RB+k+c0doVojCRM6NyKEg=
+github.com/rancher/rke v1.5.0-rc11/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906 h1:gToXZxM/5S5lze/vCpQs50PJ33QTGCOaJHzjYh6y1RE=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906/go.mod h1:IAeZiWgZLSGGlYOUa3qj/G6i1eKl2LFuZ/DKb9mIrzw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -3,6 +3,7 @@ module github.com/rancher/rancher/pkg/apis
 go 1.20
 
 replace (
+	github.com/rancher/rke => github.com/rancher/rke v1.5.0-rc11
 	// wrangler bracnhes need to be updated before replace can be removed
 	github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df
 	k8s.io/api => k8s.io/api v0.27.6
@@ -11,9 +12,21 @@ replace (
 	k8s.io/apiserver => k8s.io/apiserver v0.27.6
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.27.6
 	k8s.io/client-go => github.com/rancher/client-go v1.27.4-rancher1
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.27.6
 	k8s.io/component-base => k8s.io/component-base v0.27.6
+	k8s.io/controller-manager => k8s.io/controller-manager v0.27.6
+	k8s.io/cri-api => k8s.io/cri-api v0.27.6
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.27.6
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.6
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.27.6
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.27.6
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.27.6
 	k8s.io/kubectl => k8s.io/kubectl v0.27.6
+	k8s.io/kubelet => k8s.io/kubelet v0.27.6
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.27.6
+	k8s.io/mount-utils => k8s.io/mount-utils v0.27.6
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.27.6
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.27.6
 )
 
 require (

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -525,8 +525,8 @@ github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29 h1:+kige/h8/LnzWgPjB
 github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29/go.mod h1:kgk9kJVMj9FIrrXU0iyM6u/9Je4bEjPImqswkTVaKsQ=
 github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d h1:Ft/iTH91TlE2oBGmpkdO4I8o8cvUmCnytdwu52a/tN4=
 github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d/go.mod h1:Sm2Xqai+aecgmJ86ygyEe+TdPMLkauEpykSstBAu4Ko=
-github.com/rancher/rke v1.5.0-rc9 h1:mtnpYGrTTGsMaZHmvp9dsy28fR9QpsQGSGDcJCw7gqg=
-github.com/rancher/rke v1.5.0-rc9/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
+github.com/rancher/rke v1.5.0-rc11 h1:rp5/qeuGaIpg+f3wxCHQi0RB+k+c0doVojCRM6NyKEg=
+github.com/rancher/rke v1.5.0-rc11/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
 github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df h1:WJ+aaUICHPX8HeLmHE9JL/RFHhilMfcJlqmhgpc7gJU=
 github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df/go.mod h1:4T80p+rLh2OLbjCjdExIjRHKNBgK9NUAd7eIU/gRPKk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
For https://github.com/rancher/rancher/issues/43624

Bump rke to v1.5.0-rc11


# Note about the `replace` directive

Go Mod treats `v1.5.0-rc11` as a lower version than `v1.5.0-rc9`, so the `replace` directive is necessary here to enforce the `v1.5.0-rc11` version of RKE is applied. 

The root cause is that we do not follow the Semantic Versioning Specification (SemVer) strictly when tagging versions in RKE: SemVer requires the pre-release identifier tp be dot-separated, such as `1.5.0-rc.11`, whereas ours is `v1.5.0-rc11`.  As a result, when Go Mod determines the precedence of `v1.5.0-rc9` and `v1.5.0-rc11`, it treats `rc9` and `rc11` as strings in which `rc11` is lower than `rc9`. 
 
**The `replace` directive can be dropped when we bump the version to the released one, ie. `v1.5.0`** 