### PR TITLE
Align image collection of extensions with existing pattern

### DIFF
--- a/pkg/image/extensions.go
+++ b/pkg/image/extensions.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ExtensionsConfig struct {
-	GithubEndpoints []GithubEndpoint
+	Config ExportConfig
 }
 
 type Release struct {
@@ -26,7 +26,7 @@ var ExtensionEndpoints = []GithubEndpoint{
 }
 
 func (e ExtensionsConfig) FetchExtensionImages(imagesSet map[string]map[string]struct{}) error {
-	for _, endpoint := range e.GithubEndpoints {
+	for _, endpoint := range e.Config.GithubEndpoints {
 		// Parse the repository name from the URL
 		repoName, err := parseRepoName(endpoint.URL)
 		if err != nil {

--- a/pkg/image/extensions_test.go
+++ b/pkg/image/extensions_test.go
@@ -78,7 +78,10 @@ func TestFetchExtensionImages(t *testing.T) {
 	defer server.Close()
 
 	endpoints := []GithubEndpoint{{URL: server.URL}}
-	extensions := ExtensionsConfig{GithubEndpoints: endpoints}
+	exportConfig := ExportConfig{
+		GithubEndpoints: endpoints,
+	}
+	extensions := ExtensionsConfig{exportConfig}
 
 	imagesSet := map[string]map[string]struct{}{}
 
@@ -112,7 +115,10 @@ func TestFetchExtensionImages_NoSuitableRelease(t *testing.T) {
 	defer server.Close()
 
 	endpoints := []GithubEndpoint{{URL: server.URL}}
-	extensions := ExtensionsConfig{GithubEndpoints: endpoints}
+	exportConfig := ExportConfig{
+		GithubEndpoints: endpoints,
+	}
+	extensions := ExtensionsConfig{exportConfig}
 
 	imagesSet := map[string]map[string]struct{}{}
 

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -22,6 +22,7 @@ type ExportConfig struct {
 	OsType           OSType
 	ChartsPath       string
 	SystemChartsPath string
+	GithubEndpoints  []GithubEndpoint
 }
 
 type OSType int
@@ -61,6 +62,10 @@ func ResolveWithCluster(image string, cluster *v3.Cluster) string {
 	return image
 }
 
+// GetImages fetches the list of container images used in the sources provided in the exportConfig.
+// Rancher charts, system charts, system images and extension images of Rancher are fetched.
+// GetImages is called during runtime by Rancher catalog package which is deprecated.
+// It is actually used for generation rancher-images.txt for airgap scenarios.
 func GetImages(exportConfig ExportConfig, externalImages map[string][]string, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages) ([]string, []string, error) {
 	imagesSet := make(map[string]map[string]struct{})
 
@@ -83,9 +88,7 @@ func GetImages(exportConfig ExportConfig, externalImages map[string][]string, im
 	}
 
 	// fetch images from extension catalog images
-	extensions := ExtensionsConfig{
-		GithubEndpoints: ExtensionEndpoints,
-	}
+	extensions := ExtensionsConfig{exportConfig}
 	if err := extensions.FetchExtensionImages(imagesSet); err != nil {
 		return nil, nil, errors.Wrap(err, "failed to fetch images from extensions")
 	}

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -140,6 +140,7 @@ func GatherTargetImagesAndSources(systemChartsPath, chartsPath string, imagesFro
 		ChartsPath:       chartsPath,
 		OsType:           img.Linux,
 		RancherVersion:   rancherVersion,
+		GithubEndpoints:  img.ExtensionEndpoints,
 	}
 	targetImages, targetImagesAndSources, err := img.GetImages(exportConfig, externalLinuxImages, linuxImagesFromArgs, linuxInfo.RKESystemImages)
 	if err != nil {


### PR DESCRIPTION
## Issue: 

fixes https://github.com/rancher/rancher/issues/43779
 
## Problem

The [GetImages](https://github.com/rancher/rancher/blob/release/v2.9/pkg/image/resolve.go#L64) func is indirectly being called by a codebase in the catalogv1 package in airgap scenario.

[GetImages](https://github.com/rancher/rancher/blob/release/v2.9/pkg/image/resolve.go#L64) =>calls=> [AddImagesToImageListConfigMap](https://github.com/rancher/rancher/blob/release/v2.9/pkg/image/resolve.go#L109) =>calls=>[CatalogV1 Package](https://github.com/rancher/rancher/blob/release/v2.9/pkg/catalog/manager/catalog_sync.go#L123)

The [GetImages](https://github.com/rancher/rancher/blob/release/v2.9/pkg/image/resolve.go#L64) func is also called by [utility package](https://github.com/rancher/rancher/blob/release/v2.9/pkg/image/utilities/utilities.go#L144) for generating rancher-images.txt file for airgap scenarios.

**GetImages Func**
It takes in an argument `exportConfig` which defines where to find packages from? 

When called from [CatalogV2](https://github.com/rancher/rancher/blob/release/v2.9/pkg/catalog/manager/catalog_sync.go#L123) , it seems like it defines internal directories to fetch from. 

When called from [Utilities](https://github.com/rancher/rancher/blob/release/v2.9/pkg/image/utilities/utilities.go#L144), it defines Github URL's such as github.com/rancher/charts or github.com/rancher/system-charts. 

The [PR](https://github.com/rancher/rancher/pull/42565) adds a new entry for [Extensions](https://github.com/rancher/rancher/pull/42565/files#diff-df058c3539a16a7aa843e7dd88ea2ffb4c50e5ec45f91ab515b1a85d521748e6R82) which doesn't consider exportConfig and always fetches from github.com/rancher/ui-plugin-charts. 

 
## Solution

This PR now tries to use export config for [extensions](https://github.com/rancher/rancher/pull/43825/files#diff-2623863f3d8249bed94fa69df203ba439413583a04367f68031f176af5187200R138) as well when called from [utilities](https://github.com/rancher/rancher/pull/43825/files#diff-2623863f3d8249bed94fa69df203ba439413583a04367f68031f176af5187200R143)


## Engineering Testing
### Manual Testing

Tested if it fixes the bug. 

### Automated Testing

- Unit - Added Unit tests for the GetImage function with respective to Extensions being set and not set.

## QA Testing Considerations

**Non Airgap Scenario**
- All Rancher test cases 

**AirGap Scenario**
- All Rancher test cases

**Rancher.images.txt Generation**
- Check if rancher-images.txt is generated correctly and has right entries.