### PR TITLE
deps(wrangler): bump wrangler to latest 2.0 revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,10 @@ module github.com/rancher/rancher
 
 go 1.20
 
-// on release remove this wrangler replace and use the latest tag
-replace github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df
+// We cannot longer advance in the release-2.0 branch from wrangler without adopting the new wrangler/v2 import path
+// This requires coordination of several dependencies, so we have only performed this for Rancher >= 2.8
+// To mitigate this, a new "release-2.0-untagged" branch has been created, based on v2.0.1, to contain any needed fixes from that point
+replace github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1-0.20240307150840-1279389d86ec
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.22 // for compatibilty with docker 20.10.x

--- a/go.sum
+++ b/go.sum
@@ -1045,8 +1045,8 @@ github.com/rancher/steve v0.0.0-20240207201940-05ebdc1f5ef1/go.mod h1:tfdVny3lVO
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
-github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df h1:WJ+aaUICHPX8HeLmHE9JL/RFHhilMfcJlqmhgpc7gJU=
-github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df/go.mod h1:4T80p+rLh2OLbjCjdExIjRHKNBgK9NUAd7eIU/gRPKk=
+github.com/rancher/wrangler v1.1.1-0.20240307150840-1279389d86ec h1:1If/Fpo3yO4UPXbbNnaehEzZXyVNkTBtqqbgU2NimwQ=
+github.com/rancher/wrangler v1.1.1-0.20240307150840-1279389d86ec/go.mod h1:4T80p+rLh2OLbjCjdExIjRHKNBgK9NUAd7eIU/gRPKk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
## Issue: #44641<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem

Fixes memory leak due to leaking downstream cluster caches. See original issue and PR for more details.
 
## Solution

Unregister informers when related context is cancelled. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

I manually tested this by registering a downstream cluster, create a significant amount of 1MB-sized Secrets, then repeatedly registering/unregistering the cluster, watching how the heap grows. With this patch, this does not happen anymore and everything continues working correctly.