### PR TITLE
[2.8] Use SLE maintained tox version for integration tests

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -115,8 +115,7 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
 RUN curl -sLf https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-images.txt -o /usr/tmp/k3s-images.txt
 
 # Python related dependencies for the Integration/Validation tests.
-RUN zypper install -y python311-pip python311-base python311 python311-devel libffi-devel libopenssl-devel && \
-    pip install tox
+RUN zypper -n install python311-pip python311-base python311 python311-devel python311-tox libffi-devel libopenssl-devel
 
 ENV HELM_HOME /root/.helm
 ENV DAPPER_ENV REPO TAG CI DRONE_BUILD_NUMBER DRONE_TAG DRONE_COMMIT DRONE_BRANCH DRONE_BUILD_EVENT SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION RELEASE_ACTION RELEASE_TYPE POSTRELEASE_RANCHER_VERSION POSTRELEASE_RANCHER_STABLE DEBUG V2PROV_TEST_DIST V2PROV_TEST_RUN_REGEX


### PR DESCRIPTION
Installing via pip installs the newest released version as 'root' user, which can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead, "--user", or simply use the SUSE maintained system package instead.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
The root cause here is duplicating the packages that are installed system wide via package manager with the ones installed system wide via pip. These meshups are hard to predict and might lead to breakage (as seen in the SLE BCI integration tests that is trying to build rancher).
 
## Solution
The solution is to install the python ecosystem from a single vendor.

- GH Issue/PR: https://github.com/rancher/rancher/pull/43868
