### PR TITLE
Label unknown/deprecated settings on startup

### DIFF
--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -85,8 +85,8 @@ func (s *settingsProvider) SetIfUnset(name, value string) error {
 
 // SetAll iterates through a map of settings.Setting and updates corresponding settings in k8s
 // to match any values set for them via their respective CATTLE_<setting-name> env var, their
-// source to "env" if configured by an env var, and their default to match the setting in the
-// map.
+// source to "env" if configured by an env var, and their default to match the setting in the map.
+// NOTE: It also lists all settings in k8s and cleans up unknown (not present in settingsMap) ones.
 func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error {
 	fallback := map[string]string{}
 
@@ -162,9 +162,9 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 
 const unknownSettingLabelKey = "cattle.io/unknown"
 
-// cleanupUnknownSettings lists all the settings in the cluster and cleans up all unknown (e.g. deprecated) settings.
-// At the moment, we just mark such settings with a label.
-// In the future release we'll be removing them.
+// cleanupUnknownSettings lists all settings in the cluster and cleans up all unknown (e.g. deprecated) settings.
+// At the moment, we just mark such settings with a label so that such settings can be easily identified.
+// In the future unknown settings may be deleted instead.
 func (s *settingsProvider) cleanupUnknownSettings(settingsMap map[string]settings.Setting) error {
 	// The settings cache is not yet available at this point, thus using the client directly.
 	list, err := s.settings.List(metav1.ListOptions{})

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -86,7 +86,7 @@ func (s *settingsProvider) SetIfUnset(name, value string) error {
 // SetAll iterates through a map of settings.Setting and updates corresponding settings in k8s
 // to match any values set for them via their respective CATTLE_<setting-name> env var, their
 // source to "env" if configured by an env var, and their default to match the setting in the map.
-// NOTE: It also lists all settings in k8s and cleans up unknown (not present in settingsMap) ones.
+// NOTE: All settings not provided in settingsMap will be marked as unknown, and may be removed in the future.
 func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error {
 	fallback := map[string]string{}
 
@@ -163,8 +163,7 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 const unknownSettingLabelKey = "cattle.io/unknown"
 
 // cleanupUnknownSettings lists all settings in the cluster and cleans up all unknown (e.g. deprecated) settings.
-// At the moment, we just mark such settings with a label so that such settings can be easily identified.
-// In the future unknown settings may be deleted instead.
+// Such settings are marked as unknown with a label so that they can be easily identified and may be removed in the future.
 func (s *settingsProvider) cleanupUnknownSettings(settingsMap map[string]settings.Setting) error {
 	// The settings cache is not yet available at this point, thus using the client directly.
 	list, err := s.settings.List(metav1.ListOptions{})

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -190,13 +190,13 @@ func (s *settingsProvider) cleanupUnknownSettings(settingsMap map[string]setting
 func (s *settingsProvider) markSettingAsUnknown(setting *v3.Setting) error {
 	logrus.Warnf("Unknown setting %s", setting.Name)
 
-	isFirstAttmpt := true
+	isFirstAttempt := true
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		defer func() { isFirstAttmpt = false }()
+		defer func() { isFirstAttempt = false }()
 
 		var err error
 
-		if !isFirstAttmpt { // Refetch only if the first attempt to update failed.
+		if !isFirstAttempt { // Refetch only if the first attempt to update failed.
 			setting, err = s.settings.Get(setting.Name, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) { // The setting is no longer, move on.

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -39,15 +39,11 @@ func (s *settingsProvider) Get(name string) string {
 
 	obj, err := s.settingCache.Get(name)
 	if err != nil {
-		logrus.Errorf("Error getting setting %s: %v", name, err)
-
 		val, err := s.settings.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return s.fallback[name]
 		}
 		obj = val
-	} else {
-		logrus.Infof("Using cached setting %s", name)
 	}
 
 	if obj.Value == "" {

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -190,13 +190,13 @@ func (s *settingsProvider) cleanupUnknownSettings(settingsMap map[string]setting
 func (s *settingsProvider) markSettingAsUnknown(setting *v3.Setting) error {
 	logrus.Warnf("Unknown setting %s", setting.Name)
 
-	var try int
+	isFirstAttmpt := true
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		defer func() { try++ }()
+		defer func() { isFirstAttmpt = false }()
 
 		var err error
 
-		if try > 0 { // Refetch only if the first attempt to update failed.
+		if !isFirstAttmpt { // Refetch only if the first attempt to update failed.
 			setting, err = s.settings.Get(setting.Name, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) { // The setting is no longer, move on.

--- a/pkg/controllers/dashboardapi/settings/settings_test.go
+++ b/pkg/controllers/dashboardapi/settings/settings_test.go
@@ -303,5 +303,5 @@ func TestMarkSettingAsUnknownRetry(t *testing.T) {
 	err := provider.markSettingAsUnknown(&unknown)
 	assert.Nil(t, err)
 	assert.NotNil(t, store["unknown"].Labels)
-	assert.Equal(t, store["unknown"].Labels["cattle.io/unknown"], "true")
+	assert.Equal(t, store["unknown"].Labels[unknownSettingLabelKey], "true")
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -286,6 +286,8 @@ func init() {
 }
 
 // Provider is an interfaced used to get and set Settings.
+// NOTE: The behavior for treating unknown settings is undefined.
+// A provider may choose not to retain and/or drop unknown settings.
 type Provider interface {
 	Get(name string) string
 	Set(name, value string) error

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -287,7 +287,8 @@ func init() {
 
 // Provider is an interfaced used to get and set Settings.
 // NOTE: The behavior for treating unknown settings is undefined.
-// A provider may choose not to retain and/or drop unknown settings.
+// A provider may choose to remove settings which it has a record of,
+// but are not provided in SetAll call.
 type Provider interface {
 	Get(name string) string
 	Set(name, value string) error


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/43103
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a deprecated setting is removed from the codebase the corresponding `Setting` resource is left behind in the cluster. We would like to clean up such orphaned setting resources on Rancher startup and potentially prevent creating custom setting resources via the webhook.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
On Rancher startup we list all the setting resources in the cluster and mark all unknown/unrecognized (e.g. deprecated) settings with a label. In a future release e.g. 2.9 we'll be removing them instead. This gives an opportunity to someone who used setting resources, e.g. for integration purposes, to transition to something else.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Migrate from 2.7 to 2.8+, and run Rancher which should lead to some deprecated/removed and any custom settings being marked as unknown e.g. `kubeconfig-token-ttl-minutes`.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

* Deprecated settings left after the upgrade.
* Custom settings created in the local cluster.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A