### PR TITLE
[v2.9] Update go.mod for QA task 1118

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+	github.com/rancher/shepherd => github.com/markusewalker/shepherd v0.0.0-20240202202122-df4d337c47cb
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.1
@@ -167,7 +168,7 @@ require (
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
-	github.com/rancher/rancher/pkg/apis v0.0.0-20230915232223-a9ea4ce4a5ba
+	github.com/rancher/rancher/pkg/apis v0.0.0-20231012231324-73fed4503c08
 	github.com/rancher/shepherd v0.0.0-20240130172509-3690b7e7016b
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )

--- a/go.sum
+++ b/go.sum
@@ -1422,6 +1422,8 @@ github.com/markbates/oncer v1.0.0 h1:E83IaVAHygyndzPimgUYJjbshhDTALZyXxvk9FOlQRY
 github.com/markbates/oncer v1.0.0/go.mod h1:Z59JA581E9GP6w96jai+TGqafHPW+cPfRxz2aSZ0mcI=
 github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
+github.com/markusewalker/shepherd v0.0.0-20240202202122-df4d337c47cb h1:L2WEh7N7lNGpvI3GQ5uQ5IhuEVlD5LbJHzxJeVdDMA8=
+github.com/markusewalker/shepherd v0.0.0-20240202202122-df4d337c47cb/go.mod h1:pggo0NvlbxaplK5cwiTSp7AixbGrGWbz6CC710biulI=
 github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=
 github.com/mattermost/xml-roundtrip-validator v0.1.0/go.mod h1:qccnGMcpgwcNaBnxqpJpWWUiPNr5H3O8eDgGV9gT5To=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -1695,8 +1697,6 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.0 h1:M/YryKnBs7IwzMGA2kh1EiypVQkme6o9KSg0hlllQa4=
 github.com/rancher/rke v1.5.0/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240130172509-3690b7e7016b h1:QvwCGG/xaX0+EH+6osT62t92EJOV0fvNNw4k3Mv18J4=
-github.com/rancher/shepherd v0.0.0-20240130172509-3690b7e7016b/go.mod h1:pggo0NvlbxaplK5cwiTSp7AixbGrGWbz6CC710biulI=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906 h1:gToXZxM/5S5lze/vCpQs50PJ33QTGCOaJHzjYh6y1RE=
 github.com/rancher/steve v0.0.0-20231016202603-993540401906/go.mod h1:IAeZiWgZLSGGlYOUa3qj/G6i1eKl2LFuZ/DKb9mIrzw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -97,6 +97,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
+		provisioningConfig.NodePools[0].SpecifyCustomPublicIP = true
 		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Post release Checks on a RKE1 cluster provisioning is Failing](https://github.com/rancher/qa-tasks/issues/1118)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When running the RKE1 custom cluster provisioning tests, there is a specific check for the etcdctl version. When running the DynamicInput tests, this passes. For the static TDD tests, they fail.

Troubleshooting, it is because the etcd node has the private IP address in the external AND internal IP address for only the static tests; the dynamic tests do not share this problem.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR complements the shepherd PR to ensure the `go.mod` and `go.sum` files are updated as expected.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing

### Automated Testing
Automated runs will be provided to the reviewers offline.