### PR TITLE
Icons airgap fetching the internet

### DIFF
--- a/pkg/api/steve/catalog/content.go
+++ b/pkg/api/steve/catalog/content.go
@@ -108,10 +108,12 @@ func (i *contentDownload) serveIcon(apiContext *types.APIRequest, rw http.Respon
 	if err != nil {
 		return err
 	}
-	defer chart.Close()
+	if chart != nil {
+		_, err = io.Copy(rw, chart)
+		setIconHeaders(rw, suffix)
+		defer chart.Close()
+	}
 
-	setIconHeaders(rw, suffix)
-	_, err = io.Copy(rw, chart)
 	return err
 }
 

--- a/pkg/api/steve/catalog/content.go
+++ b/pkg/api/steve/catalog/content.go
@@ -109,8 +109,8 @@ func (i *contentDownload) serveIcon(apiContext *types.APIRequest, rw http.Respon
 		return err
 	}
 	if chart != nil {
-		_, err = io.Copy(rw, chart)
 		setIconHeaders(rw, suffix)
+		_, err = io.Copy(rw, chart)
 		defer chart.Close()
 	}
 

--- a/pkg/catalogv2/content/content.go
+++ b/pkg/catalogv2/content/content.go
@@ -436,6 +436,6 @@ func isHTTP(iconURL string) bool {
 // is from the default rancher official helm catalog and if rancher is operating at bundled mode
 // which means Rancher is at an airgapped environment
 func isRancherAndBundledCatalog(repo repoDef) bool {
-	gitDir := git.RepoDir(repo.metadata.Namespace, repo.metadata.Name, repo.spec.GitRepo)
+	gitDir := git.RepoDir(repo.metadata.Namespace, repo.metadata.Name, repo.status.URL)
 	return (git.IsBundled(gitDir) && settings.SystemCatalog.Get() == "bundled")
 }

--- a/pkg/catalogv2/content/content.go
+++ b/pkg/catalogv2/content/content.go
@@ -179,8 +179,18 @@ func (c *Manager) Icon(namespace, name, chartName, version string) (io.ReadClose
 		return nil, "", err
 	}
 
+	// If the chart icon is not an HTTP URL and the repository has a commit status,
+	// attempt to get the icon from the git repository.
 	if !isHTTP(chart.Icon) && repo.status.Commit != "" {
 		return git.Icon(namespace, name, repo.status.URL, chart)
+	}
+
+	// Check if the repository from the chart is bundled and is at an airgapped environment
+	rancherBundled := isRancherAndBundledCatalog(repo)
+	if rancherBundled {
+		// If the icon is not available in the git repository, use the fallback icon for airgapped environments.
+		// which will be handled by the UI, as long as this returns a nil io.ReadCloser and nil error.
+		return nil, "", nil
 	}
 
 	secret, err := catalogv2.GetSecret(c.secrets, repo.spec, repo.metadata.Namespace)
@@ -420,4 +430,12 @@ func (c *Manager) filterReleases(index *repo.IndexFile, k8sVersion *semver.Versi
 func isHTTP(iconURL string) bool {
 	u, err := url.Parse(iconURL)
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
+}
+
+// isRancherAndBundledCatalog - checks if the current chart repo
+// is from the default rancher official helm catalog and if rancher is operating at bundled mode
+// which means Rancher is at an airgapped environment
+func isRancherAndBundledCatalog(repo repoDef) bool {
+	gitDir := git.RepoDir(repo.metadata.Namespace, repo.metadata.Name, repo.spec.GitRepo)
+	return (git.IsBundled(gitDir) && settings.SystemCatalog.Get() == "bundled")
 }

--- a/pkg/catalogv2/git/content.go
+++ b/pkg/catalogv2/git/content.go
@@ -13,16 +13,15 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 )
 
+// Icon will return the icon for a chartName version in a local repository by getting the relative path
 func Icon(namespace, name, gitURL string, chartVersion *repo.ChartVersion) (io.ReadCloser, string, error) {
 	if len(chartVersion.Icon) == 0 {
 		return nil, "", fmt.Errorf("failed to find chartName %s version %s: %w", chartVersion.Name, chartVersion.Version, validation.NotFound)
 	}
 
-	dir := gitDir(namespace, name, gitURL)
+	dir := RepoDir(namespace, name, gitURL)
 	icon := chartVersion.Icon
-	if strings.HasPrefix(icon, "file://") && len(chartVersion.URLs[0]) > 0 {
-		icon = filepath.Join(chartVersion.URLs[0], strings.TrimPrefix(icon, "file://"))
-	}
+
 	file, err := relative(dir, gitURL, icon)
 	if err != nil {
 		return nil, "", err
@@ -33,7 +32,7 @@ func Icon(namespace, name, gitURL string, chartVersion *repo.ChartVersion) (io.R
 }
 
 func Chart(namespace, name, gitURL string, chartVersion *repo.ChartVersion) (io.ReadCloser, error) {
-	dir := gitDir(namespace, name, gitURL)
+	dir := RepoDir(namespace, name, gitURL)
 
 	if len(chartVersion.URLs) == 0 {
 		return nil, fmt.Errorf("failed to find chartName %s version %s: %w", chartVersion.Name, chartVersion.Version, validation.NotFound)

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -16,7 +16,7 @@ func Ensure(secret *corev1.Secret, namespace, name, gitURL, commit string, insec
 
 	// If the repositories are rancher managed and if bundled is set
 	// don't fetch anything from upstream.
-	if isBundled(git) && settings.SystemCatalog.Get() == "bundled" {
+	if IsBundled(git.Directory) && settings.SystemCatalog.Get() == "bundled" {
 		return nil
 	}
 
@@ -64,7 +64,7 @@ func Update(secret *corev1.Secret, namespace, name, gitURL, branch string, insec
 		return "", fmt.Errorf("update failure: %w", err)
 	}
 
-	if isBundled(git) && settings.SystemCatalog.Get() == "bundled" {
+	if IsBundled(git.Directory) && settings.SystemCatalog.Get() == "bundled" {
 		return Head(secret, namespace, name, gitURL, branch, insecureSkipTLS, caBundle)
 	}
 
@@ -94,7 +94,7 @@ func Update(secret *corev1.Secret, namespace, name, gitURL, branch string, insec
 	}
 
 	lastCommit, err := git.currentCommit()
-	if err != nil && isBundled(git) {
+	if err != nil && IsBundled(git.Directory) {
 		return Head(secret, namespace, name, gitURL, branch, insecureSkipTLS, caBundle)
 	}
 	return lastCommit, nil
@@ -106,7 +106,7 @@ func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string, insecureS
 		return nil, fmt.Errorf("%w: only http(s) or ssh:// supported", err)
 	}
 
-	dir := gitDir(namespace, name, gitURL)
+	dir := RepoDir(namespace, name, gitURL)
 	headers := map[string]string{}
 	if settings.InstallUUID.Get() != "" {
 		headers["X-Install-Uuid"] = settings.InstallUUID.Get()

--- a/pkg/catalogv2/git/index.go
+++ b/pkg/catalogv2/git/index.go
@@ -11,7 +11,7 @@ import (
 )
 
 func BuildOrGetIndex(namespace, name, gitURL string) (*repo.IndexFile, error) {
-	dir := gitDir(namespace, name, gitURL)
+	dir := RepoDir(namespace, name, gitURL)
 	return buildOrGetIndex(dir)
 }
 

--- a/pkg/catalogv2/git/utils.go
+++ b/pkg/catalogv2/git/utils.go
@@ -21,20 +21,22 @@ const (
 	localDir  = "../rancher-data/local-catalogs/v2" // identical to helm.InternalCatalog
 )
 
-func gitDir(namespace, name, gitURL string) string {
-	staticDir := filepath.Join(staticDir, namespace, name, hash(gitURL))
+// RepoDir returns the directory where the git repo is cloned.
+func RepoDir(namespace, name, gitURL string) string {
+	staticDir := filepath.Join(staticDir, namespace, name, Hash(gitURL))
 	if s, err := os.Stat(staticDir); err == nil && s.IsDir() {
 		return staticDir
 	}
-	localDir := filepath.Join(localDir, namespace, name, hash(gitURL))
+	localDir := filepath.Join(localDir, namespace, name, Hash(gitURL))
 	if s, err := os.Stat(localDir); err == nil && s.IsDir() {
 		return localDir
 	}
-	return filepath.Join(stateDir, namespace, name, hash(gitURL))
+	return filepath.Join(stateDir, namespace, name, Hash(gitURL))
 }
 
-func isBundled(git *git) bool {
-	return strings.HasPrefix(git.Directory, staticDir) || strings.HasPrefix(git.Directory, localDir)
+// IsBundled checks the directory to see if it is a bundled catalog repository.
+func IsBundled(dir string) bool {
+	return strings.HasPrefix(dir, staticDir) || strings.HasPrefix(dir, localDir)
 }
 
 // isGitSSH checks if the URL is in the SSH URL format using regular expressions.
@@ -78,7 +80,8 @@ func validateURL(gitURL string) error {
 	return nil
 }
 
-func hash(gitURL string) string {
+// Hash returns a hash of the git URL.
+func Hash(gitURL string) string {
 	b := sha256.Sum256([]byte(gitURL))
 	return hex.EncodeToString(b[:])
 }

--- a/pkg/catalogv2/git/utils_test.go
+++ b/pkg/catalogv2/git/utils_test.go
@@ -50,7 +50,7 @@ func Test_gitDir(t *testing.T) {
 		// NOTE(manno): cannot test the other cases without poluting the filesystem
 	}
 	for _, tc := range testCases {
-		actual := gitDir(tc.namespace, tc.name, tc.gitURL)
+		actual := RepoDir(tc.namespace, tc.name, tc.gitURL)
 		assert.Equalf(tc.expected, actual, "testcase: %v", tc)
 	}
 }

--- a/scripts/package
+++ b/scripts/package
@@ -58,6 +58,11 @@ if [ ! -d $CHART_REPO_DIR ]; then
     git clone --branch $CHART_DEFAULT_BRANCH https://github.com/rancher/charts $CHART_REPO_DIR
 fi
 
+if [ ! -d $SMALL_FORK_REPO_DIR ]; then
+    mkdir -p $SMALL_FORK_REPO_DIR
+    git clone --branch main https://github.com/rancher/charts-small-fork $SMALL_FORK_REPO_DIR
+fi
+
 if [ ${ARCH} == amd64 ]; then
     # Move this out of ARCH check for local dev on non-amd64 hardware.
     TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR $IMAGE $AGENT_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $WINS_AGENT_UPGRADE_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}

--- a/scripts/package-env
+++ b/scripts/package-env
@@ -4,6 +4,8 @@ ARCH=${ARCH:-"amd64"}
 SYSTEM_CHART_REPO_DIR=build/system-charts
 SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.8"}
 CHART_REPO_DIR=build/charts
+SMALL_FORK_REPO_DIR=../build/rancher-data/local-catalogs/v2/rancher-charts-small-fork/d39a2f6abd49e537e5015bbe1a4cd4f14919ba1c3353208a7ff6be37ffe00c52
+
 CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.8"}
 
 IMAGE=${REPO}/rancher:${TAG}

--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -33,6 +33,10 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
+const rancherLocalDir = "../rancher-data/local-catalogs/v2"
+const smallForkURL = "https://github.com/rancher/charts-small-fork"
+const smallForkClusterRepoName = "rancher-charts-small-fork"
+
 var propagation = metav1.DeletePropagationForeground
 
 type RancherManagedChartsTest struct {
@@ -124,29 +128,6 @@ func (w *RancherManagedChartsTest) resetSettings() {
 
 func TestRancherManagedChartsSuite(t *testing.T) {
 	suite.Run(t, new(RancherManagedChartsTest))
-}
-
-func (w *RancherManagedChartsTest) TestServeIcons() {
-	defer w.resetSettings()
-
-	// https://RANCHER_DOMAIN:8443/v1/catalog.cattle.io.clusterrepos/rancher-charts?link=index
-	charts, err := w.catalogClient.GetChartsFromClusterRepo("rancher-charts")
-	w.Require().NoError(err)
-	w.Assert().Greater(len(charts), 1)
-
-	chartsAndLatestVersions := extractChartsAndLatestVersions(charts)
-
-	// https://RANCHER_DOMAIN:8443/v1/catalog.cattle.io.clusterrepos/rancher-charts?chartName=<SOME_CHART>&link=icon&version=<SOME_VERSION>
-	err = w.catalogClient.FetchChartIcon("rancher-charts", "rancher-istio", chartsAndLatestVersions["rancher-istio"])
-	w.Require().NoError(err)
-	err = w.catalogClient.FetchChartIcon("rancher-charts", "rancher-project-monitoring", chartsAndLatestVersions["rancher-project-monitoring"])
-	w.Require().NoError(err)
-	err = w.catalogClient.FetchChartIcon("rancher-charts", "longhorn", chartsAndLatestVersions["longhorn"])
-	w.Require().NoError(err)
-	err = w.catalogClient.FetchChartIcon("rancher-charts", "rancher-monitoring", chartsAndLatestVersions["rancher-monitoring"])
-	w.Require().NoError(err)
-	err = w.catalogClient.FetchChartIcon("rancher-charts", "prometheus-federator", chartsAndLatestVersions["prometheus-federator"])
-	w.Require().NoError(err)
 }
 
 func (w *RancherManagedChartsTest) TestInstallChartLatestVersion() {
@@ -484,6 +465,77 @@ func (w *RancherManagedChartsTest) pollUntilDownloaded(ClusterRepoName string, p
 		return clusterRepo.Status.DownloadTime != prevDownloadTime, nil
 	})
 	return err
+}
+
+func (w *RancherManagedChartsTest) TestServeIcons() {
+	// Testing: Chart.icon field with (https:// scheme)
+	// https://RANCHER_DOMAIN:8443/v1/catalog.cattle.io.clusterrepos/rancher-charts?link=index
+	charts, err := w.catalogClient.GetChartsFromClusterRepo("rancher-charts")
+	w.Require().NoError(err)
+	w.Assert().Greater(len(charts), 1)
+
+	chartsAndLatestVersions := extractChartsAndLatestVersions(charts)
+
+	// https://RANCHER_DOMAIN:8443/v1/catalog.cattle.io.clusterrepos/rancher-charts?chartName=<SOME_CHART>&link=icon&version=<SOME_VERSION>
+	imgLength, err := w.catalogClient.FetchChartIcon("rancher-charts", "rancher-istio", chartsAndLatestVersions["rancher-istio"])
+	w.Require().NoError(err)
+	w.Assert().Greater(imgLength, 0)
+	imgLength, err = w.catalogClient.FetchChartIcon("rancher-charts", "rancher-project-monitoring", chartsAndLatestVersions["rancher-project-monitoring"])
+	w.Require().NoError(err)
+	w.Assert().Greater(imgLength, 0)
+	imgLength, err = w.catalogClient.FetchChartIcon("rancher-charts", "longhorn", chartsAndLatestVersions["longhorn"])
+	w.Require().NoError(err)
+	w.Assert().Greater(imgLength, 0)
+	imgLength, err = w.catalogClient.FetchChartIcon("rancher-charts", "rancher-monitoring", chartsAndLatestVersions["rancher-monitoring"])
+	w.Require().NoError(err)
+	w.Assert().Greater(imgLength, 0)
+	imgLength, err = w.catalogClient.FetchChartIcon("rancher-charts", "prometheus-federator", chartsAndLatestVersions["prometheus-federator"])
+	w.Require().NoError(err)
+	w.Assert().Greater(imgLength, 0)
+
+	// Testing: Chart.icon field with (file:// scheme)
+	// Create ClusterRepo for charts-small-fork
+	clusterRepoToCreate := rv1.NewClusterRepo("", smallForkClusterRepoName,
+		rv1.ClusterRepo{
+			Spec: rv1.RepoSpec{
+				GitRepo:   smallForkURL,
+				GitBranch: "main",
+			},
+		},
+	)
+	_, err = w.client.Steve.SteveType(catalog.ClusterRepoSteveResourceType).Create(clusterRepoToCreate)
+	w.Require().NoError(err)
+	time.Sleep(1 * time.Second)
+
+	w.Require().NoError(w.pollUntilDownloaded(smallForkClusterRepoName, metav1.Time{}))
+
+	// Get Charts from the ClusterRepo
+	smallForkCharts, err := w.catalogClient.GetChartsFromClusterRepo(smallForkClusterRepoName)
+	w.Require().NoError(err)
+	w.Assert().Greater(len(smallForkCharts), 1)
+
+	// Get the client settings to update settings.SystemCatalog
+	systemCatalog, err := w.client.Management.Setting.ByID("system-catalog")
+	w.Require().NoError(err)
+	w.Assert().Equal("external", systemCatalog.Value)
+
+	// Update settings.SystemCatalog to bundled
+	systemCatalogUpdated, err := w.client.Management.Setting.Update(systemCatalog, map[string]interface{}{"value": "bundled"})
+	w.Require().NoError(err)
+	w.Assert().Equal("bundled", systemCatalogUpdated.Value)
+
+	// Fetch one icon with https:// scheme, it should return an empty object (i.e length of image equals 0) with nil error
+	imgLength, err = w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "fleet", "102.0.0+up0.6.0")
+	w.Require().NoError(err)
+	w.Assert().Equal(0, imgLength)
+
+	// Update settings.SystemCatalog to external
+	_, err = w.client.Management.Setting.Update(systemCatalog, map[string]interface{}{"value": "external"})
+	w.Require().NoError(err)
+
+	// Deleting clusterRepo
+	err = w.catalogClient.ClusterRepos().Delete(context.Background(), smallForkClusterRepoName, metav1.DeleteOptions{})
+	w.Require().NoError(err)
 }
 
 // extractChartsAndLatestVersions returns a map of chartName -> latestVersion


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
This PR will solve these issues: 
- https://github.com/rancher/rancher/issues/41765
- https://github.com/rancher/rancher/issues/41603
 
## Problem
Rancher when operating at airgap mode with bundled catalogs is still trying to get the logos of the charts from the internet.
 
![image](https://github.com/rancher/rancher/assets/127259813/fbab0f7f-4f00-4714-a49a-9d9dfde7a054)

## Solution
This will be a 2 step solution, this PR aims to implement the 1st one
The 1st solution only fixes the 2 above-mentioned issues.
The 2nd solution will ensure a better user experience even when in air-gapped mode by providing all logos locally.

### Solution 1
1. Detect when in Bundled Mode (Airgapped environment), 
2. Try to get the image from the local bundled repository, 
3. if not possible just return a `nil chart` with a `nil error` that will trigger the generic catalog image from the default directory on the front end. 
4. Update `git.Icon` function to work with `index.yaml > icon(field): file://(scheme)`

Result:
- Rancher will not wait 30 seconds or more for the requests to finish avoiding slowdowns. 
- Rancher will not try to reach the internet. 

As you can see in the below image, all charts are fastly loaded with the local generic-catalog image without slowdowns
![image](https://github.com/rancher/rancher/assets/127259813/811f0d5c-7ded-4b74-9438-6e658f0c7926)
![image](https://github.com/rancher/rancher/assets/127259813/4af61c09-61ec-4aeb-a35e-2b4497be6349)


### Solution 2
At: 
- https://github.com/rancher/charts 
- https://github.com/rancher/partner-charts
-  https://github.com/rancher/rke2-charts
1. Download and push all logo image's charts (also resize them on minimum width x height for best performance)
2. Create script that will always keep the images up-to-date
3. Script must also modify the index.yaml file (or the main entrypoint) to point to the local images path. 

According to the: https://github.com/rancher/rancher/blob/release/v2.9/package/Dockerfile
Lines 69 -> 79
Rancher at Airgap Mode,  should always have the `rancher-charts` `rancher-partner-charts` `rancher-rke2-charts` locally.
Download and keep all these images on the repositories. 

Result:
- Image loading will be faster without failures
- Easier to manage the images especially the ones we depend on third-parties that from time-to-time get unavailable

---

## Testing

Reproducing the undesired behavior:
1. Install rancher on airgap mode with a minimum local-registry.
2. Go to Rancher in the browser and open Web Inspector at Network Tab.
3. Go to (Local Cluster) -> Apps -> Charts

See the Chart requests pointing to each of its own specific web URLs


Testing if it worked:
1. Install rancher on airgap mode with a minimum local-registry.
2. Go to Rancher in the browser and open Web Inspector at Network Tab.
3. Go to (Local Cluster) -> Apps -> Charts

See the Chart requests pointing to local host and succeeding with the generic-catalog image.

### Automated Testing
**Before adding automated testing, validate with UI team if this is a feasible solution (Solution 1 + 2)**

* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_