### PR TITLE
Update feature_request and flaky-tests issue template to hide the helper comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,13 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--A clear and concise description of what you want to happen.-->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!--A clear and concise description of any alternative solutions or features you've considered.-->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!--Add any other context or screenshots about the feature request here.-->

--- a/.github/ISSUE_TEMPLATE/flaky-tests.md
+++ b/.github/ISSUE_TEMPLATE/flaky-tests.md
@@ -8,11 +8,9 @@ assignees: ''
 ---
 
 **Flaky Test**
-
-```
-<!--File what test failed in automation. 
+<!--File what test failed in automation in a code block. 
 Make sure to assign the appropriate engineering team.-->
-```
+
 
 **Release Branch**
 


### PR DESCRIPTION
This PR updates the feature_request and flaky-tests issue template to hide/comment-out the helper comments in the markdown. It is annoying and unnecessary to see them when in the markdown.