### PR TITLE
Fix panic in etcd restore

### DIFF
--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -719,6 +719,9 @@ func (p *Planner) forceDeleteAllDeletingEtcdMachines(cp *rkev1.RKEControlPlane, 
 		}
 		logrus.Infof("[planner] rkecluster %s/%s: force deleting etcd machine %s/%s as cluster was not sane and machine was deleting", cp.Namespace, cp.Name, deletingEtcdNode.Machine.Namespace, deletingEtcdNode.Machine.Name)
 		// Update the CAPI machine annotation for exclude node draining and set it to true to get the CAPI controllers to not try to drain this node.
+		if deletingEtcdNode.Machine.Annotations == nil {
+			deletingEtcdNode.Machine.Annotations = map[string]string{}
+		}
 		deletingEtcdNode.Machine.Annotations[capi.ExcludeNodeDrainingAnnotation] = "true"
 		var err error
 		deletingEtcdNode.Machine, err = p.machines.Update(deletingEtcdNode.Machine)
@@ -733,6 +736,9 @@ func (p *Planner) forceDeleteAllDeletingEtcdMachines(cp *rkev1.RKEControlPlane, 
 		rb = rb.DeepCopy()
 		// Annotate the rkebootstrap with a "force remove" annotation. This will short-circuit the "safe etcd removal"
 		// logic because at this point we are completely taking the cluster down.
+		if rb.Annotations == nil {
+			rb.Annotations = map[string]string{}
+		}
 		rb.Annotations[capr.ForceRemoveEtcdAnnotation] = "true"
 		_, err = p.rkeBootstrap.Update(rb)
 		if err != nil {

--- a/pkg/capr/planner/etcdrestore_test.go
+++ b/pkg/capr/planner/etcdrestore_test.go
@@ -1,0 +1,281 @@
+package planner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/provisioningv2/image"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestForceDeleteAllDeletingEtcdMachines(t *testing.T) {
+	t.Parallel()
+
+	timeNow := metav1.NewTime(time.Now())
+	setup := func(t *testing.T, mp *mockPlanner) {
+		mp.machines.EXPECT().Update(gomock.Any()).DoAndReturn(func(machine *capi.Machine) (*capi.Machine, error) {
+			assert.Equal(t, machine.Annotations[capi.ExcludeNodeDrainingAnnotation], "true")
+			return machine, nil
+		}).AnyTimes()
+		mp.rkeBootstrapCache.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string) (*rkev1.RKEBootstrap, error) {
+			return &rkev1.RKEBootstrap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}, nil
+		}).AnyTimes()
+		mp.rkeBootstrap.EXPECT().Update(gomock.Any()).DoAndReturn(func(bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
+			assert.Equal(t, bootstrap.Annotations[capr.ForceRemoveEtcdAnnotation], "true")
+			return bootstrap, nil
+		}).AnyTimes()
+	}
+
+	tests := []struct {
+		name         string
+		controlPlane *rkev1.RKEControlPlane
+		plan         *plan.Plan
+		expected     int
+		setup        func(t *testing.T, mp *mockPlanner)
+	}{
+		{
+			name:         "no machines",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan:         &plan.Plan{},
+			expected:     0,
+			setup:        nil,
+		},
+		{
+			name:         "no etcd machines",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan: &plan.Plan{
+				Machines: map[string]*capi.Machine{
+					"a": {},
+				},
+				Metadata: map[string]*plan.Metadata{
+					"a": {
+						Labels: map[string]string{
+							capr.WorkerRoleLabel: "true",
+						},
+					},
+				},
+			},
+			expected: 0,
+			setup:    nil,
+		},
+		{
+			name:         "non-deleting etcd machine",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan: &plan.Plan{
+				Machines: map[string]*capi.Machine{
+					"a": {},
+				},
+				Metadata: map[string]*plan.Metadata{
+					"a": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+				},
+			},
+			expected: 0,
+			setup:    nil,
+		},
+		{
+			name:         "nil bootstrap ref",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan: &plan.Plan{
+				Machines: map[string]*capi.Machine{
+					"a": {
+						Spec: capi.MachineSpec{
+							Bootstrap: capi.Bootstrap{
+								ConfigRef: nil,
+							},
+						},
+					},
+				},
+				Metadata: map[string]*plan.Metadata{
+					"a": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+				},
+			},
+			expected: 0,
+			setup:    nil,
+		},
+		{
+			name:         "non rke.cattle.io APIVersion",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan: &plan.Plan{
+				Machines: map[string]*capi.Machine{
+					"a": {
+						Spec: capi.MachineSpec{
+							Bootstrap: capi.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "rancher.testing.io",
+								},
+							},
+						},
+					},
+				},
+				Metadata: map[string]*plan.Metadata{
+					"a": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+				},
+			},
+			expected: 0,
+			setup:    nil,
+		},
+		{
+			name:         "nil annotations",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan: &plan.Plan{
+				Machines: map[string]*capi.Machine{
+					"a": {
+						ObjectMeta: metav1.ObjectMeta{
+							DeletionTimestamp: &timeNow,
+						},
+						Spec: capi.MachineSpec{
+							Bootstrap: capi.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "rke.cattle.io",
+								},
+							},
+						},
+					},
+				},
+				Metadata: map[string]*plan.Metadata{
+					"a": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+				},
+			},
+			expected: 1,
+			setup:    setup,
+		},
+		{
+			name:         "exclude draining false",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan: &plan.Plan{
+				Machines: map[string]*capi.Machine{
+					"a": {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								capi.ExcludeNodeDrainingAnnotation: "false",
+							},
+							DeletionTimestamp: &timeNow,
+						},
+						Spec: capi.MachineSpec{
+							Bootstrap: capi.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "rke.cattle.io",
+								},
+							},
+						},
+					},
+				},
+				Metadata: map[string]*plan.Metadata{
+					"a": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+				},
+			},
+			expected: 1,
+			setup:    setup,
+		},
+		{
+			name:         "three deleting etcd",
+			controlPlane: &rkev1.RKEControlPlane{},
+			plan: &plan.Plan{
+				Machines: map[string]*capi.Machine{
+					"a": {
+						ObjectMeta: metav1.ObjectMeta{
+							DeletionTimestamp: &timeNow,
+						},
+						Spec: capi.MachineSpec{
+							Bootstrap: capi.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "rke.cattle.io",
+								},
+							},
+						},
+					},
+					"b": {
+						ObjectMeta: metav1.ObjectMeta{
+							DeletionTimestamp: &timeNow,
+						},
+						Spec: capi.MachineSpec{
+							Bootstrap: capi.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "rke.cattle.io",
+								},
+							},
+						},
+					},
+					"c": {
+						ObjectMeta: metav1.ObjectMeta{
+							DeletionTimestamp: &timeNow,
+						},
+						Spec: capi.MachineSpec{
+							Bootstrap: capi.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "rke.cattle.io",
+								},
+							},
+						},
+					},
+				},
+				Metadata: map[string]*plan.Metadata{
+					"a": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+					"b": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+					"c": {
+						Labels: map[string]string{
+							capr.EtcdRoleLabel: "true",
+						},
+					},
+				},
+			},
+			expected: 3,
+			setup:    setup,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mp := newMockPlanner(t, InfoFunctions{
+				SystemAgentImage: func() string { return "system-agent" },
+				ImageResolver:    image.ResolveWithControlPlane,
+			})
+			if tt.setup != nil {
+				tt.setup(t, mp)
+			}
+			l, err := mp.planner.forceDeleteAllDeletingEtcdMachines(tt.controlPlane, tt.plan)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, l)
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> rancher/rancher#43689 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Original PR: https://github.com/rancher/rancher/pull/43005

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When force deleting etcd machines by applying the capi `"machine.cluster.x-k8s.io/exclude-node-draining"` annotation, the annotations map may be nil.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Check if nil before assignment, and initialize if nil.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Added extensive unit testing

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
Summary: Added unit tests for every code path in the function.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Test P0 etcd restore use cases

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Shouldn't be any regressions, etcd restore should just work.

Existing / newly added automated tests that provide evidence there are no regressions:
* Added unit tests