### PR TITLE
[2.8] fix airgap automation for python framework

### DIFF
--- a/tests/v2/validation/Dockerfile.validation
+++ b/tests/v2/validation/Dockerfile.validation
@@ -29,8 +29,15 @@ RUN CGO_ENABLED=0
 # necessary to run if statements using [[ ]]
 SHELL ["/bin/bash", "-c"] 
 
-RUN if [[ -z "$EXTERNAL_ENCODED_VPN" ]] ; then echo no vpn provided ; else apt-get update && \
-    apt-get -y install openvpn net-tools && echo $EXTERNAL_ENCODED_VPN | base64 -d > external.ovpn && \
-    if [[ -z "$VPN_ENCODED_LOGIN}" ]] ; then echo no passcode provided ; else echo adding passfile && \
-    echo $VPN_ENCODED_LOGIN | base64 -d > passfile && \
-    sed -i 's/auth-user-pass/auth-user-pass passfile/g' external.ovpn; fi; fi;
+RUN if [[ -z '$EXTERNAL_ENCODED_VPN' ]] ; then \
+      echo 'no vpn provided' ; \
+    else \
+      apt-get update && apt-get -y install openvpn net-tools && \
+      echo $EXTERNAL_ENCODED_VPN | base64 -d > external.ovpn && \
+      if [[ -z '$VPN_ENCODED_LOGIN' ]] ; then \
+        echo 'no passcode provided' ; \
+      else \
+        echo 'adding passfile' && echo $VPN_ENCODED_LOGIN | base64 -d > passfile && \
+        sed -i 's/auth-user-pass/auth-user-pass passfile/g' external.ovpn; \
+        fi; \
+    fi;

--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -51,8 +51,15 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERS
 # necessary to run if statements using [[ ]]
 SHELL ["/bin/bash", "-c"] 
 
-RUN if [[ -z "$EXTERNAL_ENCODED_VPN" ]] ; then echo no vpn provided ; else apt-get update && \
-    apt-get -y install openvpn net-tools && echo $EXTERNAL_ENCODED_VPN | base64 -d > external.ovpn && \
-    if [[ -z "$VPN_ENCODED_LOGIN}" ]] ; then echo no passcode provided ; else echo adding passfile && \
-    echo $VPN_ENCODED_LOGIN | base64 -d > passfile && \
-    sed -i 's/auth-user-pass/auth-user-pass passfile/g' external.ovpn; fi; fi;
+RUN if [[ -z '$EXTERNAL_ENCODED_VPN' ]] ; then \
+      echo 'no vpn provided' ; \
+    else \
+      apt-get update && apt-get -y install openvpn net-tools && \
+      echo $EXTERNAL_ENCODED_VPN | base64 -d > external.ovpn && \
+      if [[ -z '$VPN_ENCODED_LOGIN' ]] ; then \
+        echo 'no passcode provided' ; \
+      else \
+        echo 'adding passfile' && echo $VPN_ENCODED_LOGIN | base64 -d > passfile && \
+        sed -i 's/auth-user-pass/auth-user-pass passfile/g' external.ovpn; \
+        fi; \
+    fi;

--- a/tests/validation/tests/v3_api/test_airgap_ha.py
+++ b/tests/validation/tests/v3_api/test_airgap_ha.py
@@ -175,8 +175,8 @@ def overwrite_tls_certs(external_node):
 def get_registry_resources(external_node):
     get_resources_command = \
         'scp -q -i {}/{}.pem -o StrictHostKeyChecking=no ' \
-        '-o UserKnownHostsFile=/dev/null -r {}/airgap/basic-registry/ ' \
-        '{}@{}:~/basic-registry/'.format(
+        '-o UserKnownHostsFile=/dev/null -r {}/airgap/basic-registry ' \
+        '{}@{}:~/basic-registry'.format(
             SSH_KEY_DIR, external_node.ssh_key_name, RESOURCE_DIR,
             AWS_USER, external_node.host_name)
     run_command(get_resources_command, log_out=False)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/1097

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
the ha airgap job started failing, and would not finish bringing up the airgapped environment.,

Further investigation shows that the python:3.11 dependency was updated in the upstream docker package, and now scp complains when the trailing `/` is included in the command. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
removed the `/` from the `basic-registry` scp lines. 

also addressing some Dockerfile issues with VPN to unblock some vsphere testing. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested using jenkins freeform job, and is getting past this step now. 
