### PR TITLE
feat: Added a curl exposing the system-agent-uninstall.sh

### DIFF
--- a/pkg/api/steve/additionalapi.go
+++ b/pkg/api/steve/additionalapi.go
@@ -28,6 +28,7 @@ func AdditionalAPIsPreMCM(config *wrangler.Context) func(http.Handler) http.Hand
 		mux.Handle(configserver.ConnectClusterInfo, connectHandler)
 		mux.Handle(installer.SystemAgentInstallPath, installer.Handler)
 		mux.Handle(installer.WindowsRke2InstallPath, installer.Handler)
+		mux.Handle(installer.SystemAgentUninstallPath, installer.Handler)
 		return func(next http.Handler) http.Handler {
 			mux.NotFoundHandler = next
 			return mux

--- a/pkg/capr/installer/server.go
+++ b/pkg/capr/installer/server.go
@@ -17,6 +17,8 @@ func (s *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		content, err = LinuxInstallScript(req.Context(), "", nil, req.Host)
 	case WindowsRke2InstallPath:
 		content, err = WindowsInstallScript(req.Context(), "", nil, req.Host)
+	case SystemAgentUninstallPath:
+		content, err = LinuxUninstallScript(req.Context(), nil, req.Host)
 	}
 
 	if err != nil {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -96,7 +96,8 @@ var (
 	WinsAgentVersion                    = NewSetting("wins-agent-version", "")
 	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
 	CSIProxyAgentURL                    = NewSetting("csi-proxy-agent-url", "https://acs-mirror.azureedge.net/csi-proxy/%[1]s/binaries/csi-proxy-%[1]s.tar.gz")
-	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "") // Defined via environment variable
+	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "")   // Defined via environment variable
+	SystemAgentUninstallScript          = NewSetting("system-agent-uninstall-script", "") // Defined via environment variable
 	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.4.14/install.ps1")
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "") // Defined via environment variable
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")   // Defined via environment variable


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- this PR came from a JIRA issue, also there is another PR from the community that resolves another issue from the install.sh - https://github.com/rancher/system-agent/pull/90
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

 
 A customer want a feature that you can `uninstall` the `rancher-system-agent` with a `curl` like the `install` 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The solution proposed is to expose the `uninstall script` like the `install script`
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

First you need to create a custom cluster and then install the `rancher-system-agent`
then 
```bash
curl -fL {URL}/system-agent-uninstall.sh | sudo  sh -s
```

then you can search for the folders and files to see if the uninstall was sucessful
```bash
ls /etc/systemd/system | grep rancher-system-agent.service
ls /etc/systemd/system | grep rancher-system-agent.env
ls /etc/rancher/agent
ls /var/lib/rancher/agent
ls /usr/local/bin/rancher-system-agent
```

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

You can follow the `testing` part above with all the steps for verification

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
<!-- * Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_ -->

- No application logic is modified by this change - it only serve the `uninstall script`

<!-- Summary: _TODO_ -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions 
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_ -->