### PR TITLE
[2.9] update legacy framework to override ipv6 default

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -106,6 +106,9 @@ class AmazonWebServices(CloudProviderBase):
             volume_size = AWS_WINDOWS_VOLUME_SIZE
             instance_type = AWS_WINDOWS_INSTANCE_TYPE
 
+        ipv6_addresses = 0
+        if public_ip:
+            ipv6_addresses += 1
         if key_name:
             # if cert private key
             if key_name.endswith('.pem'):
@@ -139,7 +142,8 @@ class AmazonWebServices(CloudProviderBase):
                 "NetworkInterfaces": [
                     {'DeviceIndex': 0,
                      'AssociatePublicIpAddress': public_ip,
-                     'Groups': [AWS_SECURITY_GROUP]
+                     'Groups': [AWS_SECURITY_GROUP],
+                     'Ipv6AddressCount': ipv6_addresses
                      }
                 ],
                 "Placement": {'AvailabilityZone': AWS_REGION_AZ},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
airgap isn't airgapped; aws recently set ipv6 to enabled by default, which broke our airgap which didn't explicitly set it to off
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
disable ipv6 if pubic_ip is disabled
 
