### PR TITLE
build: Set renovate base branch to v2.8

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranches": [
-    "release/v2.7"
+    "release/v2.8"
   ],
   "prHourlyLimit": 2,
   "prConcurrentLimit": 4,


### PR DESCRIPTION
The changes will force renovate to only consider `release/v2.8` going forward.