### PR TITLE
Release csp adapter version 2.0.4

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -61,7 +61,7 @@ ENV CATTLE_FLEET_MIN_VERSION=102.2.2+up0.8.2-rc.3
 # Deprecated in favor of CATTLE_RANCHER_WEBHOOK_VERSION.
 ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=''
 ENV CATTLE_RANCHER_WEBHOOK_VERSION=2.0.7+up0.3.7-rc2
-ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.3+up2.0.3-rc1
+ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.4
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44107

## Problem:
csp-adapter support for k8s 1.27

## Testing:
scenario 1.
-  Install rancher v2.7.11 and csp-adapter v2.0.4 on an EKS Kubernetes (k8s) 1.27 cluster.
- Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.
- uninstall/downgrade/upgrade

scenario 2.
- Install rancher v2.7.11 and csp-adapter v2.0.4 on an EKS Kubernetes (k8s) 1.26 cluster.
- Upgraded EKS cluster to k8s 1.27 in aws
- Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.