### PR TITLE
[v2.7.11] switch KDM branch to dev-v2.7

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -13,7 +13,7 @@ ENV HELM_UNITTEST_VERSION 0.3.2
 ENV K3D_VERSION v5.4.6
 
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
-ENV CATTLE_KDM_BRANCH=release-v2.7
+ENV CATTLE_KDM_BRANCH=dev-v2.7
 
 RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq skopeo
 # use containerd from k3s image, not from bci

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -21,7 +21,7 @@ ARG CHART_DEFAULT_BRANCH=release-v2.7
 ARG PARTNER_CHART_DEFAULT_BRANCH=main
 ARG RKE2_CHART_DEFAULT_BRANCH=main
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
-ARG CATTLE_KDM_BRANCH=release-v2.7
+ARG CATTLE_KDM_BRANCH=dev-v2.7
 
 ENV CATTLE_SYSTEM_CHART_DEFAULT_BRANCH=$SYSTEM_CHART_DEFAULT_BRANCH
 ENV CATTLE_CHART_DEFAULT_BRANCH=$CHART_DEFAULT_BRANCH

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -81,7 +81,7 @@ var (
 	KubernetesVersionToSystemImages     = NewSetting("k8s-version-to-images", "")
 	KubernetesVersionsCurrent           = NewSetting("k8s-versions-current", "")
 	KubernetesVersionsDeprecated        = NewSetting("k8s-versions-deprecated", "")
-	KDMBranch                           = NewSetting("kdm-branch", "release-v2.7")
+	KDMBranch                           = NewSetting("kdm-branch", "dev-v2.7")
 	MachineVersion                      = NewSetting("machine-version", "dev")
 	Namespace                           = NewSetting("namespace", os.Getenv("CATTLE_NAMESPACE"))
 	PasswordMinLength                   = NewSetting("password-min-length", "12")


### PR DESCRIPTION
## GH issues
https://github.com/rancher/rancher/issues/44142
https://github.com/rancher/rancher/issues/44143


## Changes
switch the KDM branch to `dev-v2.7`  to enable RKE1/RKE2/K3s 1.27 versions 

## Related PR 
[KDM - [dev-v2.7] Add 1.27 to Rancher v2.7.11](https://github.com/rancher/kontainer-driver-metadata/pull/1299)