### PR TITLE
Bump CSI proxy agent version to v1.1.3

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -46,7 +46,7 @@ ENV CATTLE_WINS_AGENT_VERSION v0.4.14
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}
-ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.1
+ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.3
 # make sure the CATTLE_SYSTEM_AGENT_VERSION is consistent with tests/v2/codecoverage/package/Dockerfile
 ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.6-rc2
 ENV CATTLE_SYSTEM_AGENT_DOWNLOAD_PREFIX https://github.com/rancher/system-agent/releases/download

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -46,7 +46,7 @@ ENV CATTLE_WINS_AGENT_VERSION v0.4.14
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}
-ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.1
+ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.3
 # make sure the CATTLE_SYSTEM_AGENT_VERSION is consistent with tests/v2/codecoverage/package/Dockerfile
 ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.6-rc2
 ENV CATTLE_SYSTEM_AGENT_DOWNLOAD_PREFIX https://github.com/rancher/system-agent/releases/download


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42298
 
## Problem
The CSI Agent Proxy version v1.1.1 contains a bug which prevents a storage class from being used by multiple PVCs on Windows nodes

## Solution
Bump the CSI Proxy version to v1.1.3
 
## Testing
A good guide on setting up an smb server locally and verifying that the CSI Proxy works as expected can be found here https://www.phillipsj.net/posts/how-to-use-the-windows-csi-proxy-and-csi-smb-driver-for-kubernetes/

To summarize the above

+ Create a cluster with at least 1 Windows node
+ Add a new Helm repository using this URL: `https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts`
+ Install the chart added by the new helm repository `csi-driver-smb`
    + During installation, ensure that `windows.enabled` is equal to `true` and that `windows.csiproxy.enabled` is set to `false`. The csi-proxy is automatically deployed by rancher-wins
+ Edit the load balancer service created by the chart. Add an additional external IP which points to the public IP of the node running the smb server. The csi-proxy runs on the windows host, and can't access internal services
+ Apply the following yaml, ensuring that the storage class `parameters.source` field follows this pattern `//<SMB_NODE_PUBLIC_IP>/share`
+ Exec into one of the pods and ensure that `ls mnt/smb` contains the `data.txt` file and that the file is not empty

<details>
<summary>
Test Yaml
</summary>

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: smb
mountOptions:
- dir_mode=0777
- file_mode=0777
- uid=1001
- gid=1001
parameters:
  csi.storage.k8s.io/node-stage-secret-name: smbcreds
  csi.storage.k8s.io/node-stage-secret-namespace: default
  csi.storage.k8s.io/provisioner-secret-name: smbcreds
  csi.storage.k8s.io/provisioner-secret-namespace: default
  source: //filestorage.domain.local/share
provisioner: smb.csi.k8s.io
reclaimPolicy: Retain
volumeBindingMode: Immediate
---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: pvc-smb-1
  annotations:
    volume.beta.kubernetes.io/storage-class: smb
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 10Gi
  storageClassName: "smb"
---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: pvc-smb-2
  annotations:
    volume.beta.kubernetes.io/storage-class: smb
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 10Gi
  storageClassName: "smb"
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: pwsh-smb-1
  labels:
    app: pwsh-1
spec:
  replicas: 1
  template:
    metadata:
      name: pwsh-1
      labels:
        app: pwsh-1
    spec:
      nodeSelector:
        "kubernetes.io/os": windows
      containers:
        - name: pwsh
          image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
          command:
            - "pwsh.exe"
            - "-Command"
            - "while (1) { Add-Content -Encoding Ascii C:\\mnt\\smb\\data.txt $(Get-Date -Format u); sleep 1 }"
          volumeMounts:
            - name: smb
              mountPath: "/mnt/smb"
              subPath: subPath
      volumes:
        - name: smb
          persistentVolumeClaim:
            claimName: pvc-smb-1
  selector:
    matchLabels:
      app: pwsh-1
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: pwsh-smb-2
  labels:
    app: pwsh-2
spec:
  replicas: 1
  template:
    metadata:
      name: pwsh-2
      labels:
        app: pwsh-2
    spec:
      nodeSelector:
        "kubernetes.io/os": windows
      containers:
        - name: pwsh
          image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
          command:
            - "pwsh.exe"
            - "-Command"
            - "while (1) { Add-Content -Encoding Ascii C:\\mnt\\smb\\data.txt $(Get-Date -Format u); sleep 1 }"
          volumeMounts:
            - name: smb
              mountPath: "/mnt/smb"
              subPath: subPath
      volumes:
        - name: smb
          persistentVolumeClaim:
            claimName: pvc-smb-2
  selector:
    matchLabels:
      app: pwsh-2
```

</details>

## Engineering Testing
### Manual Testing
I've followed the above steps and confirmed that things work as expected for v1.1.3 

### Automated Testing
## QA Testing Considerations

### Regressions Considerations

Existing / newly added automated tests that provide evidence there are no regressions:
n/a