### PR TITLE
Setting status as subresource

### DIFF
--- a/pkg/apis/catalog.cattle.io/v1/plugin.go
+++ b/pkg/apis/catalog.cattle.io/v1/plugin.go
@@ -6,6 +6,7 @@ import (
 
 // +genclient
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Plugin Name",type=string,JSONPath=`.spec.plugin.name`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.plugin.version`
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.cacheState`

--- a/pkg/crds/yaml/generated/catalog.cattle.io_uiplugins.yaml
+++ b/pkg/crds/yaml/generated/catalog.cattle.io_uiplugins.yaml
@@ -86,4 +86,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}


### PR DESCRIPTION
Status must always be a subresource. This fix wasn't the case for the UIPlugin CRD and this PR fixes that