### PR TITLE
Update drone.yaml push steps to use staging registry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -270,98 +270,106 @@ steps:
       - push
       - tag
 
-#- name: stage-binaries
-#  image: rancher/dapper:v0.6.0
-#  commands:
-#  - "cp -r ./bin/* ./package/"
-#  when:
-#    instance:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
-#    - tag
+- name: stage-binaries
+  image: rancher/dapper:v0.6.0
+  commands:
+  - "cp -r ./bin/* ./package/"
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+    - tag
 
-#- name: docker-publish-head
-#  image: plugins/docker
-#  settings:
-#    purge: false
-#    build_args:
-#    - ARCH=amd64
-#    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#    context: package/
-#    custom_dns: 1.1.1.1
-#    dockerfile: package/Dockerfile
-#    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
-#    password:
-#      from_secret: docker_password
-#    repo: rancher/rancher
-#    username:
-#      from_secret: docker_username
-#  when:
-#    ref:
-#      include:
-#      - "refs/heads/master"
-#      - "refs/heads/release/v*"
-#    event:
-#    - push
-#
-#- name: docker-publish-head-installer
-#  image: plugins/docker
-#  settings:
-#    purge: false
-#    build_args:
-#    - ARCH=amd64
-#    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
-#    context: package/
-#    custom_dns: 1.1.1.1
-#    dockerfile: package/Dockerfile.installer
-#    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
-#    password:
-#      from_secret: docker_password
-#    repo: rancher/system-agent-installer-rancher
-#    username:
-#      from_secret: docker_username
-#  when:
-#    ref:
-#      include:
-#      - "refs/heads/master"
-#      - "refs/heads/release/v*"
-#    event:
-#    - push
+- name: docker-publish-head
+  image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
+  settings:
+    purge: false
+    build_args:
+    - ARCH=amd64
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    context: package/
+    custom_dns: 1.1.1.1
+    dockerfile: package/Dockerfile
+    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    password:
+      from_secret: stage_registry_password
+    repo: rancher/rancher
+    username:
+      from_secret: stage_registry_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
 
-#- name: docker-publish-head-agent
-#  image: plugins/docker
-#  settings:
-#    purge: false
-#    build_args:
-#    - ARCH=amd64
-#    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
-#    context: package/
-#    custom_dns: 1.1.1.1
-#    dockerfile: package/Dockerfile.agent
-#    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
-#    password:
-#      from_secret: docker_password
-#    repo: rancher/rancher-agent
-#    username:
-#      from_secret: docker_username
-#  when:
-#    ref:
-#      include:
-#      - "refs/heads/master"
-#      - "refs/heads/release/v*"
-#    event:
-#    - push
+- name: docker-publish-head-installer
+  image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
+  settings:
+    purge: false
+    build_args:
+    - ARCH=amd64
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    context: package/
+    custom_dns: 1.1.1.1
+    dockerfile: package/Dockerfile.installer
+    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    password:
+      from_secret: stage_registry_password
+    repo: rancher/system-agent-installer-rancher
+    username:
+      from_secret: stage_registry_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
+
+- name: docker-publish-head-agent
+  image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
+  settings:
+    purge: false
+    build_args:
+    - ARCH=amd64
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    context: package/
+    custom_dns: 1.1.1.1
+    dockerfile: package/Dockerfile.agent
+    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    password:
+      from_secret: stage_registry_password
+    repo: rancher/rancher-agent
+    username:
+      from_secret: stage_registry_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
 
 - name: docker-publish
   image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -371,17 +379,19 @@ steps:
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
     password:
-      from_secret: docker_password
+      from_secret: stage_registry_password
     repo: rancher/rancher
     tag: "${DRONE_TAG}-linux-amd64"
     username:
-      from_secret: docker_username
+      from_secret: stage_registry_username
   when:
     event:
     - tag
 
 - name: docker-publish-installer
   image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -392,17 +402,19 @@ steps:
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.installer
     password:
-      from_secret: docker_password
+      from_secret: stage_registry_password
     repo: rancher/system-agent-installer-rancher
     tag: "${DRONE_TAG}-linux-amd64"
     username:
-      from_secret: docker_username
+      from_secret: stage_registry_username
   when:
     event:
     - tag
 
 - name: docker-publish-agent
   image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -413,11 +425,11 @@ steps:
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
     password:
