### PR TITLE
Adds automated support to test `Init node cannot be deleted` issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+	github.com/rancher/shepherd => github.com/josh-diamond/shepherd v0.0.0-20240403201708-28c4de366a83
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.1

--- a/go.sum
+++ b/go.sum
@@ -1330,6 +1330,8 @@ github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/josh-diamond/shepherd v0.0.0-20240403201708-28c4de366a83 h1:dOJ0aMK25CuPD241SCd8CNkI+tZmKDupCajk/eBwTMk=
+github.com/josh-diamond/shepherd v0.0.0-20240403201708-28c4de366a83/go.mod h1:pggo0NvlbxaplK5cwiTSp7AixbGrGWbz6CC710biulI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -1695,8 +1697,6 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.3 h1:7mGn+NIL7KXk99NwWYBgoByh2+IfVCdws5ad3X/JIZY=
 github.com/rancher/rke v1.5.3/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240212210618-6f6f377a7e21 h1:GCa3Yv6im4aAxchaPWFlsqN3jxeZGgCgNulkvRhhS7I=
-github.com/rancher/shepherd v0.0.0-20240212210618-6f6f377a7e21/go.mod h1:pggo0NvlbxaplK5cwiTSp7AixbGrGWbz6CC710biulI=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906 h1:gToXZxM/5S5lze/vCpQs50PJ33QTGCOaJHzjYh6y1RE=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906/go.mod h1:IAeZiWgZLSGGlYOUa3qj/G6i1eKl2LFuZ/DKb9mIrzw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/deleting/delete_init_machine.go
+++ b/tests/v2/validation/deleting/delete_init_machine.go
@@ -1,0 +1,40 @@
+package deleting
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/nodes"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fleetNamespace        = "fleet-default"
+	initNodeLabelKey      = "rke.cattle.io/init-node"
+	True                  = "true"
+	local                 = "local"
+	machineNameSteveLabel = "rke.cattle.io/machine-name"
+	machinePlanSecretType = "rke.cattle.io/machine-plan"
+    machineSteveResourceType = "cluster.x-k8s.io.machine"
+)
+
+func deleteInitMachine(t *testing.T, client *rancher.Client, clusterID string) {
+	initMachine, err := nodes.GetInitMachine(client, clusterID)
+	require.NoError(t, err)
+
+	err = nodes.DeleteMachineRKE2K3S(client, initMachine)
+	require.NoError(t, err)
+
+	logrus.Info("Awaiting machine replacement...")
+
+	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
+	require.NoError(t, err)
+
+	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
+	require.NoError(t, err)
+
+	err = nodes.VerifyDeletedMachineRKE2K3S(client, initMachine)
+	require.NoError(t, err)
+}

--- a/tests/v2/validation/deleting/delete_init_machine_test.go
+++ b/tests/v2/validation/deleting/delete_init_machine_test.go
@@ -1,0 +1,44 @@
+package deleting
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DeleteInitMachineTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (d *DeleteInitMachineTestSuite) TearDownSuite() {
+	d.session.Cleanup()
+}
+
+func (d *DeleteInitMachineTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	d.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(d.T(), err)
+
+	d.client = client
+}
+
+func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
+	clusterID, err := clusters.GetClusterIDByName(d.client, d.client.RancherConfig.ClusterName)
+	require.NoError(d.T(), err)
+
+	deleteInitMachine(d.T(), d.client, clusterID)
+} 
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestDeleteInitMachineTestSuite(t *testing.T) {
+	suite.Run(t, new(DeleteInitMachineTestSuite))
+}


### PR DESCRIPTION
adds a test and extensions to delete the init node of a downstream cluster, then verify successful deletion

Issue:
https://github.com/rancher/rancher/issues/42709