### PR TITLE
[Forwardport v2.9] Remove unused capi.enabled helm value for webhook

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -138,9 +138,10 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 			ExactVersionSetting: settings.RancherWebhookVersion,
 			Values: func() map[string]interface{} {
 				values := map[string]interface{}{
-					"capi": map[string]interface{}{
-						"enabled": false,
-					},
+					// This is no longer used in the webhook chart but previous values can still be found
+					// with `helm get values -n cattle-system rancher-webhook` which can be confusing. We
+					// completely remove the previous capi values by setting it to nil here.
+					"capi": nil,
 					"mcm": map[string]interface{}{
 						"enabled": features.MCM.Enabled(),
 					},

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -83,9 +83,7 @@ func Test_ChartInstallation(t *testing.T) {
 				settings.RancherWebhookVersion.Set("2.0.0")
 				expectedValues := map[string]interface{}{
 					"priorityClassName": priorityClassName,
-					"capi": map[string]interface{}{
-						"enabled": false,
-					},
+					"capi":              nil,
 					"mcm": map[string]interface{}{
 						"enabled": features.MCM.Enabled(),
 					},
@@ -134,9 +132,7 @@ func Test_ChartInstallation(t *testing.T) {
 				mocks.configCache.EXPECT().Get(gomock.Any(), chart.CustomValueMapName).Return(nil, errTest).Times(4)
 				settings.RancherWebhookVersion.Set("2.0.0")
 				expectedValues := map[string]interface{}{
-					"capi": map[string]interface{}{
-						"enabled": false,
-					},
+					"capi": nil,
 					"mcm": map[string]interface{}{
 						"enabled": features.MCM.Enabled(),
 					},
@@ -183,9 +179,7 @@ func Test_ChartInstallation(t *testing.T) {
 				mocks.configCache.EXPECT().Get(gomock.Any(), chart.CustomValueMapName).Return(emptyConfig, nil).Times(4)
 				settings.RancherWebhookVersion.Set("2.0.1")
 				expectedValues := map[string]interface{}{
-					"capi": map[string]interface{}{
-						"enabled": false,
-					},
+					"capi": nil,
 					"mcm": map[string]interface{}{
 						"enabled": features.MCM.Enabled(),
 					},
@@ -242,9 +236,7 @@ func Test_ChartInstallation(t *testing.T) {
 				features.MCM.Set(true)
 				expectedValues := map[string]interface{}{
 					"priorityClassName": "newClass",
-					"capi": map[string]interface{}{
-						"enabled": false,
-					},
+					"capi":              nil,
 					"mcm": map[string]interface{}{
 						"enabled": false,
 					},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43619

Forwardport of https://github.com/rancher/rancher/issues/44619
 
## Problem

The embedded CAPI webhook in rancher/webhook is no longer used and it was causing dependencies conflicts for k8s 1.28 support: https://github.com/rancher/rancher/issues/44018.

## Solution

We're removing the CAPI webhook from webhook completely. See https://github.com/rancher/rancher/issues/43619#issuecomment-1971574484 for details.

We're setting `capi` to nil explicitely to make sure it removes references to it in the webhook Helm values. This is just to make it less confusing if we troubleshoot those values. Those values are no longer used in webhook, so it doesn't actually matter what they are.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_