### PR TITLE
[release/v2.7] Improve create component files script

### DIFF
--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -4,7 +4,7 @@ set -e -x
 
 echo "Creating ./bin/rancher-components.txt"
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
 mkdir -p bin
 
@@ -29,8 +29,10 @@ generate_section() {
     local pattern="$1"
     local label="$2"
     local type="$3"
-    echo "" >> "$COMPONENTSFILE"
-    echo "# $label" >> "$COMPONENTSFILE"
+    {
+        echo " "
+        echo "# $label"
+    } >> "$COMPONENTSFILE"
 
     for file in "${FILES[@]}"; do
         if [[ "$file" == "./scripts/package-env" ]]; then
@@ -48,15 +50,20 @@ done | sort -u >> "$COMPONENTSFILE"
 
 generate_section "rc[.]?[0-9]+" "Components with -rc"
 
-echo "" >> $COMPONENTSFILE
-echo "# Min version components with -rc" >> $COMPONENTSFILE
+{ 
+    echo ""
+    echo "# Min version components with -rc" 
+} >> $COMPONENTSFILE
 printf '%s\n' "$(grep -n -E "_MIN_VERSION" ./package/Dockerfile | grep ENV | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' |  awk -F':' '{ sub(/^[ \t]+/, "", $2); print "* " $2 " (file /package/Dockerfile, line " $1 ")" }' | sort | grep "\-rc")" >> $COMPONENTSFILE
 
 K8SVERSIONSFILE=./bin/rancher-rke-k8s-versions.txt
 
 if [[ -f "$K8SVERSIONSFILE" ]]; then
-    echo "# RKE Kubernetes versions" >> $COMPONENTSFILE
-    cat $K8SVERSIONSFILE >> $COMPONENTSFILE
+    { 
+        echo ""
+        echo "# RKE Kubernetes versions"
+        cat $K8SVERSIONSFILE 
+    } >> $COMPONENTSFILE
 fi
 
 generate_section "dev-v2.[0-9]+" "KDM References with dev branch" "kdm"

--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -10,19 +10,47 @@ mkdir -p bin
 
 COMPONENTSFILE=./bin/rancher-components.txt
 
-echo "# Images with -rc" > $COMPONENTSFILE
+FILES=(
+    "./Dockerfile.dapper"
+    "./go.mod"
+    "./package/Dockerfile"
+    "./pkg/apis/go.mod"
+    "./pkg/client/go.mod"
+    "./pkg/settings/setting.go"
+    "./scripts/package-env"
+)
 
-printf '%s\n' "$(grep -h "\-rc" ./bin/rancher-images.txt ./bin/rancher-windows-images.txt | awk -F: '{ print $1,$2 }')" | sort -u >> $COMPONENTSFILE
+IMAGE_FILES=(
+    "./bin/rancher-images.txt"
+    "./bin/rancher-windows-images.txt"
+)
 
-echo "# Components with -rc" >> $COMPONENTSFILE
+generate_section() {
+    local pattern="$1"
+    local label="$2"
+    local type="$3"
+    echo "" >> "$COMPONENTSFILE"
+    echo "# $label" >> "$COMPONENTSFILE"
 
-printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$|MIN_VERSION" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' |  awk '{ print $2,$3 }' | sort | grep "\-rc")" >> $COMPONENTSFILE
+    for file in "${FILES[@]}"; do
+        if [[ "$file" == "./scripts/package-env" ]]; then
+            grep -h -n -E "$pattern" "$file" | grep -i -E "$type" | sed -E "s|^([^:]*):(.*)|\* \2 (file $file, line \1)|"
+        else
+            grep -h -n -E "$pattern" "$file" | grep -i -E "$type" | grep -v "// indirect" | awk -F':' -v file="$file" -v label="$label" '{ sub(/^[ \t]+/, "", $2); sub(/[ \t]+/, " ", $2); print "* " $2 " (file " file ", line " $1 ")" }'
+        fi
+    done | sort -u >> "$COMPONENTSFILE"
+}
 
-printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep -v "\/pkg\/apis|\/pkg\/client|^module" | grep -v "=>" | awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)' | sort | grep "\-rc")" >> $COMPONENTSFILE
+echo "# Images with -rc" > "$COMPONENTSFILE"
+for file in "${IMAGE_FILES[@]}"; do
+    grep -h -n -E "rc[.]?[0-9]+" "$file" | awk -F':' -v file="$file" '{ sub(/^[ \t]+/, "", $2); sub(/[ \t]+/, " ", $2); print "* " $2 " (file " file ", line " $1 ")" }'
+done | sort -u >> "$COMPONENTSFILE"
 
