### PR TITLE
[2.9] Update Charts Installations in the Validation Tests to Use Cluster Meta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,8 @@ replace (
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
-	github.com/rancher/rancher/pkg/apis v0.0.0-20240126142034-676c3eb3dfa5
-	github.com/rancher/shepherd v0.0.0-20240418211256-8212b80adcac
+	github.com/rancher/rancher/pkg/apis v0.0.0-20240415062435-07e4313daf43
+	github.com/rancher/shepherd v0.0.0-20240424170735-64c67a5265b7
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1694,8 +1694,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.6.0-rc1 h1:4aYfGiG4gxL5k44M3jpDoKfQqI1lxdl4GAVPRMvKMj8=
 github.com/rancher/rke v1.6.0-rc1/go.mod h1:vojhOf8U8VCmw7y17OENWXSIfEFPEbXCMQcmI7xN7i8=
-github.com/rancher/shepherd v0.0.0-20240418211256-8212b80adcac h1:lnW+WylOILVZsrCkDOMN/K0BZGKH8krDr0286MNEsPI=
-github.com/rancher/shepherd v0.0.0-20240418211256-8212b80adcac/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
+github.com/rancher/shepherd v0.0.0-20240424170735-64c67a5265b7 h1:Nb1ILiB0/OaNTSa2h9KIhLN3abG41aUBINNO2fSSiB4=
+github.com/rancher/shepherd v0.0.0-20240424170735-64c67a5265b7/go.mod h1:yWG+A4NlpJkY2NQf6VyZ0elGAow4uy6IdlnqvOip32M=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/charts/gatekeeper_test.go
+++ b/tests/v2/validation/charts/gatekeeper_test.go
@@ -45,8 +45,8 @@ func (g *GateKeeperTestSuite) SetupSuite() {
 	clusterName := client.RancherConfig.ClusterName
 	require.NotEmptyf(g.T(), clusterName, "Cluster name to install is not set")
 
-	// Get clusterID with clusterName
-	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	// Get cluster meta
+	cluster, err := clusters.NewClusterMeta(client, clusterName)
 	require.NoError(g.T(), err)
 
 	// get latest version of gatekeeper chart
@@ -55,7 +55,7 @@ func (g *GateKeeperTestSuite) SetupSuite() {
 
 	// Create project
 	projectConfig := &management.Project{
-		ClusterID: clusterID,
+		ClusterID: cluster.ID,
 		Name:      gatekeeperProjectName,
 	}
 	createdProject, err := client.Management.Project.Create(projectConfig)
@@ -64,12 +64,10 @@ func (g *GateKeeperTestSuite) SetupSuite() {
 	g.project = createdProject
 
 	g.gatekeeperChartInstallOptions = &charts.InstallOptions{
-		ClusterName: clusterName,
-		ClusterID:   clusterID,
-		Version:     latestGatekeeperVersion,
-		ProjectID:   createdProject.ID,
+		Cluster:   cluster,
+		Version:   latestGatekeeperVersion,
+		ProjectID: createdProject.ID,
 	}
-
 }
 
 func (g *GateKeeperTestSuite) TestGatekeeperChart() {

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -5,9 +5,8 @@ package charts
 import (
 	"fmt"
 	"math/rand"
-	"testing"
-
 	"net/url"
+	"testing"
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -56,45 +55,44 @@ func (m *MonitoringTestSuite) SetupSuite() {
 	clusterName := client.RancherConfig.ClusterName
 	require.NotEmptyf(m.T(), clusterName, "Cluster name to install is not set")
 
-	// Get clusterID with clusterName
-	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	// Get cluster meta
+	cluster, err := clusters.NewClusterMeta(client, clusterName)
 	require.NoError(m.T(), err)
 
 	// Change alert manager and grafana paths if it's not local cluster
-	if clusterID != clusterName {
-		alertManagerPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, alertManagerPath)
-		grafanaPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, grafanaPath)
-		prometheusTargetsPathAPI = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusTargetsPathAPI)
+	if !cluster.IsLocal {
+		alertManagerPath = fmt.Sprintf("k8s/clusters/%s/%s", cluster.ID, alertManagerPath)
+		grafanaPath = fmt.Sprintf("k8s/clusters/%s/%s", cluster.ID, grafanaPath)
+		prometheusTargetsPathAPI = fmt.Sprintf("k8s/clusters/%s/%s", cluster.ID, prometheusTargetsPathAPI)
 	}
 
 	// Change prometheus paths to use the clusterID
-	prometheusGraphPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusGraphPath)
-	prometheusRulesPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusRulesPath)
-	prometheusTargetsPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusTargetsPath)
+	prometheusGraphPath = fmt.Sprintf("k8s/clusters/%s/%s", cluster.ID, prometheusGraphPath)
+	prometheusRulesPath = fmt.Sprintf("k8s/clusters/%s/%s", cluster.ID, prometheusRulesPath)
+	prometheusTargetsPath = fmt.Sprintf("k8s/clusters/%s/%s", cluster.ID, prometheusTargetsPath)
 
 	// Get latest versions of the monitoring chart
 	latestMonitoringVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName, catalog.RancherChartRepo)
 	require.NoError(m.T(), err)
 
 	// Get project system projectId
