### PR TITLE
[2.9] Change rancher base image to bci-micro

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,25 @@
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-micro:15.5 AS final
 
-RUN zypper -n install --no-recommends git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small netcat-openbsd mkisofs openssh-clients && \
-    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
-    useradd rancher && \
+# Temporary build stage image
+FROM registry.suse.com/bci/bci-base:15.5 AS builder
+
+# Install system packages using builder image that has zypper
+COPY --from=final / /chroot/
+
+# Install some packages with zypper in the chroot of the final micro image
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small \
+    netcat-openbsd mkisofs openssh-clients && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+# Main stage using bco-micro as the base image
+FROM final
+
+# Copy binaries and configuration files from builder to micro
+COPY --from=builder /chroot/ /
+
+RUN useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \
     chown -R rancher /var/lib/rancher /var/lib/cattle /usr/local/bin
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -7,13 +7,14 @@ FROM registry.suse.com/bci/bci-base:15.5 AS builder
 COPY --from=final / /chroot/
 
 # Install some packages with zypper in the chroot of the final micro image
-RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+RUN zypper refresh && \
+    zypper --installroot /chroot -n in --no-recommends \
     git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small \
     netcat-openbsd mkisofs openssh-clients && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 
-# Main stage using bco-micro as the base image
+# Main stage using bci-micro as the base image
 FROM final
 
 # Copy binaries and configuration files from builder to micro

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -23,6 +23,11 @@ FROM final
 
 # Copy binaries and configuration files from builder to micro
 COPY --from=builder /chroot/ /
+COPY --from=builder \
+    /usr/bin/unshare \
+    /usr/bin/mount \
+    /usr/bin/umount \
+    /usr/bin/
 
 ARG ARCH=amd64
 ENV KUBECTL_VERSION v1.27.10

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -11,13 +11,14 @@ FROM registry.suse.com/bci/bci-base:15.5 AS builder
 COPY --from=final / /chroot/
 
 # Install some packages with zypper in the chroot of the final micro image
-RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+RUN zypper refresh && \
+    zypper --installroot /chroot -n in --no-recommends \
     curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 
-# Main stage using bco-micro as the base image
+# Main stage using bci-micro as the base image
 FROM final
 
 # Copy binaries and configuration files from builder to micro

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -1,8 +1,25 @@
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-micro:15.5 AS final
 
-RUN zypper -n install --no-recommends git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small netcat-openbsd mkisofs && \
-    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
-    useradd rancher && \
+# Temporary build stage image
+FROM registry.suse.com/bci/bci-base:15.5 AS builder
+
+# Install system packages using builder image that has zypper
+COPY --from=final / /chroot/
+
+# Install some packages with zypper in the chroot of the final micro image
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small \
+    netcat-openbsd mkisofs openssh-clients && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+# Main stage using bco-micro as the base image
+FROM final
+
+# Copy binaries and configuration files from builder to micro
+COPY --from=builder /chroot/ /
+
+RUN useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \
     chown -R rancher /var/lib/rancher /var/lib/cattle /usr/local/bin
 

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -7,13 +7,14 @@ FROM registry.suse.com/bci/bci-base:15.5 AS builder
 COPY --from=final / /chroot/
 
 # Install some packages with zypper in the chroot of the final micro image
-RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+RUN zypper refresh && \
+    zypper --installroot /chroot -n in --no-recommends \
     git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small \
     netcat-openbsd mkisofs openssh-clients && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 
-# Main stage using bco-micro as the base image
+# Main stage using bci-micro as the base image
 FROM final
 
 # Copy binaries and configuration files from builder to micro

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -11,7 +11,8 @@ FROM registry.suse.com/bci/bci-base:15.5 AS builder
 COPY --from=final / /chroot/
 
 # Install some packages with zypper in the chroot of the final micro image
-RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+RUN zypper refresh && \
+    zypper --installroot /chroot -n in --no-recommends \
     curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
     zypper --installroot /chroot clean -a && \

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -23,6 +23,11 @@ FROM final
 
 # Copy binaries and configuration files from builder to micro
 COPY --from=builder /chroot/ /
+COPY --from=builder \
+    /usr/bin/unshare \
+    /usr/bin/mount \
+    /usr/bin/umount \
+    /usr/bin/
 
 ARG ARCH=amd64
 ENV KUBECTL_VERSION v1.27.10


### PR DESCRIPTION
The previous base image (`bci-base`) contains several packages that are not required for the `rancher` container image.

The changes aim to decrease the long-term amount of base image CVEs that increases as a given container image version ages.

Follow-up from https://github.com/rancher/rancher/pull/44044.

UPDATE: It also reintroduces `umount`, `mount` and `unshare` to the `rancher/agent` image.