### PR TITLE
[v2.7] Add support for rotating worker nodes after creating an etcd snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
-	github.com/rancher/shepherd v0.0.0-20240208174732-a86abc649769
+	github.com/rancher/shepherd v0.0.0-20240212210639-54422602a3e7
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1214,8 +1214,8 @@ github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chj
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.10 h1:JP3j9mPjPojopN73Qwu5efKw9PQ7od+GKrHpVJLW3fg=
 github.com/rancher/rke v1.4.10/go.mod h1:zCL+we25sFDQb2jo6EojX8zxBfbB7FxL6Lte6A6eCiY=
-github.com/rancher/shepherd v0.0.0-20240208174732-a86abc649769 h1:IXHZFco8kT0C95bn1XedOxHDMH+ApYFM5jvXp3+EnQM=
-github.com/rancher/shepherd v0.0.0-20240208174732-a86abc649769/go.mod h1:544XWejV/CYcv5NL+NztxJHL2FnZzMqcaz6tdUd/VOs=
+github.com/rancher/shepherd v0.0.0-20240212210639-54422602a3e7 h1:nbAW4pqs7G/X/CkWvpCq4ypMg9JlvGK4LBtrIbTdp3E=
+github.com/rancher/shepherd v0.0.0-20240212210639-54422602a3e7/go.mod h1:544XWejV/CYcv5NL+NztxJHL2FnZzMqcaz6tdUd/VOs=
 github.com/rancher/steve v0.0.0-20230717160251-d040cffef385 h1:xMR4LJY5C4LAkJbmVKYvu4BaCYXx2fu99a0K+gErpA0=
 github.com/rancher/steve v0.0.0-20230717160251-d040cffef385/go.mod h1:lCxhhsajJHMUnj0EU+3mbrucc6mHDYD94abDiWX6I/Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/nodescaling/replace.go
+++ b/tests/v2/validation/nodescaling/replace.go
@@ -24,46 +24,50 @@ const (
 	clusterLabel                 = "cluster.x-k8s.io/cluster-name"
 )
 
-func MatchNodeToRole(t *testing.T, client *rancher.Client, clusterID string, isEtcd bool, isControlPlane bool, isWorker bool) (int, *management.Node) {
+func MatchNodeToRole(t *testing.T, client *rancher.Client, clusterID string, isEtcd bool, isControlPlane bool, isWorker bool) (int, []management.Node) {
 	machines, err := client.Management.Node.List(&types.ListOpts{Filters: map[string]interface{}{
 		"clusterId": clusterID,
 	}})
 	require.NoError(t, err)
+
 	numOfNodes := 0
-	lastMatchingNode := &management.Node{}
+	matchingNodes := []management.Node{}
 
 	for _, machine := range machines.Data {
 		if machine.Etcd == isEtcd && machine.ControlPlane == isControlPlane && machine.Worker == isWorker {
-			lastMatchingNode = &machine
+			matchingNodes = append(matchingNodes, machine)
 			numOfNodes++
 		}
 	}
-	require.NotEmpty(t, lastMatchingNode.NodeName, "matching node name is empty")
-	return numOfNodes, lastMatchingNode
+	require.NotEmpty(t, matchingNodes, "matching node name is empty")
+
+	return numOfNodes, matchingNodes
 }
 
 // ReplaceNodes replaces the last node with the specified role(s) in a k3s/rke2 cluster
 func ReplaceNodes(t *testing.T, client *rancher.Client, clusterName string, isEtcd bool, isControlPlane bool, isWorker bool) {
 	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
 	require.NoError(t, err)
-	numOfNodesBeforeDeletion, nodeToDelete := MatchNodeToRole(t, client, clusterID, isEtcd, isControlPlane, isWorker)
+	numOfNodesBeforeDeletion, nodesToDelete := MatchNodeToRole(t, client, clusterID, isEtcd, isControlPlane, isWorker)
 
-	machineToDelete, err := client.Steve.SteveType(machineSteveResourceType).ByID("fleet-default/" + nodeToDelete.Annotations[machineSteveAnnotation])
-	require.NoError(t, err)
+	for i := range nodesToDelete {
+		machineToDelete, err := client.Steve.SteveType(machineSteveResourceType).ByID("fleet-default/" + nodesToDelete[i].Annotations[machineSteveAnnotation])
+		require.NoError(t, err)
 
-	logrus.Info("Deleting, " + nodeToDelete.Name + " node..")
-	err = client.Steve.SteveType(machineSteveResourceType).Delete(machineToDelete)
-	require.NoError(t, err)
+		logrus.Infof("Replacing node: " + nodesToDelete[i].NodeName)
+		err = client.Steve.SteveType(machineSteveResourceType).Delete(machineToDelete)
+		require.NoError(t, err)
 
-	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
-	require.NoError(t, err)
+		err = clusters.WaitClusterToBeUpgraded(client, clusterID)
+		require.NoError(t, err)
 
-	err = nodestat.AllMachineReady(client, clusterID, defaults.ThirtyMinuteTimeout)
-	require.NoError(t, err)
+		logrus.Infof("Checking if node %s is replaced", nodesToDelete[i].NodeName)
+		_, err = nodestat.IsNodeReplaced(client, machineToDelete.ID, clusterID, numOfNodesBeforeDeletion)
+		require.NoError(t, err)
 
-	isNodeReplaced, err := nodestat.IsNodeReplaced(client, machineToDelete.ID, clusterID, numOfNodesBeforeDeletion, isEtcd, isControlPlane, isWorker)
-	require.NoError(t, err)
-	require.True(t, isNodeReplaced)
+		podErrors := pods.StatusPods(client, clusterID)
+		assert.Empty(t, podErrors)
+	}
 }
 
 // ReplaceRKE1Nodes replaces the last node with the specified role(s) in a rke1 cluster
@@ -72,21 +76,22 @@ func ReplaceRKE1Nodes(t *testing.T, client *rancher.Client, clusterName string, 
 	require.NoError(t, err)
 	numOfNodesBeforeDeletion, nodeToDelete := MatchNodeToRole(t, client, clusterID, isEtcd, isControlPlane, isWorker)
 
-	logrus.Info("Deleting, " + nodeToDelete.NodeName + " node..")
-	err = client.Management.Node.Delete(nodeToDelete)
-	require.NoError(t, err)
+	for i := range nodeToDelete {
+		logrus.Info("Replacing node: " + nodeToDelete[i].NodeName)
+		err = client.Management.Node.Delete(&nodeToDelete[i])
+		require.NoError(t, err)
 
-	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
-	require.NoError(t, err)
+		err = clusters.WaitClusterToBeUpgraded(client, clusterID)
+		require.NoError(t, err)
 
-	err = nodestat.AllManagementNodeReady(client, clusterID, defaults.ThirtyMinuteTimeout)
-	require.NoError(t, err)
+		logrus.Infof("Checking if node %s is replaced", nodeToDelete[i].NodeName)
+		err = nodestat.AllManagementNodeReady(client, clusterID, defaults.ThirtyMinuteTimeout)
+		require.NoError(t, err)
 
-	isNodeReplaced, err := nodestat.IsNodeReplaced(client, nodeToDelete.ID, clusterID, numOfNodesBeforeDeletion, isEtcd, isControlPlane, isWorker)
-	require.NoError(t, err)
+		_, err = nodestat.IsNodeReplaced(client, nodeToDelete[i].ID, clusterID, numOfNodesBeforeDeletion)
+		require.NoError(t, err)
 
-	require.True(t, isNodeReplaced)
-
-	podErrors := pods.StatusPods(client, clusterID)
-	assert.Empty(t, podErrors)
+		podErrors := pods.StatusPods(client, clusterID)
+		assert.Empty(t, podErrors)
+	}
 }

--- a/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -41,15 +41,17 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) SetupSuite() {
 
 func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion: s.clustersConfig.UpgradeKubernetesVersion,
+		UpgradeKubernetesVersion: "",
 		SnapshotRestore:          "kubernetesVersion",
 		RecurringRestores:        1,
+		ReplaceWorkerNode:        false,
 	}
 
 	snapshotRestoreAll := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion: s.clustersConfig.UpgradeKubernetesVersion,
