### PR TITLE
[v2.9] fix: update 'promoted' ClusterRole when removing all permissions from RoleTemplate

### DIFF
--- a/pkg/controllers/managementuser/rbac/handler_base_test.go
+++ b/pkg/controllers/managementuser/rbac/handler_base_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	fakes2 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
@@ -45,64 +44,99 @@ var (
 
 type clientErrs struct {
 	getError    error
+	listError   error
 	updateError error
 	createError error
 }
 
-func setupManager(roleTemplates map[string]*v3.RoleTemplate, clusterRoles map[string]*v1.ClusterRole, roles map[string]*v1.Role, projects map[string]*v3.Project, crErrs, rtErrs, rErrs clientErrs) *manager {
-	return &manager{
-		rtLister: &fakes.RoleTemplateListerMock{
+type managerOpt func(m *manager)
+
+func newManager(opts ...managerOpt) *manager {
+	manager := &manager{
+		clusterName: "testcluster",
+		rtLister:    &fakes.RoleTemplateListerMock{},
+		crLister:    &fakes2.ClusterRoleListerMock{},
+	}
+
+	for _, opt := range opts {
+		opt(manager)
+	}
+
+	return manager
+}
+
+// withRoleTemplates setup a rtLister mock with the provided roleTemplates and errors
+func withRoleTemplates(roleTemplates map[string]*v3.RoleTemplate, errs *clientErrs) managerOpt {
+	if roleTemplates == nil {
+		roleTemplates = map[string]*v3.RoleTemplate{}
+	}
+
+	if errs == nil {
+		errs = &clientErrs{}
+	}
+
+	return func(m *manager) {
+		m.rtLister = &fakes.RoleTemplateListerMock{
+			ListFunc: newListFunc(roleTemplates, errs.listError),
 			GetFunc: func(namespace string, name string) (*v3.RoleTemplate, error) {
-				if rtErrs.getError != nil {
-					return nil, rtErrs.getError
+				if errs.getError != nil {
+					return nil, errs.getError
 				}
+
 				rt, ok := roleTemplates[name]
 				if !ok {
 					return nil, errors.NewNotFound(v3.RoleTemplateGroupVersionResource.GroupResource(), name)
 				}
+
 				return rt.DeepCopy(), nil
 			},
-			ListFunc: func(namespace string, selector labels.Selector) ([]*v3.RoleTemplate, error) {
-				rts := make([]*v3.RoleTemplate, len(roleTemplates))
-				for i := range roleTemplates {
-					rts = append(rts, roleTemplates[i])
-				}
-				return rts, nil
-			},
-		},
-		crLister: &fakes2.ClusterRoleListerMock{
+		}
+	}
+}
+
+// withRoleTemplates setup a crLister and clusterRoles mock with the provided clusterRoles and errors
+func withClusterRoles(clusterRoles map[string]*v1.ClusterRole, errs *clientErrs) managerOpt {
+	if clusterRoles == nil {
+		clusterRoles = map[string]*v1.ClusterRole{}
+	}
+
+	if errs == nil {
+		errs = &clientErrs{}
+	}
+
+	return func(m *manager) {
+		m.crLister = &fakes2.ClusterRoleListerMock{
+			ListFunc: newListFunc(clusterRoles, errs.listError),
 			GetFunc: func(namespace string, name string) (*v1.ClusterRole, error) {
-				if crErrs.getError != nil {
-					return nil, crErrs.getError
+				if errs.getError != nil {
+					return nil, errs.getError
 				}
+
 				cr, ok := clusterRoles[name]
 				if !ok {
 					return nil, errors.NewNotFound(v3.RoleTemplateGroupVersionResource.GroupResource(), name)
 				}
+
 				return cr.DeepCopy(), nil
 			},
-			ListFunc: func(namespace string, selector labels.Selector) ([]*v1.ClusterRole, error) {
-				crs := make([]*v1.ClusterRole, len(roleTemplates))
-				for i := range clusterRoles {
-					crs = append(crs, clusterRoles[i])
-				}
-				return crs, nil
-			},
-		},
-		clusterRoles: &fakes2.ClusterRoleInterfaceMock{
+		}
+
+		m.clusterRoles = &fakes2.ClusterRoleInterfaceMock{
 			GetFunc: func(name string, opts metav1.GetOptions) (*v1.ClusterRole, error) {
-				if crErrs.getError != nil {
-					return nil, crErrs.getError
+				if errs.getError != nil {
+					return nil, errs.getError
 				}
+
 				cr, ok := clusterRoles[name]
 				if !ok {
 					return nil, errors.NewNotFound(v3.RoleTemplateGroupVersionResource.GroupResource(), name)
 				}
+
 				return cr.DeepCopy(), nil
 			},
 			UpdateFunc: func(cr *v1.ClusterRole) (*v1.ClusterRole, error) {
-				if crErrs.updateError != nil {
-					return nil, crErrs.updateError
+				if errs.updateError != nil {
+					return nil, errs.updateError
 				}
 				_, ok := clusterRoles[cr.Name]
 				if !ok {
@@ -112,8 +146,8 @@ func setupManager(roleTemplates map[string]*v3.RoleTemplate, clusterRoles map[st
 				return clusterRoles[cr.Name].DeepCopy(), nil
 			},
 			CreateFunc: func(cr *v1.ClusterRole) (*v1.ClusterRole, error) {
-				if crErrs.createError != nil {
-					return nil, crErrs.createError
+				if errs.createError != nil {
+					return nil, errs.createError
 				}
 				_, ok := clusterRoles[cr.Name]
 				if ok {
@@ -122,61 +156,27 @@ func setupManager(roleTemplates map[string]*v3.RoleTemplate, clusterRoles map[st
 				clusterRoles[cr.Name] = cr
 				return clusterRoles[cr.Name].DeepCopy(), nil
 			},
-		},
-		rLister: &fakes2.RoleListerMock{
-			GetFunc: func(namespace string, name string) (*v1.Role, error) {
-				if rErrs.getError != nil {
-					return nil, rErrs.getError
-				}
-				key := fmt.Sprintf("%s:%s", namespace, name)
-				r, ok := roles[key]
-				if !ok {
-					return nil, errors.NewNotFound(v3.RoleTemplateGroupVersionResource.GroupResource(), name)
-				}
-				return r.DeepCopy(), nil
-			},
-			ListFunc: func(namespace string, selector labels.Selector) ([]*v1.Role, error) {
-				rs := make([]*v1.Role, len(roles))
-				for i := range roles {
-					rs = append(rs, roles[i])
-				}
-				return rs, nil
-			},
-		},
-		roles: &fakes2.RoleInterfaceMock{
-			UpdateFunc: func(r *v1.Role) (*v1.Role, error) {
-				key := fmt.Sprintf("%s:%s", r.Namespace, r.Name)
-				_, ok := roles[key]
-				if ok {
-					return nil, errors.NewAlreadyExists(v3.RoleTemplateGroupVersionResource.GroupResource(), key)
-				}
-				roles[r.Name] = r
-				return roles[r.Name].DeepCopy(), nil
-			},
-			GetNamespacedFunc: func(namespace string, name string, opts metav1.GetOptions) (*v1.Role, error) {
-				key := fmt.Sprintf("%s:%s", namespace, name)
-				r, ok := roles[key]
-				if !ok {
-					return nil, errors.NewNotFound(v3.RoleTemplateGroupVersionResource.GroupResource(), name)
-				}
-				return r.DeepCopy(), nil
-			},
-		},
-		projectLister: &fakes.ProjectListerMock{
-			ListFunc: func(namespace string, selector labels.Selector) ([]*apimgmtv3.Project, error) {
-				rs := make([]*v3.Project, len(projects))
-				for i := range projects {
-					rs = append(rs, projects[i])
-				}
-				return rs, nil
-			},
-		},
-		clusterName: "testcluster",
+		}
+	}
+}
+
+func newListFunc[T any](resourceMap map[string]T, err error) func(string, labels.Selector) ([]T, error) {
+	return func(namespace string, selector labels.Selector) ([]T, error) {
+		if err != nil {
+			return nil, err
+		}
+
+		resourceList := make([]T, len(resourceMap))
+		for i := range resourceMap {
+			resourceList = append(resourceList, resourceMap[i])
+		}
+
+		return resourceList, nil
 	}
 }
 
 func Test_gatherRoles(t *testing.T) {
-	m := setupManager(recursiveTestRoleTemplates, make(map[string]*v1.ClusterRole), make(map[string]*v1.Role), make(map[string]*v3.Project), clientErrs{}, clientErrs{}, clientErrs{})
+	m := newManager(withRoleTemplates(recursiveTestRoleTemplates, nil))
 
 	emptyRoleTemplates := make(map[string]*v3.RoleTemplate)
 	type args struct {

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -253,8 +252,10 @@ func TestReconcileNamespaceProjectClusterRole(t *testing.T) {
 
 func TestCreateProjectNSRole(t *testing.T) {
 	t.Parallel()
+
 	crs := make(map[string]*v1.ClusterRole)
-	m := setupManager(make(map[string]*v3.RoleTemplate), crs, make(map[string]*v1.Role), make(map[string]*v3.Project), clientErrs{}, clientErrs{}, clientErrs{})
+	m := newManager(withClusterRoles(crs, nil))
+
 	type testCase struct {
 		description   string
 		verb          string
@@ -353,7 +354,8 @@ func TestCreateProjectNSRole(t *testing.T) {
 		assert.Equal(t, test.expectedCR, crs[test.expectedCR.Name], test.description)
 		delete(crs, test.expectedCR.Name)
 	}
-	m = setupManager(make(map[string]*v3.RoleTemplate), crs, make(map[string]*v1.Role), make(map[string]*v3.Project), clientErrs{createError: errors.NewInternalError(fmt.Errorf("some error"))}, clientErrs{}, clientErrs{})
+
+	m = newManager(withClusterRoles(crs, &clientErrs{createError: errors.NewInternalError(fmt.Errorf("some error"))}))
 	description := "test should return non-AlreadyExists error"
 	err := m.createProjectNSRole(fmt.Sprintf(projectNSGetClusterRoleNameFmt, "p-123xyz", "edit"), "*", "", "p-123xyz")
 	assert.NotNil(t, err, description)

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -290,12 +290,9 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 	roleName = roleName + "-promoted"
 
 	role, err := m.crLister.Get("", roleName)
-	if err != nil {
-		// return if something bad happened
-		if !apierrors.IsNotFound(err) {
-			return "", errors.Wrapf(err, "couldn't get role %v", roleName)
-		}
 
+	// we try to create the role if not found, or if we get an error (for backward compatibility)
+	if apierrors.IsNotFound(err) || err != nil {
 		logrus.Infof("Creating clusterRole %v for project access to global resource.", roleName)
 
 		clusterRole := &rbacv1.ClusterRole{

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -93,13 +94,13 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 
 	rt, err := p.m.rtLister.Get("", binding.RoleTemplateName)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't get role template %v", binding.RoleTemplateName)
+		return fmt.Errorf("couldn't get role template %v: %w", binding.RoleTemplateName, err)
 	}
 
 	// Get namespaces belonging to project
 	namespaces, err := p.m.nsIndexer.ByIndex(nsByProjectIndex, binding.ProjectName)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't list namespaces with project ID %v", binding.ProjectName)
+		return fmt.Errorf("couldn't list namespaces with project ID %v: %w", binding.ProjectName, err)
 	}
 	roles := map[string]*v3.RoleTemplate{}
 	if err := p.m.gatherRoles(rt, roles, 0); err != nil {
@@ -116,13 +117,13 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 			continue
 		}
 		if err := p.m.ensureProjectRoleBindings(ns.Name, roles, binding); err != nil {
-			return errors.Wrapf(err, "couldn't ensure binding %v in %v", binding.Name, ns.Name)
+			return fmt.Errorf("couldn't ensure binding %v in %v: %w", binding.Name, ns.Name, err)
 		}
 	}
 
 	if binding.UserName != "" {
 		if err := p.m.ensureServiceAccountImpersonator(binding.UserName); err != nil {
-			return errors.Wrapf(err, "couldn't ensure service account impersonator")
+			return fmt.Errorf("couldn't ensure service account impersonator: %w", err)
 		}
 	}
 
@@ -133,7 +134,7 @@ func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding)
 	// Get namespaces belonging to project
 	namespaces, err := p.m.nsIndexer.ByIndex(nsByProjectIndex, binding.ProjectName)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't list namespaces with project ID %v", binding.ProjectName)
+		return fmt.Errorf("couldn't list namespaces with project ID %v: %w", binding.ProjectName, err)
 	}
 
 	set := labels.Set(map[string]string{rtbOwnerLabel: pkgrbac.GetRTBLabel(binding.ObjectMeta)})
@@ -142,13 +143,13 @@ func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding)
 		bindingCli := p.m.workload.RBAC.RoleBindings(ns.Name)
 		rbs, err := p.m.rbLister.List(ns.Name, set.AsSelector())
 		if err != nil {
-			return errors.Wrapf(err, "couldn't list rolebindings with selector %s", set.AsSelector())
+			return fmt.Errorf("couldn't list rolebindings with selector %s: %w", set.AsSelector(), err)
 		}
 
 		for _, rb := range rbs {
 			if err := bindingCli.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil {
 				if !apierrors.IsNotFound(err) {
-					return errors.Wrapf(err, "error deleting rolebinding %v", rb.Name)
+					return fmt.Errorf("error deleting rolebinding %v: %w", rb.Name, err)
 				}
 			}
 		}
@@ -289,11 +290,15 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 	roleName = roleName + "-promoted"
 
 	role, err := m.crLister.Get("", roleName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("get cluster role %s failed: %w", roleName, err)
+		}
 
-	// we try to create the role if not found, or if we get an error (for backward compatibility)
-	if apierrors.IsNotFound(err) || err != nil {
-		// if no ClusterRole was found and the verbs are empty we skip the creation
-		// and we return a blank role name, to let the caller knows that this was a no-op
+		// try to create the role if not found
+
+		// if newVerbs are empty we can skip the creation and return a blank role name
+		// to let the caller knows that this was a no-op
 		if len(newVerbs) == 0 {
 			return "", nil
 		}
@@ -310,7 +315,7 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 		_, err := m.clusterRoles.Create(clusterRole)
 		if err != nil {
 			if !apierrors.IsAlreadyExists(err) {
-				return "", errors.Wrapf(err, "couldn't create role %v", roleName)
+				return "", fmt.Errorf("couldn't create role %v: %w", roleName, err)
 			}
 			logrus.Infof("Trying to create an already existing clusterRole %v for project access to global resource.", roleName)
 		}
@@ -365,7 +370,7 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 	logrus.Infof("Updating clusterRole %v for project access to global resource.", role.Name)
 	_, err = m.clusterRoles.Update(role)
 	if err != nil {
-		return "", errors.Wrapf(err, "couldn't update role %v", role.Name)
+		return "", fmt.Errorf("couldn't update role %v: %w", role.Name, err)
 	}
 	return roleName, nil
 }

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -249,7 +249,7 @@ func (m *manager) ownerExistsByNsName(nsAndName interface{}) (bool, error) {
 }
 
 // If the roleTemplate has rules granting access to non-namespaced (global) resource, return the verbs for those rules
-func (m *manager) checkForGlobalResourceRules(role *v3.RoleTemplate, resource string, baseRule rbacv1.PolicyRule) (map[string]bool, error) {
+func (m *manager) checkForGlobalResourceRules(role *v3.RoleTemplate, resource string, baseRule rbacv1.PolicyRule) (map[string]struct{}, error) {
 	var rules []rbacv1.PolicyRule
 	if role.External {
 		externalRole, err := m.crLister.Get("", role.Name)
@@ -264,14 +264,14 @@ func (m *manager) checkForGlobalResourceRules(role *v3.RoleTemplate, resource st
 		rules = role.Rules
 	}
 
-	verbs := map[string]bool{}
+	verbs := map[string]struct{}{}
 	for _, rule := range rules {
 		// given the global resource, we check if the passed in RoleTemplate has a corresponding rule, if it does, we add the verbs specified in the rule to the map of verbs that is returned
 		// NOTE: ResourceNames are checked since some global resources are scoped to specific resources, e.g. management.cattle.io/v3.Clusters are scoped to just the "local" cluster resource
 		if (slice.ContainsString(rule.Resources, resource) || slice.ContainsString(rule.Resources, "*")) && reflect.DeepEqual(rule.ResourceNames, baseRule.ResourceNames) {
 			if checkGroup(resource, rule) {
 				for _, v := range rule.Verbs {
-					verbs[v] = true
+					verbs[v] = struct{}{}
 				}
 			}
 		}
@@ -283,7 +283,7 @@ func (m *manager) checkForGlobalResourceRules(role *v3.RoleTemplate, resource st
 // reconcileRoleForProjectAccessToGlobalResource ensure the clusterRole used to grant access of global resources
 // to users/groups in projects has appropriate rules for the given resource and verbs.
 // The roleName is used to find and create/update the relevant '<roleName>-promoted' ClusterRole.
-func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string, roleName string, newVerbs map[string]bool, baseRule rbacv1.PolicyRule) (string, error) {
+func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string, roleName string, newVerbs map[string]struct{}, baseRule rbacv1.PolicyRule) (string, error) {
 	if roleName == "" {
 		return "", errors.New("cannot reconcile Role: missing roleName")
 	}
@@ -299,7 +299,7 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 			ObjectMeta: metav1.ObjectMeta{
 				Name: roleName,
 			},
-			Rules: []rbacv1.PolicyRule{buildRule(resource, newVerbs)},
+			Rules: []rbacv1.PolicyRule{buildRule(resource, newVerbs, baseRule)},
 		}
 
 		_, err := m.clusterRoles.Create(clusterRole)
@@ -348,12 +348,12 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 	added := false
 	for i, rule := range role.Rules {
 		if slice.ContainsString(rule.Resources, resource) {
-			role.Rules[i] = buildRule(resource, newVerbs)
+			role.Rules[i] = buildRule(resource, newVerbs, baseRule)
 			added = true
 		}
 	}
 	if !added {
-		role.Rules = append(role.Rules, buildRule(resource, newVerbs))
+		role.Rules = append(role.Rules, buildRule(resource, newVerbs, baseRule))
 	}
 
 	logrus.Infof("Updating clusterRole %v for project access to global resource.", role.Name)
@@ -384,7 +384,7 @@ func checkGroup(resource string, rule rbacv1.PolicyRule) bool {
 	return false
 }
 
-func buildRule(resource string, verbs map[string]bool) rbacv1.PolicyRule {
+func buildRule(resource string, verbs map[string]struct{}, baseRule rbacv1.PolicyRule) rbacv1.PolicyRule {
 	var vs []string
 	for v := range verbs {
 		vs = append(vs, v)
@@ -392,8 +392,6 @@ func buildRule(resource string, verbs map[string]bool) rbacv1.PolicyRule {
 
 	// Sort the verbs, a map does not guarantee order
 	sort.Strings(vs)
-
-	baseRule := globalResourceRulesNeededInProjects[resource]
 
 	return rbacv1.PolicyRule{
 		Resources:     []string{resource},

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -280,63 +280,90 @@ func (m *manager) checkForGlobalResourceRules(role *v3.RoleTemplate, resource st
 	return verbs, nil
 }
 
-// Ensure the clusterRole used to grant access of global resources to users/groups in projects has appropriate rules for the given resource and verbs
-func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string, rt *v3.RoleTemplate, newVerbs map[string]bool, baseRule rbacv1.PolicyRule) (string, error) {
-	clusterRoles := m.clusterRoles
-	roleName := rt.Name + "-promoted"
-	if role, err := m.crLister.Get("", roleName); err == nil && role != nil {
-		currentVerbs := map[string]bool{}
-		currentResourceNames := map[string]struct{}{}
-		for _, rule := range role.Rules {
-			if slice.ContainsString(rule.Resources, resource) {
-				for _, v := range rule.Verbs {
-					currentVerbs[v] = true
-				}
-				for _, v := range rule.ResourceNames {
-					currentResourceNames[v] = struct{}{}
-				}
-			}
+// reconcileRoleForProjectAccessToGlobalResource ensure the clusterRole used to grant access of global resources
+// to users/groups in projects has appropriate rules for the given resource and verbs.
+// The roleName is used to find and create/update the relevant '<roleName>-promoted' ClusterRole.
+func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string, roleName string, newVerbs map[string]bool, baseRule rbacv1.PolicyRule) (string, error) {
+	if roleName == "" {
+		return "", errors.New("cannot reconcile Role: missing roleName")
+	}
+	roleName = roleName + "-promoted"
+
+	role, err := m.crLister.Get("", roleName)
+	if err != nil {
+		// return if something bad happened
+		if !apierrors.IsNotFound(err) {
+			return "", errors.Wrapf(err, "couldn't get role %v", roleName)
 		}
 
-		desiredResourceNames := map[string]struct{}{}
-		for _, resourceName := range baseRule.ResourceNames {
-			desiredResourceNames[resourceName] = struct{}{}
+		logrus.Infof("Creating clusterRole %v for project access to global resource.", roleName)
+
+		clusterRole := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: roleName,
+			},
+			Rules: []rbacv1.PolicyRule{buildRule(resource, newVerbs)},
 		}
 
-		// if the verbs or the resourceNames in the promoted clusterrole don't match what's desired then the role requires updating
-		// desired verbs are passed in and the desired resourceNames come from the resource's base rule
-		if !reflect.DeepEqual(currentVerbs, newVerbs) || !reflect.DeepEqual(currentResourceNames, desiredResourceNames) {
-			role = role.DeepCopy()
-			added := false
-			for i, rule := range role.Rules {
-				if slice.ContainsString(rule.Resources, resource) {
-					role.Rules[i] = buildRule(resource, newVerbs)
-					added = true
-				}
+		_, err := m.clusterRoles.Create(clusterRole)
+		if err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return "", errors.Wrapf(err, "couldn't create role %v", roleName)
 			}
-			if !added {
-				role.Rules = append(role.Rules, buildRule(resource, newVerbs))
-			}
-			logrus.Infof("Updating clusterRole %v for project access to global resource.", role.Name)
-			_, err := clusterRoles.Update(role)
-			return roleName, err
+			logrus.Infof("Trying to create an already existing clusterRole %v for project access to global resource.", roleName)
 		}
 
 		return roleName, nil
 	}
 
-	logrus.Infof("Creating clusterRole %v for project access to global resource.", roleName)
-	rules := []rbacv1.PolicyRule{buildRule(resource, newVerbs)}
-	_, err := clusterRoles.Create(&rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: roleName,
-		},
-		Rules: rules,
-	})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return roleName, errors.Wrapf(err, "couldn't create role %v", roleName)
+	// role already exists -> updating / reconciling
+
+	currentVerbs := map[string]bool{}
+	currentResourceNames := map[string]struct{}{}
+	for _, rule := range role.Rules {
+		if slice.ContainsString(rule.Resources, resource) {
+			for _, v := range rule.Verbs {
+				currentVerbs[v] = true
+			}
+			for _, v := range rule.ResourceNames {
+				currentResourceNames[v] = struct{}{}
+			}
+		}
 	}
 
+	desiredResourceNames := map[string]struct{}{}
+	for _, resourceName := range baseRule.ResourceNames {
+		desiredResourceNames[resourceName] = struct{}{}
+	}
+
+	equalVerbs := reflect.DeepEqual(currentVerbs, newVerbs)
+	equalResources := reflect.DeepEqual(currentResourceNames, desiredResourceNames)
+
+	// if the verbs or the resourceNames matches the desired state we can return
+	if equalVerbs && equalResources {
+		return roleName, nil
+	}
+
+	// if the verbs or the resourceNames in the promoted clusterrole don't match what's desired then the role requires updating
+	// desired verbs are passed in and the desired resourceNames come from the resource's base rule
+	role = role.DeepCopy()
+
+	added := false
+	for i, rule := range role.Rules {
+		if slice.ContainsString(rule.Resources, resource) {
+			role.Rules[i] = buildRule(resource, newVerbs)
+			added = true
+		}
+	}
+	if !added {
+		role.Rules = append(role.Rules, buildRule(resource, newVerbs))
+	}
+
+	logrus.Infof("Updating clusterRole %v for project access to global resource.", role.Name)
+	_, err = m.clusterRoles.Update(role)
+	if err != nil {
+		return "", errors.Wrapf(err, "couldn't update role %v", role.Name)
+	}
 	return roleName, nil
 }
 

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -1,13 +1,18 @@
 package rbac
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	typesrbacv1fakes "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_manager_checkForGlobalResourceRules(t *testing.T) {
@@ -184,5 +189,248 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		got, err := m.checkForGlobalResourceRules(test.role, test.resource, test.baseRule)
 		assert.Nil(t, err)
 		assert.Equal(t, test.want, got, fmt.Sprintf("test %v failed", test.name))
+	}
+}
+
+func Test_manager_reconcileRoleForProjectAccessToGlobalResource(t *testing.T) {
+	// discard logs to avoid cluttering
+	logrus.SetOutput(io.Discard)
+
+	type args struct {
+		resource string
+		rtName   string
+		newVerbs map[string]struct{}
+		baseRule rbacv1.PolicyRule
+	}
+
+	tests := []struct {
+		name             string
+		crListerMock     *typesrbacv1fakes.ClusterRoleListerMock
+		clusterRolesMock *typesrbacv1fakes.ClusterRoleInterfaceMock
+		args             args
+		want             string
+		wantErr          bool
+	}{
+		{
+			name: "non existing ClusteRole will create a new promoted ClusterRole",
+			args: args{
+				rtName:   "myrole",
+				resource: "myresource",
+				newVerbs: map[string]struct{}{"get": {}, "list": {}},
+				baseRule: rbacv1.PolicyRule{
+					APIGroups:     []string{"management.cattle.io"},
+					ResourceNames: []string{"local"},
+				},
+			},
+			crListerMock: &typesrbacv1fakes.ClusterRoleListerMock{
+				GetFunc: func(namespace, name string) (*v1.ClusterRole, error) {
+					return nil, errNotFound
+				},
+			},
+			clusterRolesMock: &typesrbacv1fakes.ClusterRoleInterfaceMock{
+				CreateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Equal(t, &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myrole-promoted",
+						},
+						Rules: []rbacv1.PolicyRule{{
+							APIGroups:     []string{"management.cattle.io"},
+							ResourceNames: []string{"local"},
+							Resources:     []string{"myresource"},
+							Verbs:         []string{"get", "list"},
+						}},
+					}, in1)
+					return in1, nil
+				},
+				UpdateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Fail(t, "unexpected call to ClusterRole Update")
+					return nil, nil
+				},
+			},
+			want: "myrole-promoted",
+		},
+		{
+			name: "existing ClusteRole will update it",
+			args: args{
+				rtName:   "myrole",
+				resource: "myresource",
+				newVerbs: map[string]struct{}{"list": {}, "delete": {}},
+				baseRule: rbacv1.PolicyRule{
+					APIGroups:     []string{"management.cattle.io"},
+					ResourceNames: []string{"local"},
+				},
+			},
+			crListerMock: &typesrbacv1fakes.ClusterRoleListerMock{
+				GetFunc: func(namespace, name string) (*v1.ClusterRole, error) {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myrole-promoted",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								APIGroups:     []string{"another.cattle.io"},
+								ResourceNames: []string{"foobar"},
+								Resources:     []string{"nodes"},
+								Verbs:         []string{"create"},
+							},
+							{
+								APIGroups:     []string{"management.cattle.io"},
+								ResourceNames: []string{"local"},
+								Resources:     []string{"myresource"},
+								Verbs:         []string{"get", "list"},
+							},
+						},
+					}, nil
+				},
+			},
+			clusterRolesMock: &typesrbacv1fakes.ClusterRoleInterfaceMock{
+				CreateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Fail(t, "unexpected call to ClusterRole Create")
+					return in1, nil
+				},
+				UpdateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Equal(t, &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myrole-promoted",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								APIGroups:     []string{"another.cattle.io"},
+								ResourceNames: []string{"foobar"},
+								Resources:     []string{"nodes"},
+								Verbs:         []string{"create"},
+							},
+							{
+								APIGroups:     []string{"management.cattle.io"},
+								ResourceNames: []string{"local"},
+								Resources:     []string{"myresource"},
+								Verbs:         []string{"delete", "list"},
+							},
+						},
+					}, in1)
+					return nil, nil
+				},
+			},
+			want: "myrole-promoted",
+		},
+		{
+			name: "removing verbs from policy will remove the rule",
+			args: args{
+				rtName:   "myrole",
+				resource: "myresource",
+				newVerbs: map[string]struct{}{},
+				baseRule: rbacv1.PolicyRule{
+					APIGroups:     []string{"management.cattle.io"},
+					ResourceNames: []string{"local"},
+				},
+			},
+			crListerMock: &typesrbacv1fakes.ClusterRoleListerMock{
+				GetFunc: func(namespace, name string) (*v1.ClusterRole, error) {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myrole-promoted",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								APIGroups:     []string{"another.cattle.io"},
+								ResourceNames: []string{"foobar"},
+								Resources:     []string{"nodes"},
+								Verbs:         []string{"create"},
+							},
+							{
+								APIGroups:     []string{"management.cattle.io"},
+								ResourceNames: []string{"local"},
+								Resources:     []string{"myresource"},
+								Verbs:         []string{"get", "list"},
+							},
+						},
+					}, nil
+				},
+			},
+			clusterRolesMock: &typesrbacv1fakes.ClusterRoleInterfaceMock{
+				CreateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Fail(t, "unexpected call to ClusterRole Create")
+					return in1, nil
+				},
+				UpdateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Equal(t, &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myrole-promoted",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								APIGroups:     []string{"another.cattle.io"},
+								ResourceNames: []string{"foobar"},
+								Resources:     []string{"nodes"},
+								Verbs:         []string{"create"},
+							},
+						},
+					}, in1)
+					return in1, nil
+				},
+			},
+			want: "myrole-promoted",
+		},
+
+		{
+			name: "create a the role if get fails",
+			args: args{
+				rtName:   "myrole",
+				resource: "myresource",
+				newVerbs: map[string]struct{}{"get": {}, "list": {}},
+				baseRule: rbacv1.PolicyRule{
+					APIGroups:     []string{"management.cattle.io"},
+					ResourceNames: []string{"local"},
+				},
+			},
+			crListerMock: &typesrbacv1fakes.ClusterRoleListerMock{
+				GetFunc: func(namespace, name string) (*v1.ClusterRole, error) {
+					return nil, errors.New("get failed")
+				},
+			},
+			clusterRolesMock: &typesrbacv1fakes.ClusterRoleInterfaceMock{
+				CreateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Equal(t, &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myrole-promoted",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								APIGroups:     []string{"management.cattle.io"},
+								ResourceNames: []string{"local"},
+								Resources:     []string{"myresource"},
+								Verbs:         []string{"get", "list"},
+							},
+						},
+					}, in1)
+					return in1, nil
+				},
+				UpdateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+					assert.Fail(t, "unexpected call to ClusterRole Update")
+					return in1, nil
+				},
+			},
+			want: "myrole-promoted",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			manager := manager{
+				crLister:     tc.crListerMock,
+				clusterRoles: tc.clusterRolesMock,
+			}
+
+			got, err := manager.reconcileRoleForProjectAccessToGlobalResource(tc.args.resource, tc.args.rtName, tc.args.newVerbs, tc.args.baseRule)
+			assert.Equal(t, tc.want, got)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
@@ -140,11 +140,13 @@ func (m *manager) ensureGlobalResourcesRolesForPRTB(projectName string, rts map[
 				return nil, err
 			}
 
-			if len(verbs) > 0 {
-				roleName, err := m.reconcileRoleForProjectAccessToGlobalResource(resource, rt.Name, verbs, baseRule)
-				if err != nil {
-					return nil, err
-				}
+			roleName, err := m.reconcileRoleForProjectAccessToGlobalResource(resource, rt.Name, verbs, baseRule)
+			if err != nil {
+				return nil, err
+			}
+
+			// if a role was created or updated append it to the existing roles
+			if roleName != "" {
 				roles = append(roles, roleName)
 			}
 		}

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
@@ -139,8 +139,9 @@ func (m *manager) ensureGlobalResourcesRolesForPRTB(projectName string, rts map[
 			if err != nil {
 				return nil, err
 			}
+
 			if len(verbs) > 0 {
-				roleName, err := m.reconcileRoleForProjectAccessToGlobalResource(resource, rt, verbs, baseRule)
+				roleName, err := m.reconcileRoleForProjectAccessToGlobalResource(resource, rt.Name, verbs, baseRule)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate_test.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate_test.go
@@ -1,23 +1,33 @@
 package rbac
 
 import (
+	"io"
 	"testing"
 
 	"github.com/pkg/errors"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 	t.Parallel()
-	m := setupManager(map[string]*v3.RoleTemplate{"create-ns": createNSRoleTemplate}, make(map[string]*v1.ClusterRole), make(map[string]*v1.Role), make(map[string]*v3.Project), clientErrs{}, clientErrs{}, clientErrs{})
+	logrus.SetOutput(io.Discard)
+
+	defaultManager := setupManager(
+		map[string]*v3.RoleTemplate{"create-ns": createNSRoleTemplate},
+		map[string]*v1.ClusterRole{},
+		map[string]*v1.Role{},
+		map[string]*v3.Project{},
+		clientErrs{}, clientErrs{}, clientErrs{},
+	)
+
 	type testCase struct {
 		description   string
+		manager       *manager
 		projectName   string
 		roleTemplates map[string]*v3.RoleTemplate
 		expectedRoles []string
@@ -26,6 +36,7 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 	testCases := []testCase{
 		{
 			description:   "global resource rule should grant namespace read",
+			manager:       defaultManager,
 			projectName:   "testproject",
 			expectedRoles: []string{"testproject-namespaces-readonly"},
 			roleTemplates: map[string]*v3.RoleTemplate{
@@ -45,6 +56,7 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 		},
 		{
 			description:   "namespace create rule should grant create-ns and a namespaces-edit role",
+			manager:       defaultManager,
 			projectName:   "testproject",
 			expectedRoles: []string{"create-ns", "testproject-namespaces-edit"},
 			roleTemplates: map[string]*v3.RoleTemplate{
@@ -64,6 +76,7 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 		},
 		{
 			description:   "namespace create rule for other API group should grant namespaces-read role only",
+			manager:       defaultManager,
 			projectName:   "testproject",
 			expectedRoles: []string{"testproject-namespaces-readonly"},
 			roleTemplates: map[string]*v3.RoleTemplate{
@@ -83,6 +96,7 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 		},
 		{
 			description:   "namespace * rule for other API group should grant namespaces-read role only",
+			manager:       defaultManager,
 			projectName:   "testproject",
 			expectedRoles: []string{"testproject-namespaces-readonly"},
 			roleTemplates: map[string]*v3.RoleTemplate{
@@ -102,6 +116,7 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 		},
 		{
 			description:   "global resource rule result in promoted role returned",
+			manager:       defaultManager,
 			projectName:   "testproject",
 			expectedRoles: []string{"testproject-namespaces-readonly", "testrt5-promoted"},
 			roleTemplates: map[string]*v3.RoleTemplate{
@@ -121,6 +136,7 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 		},
 		{
 			description:   "empty project name will result in no roles returned",
+			manager:       defaultManager,
 			projectName:   "",
 			expectedRoles: nil,
 			roleTemplates: map[string]*v3.RoleTemplate{
@@ -140,6 +156,7 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 		},
 		{
 			description:   "* resources and non-core APIGroup should only result in namespace-readonly role",
+			manager:       defaultManager,
 			projectName:   "testproject",
 			expectedRoles: []string{"testproject-namespaces-readonly"},
 			roleTemplates: map[string]*v3.RoleTemplate{
@@ -158,12 +175,10 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 			},
 		},
 		{
-			description: "* resources and * APIGroup should only result in namespace-readonly and promoted role",
-			projectName: "testproject",
-			// at the time of adding these tests ensureGlobalResourceRoleForPRTB returns duplicate promoted roles
-			// names per applicable rule found in globalResourceRulesNeededInProjects. This is not incompatible with
-			// current reconcile logic but should be fixed in the future.
-			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testrt8-promoted", "testrt8-promoted", "testrt8-promoted", "testrt8-promoted", "testrt8-promoted", "testrt8-promoted"},
+			description:   "* resources and * APIGroup should only result in namespace-readonly and promoted role",
+			manager:       defaultManager,
+			projectName:   "testproject",
+			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testrt8-promoted"},
 			roleTemplates: map[string]*v3.RoleTemplate{
 				"testrt8": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -181,8 +196,9 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 		},
 		{
 			description:   "* resources and core (\"\") APIGroup should only result in namespace-readonly and promoted role",
+			manager:       defaultManager,
 			projectName:   "testproject",
-			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testrt9-promoted", "testrt9-promoted"},
+			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testrt9-promoted"},
 			roleTemplates: map[string]*v3.RoleTemplate{
 				"testrt9": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -198,58 +214,78 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 				},
 			},
 		},
+		{
+			projectName: "testproject",
+			description: "error return when RoleTemplate client returns error",
+			manager: setupManager(
+				map[string]*v3.RoleTemplate{"create-ns": createNSRoleTemplate},
+				make(map[string]*v1.ClusterRole),
+				make(map[string]*v1.Role),
+				make(map[string]*v3.Project),
+				clientErrs{},
+				clientErrs{getError: errNotFound},
+				clientErrs{},
+			),
+			isErrExpected: true,
+			roleTemplates: map[string]*v3.RoleTemplate{
+				"testrt": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testrt",
+					},
+					Rules: []v1.PolicyRule{
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{""},
+							Resources: []string{"namespaces"},
+						},
+					},
+				},
+			},
+		},
+		{
+			projectName: "testproject",
+			description: "error return when ClusterRole client returns error and RoleTemplate is external",
+			manager: setupManager(
+				map[string]*v3.RoleTemplate{"create-ns": createNSRoleTemplate},
+				make(map[string]*v1.ClusterRole),
+				make(map[string]*v1.Role),
+				make(map[string]*v3.Project),
+				clientErrs{getError: apierrors.NewInternalError(errors.New("error"))},
+				clientErrs{},
+				clientErrs{},
+			),
+			isErrExpected: true,
+			roleTemplates: map[string]*v3.RoleTemplate{
+				"testrt": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testrt",
+					},
+					Rules: []v1.PolicyRule{
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{""},
+							Resources: []string{"namespaces"},
+						},
+					},
+					External: true,
+				},
+			},
+		},
 	}
 	for _, test := range testCases {
 		test := test
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
-			roles, err := m.ensureGlobalResourcesRolesForPRTB(test.projectName, test.roleTemplates)
-			assert.Nil(t, err)
-			assert.Equal(t, test.expectedRoles, roles, test.description)
+
+			roles, err := test.manager.ensureGlobalResourcesRolesForPRTB(test.projectName, test.roleTemplates)
+
+			if test.isErrExpected {
+				assert.Error(t, err)
+				assert.Nil(t, roles)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedRoles, roles, test.description)
+			}
 		})
 	}
-
-	test := testCase{
-		projectName:   "testproject",
-		expectedRoles: []string{"create-ns", "testproject-namespaces-edit"},
-		roleTemplates: map[string]*v3.RoleTemplate{
-			"testrt": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testrt",
-				},
-				Rules: []v1.PolicyRule{
-					{
-						Verbs:     []string{"create"},
-						APIGroups: []string{""},
-						Resources: []string{"namespaces"},
-					},
-				},
-			},
-		},
-	}
-	m = setupManager(map[string]*v3.RoleTemplate{"create-ns": createNSRoleTemplate}, make(map[string]*v1.ClusterRole), make(map[string]*v1.Role), make(map[string]*v3.Project), clientErrs{}, clientErrs{getError: errNotFound}, clientErrs{})
-	test1 := test
-	test1.description = "error return when RoleTemplate client returns error"
-	t.Run(test.description, func(t *testing.T) {
-		t.Parallel()
-		_, err := m.ensureGlobalResourcesRolesForPRTB(test.projectName, test.roleTemplates)
-		assert.NotNil(t, err)
-	})
-	m = setupManager(map[string]*v3.RoleTemplate{"create-ns": createNSRoleTemplate}, make(map[string]*v1.ClusterRole), make(map[string]*v1.Role), make(map[string]*v3.Project), clientErrs{}, clientErrs{}, clientErrs{createError: errAlreadyExist})
-	test2 := test
-	test2.description = "error return when Role client returns error"
-	t.Run(test.description, func(t *testing.T) {
-		t.Parallel()
-		_, err := m.ensureGlobalResourcesRolesForPRTB(test.projectName, test.roleTemplates)
-		assert.NotNil(t, err)
-	})
-	m = setupManager(map[string]*v3.RoleTemplate{"create-ns": createNSRoleTemplate}, make(map[string]*v1.ClusterRole), make(map[string]*v1.Role), make(map[string]*v3.Project), clientErrs{getError: apierrors.NewInternalError(errors.New("error"))}, clientErrs{}, clientErrs{})
-	test3 := test
-	test3.description = "error return when ClusterRole client returns error and RoleTemplate is external"
-	test3.roleTemplates["testrt"].External = true
-	t.Run(test.description, func(t *testing.T) {
-		t.Parallel()
-		_, err := m.ensureGlobalResourcesRolesForPRTB(test.projectName, test.roleTemplates)
-		assert.NotNil(t, err)
-	})
 }

