### PR TITLE
Fix shibboleth bug

### DIFF
--- a/pkg/auth/api/secrets/store.go
+++ b/pkg/auth/api/secrets/store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rancher/norman/types/values"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
-	"github.com/rancher/rancher/pkg/namespace"
 )
 
 func Wrap(store types.Store, secrets corev1.SecretInterface) types.Store {
@@ -69,8 +68,10 @@ func (s *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 }
 
 func (s *Store) CreateOrUpdateSecrets(value, field, kind string) (string, error) {
-	if err := common.CreateOrUpdateSecrets(s.Secrets, value, strings.ToLower(field), strings.ToLower(kind)); err != nil {
-		return "", fmt.Errorf("error creating secret for %s:%s", kind, field)
+	name, err := common.CreateOrUpdateSecrets(s.Secrets, value, strings.ToLower(field), strings.ToLower(kind))
+	if err != nil {
+		return "", fmt.Errorf("error creating secret %s: %w", name, err)
 	}
-	return fmt.Sprintf("%s:%s-%s", namespace.GlobalNamespace, strings.ToLower(kind), strings.ToLower(field)), nil
+
+	return name, nil
 }

--- a/pkg/auth/providers/activedirectory/activedirectory_actions.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_actions.go
@@ -107,11 +107,12 @@ func (p *adProvider) saveActiveDirectoryConfig(config *v32.ActiveDirectoryConfig
 	config.ObjectMeta = storedConfig.ObjectMeta
 
 	field := strings.ToLower(client.ActiveDirectoryConfigFieldServiceAccountPassword)
-	if err := common.CreateOrUpdateSecrets(p.secrets, config.ServiceAccountPassword, field, strings.ToLower(convert.ToString(config.Type))); err != nil {
+	name, err := common.CreateOrUpdateSecrets(p.secrets, config.ServiceAccountPassword, field, strings.ToLower(convert.ToString(config.Type)))
+	if err != nil {
 		return err
 	}
 
-	config.ServiceAccountPassword = common.GetFullSecretName(config.Type, field)
+	config.ServiceAccountPassword = name
 
 	logrus.Debugf("updating activeDirectoryConfig")
 	_, err = p.authConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -301,11 +301,12 @@ func (ap *Provider) saveAzureConfigK8s(config *v32.AzureADConfig) error {
 	}
 
 	field := strings.ToLower(client.AzureADConfigFieldApplicationSecret)
-	if err := common.CreateOrUpdateSecrets(ap.secrets, config.ApplicationSecret, field, strings.ToLower(config.Type)); err != nil {
+	name, err := common.CreateOrUpdateSecrets(ap.secrets, config.ApplicationSecret, field, strings.ToLower(config.Type))
+	if err != nil {
 		return err
 	}
 
-	config.ApplicationSecret = common.GetFullSecretName(config.Type, field)
+	config.ApplicationSecret = name
 
 	logrus.Debugf("updating AzureADConfig")
 	_, err = ap.authConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -224,7 +224,7 @@ func (c AccessTokenCache) Export(cache cache.Marshaler, key string) {
 		return
 	}
 
-	err = common.CreateOrUpdateSecrets(c.Secrets, string(marshalled), "access-token", "azuread")
+	_, err = common.CreateOrUpdateSecrets(c.Secrets, string(marshalled), "access-token", "azuread")
 	if err != nil {
 		logrus.Errorf("[%s] failed to save the access token in Kubernetes: %v", cacheLogPrefix, err)
 	}

--- a/pkg/auth/providers/common/password.go
+++ b/pkg/auth/providers/common/password.go
@@ -14,6 +14,12 @@ import (
 
 const SecretsNamespace = namespace.GlobalNamespace
 
+// NameForSecret returns a string with the namespace:name for the provided
+// Secret.
+func NameForSecret(s *corev1.Secret) string {
+	return fmt.Sprintf("%s:%s", s.GetNamespace(), s.GetName())
+}
+
 // CreateOrUpdateSecrets creates a new Secret for a specific authorisation
 // mechanism.
 //
@@ -55,7 +61,8 @@ func CreateOrUpdateSecrets(secrets corev1.SecretInterface, secretInfo, field, au
 			return "", fmt.Errorf("error creating secret %s %w", name, err)
 		}
 	}
-	return fmt.Sprintf("%s:%s", secret.GetNamespace(), secret.GetName()), nil
+
+	return NameForSecret(secret), nil
 }
 
 func ReadFromSecret(secrets corev1.SecretInterface, secretInfo string, field string) (string, error) {

--- a/pkg/auth/providers/common/password.go
+++ b/pkg/auth/providers/common/password.go
@@ -92,5 +92,5 @@ func SavePasswordSecret(secrets corev1.SecretInterface, password string, fieldNa
 	if err := CreateOrUpdateSecrets(secrets, password, strings.ToLower(fieldName), strings.ToLower(authType)); err != nil {
 		return "", err
 	}
-	return GetFullSecretName(authType, fieldName), nil
+	return GetFullSecretName(authType, strings.ToLower(fieldName)), nil
 }

--- a/pkg/auth/providers/common/password_test.go
+++ b/pkg/auth/providers/common/password_test.go
@@ -1,13 +1,19 @@
 package common
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
-	fake1 "github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	clientv3 "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	"github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
+	fake1 "github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
 )
 
 const (
@@ -29,8 +35,8 @@ var tests = []testPair{
 
 func TestReadFromSecret(t *testing.T) {
 	secretInterface := fake1.SecretInterfaceMock{
-		GetNamespacedFunc: func(namespace string, name string, opts metav1.GetOptions) (*v1.Secret, error) {
-			s := v1.Secret{
+		GetNamespacedFunc: func(namespace string, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
+			s := corev1.Secret{
 				Data: make(map[string][]byte),
 			}
 			if name == "bar" {
@@ -45,5 +51,53 @@ func TestReadFromSecret(t *testing.T) {
 		info, err := ReadFromSecret(&secretInterface, pair.in, appSecretKey)
 		assert.Nil(t, err)
 		assert.Equal(t, pair.out, info)
+	}
+}
+
+func TestSavePasswordSecret(t *testing.T) {
+	secrets := &secretFake{}
+	secretInterface := newSecretInterfaceMock(secrets)
+
+	name, err := SavePasswordSecret(secretInterface, "test-password",
+		clientv3.LdapConfigFieldServiceAccountPassword,
+		"shibbolethConfig")
+	assert.NoError(t, err)
+
+	wantSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shibbolethconfig-serviceaccountpassword",
+			Namespace: "cattle-global-data",
+		},
+		StringData: map[string]string{
+			"serviceaccountpassword": "test-password",
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	assert.Equal(t, []*corev1.Secret{wantSecret}, secrets.Created)
+	assert.Equal(t, wantSecret.Namespace+":"+wantSecret.Name, name)
+}
+
+type secretFake struct {
+	Created []*corev1.Secret
+}
+
+func newSecretInterfaceMock(secrets *secretFake) v1.SecretInterface {
+	controller := &fakes.SecretControllerMock{
+		ListerFunc: func() v1.SecretLister {
+			return &fakes.SecretListerMock{
+				GetFunc: func(ns string, name string) (*corev1.Secret, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+				},
+			}
+		},
+	}
+	return &fakes.SecretInterfaceMock{
+		ControllerFunc: func() v1.SecretController {
+			return controller
+		},
+		CreateFunc: func(in1 *corev1.Secret) (*v1.Secret, error) {
+			secrets.Created = append(secrets.Created, in1)
+			return in1, nil
+		},
 	}
 }

--- a/pkg/auth/providers/common/password_test.go
+++ b/pkg/auth/providers/common/password_test.go
@@ -54,6 +54,24 @@ func TestReadFromSecret(t *testing.T) {
 	}
 }
 
+func TestNameForSecret(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shibbolethconfig-serviceaccountpassword",
+			Namespace: "cattle-global-data",
+		},
+		StringData: map[string]string{
+			"serviceaccountpassword": "test-password",
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	want := "cattle-global-data:shibbolethconfig-serviceaccountpassword"
+	if n := NameForSecret(secret); n != want {
+		t.Errorf("NameForSecret() got %s, want t%s", n, want)
+	}
+}
+
 func TestSavePasswordSecret(t *testing.T) {
 	secrets := &secretFake{}
 	secretInterface := newSecretInterfaceMock(secrets)

--- a/pkg/auth/providers/github/github_provider.go
+++ b/pkg/auth/providers/github/github_provider.go
@@ -119,11 +119,12 @@ func (g *ghProvider) saveGithubConfig(config *v32.GithubConfig) error {
 
 	secretInfo := convert.ToString(config.ClientSecret)
 	field := strings.ToLower(client.GithubConfigFieldClientSecret)
-	if err := common.CreateOrUpdateSecrets(g.secrets, secretInfo, field, strings.ToLower(config.Type)); err != nil {
+	name, err := common.CreateOrUpdateSecrets(g.secrets, secretInfo, field, strings.ToLower(config.Type))
+	if err != nil {
 		return err
 	}
 
-	config.ClientSecret = common.GetFullSecretName(config.Type, field)
+	config.ClientSecret = name
 
 	_, err = g.authConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)
 	if err != nil {

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -338,18 +338,20 @@ func (g *googleOauthProvider) saveGoogleOAuthConfigCR(config *v32.GoogleOauthCon
 
 	secretInfo := convert.ToString(config.OauthCredential)
 	field := strings.ToLower(client.GoogleOauthConfigFieldOauthCredential)
-	if err := common.CreateOrUpdateSecrets(g.secrets, secretInfo, field, strings.ToLower(config.Type)); err != nil {
+	name, err := common.CreateOrUpdateSecrets(g.secrets, secretInfo, field, strings.ToLower(config.Type))
+	if err != nil {
 		return err
 	}
-	config.OauthCredential = common.GetFullSecretName(config.Type, field)
+	config.OauthCredential = name
 
 	if config.ServiceAccountCredential != "" {
 		secretInfo = convert.ToString(config.ServiceAccountCredential)
 		field = strings.ToLower(client.GoogleOauthConfigFieldServiceAccountCredential)
-		if err := common.CreateOrUpdateSecrets(g.secrets, secretInfo, field, strings.ToLower(config.Type)); err != nil {
+		name, err := common.CreateOrUpdateSecrets(g.secrets, secretInfo, field, strings.ToLower(config.Type))
+		if err != nil {
 			return err
 		}
-		config.ServiceAccountCredential = common.GetFullSecretName(config.Type, field)
+		config.ServiceAccountCredential = name
 	}
 
 	_, err = g.authConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)

--- a/pkg/auth/providers/ldap/ldap_actions.go
+++ b/pkg/auth/providers/ldap/ldap_actions.go
@@ -123,12 +123,13 @@ func (p *ldapProvider) saveLDAPConfig(config *v3.LdapConfig) error {
 	config.ObjectMeta = storedConfig.ObjectMeta
 
 	field := strings.ToLower(client.LdapConfigFieldServiceAccountPassword)
-	if err := common.CreateOrUpdateSecrets(p.secrets, config.ServiceAccountPassword,
-		field, strings.ToLower(config.Type)); err != nil {
+	name, err := common.CreateOrUpdateSecrets(p.secrets, config.ServiceAccountPassword,
+		field, strings.ToLower(config.Type))
+	if err != nil {
 		return err
 	}
 
-	config.ServiceAccountPassword = common.GetFullSecretName(config.Type, field)
+	config.ServiceAccountPassword = name
 
 	logrus.Debugf("updating %s config", p.providerName)
 	_, err = p.authConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -287,17 +287,19 @@ func (o *OpenIDCProvider) saveOIDCConfig(config *v32.OIDCConfig) error {
 
 	if config.PrivateKey != "" {
 		privateKeyField := strings.ToLower(client.OIDCConfigFieldPrivateKey)
-		if err = common.CreateOrUpdateSecrets(o.Secrets, config.PrivateKey, privateKeyField, strings.ToLower(config.Type)); err != nil {
+		name, err := common.CreateOrUpdateSecrets(o.Secrets, config.PrivateKey, privateKeyField, strings.ToLower(config.Type))
+		if err != nil {
 			return err
 		}
-		config.PrivateKey = common.GetFullSecretName(config.Type, privateKeyField)
+		config.PrivateKey = name
 	}
 
 	secretField := strings.ToLower(client.OIDCConfigFieldClientSecret)
-	if err := common.CreateOrUpdateSecrets(o.Secrets, convert.ToString(config.ClientSecret), secretField, strings.ToLower(config.Type)); err != nil {
+	name, err := common.CreateOrUpdateSecrets(o.Secrets, convert.ToString(config.ClientSecret), secretField, strings.ToLower(config.Type))
+	if err != nil {
 		return err
 	}
-	config.ClientSecret = common.GetFullSecretName(config.Type, secretField)
+	config.ClientSecret = name
 
 	logrus.Debugf("[generic oidc] saveOIDCConfig: updating config")
 	_, err = o.AuthConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -210,12 +210,14 @@ func (s *Provider) saveSamlConfig(config *v32.SamlConfig) error {
 	if fields, ok := secrets.TypeToFields[configType]; ok && len(fields) > 0 {
 		field = strings.ToLower(fields[0])
 	}
-	if err := common.CreateOrUpdateSecrets(s.secrets, config.SpKey,
-		field, strings.ToLower(config.Type)); err != nil {
+	spKey, err := common.CreateOrUpdateSecrets(s.secrets, config.SpKey,
+		field, strings.ToLower(config.Type))
+	if err != nil {
 		return err
 	}
 
-	config.SpKey = common.GetFullSecretName(config.Type, field)
+	config.SpKey = spKey
+
 	if s.hasLdapGroupSearch() {
 		combinedConfig, err := s.combineSamlAndLdapConfig(config)
 		if err != nil {

--- a/pkg/controllers/management/secretmigrator/authconfig.go
+++ b/pkg/controllers/management/secretmigrator/authconfig.go
@@ -97,7 +97,7 @@ func (h *handler) migrateShibbolethSecrets(unstructuredConfig map[string]any) (*
 
 	// cannot use createOrUpdateSecretForCredential because the credential is saved in the secret with a key of
 	// "credential", but our AuthProviders look for "serviceaccountpassword"
-	_, err = h.migrator.createOrUpdateSecret(
+	secret, err := h.migrator.createOrUpdateSecret(
 		secretName,
 		namespace.GlobalNamespace,
 		map[string]string{
@@ -111,9 +111,7 @@ func (h *handler) migrateShibbolethSecrets(unstructuredConfig map[string]any) (*
 		return nil, err
 	}
 
-	lowerType := strings.ToLower(shibbConfig.Type)
-	fullSecretName := common.GetFullSecretName(lowerType, serviceAccountPasswordFieldName)
-	shibbConfig.OpenLdapConfig.ServiceAccountPassword = fullSecretName
+	shibbConfig.OpenLdapConfig.ServiceAccountPassword = common.NameForSecret(secret)
 
 	return shibbConfig, nil
 }

--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -231,10 +231,12 @@ func (m *Migrator) createOrUpdateSecret(secretName, secretNamespace string, data
 	}
 	if existing == nil {
 		return m.secrets.Create(secret)
-	} else if !reflect.DeepEqual(existing.StringData, secret.StringData) {
+	}
+	if !reflect.DeepEqual(existing.StringData, secret.StringData) {
 		existing.StringData = data
 		return m.secrets.Update(existing)
 	}
+
 	return secret, nil
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The generated name of the secret in [SavePasswordSecret](https://github.com/rancher/rancher/blob/941d6d3102a39fff855fd07ca99e2c6e39f7a6de/pkg/auth/providers/common/password.go#L90) was not correctly converting fieldName to lower when generating the secret name.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
The initial fix was to generate it with the correct name.

But these functions delegate via a `CreateOrUpdateSecrets` function which generates the name itself, there's scope for discrepancies anywhere the combination of `CreateOrUpdateSecrets` and `GetFullSecretName` were called.

This code makes `CreateOrUpdateSecrets` return the name of the generated secret which is used instead of generating the name again.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_