### PR TITLE
Adding timeout for some required manual changes

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -163,6 +163,8 @@ def test_install_rancher_ha(precheck_certificate_options):
     wait_for_status_code(url=auth_url, expected_code=200)
     admin_client = set_url_and_password(RANCHER_SERVER_URL)
     cluster = get_cluster_by_name(admin_client, "local")
+    time.sleep(120)
+    
     validate_cluster_state(admin_client, cluster, False)
     print("Local HA Rancher cluster created successfully! "
           "Access the UI via:\n{}".format(RANCHER_SERVER_URL))


### PR DESCRIPTION
Adding a timeout for cluster state as the automation scripts error out with local cluster in 
[ERROR] error syncing 'local': handler global-admin-cluster-sync: failed to get GlobalRoleBinding for 'globaladmin-user-xxxx': %!!(MISSING)w(<nil>), requeuing
