### PR TITLE
[2.9] add vsphere chart validation to automation framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240126142034-676c3eb3dfa5
-	github.com/rancher/shepherd v0.0.0-20240408151615-3346099ba044
+	github.com/rancher/shepherd v0.0.0-20240412143227-f816adca9592
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1680,8 +1680,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.3 h1:7mGn+NIL7KXk99NwWYBgoByh2+IfVCdws5ad3X/JIZY=
 github.com/rancher/rke v1.5.3/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240408151615-3346099ba044 h1:cVKHko6hjX47QegUXGoxBhLl+a+RHwKDCpW3VupQuUY=
-github.com/rancher/shepherd v0.0.0-20240408151615-3346099ba044/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
+github.com/rancher/shepherd v0.0.0-20240412143227-f816adca9592 h1:5Pb3GA8GoveL05js5ncMDn4i0IUhGdBMBUI/fjCE0Y8=
+github.com/rancher/shepherd v0.0.0-20240412143227-f816adca9592/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -500,11 +500,11 @@ func (w *RancherManagedChartsTest) TestServeIcons() {
 	w.Assert().Equal("bundled", systemCatalogUpdated.Value)
 
 	// Fetch one icon with https:// scheme, it should return an empty object (i.e length of image equals 0) with nil error
-	imgLength, err := w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "fleet", "102.0.0+up0.6.0")
+	imgLength, err := w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "fleet")
 	w.Require().NoError(err)
 	w.Assert().Equal(0, imgLength)
 
-	imgLength, err = w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "rancher-cis-benchmark", "4.0.0")
+	imgLength, err = w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "rancher-cis-benchmark")
 	w.Require().NoError(err)
 	w.Assert().Greater(imgLength, 0)
 

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -216,7 +216,8 @@ harvesterMachineConfig":
 vmwarevsphereMachineConfigs:
     datacenter: "/<datacenter>"                                 #required 
     hostSystem: "/<datacenter>/path-to-host"                    #required
-    datastore: "/<datacenter>/path-to-datastore"                #required 
+    datastoreURL: "/datastore.URL"                              #required 
+    datastore: ""/<datacenter>/path-to-datastore"               #required 
     folder: "/<datacenter>/path-to-vm-folder"                   #required 
     pool: "/<datacenter>/path-to-resource-pool"                 #required 
     vmwarevsphereMachineConfig:

--- a/tests/v2/validation/provisioning/permutations/permutations.go
+++ b/tests/v2/validation/provisioning/permutations/permutations.go
@@ -1,21 +1,29 @@
 package permutations
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/rancher/rancher/pkg/api/scheme"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/corral"
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/kubeapi/storageclasses"
+	"github.com/rancher/shepherd/extensions/kubeapi/volumes/persistentvolumeclaims"
 	"github.com/rancher/shepherd/extensions/machinepools"
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	"github.com/rancher/shepherd/extensions/rke1/componentchecks"
+	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
 	"github.com/rancher/shepherd/extensions/services"
 	"github.com/rancher/shepherd/extensions/workloads"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
