### PR TITLE
[Backport v2.7.11] Don't render providerID field into machine provision arguments

### DIFF
--- a/pkg/controllers/capr/machinenodelookup/controller.go
+++ b/pkg/controllers/capr/machinenodelookup/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rancher/lasso/pkg/dynamic"
@@ -17,15 +18,14 @@ import (
 	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/data"
 	"github.com/rancher/wrangler/pkg/generic"
+	"github.com/rancher/wrangler/pkg/summary"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -58,6 +58,8 @@ func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager 
 	clients.RKE.RKEBootstrap().OnChange(ctx, "machine-node-lookup", h.associateMachineWithNode)
 }
 
+// associateMachineWithNode back-populates the provider ID and addresses from the K8s v1 Node object onto the
+// corresponding infrastructure machine object that is referenced by the bootstrap.
 func (h *handler) associateMachineWithNode(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
 	if bootstrap == nil || bootstrap.DeletionTimestamp != nil {
 		return bootstrap, nil
@@ -77,6 +79,26 @@ func (h *handler) associateMachineWithNode(_ string, bootstrap *rkev1.RKEBootstr
 
 	if machine.Spec.ProviderID != nil && *machine.Spec.ProviderID != "" {
 		// If the machine already has its provider ID set, then we do not need to continue
+		return bootstrap, nil
+	}
+
+	gvk := schema.FromAPIVersionAndKind(machine.Spec.InfrastructureRef.APIVersion, machine.Spec.InfrastructureRef.Kind)
+	infra, err := h.dynamic.Get(gvk, machine.Namespace, machine.Spec.InfrastructureRef.Name)
+	if apierror.IsNotFound(err) {
+		return bootstrap, nil
+	} else if err != nil {
+		return bootstrap, err
+	}
+
+	d, err := data.Convert(infra)
+	if err != nil {
+		return bootstrap, err
+	}
+
+	// Do not mutate the infrastructure machine object if it is not marked as Ready, otherwise it will cause the
+	// controller to potentially re-run the provision job
+	if c := getCondition(d, "Ready"); c == nil || (c != nil && strings.ToLower(c.Status()) != "true") {
+		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, nodeErrorEnqueueTime)
 		return bootstrap, nil
 	}
 
@@ -104,27 +126,12 @@ func (h *handler) associateMachineWithNode(_ string, bootstrap *rkev1.RKEBootstr
 		return bootstrap, nil
 	}
 
-	return bootstrap, h.updateMachine(&nodes.Items[0], machine)
-}
-
-func (h *handler) updateMachine(node *corev1.Node, machine *capi.Machine) error {
-	gvk := schema.FromAPIVersionAndKind(machine.Spec.InfrastructureRef.APIVersion, machine.Spec.InfrastructureRef.Kind)
-	infra, err := h.dynamic.Get(gvk, machine.Namespace, machine.Spec.InfrastructureRef.Name)
-	if apierror.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	d, err := data.Convert(infra)
-	if err != nil {
-		return err
-	}
+	node := &nodes.Items[0]
 
 	if d.String("spec", "providerID") != node.Spec.ProviderID {
 		obj, err := data.Convert(infra.DeepCopyObject())
 		if err != nil {
-			return err
+			return bootstrap, err
 		}
 
 		obj.SetNested(node.Status.Addresses, "status", "addresses")
@@ -132,19 +139,29 @@ func (h *handler) updateMachine(node *corev1.Node, machine *capi.Machine) error 
 			Object: obj,
 		})
 		if err != nil {
-			return err
+			return bootstrap, err
 		}
 
 		obj, err = data.Convert(newObj)
 		if err != nil {
-			return err
+			return bootstrap, err
 		}
 
 		obj.SetNested(node.Spec.ProviderID, "spec", "providerID")
 		_, err = h.dynamic.Update(&unstructured.Unstructured{
 			Object: obj,
 		})
-		return err
+		return bootstrap, err
+	}
+
+	return bootstrap, nil
+}
+
+func getCondition(d data.Object, conditionType string) *summary.Condition {
+	for _, cond := range summary.GetUnstructuredConditions(d) {
+		if cond.Type() == conditionType {
+			return &cond
+		}
 	}
 
 	return nil

--- a/pkg/controllers/capr/machineprovision/args.go
+++ b/pkg/controllers/capr/machineprovision/args.go
@@ -275,6 +275,11 @@ func toArgs(driverName string, args map[string]any, clusterID string) (cmd []str
 	}
 
 	for k, v := range args {
+		// Don't render providerID into the arguments, as this is only a cluster-api required field.
+		if k == "providerID" {
+			continue
+		}
+
 		dmField := "--" + driverName + "-" + strings.ToLower(regExHyphen.ReplaceAllString(k, "${1}-${2}"))
 		if v == nil {
 			continue


### PR DESCRIPTION
## Backport Issue:
https://github.com/rancher/rancher/issues/44198

## Original Issue: 
https://github.com/rancher/rancher/issues/43505

## Backport of:
https://github.com/rancher/rancher/issues/43511
https://github.com/rancher/rancher/pull/43512
 
## Problem
The `providerID` field is set on an infrastructuremachine object after the node corresponding to the machine has successfully registered. If this field is set before the infrastructuremachine object ready condition is set to `True`, it can cause a re-run of the machine provision job that will error due the unrecognized argument.

## Solution
Ignore the providerID field if it is set in the `InfrastructureMachine` spec.
 
## Testing

## Engineering Testing
### Manual Testing
I provisioned a vSphere cluster with this change.

In order to specifically exasperate this issue, I had to create a patched version of `rancher-machine` that introduces a 5 minute delay to vSphere machine creation. As such, the reproduction steps heavily rely on using the patched version of Rancher Machine.

1. Start Rancher v2.7.9 and set environment variable `CATTLE_MACHINE_PROVISION_IMAGE=oats87/machine:v0.15.0-rancher100-vs5mdelay`
1. Create a new vSphere cluster, using K3s `v1.26.11+k3s2`, with 1 machine pool containing 1 "all-in-one" role. For my purposes of testing, I used a `Ubuntu Jammy` template.
1. Wait for the cluster to provision. Notably, due to the custom machine provision image, it will take a while (5 minutes + normal provision time) for the cluster to come online.
1. Add a second machine pool, identical to the first except for name and specifying roles as "worker only"
1. Observe that machines in the second machine pool are not successfully created, and will flash an error message about `unknown field --provider-id`
1. Upgrade Rancher to the latest minor version containing the patch from this PR
1. See cluster stabilize over time with successfully provisioned nodes

*NOTE:* This testing will inevitably leave orphaned vSphere VMs, so make sure you clean up after them.  

### Automated Testing
* Test types added/modified:
    * None
* If "None" - Reason: The existing machineprovision tests in the e2e framework should cover regression validation of the change

Summary: N/A

## QA Testing Considerations
Please see the steps I followed in the "engineering testing" section to validate that the fix enables successful provisioning of clusters. 

I would also test the major cloud infrastructure providers, i.e. I would upgrade Rancher from `v2.7.9` to the `v2.7-Patch1` version containing this fix, provisioning clusters in AWS and Azure, testing scaling before and after upgrading Rancher. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
I do not anticipate regressions with this change as the logic gates that existed prior to this change prevent machine from being invoked in a job as the `Ready` condition is set on the corresponding machine object. In the standard order of operations, `rancher-machine` is finished running and `CAPI` can mark the object as `Ready` before the `machinenodelookup` controller has the opportunity to set the `providerID` field on the object. Due to slowness with vSphere nodes where VMware Tools can take a while to start up, it is possible that the node comes up, gets assigned a provider ID, and has this provider ID backpopulated onto the object before machine is finished running. 

Existing / newly added automated tests that provide evidence there are no regressions:
* None