### PR TITLE
Snapshot Retention test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240126142034-676c3eb3dfa5
-	github.com/rancher/shepherd v0.0.0-20240325171517-cd47e2cf408b
+	github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1680,8 +1680,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.3 h1:7mGn+NIL7KXk99NwWYBgoByh2+IfVCdws5ad3X/JIZY=
 github.com/rancher/rke v1.5.3/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240325171517-cd47e2cf408b h1:SMIKB/OXY1b22+xJcnBTC4ED+m5F8xa0fhOMdy+dctM=
-github.com/rancher/shepherd v0.0.0-20240325171517-cd47e2cf408b/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
+github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df h1:eXq5QDlpTD/6+RNftVvsAHnZqpj2wcmf1va8s2BKNzY=
+github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/snapshot/snapshot.go
+++ b/tests/v2/validation/snapshot/snapshot.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"strings"
 	"testing"
+	"time"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/apps/v1"
@@ -12,6 +13,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	extdefault "github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 	"github.com/rancher/shepherd/extensions/ingresses"
 	nodestat "github.com/rancher/shepherd/extensions/nodes"
@@ -412,4 +414,36 @@ func createPostBackupWorkloads(t *testing.T, client *rancher.Client, clusterID s
 	err = workloads.VerifyDeployment(steveclient, postDeploymentResp)
 	require.NoError(t, err)
 	require.Equal(t, WorkloadNamePostBackup, postDeploymentResp.ObjectMeta.Name)
+}
+
+// This function waits for retentionlimit+1 automatic snapshots to be taken before verifying that the retention limit is respected
+func createSnapshotsUntilRetentionLimit(t *testing.T, client *rancher.Client, clusterName string, retentionLimit int, timeBetweenSnapshots int) {
+	v1ClusterID, err := clusters.GetV1ProvisioningClusterByName(client, clusterName)
+	if v1ClusterID == "" {
+		v3ClusterID, err := clusters.GetClusterIDByName(client, clusterName)
+		require.NoError(t, err)
+		v1ClusterID = "fleet-default/" + v3ClusterID
+	}
+	require.NoError(t, err)
+
+	fleetCluster, err := client.Steve.SteveType(stevetypes.FleetCluster).ByID(v1ClusterID)
+	require.NoError(t, err)
+
+	provider := fleetCluster.ObjectMeta.Labels["provider.cattle.io"]
+	if provider == "rke" {
+		sleepNum := (retentionLimit + 1) * timeBetweenSnapshots
+		logrus.Infof("Waiting %v hours for %v automatic snapshots to be taken", sleepNum, (retentionLimit + 1))
+		time.Sleep(time.Duration(sleepNum)*time.Hour + time.Minute*5)
+
+		err := etcdsnapshot.RKE1RetentionLimitCheck(client, clusterName)
+		require.NoError(t, err)
+
+	} else {
+		sleepNum := (retentionLimit + 1) * timeBetweenSnapshots
+		logrus.Infof("Waiting %v minutes for %v automatic snapshots to be taken", sleepNum, (retentionLimit + 1))
+		time.Sleep(time.Duration(sleepNum)*time.Minute + time.Minute*5)
+
+		err := etcdsnapshot.RKE2K3SRetentionLimitCheck(client, clusterName)
+		require.NoError(t, err)
+	}
 }

