### PR TITLE
[release/v2.8] [v2.7 forwardport] check that snapshot creation time is not nil

### DIFF
--- a/tests/v2prov/operations/etcdsnapshot.go
+++ b/tests/v2prov/operations/etcdsnapshot.go
@@ -182,7 +182,7 @@ func RunSnapshotCreateTest(t *testing.T, clients *clients.Clients, c *v1.Cluster
 					// Workaround in response to K3s/RKE2 bug around etcd snapshot configmap existence: https://github.com/k3s-io/k3s/issues/9047
 					// Ensure that there are at least 2 snapshots for the given target node, as the first snapshot is not usable.
 					spec, err := capr.ParseSnapshotClusterSpecOrError(&s)
-					if err != nil || spec == nil {
+					if err != nil || spec == nil || s.SnapshotFile.CreatedAt == nil {
 						continue // ignore errors parsing the snapshot
 					}
 					// Only count snapshots that were created after the first snapshots were taken.

--- a/tests/v2prov/operations/etcdsnapshot.go
+++ b/tests/v2prov/operations/etcdsnapshot.go
@@ -161,7 +161,7 @@ func RunSnapshotCreateTest(t *testing.T, clients *clients.Clients, c *v1.Cluster
 	var snapshot *rkev1.ETCDSnapshot
 	// Get the etcd snapshot object
 	if err := retry.OnError(wait.Backoff{
-		Steps:    10,
+		Steps:    30,
 		Duration: 30 * time.Second,
 		Factor:   1.0,
 		Jitter:   0.1,


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/43658

Continuation of https://github.com/rancher/rancher/pull/43776 

While attempting to backport the original commit to release/v2.7, a fix was needed to be added to `release/v2.7`: https://github.com/rancher/rancher/pull/43789

Synchronize `release/v2.7` and `release/v2.8` tests so that they do not deviate and lead to different results.