### PR TITLE
[v2.8] Add snapshot test files catered to replace worker nodes and recurring restores

### DIFF
--- a/tests/v2/validation/snapshot/README.md
+++ b/tests/v2/validation/snapshot/README.md
@@ -24,6 +24,7 @@ snapshotInput:
   controlPlaneUnavailableValue: "1"
   workerUnavailableValue: "10%"
   recurringRestores: 1 # By default, this is set to 1 if this field is not included in the config.
+  replaceWorkerNode: false
 ```
 
 Additionally, S3 is a supported restore option. If you choose to use S3, then you must have it already enabled on the downstream cluster.
@@ -41,3 +42,6 @@ These tests utilize Go build tags. Due to this, see the below example on how to 
 ### Sanpshot restore with upgrade strategy
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreUpgradeStrategyTestSuite/TestSnapshotRestoreUpgradeStrategy"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreUpgradeStrategyTestSuite/TestSnapshotRestoreUpgradeStrategyDynamicInput"`
+
+### Sanpshot additional tests
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotAdditionalTestsTestSuite$"`

--- a/tests/v2/validation/snapshot/snapshot_additional_test.go
+++ b/tests/v2/validation/snapshot/snapshot_additional_test.go
@@ -1,0 +1,108 @@
+//go:build validation
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/etcdsnapshot"
+
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type SnapshotAdditionalTestsTestSuite struct {
+	suite.Suite
+	session        *session.Session
+	client         *rancher.Client
+	clustersConfig *etcdsnapshot.Config
+}
+
+func (s *SnapshotAdditionalTestsTestSuite) TearDownSuite() {
+	s.session.Cleanup()
+}
+
+func (s *SnapshotAdditionalTestsTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	s.session = testSession
+
+	s.clustersConfig = new(etcdsnapshot.Config)
+	config.LoadConfig(etcdsnapshot.ConfigurationFileKey, s.clustersConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(s.T(), err)
+
+	s.client = client
+}
+
+func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceWorkerNode() {
+	snapshotRestoreAll := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "all",
+		RecurringRestores:        1,
+		ReplaceWorkerNode:        true,
+	}
+
+	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "kubernetesVersion",
+		RecurringRestores:        1,
+		ReplaceWorkerNode:        true,
+	}
+
+	snapshotRestoreNone := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceWorkerNode:        true,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"Replace worker nodes and restore cluster config, Kubernetes version and etcd", snapshotRestoreAll, s.client},
+		{"Replace worker nodes and restore Kubernetes version and etcd", snapshotRestoreK8sVersion, s.client},
+		{"Replace worker nodes and restore etcd only", snapshotRestoreNone, s.client},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
+		})
+	}
+}
+
+func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotRecurringRestores() {
+	snapshotRestoreFiveTimes := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "all",
+		RecurringRestores:        5,
+		ReplaceWorkerNode:        false,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"Restore snapshot 5 times", snapshotRestoreFiveTimes, s.client},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
+		})
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestSnapshotAdditionalTestsTestSuite(t *testing.T) {
+	suite.Run(t, new(SnapshotAdditionalTestsTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Add snapshot test files that include static test cases for recurring restores and replacing worker nodes](https://github.com/rancher/qa-tasks/issues/1143)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
As we move towards the idea of prioritizing static test cases, a point of conversation was ensuring existing functionality is properly being tested in static functions. For snapshots, recurring restores and replacing worker nodes, these are not tested in static functions, which isn't ideal for QA's code coverage.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Created new test additional snapshot file that have static test cases around snapshot recurring restores and replacing worker nodes.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing

### Automated Testing
Jenkins jobs will be provided to reviewers offline.