### PR TITLE
[v2.9] feat: added capi label to kubeconfig secrets

### DIFF
--- a/pkg/provisioningv2/kubeconfig/manager.go
+++ b/pkg/provisioningv2/kubeconfig/manager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -251,7 +252,7 @@ func (m *Manager) GetCRTBForClusterOwner(cluster *v1.Cluster, status v1.ClusterS
 // kubeConfigValid accepts a kubeconfig and corresponding data, and validates that the kubeconfig is valid for the
 // cluster in question. It returns two booleans, the first of which is whether an error occurred parsing the kubeconfig
 // or retrieving information related to the kubeconfig, and the second which indicates whether the kubeconfig is valid.
-func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentServerURL, currentServerCA, currentManagementClusterName string) (bool, bool) {
+func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentServerURL, currentServerCA, currentManagementClusterName string, secretLabels map[string]string) (bool, bool) {
 	if len(kcData) == 0 {
 		return true, false
 	}
@@ -289,6 +290,13 @@ func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentSer
 		tokenMatches = err == nil
 	}
 
+	// Check if the required CAPI cluster label is present in the secretLabels map
+	capiClusterLabelValue, labelPresent := secretLabels[capi.ClusterNameLabel]
+	if !labelPresent || capiClusterLabelValue != cluster.Name {
+		logrus.Tracef("[kubeconfigmanager] cluster %s/%s: kubeconfig secret failed validation due to missing or incorrect label", cluster.Namespace, cluster.Name)
+		return false, false
+	}
+
 	if serverURL != currentServerURL || !bytes.Equal([]byte(strings.TrimSpace(currentServerCA)), kc.Clusters["cluster"].CertificateAuthorityData) || managementCluster != currentManagementClusterName || !tokenMatches {
 		logrus.Tracef("[kubeconfigmanager] cluster %s/%s: kubeconfig secret failed validation, did not match provided data", cluster.Namespace, cluster.Name)
 		return false, false
@@ -305,7 +313,7 @@ func (m *Manager) getKubeConfigData(cluster *v1.Cluster, secretName, managementC
 
 	secret, err := m.secretCache.Get(cluster.Namespace, secretName)
 	if err == nil {
-		retrievalError, isValid := m.kubeConfigValid(secret.Data["value"], cluster, serverURL, cacert, managementClusterName)
+		retrievalError, isValid := m.kubeConfigValid(secret.Data["value"], cluster, serverURL, cacert, managementClusterName, secret.Labels)
 		if (!retrievalError && !isValid) || secret.Data == nil || secret.Data["token"] == nil || len(secret.OwnerReferences) == 0 {
 			logrus.Infof("[kubeconfigmanager] deleting kubeconfig secret for cluster %s/%s", cluster.Namespace, cluster.Name)
 			// Check if we require a new secret based on the token value and annotation(s). We delete the old secret since it may contain
@@ -368,6 +376,9 @@ func (m *Manager) getKubeConfigData(cluster *v1.Cluster, secretName, managementC
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			}},
+			Labels: map[string]string{
+				capi.ClusterNameLabel: cluster.Name,
+			},
 		},
 		Data: map[string][]byte{
 			"value": data,

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -545,27 +545,27 @@ func insertOrUpdateCondition(d data.Object, desiredCondition summary.Condition) 
 }
 
 func migrateCAPIKubeconfigs(w *wrangler.Context) error {
-	logrus.Info("Running CAPI secret migration")
+	logrus.Info("Running provisioningv2 CAPI kubeconfig secret migration")
 
-	mgmtClusters, err := w.Mgmt.Cluster().List(metav1.ListOptions{})
+	namespaces, err := w.Core.Namespace().List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for _, mgmtCluster := range mgmtClusters.Items {
-		logrus.Tracef("Checking if migration for cluster %s is needed", mgmtCluster.Name)
-
-		provClusters, err := w.Provisioning.Cluster().List(mgmtCluster.Spec.FleetWorkspaceName, metav1.ListOptions{})
+	for _, ns := range namespaces.Items {
+		provClusters, err := w.Provisioning.Cluster().List(ns.Name, metav1.ListOptions{})
 		if k8serror.IsNotFound(err) || len(provClusters.Items) == 0 {
+			logrus.Tracef("No provisioningv2 clusters in namespace %s", ns.Name)
 			continue
 		} else if err != nil {
 			return err
 		}
 		for _, provCluster := range provClusters.Items {
 			if provCluster.Spec.RKEConfig == nil {
+				logrus.Tracef("No provisioningv2 clusters in namespace %s", ns.Name)
 				continue
 			}
-			logrus.Tracef("Running migration for cluster %s", provCluster.Name)
+			logrus.Tracef("Running provisioningv2 CAPI kubeconfig secret migration for cluster %s", provCluster.Name)
 
 			if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				secretName := fmt.Sprintf("%s-kubeconfig", provCluster.Name)
@@ -605,7 +605,7 @@ func migrateCAPIKubeconfigs(w *wrangler.Context) error {
 		}
 	}
 
-	logrus.Info("Finished migrating CAPI kubeconfig secrets")
+	logrus.Info("Finished migrating provisioningv2 CAPI kubeconfig secrets")
 
 	return nil
 }


### PR DESCRIPTION
## Issue: #42333 

> This is a forward port of #42406
 
## Problem

If we upgrade to use CAPI 1.5.0 or higher its required that the secrets used for kubeconfigs contain a label cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}. Without this, the CAPI cluster/machine reconcilers will fail with a failed to retrieve kubeconfig secret for Cluster error.

See the CAPI migration guide: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md#other
 
## Solution

This adds the required label when we create the secret that contains the kubeconfig. A migration has also been added thats called at startup (on leader election) that will add the label to any kubeconfig secret for an RKE2 cluster.

Even though 1.4.4 will be used with the un-embedding it would be good to get this change in upfront.
 
## Testing

1 .Create an RKE2 based cluster with a previous version
1. Find the kubeconfig secret for the cluster. It will be named [CLUSTERNAME]-kubeconfig and will likely be in the fleet-default namespace
1. Check that it does NOT have a label name cluster.x-k8s.io/cluster-name
1. Upgrade Rancher to a version with the change in
1. Check the same secret to see if the cluster.x-k8s.io/cluster-name now exists.
1. Create a new RKE2 based cluster and when its provisioned, check that the kubeconfig secret has the cluster.x-k8s.io/cluster-name label

## Engineering Testing
### Manual Testing

Manually local testing carried out.

### Automated Testing

NONE

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_