@@ -26,6 +34,9 @@ import (
 	"github.com/stretchr/testify/suite"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -47,6 +58,9 @@ const (
 	nginxName            = "nginx"
 	defaultNamespace     = "default"
 
+	pollInterval = time.Duration(1 * time.Second)
+	pollTimeout  = time.Duration(1 * time.Minute)
+
 	repoType                     = "catalog.cattle.io.clusterrepo"
 	appsType                     = "catalog.cattle.io.apps"
 	awsUpstreamCloudProviderRepo = "https://github.com/kubernetes/cloud-provider-aws.git"
@@ -55,6 +69,13 @@ const (
 	kubeSystemNamespace          = "kube-system"
 	systemProject                = "System"
 	externalProviderString       = "external"
+	vsphereCPIchartName          = "rancher-vsphere-cpi"
+	vsphereCSIchartName          = "rancher-vsphere-csi"
+)
+
+var (
+	group int64
+	user  int64
 )
 
 // RunTestPermutations runs through all relevant perumutations in a given config file, including node providers, k8s versions, and CNIs
@@ -76,14 +97,24 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 	} else {
 		providers = provisioningConfig.Providers
 	}
+
 	for _, nodeProviderName := range providers {
+
 		nodeProvider, rke1Provider, customProvider, kubeVersions := GetClusterProvider(clusterType, nodeProviderName, provisioningConfig)
+
 		for _, kubeVersion := range kubeVersions {
 			for _, cni := range provisioningConfig.CNIs {
+
 				testClusterConfig = clusters.ConvertConfigToClusterConfig(provisioningConfig)
 				testClusterConfig.CNI = cni
 				name = testNamePrefix + " Node Provider: " + nodeProviderName + " Kubernetes version: " + kubeVersion + " cni: " + cni
+
+				clusterObject := &steveV1.SteveAPIObject{}
+				rke1ClusterObject := &management.Cluster{}
+				nodeTemplate := &nodetemplates.NodeTemplate{}
+
 				s.Run(name, func() {
+
 					if testClusterConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
 						byteYaml, err := os.ReadFile(outOfTreeAWSFilePath)
 						require.NoError(s.T(), err)
@@ -95,92 +126,66 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 					switch clusterType {
 					case RKE2ProvisionCluster, K3SProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
-						clusterObject, err := provisioning.CreateProvisioningCluster(client, *nodeProvider, testClusterConfig, hostnameTruncation)
+						clusterObject, err = provisioning.CreateProvisioningCluster(client, *nodeProvider, testClusterConfig, hostnameTruncation)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
 
-						if testClusterConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
-							lbServiceResp := CreateCloudProviderWorkloadAndServicesLB(s.T(), client, clusterObject)
-
-							status := &provv1.ClusterStatus{}
-							err := steveV1.ConvertToK8sType(clusterObject.Status, status)
-							require.NoError(s.T(), err)
-
-							services.VerifyAWSLoadBalancer(s.T(), client, lbServiceResp, status.ClusterName)
-						}
-
 					case RKE1ProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
-						nodeTemplate, err := rke1Provider.NodeTemplateFunc(client)
+						nodeTemplate, err = rke1Provider.NodeTemplateFunc(client)
 						require.NoError(s.T(), err)
-
-						clusterObject, err := provisioning.CreateProvisioningRKE1Cluster(client, *rke1Provider, testClusterConfig, nodeTemplate)
-						require.NoError(s.T(), err)
-
-						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, clusterObject)
-
-						if strings.Contains(testClusterConfig.CloudProvider, provisioninginput.AWSProviderName.String()) {
-							if strings.Contains(testClusterConfig.CloudProvider, externalProviderString) {
-								err = CreateAndInstallAWSExternalCharts(client, clusterObject.ID, false)
-								require.NoError(s.T(), err)
-
-								podErrors := pods.StatusPods(client, clusterObject.ID)
-								require.Empty(s.T(), podErrors)
-							}
-
-							adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
-							require.NoError(s.T(), err)
-
-							steveClusterObject, err := adminClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(provisioninginput.Namespace + "/" + clusterObject.ID)
-							require.NoError(s.T(), err)
-
-							lbServiceResp := CreateCloudProviderWorkloadAndServicesLB(s.T(), client, steveClusterObject)
-
-							status := &provv1.ClusterStatus{}
-							err = steveV1.ConvertToK8sType(steveClusterObject.Status, status)
-							require.NoError(s.T(), err)
-
-							services.VerifyAWSLoadBalancer(s.T(), client, lbServiceResp, status.ClusterName)
+						// workaround to simplify config for rke1 clusters with cloud provider set. This will allow external charts to be installed
+						// while using the rke2 CloudProvider.
+						if testClusterConfig.CloudProvider == provisioninginput.VsphereCloudProviderName.String() {
+							testClusterConfig.CloudProvider = "external"
 						}
+
+						rke1ClusterObject, err = provisioning.CreateProvisioningRKE1Cluster(client, *rke1Provider, testClusterConfig, nodeTemplate)
+						require.NoError(s.T(), err)
+
+						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, rke1ClusterObject)
 
 					case RKE2CustomCluster, K3SCustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
 
-						clusterObject, err := provisioning.CreateProvisioningCustomCluster(client, customProvider, testClusterConfig)
+						clusterObject, err = provisioning.CreateProvisioningCustomCluster(client, customProvider, testClusterConfig)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
-						if testClusterConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
-							lbServiceResp := CreateCloudProviderWorkloadAndServicesLB(s.T(), client, clusterObject)
-
-							status := &provv1.ClusterStatus{}
-							err := steveV1.ConvertToK8sType(clusterObject.Status, status)
-							require.NoError(s.T(), err)
-
-							services.VerifyAWSLoadBalancer(s.T(), client, lbServiceResp, status.ClusterName)
-						}
 
 					case RKE1CustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
-						clusterObject, nodes, err := provisioning.CreateProvisioningRKE1CustomCluster(client, customProvider, testClusterConfig)
+						// workaround to simplify config for rke1 clusters with cloud provider set. This will allow external charts to be installed
+						// while using the rke2 CloudProvider name in the
+						if testClusterConfig.CloudProvider == provisioninginput.VsphereCloudProviderName.String() {
+							testClusterConfig.CloudProvider = "external"
+						}
+
+						rke1ClusterObject, nodes, err := provisioning.CreateProvisioningRKE1CustomCluster(client, customProvider, testClusterConfig)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, clusterObject)
-						etcdVersion, err := componentchecks.CheckETCDVersion(client, nodes, clusterObject.ID)
+						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, rke1ClusterObject)
+						etcdVersion, err := componentchecks.CheckETCDVersion(client, nodes, rke1ClusterObject.ID)
 						require.NoError(s.T(), err)
 						require.NotEmpty(s.T(), etcdVersion)
 
 					// airgap currently uses corral to create nodes and register with rancher
 					case RKE2AirgapCluster, K3SAirgapCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
-						clusterObject, err := provisioning.CreateProvisioningAirgapCustomCluster(client, testClusterConfig, corralPackages)
+						clusterObject, err = provisioning.CreateProvisioningAirgapCustomCluster(client, testClusterConfig, corralPackages)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
 
 					case RKE1AirgapCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
+						// workaround to simplify config for rke1 clusters with cloud provider set. This will allow external charts to be installed
+						// while using the rke2 CloudProvider name in the
+						if testClusterConfig.CloudProvider == provisioninginput.VsphereCloudProviderName.String() {
+							testClusterConfig.CloudProvider = "external"
+						}
+
 						clusterObject, err := provisioning.CreateProvisioningRKE1AirgapCustomCluster(client, testClusterConfig, corralPackages)
 						require.NoError(s.T(), err)
 
@@ -190,8 +195,72 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						s.T().Fatalf("Invalid cluster type: %s", clusterType)
 					}
 
+					RunPostClusterCloudProviderChecks(s.T(), client, clusterType, nodeTemplate, testClusterConfig, clusterObject, rke1ClusterObject)
+
 				})
 			}
