### PR TITLE
[2.9] Fix Response Body Reading in Charts Validation Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240126142034-676c3eb3dfa5
-	github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df
+	github.com/rancher/shepherd v0.0.0-20240401195459-dd0f1e7e8dca
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1680,8 +1680,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.3 h1:7mGn+NIL7KXk99NwWYBgoByh2+IfVCdws5ad3X/JIZY=
 github.com/rancher/rke v1.5.3/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df h1:eXq5QDlpTD/6+RNftVvsAHnZqpj2wcmf1va8s2BKNzY=
-github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
+github.com/rancher/shepherd v0.0.0-20240401195459-dd0f1e7e8dca h1:KAHug2X7fO15XZzpH+AlxzuqXLwaPRWpJXDJbrFn8ds=
+github.com/rancher/shepherd v0.0.0-20240401195459-dd0f1e7e8dca/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/charts/gatekeeper.go
+++ b/tests/v2/validation/charts/gatekeeper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -31,8 +32,7 @@ func getAuditTimestamp(client *rancher.Client, project *management.Project) erro
 	if err != nil {
 		return err
 	}
-	return wait.Poll(1*time.Second, 5*time.Minute, func() (done bool, err error) {
-
+	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 5*time.Minute, true, func(context.Context) (done bool, err error) {
 		// get list of constraints
 		auditList, err := steveClient.SteveType(ConstraintResourceSteveType).List(nil)
 		if err != nil {
@@ -53,5 +53,4 @@ func getAuditTimestamp(client *rancher.Client, project *management.Project) erro
 		}
 		return true, nil
 	})
-
 }

--- a/tests/v2/validation/charts/webhook_test.go
+++ b/tests/v2/validation/charts/webhook_test.go
@@ -47,7 +47,6 @@ func (w *WebhookTestSuite) SetupSuite() {
 	w.clusterName = client.RancherConfig.ClusterName
 	w.chartVersion, err = client.Catalog.GetLatestChartVersion(charts.RancherWebhookName, catalog.RancherChartRepo)
 	require.NoError(w.T(), err)
-
 }
 
 func (w *WebhookTestSuite) TestWebhookChart() {
@@ -78,7 +77,6 @@ func (w *WebhookTestSuite) TestWebhookChart() {
 		})
 
 		w.Run("Verify webhook pod logs", func() {
-
 			steveClient, err := w.client.Steve.ProxyDownstream(clusterID)
 			require.NoError(w.T(), err)
 
@@ -106,10 +104,8 @@ func (w *WebhookTestSuite) TestWebhookChart() {
 			log.Info("Count of webhook obtained for the cluster: ", tt.cluster, " is ", len(webhookList))
 			listStr := strings.Join(webhookList, ", ")
 			log.WithField("", listStr).Info("List of webhooks obtained for the ", tt.cluster)
-
 		})
 	}
-
 }
 
 func (w *WebhookTestSuite) TestWebhookEscalationCheck() {
@@ -132,7 +128,6 @@ func (w *WebhookTestSuite) TestWebhookEscalationCheck() {
 		assert.Contains(w.T(), err.Error(), errMessage)
 	})
 }
-
 
 func TestWebhookTestSuite(t *testing.T) {
 	suite.Run(t, new(WebhookTestSuite))


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/1114
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The charts test became flaky after recent HTTP call updates in external ingress helpers. The root cause; the body is drained as it's closed. But it's not read or stored anywhere. The same drained response body is used on the Rancher validation side, but it happens too late to read the body.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added read body part to the function where the HTTP call happens. And now it returns the body as a string for further use of the same body.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Provided offline.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)