### PR TITLE
Skipping dynamic tests when no input is provided

### DIFF
--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -157,11 +157,15 @@ func (rb *RBTestSuite) TestRBACDynamicInput() {
 	user.Password = userConfig.Password
 
 	role := userConfig.Role
-	val, ok := roles[role]
-	if !ok {
-		rb.FailNow("Incorrect usage of roles. Please go through the readme for correct role configurations")
+	if userConfig.Role == "" {
+		rb.T().Skip()
+	}else {
+		val, ok := roles[role]
+		if !ok {
+			rb.FailNow("Incorrect usage of roles. Please go through the readme for correct role configurations")
+		}
+		role = val
 	}
-	role = val
 
 	if role == restrictedAdmin {
 		member = restrictedAdmin


### PR DESCRIPTION
In rbac tests, we have dynamic tests that run even when role is not provided but error out. Skipping these tests so it wont run when a role is not provided.