### PR TITLE
AzureAD auth provider RFE. Extended with optional filter group memberships

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -280,14 +280,15 @@ type GoogleOauthConfigApplyInput struct {
 type AzureADConfig struct {
 	AuthConfig `json:",inline" mapstructure:",squash"`
 
-	Endpoint          string `json:"endpoint,omitempty" norman:"default=https://login.microsoftonline.com/,required,notnullable"`
-	GraphEndpoint     string `json:"graphEndpoint,omitempty" norman:"required,notnullable"`
-	TokenEndpoint     string `json:"tokenEndpoint,omitempty" norman:"required,notnullable"`
-	AuthEndpoint      string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
-	TenantID          string `json:"tenantId,omitempty" norman:"required,notnullable"`
-	ApplicationID     string `json:"applicationId,omitempty" norman:"required,notnullable"`
-	ApplicationSecret string `json:"applicationSecret,omitempty" norman:"required,type=password"`
-	RancherURL        string `json:"rancherUrl,omitempty" norman:"required,notnullable"`
+	Endpoint              string `json:"endpoint,omitempty" norman:"default=https://login.microsoftonline.com/,required,notnullable"`
+	GraphEndpoint         string `json:"graphEndpoint,omitempty" norman:"required,notnullable"`
+	TokenEndpoint         string `json:"tokenEndpoint,omitempty" norman:"required,notnullable"`
+	AuthEndpoint          string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
+	TenantID              string `json:"tenantId,omitempty" norman:"required,notnullable"`
+	ApplicationID         string `json:"applicationId,omitempty" norman:"required,notnullable"`
+	ApplicationSecret     string `json:"applicationSecret,omitempty" norman:"required,type=password"`
+	RancherURL            string `json:"rancherUrl,omitempty" norman:"required,notnullable"`
+	FilterGroupMembership string `json:"filterGroupMembership,omitempty"`
 }
 
 type AzureADConfigTestOutput struct {

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -103,7 +103,7 @@ func (ap *Provider) RefetchGroupPrincipals(principalID, secret string) ([]v3.Pri
 
 	logrus.Debug("[AZURE_PROVIDER] Completed getting user info from AzureAD")
 
-	userGroups, err := azureClient.ListGroupMemberships(clients.GetPrincipalID(userPrincipal))
+	userGroups, err := azureClient.ListGroupMemberships(clients.GetPrincipalID(userPrincipal), cfg.FilterGroupMembership)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/providers/azure/clients/ad_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ad_graph_client.go
@@ -74,7 +74,7 @@ func (c *azureADGraphClient) ListGroups(filter string) ([]v3.Principal, error) {
 }
 
 // ListGroupMemberships takes a user ID and fetches the user's group principals as strings IDs from the Azure AD Graph API.
-func (c *azureADGraphClient) ListGroupMemberships(id string) ([]string, error) {
+func (c *azureADGraphClient) ListGroupMemberships(id string, filter string) ([]string, error) {
 	securityEnabledOnly := false
 	params := graphrbac.UserGetMemberGroupsParameters{
 		SecurityEnabledOnly: &securityEnabledOnly,
@@ -101,7 +101,7 @@ func (c *azureADGraphClient) LoginUser(_ *v32.AzureADConfig, _ *v32.AzureADLogin
 	userPrincipal.Me = true
 	logrus.Debug("[AZURE_PROVIDER] Completed getting user info from AzureAD")
 
-	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal))
+	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal), "")
 	if err != nil {
 		return v3.Principal{}, nil, "", err
 	}

--- a/pkg/auth/providers/azure/clients/client.go
+++ b/pkg/auth/providers/azure/clients/client.go
@@ -20,7 +20,7 @@ type AzureClient interface {
 	ListUsers(filter string) ([]v3.Principal, error)
 	GetGroup(id string) (v3.Principal, error)
 	ListGroups(filter string) ([]v3.Principal, error)
-	ListGroupMemberships(id string) ([]string, error)
+	ListGroupMemberships(id string, filter string) ([]string, error)
 }
 
 // NewAzureClientFromCredential returns a new client to be used for first-time authentication. This means it does not need any

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -93,8 +93,10 @@ func (c azureMSGraphClient) ListGroups(filter string) ([]v3.Principal, error) {
 }
 
 // ListGroupMemberships takes a user ID and fetches the user's group principals as string IDs from the Microsoft Graph API.
-func (c azureMSGraphClient) ListGroupMemberships(id string) ([]string, error) {
-	groups, _, err := c.userClient.ListGroupMemberships(context.Background(), id, odata.Query{})
+func (c azureMSGraphClient) ListGroupMemberships(id string, filter string) ([]string, error) {
+	groups, _, err := c.userClient.ListGroupMemberships(context.Background(), id, odata.Query{
+		Filter: filter,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +129,7 @@ func (c azureMSGraphClient) LoginUser(config *v32.AzureADConfig, credential *v32
 	userPrincipal.Me = true
 	logrus.Debugf("[%s] Completed getting user info from AzureAD", providerLogPrefix)
 
-	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal))
+	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal), config.FilterGroupMembership)
 	if err != nil {
 		return v3.Principal{}, nil, "", err
 	}
@@ -302,7 +304,9 @@ func (c azureMSGraphClient) userToPrincipal(user msgraph.User) (v3.Principal, er
 
 func (c azureMSGraphClient) groupToPrincipal(group msgraph.Group) (v3.Principal, error) {
 	return v3.Principal{
-		ObjectMeta:    metav1.ObjectMeta{Name: Name + "_group://" + *group.ID},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: Name + "_group://" + *group.ID,
+		},
 		DisplayName:   *group.DisplayName,
 		PrincipalType: "group",
 		Provider:      Name,

--- a/pkg/client/generated/management/v3/zz_generated_azure_adconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_azure_adconfig.go
@@ -1,50 +1,52 @@
 package client
 
 const (
-	AzureADConfigType                     = "azureADConfig"
-	AzureADConfigFieldAccessMode          = "accessMode"
-	AzureADConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
-	AzureADConfigFieldAnnotations         = "annotations"
-	AzureADConfigFieldApplicationID       = "applicationId"
-	AzureADConfigFieldApplicationSecret   = "applicationSecret"
-	AzureADConfigFieldAuthEndpoint        = "authEndpoint"
-	AzureADConfigFieldCreated             = "created"
-	AzureADConfigFieldCreatorID           = "creatorId"
-	AzureADConfigFieldEnabled             = "enabled"
-	AzureADConfigFieldEndpoint            = "endpoint"
-	AzureADConfigFieldGraphEndpoint       = "graphEndpoint"
-	AzureADConfigFieldLabels              = "labels"
-	AzureADConfigFieldName                = "name"
-	AzureADConfigFieldOwnerReferences     = "ownerReferences"
-	AzureADConfigFieldRancherURL          = "rancherUrl"
-	AzureADConfigFieldRemoved             = "removed"
-	AzureADConfigFieldStatus              = "status"
-	AzureADConfigFieldTenantID            = "tenantId"
-	AzureADConfigFieldTokenEndpoint       = "tokenEndpoint"
-	AzureADConfigFieldType                = "type"
-	AzureADConfigFieldUUID                = "uuid"
+	AzureADConfigType                       = "azureADConfig"
+	AzureADConfigFieldAccessMode            = "accessMode"
+	AzureADConfigFieldAllowedPrincipalIDs   = "allowedPrincipalIds"
+	AzureADConfigFieldAnnotations           = "annotations"
+	AzureADConfigFieldApplicationID         = "applicationId"
+	AzureADConfigFieldApplicationSecret     = "applicationSecret"
+	AzureADConfigFieldAuthEndpoint          = "authEndpoint"
+	AzureADConfigFieldCreated               = "created"
+	AzureADConfigFieldCreatorID             = "creatorId"
+	AzureADConfigFieldEnabled               = "enabled"
+	AzureADConfigFieldEndpoint              = "endpoint"
+	AzureADConfigFieldFilterGroupMembership = "filterGroupMembership"
+	AzureADConfigFieldGraphEndpoint         = "graphEndpoint"
+	AzureADConfigFieldLabels                = "labels"
+	AzureADConfigFieldName                  = "name"
+	AzureADConfigFieldOwnerReferences       = "ownerReferences"
+	AzureADConfigFieldRancherURL            = "rancherUrl"
+	AzureADConfigFieldRemoved               = "removed"
+	AzureADConfigFieldStatus                = "status"
+	AzureADConfigFieldTenantID              = "tenantId"
+	AzureADConfigFieldTokenEndpoint         = "tokenEndpoint"
+	AzureADConfigFieldType                  = "type"
+	AzureADConfigFieldUUID                  = "uuid"
 )
 
 type AzureADConfig struct {
-	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
-	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
-	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	ApplicationID       string            `json:"applicationId,omitempty" yaml:"applicationId,omitempty"`
-	ApplicationSecret   string            `json:"applicationSecret,omitempty" yaml:"applicationSecret,omitempty"`
-	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
-	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Endpoint            string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	GraphEndpoint       string            `json:"graphEndpoint,omitempty" yaml:"graphEndpoint,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
-	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
-	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Status              *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
-	TenantID            string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
-	TokenEndpoint       string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
-	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
-	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	AccessMode            string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AllowedPrincipalIDs   []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations           map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	ApplicationID         string            `json:"applicationId,omitempty" yaml:"applicationId,omitempty"`
+	ApplicationSecret     string            `json:"applicationSecret,omitempty" yaml:"applicationSecret,omitempty"`
+	AuthEndpoint          string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Created               string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID             string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled               bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Endpoint              string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	FilterGroupMembership string            `json:"filterGroupMembership,omitempty" yaml:"filterGroupMembership,omitempty"`
+	GraphEndpoint         string            `json:"graphEndpoint,omitempty" yaml:"graphEndpoint,omitempty"`
+	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
+	OwnerReferences       []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	RancherURL            string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed               string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Status                *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	TenantID              string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	TokenEndpoint         string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
+	Type                  string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                  string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

This is a forward port of the closed PR #39757 to the 2.9 branch.
 
## Problem

See originating issue #42940
Ref SURE-5641
 
## Solution

The `AzureADConfig` structure is extended with a string field `FilterGroupMembership` to contain the filter clauses.
The internal client interface's `ListGroupMemberships` (LGM) function is extended to take the filter as argument.
The AzureAD provider is extended to pass the filter from config to the chosen client's `LGM`.
The old AD graph client ignores the information.
The newer MS graph client passes the filter down to the MS graph API.

:construction: See what (unit) tests can be written.

:warning: This change requires an appropriate extension of the UI AzureAD configuration dialog. IOW the dialog has to provide an additional string field where the use is able enter the desired filter clauses as part of the setting up Rancher with an AzureAD auth provider.
 
@MbolotSuse I looked into your request of replacing the currently used [hamilton/msgraph](https://pkg.go.dev/github.com/manicminer/hamilton/msgraph) package with the official [MS SDK](https://pkg.go.dev/github.com/microsoftgraph/msgraph-sdk-go) and have come to the conclusion that such a switch is best done as a completely separate PR and work. 

## Testing

## Engineering Testing
### Manual Testing

  1. The code compiles without error.
  2. Setting up an AzureAD auth provider with the changed Rancher was successful.
  3. As a variant, after removing the `omitempty` clause on the new `FilterGroupMembership` field, recompiling, and then redoing 2 had the new field properly showing up in the `AuthConfig` resource for AzureAD.

:construction: No unit tests yet.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_