### PR TITLE
fix the issue that the promote-to-stable script can not find the target build number

### DIFF
--- a/scripts/chart/promote-to-stable.sh
+++ b/scripts/chart/promote-to-stable.sh
@@ -26,12 +26,20 @@ if ! drone -v; then
     exit 1
 fi
 
-build_number=$(drone build ls rancher/rancher --event tag --format "{{.Number}},{{.Ref}}"| grep ${1}$ |cut -d',' -f1|head -1)
-
-if [[ -n ${build_number} ]];then 
-  drone build promote rancher/rancher ${build_number} promote-stable
-  exit 0
-fi
+source_tag=$1
+page=1
+until [ $page -gt 100 ]; do
+  echo "Finding build number for tag ${source_tag}"
+  build_number=$(drone build ls rancher/rancher --page $page --event tag --format "{{.Number}},{{.Ref}}"| grep "${source_tag}"$ |cut -d',' -f1|head -1)
+  if [[ -n ${build_number} ]]; then
+    echo "Found build number ${build_number} for tag ${source_tag}"
+    drone build promote rancher/rancher "${build_number}" promote-stable
+    exit 0
+    break
+  fi
+  ((page++))
+  sleep 1
+done
 
 echo "No Build Found for TAG: ${1}"
 exit 1


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/44267
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The script `promote-to-stable.sh` errors out like the below:
```
./scripts/chart/promote-to-stable.sh v2.8.1
2024/01/31 10:25:51 proto: duplicate proto type registered: PluginSpec
2024/01/31 10:25:51 proto: duplicate proto type registered: PluginPrivilege
drone version 1.7.0
2024/01/31 10:25:51 proto: duplicate proto type registered: PluginSpec
2024/01/31 10:25:51 proto: duplicate proto type registered: PluginPrivilege
No Build Found for TAG: v2.8.1
```

It happens because the output of the 'drone build ls' command is paged, and `promote-to-stable.sh` does not handle the paging so it checks only the 1st page.  

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Add the logic for  handling the paging, which has been implemented in the [scripts/promote-docker-image.sh](https://github.com/rancher/rancher/blob/4a99245286d7981c27ce2a51c2933e6bfd0743f5/scripts/promote-docker-image.sh#L39-L51)

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

N/A

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The core logic is validated locally:
```
> source_tag=v2.8.1
page=1
until [ $page -gt 100 ]; do
  echo "Finding build number for tag ${source_tag}"
  build_number=$(drone build ls rancher/rancher --page $page --event tag --format "{{.Number}},{{.Ref}}"| grep "${source_tag}"$ |cut -d',' -f1|head -1)
  if [[ -n ${build_number} ]]; then
    echo "Found build number ${build_number} for tag ${source_tag}"
    break
  fi
  ((page++))
  sleep 1
done

Finding build number for tag v2.8.1
2024/01/31 12:28:08 proto: duplicate proto type registered: PluginSpec
2024/01/31 12:28:08 proto: duplicate proto type registered: PluginPrivilege
Finding build number for tag v2.8.1
2024/01/31 12:28:10 proto: duplicate proto type registered: PluginSpec
2024/01/31 12:28:10 proto: duplicate proto type registered: PluginPrivilege
Finding build number for tag v2.8.1
2024/01/31 12:28:11 proto: duplicate proto type registered: PluginSpec
2024/01/31 12:28:11 proto: duplicate proto type registered: PluginPrivilege
Found build number 11363 for tag v2.8.1
```

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

None

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

N/A

Existing / newly added automated tests that provide evidence there are no regressions:

N/A