### PR TITLE
Use apimachinery semantic.DeepEqual to compare Rules

### DIFF
--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -3,7 +3,6 @@ package rbac
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -21,6 +20,7 @@ import (
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -200,7 +200,7 @@ func (m *manager) ensureClusterRoles(rt *v3.RoleTemplate) error {
 }
 
 func (m *manager) compareAndUpdateClusterRole(clusterRole *rbacv1.ClusterRole, rt *v3.RoleTemplate) error {
-	if reflect.DeepEqual(clusterRole.Rules, rt.Rules) {
+	if equality.Semantic.DeepEqual(clusterRole.Rules, rt.Rules) {
 		return nil
 	}
 	clusterRole = clusterRole.DeepCopy()
@@ -318,7 +318,7 @@ func (m *manager) updateRole(rt *v3.RoleTemplate, namespace string) error {
 }
 
 func (m *manager) compareAndUpdateNamespacedRole(role *rbacv1.Role, rt *v3.RoleTemplate, namespace string) error {
-	if reflect.DeepEqual(role.Rules, rt.Rules) {
+	if equality.Semantic.DeepEqual(role.Rules, rt.Rules) {
 		return nil
 	}
 	role = role.DeepCopy()

--- a/pkg/controllers/managementuser/rbac/handler_base_test.go
+++ b/pkg/controllers/managementuser/rbac/handler_base_test.go
@@ -324,14 +324,7 @@ func TestCompareAndUpdateClusterRole(t *testing.T) {
 }
 
 func TestCompareAndUpdateNamespacedRole(t *testing.T) {
-        t.Parallel()
-	numUpdatesCalled := 0
-	rolesMock := &fakes2.RoleInterfaceMock{
-		UpdateFunc: func(in1 *v1.Role) (*v1.Role, error) {
-			numUpdatesCalled++
-			return &v1.Role{}, nil
-		},
-	}
+	t.Parallel()
 
 	tests := map[string]struct {
 		role                *v1.Role
@@ -406,8 +399,16 @@ func TestCompareAndUpdateNamespacedRole(t *testing.T) {
 	}
 
 	for name, test := range tests {
+		test := test
 		t.Run(name, func(t *testing.T) {
-			numUpdatesCalled = 0
+			t.Parallel()
+			numUpdatesCalled := 0
+			rolesMock := &fakes2.RoleInterfaceMock{
+				UpdateFunc: func(in1 *v1.Role) (*v1.Role, error) {
+					numUpdatesCalled++
+					return &v1.Role{}, nil
+				},
+			}
 			m := manager{roles: rolesMock}
 			err := m.compareAndUpdateNamespacedRole(test.role, test.roleTemplate, "")
 			assert.NoError(t, err)

--- a/pkg/controllers/managementuser/rbac/handler_base_test.go
+++ b/pkg/controllers/managementuser/rbac/handler_base_test.go
@@ -229,3 +229,187 @@ func Test_gatherRoles(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareAndUpdateClusterRole(t *testing.T) {
+	numUpdatesCalled := 0
+	clusterRolesMock := &fakes2.ClusterRoleInterfaceMock{
+		UpdateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+			numUpdatesCalled++
+			return &v1.ClusterRole{}, nil
+		},
+	}
+
+	tests := map[string]struct {
+		clusterRole         *v1.ClusterRole
+		roleTemplate        *v3.RoleTemplate
+		wantNumUpdatesCalls int
+	}{
+		"semantic difference": {
+			clusterRole: &v1.ClusterRole{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			roleTemplate: &v3.RoleTemplate{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:           []string{"get"},
+						APIGroups:       []string{""},
+						Resources:       []string{"pods"},
+						ResourceNames:   []string{},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+			wantNumUpdatesCalls: 0,
+		},
+		"no difference": {
+			clusterRole: &v1.ClusterRole{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			roleTemplate: &v3.RoleTemplate{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			wantNumUpdatesCalls: 0,
+		},
+		"difference": {
+			clusterRole: &v1.ClusterRole{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			roleTemplate: &v3.RoleTemplate{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get", "update"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			wantNumUpdatesCalls: 1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			numUpdatesCalled = 0
+			m := manager{clusterRoles: clusterRolesMock}
+			err := m.compareAndUpdateClusterRole(test.clusterRole, test.roleTemplate)
+			assert.NoError(t, err)
+			assert.Equal(t, numUpdatesCalled, test.wantNumUpdatesCalls)
+		})
+	}
+}
+
+func TestCompareAndUpdateNamespacedRole(t *testing.T) {
+	numUpdatesCalled := 0
+	rolesMock := &fakes2.RoleInterfaceMock{
+		UpdateFunc: func(in1 *v1.Role) (*v1.Role, error) {
+			numUpdatesCalled++
+			return &v1.Role{}, nil
+		},
+	}
+
+	tests := map[string]struct {
+		role                *v1.Role
+		roleTemplate        *v3.RoleTemplate
+		wantNumUpdatesCalls int
+	}{
+		"semantic difference": {
+			role: &v1.Role{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			roleTemplate: &v3.RoleTemplate{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:           []string{"get"},
+						APIGroups:       []string{""},
+						Resources:       []string{"pods"},
+						ResourceNames:   []string{},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+			wantNumUpdatesCalls: 0,
+		},
+		"no difference": {
+			role: &v1.Role{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			roleTemplate: &v3.RoleTemplate{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			wantNumUpdatesCalls: 0,
+		},
+		"difference": {
+			role: &v1.Role{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			roleTemplate: &v3.RoleTemplate{
+				Rules: []v1.PolicyRule{
+					{
+						Verbs:     []string{"get", "update"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			wantNumUpdatesCalls: 1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			numUpdatesCalled = 0
+			m := manager{roles: rolesMock}
+			err := m.compareAndUpdateNamespacedRole(test.role, test.roleTemplate, "")
+			assert.NoError(t, err)
+			assert.Equal(t, numUpdatesCalled, test.wantNumUpdatesCalls)
+		})
+	}
+}

--- a/pkg/controllers/managementuser/rbac/handler_base_test.go
+++ b/pkg/controllers/managementuser/rbac/handler_base_test.go
@@ -231,6 +231,7 @@ func Test_gatherRoles(t *testing.T) {
 }
 
 func TestCompareAndUpdateClusterRole(t *testing.T) {
+	t.Parallel()
 	numUpdatesCalled := 0
 	clusterRolesMock := &fakes2.ClusterRoleInterfaceMock{
 		UpdateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
@@ -323,6 +324,7 @@ func TestCompareAndUpdateClusterRole(t *testing.T) {
 }
 
 func TestCompareAndUpdateNamespacedRole(t *testing.T) {
+        t.Parallel()
 	numUpdatesCalled := 0
 	rolesMock := &fakes2.RoleInterfaceMock{
 		UpdateFunc: func(in1 *v1.Role) (*v1.Role, error) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40484
 
## Problem
If a `RoleTemplate` is created with an empty list in any `Rule`, then rancher creates a corresponding `ClusterRole` with a nil list. When Rancher goes to sync `RoleTemplates` and `ClusterRoles` it will detect that emptyList != nil list and attempt to update the `ClusterRole`.
 
## Solution
Use apimachinery [semantic.DeepEqual()](https://github.com/kubernetes/apimachinery/blob/v0.29.2/third_party/forked/golang/reflect/deep_equal.go#L263) instead of `reflect.Equal()` to compare `Rules`. This function considers a nil list to be equal to an empty list.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Followed the steps to reproduce the bug and didn't see the following message:
```
Updating clusterRole rt-77txz because of rules difference with roleTemplate Custom Test Role (rt-77txz).
```

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added:
    * Unit

## QA Testing Considerations
No specific recommendations on fresh and upgrade scenarios.
 
### Regressions Considerations
No regressions considered as apimachinery `semantic.DeepEqual` is like `reflect.DeepEqual`, but focused on semantic equality instead of memory equality.