--- a/tests/v2/validation/snapshot/snapshot_retention_test.go
+++ b/tests/v2/validation/snapshot/snapshot_retention_test.go
@@ -1,0 +1,118 @@
+//go:build (validation || extended || infra.any || cluster.any) && !sanity && !stress
+
+package snapshot
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// For SnapshotInterval this will be hours for rke1 and minutes for rke2
+type SnapshotRetentionConfig struct {
+	ClusterName       string `json:"clusterName" yaml:"clusterName"`
+	SnapshotInterval  int    `json:"snapshotInterval" yaml:"snapshotInterval"`
+	SnapshotRetention int    `json:"snapshotRetention" yaml:"snapshotRetention"`
+}
+
+type SnapshotRetentionTestSuite struct {
+	suite.Suite
+	session        *session.Session
+	client         *rancher.Client
+	snapshotConfig *SnapshotRetentionConfig
+	provider       string
+}
+
+func (s *SnapshotRetentionTestSuite) TearDownSuite() {
+	s.session.Cleanup()
+}
+
+func (s *SnapshotRetentionTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	s.session = testSession
+
+	s.snapshotConfig = new(SnapshotRetentionConfig)
+	config.LoadConfig("retentionTest", s.snapshotConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(s.T(), err)
+
+	s.client = client
+
+	v1ClusterID, err := clusters.GetV1ProvisioningClusterByName(client, s.snapshotConfig.ClusterName)
+	var v3ClusterID string
+	if v1ClusterID == "" {
+		v3ClusterID, err = clusters.GetClusterIDByName(client, s.snapshotConfig.ClusterName)
+		require.NoError(s.T(), err)
+		v1ClusterID = "fleet-default/" + v3ClusterID
+	}
+
+	require.NoError(s.T(), err)
+	fleetCluster, err := s.client.Steve.SteveType(stevetypes.FleetCluster).ByID(v1ClusterID)
+	require.NoError(s.T(), err)
+
+	s.provider = fleetCluster.ObjectMeta.Labels["provider.cattle.io"]
+
+	if s.provider == "rke" {
+		clusterObject, err := s.client.Management.Cluster.ByID(v3ClusterID)
+		require.NoError(s.T(), err)
+
+		updatedClusterObject := clusterObject
+		updatedClusterObject.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.Retention = int64(s.snapshotConfig.SnapshotRetention)
+		updatedClusterObject.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.IntervalHours = int64(s.snapshotConfig.SnapshotInterval)
+
+		_, err = s.client.Management.Cluster.Update(clusterObject, updatedClusterObject)
+		require.NoError(s.T(), err)
+	} else {
+		if s.snapshotConfig.SnapshotInterval < 5 {
+			logrus.Info("Snapshot cron schedules below 2 minutes can cause unexpected behaviors in rancher")
+		}
+
+		clusterObject, clusterResponse, err := clusters.GetProvisioningClusterByName(s.client, s.snapshotConfig.ClusterName, "fleet-default")
+		require.NoError(s.T(), err)
+
+		clusterObject.Spec.RKEConfig.ETCD.SnapshotRetention = s.snapshotConfig.SnapshotRetention
+		cronSchedule := fmt.Sprintf("%s%v%s", "*/", s.snapshotConfig.SnapshotInterval, " * * * *")
+		clusterObject.Spec.RKEConfig.ETCD.SnapshotScheduleCron = cronSchedule
+		_, err = s.client.Steve.SteveType(stevetypes.Provisioning).Update(clusterResponse, clusterObject)
+		require.NoError(s.T(), err)
+	}
+}
+
+func (s *SnapshotRetentionTestSuite) TestAutomaticSnapshotRetention() {
+	tests := []struct {
+		testName                 string
+		client                   *rancher.Client
+		clusterName              string
+		retentionLimit           int
+		intervalBetweenSnapshots int
+	}{
+		{"Retention limit test", s.client, s.snapshotConfig.ClusterName, 2, 1},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.testName, func() {
+			config := s.snapshotConfig
+			createSnapshotsUntilRetentionLimit(s.T(), s.client, config.ClusterName, config.SnapshotRetention, config.SnapshotInterval)
+		})
+	}
+}
+
+func (s *SnapshotRetentionTestSuite) TestAutomaticSnapshotRetentionDynamic() {
+	config := s.snapshotConfig
+	createSnapshotsUntilRetentionLimit(s.T(), s.client, config.ClusterName, config.SnapshotRetention, config.SnapshotInterval)
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestSnapshotRetentionTestSuite(t *testing.T) {
+	suite.Run(t, new(SnapshotRetentionTestSuite))
+}


### PR DESCRIPTION
Snapshot retention check

## Issue: [QA task 895](https://github.com/rancher/qa-tasks/issues/895)
 
## Problem
We need a test to verify that the snapshot retention limit is respected.
 
## Solution
Created a test that sets the retention limit and snapshot schedule of an existing cluster and then waits for the limit + 1 snapshots to be taken before checking to make sure the retention limit is respected. 
 
## Testing
Local testing and Jenkins testing.

## Engineering Testing
### Manual Testing
Ran the test against an RKE1, RKE2 and K3s cluster