+		UpgradeKubernetesVersion: "",
 		SnapshotRestore:          "all",
 		RecurringRestores:        1,
+		ReplaceWorkerNode:        false,
 	}
 
 	tests := []struct {
@@ -69,6 +71,10 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 }
 
 func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgradeDynamicInput() {
+	if s.clustersConfig == nil {
+		s.T().Skip()
+	}
+
 	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig)
 }
 

--- a/tests/v2/validation/snapshot/snapshot_restore_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_test.go
@@ -44,6 +44,7 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 		UpgradeKubernetesVersion: "",
 		SnapshotRestore:          "none",
 		RecurringRestores:        1,
+		ReplaceWorkerNode:        false,
 	}
 
 	tests := []struct {
@@ -62,6 +63,10 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 }
 
 func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnlyDynamicInput() {
+	if s.clustersConfig == nil {
+		s.T().Skip()
+	}
+
 	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig)
 }
 

--- a/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -41,23 +41,25 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) SetupSuite() {
 
 func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStrategy() {
 	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion:     s.clustersConfig.UpgradeKubernetesVersion,
+		UpgradeKubernetesVersion:     "",
 		SnapshotRestore:              "kubernetesVersion",
 		ControlPlaneConcurrencyValue: "15%",
-		ControlPlaneUnavailableValue: "1",
+		ControlPlaneUnavailableValue: "3",
 		WorkerConcurrencyValue:       "20%",
-		WorkerUnavailableValue:       "10%",
+		WorkerUnavailableValue:       "15%",
 		RecurringRestores:            1,
+		ReplaceWorkerNode:            false,
 	}
 
 	snapshotRestoreAll := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion:     s.clustersConfig.UpgradeKubernetesVersion,
+		UpgradeKubernetesVersion:     "",
 		SnapshotRestore:              "all",
 		ControlPlaneConcurrencyValue: "15%",
-		ControlPlaneUnavailableValue: "1",
+		ControlPlaneUnavailableValue: "3",
 		WorkerConcurrencyValue:       "20%",
-		WorkerUnavailableValue:       "10%",
+		WorkerUnavailableValue:       "15%",
 		RecurringRestores:            1,
+		ReplaceWorkerNode:            false,
 	}
 
 	tests := []struct {
@@ -77,6 +79,10 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 }
 
 func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStrategyDynamicInput() {
+	if s.clustersConfig == nil {
+		s.T().Skip()
+	}
+
 	snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, s.clustersConfig)
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Automate rotating nodes after creating an etcd snapshot](https://github.com/rancher/qa-tasks/issues/989)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
v2.8 backport of https://github.com/rancher/rancher/pull/44338.