### PR TITLE
Do not add bindings for projects that are being deleted

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -176,6 +176,10 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 		return err
 	}
 	for _, p := range projects {
+		if p.DeletionTimestamp != nil {
+			logrus.Warnf("Project %v is being deleted, not creating membership bindings", p.Name)
+			continue
+		}
 		if err := c.mgr.grantManagementClusterScopedPrivilegesInProjectNamespace(binding.RoleTemplateName, p.Name, projectManagmentPlaneResources, subject, binding); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42904
 
## Problem
This is a continuation of a previous solution related to namespaces stuck in terminating. This particular bug is related to projects being stuck while getting deleted. During a project deletion, it deletes the project namespaces, but if the project hasn't finished deleting, there will be an attempt to create the necessary cluster role bindings in those project namespaces for any cluster owners. That results in the logs being spammed with error messages.
 
## Solution
To prevent this from happening, I added a check before we create the bindings to see if `DeletionTimestamp` is set. If it is, that means we are in the process of deleting the project and should not create bindings for it.
 
## Testing

Steps:
1. Create a downstream cluster
2. Create a project in that downstream cluster
3. Get it stuck in deleting (for testing I used a fake finalizer)
4. Add a new cluster-owner to the downstream cluster
5. See lots of `[ERROR] error syncing` log messages