-      from_secret: docker_password
+      from_secret: stage_registry_password
     repo: rancher/rancher-agent
     tag: "${DRONE_TAG}-linux-amd64"
     username:
-      from_secret: docker_username
+      from_secret: stage_registry_username
   when:
     event:
     - tag
@@ -508,118 +520,126 @@ steps:
     event:
     - pull_request
 
-#- name: build-push-tag
-#  image: rancher/dapper:v0.6.0
-#  commands:
-#  - dapper ci
-#  privileged: true
-#  volumes:
-#  - name: docker
-#    path: /var/run/docker.sock
-#  when:
-#    instance:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
-#    - tag
+- name: build-push-tag
+  image: rancher/dapper:v0.6.0
+  commands:
+  - dapper ci
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+    - tag
 
-#- name: stage-binaries
-#  image: rancher/dapper:v0.6.0
-#  commands:
-#  - "cp -r ./bin/* ./package/"
-#  when:
-#    instance:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
-#    - tag
+- name: stage-binaries
+  image: rancher/dapper:v0.6.0
+  commands:
+  - "cp -r ./bin/* ./package/"
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+    - tag
 
-#- name: docker-publish-head
-#  image: plugins/docker
-#  settings:
-#    purge: false
-#    build_args:
-#    - ARCH=arm64
-#    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#    context: package/
-#    custom_dns: 1.1.1.1
-#    dockerfile: package/Dockerfile
-#    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
-#    password:
-#      from_secret: docker_password
-#    repo: rancher/rancher
-#    username:
-#      from_secret: docker_username
-#  when:
-#    ref:
-#      include:
-#      - "refs/heads/master"
-#      - "refs/heads/release/v*"
-#    event:
-#    - push
+- name: docker-publish-head
+  image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
+  settings:
+    purge: false
+    build_args:
+    - ARCH=arm64
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    context: package/
+    custom_dns: 1.1.1.1
+    dockerfile: package/Dockerfile
+    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    password:
+      from_secret: stage_registry_password
+    repo: rancher/rancher
+    username:
+      from_secret: stage_registry_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
 
-#- name: docker-publish-head-installer
-#  image: plugins/docker
-#  settings:
-#    purge: false
-#    build_args:
-#    - ARCH=arm64
-#    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
-#    context: package/
-#    custom_dns: 1.1.1.1
-#    dockerfile: package/Dockerfile.installer
-#    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
-#    password:
-#      from_secret: docker_password
-#    repo: rancher/system-agent-installer-rancher
-#    username:
-#      from_secret: docker_username
-#  when:
-#    ref:
-#      include:
-#      - "refs/heads/master"
-#      - "refs/heads/release/v*"
-#    event:
-#    - push
+- name: docker-publish-head-installer
+  image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
+  settings:
+    purge: false
+    build_args:
+    - ARCH=arm64
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    context: package/
+    custom_dns: 1.1.1.1
+    dockerfile: package/Dockerfile.installer
+    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    password:
+      from_secret: stage_registry_password
+    repo: rancher/system-agent-installer-rancher
+    username:
+      from_secret: stage_registry_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
 
-#- name: docker-publish-head-agent
-#  image: plugins/docker
-#  settings:
-#    purge: false
-#    build_args:
-#    - ARCH=arm64
-#    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
-#    context: package/
-#    custom_dns: 1.1.1.1
-#    dockerfile: package/Dockerfile.agent
-#    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
-#    password:
-#      from_secret: docker_password
-#    repo: rancher/rancher-agent
-#    username:
-#      from_secret: docker_username
-#  when:
-#    ref:
-#      include:
-#      - "refs/heads/master"
-#      - "refs/heads/release/v*"
-#    event:
-#    - push
+- name: docker-publish-head-agent
+  image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
+  settings:
+    purge: false
+    build_args:
+    - ARCH=arm64
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    context: package/
+    custom_dns: 1.1.1.1
+    dockerfile: package/Dockerfile.agent
+    tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    password:
+      from_secret: stage_registry_password
+    repo: rancher/rancher-agent
+    username:
+      from_secret: stage_registry_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
 
 - name: docker-publish
   image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -629,17 +649,19 @@ steps:
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
     password:
-      from_secret: docker_password
+      from_secret: stage_registry_password
     repo: rancher/rancher
     tag: "${DRONE_TAG}-linux-arm64"
     username:
