### PR TITLE
Adds the ability to supress crd-gen output.

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1,5 +1,5 @@
 //go:generate go run pkg/codegen/buildconfig/writer.go pkg/codegen/buildconfig/main.go
 //go:generate go run pkg/codegen/generator/cleanup/main.go
 //go:generate go run pkg/codegen/main.go
-//go:generate scripts/build-crds
+//go:generate scripts/build-crds --quiet
 package main

--- a/scripts/build-crds
+++ b/scripts/build-crds
@@ -1,10 +1,29 @@
-#! /bin/sh
+#! /bin/bash
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -q|--quiet)
+            QUIET=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
 
 cd $(dirname $0)/../
 
 # This will return non-zero until all of our objects in ./pkg/apis can generate valid crds.
 # allowDangerousTypes is needed for struct that use floats
-controller-gen crd:generateEmbeddedObjectMeta=true,allowDangerousTypes=false paths=./pkg/apis/... output:crd:dir=./pkg/crds/yaml/generated
+GEN_CMD="controller-gen crd:generateEmbeddedObjectMeta=true,allowDangerousTypes=false paths=./pkg/apis/... output:crd:dir=./pkg/crds/yaml/generated"
 
+# supress errors when running controller-gen since we have not fully migrated all of our CRDs to be compatible.
+if [ "$QUIET" = true ]; then
+    $GEN_CMD > /dev/null 2>&1
+else
+    $GEN_CMD
+fi
 # remove empty CRD that is generated from our use of // +kubebuilder:skipversion
 rm -f ./pkg/crds/yaml/generated/_.yaml


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43691
 
## Problem
Github action UI automatically classifies lines containing the string `errors` as an error with the action even if the return code is 0.
 
## Solution
Suppress the messages of expected errors during go generate.
 
## Testing
None
