### PR TITLE
Skip the oci artifact config api call

### DIFF
--- a/pkg/catalogv2/oci/client.go
+++ b/pkg/catalogv2/oci/client.go
@@ -128,7 +128,6 @@ func (o *Client) fetchChart(orasRepository *remote.Repository) (string, bool, er
 			PreCopy: func(ctx context.Context, desc ocispecv1.Descriptor) error {
 				// Download only helm chart related descriptors.
 				if desc.MediaType == ocispecv1.MediaTypeImageManifest ||
-					desc.MediaType == helmregistry.ConfigMediaType ||
 					desc.MediaType == helmregistry.ChartLayerMediaType {
 					// We cannot load huge amounts of data into the memory
 					// and so we are defining a limit before fetching.

--- a/pkg/catalogv2/oci/oci.go
+++ b/pkg/catalogv2/oci/oci.go
@@ -56,7 +56,6 @@ func Chart(credentialSecret *corev1.Secret, chart *repo.ChartVersion, clusterRep
 			PreCopy: func(ctx context.Context, desc ocispecv1.Descriptor) error {
 				// Download only helm chart related descriptors.
 				if desc.MediaType == ocispecv1.MediaTypeImageManifest ||
-					desc.MediaType == registry.ConfigMediaType ||
 					desc.MediaType == registry.ChartLayerMediaType {
 					// We cannot load huge amounts of data into the memory
 					// and so we are defining a limit before fetching.


### PR DESCRIPTION
After analyzing the API calls that are being made by the Rancher manager while using OCI functionality, I have noticed that there is an unnecessary config layer API being made. So, removing it now.

## Engineering Testing

- [ ] Test CRUD functionality of an OCI repository
- [ ] Test Installation/Upgradation of a Helm Chart. 

