### PR TITLE
Fix test_globalrolebinding_finalizer_cleanup flaky test

### DIFF
--- a/tests/integration/suite/test_users.py
+++ b/tests/integration/suite/test_users.py
@@ -89,10 +89,11 @@ def test_globalrolebinding_finalizer_cleanup(admin_mc, remove_resource):
         plural="globalrolebindings",
         name=grb_k8s.id,
     )
-    assert (
-        "clusterscoped.controller.cattle.io/grb-sync_fake"
-        not in grb1["metadata"]["finalizers"]
-    )
+    if "finalizers" in grb1["metadata"]:
+        assert (
+            "clusterscoped.controller.cattle.io/grb-sync_fake"
+            not in grb1["metadata"]["finalizers"]
+        )
 
 
 def test_roletemplate_finalizer_cleanup(admin_mc, remove_resource):


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43113
 
## Problem
`test_globalrolebinding_finalizer_cleanup` is asserting that the finalizer `clusterscoped.controller.cattle.io/grb-sync_fake` is cleaned up. The issue arises from the assumption in the test that metadata always contains a `finalizers` field. Although `finalizers` will eventually be present, there's a small window where `metadata` doesn't have `finalizers`. This happens when `clusterscoped.controller.cattle.io/grb-sync_fake` is removed, and before the `controller.cattle.io/mgmt-auth-grb-controller` finalizer is added. This creates a race condition in the test, leading to failures from time to time.

## Solution
Check if `finalizers` is present in the `metadata` field before asserting. If there is no finalizers, it indicates that `clusterscoped.controller.cattle.io/grb-sync_fake` has been removed.
 
## Testing
I ran the test several times before implementing the fix in this PR, and it failed intermittently. However, after implementing the fix, it no longer fails.
