### PR TITLE
[2.9] Change rancher-agent base image to bci-micro

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -2,14 +2,31 @@ ARG RANCHER_TAG=dev
 ARG RANCHER_REPO=rancher
 FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
-FROM registry.suse.com/bci/bci-base:15.5
-ARG ARCH=amd64
+FROM registry.suse.com/bci/bci-micro:15.5 AS final
 
-ENV KUBECTL_VERSION v1.25.12
-RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
+# Temporary build stage image
+FROM registry.suse.com/bci/bci-base:15.5 AS builder
+
+# Install system packages using builder image that has zypper
+COPY --from=final / /chroot/
+
+# Install some packages with zypper in the chroot of the final micro image
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
-    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+# Main stage using bco-micro as the base image
+FROM final
+
+# Copy binaries and configuration files from builder to micro
+COPY --from=builder /chroot/ /
+
+ARG ARCH=amd64
+ENV KUBECTL_VERSION v1.25.12
+
+RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 ENV LOGLEVEL_VERSION v0.1.5

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -2,14 +2,31 @@ ARG RANCHER_TAG=dev
 ARG RANCHER_REPO=rancher
 FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
-FROM registry.suse.com/bci/bci-base:15.5
-ARG ARCH=amd64
+FROM registry.suse.com/bci/bci-micro:15.5 AS final
 
-ENV KUBECTL_VERSION v1.25.12
-RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
+# Temporary build stage image
+FROM registry.suse.com/bci/bci-base:15.5 AS builder
+
+# Install system packages using builder image that has zypper
+COPY --from=final / /chroot/
+
+# Install some packages with zypper in the chroot of the final micro image
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
-    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+# Main stage using bco-micro as the base image
+FROM final
+
+# Copy binaries and configuration files from builder to micro
+COPY --from=builder /chroot/ /
+
+ARG ARCH=amd64
+ENV KUBECTL_VERSION v1.25.12
+
+RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 ENV LOGLEVEL_VERSION v0.1.5


### PR DESCRIPTION
The previous base image (`bci-base`) contains several packages that are not required for the `rancher-agent` container image.

The changes aim to decrease the long-term amount of base image CVEs that increases as a given container image version ages.