### PR TITLE
Bump csp adapter to 3.0.1-rc2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
 webhookVersion: 103.0.1+up0.4.2
-cspAdapterMinVersion: 103.0.0+up3.0.0
+cspAdapterMinVersion: 103.0.1+up3.0.1-rc2
 defaultShellVersion: rancher/shell:v0.1.23-rc3
 fleetVersion: 103.1.1+up0.9.1-rc.4

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion = "103.0.0+up3.0.0"
+	CspAdapterMinVersion = "103.0.1+up3.0.1-rc2"
 	DefaultShellVersion  = "rancher/shell:v0.1.23-rc3"
 	FleetVersion         = "103.1.1+up0.9.1-rc.4"
 	WebhookVersion       = "103.0.1+up0.4.2"


### PR DESCRIPTION
## Issue: 
       [ rancher/rancher#43729  ](https://github.com/rancher/rancher/issues/43729)
## Problem: 
      Support for k8s 1.28
## Testing:
    Spun up an EKS cluster with k8s 1.27 and install rancher v2.8.2 and install csp adapter chart 103.0.0+up3.0.0
    Upgrade rancher to a locally built 2.8 image (with k8s 1.28 support) with CATTLE_CSP_ADAPTER_MIN_VERSION="103.0.1+up3.0.1-rc2" (build.yaml change)
    Updated charts repo to point to my forked repo/branch with 103.0.1+up3.0.1-rc2 charts
    Upgraded csp-adapter to the new chart version
    Ran the tests: 
	    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Deleted the cluster, validated that the out-of-compliance message is no longer displayed.
    Uninstall the chart