+generate_section "rc[.]?[0-9]+" "Components with -rc"
+
+echo "" >> $COMPONENTSFILE
 echo "# Min version components with -rc" >> $COMPONENTSFILE
-
-printf '%s\n' "$(grep "_MIN_VERSION" ./package/Dockerfile | grep ENV | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' |  awk '{ print $2,$3 }' | sort | grep "\-rc")" >> $COMPONENTSFILE
+printf '%s\n' "$(grep -n -E "_MIN_VERSION" ./package/Dockerfile | grep ENV | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' |  awk -F':' '{ sub(/^[ \t]+/, "", $2); print "* " $2 " (file /package/Dockerfile, line " $1 ")" }' | sort | grep "\-rc")" >> $COMPONENTSFILE
 
 K8SVERSIONSFILE=./bin/rancher-rke-k8s-versions.txt
 
@@ -31,8 +59,7 @@ if [[ -f "$K8SVERSIONSFILE" ]]; then
     cat $K8SVERSIONSFILE >> $COMPONENTSFILE
 fi
 
-echo "# Chart/KDM sources" >> $COMPONENTSFILE
-
-bash ./scripts/check-chart-kdm-source-values >> $COMPONENTSFILE
+generate_section "dev-v2.[0-9]+" "KDM References with dev branch" "kdm"
+generate_section "dev-v2.[0-9]+" "Chart References with dev branch" "chart"
 
 echo "Done creating ./bin/rancher-components.txt"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/ecm-distro-tools/issues/291
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
 As part of the release improvement process, this change will allow for broader coverage of the modified files during the release process. It will also provide more detailed information about all the rc tags and -dev dependencies, showcasing specifics such as the file and line containing these dependencies in the exported file. This enhancement aims to streamline the release process by offering detailed insights into the altered files and their corresponding lines, facilitating a more comprehensive overview.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The solution involved refactoring the existing code to encompass all dependencies.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

New exportation 

1 - Open rancher project with this branch
2 - Execute `./scripts/create-components-file.sh`
3- The exportation should be something like:
```
# Images with -rc
* rancher/backup-restore-operator v4.0.0-rc1 (file ./bin/rancher-images.txt, line 1)
* rancher/fleet-agent v0.9.0-rc.5 (file ./bin/rancher-images.txt, line 3)
* rancher/fleet v0.9.0-rc.5 (file ./bin/rancher-images.txt, line 2)
* rancher/rancher-agent v2.8.0-rc3 (file ./bin/rancher-windows-images.txt, line 2)
* rancher/rancher v2.8.0-rc3 (file ./bin/rancher-windows-images.txt, line 1)
* rancher/system-agent v0.3.4-rc1-suc (file ./bin/rancher-windows-images.txt, line 3)

# Components with -rc
* ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.2-rc2 (file ./package/Dockerfile, line 62)
* ENV LOGLEVEL_VERSION v0.1.5-rc1 (file ./package/Dockerfile, line 35)

# Min version components with -rc
* ENV CSP_ADAPTER_MIN_VERSION 2.0.2-rc2 (file /package/Dockerfile, line 62)

# KDM References with dev branch
* ARG CATTLE_KDM_BRANCH=dev-v2.7 (file ./package/Dockerfile, line 24)
* ENV CATTLE_KDM_BRANCH=dev-v2.7 (file ./Dockerfile.dapper, line 16)
* KDMBranch = NewSetting("kdm-branch", "dev-v2.7") (file ./pkg/settings/setting.go, line 84)

# Chart References with dev branch
* ARG CHART_DEFAULT_BRANCH=dev-v2.7 (file ./package/Dockerfile, line 20)
* ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.7 (file ./package/Dockerfile, line 19)
* CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.7"} (file ./scripts/package-env, line 7)
* ChartDefaultBranch = NewSetting("chart-default-branch", "dev-v2.7") (file ./pkg/settings/setting.go, line 117)
* SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.7"} (file ./scripts/package-env, line 5)
```

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_