### PR TITLE
[release/v2.9] Bump rancher/system-agent to v0.3.6-rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -48,7 +48,7 @@ ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}
 ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.1
 # make sure the CATTLE_SYSTEM_AGENT_VERSION is consistent with tests/v2/codecoverage/package/Dockerfile
-ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.5-rc2
+ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.6-rc1
 ENV CATTLE_SYSTEM_AGENT_DOWNLOAD_PREFIX https://github.com/rancher/system-agent/releases/download
 ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE rancher/system-agent:${CATTLE_SYSTEM_AGENT_VERSION}-suc
 ENV CATTLE_SYSTEM_AGENT_INSTALLER_IMAGE rancher/system-agent-installer-

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -48,7 +48,7 @@ ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}
 ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.1
 # make sure the CATTLE_SYSTEM_AGENT_VERSION is consistent with tests/v2/codecoverage/package/Dockerfile
-ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.5-rc2
+ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.6-rc1
 ENV CATTLE_SYSTEM_AGENT_DOWNLOAD_PREFIX https://github.com/rancher/system-agent/releases/download
 ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE rancher/system-agent:${CATTLE_SYSTEM_AGENT_VERSION}-suc
 ENV CATTLE_SYSTEM_AGENT_INSTALLER_IMAGE rancher/system-agent-installer-


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/43991
 
## Problem
`rancher/system-agent` was bumped to `v0.3.5-rc2` in PR here: https://github.com/rancher/rancher/pull/44314 but as `v2.7` was pinned to `v0.3.5-rc1` and no official system-agent tag was cut for that commit, we cut commit `v0.3.5` with identical commit ID to `v0.3.5-rc1` and bumped `v0.3.5-rc2` to the `v0.3.6` commit line.

## Solution
Cut `rancher/system-agent` `v0.3.6-rc1`: https://github.com/rancher/system-agent/releases/tag/v0.3.6-rc1 and bump the `rancher/system-agent` version references in `rancher/rancher` to `v0.3.6-rc1`
 
## Testing

## Engineering Testing
### Manual Testing
N/A

### Automated Testing
* Test types added/modified:
    * None

* If "None" - GH Issue/PR: N/A

Summary: Existing integration tests should be able to validate whether bump is valid.

## QA Testing Considerations
N/A

### Regressions Considerations
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A