### PR TITLE
[v2.8] Add PSACT test files for Qase coverage

### DIFF
--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -12,8 +12,9 @@ Please see below for more details for your config. Please see below for more det
 3. [Cloud Credential](#cloud-credentials)
 4. [Configure providers to use for Node Driver Clusters](#machine-k3s-config)
 5. [Configuring Custom Clusters](#custom-cluster)
-6. [Advanced Cluster Settings](#advanced-settings)
-7. [Back to general provisioning](../README.md)
+6. [Static test cases](#static-test-cases) 
+7. [Advanced Cluster Settings](#advanced-settings)
+8. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
 provisioningInput is needed to the run the K3S tests, specifically kubernetesVersion and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged`, `rancher-restricted` or `rancher-baseline`.
@@ -276,6 +277,55 @@ These tests utilize Go build tags. Due to this, see the below examples on how to
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterK3SProvisioningTestSuite/TestProvisioningK3SCustomClusterDynamicInput"`
 
 If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Static Test Cases
+In an effort to have uniform testing across our internal QA test case reporter, there are specific test cases that are put into their respective test files. This section highlights those test cases.
+
+### PSACT
+These test cases cover the following PSACT values as both an admin and standard user:
+1. `rancher-privileged`
+2. `rancher-restricted`
+3. `rancher-baseline`
+
+See an example YAML below:
+
+```yaml
+rancher:
+  host: "<rancher server url>"
+  adminToken: "<rancher admin bearer token>"
+  cleanup: false
+  clusterName: "<provided cluster name>"
+  insecure: true
+provisioningInput:
+  k3sKubernetesVersion: ["v1.27.10+k3s2"]
+  cni: ["calico"]
+  providers: ["linode"]
+  nodeProviders: ["ec2"]
+linodeCredentials:
+   token: ""
+linodeMachineConfigs:
+  region: "us-west"
+  linodeMachineConfig:
+  - roles: ["etcd", "controlplane", "worker"]
+    authorizedUsers: ""
+    createPrivateIp: true
+    dockerPort: "2376"
+    image: "linode/ubuntu22.04"
+    instanceType: "g6-standard-8"
+    region: "us-west"
+    rootPass: ""
+    sshPort: "22"
+    sshUser: ""
+    stackscript: ""
+    stackscriptData: ""
+    swapSize: "512"
+    tags: ""
+    uaPrefix: "Rancher"
+```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestK3SPSACTTestSuite$"`
 
 ## Advanced Settings
 This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:

--- a/tests/v2/validation/provisioning/k3s/psact_test.go
+++ b/tests/v2/validation/provisioning/k3s/psact_test.go
@@ -1,0 +1,160 @@
+//go:build validation
+
+package k3s
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type K3SPSACTTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	provisioningConfig *provisioninginput.Config
+}
+
+func (k *K3SPSACTTestSuite) TearDownSuite() {
+	k.session.Cleanup()
+}
+
+func (k *K3SPSACTTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	k.session = testSession
+
+	k.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+
+	k.provisioningConfig.K3SKubernetesVersions, err = kubernetesversions.Default(
+		k.client, clusters.K3SClusterType.String(), k.provisioningConfig.K3SKubernetesVersions)
+	require.NoError(k.T(), err)
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(k.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(k.T(), err)
+
+	k.standardUserClient = standardUserClient
+}
+
+func (k *K3SPSACTTestSuite) TestK3SPSACTNodeDriverCluster() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		psact        provisioninginput.PSACT
+		client       *rancher.Client
+	}{
+		{
+			name:         "Rancher Privileged " + provisioninginput.StandardClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-privileged",
+			client:       k.standardUserClient,
+		},
+		{
+			name:         "Rancher Restricted " + provisioninginput.StandardClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-restricted",
+			client:       k.standardUserClient,
+		},
+		{
+			name:         "Rancher Baseline " + provisioninginput.AdminClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-baseline",
+			client:       k.client,
+		},
+	}
+
+	for _, tt := range tests {
+		provisioningConfig := *k.provisioningConfig
+		provisioningConfig.MachinePools = tt.machinePools
+		provisioningConfig.PSACT = string(tt.psact)
+		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig,
+			permutations.K3SProvisionCluster, nil, nil)
+	}
+}
+
+func (k *K3SPSACTTestSuite) TestK3SPSACTCustomCluster() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		psact        provisioninginput.PSACT
+		client       *rancher.Client
+	}{
+		{
+			"Rancher Privileged " + provisioninginput.StandardClientName.String(),
+			nodeRolesDedicated,
+			"rancher-privileged",
+			k.standardUserClient,
+		},
+		{
+			"Rancher Restricted " + provisioninginput.StandardClientName.String(),
+			nodeRolesDedicated,
+			"rancher-restricted",
+			k.standardUserClient,
+		},
+		{
+			"Rancher Baseline " + provisioninginput.AdminClientName.String(),
+			nodeRolesDedicated,
+			"rancher-baseline",
+			k.client,
+		},
+	}
+
+	for _, tt := range tests {
+		provisioningConfig := *k.provisioningConfig
+		provisioningConfig.MachinePools = tt.machinePools
+		provisioningConfig.PSACT = string(tt.psact)
+		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig,
+			permutations.K3SCustomCluster, nil, nil)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestK3SPSACTTestSuite(t *testing.T) {
+	suite.Run(t, new(K3SPSACTTestSuite))
+}

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -11,8 +11,9 @@ Please see below for more details for your config. Please note that the config c
 2. [Define your test](#Provisioning-Input)
 3. [Configure providers to use for Node Driver Clusters](#NodeTemplateConfigs)
 4. [Configuring Custom Clusters](#Custom-Cluster)
-5. [Advanced Cluster Settings](#advanced-settings)
-6. [Back to general provisioning](../README.md)
+5. [Static test cases](#static-test-cases) 
+6. [Advanced Cluster Settings](#advanced-settings)
+7. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
 provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged`, `rancher-restricted` or `rancher-baseline`.
@@ -280,6 +281,53 @@ provisioningInput:
   nodeProviders: ["ec2"]
   psact: ""
 ```
+
+## Static Test Cases
+In an effort to have uniform testing across our internal QA test case reporter, there are specific test cases that are put into their respective test files. This section highlights those test cases.
+
+### PSACT
+These test cases cover the following PSACT values as both an admin and standard user:
+1. `rancher-privileged`
+2. `rancher-restricted`
+3. `rancher-baseline`
+
+See an example YAML below:
+
+```yaml
+rancher:
+  host: "<rancher server url>"
+  adminToken: "<rancher admin bearer token>"
+  cleanup: false
+  clusterName: "<provided cluster name>"
+  insecure: true
+provisioningInput:
+  rke1KubernetesVersion: ["v1.27.10-rancher1-1"]
+  cni: ["calico"]
+  providers: ["linode"]
+  nodeProviders: ["ec2"]
+linodeNodeTemplate:
+  authorizedUsers: ""
+  createPrivateIp: true
+  dockerPort: "2376"
+  image: "linode/ubuntu22.04"
+  instanceType: "g6-dedicated-8"
+  label: ""
+  region: "us-west"
+  rootPass: ""
+  sshPort: "22"
+  sshUser: "root"
+  stackscript: ""
+  stackscriptData: ""
+  swapSize: "512"
+  tags: ""
+  token: ""
+  type: "linodeConfig"
+  uaPrefix: "Rancher"
+```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke1 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE1PSACTTestSuite$"`
 
 ## Advanced Settings
 This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:

--- a/tests/v2/validation/provisioning/rke1/psact_test.go
+++ b/tests/v2/validation/provisioning/rke1/psact_test.go
@@ -1,0 +1,163 @@
+//go:build validation
+
+package rke1
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RKE1PSACTTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	provisioningConfig *provisioninginput.Config
+}
+
+func (r *RKE1PSACTTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *RKE1PSACTTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	r.session = testSession
+
+	r.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	r.provisioningConfig.RKE1KubernetesVersions, err = kubernetesversions.Default(
+		r.client, clusters.RKE1ClusterType.String(), r.provisioningConfig.RKE1KubernetesVersions)
+	require.NoError(r.T(), err)
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+}
+
+func (r *RKE1PSACTTestSuite) TestRKE1PSACTNodeDriverCluster() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdNodePool,
+		provisioninginput.ControlPlaneNodePool,
+		provisioninginput.WorkerNodePool,
+	}
+
+	tests := []struct {
+		name      string
+		nodePools []provisioninginput.NodePools
+		psact     provisioninginput.PSACT
+		client    *rancher.Client
+	}{
+		{
+			name:      "Rancher Privileged " + provisioninginput.StandardClientName.String(),
+			nodePools: nodeRolesDedicated,
+			psact:     "rancher-privileged",
+			client:    r.standardUserClient,
+		},
+		{
+			name:      "Rancher Restricted " + provisioninginput.StandardClientName.String(),
+			nodePools: nodeRolesDedicated,
+			psact:     "rancher-restricted",
+			client:    r.standardUserClient,
+		},
+		{
+			name:      "Rancher Baseline " + provisioninginput.AdminClientName.String(),
+			nodePools: nodeRolesDedicated,
+			psact:     "rancher-baseline",
+			client:    r.client,
+		},
+	}
+
+	for _, tt := range tests {
+		provisioningConfig := *r.provisioningConfig
+		provisioningConfig.NodePools = tt.nodePools
+		provisioningConfig.PSACT = string(tt.psact)
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
+			permutations.RKE1ProvisionCluster, nil, nil)
+	}
+}
+
+func (r *RKE1PSACTTestSuite) TestRKE1PSACTCustomCluster() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdNodePool,
+		provisioninginput.ControlPlaneNodePool,
+		provisioninginput.WorkerNodePool,
+	}
+
+	require.GreaterOrEqual(r.T(), len(r.provisioningConfig.CNIs), 1)
+
+	tests := []struct {
+		name      string
+		nodePools []provisioninginput.NodePools
+		psact     provisioninginput.PSACT
+		client    *rancher.Client
+	}{
+		{
+			name:      "Rancher Privileged " + provisioninginput.StandardClientName.String(),
+			nodePools: nodeRolesDedicated,
+			psact:     "rancher-privileged",
+			client:    r.standardUserClient,
+		},
+		{
+			name:      "Rancher Restricted " + provisioninginput.StandardClientName.String(),
+			nodePools: nodeRolesDedicated,
+			psact:     "rancher-restricted",
+			client:    r.standardUserClient,
+		},
+		{
+			name:      "Rancher Baseline " + provisioninginput.AdminClientName.String(),
+			nodePools: nodeRolesDedicated,
+			psact:     "rancher-baseline",
+			client:    r.client,
+		},
+	}
+
+	for _, tt := range tests {
+		provisioningConfig := *r.provisioningConfig
+		provisioningConfig.NodePools = tt.nodePools
+		provisioningConfig.PSACT = string(tt.psact)
+		provisioningConfig.NodePools[0].SpecifyCustomPublicIP = true
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
+			permutations.RKE1CustomCluster, nil, nil)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestRKE1PSACTTestSuite(t *testing.T) {
+	suite.Run(t, new(RKE1PSACTTestSuite))
+}

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -13,7 +13,8 @@ Please see below for more details for your config. Please see below for more det
 4. [Configure providers to use for Node Driver Clusters](#machine-rke2-config)
 5. [Configuring Custom Clusters](#custom-cluster)
 6. [Advanced Cluster Settings](#advanced-settings)
-7. [Back to general provisioning](../README.md)
+7. [Static test cases](#static-test-cases) 
+8. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
 provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged`, `rancher-restricted` or `rancher-baseline`.
@@ -290,6 +291,55 @@ These tests utilize Go build tags. Due to this, see the below examples on how to
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomClusterDynamicInput"`
 
 If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Static Test Cases
+In an effort to have uniform testing across our internal QA test case reporter, there are specific test cases that are put into their respective test files. This section highlights those test cases.
+
+### PSACT
+These test cases cover the following PSACT values as both an admin and standard user:
+1. `rancher-privileged`
+2. `rancher-restricted`
+3. `rancher-baseline`
+
+See an example YAML below:
+
+```yaml
+rancher:
+  host: "<rancher server url>"
+  adminToken: "<rancher admin bearer token>"
+  cleanup: false
+  clusterName: "<provided cluster name>"
+  insecure: true
+provisioningInput:
+  rke2KubernetesVersion: ["v1.27.10+rke2r1"]
+  cni: ["calico"]
+  providers: ["linode"]
+  nodeProviders: ["ec2"]
+linodeCredentials:
+   token: ""
+linodeMachineConfigs:
+  region: "us-west"
+  linodeMachineConfig:
+  - roles: ["etcd", "controlplane", "worker"]
+    authorizedUsers: ""
+    createPrivateIp: true
+    dockerPort: "2376"
+    image: "linode/ubuntu22.04"
+    instanceType: "g6-standard-8"
+    region: "us-west"
+    rootPass: ""
+    sshPort: "22"
+    sshUser: ""
+    stackscript: ""
+    stackscriptData: ""
+    swapSize: "512"
+    tags: ""
+    uaPrefix: "Rancher"
+```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE2PSACTTestSuite$"`
 
 ## Advanced Settings
 This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:

--- a/tests/v2/validation/provisioning/rke2/psact_test.go
+++ b/tests/v2/validation/provisioning/rke2/psact_test.go
@@ -1,0 +1,160 @@
+//go:build validation
+
+package rke2
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RKE2PSACTTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	provisioningConfig *provisioninginput.Config
+}
+
+func (r *RKE2PSACTTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *RKE2PSACTTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	r.session = testSession
+
+	r.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	r.provisioningConfig.RKE2KubernetesVersions, err = kubernetesversions.Default(
+		r.client, clusters.RKE2ClusterType.String(), r.provisioningConfig.RKE2KubernetesVersions)
+	require.NoError(r.T(), err)
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+}
+
+func (r *RKE2PSACTTestSuite) TestRKE2PSACTNodeDriverCluster() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		psact        provisioninginput.PSACT
+		client       *rancher.Client
+	}{
+		{
+			name:         "Rancher Privileged " + provisioninginput.StandardClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-privileged",
+			client:       r.standardUserClient,
+		},
+		{
+			name:         "Rancher Restricted " + provisioninginput.StandardClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-restricted",
+			client:       r.standardUserClient,
+		},
+		{
+			name:         "Rancher Baseline " + provisioninginput.AdminClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-baseline",
+			client:       r.client,
+		},
+	}
+
+	for _, tt := range tests {
+		provisioningConfig := *r.provisioningConfig
+		provisioningConfig.MachinePools = tt.machinePools
+		provisioningConfig.PSACT = string(tt.psact)
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
+			permutations.RKE2ProvisionCluster, nil, nil)
+	}
+}
+
+func (r *RKE2PSACTTestSuite) TestRKE2PSACTCustomCluster() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		psact        provisioninginput.PSACT
+		client       *rancher.Client
+	}{
+		{
+			name:         "Rancher Privileged " + provisioninginput.StandardClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-privileged",
+			client:       r.standardUserClient,
+		},
+		{
+			name:         "Rancher Restricted " + provisioninginput.StandardClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-restricted",
+			client:       r.standardUserClient,
+		},
+		{
+			name:         "Rancher Baseline " + provisioninginput.AdminClientName.String(),
+			machinePools: nodeRolesDedicated,
+			psact:        "rancher-baseline",
+			client:       r.client,
+		},
+	}
+
+	for _, tt := range tests {
+		provisioningConfig := *r.provisioningConfig
+		provisioningConfig.MachinePools = tt.machinePools
+		provisioningConfig.PSACT = string(tt.psact)
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
+			permutations.RKE2CustomCluster, nil, nil)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestRKE2PSACTTestSuite(t *testing.T) {
+	suite.Run(t, new(RKE2PSACTTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Add PSACT test file to cover static test files for rancher-privileged, rancher-restricted and rancher-baseline](https://github.com/rancher/qa-tasks/issues/1173)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
As part of having better Qase coverage across our provisioning tests, we need to ensure that PSACT is covered as part of this effort. This includes `rancher-privileged`, `rancher-restricted` and `rancher-baseline`.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Created test files that specifically provision dedicated role clusters with each PSACT value type. This is across RKE1/RKE2/K3S and the READMEs have been updated accordingly.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually tested RKE1, RKE2 and K3s node driver test.

### Automated Testing
Jenkins jobs will be provided to reviewers offline.