### PR TITLE
Support overriding the default path in ingress template

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -43,7 +43,8 @@ spec:
   - host: {{ .Values.hostname }}  # hostname to access rancher server
     http:
       paths:
-      {{- range default ["/"] .Values.ingress.paths }}
+      {{- $defaultPaths := list "/" }}
+      {{- range default $defaultPaths .Values.ingress.paths }}
       - backend:
           {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
           service:
@@ -58,6 +59,7 @@ spec:
         pathType: ImplementationSpecific
         path: {{ . }}
         {{- end }}
+      {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:
   - hosts:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -43,6 +43,7 @@ spec:
   - host: {{ .Values.hostname }}  # hostname to access rancher server
     http:
       paths:
+      {{- range .Values.ingress.paths }}
       - backend:
           {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
           service:
@@ -55,7 +56,7 @@ spec:
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
         pathType: ImplementationSpecific
-        path: "/"
+        path: {{ . }}
         {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -43,7 +43,7 @@ spec:
   - host: {{ .Values.hostname }}  # hostname to access rancher server
     http:
       paths:
-      {{- range .Values.ingress.paths }}
+      {{- range default ["/"] .Values.ingress.paths }}
       - backend:
           {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
           service:

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -238,3 +238,23 @@ tests:
                     number: 80
               pathType: ImplementationSpecific
               path: /
+- it: should create a http rule and override path
+  set:
+    hostname: host.example.com
+    ingress:
+      paths:
+        - "/*"
+  asserts:
+  - equal:
+      path: spec.rules
+      value:
+        - host: host.example.com
+          http:
+            paths:
+            - backend:
+                service:
+                  name: RELEASE-NAME-rancher
+                  port:
+                    number: 80
+              pathType: ImplementationSpecific
+              path: "/*"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -63,6 +63,9 @@ ingress:
   # backend port number
   servicePort: 80
 
+  paths:
+    - /
+
   # configurationSnippet - Add additional Nginx configuration. This example statically sets a header on the ingress.
   # configurationSnippet: |
   #   more_set_input_headers "X-Forwarded-Host: {{ .Values.hostname }}";


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/44160
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently the helm chart `Ingress` template hard code `path` to `/`, and `pathType` to `ImplementationSpecific`. Unfortunately this doesn't work with AWS Load Balancer Controller, because if we intend the path definition here to be `Prefix`, we need `path` to be `/*`.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 This change here would allow user to override `paths` based on individual need (which would match the `pathType` of `ImplementationSpecific`). It uses `["/"]` as default which maintains backward compatibility
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit (helm unittest)

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Test a values file against the helm chart with `.ingress.paths` defined as well as with no `.ingress.paths` set. In the latter case, the generated Ingress resource should by default use "/" as `path`, same as current behavior
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
- `it: should create a http rule with path` (existing test) validates no `.ingress.paths` set
- `it: should create a http rule and override path` (new test) validates `.ingress.paths` set overrides the default value