-      from_secret: docker_username
+      from_secret: stage_registry_username
   when:
     event:
     - tag
 
 - name: docker-publish-installer
   image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -650,17 +672,19 @@ steps:
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.installer
     password:
-      from_secret: docker_password
+      from_secret: stage_registry_password
     repo: rancher/system-agent-installer-rancher
     tag: "${DRONE_TAG}-linux-arm64"
     username:
-      from_secret: docker_username
+      from_secret: stage_registry_username
   when:
     event:
     - tag
 
 - name: docker-publish-agent
   image: plugins/docker
+  environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -671,11 +695,11 @@ steps:
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
     password:
-      from_secret: docker_password
+      from_secret: stage_registry_password
     repo: rancher/rancher-agent
     tag: "${DRONE_TAG}-linux-arm64"
     username:
-      from_secret: docker_username
+      from_secret: stage_registry_username
   when:
     event:
     - tag
@@ -716,72 +740,76 @@ steps:
       event:
         - pull_request
 
-#  - name: build-push-tag
-#    pull: always
-#    image: rancher/dapper:v0.6.0
-#    commands:
-#      - dapper.exe -f Dockerfile-windows.dapper -d ci
-#    volumes:
-#      - name: docker_pipe
-#        path: \\\\.\\pipe\\docker_engine
-#    when:
-#      instance:
-#        - drone-publish.rancher.io
-#      ref:
-#        include:
-#          - "refs/heads/master"
-#          - "refs/heads/release/v*"
-#          - "refs/tags/v*"
-#      event:
-#        - push
-#        - tag
+  - name: build-push-tag
+    pull: always
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper.exe -f Dockerfile-windows.dapper -d ci
+    volumes:
+      - name: docker_pipe
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/master"
+          - "refs/heads/release/v*"
+          - "refs/tags/v*"
+      event:
+        - push
+        - tag
 
-#  - name: stage-binaries
-#    image: rancher/dapper:v0.6.0
-#    commands:
-#      - "cp -r ./bin/* ./package/windows/"
-#    when:
-#      instance:
-#        - drone-publish.rancher.io
-#      ref:
-#        include:
-#          - "refs/heads/master"
-#          - "refs/heads/release/v*"
-#          - "refs/tags/v*"
-#      event:
-#        - push
-#        - tag
+  - name: stage-binaries
+    image: rancher/dapper:v0.6.0
+    commands:
+      - "cp -r ./bin/* ./package/windows/"
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/master"
+          - "refs/heads/release/v*"
+          - "refs/tags/v*"
+      event:
+        - push
+        - tag
 
-#  - name: docker-publish-head-agent
-#    image: plugins/docker:windows-1809-amd64
-#    settings:
-#      purge: false
-#      build_args:
-#        - SERVERCORE_VERSION=1809
-#        - ARCH=amd64
-#        - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#      context: package/windows
-#      custom_dns: 1.1.1.1
-#      dockerfile: package/windows/Dockerfile.agent
-#      password:
-#        from_secret: docker_password
-#      repo: rancher/rancher-agent
-#      tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-windows-1809
-#      username:
-#        from_secret: docker_username
-#    volumes:
-#      - name: docker_pipe
-#        path: \\\\.\\pipe\\docker_engine
-#    when:
-#      ref:
-#        include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#      event:
-#        - push
+  - name: docker-publish-head-agent
+    image: plugins/docker:windows-1809-amd64
+    environment:
+      DOCKER_REGISTRY: stgregistry.suse.com
+    settings:
+      purge: false
+      build_args:
+        - SERVERCORE_VERSION=1809
+        - ARCH=amd64
+        - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+      context: package/windows
+      custom_dns: 1.1.1.1
+      dockerfile: package/windows/Dockerfile.agent
+      password:
+        from_secret: stage_registry_password
+      repo: rancher/rancher-agent
+      tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-windows-1809
+      username:
+        from_secret: stage_registry_username
+    volumes:
+      - name: docker_pipe
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      ref:
+        include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+      event:
+        - push
 
   - name: docker-publish-agent
     image: plugins/docker:windows-1809-amd64
+    environment:
+      DOCKER_REGISTRY: stgregistry.suse.com
     settings:
       purge: false
       build_args:
