### PR TITLE
Fix links in Chart.yaml

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -10,7 +10,6 @@ keywords:
   - rancher
 sources:
   - https://github.com/rancher/rancher
-  - https://github.com/rancher/server-chart
 maintainers:
   - name: Rancher Labs
     email: charts@rancher.com


### PR DESCRIPTION
## Problem
One `sources` link links to an outdated repo.
 
## Solution
Remove link to archived repo as the chart is managed in this repo.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
None
