### PR TITLE
[v2.7.11] bumped rke to v1.4.15-rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.3.0
-	github.com/rancher/rke v1.4.15-rc2
+	github.com/rancher/rke v1.4.15-rc3
 	github.com/rancher/steve v0.0.0-20240207201940-05ebdc1f5ef1
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcpvX1sM=
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.4.15-rc2 h1:P6gCDPVTWw1GUh8G0yqeCdPR4DvSZ4103RZ1jFYdbfg=
-github.com/rancher/rke v1.4.15-rc2/go.mod h1:odOtH55WTQ5jwlhqTYkwxlbYcOzR6UkFUYXLuaGrVYY=
+github.com/rancher/rke v1.4.15-rc3 h1:L9KdqTdeWLtWjddoHix4AGGvsPVf05Ctsz2M0ErQoi8=
+github.com/rancher/rke v1.4.15-rc3/go.mod h1:odOtH55WTQ5jwlhqTYkwxlbYcOzR6UkFUYXLuaGrVYY=
 github.com/rancher/steve v0.0.0-20240207201940-05ebdc1f5ef1 h1:1I2qcnQUrs2eyrAc4Vi9WTBOaSbIfYCUCaQx6zDOIrA=
 github.com/rancher/steve v0.0.0-20240207201940-05ebdc1f5ef1/go.mod h1:tfdVny3lVO6H0JyysFBZ1ce45kH9VgWLPa9z9TZVI+U=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20230901075223-437edb7091f5
 	github.com/rancher/gke-operator v1.1.6
 	github.com/rancher/norman v0.0.0-20240207153035-cb54924f25c7
-	github.com/rancher/rke v1.4.15-rc2
+	github.com/rancher/rke v1.4.15-rc3
 	github.com/rancher/wrangler v1.1.1
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.27.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -488,8 +488,8 @@ github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29 h1:+kige/h8/LnzWgPjB
 github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29/go.mod h1:kgk9kJVMj9FIrrXU0iyM6u/9Je4bEjPImqswkTVaKsQ=
 github.com/rancher/norman v0.0.0-20240207153035-cb54924f25c7 h1:NojnqhDccRXZTmsGisFu1EJjim2OTQZFSEYMbwbbPn0=
 github.com/rancher/norman v0.0.0-20240207153035-cb54924f25c7/go.mod h1:Sm2Xqai+aecgmJ86ygyEe+TdPMLkauEpykSstBAu4Ko=
-github.com/rancher/rke v1.4.15-rc2 h1:P6gCDPVTWw1GUh8G0yqeCdPR4DvSZ4103RZ1jFYdbfg=
-github.com/rancher/rke v1.4.15-rc2/go.mod h1:odOtH55WTQ5jwlhqTYkwxlbYcOzR6UkFUYXLuaGrVYY=
+github.com/rancher/rke v1.4.15-rc3 h1:L9KdqTdeWLtWjddoHix4AGGvsPVf05Ctsz2M0ErQoi8=
+github.com/rancher/rke v1.4.15-rc3/go.mod h1:odOtH55WTQ5jwlhqTYkwxlbYcOzR6UkFUYXLuaGrVYY=
 github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df h1:WJ+aaUICHPX8HeLmHE9JL/RFHhilMfcJlqmhgpc7gJU=
 github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df/go.mod h1:4T80p+rLh2OLbjCjdExIjRHKNBgK9NUAd7eIU/gRPKk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/44205
bumped rke version includes k8s jan patch versions.