### PR TITLE
[v2.8] Bump rancher-webhook to v0.4.3

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 103.0.2+up0.4.3-rc1
+webhookVersion: 103.0.2+up0.4.3
 cspAdapterMinVersion: 103.0.1+up3.0.1
 defaultShellVersion: rancher/shell:v0.1.23-rc3
 fleetVersion: 103.1.1+up0.9.1-rc.6

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,5 +6,5 @@ const (
 	CspAdapterMinVersion = "103.0.1+up3.0.1"
 	DefaultShellVersion  = "rancher/shell:v0.1.23-rc3"
 	FleetVersion         = "103.1.1+up0.9.1-rc.6"
-	WebhookVersion       = "103.0.2+up0.4.3-rc1"
+	WebhookVersion       = "103.0.2+up0.4.3"
 )


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44018

We're unRCing webhook which contains these changes:

Also includes CAPI removal from https://github.com/rancher/rancher/issues/44619 to make bump to 1.28 k8s possible.

## Problem

We want to support 1.28 k8s.

## Solution

Bump relevant dependencies. cluster-api v1.5.5 conflicts with k8s.io/* 0.28. One option is to remove it entirely from webhook since we aren't using it anymore (since v2.7.7).

The changes are:
- Upgraded cluster-api to v1.5.5 to match rancher/rancher v2.8
- Upgraded controller-runtime to v0.15.3
- Upgraded github.com/rancher/rke to v1.5.7-rc2
- Upgraded lasso which supports 1.28
- Upgraded to wrangler v2 so that's why there is a LOT of files modified.
- Upgraded dynamiclistener to v0.4.0-rc2 because it contains 1.28 support + wrangler v2. Otherwise conflicts, can't compile. Here's the comparison of the previous version vs this one: https://github.com/rancher/dynamiclistener/compare/v0.3.5...v0.4.0-rc2. Some non-trivial changes here, but it seemed okay to do in rancher/rancher so should be safe here.
- Upgrade the k8s dependencies to v0.28.6

And also fully removes CAPI webhook from rancher/webhook.

(Also removes the webhook version reference that is no longer needed)
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_