### PR TITLE
[2.8] Use `plugins/docker` for ltsc2022 publish events

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -935,7 +935,7 @@ steps:
         - tag
 
   - name: docker-publish-head-agent
-    image: rancher/drone-images:docker-amd64-ltsc2022
+    image: plugins/docker:windows-ltsc2022-amd64
     settings:
       purge: false
       build_args:
@@ -963,7 +963,7 @@ steps:
         - push
 
   - name: docker-publish-agent
-    image: rancher/drone-images:docker-amd64-ltsc2022
+    image: plugins/docker:windows-ltsc2022-amd64
     settings:
       purge: false
       build_args:


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44401
 
## Problem
The windows-ltsc2022 pipeline stage uses the `rancher/drone-images` image to publish images to dockerhub. It seems this approach was taken a few years ago due to drone not publishing ltsc2022 tags of the `plugins/docker` image. Unfortunately documentation on how the `rancher/drone-images` image works, and what its settings are, seems to have been misplaced. This makes it difficult to update.

## Solution

In the past year ltsc2022 tags of the plugins/docker drone image [have been published.](https://hub.docker.com/r/plugins/docker/tags?page=1&name=2022) This means we can standardize the ltsc2022 stage to use the same image as other pipeline stages which publish docker images.
 
## Testing
This change was tested on the 2.7.11 branch and I confirmed that images were pushed without issue https://drone-publish.rancher.io/rancher/rancher/11509/8/4

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

## QA Testing Considerations

### Regressions Considerations


Existing / newly added automated tests that provide evidence there are no regressions:
