### PR TITLE
[v2.9] chore: remove usage of beta labels

### DIFF
--- a/pkg/controllers/managementuser/windows/linux_node_taints.go
+++ b/pkg/controllers/managementuser/windows/linux_node_taints.go
@@ -18,16 +18,13 @@ var (
 	}
 	HostOSLabels = []labels.Set{
 		labels.Set(map[string]string{
-			"beta.kubernetes.io/os": "linux",
-		}),
-		labels.Set(map[string]string{
 			"kubernetes.io/os": "linux",
 		}),
 	}
 )
 
 // NodeTaintsController This controller will only run on the cluster with windowsPreferred is true.
-// It will add taints to the v1.Node.Spec.Taints to the nodes with label beta.kubernetes.io/os=linux.
+// It will add taints to the v1.Node.Spec.Taints to the nodes with label kubernetes.io/os=linux.
 type NodeTaintsController struct {
 	nodeClient apicorev1.NodeInterface
 }

--- a/pkg/controllers/managementuser/windows/node_test.go
+++ b/pkg/controllers/managementuser/windows/node_test.go
@@ -20,7 +20,7 @@ type testcase struct {
 
 var (
 	windowsNodeLabel = map[string]string{
-		"beta.kubernetes.io/os": "windows",
+		"kubernetes.io/os": "windows",
 	}
 )
 

--- a/pkg/settings/affinity.go
+++ b/pkg/settings/affinity.go
@@ -10,7 +10,7 @@ const (
         {
           "matchExpressions": [
             {
-              "key": "beta.kubernetes.io/os",
+              "key": "kubernetes.io/os",
               "operator": "NotIn",
               "values": [
                 "windows"

--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -78,7 +78,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "734cc6a47dfa564f230d39da48782e6f2ba9a55e0385aaa4d2fa7405375d8527",
+				"cattle-cluster-agent": "af423175a04aab708ccaa721ed570fad2f8fc12dcf5bac3e3859004002db0fca",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -113,7 +113,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "734cc6a47dfa564f230d39da48782e6f2ba9a55e0385aaa4d2fa7405375d8527",
+				"cattle-cluster-agent": "af423175a04aab708ccaa721ed570fad2f8fc12dcf5bac3e3859004002db0fca",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -151,7 +151,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 			token:      "some-dummy-token",
 			agentImage: "my/agent:image",
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "1d9554ad0e8dda26a8e4fa96879a5954a478bf9b22e2b1de4273292774390226",
+				"cattle-cluster-agent": "2bdecab02a36b0c4761e82843c4599e6121dbcdecd000493309ff9c6282a3ae1",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -217,7 +217,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows
@@ -318,7 +318,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - linux
@@ -415,7 +415,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows
@@ -424,7 +424,7 @@ spec:
                   values:
                     - "true"
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows
@@ -433,7 +433,7 @@ spec:
                   values:
                     - "true"
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/39052
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Allow to deploy cluster-agent on GKE Autopilot nodes, labeled with "kubernetes.io/os": "linux"
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_