### PR TITLE
[2.8] Backup/Restore P0 Test Case

### DIFF
--- a/tests/v2/validation/charts/backup_restore/README.md
+++ b/tests/v2/validation/charts/backup_restore/README.md
@@ -1,0 +1,30 @@
+# Backup Restore Operator (BRO)
+Backup Restore Operator (BRO for short) is a disaster recovery chart that can be installed on the local cluster only, and is used to create backups of Rancher resources contained in the `rancher-resource-set`. The resource set becomes available after the chart is installed and can be edited as a user needs. Once a backup is created and stored in either a local volume or in an S3 storage location (such as AWS S3 or Minio S3), a restore operation can be created to restore Rancher back to the backed up version of the Rancher resources.
+
+## Pre-requisites
+- Downstream RKE1 and RKE2 clusters are required before running the test(s)
+- All tests require configs pulled in from the broInput parameter.
+
+## Test Setup
+In your config file, set the following:
+```
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  userToken: "rancher_user_token"
+  insecure: True
+  cleanup: True
+  clusterName: "downstream_cluster_name"
+broInput:
+  backupName: ""
+  s3BucketName: ""
+  s3FolderName: ""
+  s3Region: ""
+  s3Endpoint: ""
+  volumeName: ""
+  credentialSecretNamespace: ""
+  prune: true/false
+  resourceSetName: ""
+  accessKey: ""
+  secretKey: ""
+```

