### PR TITLE
[v2.7] Fix etcd version not displaying version in CheckETCDVersion

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -325,9 +325,6 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace string, clustersConfig *Clus
 	}
 	if clustersConfig.ETCD != nil {
 		etcd = clustersConfig.ETCD
-		if etcd.S3 != nil {
-			etcd.S3.CloudCredentialName = cloudCredentialSecretName
-		}
 	}
 
 	chartValuesMap := rkev1.GenericMap{

--- a/tests/framework/extensions/rke1/componentchecks/etcdversion.go
+++ b/tests/framework/extensions/rke1/componentchecks/etcdversion.go
@@ -24,9 +24,9 @@ func CheckETCDVersion(client *rancher.Client, nodes []*nodes.Node, clusterID str
 
 	for _, rancherNode := range nodesList.Data {
 		externalIP := rancherNode.Annotations["rke.cattle.io/external-ip"]
-		etcdRole := rancherNode.Labels["node-role.kubernetes.io/etcd"]
+		etcdRole := rancherNode.Labels["node-role.kubernetes.io/etcd"] == "true"
 
-		if etcdRole == "true" {
+		if etcdRole {
 			for _, node := range nodes {
 				if strings.Contains(node.PublicIPAddress, externalIP) {
 					command := "docker exec etcd etcdctl version"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
For RKE1 custom cluster provisioning, we perform a check for the etcd etcdctl version in each etcd node. This test specifically was created when we are doing release checks. This is not working due to an issue seen in the function `CheckETCDVersion`.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Fixed the issue in `CheckETCDVersion` function.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually ran the RKE1 custom cluster test and this was successful.

### Automated Testing
Jenkins jobs will be provided offline to reviewers.