### PR TITLE
Add AmazonEBSCSIDriverPolicy to AWS NodeInstanceRole.

### DIFF
--- a/pkg/kontainer-engine/drivers/eks/templates.go
+++ b/pkg/kontainer-engine/drivers/eks/templates.go
@@ -541,6 +541,7 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonEBSCSIDriverPolicy
 
   NodeSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
 ## Problem
Deploying postgres helm chart on EKS cluster results with "running PreBind plugin "VolumeBinding": binding volumes: timed out waiting for the condition".
 
## Solution
Add the AmazonEBSCSIDriverPolicy policy that allows the Amazon EBS Container Storage Interface (CSI) driver to create, modify, attach, detach, and delete volumes on your behalf.