### PR TITLE
Ensure drone passes proper registry url to agent and installer dockerfiles 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -319,6 +319,7 @@ steps:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.installer
@@ -345,6 +346,7 @@ steps:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -392,6 +394,7 @@ steps:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-amd64"
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.installer
@@ -414,6 +417,7 @@ steps:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-amd64"
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -583,6 +587,7 @@ steps:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.installer
@@ -609,6 +614,7 @@ steps:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -656,6 +662,7 @@ steps:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-arm64"
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.installer
@@ -680,6 +687,7 @@ steps:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-arm64"
+    - RANCHER_REPO=stgregistry.suse.com/rancher
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Both the rancher agent and installer Dockerfiles use the rancher image as a base. By default, we attempt to retrieve the base from dockerhub. In situations where a staging registry is used, this will fail, as the base image will not be present. 
 
## Solution
Both the agent and installer Dockerfiles provide a `RANCHER_REPO` argument, which is used in the `FROM` statement. By setting the `RANCHER_REPO` argument within drone, we will ensure that 
```
FROM rancher/rancher:${RANCHER_TAG} as rancher
```
becomes 
```
FROM STAGING_REGISTRY/rancher/rancher:${RANCHER_TAG} as rancher
```

## Testing

## Engineering Testing
### Manual Testing
### Automated Testing

## QA Testing Considerations

### Regressions Considerations
