### PR TITLE
[v2.8] [Backport] fix the bug that a panic happens when we create an RKE cluster with clusterTemplateRevision

### DIFF
--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -434,7 +434,11 @@ func loadDataFromTemplate(clusterTemplateRevision *apimgmtv3.ClusterTemplateRevi
 					if err != nil {
 						return nil, httperror.WrapAPIError(err, httperror.ServerError, processingError)
 					}
-					question.Default = registries[index]["password"].(string)
+					// the key may not exist if the password is not set in the clusterTemplateRevision
+					password, ok := registries[index]["password"]
+					if ok {
+						question.Default = password.(string)
+					}
 				} else if strings.HasPrefix(question.Variable, "rancherKubernetesEngineConfig.cloudProvider.vsphereCloudProvider.virtualCenter") {
 					vcenters, ok := values.GetValue(dataFromTemplate, "rancherKubernetesEngineConfig", "cloudProvider", "vsphereCloudProvider", "virtualCenter")
 					if !ok {
@@ -537,7 +541,7 @@ func loadDataFromTemplate(clusterTemplateRevision *apimgmtv3.ClusterTemplateRevi
 		dataFromTemplate[managementv3.ClusterFieldFleetWorkspaceName] = fleetworkspace
 	}
 
-	//validate that the data loaded is valid clusterSpec
+	// validate that the data loaded is valid clusterSpec
 	var spec apimgmtv3.ClusterSpec
 	if err := convert.ToObj(dataFromTemplate, &spec); err != nil {
 		return nil, httperror.WrapAPIError(err, httperror.InvalidBodyContent, "Invalid clusterTemplate, cannot convert to cluster spec")


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/44410

backport of the PR https://github.com/rancher/rancher/pull/44373 

Below is copied from the original PR
---

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

We can create an RKE1 cluster template revision with the private registry enabled but without a password. Panic happens when we create an RKE cluster with that cluster template revision, regardless of whether we set the password or not in the cluster creation page.

In the backend, we need to load the cluster template revision when generating the MgmtCluster object for the cluster, the cluster template revision is converted into an object of the type  `[]map[string]interface{}` where the values are also of the type  `[]map[string]interface{}`. It means that if the password value is not set then the key "password" will not be in the map. 

Later on, when we try to get the password value from a `[]map[string]interface{}` object,  we do not check if the key `password` exists or not before performing a type assertion, which leads to the panic in the backend when the password is unset. ([code](https://github.com/rancher/rancher/blob/565c372ce595dddb01b9698f1d4f7674cd1b7f11/pkg/api/norman/store/cluster/cluster_store.go#L437))


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

We will perform the type asserting to get its value only if the key "password" exists.


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Following the steps provided in the GH issue, I have validated that the panic error does not happen anymore, the red error box does not appear in UI, and the cluster is created successfully.  

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
 
None, lack of the framework capable of testing this fix/change
 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Create or update an RKE1 cluster with an RKE1 template containing a private registry with an empty password. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 

n/a 

Existing / newly added automated tests that provide evidence there are no regressions:

n/a 