### PR TITLE
Update dockerconfigjson to use base64 StdEncoding

### DIFF
--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -96,7 +96,7 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 			if err != nil {
 				return registry.URL, "", err
 			}
-			return registry.URL, base64.URLEncoding.EncodeToString(encodedJSON), nil
+			return registry.URL, base64.StdEncoding.EncodeToString(encodedJSON), nil
 		}
 
 		// no private registry secret, generate authconfig based on existing fields
@@ -107,7 +107,7 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 		// check for the RKE1 registry secret next
 		registrySecret, err := secretLister.Get(namespace.GlobalNamespace, registrySecretName)
 		if err == nil {
-			return registry.URL, base64.URLEncoding.EncodeToString(registrySecret.Data[corev1.DockerConfigJsonKey]), nil
+			return registry.URL, base64.StdEncoding.EncodeToString(registrySecret.Data[corev1.DockerConfigJsonKey]), nil
 		}
 		if err != nil && !apierrors.IsNotFound(err) { // ignore secret not found errors as we need to check v2prov clusters
 			return registry.URL, "", err
@@ -149,5 +149,5 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 		return registryURL, "", err
 	}
 
-	return registryURL, base64.URLEncoding.EncodeToString(registryJSON), nil
+	return registryURL, base64.StdEncoding.EncodeToString(registryJSON), nil
 }

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -50,7 +50,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 		{
 			name:           "rke1 private registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
-			expectedConfig: base64.URLEncoding.EncodeToString([]byte("testConfig")), // should be directly copied from RKE1 secret
+			expectedConfig: base64.StdEncoding.EncodeToString([]byte("testConfig")), // should be directly copied from RKE1 secret
 			expectedError:  "",
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{
@@ -84,7 +84,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 		{
 			name:           "v2prov private registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
-			expectedConfig: base64.URLEncoding.EncodeToString([]byte(`{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`)),
+			expectedConfig: base64.StdEncoding.EncodeToString([]byte(`{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`)),
 			expectedError:  "",
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> rancher/rancher#42675 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Backport Issue rancher/rancher#42044 
Backport PR rancher/rancher#42069 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Generating a private registry `.dockerconfigjson` used URL encoding instead of standard b64 encoding.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Use standard encoding.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Updated existing unit tests to confirm expected config

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Test system default registries and cluster private registries
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Regressions should be unlikely, either private registries work or they don't.

Existing / newly added automated tests that provide evidence there are no regressions:
Covered by existing private registry automation tests