### PR TITLE
Fleet RBAC

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -57,6 +57,8 @@ const (
 	ClusterConditionDefaultProjectCreated condition.Cond = "DefaultProjectCreated"
 	// ClusterConditionSystemProjectCreated true when system project has been created
 	ClusterConditionSystemProjectCreated condition.Cond = "SystemProjectCreated"
+	// FleetWorkspacesSystemProjectCreated true when fleetworkspaces project has been created
+	FleetWorkspacesSystemProjectCreated condition.Cond = "FleetWorkspacesProjectCreated"
 	// Deprecated: ClusterConditionDefaultNamespaceAssigned true when cluster's default namespace has been initially assigned
 	ClusterConditionDefaultNamespaceAssigned condition.Cond = "DefaultNamespaceAssigned"
 	// Deprecated: ClusterConditionSystemNamespacesAssigned true when cluster's system namespaces has been initially assigned to

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -182,7 +182,7 @@ func (n *nsLifecycle) GetSystemProjectName() (string, error) {
 }
 
 func IsFleetNamespace(ns *v1.Namespace) bool {
-	return ns.Name == fleetconst.ClustersLocalNamespace || ns.Name == fleetconst.ClustersDefaultNamespace || ns.Name == fleetconst.ReleaseClustersNamespace || ns.Labels["fleet.cattle.io/managed"] == "true"
+	return ns.Name == fleetconst.ClustersLocalNamespace || ns.Name == fleetconst.ReleaseClustersNamespace || ns.Labels["fleet.cattle.io/managed"] == "true"
 }
 
 func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {

--- a/pkg/controllers/provisioningv2/fleetworkspace/controller_test.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller_test.go
@@ -1,0 +1,188 @@
+package fleetworkspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
+	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/project"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestOnChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fleetWorkspacesProject := v3.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "FleetWorkspaces",
+		},
+		Spec: v3.ProjectSpec{
+			ClusterName: "local",
+		},
+	}
+	workspace := v3.FleetWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "workspace",
+		},
+	}
+
+	tests := map[string]struct {
+		projectsMock       func() mgmtcontrollers.ProjectCache
+		expectedNamespaces []runtime.Object
+		expectedErr        error
+	}{
+		"FleetWorkspaces project exists": {
+			projectsMock: func() mgmtcontrollers.ProjectCache {
+				projectsMock := fake.NewMockCacheInterface[*v3.Project](ctrl)
+				projectsMock.EXPECT().List("local", labels.Set(project.FleetWorkspacesProjectLabel).AsSelector()).Return([]*v3.Project{&fleetWorkspacesProject}, nil)
+
+				return projectsMock
+			},
+			expectedNamespaces: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: workspace.Name,
+						Annotations: map[string]string{
+							nslabels.ProjectIDFieldLabel: fmt.Sprintf("%v:%v", fleetWorkspacesProject.Spec.ClusterName, fleetWorkspacesProject.Name),
+						},
+						Labels: map[string]string{},
+					},
+				},
+			},
+		},
+		"FleetWorkspaces project does not exists": {
+			projectsMock: func() mgmtcontrollers.ProjectCache {
+				ctrl := gomock.NewController(t)
+				projectsMock := fake.NewMockCacheInterface[*v3.Project](ctrl)
+				projectsMock.EXPECT().List("local", labels.Set(project.FleetWorkspacesProjectLabel).AsSelector()).Return([]*v3.Project{}, nil)
+
+				return projectsMock
+			},
+			expectedErr: errorFleetWorkspacesProjectNotFound,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := handle{
+				projectsCache: test.projectsMock(),
+			}
+
+			namespaces, _, err := h.OnChange(&workspace, v3.FleetWorkspaceStatus{})
+
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expectedNamespaces, namespaces)
+		})
+	}
+}
+
+func TestOnSetting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	fleetWorkspacesProject := v3.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "FleetWorkspaces",
+		},
+		Spec: v3.ProjectSpec{
+			ClusterName: "local",
+		},
+	}
+	setting := v3.Setting{
+		Value: "setting",
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fleet-default-workspace-name",
+		},
+	}
+
+	tests := map[string]struct {
+		projectsMock        func() mgmtcontrollers.ProjectCache
+		workspacesCacheMock func() mgmtcontrollers.FleetWorkspaceCache
+		workspacesMock      func() mgmtcontrollers.FleetWorkspaceClient
+		expectedErr         error
+	}{
+		"workspace is created when it doesn't exist": {
+			projectsMock: func() mgmtcontrollers.ProjectCache {
+				projectsMock := fake.NewMockCacheInterface[*v3.Project](ctrl)
+				projectsMock.EXPECT().List("local", labels.Set(project.FleetWorkspacesProjectLabel).AsSelector()).Return([]*v3.Project{&fleetWorkspacesProject}, nil)
+
+				return projectsMock
+			},
+			workspacesCacheMock: func() mgmtcontrollers.FleetWorkspaceCache {
+				workspacesCacheMock := fake.NewMockNonNamespacedCacheInterface[*v3.FleetWorkspace](ctrl)
+				workspacesCacheMock.EXPECT().Get(gomock.Any()).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
+
+				return workspacesCacheMock
+			},
+			workspacesMock: func() mgmtcontrollers.FleetWorkspaceClient {
+				workspacesMock := fake.NewMockNonNamespacedControllerInterface[*v3.FleetWorkspace, *v3.FleetWorkspaceList](ctrl)
+				workspacesMock.EXPECT().Create(&v3.FleetWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: setting.Value,
+						Annotations: map[string]string{
+							nslabels.ProjectIDFieldLabel: fmt.Sprintf("%v:%v", fleetWorkspacesProject.Spec.ClusterName, fleetWorkspacesProject.Name),
+						},
+					},
+				}).Return(nil, nil)
+
+				return workspacesMock
+			},
+		},
+		"workspace is not created when it exists": {
+			projectsMock: func() mgmtcontrollers.ProjectCache {
+				projectsMock := fake.NewMockCacheInterface[*v3.Project](ctrl)
+				projectsMock.EXPECT().List("local", labels.Set(project.FleetWorkspacesProjectLabel).AsSelector()).Return([]*v3.Project{&fleetWorkspacesProject}, nil)
+
+				return projectsMock
+			},
+			workspacesCacheMock: func() mgmtcontrollers.FleetWorkspaceCache {
+				workspacesCacheMock := fake.NewMockNonNamespacedCacheInterface[*v3.FleetWorkspace](ctrl)
+				workspacesCacheMock.EXPECT().Get(gomock.Any()).Return(nil, nil)
+
+				return workspacesCacheMock
+			},
+			workspacesMock: func() mgmtcontrollers.FleetWorkspaceClient {
+				return fake.NewMockNonNamespacedControllerInterface[*v3.FleetWorkspace, *v3.FleetWorkspaceList](ctrl)
+			},
+		},
+		"error returned if FleetWorkspaces project doesn't exist": {
+			projectsMock: func() mgmtcontrollers.ProjectCache {
+				projectsMock := fake.NewMockCacheInterface[*v3.Project](ctrl)
+				projectsMock.EXPECT().List("local", labels.Set(project.FleetWorkspacesProjectLabel).AsSelector()).Return([]*v3.Project{}, nil)
+
+				return projectsMock
+			},
+			workspacesCacheMock: func() mgmtcontrollers.FleetWorkspaceCache {
+				return fake.NewMockNonNamespacedCacheInterface[*v3.FleetWorkspace](ctrl)
+			},
+			workspacesMock: func() mgmtcontrollers.FleetWorkspaceClient {
+				return fake.NewMockNonNamespacedControllerInterface[*v3.FleetWorkspace, *v3.FleetWorkspaceList](ctrl)
+			},
+			expectedErr: errorFleetWorkspacesProjectNotFound,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := handle{
+				projectsCache:  test.projectsMock(),
+				workspaces:     test.workspacesMock(),
+				workspaceCache: test.workspacesCacheMock(),
+			}
+
+			_, err := h.OnSetting("", &setting)
+
+			assert.Equal(t, test.expectedErr, err)
+		})
+	}
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	System  = "System"
-	Default = "Default"
+	System          = "System"
+	Default         = "Default"
+	FleetWorkspaces = "FleetWorkspaces"
 )
 
 const (
@@ -18,7 +19,8 @@ const (
 )
 
 var (
-	SystemProjectLabel = map[string]string{"authz.management.cattle.io/system-project": "true"}
+	SystemProjectLabel          = map[string]string{"authz.management.cattle.io/system-project": "true"}
+	FleetWorkspacesProjectLabel = map[string]string{"authz.management.cattle.io/fleet-workspaces-project": "true"}
 )
 
 func GetSystemProject(clusterName string, projectLister mgmtv3.ProjectLister) (*mgmtv3.Project, error) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42170
 
## Problem
Rancher needs a mechanism to grant users access to fleet resources. Currently, the built-in restricted admin role offers a way for non-admin users to access fleet resources. However, this setup lacks flexibility, and the restricted admin role is now deprecated. We aim to provide users with more flexible options, such as creating a user with view-only permissions or a user with access limited to a single workspace.

## Solution
To address this issue this PR introduces a new `Project` called `FleetWorkspaces`. Backing namespaces for all fleet workspaces (except `fleet-local`) are created in this new `Project`. This enables administrators to create users capable of deploying resources with fleet by defining GlobalRoles and ProjectRoles.
 
## Engineering Testing
### Manual Testing

Use cases:

Capable of deploying in all clusters except the local one and can transfer clusters between workspaces (Restricted Admin) :
- `GlobalRole` with * permissions for  `fleetworkspaces.management.cattle.io `, and  `cluster-owner ` as  `inheretedClusterRole`.
- `ProjectRole` in `FleetWorkspaces` with * permission for all fleet resources: gitrepos, bundles, clusterregistrationtokens,  gitreporestrictions, clusterregistrations, clusters, clustergroups.
- Note: the user can see the local cluster in the UI.

Capable of deploying in all clusters except the local one, but can't transfer clusters between workspaces (Restricted Admin) :
- `GlobalRole` with * permissions for  `fleetworkspaces.management.cattle.io `
- `ProjectRole` in `FleetWorkspaces` with * permission for all fleet resources: gitrepos, bundles, clusterregistrationtokens,  gitreporestrictions, clusterregistrations, clusters, clustergroups.
- Note: the user can see the local cluster in the UI.

View only:
- `GlobalRole` with read, list permission for  `fleetworkspaces.management.cattle.io`
- `ProjectRole` in `FleetWorkspaces` with read, list permission for all fleet resources: gitrepos, bundles, clusterregistrationtokens,  gitreporestrictions, clusterregistrations, clusters, clustergroups.

Capable of managing specific workspace:
- `GlobalRole` with read, list permission for  `fleetworkspaces.management.cattle.io`
- `Role` and `RoleBinding` to one or multiple fleet workspaces backing namespaces with * permission for all fleet resources: gitrepos, bundles, clusterregistrationtokens, gitreporestrictions, clusterregistrations, clusters, clustergroups
- Note: all workspaces are displayed, but the user can just see/modify GitRepos for the workspaces he has permissions for.

For example, this role just gives permission to the `test` `FleetWorkspace`:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: role
  namespace: test
rules:
- apiGroups:
  - fleet.cattle.io
  resources:
  - gitrepos
  - bundles
  - clusterregistrationtokens
  - gitreporestrictions
  - clusters
  - clustergroups
  verbs:
  - "*"
```

Capable of reading a specific workspace:
- `GlobalRole` with read, list permission for  `fleetworkspaces.management.cattle.io`
- `Role` and `RoleBinding` to one or multiple fleet workspaces backing namespaces with read, list permission for all fleet resources: gitrepos, bundles, clusterregistrationtokens, gitreporestrictions, clusterregistrations, clusters, clustergroups
Note: all workspaces are displayed, but the user can just see GitRepos for the workspaces he has permissions for.

### Automated Testing

* Test types added/modified:
    * Unit

## QA Testing Considerations
Keep in mind that when upgrading Rancher existing workspaces should be migrated to the new `FleetWorkspaces` project.
 