+		}
+	}
+}
+
+// RunPostClusterCloudProviderChecks does additinal checks on the cluster if there's a cloud provider set
+// on an active cluster.
+func RunPostClusterCloudProviderChecks(t *testing.T, client *rancher.Client, clusterType string, nodeTemplate *nodetemplates.NodeTemplate, testClusterConfig *clusters.ClusterConfig, clusterObject *steveV1.SteveAPIObject, rke1ClusterObject *management.Cluster) {
+	if strings.Contains(clusterType, clusters.RKE1ClusterType.String()) {
+		providers := *testClusterConfig.Providers
+		adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+		require.NoError(t, err)
+
+		if strings.Contains(testClusterConfig.CloudProvider, provisioninginput.AWSProviderName.String()) {
+			if strings.Contains(testClusterConfig.CloudProvider, externalProviderString) {
+				err := CreateAndInstallAWSExternalCharts(client, rke1ClusterObject.ID, false)
+				require.NoError(t, err)
+
+				podErrors := pods.StatusPods(client, rke1ClusterObject.ID)
+				require.Empty(t, podErrors)
+			}
+
+			clusterObject, err = adminClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(provisioninginput.Namespace + "/" + rke1ClusterObject.ID)
+			require.NoError(t, err)
+
+			lbServiceResp := CreateCloudProviderWorkloadAndServicesLB(t, client, clusterObject)
+
+			status := &provv1.ClusterStatus{}
+			err = steveV1.ConvertToK8sType(clusterObject.Status, status)
+			require.NoError(t, err)
+
+			services.VerifyAWSLoadBalancer(t, client, lbServiceResp, status.ClusterName)
+		} else if strings.Contains(testClusterConfig.CloudProvider, "external") && providers[0] == provisioninginput.VsphereProviderName.String() {
+			err := charts.InstallVsphereOutOfTreeCharts(client, nodeTemplate, catalog.RancherChartRepo, rke1ClusterObject.ID)
+			require.NoError(t, err)
+
+			podErrors := pods.StatusPods(client, rke1ClusterObject.ID)
+			require.Empty(t, podErrors)
+
+			clusterObject, err := adminClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(provisioninginput.Namespace + "/" + rke1ClusterObject.ID)
+			require.NoError(t, err)
+
+			CreatePVCWorkload(t, client, clusterObject)
+		}
+	} else if strings.Contains(clusterType, clusters.RKE2ClusterType.String()) {
+		adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+		require.NoError(t, err)
+
+		if testClusterConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
+			clusterObject, err := adminClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterObject.ID)
+			require.NoError(t, err)
+
+			lbServiceResp := CreateCloudProviderWorkloadAndServicesLB(t, client, clusterObject)
+
+			status := &provv1.ClusterStatus{}
+			err = steveV1.ConvertToK8sType(clusterObject.Status, status)
+			require.NoError(t, err)
+
+			services.VerifyAWSLoadBalancer(t, client, lbServiceResp, status.ClusterName)
+		}
+
+		if testClusterConfig.CloudProvider == provisioninginput.VsphereCloudProviderName.String() {
+			CreatePVCWorkload(t, client, clusterObject)
 		}
 	}
 }
