### PR TITLE
Updated the tests to use the modified CreateNamespace function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240126142034-676c3eb3dfa5
-	github.com/rancher/shepherd v0.0.0-20240405160434-1192ba6d32ec
+	github.com/rancher/shepherd v0.0.0-20240405191643-ef88013799bb
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1680,8 +1680,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.3 h1:7mGn+NIL7KXk99NwWYBgoByh2+IfVCdws5ad3X/JIZY=
 github.com/rancher/rke v1.5.3/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240405160434-1192ba6d32ec h1:FQX/H9aIfu0LwMyzdYZpL4jZjkucj670w9JcvryPZh0=
-github.com/rancher/shepherd v0.0.0-20240405160434-1192ba6d32ec/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
+github.com/rancher/shepherd v0.0.0-20240405191643-ef88013799bb h1:Gk+h90ulkwy0LJhOtvtFwYQdbaaVksIju+ON2w6WjeU=
+github.com/rancher/shepherd v0.0.0-20240405191643-ef88013799bb/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/integration/rtbs/rtbs_test.go
+++ b/tests/v2/integration/rtbs/rtbs_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
@@ -80,7 +81,8 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 	client, err := p.client.WithSession(subSession)
 	require.NoError(p.T(), err)
 
-	createdNamespace, err := extnamespaces.CreateNamespace(client, namegen.AppendRandomString("testns-"), "{}", map[string]string{}, map[string]string{}, p.project)
+	projectName := strings.Split(p.project.ID, ":")[1]
+	createdNamespace, err := extnamespaces.CreateNamespace(client, p.downstreamClusterID, projectName, namegen.AppendRandomString("testns-"), "{}", map[string]string{}, map[string]string{})
 	require.NoError(p.T(), err)
 
 	testUser, err := client.AsUser(p.testUser)
@@ -211,7 +213,8 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 	// Test that user can get a specified namespace once granted the permission to do so via roletemplate inheritance bounded
 	// by a CRTB.
 
-	ns, err := extnamespaces.CreateNamespace(client, namegen.AppendRandomString("testns-"), "{}", map[string]string{}, map[string]string{}, p.project)
+	projectName := strings.Split(p.project.ID, ":")[1]
+	ns, err := extnamespaces.CreateNamespace(client, p.downstreamClusterID, projectName, namegen.AppendRandomString("testns-"), "{}", map[string]string{}, map[string]string{})
 	require.NoError(p.T(), err)
 
 	testUser, err := client.AsUser(p.testUser)
@@ -288,7 +291,7 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
 	require.NoError(p.T(), err)
 
-	anotherNS, err := extnamespaces.CreateNamespace(client, namegen.AppendRandomString("testns-"), "{}", map[string]string{}, map[string]string{}, p.project)
+	anotherNS, err := extnamespaces.CreateNamespace(client, p.downstreamClusterID, projectName, namegen.AppendRandomString("testns-"), "{}", map[string]string{}, map[string]string{})
 	require.NoError(p.T(), err)
 
 	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, anotherNS.Name)


### PR DESCRIPTION
Create Namespace function in the kube api package has been modified to keep the function generic and not tied to any specific API (norman/steve/public): https://github.com/rancher/shepherd/pull/110
The function now accepts clusterID and projectID as inputs instead of norman project. So, the integration tests using this function has been modified to use the updated function.

Backports:
- 2.7: https://github.com/rancher/rancher/pull/44841
- 2.8: https://github.com/rancher/rancher/pull/44842