### PR TITLE
[GITHUB BUG] Change token reference to fix broken port-issue workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Check org membership
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
               echo "${GITHUB_ACTOR} is a member"
@@ -27,7 +27,7 @@ jobs:
       - name: Check milestone
         if: env.is_member == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
@@ -47,7 +47,7 @@ jobs:
           env.is_member == 'true' &&
           env.milestone_exists == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |


### PR DESCRIPTION
 
## Problem
The GitHub action port-issue was failing with the following error: 

`gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
 env:
 GH_TOKEN: ${{ github.token }}
Error: Process completed with exit code 4.`
 
## Solution
manual.yml was using  ${{ secrets.GH}} instead of  ${{ secrets.GITHUB_TOKEN }}. I am updating to the same naming convention the other actions are using with the hope that it will prevent the action from failing in the future.
 

## Engineering Testing
### Manual Testing
I do not know how to trigger edited GitHub actions prior to merging. 

