### PR TITLE
Add RBAC for statefulsets/scale for the Manage Workloads RoleTemplate

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -335,7 +335,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("").resources("pods", "pods/attach", "pods/exec", "pods/portforward", "pods/proxy", "replicationcontrollers",
 		"replicationcontrollers/scale").verbs("*").
 		addRule().apiGroups("apps").resources("daemonsets", "deployments", "deployments/rollback", "deployments/scale", "replicasets",
-		"replicasets/scale", "statefulsets").verbs("*").
+		"replicasets/scale", "statefulsets", "statefulsets/scale").verbs("*").
 		addRule().apiGroups("autoscaling").resources("horizontalpodautoscalers").verbs("*").
 		addRule().apiGroups("batch").resources("cronjobs", "jobs").verbs("*").
 		addRule().apiGroups("").resources("limitranges", "pods/log", "pods/status", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status", "bindings").verbs("get", "list", "watch").


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#40303 
 
## Problem
Users assigned "manage workloads" for a given project do NOT have the ability to scale statefulsets.
The required rbac for statefulsets is present, but not on statefulsets/scale, which appears to be an accidental omission.
 
## Solution
Grant rbac for the "manage workloads" role on group: apps resource: statefulsets/scale.
 
## Testing
Create a downstream cluster
In that new cluster, create the following:
  1. A user (which will be assigned "manage workloads") below
  2. A project, here is where you can also add the newly created user as a workload manager
  3. A namespace inside the new project
  4. A statefulset inside the namespace created above

Login as the new user created above.
Navigate to the cluster/project/namespace where the statefulset was created
You should be able to see the statefulset and navigate to it.

Before this fix, the "Scale" buttons (top right of the UI) were NOT present.  They are now there and they work.


Alternatively, you can test with kubectl instead of the UI to verify that scaling works.
Get a shell in the downstream cluster for the user granted "manage workloads" role.
`kubectl scale statefulsets -n <namespace> <statefulset name> --replicas=<integer>`



## Engineering Testing
### Manual Testing
Manual testing performed as described above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
No new unit tests created for this since the rolebuilder_test.go suite already exercises the functions used in this change, which just adds a new resource (in role_data.go) to an existing rbac create.

It may desirable to include a new integration test for this.



Summary: 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
This is a very small, targeted change.  That being said, it might be useful to test with a pre-existing user (that had "manage workloads" before the upgrade (when this functionality was broken).  Post-upgrade, that user should be able to scale statefulsets without further intervention.
 
### Regressions Considerations
This change only adds to rbac granted for the manage workload role, so I wouldn't expect other existing functionality to be affected by this.
