### PR TITLE
[DRAFT] RBAC Ensurer

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers"
 	mgmtcontroller "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -13,6 +14,7 @@ import (
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/rbac"
+	"github.com/rancher/rancher/pkg/rbac/ensure"
 	"github.com/rancher/rancher/pkg/types/config"
 	wcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	wrangler "github.com/rancher/wrangler/pkg/name"
@@ -56,7 +58,7 @@ func newGlobalRoleBindingLifecycle(management *config.ManagementContext, cluster
 		crbClient:         management.RBAC.ClusterRoleBindings(""),
 		crbLister:         management.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		crLister:          management.RBAC.ClusterRoles("").Controller().Lister(),
-		crtbClient:        management.Management.ClusterRoleTemplateBindings(""),
+		crtbClient:        management.Wrangler.Mgmt.ClusterRoleTemplateBinding(),
 		crtbCache:         management.Wrangler.Mgmt.ClusterRoleTemplateBinding().Cache(),
 		grLister:          management.Management.GlobalRoles("").Controller().Lister(),
 		nsCache:           management.Wrangler.Core.Namespace().Cache(),
@@ -85,9 +87,9 @@ type globalRoleBindingLifecycle struct {
 	clusterRoles      rbacv1.ClusterRoleInterface
 	crLister          rbacv1.ClusterRoleLister
 	crbClient         rbacv1.ClusterRoleBindingInterface
+	crtbClient        mgmtcontroller.ClusterRoleTemplateBindingClient
 	crbLister         rbacv1.ClusterRoleBindingLister
 	crtbCache         mgmtcontroller.ClusterRoleTemplateBindingCache
-	crtbClient        v3.ClusterRoleTemplateBindingInterface
 	grLister          v3.GlobalRoleLister
 	nsCache           wcorev1.NamespaceCache
 	roles             rbacv1.RoleInterface
@@ -98,7 +100,7 @@ type globalRoleBindingLifecycle struct {
 
 func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
 	var returnError error
-	err := grb.reconcileClusterPermissions(obj)
+	err := grb.ensureClusterPermissions(obj)
 	if err != nil {
 		returnError = multierror.Append(returnError, err)
 	}
@@ -115,7 +117,7 @@ func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (runtim
 
 func (grb *globalRoleBindingLifecycle) Updated(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
 	var returnError error
-	err := grb.reconcileClusterPermissions(obj)
+	err := grb.ensureClusterPermissions(obj)
 	if err != nil {
 		returnError = multierror.Append(returnError, err)
 	}
@@ -185,9 +187,9 @@ func (grb *globalRoleBindingLifecycle) deleteAdminBinding(obj *v3.GlobalRoleBind
 	return nil
 }
 
-// reconcileClusterPermissions grants permissions for the binding in all downstream (non-local) clusters. Will also
+// ensureClusterPermissions grants permissions for the binding in all downstream (non-local) clusters. Will also
 // remove invalid bindings (bindings not for active RoleTemplates or for invalid subjects).
-func (grb *globalRoleBindingLifecycle) reconcileClusterPermissions(globalRoleBinding *v3.GlobalRoleBinding) error {
+func (grb *globalRoleBindingLifecycle) ensureClusterPermissions(globalRoleBinding *v3.GlobalRoleBinding) error {
 	globalRole, err := grb.grLister.Get("", globalRoleBinding.GlobalRoleName)
 	if err != nil {
 		return fmt.Errorf("unable to get globalRole %s: %w", globalRoleBinding.Name, err)
@@ -196,65 +198,38 @@ func (grb *globalRoleBindingLifecycle) reconcileClusterPermissions(globalRoleBin
 	if err != nil {
 		return fmt.Errorf("unable to list clusters when reconciling globalRoleBinding %s: %w", globalRoleBinding.Name, err)
 	}
-
 	var missedClusters bool
 	for _, cluster := range clusters {
-		// we don't sync permissions for the local cluster, but we do want to purge user-created permissions
-		if cluster.Name == localClusterName {
-			err := grb.purgeCorruptRoles(nil, cluster, globalRoleBinding)
-			if err != nil {
-				// failure to remove bad bindings shouldn't affect our ability to sync new permissions, so we log and keep processing
-				logrus.Errorf("unable to purge roles for cluster %s and grb %s, some bindings may remain: %s", cluster.Name, globalRoleBinding.Name, err.Error())
-				missedClusters = true
+		checker := newCRTBValidChecker(*globalRoleBinding, *globalRole, cluster.Name)
+		ensurer := ensure.Ensurer[*apisv3.ClusterRoleTemplateBinding]{
+			ExistingStrategy: &ensure.IndexedExistingStrategy[*apisv3.ClusterRoleTemplateBinding]{
+				Cache:     grb.crtbCache,
+				IndexName: crtbGrbOwnerIndex,
+				Key:       fmt.Sprintf("%s/%s", cluster.Name, globalRoleBinding.Name),
+			},
+			ObjectIdentifier: func(crtb *apisv3.ClusterRoleTemplateBinding) string {
+				// we want only one CRTB per roleTemplate
+				return crtb.RoleTemplateName
+			},
+			InvalidStrategy: &ensure.DeleteInvalidObjStrategy[*apisv3.ClusterRoleTemplateBinding, *apisv3.ClusterRoleTemplateBindingList]{
+				Client: grb.crtbClient,
+			},
+			ValidStrategy: &ensure.CreateValidObjStrategy[*apisv3.ClusterRoleTemplateBinding, *apisv3.ClusterRoleTemplateBindingList]{
+				Client: grb.crtbClient,
+			},
+			IsValid: checker.IsValid,
+		}
+		objs := []*apisv3.ClusterRoleTemplateBinding{}
+		if cluster.Name != "local" {
+			for _, roleTemplate := range globalRole.InheritedClusterRoles {
+				objs = append(objs, templateCRTB(globalRoleBinding, cluster.Name, roleTemplate))
 			}
-			// inheritedClusterRoles only apply on non-local clusters, so skip the local cluster
-			continue
 		}
-		err := grb.purgeCorruptRoles(globalRole.InheritedClusterRoles, cluster, globalRoleBinding)
+		err := ensurer.Ensure(objs...)
+		// we don't immediately return so that we can create as many CRTBs as we can
 		if err != nil {
-			// failure to remove bad bindings shouldn't affect our ability to sync new permissions, so we log and keep processing
-			logrus.Errorf("unable to purge roles for cluster %s and grb %s, some bindings may remain: %s", cluster.Name, globalRoleBinding.Name, err.Error())
+			logrus.Errorf("failed to create crtb for globalRoleBinding %s in cluster %s: %s", globalRoleBinding.Name, cluster.Name, err.Error())
 			missedClusters = true
-		}
-		missingRTs, err := grb.findMissingRTs(globalRole.InheritedClusterRoles, cluster, globalRoleBinding)
-		if err != nil {
-			logrus.Errorf("unable to find missing roles for cluster %s and grb %s, some permissions may be missing: %s", cluster.Name, globalRoleBinding.Name, err.Error())
-			missedClusters = true
-			continue
-		}
-		// at this point, the only remaining items are roleTemplates that we don't have a CRTB for in this cluster
-		for _, wantRT := range missingRTs {
-			// create a crtb in the backing namespace for the cluster
-			logrus.Infof("creating backing crtb for grb %s in cluster %s for roleTemplate %s", globalRoleBinding.Name, cluster.Name, wantRT)
-			_, err = grb.crtbClient.Create(&v3.ClusterRoleTemplateBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "crtb-grb-",
-					Namespace:    cluster.Name,
-					// the owner ref needs to be mutable by the k8s garbage collector but we need
-					// a way to identify what CRTBs are from GRBs unambiguously for validation
-					Labels: map[string]string{
-						grbOwnerLabel:               globalRoleBinding.Name,
-						controllers.K8sManagedByKey: controllers.ManagerValue,
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: v3.GlobalRoleBindingGroupVersionKind.GroupVersion().String(),
-							Kind:       v3.GlobalRoleBindingGroupVersionKind.Kind,
-							Name:       globalRoleBinding.Name,
-							UID:        globalRoleBinding.UID,
-						},
-					},
-				},
-				ClusterName:        cluster.Name,
-				RoleTemplateName:   wantRT,
-				UserName:           globalRoleBinding.UserName,
-				GroupPrincipalName: globalRoleBinding.GroupPrincipalName,
-			})
-			// we don't immediately return so that we can create as many CRTBs as we can
-			if err != nil {
-				logrus.Errorf("failed to create crtb for globalRoleBinding %s in cluster %s: %s", globalRoleBinding.Name, cluster.Name, err.Error())
-				missedClusters = true
-			}
 		}
 	}
 	if missedClusters {
@@ -263,65 +238,70 @@ func (grb *globalRoleBindingLifecycle) reconcileClusterPermissions(globalRoleBin
 	return nil
 }
 
-// purgeCorruptRoles removes any CRTBs which were created for this role in the past, but are no longer valid, either
-// because they aren't for a currently requested RoleTemplate, or because they have been corrupted by user intervention.
-// Will return an error if a binding can't be deleted
-func (grb *globalRoleBindingLifecycle) purgeCorruptRoles(wantRTs []string, cluster *v3.Cluster, binding *v3.GlobalRoleBinding) error {
-	currentCRTBs, err := grb.crtbCache.GetByIndex(crtbGrbOwnerIndex, fmt.Sprintf("%s/%s", cluster.Name, binding.Name))
-	if err != nil {
-		return fmt.Errorf("unable to get CRTBs for cluster %s: %w", cluster.Name, err)
+func templateCRTB(globalRoleBinding *v3.GlobalRoleBinding, clusterName string, roleTemplateName string) *apisv3.ClusterRoleTemplateBinding {
+	return &apisv3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "crtb-grb-",
+			Namespace:    clusterName,
+			// the owner ref needs to be mutable by the k8s garbage collector but we need
+			// a way to identify what CRTBs are from GRBs unambiguously for validation
+			Labels: map[string]string{
+				grbOwnerLabel:               globalRoleBinding.Name,
+				controllers.K8sManagedByKey: controllers.ManagerValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v3.GlobalRoleBindingGroupVersionKind.GroupVersion().String(),
+					Kind:       v3.GlobalRoleBindingGroupVersionKind.Kind,
+					Name:       globalRoleBinding.Name,
+					UID:        globalRoleBinding.UID,
+				},
+			},
+		},
+		ClusterName:        clusterName,
+		RoleTemplateName:   roleTemplateName,
+		UserName:           globalRoleBinding.UserName,
+		GroupPrincipalName: globalRoleBinding.GroupPrincipalName,
 	}
-	var deleteErr error
-	seenRTs := map[string]struct{}{}
-	for _, crtb := range currentCRTBs {
-		foundRT := false
-		for _, roleTemplate := range wantRTs {
-			if roleTemplate == crtb.RoleTemplateName {
-				foundRT = true
-				break
-			}
-		}
-		_, seen := seenRTs[crtb.RoleTemplateName]
-		// if the RT isn't one of the ones that we requested, or is corrupt, or refers to the same RT as a prior
-		// valid RT, then we remove it.
-		if !foundRT || !isCRTBValid(crtb, cluster, binding) || seen {
-			// CRTBs can't update some of these fields, so the safest method is to delete/re-create
-			err := grb.crtbClient.DeleteNamespaced(crtb.Namespace, crtb.Name, &metav1.DeleteOptions{})
-			if err != nil {
-				// failure to delete one crtb does not prevent our ability to delete other crtbs, or to determine
-				// which rts we want to remove
-				crtbErr := fmt.Errorf("unable to delete backing crtb %s for globalRoleBinding %s: %w", crtb.Name, binding.Name, err)
-				deleteErr = multierror.Append(deleteErr, crtbErr)
-			}
-		} else {
-			seenRTs[crtb.RoleTemplateName] = struct{}{}
-		}
-	}
-	return deleteErr
 }
 
-// findMissingRTs finds which RoleTemplates were in wantRTs but don't have a valid binding for this cluster yet
-func (grb *globalRoleBindingLifecycle) findMissingRTs(wantRTs []string, cluster *v3.Cluster, binding *v3.GlobalRoleBinding) ([]string, error) {
-	currentRTs := map[string]struct{}{}
-	for _, wantRT := range wantRTs {
-		currentRTs[wantRT] = struct{}{}
-	}
-	currentCRTBs, err := grb.crtbCache.GetByIndex(crtbGrbOwnerIndex, fmt.Sprintf("%s/%s", cluster.Name, binding.Name))
-	if err != nil {
-		return nil, fmt.Errorf("unable to get CRTBs for cluster %s: %w", cluster.Name, err)
-	}
-	for _, crtb := range currentCRTBs {
-		_, rtOk := currentRTs[crtb.RoleTemplateName]
-		if rtOk && isCRTBValid(crtb, cluster, binding) {
-			delete(currentRTs, crtb.RoleTemplateName)
-		}
-	}
-	missingRTs := make([]string, 0, len(currentRTs))
-	for missingRT := range currentRTs {
-		missingRTs = append(missingRTs, missingRT)
-	}
-	return missingRTs, nil
+type crtbValidChecker struct {
+	roleTemplates      map[string]struct{}
+	userName           string
+	groupPrincipalName string
+	clusterName        string
+}
 
+func newCRTBValidChecker(grb apisv3.GlobalRoleBinding, gr apisv3.GlobalRole, clusterName string) crtbValidChecker {
+	c := crtbValidChecker{
+		userName:           grb.UserName,
+		groupPrincipalName: grb.GroupPrincipalName,
+		clusterName:        clusterName,
+	}
+	roleTemplates := map[string]struct{}{}
+	for _, rt := range gr.InheritedClusterRoles {
+		roleTemplates[rt] = struct{}{}
+	}
+	c.roleTemplates = roleTemplates
+	return c
+}
+
+func (c *crtbValidChecker) IsValid(crtb *apisv3.ClusterRoleTemplateBinding) bool {
+	if crtb == nil || crtb.ClusterName == "local" {
+		return false
+	}
+	_, ok := c.roleTemplates[crtb.RoleTemplateName]
+	if !ok {
+		return false
+	}
+	valid := crtb.ClusterName == c.clusterName &&
+		crtb.UserName == c.userName &&
+		crtb.GroupPrincipalName == c.groupPrincipalName &&
+		crtb.DeletionTimestamp == nil
+	if valid {
+		delete(c.roleTemplates, crtb.RoleTemplateName)
+	}
+	return valid
 }
 
 func (grb *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBinding *v3.GlobalRoleBinding) error {
@@ -717,14 +697,4 @@ func (grb *globalRoleBindingLifecycle) purgeInvalidNamespacedRBs(rbs []*v1.RoleB
 		}
 	}
 	return returnError
-}
-
-// isCRTBValid determines if a given CRTB is up to date for a given cluster and owning global role binding. Should
-// only be used in the context of CRTBs owned by GRBs
-func isCRTBValid(crtb *v3.ClusterRoleTemplateBinding, cluster *v3.Cluster, binding *v3.GlobalRoleBinding) bool {
-	return crtb != nil && cluster != nil && binding != nil &&
-		crtb.ClusterName == cluster.Name &&
-		crtb.UserName == binding.UserName &&
-		crtb.GroupPrincipalName == binding.GroupPrincipalName &&
-		crtb.DeletionTimestamp == nil
 }

--- a/pkg/rbac/ensure/ensurer.go
+++ b/pkg/rbac/ensure/ensurer.go
@@ -10,26 +10,29 @@ import (
 // Ensurer is used to ensure that a group of objects has been created in k8s, and that all related corrupted versions
 // of the object are properly processed.
 type Ensurer[T generic.RuntimeMetaObject] struct {
-	// CurrentStrategy is the strategy for retrieving existing objects
-	CurrentStrategy ExistingStrategy[T]
-	// MatchStrategy compares the requested set of objects with the currently existing, valid
-	// set of objects
-	MatchStrategy func(want []T, current []T) ([]T, error)
+	// ExistingStrategy is the strategy for retrieving existing objects that should be compared with the requested
+	// objects
+	ExistingStrategy ExistingStrategy[T]
+	// ObjectIdentifier produces a string that is unique to T. Used to tell if a requested object
+	// is covered by exising objects
+	ObjectIdentifier func(T) string
 	// IsValid is used to determine if a current object should be processed by ValidStrategy
 	// or by InvalidStrategy
 	IsValid func(obj T) bool
-	// InvalidStrategy describes how to process invalid objects
+	// InvalidStrategy describes how to process invalid objects. Invalid objects will not be matched with requested objects
+	// after processing, and are not altered further by Ensure.
 	InvalidStrategy InvalidObjStrategy[T]
-	// ValidStrategy describes how to process valid objects
+	// ValidStrategy describes how to process valid objects. Valid objects are objects which not currently covered by
+	// an existing object, but were requested in parameters of Ensure
 	ValidStrategy ValidObjStrategy[T]
 }
 
 // Ensure uses CurrentStrategy to determine what objects exist, IsValid to determine which objects are valid,
-// InvalidStrategy to process the invalid objects, MatchStrategy to find out what objs are currently covered by valid
+// InvalidStrategy to process the invalid objects, ObjectIdentifier to find out what objs are currently covered by valid
 // objects, and ValidStrategy to process the the uncovered valid objects. Will return an error if it is not able to
 // process any valid/invalid objects, but only after trying to process everything that can be confirmed.
-func (e *Ensurer[T]) Ensure(objs []T) error {
-	current, err := e.CurrentStrategy.GetCurrent()
+func (e *Ensurer[T]) Ensure(objs ...T) error {
+	current, err := e.ExistingStrategy.GetCurrent()
 	if err != nil {
 		return fmt.Errorf("unable to get current items: %w", err)
 	}
@@ -48,10 +51,7 @@ func (e *Ensurer[T]) Ensure(objs []T) error {
 		// we still want to process as many valid objects as possible
 		invalidErr = fmt.Errorf("unable to remove all invalid objects: %w", invalidErr)
 	}
-	needs, err := e.MatchStrategy(objs, valid)
-	if err != nil {
-		return errors.Join(invalidErr, fmt.Errorf("unable to determine which objects are needed: %w", err))
-	}
+	needs := e.match(objs, valid)
 
 	var validErr error
 	for _, needObj := range needs {
@@ -62,4 +62,20 @@ func (e *Ensurer[T]) Ensure(objs []T) error {
 	}
 
 	return errors.Join(invalidErr, validErr)
+}
+
+// match returns a list of items from want which aren't in exists, using ObjectIdentifier to match between the two slices
+func (e *Ensurer[T]) match(want []T, exists []T) []T {
+	existsMap := map[string]struct{}{}
+	for _, existsItem := range exists {
+		existsMap[e.ObjectIdentifier(existsItem)] = struct{}{}
+	}
+	needs := []T{}
+	for _, wantItem := range want {
+		key := e.ObjectIdentifier(wantItem)
+		if _, ok := existsMap[key]; !ok {
+			needs = append(needs, wantItem)
+		}
+	}
+	return needs
 }

--- a/pkg/rbac/ensure/ensurer.go
+++ b/pkg/rbac/ensure/ensurer.go
@@ -1,0 +1,65 @@
+package ensure
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rancher/wrangler/pkg/generic"
+)
+
+// Ensurer is used to ensure that a group of objects has been created in k8s, and that all related corrupted versions
+// of the object are properly processed.
+type Ensurer[T generic.RuntimeMetaObject] struct {
+	// CurrentStrategy is the strategy for retrieving existing objects
+	CurrentStrategy ExistingStrategy[T]
+	// MatchStrategy compares the requested set of objects with the currently existing, valid
+	// set of objects
+	MatchStrategy func(want []T, current []T) ([]T, error)
+	// IsValid is used to determine if a current object should be processed by ValidStrategy
+	// or by InvalidStrategy
+	IsValid func(obj T) bool
+	// InvalidStrategy describes how to process invalid objects
+	InvalidStrategy InvalidObjStrategy[T]
+	// ValidStrategy describes how to process valid objects
+	ValidStrategy ValidObjStrategy[T]
+}
+
+// Ensure uses CurrentStrategy to determine what objects exist, IsValid to determine which objects are valid,
+// InvalidStrategy to process the invalid objects, MatchStrategy to find out what objs are currently covered by valid
+// objects, and ValidStrategy to process the the uncovered valid objects. Will return an error if it is not able to
+// process any valid/invalid objects, but only after trying to process everything that can be confirmed.
+func (e *Ensurer[T]) Ensure(objs []T) error {
+	current, err := e.CurrentStrategy.GetCurrent()
+	if err != nil {
+		return fmt.Errorf("unable to get current items: %w", err)
+	}
+	valid := []T{}
+	var invalidErr error
+	for _, item := range current {
+		isValid := e.IsValid(item)
+		if isValid {
+			valid = append(valid, item)
+			continue
+		}
+		invalidErr = errors.Join(invalidErr, e.InvalidStrategy.ProcessInvalid(item))
+	}
+	if invalidErr != nil {
+		// we don't immediately return this error - even if we can't determine what objects are invalid
+		// we still want to process as many valid objects as possible
+		invalidErr = fmt.Errorf("unable to remove all invalid objects: %w", invalidErr)
+	}
+	needs, err := e.MatchStrategy(objs, valid)
+	if err != nil {
+		return errors.Join(invalidErr, fmt.Errorf("unable to determine which objects are needed: %w", err))
+	}
+
+	var validErr error
+	for _, needObj := range needs {
+		validErr = errors.Join(validErr, e.ValidStrategy.ProcessValid(needObj))
+	}
+	if validErr != nil {
+		validErr = fmt.Errorf("unable to process all valid objects: %w", validErr)
+	}
+
+	return errors.Join(invalidErr, validErr)
+}

--- a/pkg/rbac/ensure/existing_strategy.go
+++ b/pkg/rbac/ensure/existing_strategy.go
@@ -1,0 +1,24 @@
+package ensure
+
+import (
+	"github.com/rancher/wrangler/pkg/generic"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ExistingStrategy describes the strategy to find currently existing objects that an ensurer should validate
+// and process as invalid or valid
+type ExistingStrategy[T runtime.Object] interface {
+	GetCurrent() ([]T, error)
+}
+
+// IndexedExistingStrategy implements ExistingStrategy using an Indexer, provided
+// the Cache, IndexName, and Key
+type IndexedExistingStrategy[T runtime.Object] struct {
+	Cache     generic.CacheInterface[T]
+	IndexName string
+	Key       string
+}
+
+func (i *IndexedExistingStrategy[T]) GetCurrent() ([]T, error) {
+	return i.Cache.GetByIndex(i.IndexName, i.Key)
+}

--- a/pkg/rbac/ensure/invalid_obj_strategy.go
+++ b/pkg/rbac/ensure/invalid_obj_strategy.go
@@ -1,0 +1,21 @@
+package ensure
+
+import (
+	"github.com/rancher/wrangler/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// InvalidObjStrategy describes the strategy for how to process objects which are invalid.
+type InvalidObjStrategy[T generic.RuntimeMetaObject] interface {
+	ProcessInvalid(invalid T) error
+}
+
+// DeleteInvalidObjStrategy implements InvalidObjStrategy and deletes all invalid objects
+type DeleteInvalidObjStrategy[T generic.RuntimeMetaObject, TList runtime.Object] struct {
+	Client generic.ClientInterface[T, TList]
+}
+
+func (d *DeleteInvalidObjStrategy[T, TList]) ProcessInvalid(invalid T) error {
+	return d.Client.Delete(invalid.GetNamespace(), invalid.GetName(), &metav1.DeleteOptions{})
+}

--- a/pkg/rbac/ensure/valid_obj_strategy.go
+++ b/pkg/rbac/ensure/valid_obj_strategy.go
@@ -1,0 +1,21 @@
+package ensure
+
+import (
+	"github.com/rancher/wrangler/pkg/generic"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ValidObjStrategy defines a strategy to process a valid object that is not yet covred by the existing objects
+type ValidObjStrategy[T generic.RuntimeMetaObject] interface {
+	ProcessValid(valid T) error
+}
+
+// CreateValidObjStrategy creates any valid object. Does not check if the object exists before creating.
+type CreateValidObjStrategy[T generic.RuntimeMetaObject, TList runtime.Object] struct {
+	Client generic.ClientInterface[T, TList]
+}
+
+func (c *CreateValidObjStrategy[T, TList]) ProcessValid(valid T) error {
+	_, err := c.Client.Create(valid)
+	return err
+}


### PR DESCRIPTION
Adds an RBAC Ensurer - an object which can be used by RBAC handlers to handle creating/updating/deleting objects without needing to define the entire loop within the handler. Also updates the `inheritedClusterRoles` logic of global roles to use the new ensurer as an example of possible use cases.

At this time, this PR is experimental - more tests are needed for the actual ensurer object before something like this can be merged.