### PR TITLE
bump rancher-webhook to v0.5.0-rc2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 103.0.1+up0.4.2
+webhookVersion: 104.0.0+up0.5.0-rc2
 cspAdapterMinVersion: 103.0.0+up3.0.0
 defaultShellVersion: rancher/shell:v0.1.22
 fleetVersion: 103.1.0+up0.9.0

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,5 +6,5 @@ const (
 	CspAdapterMinVersion = "103.0.0+up3.0.0"
 	DefaultShellVersion  = "rancher/shell:v0.1.22"
 	FleetVersion         = "103.1.0+up0.9.0"
-	WebhookVersion       = "103.0.1+up0.4.2"
+	WebhookVersion       = "104.0.0+up0.5.0-rc2"
 )

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -19,8 +19,6 @@ RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_V
 ARG VERSION=dev
 LABEL io.cattle.agent true
 ENV AGENT_IMAGE ${RANCHER_REPO}/rancher-agent:${VERSION}
-# For now, this value needs to be manually synced with the one in the main Dockerfile. This pins downstream webhook's version.
-ENV CATTLE_RANCHER_WEBHOOK_VERSION=103.0.1+up0.4.2
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 ARG CATTLE_RANCHER_WEBHOOK_VERSION
 ENV CATTLE_RANCHER_WEBHOOK_VERSION=$CATTLE_RANCHER_WEBHOOK_VERSION


### PR DESCRIPTION
Updating to the latest chart: https://github.com/rancher/charts/pull/3351