### PR TITLE
Passing empty list for extra settings

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -337,7 +337,7 @@ def add_repo_create_namespace(repo=RANCHER_HELM_REPO, url=RANCHER_HELM_URL):
 
 
 def install_rancher(type=RANCHER_HA_CERT_OPTION, repo=RANCHER_HELM_REPO,
-                    upgrade=False, extra_settings=None):
+                    upgrade=False, extra_settings=[]):
     operation = "install"
 
     if upgrade:


### PR DESCRIPTION
Updating extra settings in install_rancher to be an empty list as for test_upgrade_rancher_ha when extra settings are passed, since it is defined as None, appending helm settings errors out with `'NoneType' object has no attribute 'append'` 