### PR TITLE
[v2.9] chore: improve error message when eks cluster does not have nodes

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -190,7 +190,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 		// EKS cluster must have at least one node to run cluster agent. The best way to verify
 		// if a cluster has self-managed node or nodegroup is to check if the cluster agent was deployed.
 		// Issue: https://github.com/rancher/eks-operator/issues/301
-		addNgMessage := "Cluster must have at least one managed nodegroup."
+		addNgMessage := "Cluster must have at least one managed nodegroup or one self-managed node."
 		noNodeGroupsOnSpec := len(cluster.Spec.EKSConfig.NodeGroups) == 0
 		noNodeGroupsOnUpstreamSpec := len(cluster.Status.EKSStatus.UpstreamSpec.NodeGroups) == 0
 		if !apimgmtv3.ClusterConditionAgentDeployed.IsTrue(cluster) &&


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44239
 
## Problem
After merging https://github.com/rancher/rancher/pull/43882, imported EKS clusters without managed node groups no longer cause an error as long as the agent is installed in a self-managed node. The error message when the cluster has zero nodes (either managed or self-managed) is still the same and not aligned with the requirements.
 
## Solution
The error message is updated to include self-managed nodes as a valid compute option.
 
## Testing


## Engineering Testing
### Manual Testing

### Automated Testing
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_