### PR TITLE
[v2.8] Update Ubuntu 20.04 to Ubuntu 22.04

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -25,8 +25,8 @@ AWS_SSH_KEY_NAME = os.environ.get("AWS_SSH_KEY_NAME")
 AWS_CICD_INSTANCE_TAG = os.environ.get("AWS_CICD_INSTANCE_TAG",
                                        'rancher-validation')
 AWS_IAM_PROFILE = os.environ.get("AWS_IAM_PROFILE", "")
-# by default the public Ubuntu 20.04 AMI is used
-AWS_DEFAULT_AMI = "ami-012fd49f6b0c404c7"
+# by default the public Ubuntu 22.04 AMI is used
+AWS_DEFAULT_AMI = "ami-0930eb63bafda06d1"
 AWS_DEFAULT_USER = "ubuntu"
 AWS_AMI = os.environ.get("AWS_AMI", AWS_DEFAULT_AMI)
 AWS_USER = os.environ.get("AWS_USER", AWS_DEFAULT_USER)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->[Update default Jenkins AMIs from Ubuntu 20.04 to Ubuntu 22.04](https://github.com/rancher/qa-tasks/issues/1176)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Internal automation is currently using Ubuntu 20.04 as default AMIs. While Ubuntu 20.04 is still actively supported, it is not there in Rancher Support matrix. we should update the default AMI to use Ubuntu 22.04.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the `aws.py` to use an Ubuntu 22.04 AMI that has been validated to successfully work.
 