### PR TITLE
Remove unused tests codebase from Rancher container image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -84,6 +84,7 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     git config --global url."https://github.com/rancher/".insteadOf https://git.rancher.io/ && \
     # Charts need to be copied into the sha256 value of git url computed in https://github.com/rancher/rancher/blob/5ebda9ac23c06e9647b586ec38aa51cc9ff9b031/pkg/catalogv2/git/download.go#L102 to create a unique folder per url
     git clone -b $CATTLE_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/charts /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/ && \
+    rm -Rf /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/tests && \
     git clone -b $CATTLE_PARTNER_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974 && \
     git clone -b $CATTLE_RKE2_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 && \
     # Revert the previous change in git.rancher.io from .gitconfig

--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -351,3 +351,13 @@ func (g *git) gitCmd(output io.Writer, args ...string) error {
 	}
 	return nil
 }
+
+func (g *git) cleanTestDir() {
+	if !strings.Contains(g.Directory, "rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721") {
+		return
+	}
+	testFolderPath := fmt.Sprintf("%s/%s", g.Directory, "tests")
+	if _, err := os.Stat(testFolderPath); !os.IsNotExist(err) {
+		os.RemoveAll(testFolderPath)
+	}
+}


### PR DESCRIPTION
## Problem
`charts/tests` folder repository was adding size and potential vulnerabilities
 
## Solution
Remove folder from Dockerfile and prevent catalogv2 package of re-creating it. 
 