@@ -792,11 +820,11 @@ steps:
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
       password:
-        from_secret: docker_password
+        from_secret: stage_registry_password
       repo: rancher/rancher-agent
       tag: "${DRONE_TAG}-windows-1809"
       username:
-        from_secret: docker_username
+        from_secret: stage_registry_username
     volumes:
       - name: docker_pipe
         path: \\\\.\\pipe\\docker_engine
@@ -841,69 +869,69 @@ steps:
       event:
         - pull_request
 
-#  - name: build-push-tag
-#    pull: always
-#    image: rancher/dapper:v0.6.0
-#    commands:
-#      - dapper.exe -f Dockerfile-windows.dapper -d ci
-#    volumes:
-#      - name: docker_pipe
-#        path: \\\\.\\pipe\\docker_engine
-#    when:
-#      instance:
-#        - drone-publish.rancher.io
-#      ref:
-#        include:
-#          - "refs/heads/master"
-#          - "refs/heads/release/v*"
-#          - "refs/tags/v*"
-#      event:
-#        - push
-#        - tag
+  - name: build-push-tag
+    pull: always
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper.exe -f Dockerfile-windows.dapper -d ci
+    volumes:
+      - name: docker_pipe
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/master"
+          - "refs/heads/release/v*"
+          - "refs/tags/v*"
+      event:
+        - push
+        - tag
 
-#  - name: stage-binaries
-#    image: rancher/dapper:v0.6.0
-#    commands:
-#      - "cp -r ./bin/* ./package/windows/"
-#    when:
-#      instance:
-#        - drone-publish.rancher.io
-#      ref:
-#        include:
-#          - "refs/heads/master"
-#          - "refs/heads/release/v*"
-#          - "refs/tags/v*"
-#      event:
-#        - push
-#        - tag
+  - name: stage-binaries
+    image: rancher/dapper:v0.6.0
+    commands:
+      - "cp -r ./bin/* ./package/windows/"
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        include:
+          - "refs/heads/master"
+          - "refs/heads/release/v*"
+          - "refs/tags/v*"
+      event:
+        - push
+        - tag
 
-#  - name: docker-publish-head-agent
-#    image: rancher/drone-images:docker-amd64-ltsc2022
-#    settings:
-#      purge: false
-#      build_args:
-#        - SERVERCORE_VERSION=ltsc2022
-#        - ARCH=amd64
-#        - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-#      context: package/windows
-#      custom_dns: 1.1.1.1
-#      dockerfile: package/windows/Dockerfile.agent
-#      password:
-#        from_secret: docker_password
-#      repo: rancher/rancher-agent
-#      tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-windows-ltsc2022
-#      username:
-#        from_secret: docker_username
-#    volumes:
-#      - name: docker_pipe
-#        path: \\\\.\\pipe\\docker_engine
-#    when:
-#      ref:
-#        include:
-#          - "refs/heads/master"
-#          - "refs/heads/release/v*"
-#      event:
-#        - push
+  - name: docker-publish-head-agent
+    image: rancher/drone-images:docker-amd64-ltsc2022
+    settings:
+      purge: false
+      build_args:
+        - SERVERCORE_VERSION=ltsc2022
+        - ARCH=amd64
+        - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+      context: package/windows
+      custom_dns: 1.1.1.1
+      dockerfile: package/windows/Dockerfile.agent
+      password:
+        from_secret: stage_registry_password
+      repo: stgregistry.suse.com/rancher/rancher-agent
+      tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-windows-ltsc2022
+      username:
+        from_secret: stage_registry_username
+    volumes:
+      - name: docker_pipe
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      ref:
+        include:
+          - "refs/heads/master"
+          - "refs/heads/release/v*"
+      event:
+        - push
 
   - name: docker-publish-agent
     image: rancher/drone-images:docker-amd64-ltsc2022
@@ -917,11 +945,11 @@ steps:
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
       password:
-        from_secret: docker_password
-      repo: rancher/rancher-agent
+        from_secret: stage_registry_password
+      repo: stgregistry.suse.com/rancher/rancher-agent
       tag: "${DRONE_TAG}-windows-ltsc2022"
       username:
-        from_secret: docker_username
+        from_secret: stage_registry_username
     volumes:
       - name: docker_pipe
         path: \\\\.\\pipe\\docker_engine
