### PR TITLE
Check if necessary clusterroles exist on test

### DIFF
--- a/tests/integration/suite/test_default_roles.py
+++ b/tests/integration/suite/test_default_roles.py
@@ -49,16 +49,16 @@ def add_cluster_roles(admin_mc, remove_resource):
     roles = rbac_api.list_cluster_role()
 
     cr1 = add_cr_if_not_exist(roles=roles,
-                             name="monitoring-ui-view",
-                             rbac_api=rbac_api)
+                              name="monitoring-ui-view",
+                              rbac_api=rbac_api)
 
     cr2 = add_cr_if_not_exist(roles=roles,
-                             name="navlinks-view",
-                             rbac_api=rbac_api)
+                              name="navlinks-view",
+                              rbac_api=rbac_api)
 
     cr3 = add_cr_if_not_exist(roles=roles,
-                             name="navlinks-manage",
-                             rbac_api=rbac_api)
+                              name="navlinks-manage",
+                              rbac_api=rbac_api)
 
     yield
 
@@ -305,7 +305,7 @@ def add_cr_if_not_exist(roles, name, rbac_api):
     for r in roles.items:
         if r.metadata.name == name:
             hasRole = True
-    
+
     if not hasRole:
         body = kubernetes.client.V1ClusterRole()
         body.metadata = kubernetes.client.V1ObjectMeta(name=name)

--- a/tests/integration/suite/test_default_roles.py
+++ b/tests/integration/suite/test_default_roles.py
@@ -2,7 +2,8 @@ import pytest
 import kubernetes
 import json
 from .common import random_str
-from .conftest import wait_for_condition, wait_until, wait_for, kubernetes_api_client
+from .conftest import (
+    wait_for_condition, wait_until, wait_for, kubernetes_api_client)
 
 CREATOR_ANNOTATION = 'authz.management.cattle.io/creator-role-bindings'
 systemProjectLabel = "authz.management.cattle.io/system-project"
@@ -39,6 +40,7 @@ def cleanup_roles(request, admin_mc):
 
     request.addfinalizer(_cleanup)
 
+
 @pytest.fixture(autouse=True)
 def add_cluster_roles(admin_mc, remove_resource):
     k8s_client = kubernetes_api_client(admin_mc.client, 'local')
@@ -46,29 +48,28 @@ def add_cluster_roles(admin_mc, remove_resource):
 
     roles = rbac_api.list_cluster_role()
 
-    hasMon = False
-    hasNavManage = False
-    hasNavView = False
-    for r in roles.items:
-        if r.metadata.name == "monitoring-ui-view":
-            hasMon = True
-        if r.metadata.name == "navlinks-view":
-            hasNavView = True
-        if r.metadata.name == "navlinks-manage":
-            hasNavManage = True
+    cr1 = add_cr_if_not_exist(roles=roles,
+                             name="monitoring-ui-view",
+                             rbac_api=rbac_api)
 
-    if not hasMon:
-        body = kubernetes.client.V1ClusterRole()
-        body.metadata = kubernetes.client.V1ObjectMeta(name="monitoring-ui-view")
-        rbac_api.create_cluster_role(body=body)
-    if not hasNavView:
-        body = kubernetes.client.V1ClusterRole()
-        body.metadata = kubernetes.client.V1ObjectMeta(name="navlinks-view")
-        rbac_api.create_cluster_role(body=body)
-    if not hasNavManage:
-        body = kubernetes.client.V1ClusterRole()
-        body.metadata = kubernetes.client.V1ObjectMeta(name="navlinks-manage")
-        rbac_api.create_cluster_role(body=body)
+    cr2 = add_cr_if_not_exist(roles=roles,
+                             name="navlinks-view",
+                             rbac_api=rbac_api)
+
+    cr3 = add_cr_if_not_exist(roles=roles,
+                             name="navlinks-manage",
+                             rbac_api=rbac_api)
+
+    yield
+
+    # if the cluster role didn't exist before, delete it after the test
+    if cr1:
+        rbac_api.delete_cluster_role("monitoring-ui-view")
+    if cr2:
+        rbac_api.delete_cluster_role("navlinks-view")
+    if cr3:
+        rbac_api.delete_cluster_role("navlinks-manage")
+
 
 @pytest.mark.nonparallel
 def test_cluster_create_default_role(admin_mc, cleanup_roles, remove_resource):
@@ -297,3 +298,15 @@ def crtb_cb(client, crtb):
         c = client.reload(crtb)
         return c.userId is not None
     return cb
+
+
+def add_cr_if_not_exist(roles, name, rbac_api):
+    hasRole = False
+    for r in roles.items:
+        if r.metadata.name == name:
+            hasRole = True
+    
+    if not hasRole:
+        body = kubernetes.client.V1ClusterRole()
+        body.metadata = kubernetes.client.V1ObjectMeta(name=name)
+        return rbac_api.create_cluster_role(body=body)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Currently the integration tests are failing because this issue https://github.com/rancher/webhook/pull/320 checks for ClusterRoles that match the RoleTemplates. If a user hasn't enabled monitoring (like in our CI or dev environments) 3 of the ClusterRoles referenced by RoleTemplates don't exist.

Names of ClusterRoles not created:
`monitoring-ui-view`
`navlinks-view`
`navlinks-manage`
 
## Solution
For the particular integration tests that require these CRs, check that they get created before the tests run. Otherwise the test will fail
 
## Testing
Integration tests pass, on the first attempt and on any subsequent runs.
