### PR TITLE
Link to installation docs is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Open your browser to https://localhost
 
 ## Installation
 
-See [Installing/Upgrading Rancher](https://rancher.com/docs/rancher/v2.8/en/installation/) for all installation options.
+See [Installing/Upgrading Rancher](https://ranchermanager.docs.rancher.com/v2.8/pages-for-subheaders/installation-and-upgrade) for all installation options.
 
 ### Minimum Requirements
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher-docs/issues/1034
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Installation link points to a page that doesn't exist
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Updating link to point to installation docs page
 