### PR TITLE
Add Norman validation to projects for container default resource limits

### DIFF
--- a/pkg/api/norman/customization/project/project_store_test.go
+++ b/pkg/api/norman/customization/project/project_store_test.go
@@ -1,0 +1,89 @@
+package project
+
+import "testing"
+
+func TestValidateLimitRange(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		data        map[string]any
+		errExpected bool
+	}{
+		{
+			name: "missing limit produces no error",
+		},
+		{
+			name: "valid case",
+			data: map[string]any{
+				"containerDefaultResourceLimit": map[string]any{
+					"requestsCpu":    "1m",
+					"limitsCpu":      "20m",
+					"requestsMemory": "1Mi",
+					"limitsMemory":   "20Mi",
+				},
+			},
+		},
+		{
+			name: "cpu and memory requests equal to limits",
+			data: map[string]any{
+				"containerDefaultResourceLimit": map[string]any{
+					"requestsCpu":    "20m",
+					"limitsCpu":      "20m",
+					"requestsMemory": "30Mi",
+					"limitsMemory":   "30Mi",
+				},
+			},
+		},
+		{
+			name: "cpu request over limit",
+			data: map[string]any{
+				"containerDefaultResourceLimit": map[string]any{
+					"requestsCpu":    "30m",
+					"limitsCpu":      "20m",
+					"requestsMemory": "1Mi",
+					"limitsMemory":   "20Mi",
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "cpu and memory requests over limits",
+			data: map[string]any{
+				"containerDefaultResourceLimit": map[string]any{
+					"requestsCpu":    "30m",
+					"limitsCpu":      "20m",
+					"requestsMemory": "30Mi",
+					"limitsMemory":   "20Mi",
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "negative values cause an error",
+			data: map[string]any{
+				"containerDefaultResourceLimit": map[string]any{
+					"requestsCpu":    "-1m",
+					"limitsCpu":      "20m",
+					"requestsMemory": "1Mi",
+					"limitsMemory":   "20Mi",
+				},
+			},
+			errExpected: true,
+		},
+	}
+
+	var store projectStore
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := store.validateContainerDefaultResourceLimit(test.data)
+			if test.errExpected && err == nil {
+				t.Fatalf("expected an error, but did not get it")
+			}
+			if !test.errExpected && err != nil {
+				t.Fatalf("got an unexpected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39700
 
## Problem

Norman doesn't validate container resource default limits that are associated with a new or updated Project. This results in controllers responsible for making the corresponding limit ranges in the project's namespaces to fail asynchronously. The K8s API server rejects limit ranges whose requests are greater than limits for any resource.
 
## Solution

Add validation to Norman on Project create and update.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Manual tests with the UI and Rancher's Terraform provider (which also makes requests to Norman).

### Automated Testing

<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_