### PR TITLE
Update drone.yaml to use `plugins/docker`, update publishing steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -906,7 +906,9 @@ steps:
         - tag
 
   - name: docker-publish-head-agent
-    image: rancher/drone-images:docker-amd64-ltsc2022
+    image: plugins/docker:windows-ltsc2022-amd64
+    environment:
+      DOCKER_REGISTRY: stgregistry.suse.com
     settings:
       purge: false
       build_args:
@@ -918,7 +920,7 @@ steps:
       dockerfile: package/windows/Dockerfile.agent
       password:
         from_secret: stage_registry_password
-      repo: stgregistry.suse.com/rancher/rancher-agent
+      repo: rancher/rancher-agent
       tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-windows-ltsc2022
       username:
         from_secret: stage_registry_username
@@ -934,7 +936,9 @@ steps:
         - push
 
   - name: docker-publish-agent
-    image: rancher/drone-images:docker-amd64-ltsc2022
+    image: plugins/docker:windows-ltsc2022-amd64
+    environment:
+      DOCKER_REGISTRY: stgregistry.suse.com
     settings:
       purge: false
       build_args:
@@ -946,7 +950,7 @@ steps:
       dockerfile: package/windows/Dockerfile.agent
       password:
         from_secret: stage_registry_password
-      repo: stgregistry.suse.com/rancher/rancher-agent
+      repo: rancher/rancher-agent
       tag: "${DRONE_TAG}-windows-ltsc2022"
       username:
         from_secret: stage_registry_username

--- a/.drone.yml
+++ b/.drone.yml
@@ -288,8 +288,6 @@ steps:
 
 - name: docker-publish-head
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -301,7 +299,8 @@ steps:
     tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher
+    repo: stgregistry.suse.com/rancher/rancher
+    registry: stgregistry.suse.com
     username:
       from_secret: stage_registry_username
   when:
@@ -314,8 +313,6 @@ steps:
 
 - name: docker-publish-head-installer
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -328,7 +325,8 @@ steps:
     tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
     password:
       from_secret: stage_registry_password
-    repo: rancher/system-agent-installer-rancher
+    repo: stgregistry.suse.com/rancher/system-agent-installer-rancher
+    registry: stgregistry.suse.com
     username:
       from_secret: stage_registry_username
   when:
@@ -341,8 +339,6 @@ steps:
 
 - name: docker-publish-head-agent
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -355,7 +351,8 @@ steps:
     tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher-agent
+    repo: stgregistry.suse.com/rancher/rancher-agent
+    registry: stgregistry.suse.com
     username:
       from_secret: stage_registry_username
   when:
@@ -368,8 +365,6 @@ steps:
 
 - name: docker-publish
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -380,7 +375,8 @@ steps:
     dockerfile: package/Dockerfile
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher
+    repo: stgregistry.suse.com/rancher/rancher
+    registry: stgregistry.suse.com
     tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: stage_registry_username
@@ -390,8 +386,6 @@ steps:
 
 - name: docker-publish-installer
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -403,7 +397,8 @@ steps:
     dockerfile: package/Dockerfile.installer
     password:
       from_secret: stage_registry_password
-    repo: rancher/system-agent-installer-rancher
+    repo: stgregistry.suse.com/rancher/system-agent-installer-rancher
+    registry: stgregistry.suse.com
     tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: stage_registry_username
@@ -413,8 +408,6 @@ steps:
 
 - name: docker-publish-agent
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -426,7 +419,8 @@ steps:
     dockerfile: package/Dockerfile.agent
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher-agent
+    repo: stgregistry.suse.com/rancher/rancher-agent
+    registry: stgregistry.suse.com
     tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: stage_registry_username
@@ -558,8 +552,6 @@ steps:
 
 - name: docker-publish-head
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -571,7 +563,8 @@ steps:
     tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher
+    repo: stgregistry.suse.com/rancher/rancher
+    registry: stgregistry.suse.com
     username:
       from_secret: stage_registry_username
   when:
