### PR TITLE
[2.8] allow multiple configs for k3s/rke2 automation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20230915232223-a9ea4ce4a5ba
-	github.com/rancher/shepherd v0.0.0-20240130214356-3e2c5037defb
+	github.com/rancher/shepherd v0.0.0-20240205165104-af35b26e7527
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1040,8 +1040,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.2-rc1 h1:8SY4nmluZFYY1+w1WdSUkku0w7fxiMZ03D4yXu17GiU=
 github.com/rancher/rke v1.5.2-rc1/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240130214356-3e2c5037defb h1:VDAgPF6Q5yJzqoCKvuCrvwWgdqqiC5zRzrmmVYdudk0=
-github.com/rancher/shepherd v0.0.0-20240130214356-3e2c5037defb/go.mod h1:WqUGpxXtHYkRV2ldhOJNDko0KZue8LBfy+gsCB7As4U=
+github.com/rancher/shepherd v0.0.0-20240205165104-af35b26e7527 h1:4ZDBAwsO4TmTdLSw5Oq2eBD0UtcZX28Y42YWVKXClzk=
+github.com/rancher/shepherd v0.0.0-20240205165104-af35b26e7527/go.mod h1:WqUGpxXtHYkRV2ldhOJNDko0KZue8LBfy+gsCB7As4U=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906 h1:gToXZxM/5S5lze/vCpQs50PJ33QTGCOaJHzjYh6y1RE=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906/go.mod h1:IAeZiWgZLSGGlYOUa3qj/G6i1eKl2LFuZ/DKb9mIrzw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -97,6 +97,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
+		provisioningConfig.NodePools[0].SpecifyCustomPublicIP = true
 		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
 	}
 }

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -38,7 +38,7 @@ provisioningInput:
     desiredflags: "Short|Long" #These flags are for running TestProvisioningRKE2Cluster or TestProvisioningRKE2CustomCluster it is not needed for the dynamic tests.
   rke2KubernetesVersion: ["v1.27.6+rke2r1"]
   cni: ["calico"]
-  providers: ["linode", "aws", "do", "harvester"]
+  providers: ["linode", "aws", "do", "harvester", "vsphere"]
   nodeProviders: ["ec2"]
   hardened: false
   psact: ""
