### PR TITLE
[v2.8] Bump RKE to v1.5.7-rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.3.0
-	github.com/rancher/rke v1.5.7-rc2
+	github.com/rancher/rke v1.5.7-rc3
 	github.com/rancher/steve v0.0.0-20240213172920-24878f9eedc5
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler/v2 v2.1.3

--- a/go.sum
+++ b/go.sum
@@ -1638,8 +1638,8 @@ github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVf
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa/go.mod h1:NP3xboG+t2p+XMnrcrJ/L384Ki0Cp3Pww/X+vm5Jcy0=
 github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcpvX1sM=
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.5.7-rc2 h1:DikVnA+6HU7m/UvmIsi5a8H4JWT5/ec1JXSQa9wvAnk=
-github.com/rancher/rke v1.5.7-rc2/go.mod h1:+lcRKCxBLtfaSZQ9Q+BA82cHhSImF62mfElqJvHJUls=
+github.com/rancher/rke v1.5.7-rc3 h1:UyPGHCE3m69A2UoIQ4VKoXIKYrM593XCgw5USVL741Y=
+github.com/rancher/rke v1.5.7-rc3/go.mod h1:+lcRKCxBLtfaSZQ9Q+BA82cHhSImF62mfElqJvHJUls=
 github.com/rancher/shepherd v0.0.0-20240226222603-98384bb5e464 h1:n0E/HmgncWsdHnFEOm91m7MOyHj2Kubi/tpolqldjpE=
 github.com/rancher/shepherd v0.0.0-20240226222603-98384bb5e464/go.mod h1:WqUGpxXtHYkRV2ldhOJNDko0KZue8LBfy+gsCB7As4U=
 github.com/rancher/steve v0.0.0-20240213172920-24878f9eedc5 h1:WEDoTc0u+L42zFKBHSfxKgAwYVbUW+Nvu6TVTJi1MvE=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.9.1-rc.2.0.20240213164401-2c6b1019687c
 	github.com/rancher/gke-operator v1.2.1-rc4
 	github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c
-	github.com/rancher/rke v1.5.7-rc2
+	github.com/rancher/rke v1.5.7-rc3
 	github.com/rancher/wrangler/v2 v2.1.3
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.28.6

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -116,8 +116,8 @@ github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa h1:eRhvQJjIpPxJunlS3
 github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa/go.mod h1:utdskbIL7kdVvPCUFPEJQDWJwPHGFpUCRfVkX2G2Xxg=
 github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c h1:ayqZqJ4AYYVaZGlBztLBij81z/QRsSFbQfxs9bzA+Tg=
 github.com/rancher/norman v0.0.0-20240206180703-6eda4bc94b4c/go.mod h1:WbNpu/HwChwKk54W0rWBdioxYVVZwVVz//UX84m/NvY=
-github.com/rancher/rke v1.5.7-rc2 h1:DikVnA+6HU7m/UvmIsi5a8H4JWT5/ec1JXSQa9wvAnk=
-github.com/rancher/rke v1.5.7-rc2/go.mod h1:+lcRKCxBLtfaSZQ9Q+BA82cHhSImF62mfElqJvHJUls=
+github.com/rancher/rke v1.5.7-rc3 h1:UyPGHCE3m69A2UoIQ4VKoXIKYrM593XCgw5USVL741Y=
+github.com/rancher/rke v1.5.7-rc3/go.mod h1:+lcRKCxBLtfaSZQ9Q+BA82cHhSImF62mfElqJvHJUls=
 github.com/rancher/wrangler/v2 v2.1.3 h1:ggCPFD14emodJjR4Pi6mcDGgtNo04tjCKZ71S76uWg8=
 github.com/rancher/wrangler/v2 v2.1.3/go.mod h1:af5OaGU/COgreQh1mRbKiUI64draT2NN34uk+PALFY8=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/44520

- bumped rke version to `v1.5.7-rc3` from `v1.5.7-rc2`