--- a/pkg/controllers/managementuser/rbac/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplate_handler.go
@@ -77,7 +77,6 @@ func (c *rtSync) syncRT(template *v3.RoleTemplate, usedInProjects bool, prtbs []
 		return errors.Wrapf(err, "couldn't ensure roles")
 	}
 
-	rolesToKeep := make(map[string]bool)
 	if usedInProjects {
 		for _, rt := range roleTemplates {
 			for resource, baseRule := range globalResourceRulesNeededInProjects {
@@ -85,12 +84,12 @@ func (c *rtSync) syncRT(template *v3.RoleTemplate, usedInProjects bool, prtbs []
 				if err != nil {
 					return err
 				}
+
 				if len(verbs) > 0 {
-					roleName, err := c.m.reconcileRoleForProjectAccessToGlobalResource(resource, rt, verbs, baseRule)
+					roleName, err := c.m.reconcileRoleForProjectAccessToGlobalResource(resource, rt.Name, verbs, baseRule)
 					if err != nil {
-						return errors.Wrapf(err, "couldn't reconcile role for project access to global resources")
+						return errors.Wrapf(err, "couldn't reconcile role '%s' for project access to global resources", roleName)
 					}
-					rolesToKeep[roleName] = true
 				}
 			}
 		}

--- a/pkg/controllers/managementuser/rbac/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplate_handler.go
@@ -85,11 +85,9 @@ func (c *rtSync) syncRT(template *v3.RoleTemplate, usedInProjects bool, prtbs []
 					return err
 				}
 
-				if len(verbs) > 0 {
-					roleName, err := c.m.reconcileRoleForProjectAccessToGlobalResource(resource, rt.Name, verbs, baseRule)
-					if err != nil {
-						return errors.Wrapf(err, "couldn't reconcile role '%s' for project access to global resources", roleName)
-					}
+				roleName, err := c.m.reconcileRoleForProjectAccessToGlobalResource(resource, rt.Name, verbs, baseRule)
+				if err != nil {
+					return errors.Wrapf(err, "couldn't reconcile role '%s' for project access to global resources", roleName)
 				}
 			}
 		}


### PR DESCRIPTION
Fix #43292 

## Issue: <!-- link the issue or issues this PR resolves here -->
 - https://github.com/rancher/rancher/issues/43292
 
## Problem

This PR fixes the missing update of the `-promoted` ClusterRole when removing all the permissions.
The issue was due to a check of the length of the `newVerbs`. When `0` the update was skipped.
 
## Solution

To fix the issue I moved the check internally, removing the matching rules when no verbs are specified.

The small refactor of the func was made to have a more linear and clear flow, with some early returns/checks.
Added also some unit tests.

One note: in the previous implementation this was the check:

```go
if role, err := m.crLister.Get("", roleName); err == nil && role != nil {
	// update ClusterRole
}
// else create new ClusterRole
```

that means if an error occured (not only a "not found" error) then an update will be performed. I kept this behaviour for compatibility (other tests were failing) but I don't think it's actually needed.

```go
role, err := m.crLister.Get("", roleName)
// we try to create the role if not found, or if we get an error (for backward compatibility)
if apierrors.IsNotFound(err) || err != nil {
	// create
}
// else update
```
 
## Testing

Repro steps in the original issue are valid.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

* Test types added/modified:
    * Unit
