### PR TITLE
Updating local cluster to be run as part of webhook checks

### DIFF
--- a/tests/v2/validation/charts/README.md
+++ b/tests/v2/validation/charts/README.md
@@ -18,3 +18,9 @@ From there, please use one of the following links to check charts tests:
 1. [Monitoring Chart](monitoring_test.go)
 2. [Gatekeeper Chart](gatekeeper_test.go)
 3. [Istio Chart](istio_test.go)
+4. [Webhook Chart](webhook_test.go)
+
+
+## Note
+* For webhook charts, validations are run on the local cluster and the cluster name provided in the config.yaml. Please make sure to provide a downstream cluster name in the config.yaml instead of local cluster, so the validations are not run on the local cluster twice.
+

--- a/tests/v2/validation/charts/webhook.go
+++ b/tests/v2/validation/charts/webhook.go
@@ -1,6 +1,8 @@
 package charts
 
 import (
+	"strings"
+
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/kubeapi/webhook"
 )
@@ -9,6 +11,7 @@ const (
 	resourceName    = "rancher.cattle.io"
 	restrictedAdmin = "restricted-admin"
 	admin           = "admin"
+	localCluster    = "local"
 )
 
 func getWebhookNames(client *rancher.Client, clusterID, resourceName string) ([]string, error) {
@@ -24,4 +27,17 @@ func getWebhookNames(client *rancher.Client, clusterID, resourceName string) ([]
 
 	return webhookL, nil
 
+}
+
+func validateWebhookPodLogs(podLogs string) interface{} {
+
+	delimiter := "\n"
+	segments := strings.Split(podLogs, delimiter)
+
+	for _, segment := range segments {
+		if strings.Contains(segment, "level=error") {
+			return "Error logs in webhook" + segment
+		}
+	}
+	return nil
 }

--- a/tests/v2/validation/charts/webhook_test.go
+++ b/tests/v2/validation/charts/webhook_test.go
@@ -26,7 +26,7 @@ type WebhookTestSuite struct {
 	suite.Suite
 	client       *rancher.Client
 	session      *session.Session
-	clusterList  string
+	clusterName  string
 	chartVersion string
 }
 
@@ -44,38 +44,9 @@ func (w *WebhookTestSuite) SetupSuite() {
 	w.client = client
 
 	// Get clusterName from config yaml
-	w.clusterList = client.RancherConfig.ClusterName
+	w.clusterName = client.RancherConfig.ClusterName
 	w.chartVersion, err = client.Catalog.GetLatestChartVersion(charts.RancherWebhookName, catalog.RancherChartRepo)
 	require.NoError(w.T(), err)
-
-}
-
-func (w *WebhookTestSuite) ValidateEscalationCheck(client *rancher.Client) {
-
-	getAdminRole, err := client.Management.GlobalRole.ByID(admin)
-	require.NoError(w.T(), err)
-	updatedAdminRole := *getAdminRole
-	updatedAdminRole.NewUserDefault = true
-
-	_, err = client.Management.GlobalRole.Update(getAdminRole, updatedAdminRole)
-	require.Error(w.T(), err)
-	errMessage := "admission webhook \"rancher.cattle.io.globalroles.management.cattle.io\" denied the request"
-
-	assert.Contains(w.T(), err.Error(), errMessage)
-}
-
-func (w *WebhookTestSuite) ValidateWebhookPodLogs(podName, clusterID string) {
-
-	podLogs, err := kubeconfig.GetPodLogs(w.client, clusterID, podName, charts.RancherWebhookNamespace)
-	require.NoError(w.T(), err)
-	delimiter := "\n"
-	segments := strings.Split(podLogs, delimiter)
-
-	for _, segment := range segments {
-		if strings.Contains(segment, "level=error") {
-			w.Fail("Error logs in webhook", segment)
-		}
-	}
 
 }
 
@@ -83,49 +54,65 @@ func (w *WebhookTestSuite) TestWebhookChart() {
 	subSession := w.session.NewSession()
 	defer subSession.Cleanup()
 
-	clusterID, err := clusters.GetClusterIDByName(w.client, w.clusterList)
-	require.NoError(w.T(), err)
+	tests := []struct {
+		cluster string
+	}{
+		{localCluster},
+		{w.clusterName},
+	}
 
-	w.Run("Verify the version of webhook on local and downstream cluster", func() {
-		subSession := w.session.NewSession()
-		defer subSession.Cleanup()
+	for _, tt := range tests {
 
-		initialWebhookChart, err := charts.GetChartStatus(w.client, clusterID, charts.RancherWebhookNamespace, charts.RancherWebhookName)
-		require.NoError(w.T(), err)
-		chartVersion := initialWebhookChart.ChartDetails.Spec.Chart.Metadata.Version
-		require.NoError(w.T(), err)
-		assert.Equal(w.T(), w.chartVersion, chartVersion)
-	})
-
-	w.Run("Verify webhook pod logs", func() {
-
-		steveClient, err := w.client.Steve.ProxyDownstream(clusterID)
+		clusterID, err := clusters.GetClusterIDByName(w.client, tt.cluster)
 		require.NoError(w.T(), err)
 
-		pods, err := steveClient.SteveType(pods.PodResourceSteveType).NamespacedSteveClient(charts.RancherWebhookNamespace).List(nil)
-		require.NoError(w.T(), err)
+		w.Run("Verify the version of webhook on "+tt.cluster, func() {
+			subSession := w.session.NewSession()
+			defer subSession.Cleanup()
 
-		var podName string
-		for _, pod := range pods.Data {
-			if strings.Contains(pod.Name, charts.RancherWebhookName) {
-				podName = pod.Name
+			initialWebhookChart, err := charts.GetChartStatus(w.client, clusterID, charts.RancherWebhookNamespace, charts.RancherWebhookName)
+			require.NoError(w.T(), err)
+			chartVersion := initialWebhookChart.ChartDetails.Spec.Chart.Metadata.Version
+			require.NoError(w.T(), err)
+			assert.Equal(w.T(), w.chartVersion, chartVersion)
+		})
+
+		w.Run("Verify webhook pod logs", func() {
+
+			steveClient, err := w.client.Steve.ProxyDownstream(clusterID)
+			require.NoError(w.T(), err)
+
+			pods, err := steveClient.SteveType(pods.PodResourceSteveType).NamespacedSteveClient(charts.RancherWebhookNamespace).List(nil)
+			require.NoError(w.T(), err)
+
+			var podName string
+			for _, pod := range pods.Data {
+				if strings.Contains(pod.Name, charts.RancherWebhookName) {
+					podName = pod.Name
+				}
 			}
-		}
-		w.ValidateWebhookPodLogs(podName, clusterID)
 
-	})
+			podLogs, err := kubeconfig.GetPodLogs(w.client, clusterID, podName, charts.RancherWebhookNamespace)
+			require.NoError(w.T(), err)
+			webhookLogs := validateWebhookPodLogs(podLogs)
+			require.Nil(w.T(), webhookLogs)
+		})
 
-	w.Run("Verify the count of webhook is greater than zero and list webhooks", func() {
-		webhookList, err := getWebhookNames(w.client, clusterID, resourceName)
-		require.NoError(w.T(), err)
+		w.Run("Verify the count of webhook is greater than zero and list webhooks", func() {
+			webhookList, err := getWebhookNames(w.client, clusterID, resourceName)
+			require.NoError(w.T(), err)
 
-		assert.True(w.T(), len(webhookList) > 0, "Expected webhooks list to be greater than zero")
-		log.Info("Count of webhook obtained for the cluster: ", w.clusterList, "is ", len(webhookList))
-		listStr := strings.Join(webhookList, ", ")
-		log.WithField("", listStr).Info("List of webhooks obtained for the ", w.clusterList)
+			assert.True(w.T(), len(webhookList) > 0, "Expected webhooks list to be greater than zero")
+			log.Info("Count of webhook obtained for the cluster: ", tt.cluster, " is ", len(webhookList))
+			listStr := strings.Join(webhookList, ", ")
+			log.WithField("", listStr).Info("List of webhooks obtained for the ", tt.cluster)
 
-	})
+		})
+	}
 
+}
+
+func (w *WebhookTestSuite) TestWebhookEscalationCheck() {
 	w.Run("Verify escalation check", func() {
 		newUser, err := users.CreateUserWithRole(w.client, users.UserConfig(), restrictedAdmin)
 		require.NoError(w.T(), err)
@@ -134,10 +121,18 @@ func (w *WebhookTestSuite) TestWebhookChart() {
 		restrictedAdminClient, err := w.client.AsUser(newUser)
 		require.NoError(w.T(), err)
 
-		w.ValidateEscalationCheck(restrictedAdminClient)
-	})
+		getAdminRole, err := restrictedAdminClient.Management.GlobalRole.ByID(admin)
+		require.NoError(w.T(), err)
+		updatedAdminRole := *getAdminRole
+		updatedAdminRole.NewUserDefault = true
 
+		_, err = restrictedAdminClient.Management.GlobalRole.Update(getAdminRole, updatedAdminRole)
+		require.Error(w.T(), err)
+		errMessage := "admission webhook \"rancher.cattle.io.globalroles.management.cattle.io\" denied the request"
+		assert.Contains(w.T(), err.Error(), errMessage)
+	})
 }
+
 
 func TestWebhookTestSuite(t *testing.T) {
 	suite.Run(t, new(WebhookTestSuite))


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/1171
 
## Problem
Current automation runs only for a single cluster. Added local cluster in the configs, so the validations are run for the local cluster as well as the cluster name provided in the config.yaml.
 
## Note:
This requires back ports to 2.8 and 2.7
