### PR TITLE
[v2.7] Update go.mod for QA task 1118

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 	github.com/rancher/machine => github.com/rancher/machine v0.15.0-rancher109
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+	github.com/rancher/shepherd => github.com/markusewalker/shepherd v0.0.0-20240202202207-c6031e2687f7
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -933,6 +933,8 @@ github.com/markbates/oncer v1.0.0 h1:E83IaVAHygyndzPimgUYJjbshhDTALZyXxvk9FOlQRY
 github.com/markbates/oncer v1.0.0/go.mod h1:Z59JA581E9GP6w96jai+TGqafHPW+cPfRxz2aSZ0mcI=
 github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
+github.com/markusewalker/shepherd v0.0.0-20240202202207-c6031e2687f7 h1:wv4hJ82qmkiMZYiRVDoFQhHdik9A59WjAeGIC4sg/GI=
+github.com/markusewalker/shepherd v0.0.0-20240202202207-c6031e2687f7/go.mod h1:544XWejV/CYcv5NL+NztxJHL2FnZzMqcaz6tdUd/VOs=
 github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=
 github.com/mattermost/xml-roundtrip-validator v0.1.0/go.mod h1:qccnGMcpgwcNaBnxqpJpWWUiPNr5H3O8eDgGV9gT5To=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -1214,8 +1216,6 @@ github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chj
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.10 h1:JP3j9mPjPojopN73Qwu5efKw9PQ7od+GKrHpVJLW3fg=
 github.com/rancher/rke v1.4.10/go.mod h1:zCL+we25sFDQb2jo6EojX8zxBfbB7FxL6Lte6A6eCiY=
-github.com/rancher/shepherd v0.0.0-20240130172559-0b66a23953f2 h1:dIhaNNzN32qrKfhCwPs8L5lTWy2NTy3xzSDcMzccxYU=
-github.com/rancher/shepherd v0.0.0-20240130172559-0b66a23953f2/go.mod h1:544XWejV/CYcv5NL+NztxJHL2FnZzMqcaz6tdUd/VOs=
 github.com/rancher/steve v0.0.0-20230717160251-d040cffef385 h1:xMR4LJY5C4LAkJbmVKYvu4BaCYXx2fu99a0K+gErpA0=
 github.com/rancher/steve v0.0.0-20230717160251-d040cffef385/go.mod h1:lCxhhsajJHMUnj0EU+3mbrucc6mHDYD94abDiWX6I/Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -97,6 +97,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
+		provisioningConfig.NodePools[0].SpecifyCustomPublicIP = true
 		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Post release Checks on a RKE1 cluster provisioning is Failing](https://github.com/rancher/qa-tasks/issues/1118)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When running the RKE1 custom cluster provisioning tests, there is a specific check for the etcdctl version. When running the DynamicInput tests, this passes. For the static TDD tests, they fail.

Troubleshooting, it is because the etcd node has the private IP address in the external AND internal IP address for only the static tests; the dynamic tests do not share this problem.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR complements the shepherd PR to ensure the `go.mod` and `go.sum` files are updated as expected.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing

### Automated Testing
Automated runs will be provided to the reviewers offline.