### PR TITLE
Enable Fleet v2prov integrationtests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -31,7 +31,7 @@ else
 fi
 
 if [ -z "${V2PROV_TEST_RUN_REGEX}" ]; then
-  V2PROV_TEST_RUN_REGEX="^Test_(General|Provisioning)_.*$"
+  V2PROV_TEST_RUN_REGEX="^Test_(General|Provisioning|Fleet)_.*$"
 fi
 
 RUNARG="-run ${V2PROV_TEST_RUN_REGEX}"

--- a/tests/v2prov/tests/fleet/cluster_bootstrap_test.go
+++ b/tests/v2prov/tests/fleet/cluster_bootstrap_test.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestFleetClusterBootstrap(t *testing.T) {
+func Test_Fleet_ClusterBootstrap(t *testing.T) {
 	const waitFor = 5 * time.Minute
 	const tick = 2 * time.Second
 	assert := assert.New(t)

--- a/tests/v2prov/tests/fleet/fleetcluster_test.go
+++ b/tests/v2prov/tests/fleet/fleetcluster_test.go
@@ -74,7 +74,7 @@ var (
 	}
 )
 
-func TestFleetCluster(t *testing.T) {
+func Test_Fleet_Cluster(t *testing.T) {
 	require := require.New(t)
 	clients, err := clients.New()
 	if err != nil {


### PR DESCRIPTION
refers to https://github.com/rancher/rancher/issues/44630

The V2PROV_TEST_RUN_REGEX in line 33 of `scripts/provisioning-tests` ignored Fleet tests.
