### PR TITLE
[v2.9] require helm check cluster version in airgap setup

### DIFF
--- a/tests/validation/tests/v3_api/test_airgap_ha.py
+++ b/tests/validation/tests/v3_api/test_airgap_ha.py
@@ -364,7 +364,7 @@ def setup_airgap_rancher(bastion_node, number_of_nodes=NUMBER_OF_INSTANCES):
         "--set rancherImage={2}/rancher/rancher " \
         "--set systemDefaultRegistry={2} " \
         "--set useBundledSystemChart=true --set ingress.tls.source=secret " \
-        "--set rancherImageTag={0} --no-hooks".format(
+        "--set rancherImageTag={0} --no-hooks --validate".format(
             RANCHER_SERVER_VERSION,
             RANCHER_AG_INTERNAL_HOSTNAME,
             REGISTRY_HOSTNAME,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 airgap job was failing for python tests

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 helm was using k8s client version, not server version

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
add `--validate` flag to helm template command to match behavior for helm install, which checks the server version
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested locally during release testing