@@ -938,190 +966,190 @@ trigger:
   event:
     exclude:
       - promote
-#---
-#
-#kind: pipeline
-#name: manifest
-#
-#steps:
-#- name: push-installer-manifest
-#  image: plugins/manifest
-#  settings:
-#    username:
-#      from_secret: docker_username
-#    password:
-#      from_secret: docker_password
-#    spec: manifest-installer.tmpl
-#    ignore_missing: true
-#  when:
-#    instance:
-#      include:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
-#    - tag
+---
 
-#- name: push-installer-manifest-head
-#  image: plugins/manifest
-#  settings:
-#    username:
-#      from_secret: docker_username
-#    password:
-#      from_secret: docker_password
-#    spec: manifest-installer-head.tmpl
-#    ignore_missing: true
-#  when:
-#    instance:
-#      include:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
+kind: pipeline
+name: manifest
 
-#- name: push-agent-manifest
-#  image: plugins/manifest
-#  settings:
-#    username:
-#      from_secret: docker_username
-#    password:
-#      from_secret: docker_password
-#    spec: manifest-agent.tmpl
-#    ignore_missing: true
-#  when:
-#    instance:
-#      include:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
-#    - tag
+steps:
+- name: push-installer-manifest
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: stage_registry_username
+    password:
+      from_secret: stage_registry_password
+    spec: manifest-installer.tmpl
+    ignore_missing: true
+  when:
+    instance:
+      include:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+    - tag
 
-#- name: push-agent-manifest-head
-#  image: plugins/manifest
-#  settings:
-#    username:
-#      from_secret: docker_username
-#    password:
-#      from_secret: docker_password
-#    spec: manifest-agent-head.tmpl
-#    ignore_missing: true
-#  when:
-#    instance:
-#      include:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
+- name: push-installer-manifest-head
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: stage_registry_username
+    password:
+      from_secret: stage_registry_password
+    spec: manifest-installer-head.tmpl
+    ignore_missing: true
+  when:
+    instance:
+      include:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
 
-#- name: push-manifest-head
-#  image: plugins/manifest
-#  settings:
-#    username:
-#      from_secret: docker_username
-#    password:
-#      from_secret: docker_password
-#    spec: manifest-head.tmpl
-#    ignore_missing: true
-#  when:
-#    instance:
-#      include:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
+- name: push-agent-manifest
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: stage_registry_username
+    password:
+      from_secret: stage_registry_password
+    spec: manifest-agent.tmpl
+    ignore_missing: true
+  when:
+    instance:
+      include:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+    - tag
 
-#- name: push-manifest
-#  image: plugins/manifest
-#  settings:
-#    username:
-#      from_secret: docker_username
-#    password:
-#      from_secret: docker_password
-#    spec: manifest.tmpl
-#    ignore_missing: true
-#  when:
-#    instance:
-#      include:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
-#    - tag
-#
-#- name: build-chart
-#  image: rancher/dapper:v0.6.0
-#  commands:
-#  - dapper chart/ci
-#  privileged: true
-#  volumes:
-#  - name: docker
-#    path: /var/run/docker.sock
-#  when:
-#    instance:
-#      - drone-publish.rancher.io
-#    ref:
-#      include:
-#        - "refs/heads/master"
-#        - "refs/heads/release/v*"
-#        - "refs/tags/v*"
-#    event:
-#    - push
-#    - tag
-#
-#- name: chart-publish
-#  image: plugins/gcs
-#  settings:
-#    acl:
-#    - allUsers:READER
-#    cache_control: "public,no-cache,proxy-revalidate"
-#    source: bin/chart
-#    target: releases.rancher.com/server-charts
-#    token:
-#      from_secret: google_auth_key
-#  when:
-#    event:
-#    - tag
-#
-#volumes:
-#- name: docker
-#  host:
-#    path: /var/run/docker.sock
-#
-#trigger:
-#  event:
-#    exclude:
-#    - promote
-#
-#depends_on:
-#- default-linux-amd64
-#- default-linux-arm64
-#- default-windows-1809
-#- default-windows-ltsc2022
+- name: push-agent-manifest-head
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: stage_registry_username
+    password:
+      from_secret: stage_registry_password
+    spec: manifest-agent-head.tmpl
+    ignore_missing: true
+  when:
+    instance:
+      include:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+
+- name: push-manifest-head
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: stage_registry_username
+    password:
+      from_secret: stage_registry_password
+    spec: manifest-head.tmpl
+    ignore_missing: true
+  when:
+    instance:
+      include:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+
+- name: push-manifest
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: stage_registry_username
+    password:
+      from_secret: stage_registry_password
+    spec: manifest.tmpl
+    ignore_missing: true
+  when:
+    instance:
+      include:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+    - tag
+
+- name: build-chart
+  image: rancher/dapper:v0.6.0
+  commands:
+  - dapper chart/ci
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
+    - tag
+
+- name: chart-publish
+  image: plugins/gcs
+  settings:
+    acl:
+    - allUsers:READER
+    cache_control: "public,no-cache,proxy-revalidate"
+    source: bin/chart
+    target: releases.rancher.com/server-charts
+    token:
+      from_secret: google_auth_key
+  when:
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+trigger:
+  event:
+    exclude:
+    - promote
+
+depends_on:
+- default-linux-amd64
+- default-linux-arm64
+- default-windows-1809
+- default-windows-ltsc2022
 ---
 kind: pipeline
 name: docker-image-digests-linux
