### PR TITLE
Update etcd healthcheck command for distroless image

### DIFF
--- a/tests/validation/tests/rke/common.py
+++ b/tests/validation/tests/rke/common.py
@@ -147,13 +147,16 @@ def wait_for_etcd_cluster_health(node, etcd_private_ip=False):
         )
     else:
         etcd_tls_cmd = (
-            'ETCDCTL_API=3 etcdctl endpoint health --cluster'
+            'etcdctl endpoint health --cluster'
         )
 
     print(etcd_tls_cmd)
     start_time = time.time()
     while start_time - time.time() < 120:
-        result = node.docker_exec('etcd', "sh -c '" + etcd_tls_cmd + "'")
+        if k8s_rancher_version <= k8s_fixed_version:
+            result = node.docker_exec('etcd', "sh -c '" + etcd_tls_cmd + "'")
+        else:
+            result = node.docker_exec('etcd', etcd_tls_cmd)
         print("**RESULT**")
         print(result)
         if k8s_rancher_version <= k8s_fixed_version:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- In rke_support_matrix jenkins job etcd healtcheck command started failing as it was invoking "sh" command on distroless etcd image.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Updated command to run on distroless image.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
- Tested it by running python test `test_install_config_1` locally using RKE v1.5.0-rc11 and job passed successfully.
