### PR TITLE
[2.8] removing sh exec due to distroless upstream

### DIFF
--- a/tests/validation/tests/rke/common.py
+++ b/tests/validation/tests/rke/common.py
@@ -140,20 +140,20 @@ def wait_for_etcd_cluster_health(node, etcd_private_ip=False):
         endpoints = node.private_ip_address
     if k8s_rancher_version <= k8s_fixed_version:
         etcd_tls_cmd = (
-                'ETCDCTL_API=2 etcdctl --endpoints "https://' + endpoints + ':2379" '
+                'etcdctl --endpoints "https://' + endpoints + ':2379" '
                  ' --ca-file /etc/kubernetes/ssl/kube-ca.pem --cert-file '
                  ' $ETCDCTL_CERT --key-file '
-                 ' $ETCDCTL_KEY cluster-health'
+                 ' $ETCDCTL_KEY cluster-health ETCDCTL_API=2'
         )
     else:
         etcd_tls_cmd = (
-            'ETCDCTL_API=3 etcdctl endpoint health --cluster'
+            'etcdctl endpoint health --cluster ETCDCTL_API=3'
         )
 
     print(etcd_tls_cmd)
     start_time = time.time()
     while start_time - time.time() < 120:
-        result = node.docker_exec('etcd', "sh -c '" + etcd_tls_cmd + "'")
+        result = node.docker_exec('etcd', etcd_tls_cmd)
         print("**RESULT**")
         print(result)
         if k8s_rancher_version <= k8s_fixed_version:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
rke-support-matrix job was failing
https://github.com/rancher/qa-tasks/issues/1072
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
as of coreos/etcd:v1.5.7 (rke v1.5.0 bumped this from 1.5.6 -> 1.5.7), upstream switched to a distroless image. This greatly reduces the image size, however limits the functionality of the container to basically only etcd and etcdctl. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
change commands in rke standalone test to only use etcd / etcdctl instead of sh. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
local testing done

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
