### PR TITLE
Add CA of cluster beside host in local kubeconfig secret

### DIFF
--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -2,6 +2,7 @@ package fleetcluster
 
 import (
 	"context"
+	"os"
 	"time"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -160,7 +161,11 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 
 	objs := []runtime.Object{}
 	if mgmtCluster.Spec.Internal {
-		h.addAPIServer(clientSecret)
+		// When not running inside a cluster (which may happen in local dev setups), do not populate API server
+		// host and CA information which then comes from the local host
+		if os.Getenv("KUBERNETES_PORT") != "" {
+			h.addAPIServer(clientSecret)
+		}
 
 		agentNamespace = fleetconst.ReleaseLocalNamespace
 		// restore fleet's hardcoded name label for the local cluster

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
@@ -209,6 +209,7 @@ func TestCreateCluster(t *testing.T) {
 		status         provv1.ClusterStatus
 		cachedClusters map[string]*apimgmtv3.Cluster
 		APIServerURL   string
+		APIServerCA    []byte
 		expectedLen    int
 	}{
 		{
@@ -265,6 +266,7 @@ func TestCreateCluster(t *testing.T) {
 				),
 			},
 			APIServerURL: "http://42.42.42.42:4242",
+			APIServerCA:  []byte("foo"),
 			expectedLen:  2, // cluster and cluster group
 		},
 	}
@@ -274,7 +276,7 @@ func TestCreateCluster(t *testing.T) {
 
 			if tt.APIServerURL != "" {
 				hostGetter := NewMockClusterHostGetter(ctrl)
-				hostGetter.EXPECT().GetClusterHost(gomock.Any()).Return(tt.APIServerURL, nil)
+				hostGetter.EXPECT().GetClusterHost(gomock.Any()).Return(tt.APIServerURL, tt.APIServerCA, nil)
 				h.hostGetter = hostGetter
 
 				updatedSecret := corev1.Secret{
@@ -283,6 +285,7 @@ func TestCreateCluster(t *testing.T) {
 					},
 					Data: map[string][]byte{
 						"apiServerURL": []byte(tt.APIServerURL),
+						"apiServerCA":  []byte(tt.APIServerCA),
 					},
 				}
 				h.secretsController = newSecretsController(t, tt.cluster.Namespace, &updatedSecret)

--- a/pkg/controllers/provisioningv2/fleetcluster/mock_cluster_host_getter_test.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/mock_cluster_host_getter_test.go
@@ -35,12 +35,13 @@ func (m *MockClusterHostGetter) EXPECT() *MockClusterHostGetterMockRecorder {
 }
 
 // GetClusterHost mocks base method.
-func (m *MockClusterHostGetter) GetClusterHost(arg0 clientcmd.ClientConfig) (string, error) {
+func (m *MockClusterHostGetter) GetClusterHost(arg0 clientcmd.ClientConfig) (string, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterHost", arg0)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetClusterHost indicates an expected call of GetClusterHost.


### PR DESCRIPTION
This should prevent the Fleet agent from failing to reach the management cluster with errors about a certificate being signed by an unknown authority.

This is a follow-up to #44612.
## Issue: #44630

## Problem
When installing Rancher (eg. basic install via Helm), the Fleet agent fails to reach the management cluster and logs something like:
```
time="2024-03-06T09:51:55Z" level=error msg="Failed to register agent: registration failed: cannot create clusterregistration on management cluster for cluster id '<id>': Post "https://<ip>:443/apis/fleet.cattle.io/v1alpha1/namespaces/fleet-local/clusterregistrations](": tls: failed to verify certificate: x509: certificate signed by unknown authority"
```
 
## Solution
Add CA data, for the cluster for which the host is extracted, to the local kubeconfig secret.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
1. Built a custom Rancher image locally via [dev-scripts/build-local.sh](https://github.com/rancher/rancher/blob/release/v2.9/dev-scripts/build-local.sh)
2. Created a k3d cluster and imported that image into it
3. Installed Rancher via Helm, using flags `--set rancherImageTag=<custom_image> --set rancherImage=<custom_tag>`
4. Could see the Fleet agent registering successfully:
```
 {"level":"info","ts":"2024-03-07T12:33:15Z","logger":"setup","msg":"starting registration on upstream cluster","namespace":"cattle-fleet-local-system"}                                                                                                                         
time="2024-03-07T12:33:15Z" level=warning msg="Cannot find fleet-agent secret, running registration"                                                                                                                                                                             
time="2024-03-07T12:33:15Z" level=info msg="Creating clusterregistration with id 'h92764vkzqrcsttmln5nnssxzvkl8qcf7w87r9hkfgzx9q5q8mwdbn' for new token"                                                                                                                         
time="2024-03-07T12:33:17Z" level=info msg="Waiting for secret 'cattle-fleet-clusters-system/c-0280754ec36ebc74bf2c9fdc163851b60b90a9c247331b704960479a2ede0' on management cluster for request 'fleet-local/request-km4gt': secrets \"c-0280754ec36ebc74bf2c9fdc163851b60b90    {"level":"info","ts":"2024-03-07T12:33:19Z","logger":"setup","msg":"successfully registered with upstream cluster","namespace":"cluster-fleet-local-local-1a3d67d0a899"}
```

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->