@@ -110,116 +110,128 @@ Machine RKE2 config is the final piece needed for the config to run RKE2 provisi
 
 ### AWS RKE2 Machine Config
 ```yaml
-awsMachineConfig:
+awsMachineConfigs:
   region: "us-east-2"
-  ami: ""
-  instanceType: "t3a.medium"
-  sshUser: "ubuntu"
-  vpcId: ""
-  volumeType: "gp2"
-  zone: "a"
-  retries: "5"
-  rootSize: "60"
-  securityGroup: [""]
+  awsMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    ami: ""
+    instanceType: "t3a.medium"
+    sshUser: "ubuntu"
+    vpcId: ""
+    volumeType: "gp2"
+    zone: "a"
+    retries: "5"
+    rootSize: "60"
+    securityGroup: [""]
 ```
 ### Digital Ocean RKE2 Machine Config
 ```yaml
-doMachineConfig:
-  image: "ubuntu-20-04-x64"
-  backups: false
-  ipv6: false
-  monitoring: false
-  privateNetworking: false
+doMachineConfigs:
   region: "nyc3"
-  size: "s-2vcpu-4gb"
-  sshKeyContents: ""
-  sshKeyFingerprint: ""
-  sshPort: "22"
-  sshUser: "root"
-  tags: ""
-  userdata: ""
+  doMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    image: "ubuntu-20-04-x64"
+    backups: false
+    ipv6: false
+    monitoring: false
+    privateNetworking: false
+    size: "s-2vcpu-4gb"
+    sshKeyContents: ""
+    sshKeyFingerprint: ""
+    sshPort: "22"
+    sshUser: "root"
+    tags: ""
+    userdata: ""
 ```
 ### Linode RKE2 Machine Config
 ```yaml
-linodeMachineConfig:
-  authorizedUsers: ""
-  createPrivateIp: true
-  dockerPort: "2376"
-  image: "linode/ubuntu22.04"
-  instanceType: "g6-standard-8"
+linodeMachineConfigs:
   region: "us-west"
-  rootPass: ""
-  sshPort: "22"
-  sshUser: ""
-  stackscript: ""
-  stackscriptData: ""
-  swapSize: "512"
-  tags: ""
-  uaPrefix: "Rancher"
+  linodeMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    authorizedUsers: ""
+    createPrivateIp: true
+    dockerPort: "2376"
+    image: "linode/ubuntu22.04"
+    instanceType: "g6-standard-8"
+    rootPass: ""
+    sshPort: "22"
+    sshUser: ""
+    stackscript: ""
+    stackscriptData: ""
+    swapSize: "512"
+    tags: ""
+    uaPrefix: "Rancher"
 ```
 ### Azure RKE2 Machine Config
 ```yaml
-azureMachineConfig:
-  availabilitySet: "docker-machine"
-  diskSize: "30"
+azureMachineConfigs:
   environment: "AzurePublicCloud"
-  faultDomainCount: "3"
-  image: "canonical:UbuntuServer:22.04-LTS:latest"
-  location: "westus"
-  managedDisks: false
-  noPublicIp: false
-  nsg: ""
-  openPort: ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"]
-  resourceGroup: "docker-machine"
-  size: "Standard_D2_v2"
-  sshUser: "docker-user"
-  staticPublicIp: false
-  storageType: "Standard_LRS"
-  subnet: "docker-machine"
-  subnetPrefix: "192.168.0.0/16"
-  updateDomainCount: "5"
-  usePrivateIp: false
-  vnet: "docker-machine-vnet"
+  azureMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    availabilitySet: "docker-machine"
+    diskSize: "30"
+    faultDomainCount: "3"
+    image: "canonical:UbuntuServer:22.04-LTS:latest"
+    location: "westus"
+    managedDisks: false
+    noPublicIp: false
+    nsg: ""
+    openPort: ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"]
+    resourceGroup: "docker-machine"
+    size: "Standard_D2_v2"
+    sshUser: "docker-user"
+    staticPublicIp: false
+    storageType: "Standard_LRS"
+    subnet: "docker-machine"
+    subnetPrefix: "192.168.0.0/16"
+    updateDomainCount: "5"
+    usePrivateIp: false
+    vnet: "docker-machine-vnet"
 ```
 ### Harvester RKE2 Machine Config
 ```yaml
-harvesterMachineConfig":
-  diskSize: "40"
-  cpuCount: "2"
-  memorySize: "8"
-  networkName: "default/ctw-network-1"
-  imageName: "default/image-rpj98"
+harvesterMachineConfigs:
   vmNamespace: "default"
-  sshUser: "ubuntu"
-  diskBus: "virtio
+  harvesterMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    diskSize: "40"
+    cpuCount: "2"
+    memorySize: "8"
+    networkName: "default/ctw-network-1"
+    imageName: "default/image-rpj98"
+    sshUser: "ubuntu"
+    diskBus: "virtio
 ```
 ## Vsphere RKE2 Machine Config
 ```yaml
-vmwarevsphereMachineConfig:
-  cfgparam: ["disk.enableUUID=TRUE"]
-  cloneFrom: ""
-  cloudinit: ""
-  contentLibrary: ""
-  cpuCount: "4"
-  creationType: ""
-  datacenter: ""
-  datastore: ""
-  datastoreCluster: ""
-  diskSize: "20000"
-  folder: ""
-  hostSystem: ""
-  memorySize: "4096"
-  network: [""]
-  os: "linux"
-  password: ""
-  pool: ""
-  sshPassword: ""
-  sshPort: "22"
-  sshUser: ""
-  sshUserGroup: ""
+vmwarevsphereMachineConfigs:
   username: ""
   vcenter: ""
   vcenterPort: "443"
+  password: ""
+  pool: ""
+  datacenter: ""
+  datastore: ""
+  folder: ""
+  hostSystem: ""
+  vmwarevsphereMachineConfig:
+  - roles: ["etcd","controlplane","worker","windows"]
+    cfgparam: ["disk.enableUUID=TRUE"]
+    cloneFrom: ""
+    cloudinit: ""
+    contentLibrary: "" 
+    cpuCount: "4"
+    creationType: "template" # library, clone
+    datastoreCluster: ""
+    diskSize: "20000"
+    memorySize: "4096"
+    network: [""]
+    os: "linux" # windows
+    sshPassword: ""
+    sshPort: "22"
+    sshUser: ""
+    sshUserGroup: ""
 ```
 
 These tests utilize Go build tags. Due to this, see the below examples on how to run the node driver tests:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/523
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
vsphere node driver requires multiple configuration support in order to use windows nodes. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Enable multiple configuration for all node drivers **Breaking Change** (see readme) following the following format:
```
GenericMachineConfigs:
  region: your_region
  GenericMachineConfig:
  - config_1_var_1: ...
    config_1_var_2: ...
  - config_2_var_1: ...
    config_2_var_2: ...
...
```

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
locally tested using aws and vsphere

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_