### PR TITLE
[release/v2.7] Bump kontainer-engine-driver-lke to v0.0.8

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -102,8 +102,8 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 	if err := creator.addCustomDriver(
 		"linodekubernetesengine",
-		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.6/kontainer-engine-driver-lke-linux-amd64",
-		"233cbd550a93ded322906b9fc6ebc88b8791e53d31f0d21d501feb0bad77461c",
+		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.8/kontainer-engine-driver-lke-linux-amd64",
+		"53b6ff92de696cfaa40249f1a3e0d1545882db1727160e76b056a189a754b41d",
 		"",
 		false,
 		"api.linode.com",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Related PR for `release/v2.8`: https://github.com/rancher/rancher/pull/43584

Resolves #43583
 
## Problem

In newer versions of Kubernetes, service account secrets are not implicitly created alongside service accounts. This is preventing LKE clusters from being provisioned through Rancher because older versions of kontainer-engine-driver-lke rely on this implicitly created token.
 
## Solution

This PR bumps kontainer-engine-driver-lke to [v0.0.8](https://github.com/linode/kontainer-engine-driver-lke/releases/tag/v0.0.8), which should resolve the LKE cluster provisioning issue.