@@ -1196,7 +1224,7 @@ steps:
     PLUGIN_GITHUB_TAG: "${DRONE_TAG}"
     PLUGIN_INPUT_FILE: "rancher-windows-images.txt"
     PLUGIN_OUTPUT_FILE: "rancher-images-digests-windows-1809.txt"
-    PLUGIN_REGISTRY: "docker.io"
+    PLUGIN_REGISTRY: "stgregistry.suse.com"
   volumes:
     - name: docker_pipe
       path: \\\\.\\pipe\\docker_engine
@@ -1246,7 +1274,7 @@ steps:
     PLUGIN_GITHUB_TAG: "${DRONE_TAG}"
     PLUGIN_INPUT_FILE: "rancher-windows-images.txt"
     PLUGIN_OUTPUT_FILE: "rancher-images-digests-windows-ltsc2022.txt"
-    PLUGIN_REGISTRY: "docker.io"
+    PLUGIN_REGISTRY: "stgregistry.suse.com"
   volumes:
     - name: docker_pipe
       path: \\\\.\\pipe\\docker_engine
@@ -1329,7 +1357,7 @@ steps:
 - name: docker-image-promote
   image: quay.io/skopeo/stable:v1.1.1
   commands:
-  - echo $${DOCKER_PASSWORD} | skopeo login docker.io --username $${DOCKER_USERNAME} --password-stdin
+  - echo $${DOCKER_PASSWORD} | skopeo login $${DOCKER_REGISTRY} --username $${DOCKER_USERNAME} --password-stdin
   - skopeo copy docker://rancher/rancher:$${SOURCE_TAG} docker://rancher/rancher:$${DESTINATION_TAG} --all
   settings:
     custom_dns: 1.1.1.1
@@ -1337,10 +1365,11 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   environment:
+    DOCKER_REGISTRY: stgregistry.suse.com
     DOCKER_PASSWORD:
-      from_secret: docker_password
+      from_secret: stage_registry_password
     DOCKER_USERNAME:
-      from_secret: docker_username
+      from_secret: stage_registry_username
   when:
     event:
     - promote

--- a/manifest-agent-head.tmpl
+++ b/manifest-agent-head.tmpl
@@ -1,29 +1,29 @@
-image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
 manifests:
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-1809
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-1809
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-ltsc2022
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-ltsc2022
     platform:
       architecture: amd64
       os: windows
       version: ltsc2022
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
     platform:
       architecture: s390x
       os: linux

--- a/manifest-agent.tmpl
+++ b/manifest-agent.tmpl
@@ -1,29 +1,29 @@
-image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}-head{{/if}}
+image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}-head{{/if}}
 manifests:
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-1809
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-1809
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-ltsc2022
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-windows-ltsc2022
     platform:
       architecture: amd64
       os: windows
       version: ltsc2022
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
+    image: stgregistry.suse.com/rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
     platform:
       architecture: s390x
       os: linux

--- a/manifest-head.tmpl
+++ b/manifest-head.tmpl
@@ -1,17 +1,17 @@
-image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}-head{{/if}}
+image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}-head{{/if}}
 manifests:
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
+    image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
+    image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
+    image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
     platform:
       architecture: s390x
       os: linux