--- a/tests/v2/validation/charts/backup_restore/backup_restore.go
+++ b/tests/v2/validation/charts/backup_restore/backup_restore.go
@@ -1,0 +1,261 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/secrets"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	bv1 "github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	backupName = namegen.AppendRandomString("backup")
+	secretName = namegen.AppendRandomString("broSecretName")
+	roleName   = namegen.AppendRandomString("broRole")
+	userList   = []*management.User{}
+	projList   = []*management.Project{}
+	roleList   = []*management.RoleTemplate{}
+
+	rules = []management.PolicyRule{
+		{
+			APIGroups: []string{"management.cattle.io"},
+			Resources: []string{"projects"},
+			Verbs:     []string{psaRole},
+		},
+	}
+)
+
+const (
+	backupEnabled        = true
+	backupChartNamespace = "cattle-resources-system"
+	backupChartName      = "rancher-backup"
+	backupSteveType      = "resources.cattle.io.backup"
+	restoreSteveType     = "resources.cattle.io.restore"
+	psaRole              = "updatepsa"
+	roleContext          = "cluster"
+	clusterProject       = "System"
+	cluster              = "local"
+	member               = "user"
+)
+
+func setBackupObject() bv1.Backup {
+	broConfig := new(charts.Config)
+	config.LoadConfig(charts.ConfigurationFileKey, broConfig)
+
+	backup := bv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: backupName,
+		},
+		Spec: bv1.BackupSpec{
+			ResourceSetName: broConfig.ResourceSetName,
+		},
+	}
+	return backup
+}
+
+func setRestoreObject() bv1.Restore {
+	broConfig := new(charts.Config)
+	config.LoadConfig(charts.ConfigurationFileKey, broConfig)
+
+	restore := bv1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "restore-",
+		},
+		Spec: bv1.RestoreSpec{
+			BackupFilename: backupName,
+			Prune:          &broConfig.Prune,
+		},
+	}
+	return restore
+}
+
+func installBroChart(t *testing.T, client *rancher.Client, chartInstallOptions *charts.InstallOptions, chartFeatureOptions *charts.RancherBackupOpts, project *management.Project) {
+	_, err := createOpaqueS3Secret(client.Steve)
+	require.NoError(t, err)
+
+	logrus.Info("Installing backup chart")
+	err = charts.InstallRancherBackupChart(client, chartInstallOptions, chartFeatureOptions, true)
+	require.NoError(t, err)
+
+	logrus.Info("Waiting for backup chart deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, project.ClusterID, backupChartNamespace, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	logrus.Info("Waiting for backup chart DaemonSets to have expected number of available nodes")
+	err = charts.WatchAndWaitDaemonSets(client, project.ClusterID, backupChartNamespace, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	logrus.Info("Waiting for backup chart StatefulSets to have expected number of ready replicas")
+	err = charts.WatchAndWaitStatefulSets(client, project.ClusterID, backupChartNamespace, metav1.ListOptions{})
+	require.NoError(t, err)
+}
+
+func createOpaqueS3Secret(steveClient *v1.Client) (string, error) {
+	broConfig := new(charts.Config)
+	config.LoadConfig(charts.ConfigurationFileKey, broConfig)
+
+	logrus.Infof("Creating an opaque secret with name: %v", secretName)
+	secretTemplate := secrets.NewSecretTemplate(secretName, broConfig.CredentialSecretNamespace, map[string][]byte{"accessKey": []byte(broConfig.AccessKey), "secretKey": []byte(broConfig.SecretKey)}, corev1.SecretTypeOpaque)
+	createdSecret, err := steveClient.SteveType(secrets.SecretSteveType).Create(secretTemplate)
+
+	return createdSecret.Name, err
+}
+
+func createProject(client *rancher.Client, clusterID string) (*management.Project, error) {
+	projectConfig := &management.Project{
+		ClusterID: clusterID,
+		Name:      clusterProject,
+	}
+	createProject, err := client.Management.Project.Create(projectConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return createProject, nil
+}
+
+func createRole(client *rancher.Client, context string, roleName string, rules []management.PolicyRule) (role *management.RoleTemplate, err error) {
+	role, err = client.Management.RoleTemplate.Create(
+		&management.RoleTemplate{
+			Context: context,
+			Name:    roleName,
+			Rules:   rules,
+		})
+
+	return
+}
+
+func createBackup(client *rancher.Client, name string) (*v1.SteveAPIObject, error) {
+	backup := setBackupObject()
+	backupTemplate := bv1.NewBackup("", name, backup)
+	completedBackup, err := client.Steve.SteveType(backupSteveType).Create(backupTemplate)
+
+	return completedBackup, err
+}
+
+func createRestore(client *rancher.Client, fileName string) (*v1.SteveAPIObject, error) {
+	restore := setRestoreObject()
+	restoreTemplate := bv1.NewRestore("", "", restore)
+	restoreTemplate.Spec.BackupFilename = fileName
+	completedRestore, err := client.Steve.SteveType(restoreSteveType).Create(restoreTemplate)
+
+	return completedRestore, err
+}
+
+func validateAWSS3BackupExists(t *testing.T, bucket string, folder string, key string) (bool, error) {
+	if len(folder) > 0 {
+		folder += key
+		isPresent, err := checkAWSS3Object(t, bucket, folder)
+		return isPresent, err
+	}
+	isPresent, err := checkAWSS3Object(t, bucket, key)
+	return isPresent, err
+}
+
+func checkAWSS3Object(t *testing.T, bucket string, key string) (bool, error) {
+	sdkConfig, err := awsConfig.LoadDefaultConfig(context.TODO())
+	require.NoError(t, err)
+
+	s3Client := s3.NewFromConfig(sdkConfig)
+	_, err = s3Client.HeadObject(context.TODO(), &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "NotFound":
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func deleteAWSBackup(t *testing.T, bucket string, folder string, key string) {
+	sdkConfig, err := awsConfig.LoadDefaultConfig(context.TODO())
+	require.NoError(t, err)
+	svc := s3.NewFromConfig(sdkConfig)
+
+	input := &s3.DeleteObjectInput{}
+
+	input = &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+	if len(folder) > 0 {
+		folder += key
+		input = &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(folder),
+		}
+	}
+
+	_, err = svc.DeleteObject(context.TODO(), input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			fmt.Println(err.Error())
+		}
+		return
+	}
+}
+
+func verifyUserResources(t *testing.T, client *rancher.Client, resource []*management.User) {
+	logrus.Info("Verifying user resources...")
+	for i := range userList {
+		user, err := users.GetUserIDByName(client, resource[i].Name)
+		if err != nil {
+			assert.Equal(t, "", user)
+		}
+		assert.NotNil(t, user)
+	}
+}
+
+func verifyProjectResources(t *testing.T, client *rancher.Client, resource []*management.Project) {
+	logrus.Info("Verifying project resources...")
+	for i := range projList {
+		project, err := client.Management.Project.ByID(resource[i].ID)
+		if err != nil {
+			assert.ErrorContains(t, err, resource[i].ID)
+		}
+		assert.Equal(t, project.ID, resource[i].ID)
+	}
+}
+
+func verifyRoleResources(t *testing.T, client *rancher.Client, resource []*management.RoleTemplate) {
+	logrus.Info("Verifying role resources...")
+	for i := range roleList {
+		roleTemplate, err := client.Management.RoleTemplate.ByID(resource[i].ID)
+		if err != nil {
+			assert.ErrorContains(t, err, resource[i].ID)
+		}
+		assert.Equal(t, roleTemplate.ID, resource[i].ID)
+	}
+}

--- a/tests/v2/validation/charts/backup_restore/backup_restore_test.go
+++ b/tests/v2/validation/charts/backup_restore/backup_restore_test.go
@@ -1,0 +1,204 @@
+package charts
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	bv1 "github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/sirupsen/logrus"
+
+	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/projects"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type BackupTestSuite struct {
+	suite.Suite
+	client              *rancher.Client
+	session             *session.Session
+	project             *management.Project
+	chartInstallOptions *charts.InstallOptions
+	chartFeatureOptions *charts.RancherBackupOpts
+	S3Client            *s3.Client
+}
+
+func (b *BackupTestSuite) TearDownSuite() {
+	b.session.Cleanup()
+}
+
+func (b *BackupTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	b.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(b.T(), err)
+
+	b.client = client
+
+	broConfig := new(charts.Config)
+	config.LoadConfig(charts.ConfigurationFileKey, broConfig)
+
+	project, err := projects.GetProjectByName(client, cluster, clusterProject)
+	require.NoError(b.T(), err)
+
+	// Get clusterName from config yaml
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(b.T(), clusterName, "Cluster name to install is not set")
+
+	// Get cluster meta
+	cluster, err := clusters.NewClusterMeta(client, clusterName)
+	require.NoError(b.T(), err)
+
+	// Get latest version of Rancher Backup chart
+	latestBackupVersion, err := client.Catalog.GetLatestChartVersion(backupChartName, catalog.RancherChartRepo)
+	require.NoError(b.T(), err)
+
+	b.chartInstallOptions = &charts.InstallOptions{
+		Cluster:   cluster,
+		Version:   latestBackupVersion,
+		ProjectID: project.ID,
+	}
+	b.chartFeatureOptions = &charts.RancherBackupOpts{
+		VolumeName:                broConfig.VolumeName,
+		BucketName:                broConfig.S3BucketName,
+		CredentialSecretName:      secretName,
+		CredentialSecretNamespace: broConfig.CredentialSecretNamespace,
+		Enabled:                   backupEnabled,
+		Endpoint:                  broConfig.S3Endpoint,
+		Folder:                    broConfig.S3FolderName,
+		Region:                    broConfig.S3Region,
+	}
+
+	subSession := b.session.NewSession()
+	defer subSession.Cleanup()
+}
+
+func (b *BackupTestSuite) TestBackupChart() {
+	subSession := b.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := b.client.WithSession(subSession)
+	require.NoError(b.T(), err)
+
+	b.client = client
+
+	broConfig := new(charts.Config)
+	config.LoadConfig(charts.ConfigurationFileKey, broConfig)
+
+	project, err := projects.GetProjectByName(b.client, cluster, clusterProject)
+	require.NoError(b.T(), err)
+
+	b.project = project
+
+	logrus.Info("Checking if the backup chart is already installed...")
+	initialBackupChart, err := charts.GetChartStatus(b.client, b.project.ClusterID, backupChartNamespace, backupChartName)
+	require.NoError(b.T(), err)
+
+	if !initialBackupChart.IsAlreadyInstalled {
+		installBroChart(b.T(), b.client, b.chartInstallOptions, b.chartFeatureOptions, b.project)
+	}
+
+	client, err = b.client.ReLogin()
+	require.NoError(b.T(), err)
+
+	logrus.Info("Creating two users...")
+	u1, err := users.CreateUserWithRole(client, users.UserConfig(), member)
+	require.NoError(b.T(), err)
+	userList = append(userList, u1)
+
+	u2, err := users.CreateUserWithRole(client, users.UserConfig(), member)
+	require.NoError(b.T(), err)
+	userList = append(userList, u2)
+
+	logrus.Info("Creating two projects...")
+	p1, err := createProject(client, b.project.ClusterID)
+	require.NoError(b.T(), err)
+	projList = append(projList, p1)
+
+	p2, err := createProject(client, b.project.ClusterID)
+	require.NoError(b.T(), err)
+	projList = append(projList, p2)
+
+	logrus.Info("Creating two role templates...")
+	rt1, err := createRole(client, roleContext, roleName, rules)
+	require.NoError(b.T(), err)
+	roleList = append(roleList, rt1)
+
+	rt2, err := createRole(client, roleContext, roleName, rules)
+	require.NoError(b.T(), err)
+	roleList = append(roleList, rt2)
+
+	logrus.Info("Creating a backup of the local cluster...")
+	firstBackup, err := createBackup(client, backupName)
+	require.NoError(b.T(), err)
+	charts.VerifyBackupCompleted(b.T(), client, backupSteveType, firstBackup)
+
+	backupObj, err := client.Steve.SteveType(backupSteveType).ByID(backupName)
+	require.NoError(b.T(), err)
+	backupK8Obj := &bv1.Backup{}
+	error := v1.ConvertToK8sType(backupObj.JSONResp, backupK8Obj)
+	require.NoError(b.T(), error)
+	backupFileName := backupK8Obj.Status.Filename
+
+	logrus.Info("Validating backup file is in AWS S3...")
+	backupPresent, err := validateAWSS3BackupExists(b.T(), broConfig.S3BucketName, broConfig.S3FolderName, backupFileName)
+	require.NoError(b.T(), err)
+	assert.True(b.T(), backupPresent)
+
+	logrus.Info("Creating two more users...")
+	u3, err := users.CreateUserWithRole(client, users.UserConfig(), member)
+	require.NoError(b.T(), err)
+	userList = append(userList, u3)
+
+	u4, err := users.CreateUserWithRole(client, users.UserConfig(), member)
+	require.NoError(b.T(), err)
+	userList = append(userList, u4)
+
+	logrus.Info("Creating two more projects...")
+	p3, err := createProject(client, b.project.ClusterID)
+	require.NoError(b.T(), err)
+	projList = append(projList, p3)
+
+	p4, err := createProject(client, b.project.ClusterID)
+	require.NoError(b.T(), err)
+	projList = append(projList, p4)
+
+	logrus.Info("Creating two more role templates...")
+	rt3, err := createRole(client, roleContext, roleName, rules)
+	require.NoError(b.T(), err)
+	roleList = append(roleList, rt3)
+
+	rt4, err := createRole(client, roleContext, roleName, rules)
+	require.NoError(b.T(), err)
+	roleList = append(roleList, rt4)
+
+	logrus.Infof("Creating a restore using backup file: %v", backupFileName)
+	completedRestore, err := createRestore(client, backupFileName)
+	require.NoError(b.T(), err)
+	charts.VerifyRestoreCompleted(b.T(), client, restoreSteveType, completedRestore)
+
+	logrus.Info("Restore complete, validating Rancher resources...")
+	verifyUserResources(b.T(), client, userList)
+	verifyProjectResources(b.T(), client, projList)
+	verifyRoleResources(b.T(), client, roleList)
+
+	logrus.Info("Validations complete, deleting backup from S3 bucket...")
+	deleteAWSBackup(b.T(), broConfig.S3BucketName, broConfig.S3FolderName, backupFileName)
+	backupDeleted, err := validateAWSS3BackupExists(b.T(), broConfig.S3BucketName, broConfig.S3FolderName, backupFileName)
+	assert.ErrorContains(b.T(), err, "404")
+	assert.False(b.T(), backupDeleted)
+}
+
+func TestBackupTestSuite(t *testing.T) {
+	suite.Run(t, new(BackupTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- resolves https://github.com/rancher/qa-tasks/issues/999
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The need for automated validation tests of backup and restore operator functions. This PR specifically tests the in-place restore P0 test case.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Created new files and functions to install the Rancher Backups chart with or without storage configured on install as well as creating an opaque secret with S3 creds for use in the chart install. The test creates new Rancher resources, provisions a downstream RKE1 and RKE2 cluster, performs a backup, creates more resources, takes another backup, performs a restore using the first backup file, and then validates that the expected resources are present.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)

Summary: Added automation for Rancher Backups P0 in-place restore test case

Associated Shepherd PR for BRO Extensions: https://github.com/rancher/shepherd/pull/114