### PR TITLE
Fix OIDCConfig.Scopes struct field tag

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -454,7 +454,7 @@ type OIDCConfig struct {
 
 	ClientID           string `json:"clientId" norman:"required"`
 	ClientSecret       string `json:"clientSecret,omitempty" norman:"required,type=password"`
-	Scopes             string `json:"scope" norman:"required,notnullable"`
+	Scopes             string `json:"scope"`
 	AuthEndpoint       string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
 	Issuer             string `json:"issuer" norman:"required,notnullable"`
 	Certificate        string `json:"certificate,omitempty"`

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -454,7 +454,7 @@ type OIDCConfig struct {
 
 	ClientID           string `json:"clientId" norman:"required"`
 	ClientSecret       string `json:"clientSecret,omitempty" norman:"required,type=password"`
-	Scopes             string `json:"scope", norman:"required,notnullable"`
+	Scopes             string `json:"scope" norman:"required,notnullable"`
 	AuthEndpoint       string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
 	Issuer             string `json:"issuer" norman:"required,notnullable"`
 	Certificate        string `json:"certificate,omitempty"`

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -46,9 +46,9 @@ type OpenIDCProvider struct {
 type ClaimInfo struct {
 	Subject           string   `json:"sub"`
 	Name              string   `json:"name"`
-	PreferredUsername string   `json:preferred_username`
-	GivenName         string   `json:given_name`
-	FamilyName        string   `json:family_name`
+	PreferredUsername string   `json:"preferred_username"`
+	GivenName         string   `json:"given_name"`
+	FamilyName        string   `json:"family_name"`
 	Email             string   `json:"email"`
 	EmailVerified     bool     `json:"email_verified"`
 	Groups            []string `json:"groups"`


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/43668
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

There is a typo in the type declaration
```golang
type OIDCConfig struct {
	// ...
	Scopes             string `json:"scope", norman:"required,notnullable"`
	//                                     ^
	//...
}
```
Tags shouldn't be separated by a comma.

```
struct field tag `json:"scope", norman:"required,notnullable"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spacesstructtag[default](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/structtag)
```

And another one
```golang
type ClaimInfo struct {
	// ...
	PreferredUsername string   `json:preferred_username`
	GivenName         string   `json:given_name`
	FamilyName        string   `json:family_name`
	// ...
}
```
Missing double quotes around the field names.

```
struct field tag `json:given_name` not compatible with reflect.StructTag.Get: bad syntax for struct tag valuestructtag[default](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/structtag)
```

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Remove norman tag from `OIDCConfig.Scopes` field to keep validation intact and add missing double quotes in `ClaimInfo`.

Note [this](https://github.com/rancher/rancher/blob/07b114dd21372f69efdec2d5c5222b696af9eaa0/pkg/auth/providers/oidc/oidc_provider.go#L420-L421) ensures we have at least one scope (`openid`) set.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Make sure keycloak configuration works.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_