### PR TITLE
Bump csp adapter to 2.0.3-rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -59,7 +59,7 @@ ENV CATTLE_FLEET_MIN_VERSION=102.2.0+up0.8.0
 # Deprecated in favor of CATTLE_RANCHER_WEBHOOK_VERSION.
 ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=''
 ENV CATTLE_RANCHER_WEBHOOK_VERSION=2.0.6+up0.3.6
-ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.2
+ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.3+up2.0.3-rc1
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44107

## Problem:
Support for k8s 1.27

## Testing:

-  Built the rancher image locally with the changes that support k8s 1.27 and installed this on EKS K8s 1.27 cluster
-  Install this version (2.0.3+up2.0.3-rc1) of the rancher-csp-adapter on an EKS Kubernetes (K8s) 1.27 cluster.
-  Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. When the downstream cluster was destroyed, validate that the out-of-compliance message is no longer displayed.
-  Validate support config