@@ -238,6 +307,7 @@ func GetClusterProvider(clusterType string, nodeProviderName string, provisionin
 // This should be used when testing cloud provider with in-tree or out-of-tree set on the cluster.
 func CreateCloudProviderWorkloadAndServicesLB(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) *steveV1.SteveAPIObject {
 	status := &provv1.ClusterStatus{}
+
 	err := steveV1.ConvertToK8sType(cluster.Status, status)
 	require.NoError(t, err)
 
@@ -266,6 +336,112 @@ func CreateCloudProviderWorkloadAndServicesLB(t *testing.T, client *rancher.Clie
 	logrus.Info("loadbalancer created for nginx workload.")
 
 	return lbServiceResp
+}
+
+// CreatePVCWorkload creates a workload with a PVC for storage. This helper should be used to test
+// storage class functionality, i.e. for an in-tree / out-of-tree cloud provider
+func CreatePVCWorkload(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) *steveV1.SteveAPIObject {
+
+	status := &provv1.ClusterStatus{}
+	err := steveV1.ConvertToK8sType(cluster.Status, status)
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	steveclient, err := adminClient.Steve.ProxyDownstream(status.ClusterName)
+	require.NoError(t, err)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(status.ClusterName)
+	require.NoError(t, err)
+
+	storageClassVolumesResource := dynamicClient.Resource(storageclasses.StorageClassGroupVersionResource).Namespace("")
+
+	ctx := context.Background()
+	unstructuredResp, err := storageClassVolumesResource.List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	storageClasses := &v1.StorageClassList{}
+
+	err = scheme.Scheme.Convert(unstructuredResp, storageClasses, unstructuredResp.GroupVersionKind())
+	require.NoError(t, err)
+
+	storageClass := storageClasses.Items[0]
+
+	logrus.Infof("creating PVC")
+
+	accessModes := []corev1.PersistentVolumeAccessMode{
+		"ReadWriteOnce",
+	}
+
+	persistentVolumeClaim, err := persistentvolumeclaims.CreatePersistentVolumeClaim(
+		client,
+		status.ClusterName,
+		namegenerator.AppendRandomString("pvc"),
+		"test-pvc-volume",
+		defaultNamespace,
+		1,
+		accessModes,
+		nil,
+		&storageClass,
+	)
+	require.NoError(t, err)
+
+	pvcStatus := &corev1.PersistentVolumeClaimStatus{}
+	stevePvc := &steveV1.SteveAPIObject{}
+
+	err = wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (done bool, err error) {
+
+		stevePvc, err = steveclient.SteveType(persistentvolumeclaims.PersistentVolumeClaimType).ByID(defaultNamespace + "/" + persistentVolumeClaim.Name)
+		require.NoError(t, err)
+
+		err = steveV1.ConvertToK8sType(stevePvc.Status, pvcStatus)
+		require.NoError(t, err)
+
+		if pvcStatus.Phase == persistentvolumeclaims.PersistentVolumeBoundStatus {
+			return true, nil
+		}
+		return false, err
+	})
+	require.NoError(t, err)
+
+	nginxResponse, err := createNginxDeploymentWithPVC(steveclient, "pvcwkld", persistentVolumeClaim.Name, string(stevePvc.Spec.(map[string]interface{})[persistentvolumeclaims.StevePersistentVolumeClaimVolumeName].(string)))
+	require.NoError(t, err)
+
+	return nginxResponse
+}
+
+// createNginxDeploymentWithPVC is a helper function that creates a nginx deployment in a cluster's default namespace
+func createNginxDeploymentWithPVC(steveclient *steveV1.Client, containerNamePrefix, pvcName, volName string) (*steveV1.SteveAPIObject, error) {
+
+	logrus.Infof("Vol: %s", volName)
+	logrus.Infof("Pod: %s", pvcName)
+
+	containerName := namegenerator.AppendRandomString(containerNamePrefix)
+	volMount := *&corev1.VolumeMount{
+		MountPath: "/auto-mnt",
+		Name:      volName,
+	}
+
+	podVol := corev1.Volume{
+		Name: volName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	}
+
+	containerTemplate := workloads.NewContainer(nginxName, nginxName, corev1.PullAlways, []corev1.VolumeMount{volMount}, []corev1.EnvFromSource{}, nil, nil, nil)
+	podTemplate := workloads.NewPodTemplate([]corev1.Container{containerTemplate}, []corev1.Volume{podVol}, []corev1.LocalObjectReference{}, nil)
+	deployment := workloads.NewDeploymentTemplate(containerName, defaultNamespace, podTemplate, true, nil)
+
+	deploymentResp, err := steveclient.SteveType(workloads.DeploymentSteveType).Create(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	return deploymentResp, err
 }
 
 // createNginxDeployment is a helper function that creates a nginx deployment in a cluster's default namespace

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -68,6 +68,19 @@ provisioningInput:
     snapshot: false
 ```
 
+
+## Cloud Provider
+Cloud Provider enables additional options through the cloud provider, like cloud persistent storage or cloud provisioned load balancers.
+
+Names of cloud provider options are typically controlled by rancher product. Hence the discrepancy in rke2 vs. rke1 AWS in-tree and out-of-tree options. 
+To use automation with a cloud provider, simply enter one of the following options in the `cloudProvider` field in the config. 
+
+### RKE1 Cloud Provider Options
+* external-aws
+* aws
+* rancher-vsphere
+
+
 ## NodeTemplateConfigs
 RKE1 specifically needs a node template config to run properly. These are the inputs needed for the different node providers.
 Top level node template config entries can be set. The top level nodeTemplate is optional, and is not need for the different node
@@ -209,6 +222,7 @@ vmwarevsphereNodeConfig:
   creationType: ""
   datacenter: ""
   datastore: ""
+  datastoreURL: ""
   datastoreCluster: ""
   diskSize: "20000"
   folder: ""

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -123,11 +123,15 @@ vmwarevsphereCredentials:
 ```
 
 ## Cloud Provider
-Cloud Provider enables additional options such as load-balancers and storage devices to be provisioned through your cluster
-available options:
-### AWS
+Cloud Provider enables additional options through the cloud provider, like cloud persistent storage or cloud provisioned load balancers.
+
+Names of cloud provider options are typically controlled by rancher product. Hence the discrepancy in rke2 vs. rke1 AWS in-tree and out-of-tree options. 
+To use automation with a cloud provider, simply enter one of the following options in the `cloudProvider` field in the config. 
+
+### RKE2 Cloud Provider Options
 * `aws-in-tree` uses the in-tree provider for aws -- **Deprecated on kubernetes 1.26 and below**
 * `aws` uses the out-of-tree provider for aws. Built in logic to the automation will be applied to the cluster that applies the correct configuration for the out-of-tree charts to be installed. Supported on kubernetes 1.22+
+* rancher-vsphere
 
 ## Machine RKE2 Config
 Machine RKE2 config is the final piece needed for the config to run RKE2 provisioning tests.
@@ -233,6 +237,7 @@ vmwarevsphereMachineConfigs:
     datacenter: "/<datacenter>"                                 #required 
     hostSystem: "/<datacenter>/path-to-host"                    #required
     datastore: "/<datacenter>/path-to-datastore"                #required 
+    datastoreURL: "ds:///<url>"             
     folder: "/<datacenter>/path-to-vm-folder"                   #required 
     pool: "/<datacenter>/path-to-resource-pool"                 #required 
     vmwarevsphereMachineConfig:


### PR DESCRIPTION
add vsphere chart validation to automation framework

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/936
https://github.com/rancher/qa-tasks/issues/872
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
we need a way to use vsphere cloud provider in our automation 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
implement a similar method to what was used for aws cloud provider support. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_