@@ -584,8 +577,6 @@ steps:
 
 - name: docker-publish-head-installer
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -598,7 +589,8 @@ steps:
     tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
     password:
       from_secret: stage_registry_password
-    repo: rancher/system-agent-installer-rancher
+    repo: stgregistry.suse.com/rancher/system-agent-installer-rancher
+    registry: stgregistry.suse.com
     username:
       from_secret: stage_registry_username
   when:
@@ -611,8 +603,6 @@ steps:
 
 - name: docker-publish-head-agent
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -625,7 +615,8 @@ steps:
     tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher-agent
+    repo: stgregistry.suse.com/rancher/rancher-agent
+    registry: stgregistry.suse.com
     username:
       from_secret: stage_registry_username
   when:
@@ -638,8 +629,6 @@ steps:
 
 - name: docker-publish
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -650,7 +639,8 @@ steps:
     dockerfile: package/Dockerfile
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher
+    repo: stgregistry.suse.com/rancher/rancher
+    registry: stgregistry.suse.com
     tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: stage_registry_username
@@ -660,8 +650,6 @@ steps:
 
 - name: docker-publish-installer
   image: plugins/docker
-  environment:
-    DOCKER_REGISTRY: stgregistry.suse.com
   settings:
     purge: false
     build_args:
@@ -673,7 +661,8 @@ steps:
     dockerfile: package/Dockerfile.installer
     password:
       from_secret: stage_registry_password
-    repo: rancher/system-agent-installer-rancher
+    repo: stgregistry.suse.com/rancher/system-agent-installer-rancher
+    registry: stgregistry.suse.com
     tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: stage_registry_username
@@ -696,7 +685,8 @@ steps:
     dockerfile: package/Dockerfile.agent
     password:
       from_secret: stage_registry_password
-    repo: rancher/rancher-agent
+    repo: stgregistry.suse.com/rancher/rancher-agent
+    registry: stgregistry.suse.com
     tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: stage_registry_username
@@ -778,8 +768,6 @@ steps:
 
   - name: docker-publish-head-agent
     image: plugins/docker:windows-1809-amd64
-    environment:
-      DOCKER_REGISTRY: stgregistry.suse.com
     settings:
       purge: false
       build_args:
@@ -791,7 +779,8 @@ steps:
       dockerfile: package/windows/Dockerfile.agent
       password:
         from_secret: stage_registry_password
-      repo: rancher/rancher-agent
+      repo: stgregistry.suse.com/rancher/rancher-agent
+      registry: stgregistry.suse.com
       tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-windows-1809
       username:
         from_secret: stage_registry_username
@@ -808,8 +797,6 @@ steps:
 
   - name: docker-publish-agent
     image: plugins/docker:windows-1809-amd64
-    environment:
-      DOCKER_REGISTRY: stgregistry.suse.com
     settings:
       purge: false
       build_args:
@@ -821,7 +808,8 @@ steps:
       dockerfile: package/windows/Dockerfile.agent
       password:
         from_secret: stage_registry_password
-      repo: rancher/rancher-agent
+      repo: stgregistry.suse.com/rancher/rancher-agent
+      registry: stgregistry.suse.com
       tag: "${DRONE_TAG}-windows-1809"
       username:
         from_secret: stage_registry_username
@@ -907,8 +895,6 @@ steps:
 
   - name: docker-publish-head-agent
     image: plugins/docker:windows-ltsc2022-amd64
-    environment:
-      DOCKER_REGISTRY: stgregistry.suse.com
     settings:
       purge: false
       build_args:
@@ -920,7 +906,8 @@ steps:
       dockerfile: package/windows/Dockerfile.agent
       password:
         from_secret: stage_registry_password