-	project, err := projects.GetProjectByName(client, clusterID, projectName)
+	project, err := projects.GetProjectByName(client, cluster.ID, projectName)
 	require.NoError(m.T(), err)
 
 	m.project = project
 	require.NotEmpty(m.T(), m.project)
 
 	m.chartInstallOptions = &charts.InstallOptions{
-		ClusterName: clusterName,
-		ClusterID:   clusterID,
-		Version:     latestMonitoringVersion,
-		ProjectID:   m.project.ID,
+		Cluster:   cluster,
+		Version:   latestMonitoringVersion,
+		ProjectID: m.project.ID,
 	}
 	m.chartFeatureOptions = &charts.RancherMonitoringOpts{
-		IngressNginx:         true,
-		RKEControllerManager: true,
-		RKEEtcd:              true,
-		RKEProxy:             true,
-		RKEScheduler:         true,
+		IngressNginx:      true,
+		ControllerManager: true,
+		Etcd:              true,
+		Proxy:             true,
+		Scheduler:         true,
 	}
 }
 

--- a/tests/v2/validation/upgrade/cloud_provider_aws_migration.go
+++ b/tests/v2/validation/upgrade/cloud_provider_aws_migration.go
@@ -118,7 +118,6 @@ func enableLeaderMigrationRKE1(rke1Cluster *management.Cluster) *management.Clus
 
 // rke1AWSCloudProviderMigration is a helper function to migrate from aws in-tree to out-of-tree on rke1 clusters
 func rke1AWSCloudProviderMigration(t *testing.T, client *rancher.Client, clusterName string) {
-
 	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
 	require.NoError(t, err)
 
@@ -166,7 +165,10 @@ func rke1AWSCloudProviderMigration(t *testing.T, client *rancher.Client, cluster
 
 	logrus.Info("Upgrading the cluster to preform in-tree to out-of-tree migration.")
 
-	err = permutations.CreateAndInstallAWSExternalCharts(client, status.ClusterName, true)
+	clusterMeta, err := clusters.NewClusterMeta(client, status.ClusterName)
+	require.NoError(t, err)
+
+	err = permutations.CreateAndInstallAWSExternalCharts(client, clusterMeta, true)
 	require.NoError(t, err)
 
 	newRKE1Cluster = rke1Cluster
@@ -288,5 +290,4 @@ func rke2AWSCloudProviderMigration(t *testing.T, client *rancher.Client, steveCl
 	lbServiceResponseOOT := permutations.CreateCloudProviderWorkloadAndServicesLB(t, client, steveClusterObject)
 
 	services.VerifyAWSLoadBalancer(t, client, lbServiceResponseOOT, status.ClusterName)
-
 }

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -259,16 +259,16 @@ func (u *UpgradeWorkloadTestSuite) testPreUpgradeSingleCluster(clusterName strin
 		require.NoError(u.T(), err)
 
 		if !loggingChart.IsAlreadyInstalled {
-			clusterName, err := clusters.GetClusterNameByID(client, project.ClusterID)
+			// Get cluster meta
+			cluster, err := clusters.NewClusterMeta(client, clusterName)
 			require.NoError(u.T(), err)
 			latestLoggingVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherLoggingName, catalog.RancherChartRepo)
 			require.NoError(u.T(), err)
 
 			loggingChartInstallOption := &charts.InstallOptions{
-				ClusterName: clusterName,
-				ClusterID:   project.ClusterID,
-				Version:     latestLoggingVersion,
-				ProjectID:   project.ID,
+				Cluster:   cluster,
+				Version:   latestLoggingVersion,
+				ProjectID: project.ID,
 			}
 
 			loggingChartFeatureOption := &charts.RancherLoggingOpts{


### PR DESCRIPTION
## Issue(s): https://github.com/rancher/qa-tasks/issues/1195 & https://github.com/rancher/qa-tasks/issues/1199 & https://github.com/rancher/qa-tasks/issues/1194
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Chart installations only support RKE1 clusters. Ultimately for chart installations on the Airgap environment, the chart tests need to be enhanced to include an Alerting Driver chart too.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add Monitoring and Logging charts' payload mappers. Update chart installs option struct to have cluster meta - which is used within these mappers. Add Alerting Driver installation function that supports RKE1/RKE2/K3s installations.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Provided offline.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)


TODOs: 
- [ ] PR needs a rebase after this merges https://github.com/rancher/rancher/pull/44711