### PR TITLE
[v2.8.1] Align image collection of extensions with existing pattern

### DIFF
--- a/pkg/image/extensions.go
+++ b/pkg/image/extensions.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ExtensionsConfig struct {
-	GithubEndpoints []GithubEndpoint
+	Config ExportConfig
 }
 
 type Release struct {
@@ -26,7 +26,7 @@ var ExtensionEndpoints = []GithubEndpoint{
 }
 
 func (e ExtensionsConfig) FetchExtensionImages(imagesSet map[string]map[string]struct{}) error {
-	for _, endpoint := range e.GithubEndpoints {
+	for _, endpoint := range e.Config.GithubEndpoints {
 		// Parse the repository name from the URL
 		repoName, err := parseRepoName(endpoint.URL)
 		if err != nil {

--- a/pkg/image/extensions_test.go
+++ b/pkg/image/extensions_test.go
@@ -78,7 +78,10 @@ func TestFetchExtensionImages(t *testing.T) {
 	defer server.Close()
 
 	endpoints := []GithubEndpoint{{URL: server.URL}}
-	extensions := ExtensionsConfig{GithubEndpoints: endpoints}
+	exportConfig := ExportConfig{
+		GithubEndpoints: endpoints,
+	}
+	extensions := ExtensionsConfig{exportConfig}
 
 	imagesSet := map[string]map[string]struct{}{}
 
@@ -112,7 +115,10 @@ func TestFetchExtensionImages_NoSuitableRelease(t *testing.T) {
 	defer server.Close()
 
 	endpoints := []GithubEndpoint{{URL: server.URL}}
-	extensions := ExtensionsConfig{GithubEndpoints: endpoints}
+	exportConfig := ExportConfig{
+		GithubEndpoints: endpoints,
+	}
+	extensions := ExtensionsConfig{exportConfig}
 
 	imagesSet := map[string]map[string]struct{}{}
 

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -22,6 +22,7 @@ type ExportConfig struct {
 	OsType           OSType
 	ChartsPath       string
 	SystemChartsPath string
+	GithubEndpoints  []GithubEndpoint
 }
 
 type OSType int
@@ -61,6 +62,10 @@ func ResolveWithCluster(image string, cluster *v3.Cluster) string {
 	return image
 }
 
+// GetImages fetches the list of container images used in the sources provided in the exportConfig.
+// Rancher charts, system charts, system images and extension images of Rancher are fetched.
+// GetImages is called during runtime by Rancher catalog package which is deprecated.
+// It is actually used for generation rancher-images.txt for airgap scenarios.
 func GetImages(exportConfig ExportConfig, externalImages map[string][]string, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages) ([]string, []string, error) {
 	imagesSet := make(map[string]map[string]struct{})
 
@@ -83,9 +88,7 @@ func GetImages(exportConfig ExportConfig, externalImages map[string][]string, im
 	}
 
 	// fetch images from extension catalog images
-	extensions := ExtensionsConfig{
-		GithubEndpoints: ExtensionEndpoints,
-	}
+	extensions := ExtensionsConfig{exportConfig}
 	if err := extensions.FetchExtensionImages(imagesSet); err != nil {
 		return nil, nil, errors.Wrap(err, "failed to fetch images from extensions")
 	}

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -140,6 +140,7 @@ func GatherTargetImagesAndSources(systemChartsPath, chartsPath string, imagesFro
 		ChartsPath:       chartsPath,
 		OsType:           img.Linux,
 		RancherVersion:   rancherVersion,
+		GithubEndpoints:  img.ExtensionEndpoints,
 	}
 	targetImages, targetImagesAndSources, err := img.GetImages(exportConfig, externalLinuxImages, linuxImagesFromArgs, linuxInfo.RKESystemImages)
 	if err != nil {


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/43910

Cherry-pick backport of https://github.com/rancher/rancher/pull/43825, see details in the linked PR.