-      repo: rancher/rancher-agent
+      repo: stgregistry.suse.com/rancher/rancher-agent
+      registry: stgregistry.suse.com
       tag: ${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-windows-ltsc2022
       username:
         from_secret: stage_registry_username
@@ -937,8 +924,6 @@ steps:
 
   - name: docker-publish-agent
     image: plugins/docker:windows-ltsc2022-amd64
-    environment:
-      DOCKER_REGISTRY: stgregistry.suse.com
     settings:
       purge: false
       build_args:
@@ -950,7 +935,8 @@ steps:
       dockerfile: package/windows/Dockerfile.agent
       password:
         from_secret: stage_registry_password
-      repo: rancher/rancher-agent
+      repo: stgregistry.suse.com/rancher/rancher-agent
+      registry: stgregistry.suse.com
       tag: "${DRONE_TAG}-windows-ltsc2022"
       username:
         from_secret: stage_registry_username


### PR DESCRIPTION
## Issue: TODO
 
## Problem
#### Problem 1.
Additional changes are needed to publish steps in order to properly authenticate with and push images to the staging registry

#### Problem 2. 
The `windows-ltsc2022` pipeline uses the `rancher/drone-images` image to publish images to dockerhub. It seems this approach was taken a few years ago due to drone not publishing `ltsc2022` tags of the `plugins/docker` image. Unfortunately documentation on how this image works, and what its settings are, seems to have been misplaced. This makes it difficult to update this pipeline.

Specifically, this PR aims to solve the CI failure seen here https://drone-publish.rancher.io/rancher/rancher/11482/8/4, which is due to `rancher/drone-images` not having a well documented list of settings that can be used to define image registries other than docker.io. 
 
## Solution
In the past year `ltsc2022` tags of the `plugins/docker` drone image [have been published!](https://hub.docker.com/r/plugins/docker/tags?page=1&name=2022) This means we can standardize the `ltsc2022` pipeline to use the same image as other pipelines which publish docker images. 

This PR focuses on 2.7.11, but this change should be forward ported / back ported to other release lines.
 
## Testing
This is a pipeline change for post merge CI, it cannot be tested until this pr has been merged 

## Engineering Testing
### Manual Testing

I've verified that the image specified in the `docker-publish-agent-head` and `docker-publish-agent` steps exists by running `crane manifest plugins/docker:windows-ltsc2022-amd64`

```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "size": 4873,
      "digest": "sha256:9a9d42d0b40c4de8faa52803920096d16e8144dfa9579f607d40d462af394e40"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 120604344,
         "digest": "sha256:fff54800e03713ba81736f43d985319592fc643a1a32b62dbd5c0ec36549de00"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1088,
         "digest": "sha256:770c1fb07691026f5702641c62aa7181f1d4890b3e013fb101d9c9b14d5b05e1"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1180,
         "digest": "sha256:c8f931f8b6552a69a44da2914d5183bcfba1b557e8c53305d3199aee1c88ba50"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 83092,
         "digest": "sha256:b526c4573cdbe3fc494351784a304c163acf87baa0ffd62319584e683fc7b0b4"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 48434,
         "digest": "sha256:59f3b8a468fc2c40fe8b0b86de938ef17e89adf8b7f62fae64bccec5675f53b1"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 17431517,
         "digest": "sha256:ffb40493700b856f0c8e91105bb46aaa73566a2b10259341a98708daec186d14"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 4359156,
         "digest": "sha256:13c5089a31f6c823356f16bd22a4b5686f74361afe7c86a7aca29b4652331453"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1030,
         "digest": "sha256:002465a6ee4c361ba09f3c7ffe5f1da7c2a59b72e6ed84d7c7d9e3acd84ad26d"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1174,
         "digest": "sha256:9363a4edc6a3152f5de4bc17ed8f78ced685179d30af3e0b89af54dda1efdd42"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1032,
         "digest": "sha256:d1272fe1dd8830cbc6fd12721792136dc18795dd74628fc10239b9b05e778536"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1062,
         "digest": "sha256:90395343beb42948a88db107231ba81d810e0de81dce166e01dd2701c1c77ee7"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1039,
         "digest": "sha256:93c0da37b198cd7e04087573f390aa375ca8495fb457462f27d3296f30dd9794"
      }
   ]
}
```

### Automated Testing


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_