--- a/manifest-installer-head.tmpl
+++ b/manifest-installer-head.tmpl
@@ -1,17 +1,17 @@
-image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
 manifests:
   -
-    image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
+    image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
+    image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
+    image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
     platform:
       architecture: s390x
       os: linux

--- a/manifest-installer.tmpl
+++ b/manifest-installer.tmpl
@@ -1,17 +1,17 @@
-image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}-head{{/if}}
+image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}-head{{/if}}
 manifests:
   -
-    image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
+    image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
+    image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
+    image: stgregistry.suse.com/rancher/system-agent-installer-rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
     platform:
       architecture: s390x
       os: linux

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,17 +1,17 @@
-image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
 manifests:
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
+    image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
+    image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
+    image: stgregistry.suse.com/rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-s390x
     platform:
       architecture: s390x
       os: linux


### PR DESCRIPTION
## Issue: 
Relates to: https://github.com/rancher/rancher/issues/44141
## Problem

We want to push images relating to the v2.7.11 release to a staging docker registry, and not docker.io. 

## Solution

Reenable the push steps in drone.yaml, for each step which publishes a docker image change the following 

1. For each step which uses the `plugin/docker` Drone plugin
    1.  add an extra environment variable (`DOCKER_REGISTRY`), which is picked up by the `drone/docker` plugin (As can be seen here, [1](https://github.com/drone-plugins/drone-docker/blob/939591f01828eceae54f5768dc7ce08ad0ad0bba/cmd/drone-docker/main.go#L209-L214), [2](https://github.com/drone-plugins/drone-docker/blob/939591f01828eceae54f5768dc7ce08ad0ad0bba/cmd/drone-docker/main.go#L317), [3](https://github.com/drone-plugins/drone-docker/blob/939591f01828eceae54f5768dc7ce08ad0ad0bba/cmd/drone-docker/main.go#L355)). This will ensure that we push images to the staging registry instead of docker.io
    2. Update all references to `docker_username` and `docker_password` to the drone secrets for the staging registry 
2. For each step which uses the `plugins/manifest` plugin, update the associated manifest `.tmpl` file passed to the plugin. Prepend the staging registry URL to all image names. This will cause `plugins/manifest` to publish image manifests to the staging repo ([1](https://github.com/rancher/rancher/blob/798b3da89d6c71f8a30994c0bd7303a755ae55a8/manifest-agent-head.tmpl#L1), [2](https://github.com/rancher/rancher/blob/798b3da89d6c71f8a30994c0bd7303a755ae55a8/.drone.yml#L976), [3](https://github.com/drone-plugins/drone-manifest/blob/af5721dace68ce1cacae7fccdf948efda66da35a/plugin/plugin.go#L99), [4](https://github.com/estesp/manifest-tool/blob/29c4cb6a3402f479ff3bd44bbfe0d9b3273a2e4c/v2/pkg/registry/push.go#L19), [5](https://github.com/distribution/distribution/blob/7c354a4b40feeea21d7eeae4de91c8ff7951e672/reference/normalize.go#L37), [6](https://github.com/distribution/distribution/blob/7c354a4b40feeea21d7eeae4de91c8ff7951e672/reference/normalize.go#L91))
3. For each step using the `rancher/drone-docker-image-digests` image, update the `PLUGIN_REGISTRY` to point to the staging registry ([1](https://github.com/rancher/drone-docker-image-digests/blob/1597b8d26ddfde7cff724783790e9a7270cfd2ff/plugin/main.go#L38-L42))
4. Two steps related to publishing windows images use the image `rancher/drone-images`, so far I have been unable to find the source code or repository which publishes that image, making updating the pipeline for windows a bit difficult. **For these two steps, I have simply updated the `repo` setting and prepended the staging registry URL. This change will need to be confirmed post merge, as I cannot find documentation on if additional settings are needed to push to a non-docker.io registry when using this drone image**

### **Note:** **None of the steps related to Helm charts have been updated.** 

## Testing
Since this is a pipeline change we will need to merge this PR to ensure these changes work as expected

## Engineering Testing
### Manual Testing

### Automated Testing

## QA Testing Considerations

### Regressions Considerations

Existing / newly added automated tests that provide evidence there are no regressions:
