### PR TITLE
Updating configs in the jenkins pipeline to take in rule as a config

### DIFF
--- a/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.ha
+++ b/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.ha
@@ -174,6 +174,18 @@ node {
                 ).trim()
                 println "HA helm repo: ${env.HA_HELM_REPO}"
 
+                env.HA_HELM_URL= sh (
+                  script: "./yq '.ha.helmURL' ${initConfigPath}",
+                  returnStdout: true
+                ).trim()
+                println "HA helm url: ${env.HA_HELM_URL}"
+
+                env.HA_HELM_URL_TO_UPGRADE= sh (
+                  script: "./yq '.ha.helmURLToUpgrade' ${initConfigPath}",
+                  returnStdout: true
+                ).trim()
+                println "HA helm url to upgrade: ${env.HA_HELM_URL_TO_UPGRADE}"
+
                 env.RKE_VERSION= sh (
                   script: "./yq '.ha.rkeVersion' ${initConfigPath}",
                   returnStdout: true
@@ -226,6 +238,7 @@ node {
                  string(name: 'RANCHER_CHART_VERSION', value: "${env.HA_CHART_VERSION}"),
                  string(name: 'RANCHER_IMAGE_TAG', value: "${env.HA_IMAGE_TAG}"),
                  string(name: 'RANCHER_HELM_REPO', value: "${env.HA_HELM_REPO}"),
+                 string(name: 'RANCHER_HELM_URL', value: "${env.HA_HELM_URL}"),
                  string(name: 'RANCHER_HA_CERT_OPTION', value: "${env.HA_CERT_OPTION}"),
                  string(name: 'RKE_VERSION', value: "${env.RKE_VERSION}"),
                  string(name: 'RANCHER_HA_HARDENED', value: "${env.RANCHER_HA_HARDENED}"),
@@ -366,6 +379,7 @@ node {
                 string(name: 'RANCHER_CHART_VERSION', value: "${env.HA_CHART_VERSION_TO_UPGRADE}"),
                 string(name: 'RANCHER_IMAGE_TAG', value: "${env.HA_IMAGE_TAG_TO_UPGRADE}"),
                 string(name: 'RANCHER_HELM_REPO', value: "${env.HA_HELM_REPO}"),
+                string(name: 'RANCHER_HELM_URL', value: "${env.HA_HELM_URL_TO_UPGRADE}"),
                 string(name: 'RANCHER_HA_CERT_OPTION', value: "${env.HA_CERT_OPTION}"),
                 string(name: 'RANCHER_HA_KUBECONFIG', value: "${env.HA_KUBECONFIG}"),
                 string(name: 'RANCHER_HELM_EXTRA_SETTINGS', value: "${env.RANCHER_HELM_EXTRA_SETTINGS_TO_UPGRADE}")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Using the current ha pipeline, we cannot add helm urls to be able to install prime charts

## Solution
In this PR, we are adding the helm repo urls as a config, so we can update the prime repos in the configs. 

