### PR TITLE
Bump webhook to v0.5.0-rc6

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 104.0.0+up0.5.0-rc4
+webhookVersion: 104.0.0+up0.5.0-rc6
 cspAdapterMinVersion: 103.0.0+up3.0.0
 defaultShellVersion: rancher/shell:v0.1.22
 fleetVersion: 103.1.0+up0.9.0

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,5 +6,5 @@ const (
 	CspAdapterMinVersion = "103.0.0+up3.0.0"
 	DefaultShellVersion  = "rancher/shell:v0.1.22"
 	FleetVersion         = "103.1.0+up0.9.0"
-	WebhookVersion       = "104.0.0+up0.5.0-rc4"
+	WebhookVersion       = "104.0.0+up0.5.0-rc6"
 )


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40584

Fixes an issue that's preventing the CI to run.
 
This should fix the integration tests in rancher/rancher issue that was introduced in https://github.com/rancher/webhook/pull/328 (see also https://github.com/rancher/rancher/issues/40584) which results in the following tests to fail:

```
test_default_roles.py::test_cluster_create_role_locked
test_default_roles.py::test_project_create_default_role
test_default_roles.py::test_project_create_role_locked
test_default_roles.py::test_user_create_default_role
```

The error looks like the following:

```
"rancher.cattle.io.roletemplates.management.cattle.io" denied the request: roletemplate.rules[8].nonResourceURLs: Invalid value: []string{"*"}: namespaced rules cannot apply to non-resource URLs\n\t{\'baseType\': \'error\', \'code\': \'BadRequest\', \'message\': \'admission webhook "rancher.cattle.io.roletemplates.management.cattle.io" denied the request: roletemplate.rules[8].nonResourceURLs: Invalid value: []string{"*"}: namespaced rules cannot apply to non-resource URLs\', \'status\': 400, \'type\': \'error\'}')
```
