### PR TITLE
Update the rancher dynamic client to use its concrete struct types

### DIFF
--- a/tests/framework/clients/dynamic/dynamic.go
+++ b/tests/framework/clients/dynamic/dynamic.go
@@ -23,7 +23,7 @@ type Client struct {
 }
 
 // NewForConfig creates a new dynamic client or returns an error.
-func NewForConfig(ts *session.Session, inConfig *rest.Config) (dynamic.Interface, error) {
+func NewForConfig(ts *session.Session, inConfig *rest.Config) (*Client, error) {
 	logrus.Debugf("Dynamic Client Host:%s", inConfig.Host)
 
 	dynamicClient, err := dynamic.NewForConfig(inConfig)
@@ -44,7 +44,7 @@ func NewForConfig(ts *session.Session, inConfig *rest.Config) (dynamic.Interface
 //		  Version:  "v3",
 //		  Resource: "users",
 //	 }
-func (d *Client) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+func (d *Client) Resource(resource schema.GroupVersionResource) *NamespaceableResourceClient {
 	return &NamespaceableResourceClient{
 		NamespaceableResourceInterface: d.Interface.Resource(resource),
 		ts:                             d.ts,
@@ -59,7 +59,7 @@ type NamespaceableResourceClient struct {
 }
 
 // Namespace returns a dynamic.ResourceInterface that is embedded in ResourceClient, so ultimately its Create is overwritten.
-func (d *NamespaceableResourceClient) Namespace(s string) dynamic.ResourceInterface {
+func (d *NamespaceableResourceClient) Namespace(s string) *ResourceClient {
 	return &ResourceClient{
 		ResourceInterface: d.NamespaceableResourceInterface.Namespace(s),
 		ts:                d.ts,

--- a/tests/framework/clients/rancher/client.go
+++ b/tests/framework/clients/rancher/client.go
@@ -16,6 +16,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 
+	rancherDynamic "github.com/rancher/rancher/tests/framework/clients/dynamic"
 	kubeProvisioning "github.com/rancher/rancher/tests/framework/clients/provisioning"
 	kubeRKE "github.com/rancher/rancher/tests/framework/clients/rke"
 	"github.com/rancher/rancher/tests/framework/pkg/clientbase"
@@ -25,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -202,7 +202,7 @@ func (c *Client) GetClusterCatalogClient(clusterID string) (*catalog.Client, err
 }
 
 // GetRancherDynamicClient is a helper function that instantiates a dynamic client to communicate with the rancher host.
-func (c *Client) GetRancherDynamicClient() (dynamic.Interface, error) {
+func (c *Client) GetRancherDynamicClient() (*rancherDynamic.Client, error) {
 	dynamic, err := frameworkDynamic.NewForConfig(c.Session, c.restConfig)
 	if err != nil {
 		return nil, err
@@ -231,7 +231,7 @@ func (c *Client) GetKubeAPIRKEClient() (*kubeRKE.Client, error) {
 }
 
 // GetDownStreamClusterClient is a helper function that instantiates a dynamic client to communicate with a specific cluster.
-func (c *Client) GetDownStreamClusterClient(clusterID string) (dynamic.Interface, error) {
+func (c *Client) GetDownStreamClusterClient(clusterID string) (*rancherDynamic.Client, error) {
 	restConfig := *c.restConfig
 	restConfig.Host = fmt.Sprintf("https://%s/k8s/clusters/%s", c.restConfig.Host, clusterID)
 
@@ -243,7 +243,7 @@ func (c *Client) GetDownStreamClusterClient(clusterID string) (dynamic.Interface
 }
 
 // SwitchContext is a helper function that changes the current context to `context` and instantiates a dynamic client
-func (c *Client) SwitchContext(context string, clientConfig *clientcmd.ClientConfig) (dynamic.Interface, error) {
+func (c *Client) SwitchContext(context string, clientConfig *clientcmd.ClientConfig) (*rancherDynamic.Client, error) {
 	overrides := clientcmd.ConfigOverrides{CurrentContext: context}
 
 	rawConfig, err := (*clientConfig).RawConfig()

--- a/tests/framework/extensions/codecoverage/codecoverage.go
+++ b/tests/framework/extensions/codecoverage/codecoverage.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rancherDynamic "github.com/rancher/rancher/tests/framework/clients/dynamic"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
@@ -17,7 +18,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 )
 
 var podGroupVersionResource = corev1.SchemeGroupVersion.WithResource("pods")
@@ -30,7 +30,7 @@ const (
 	outputDir             = "cover"
 )
 
-func checkServiceIsRunning(dynamicClient dynamic.Interface) error {
+func checkServiceIsRunning(dynamicClient rancherDynamic.Client) error {
 	return kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
 		_, err = dynamicClient.Resource(podGroupVersionResource).Namespace(cattleSystemNameSpace).List(context.Background(), metav1.ListOptions{})
 		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
@@ -120,7 +120,7 @@ func KillRancherTestServicesRetrieveCoverage(client *rancher.Client) error {
 		return err
 	}
 
-	err = checkServiceIsRunning(dynamicClient)
+	err = checkServiceIsRunning(*dynamicClient)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func KillAgentTestServicesRetrieveCoverage(client *rancher.Client) error {
 				return err
 			}
 
-			err = checkServiceIsRunning(dynamicClient)
+			err = checkServiceIsRunning(*dynamicClient)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

## Problem
As a developer attempting to debug issues while using the dynamic client, it was difficult to follow what code implemented the underlying functions. This was due to the dynamic client functions returning the upstream k8s dynamic client types instead of the concrete ones of the rancher dynamic client.
 
## Solution
Update the dynamic client and other references to it so that they reference the concrete rancher dynamic client types.
 
## Testing
Was able to build locally, have not run any tests from the rancher/rancher repo that might utilize the dynamic client. Custom tests utilizing the rancher dynamic client were able to run successfully and made debugging a bit easier.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
There should not be regressions as this is a minor change that updates the types to the concrete ones provided in the rancher dynamic client code.

Existing / newly added automated tests that provide evidence there are no regressions: N/A