### PR TITLE
Adding helm repo to upgrade for prime checks

### DIFF
--- a/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.ha
+++ b/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.ha
@@ -174,6 +174,12 @@ node {
                 ).trim()
                 println "HA helm repo: ${env.HA_HELM_REPO}"
 
+                env.HA_HELM_REPO_TO_UPGRADE= sh (
+                  script: "./yq '.ha.helmRepoToUpgrade' ${initConfigPath}",
+                  returnStdout: true
+                ).trim()
+                println "HA helm repo to upgrade: ${env.HA_HELM_REPO_TO_UPGRADE}"
+
                 env.HA_HELM_URL= sh (
                   script: "./yq '.ha.helmURL' ${initConfigPath}",
                   returnStdout: true
@@ -378,7 +384,7 @@ node {
                 string(name: 'RANCHER_HA_HOSTNAME', value: "${env.HA_HOST}"),
                 string(name: 'RANCHER_CHART_VERSION', value: "${env.HA_CHART_VERSION_TO_UPGRADE}"),
                 string(name: 'RANCHER_IMAGE_TAG', value: "${env.HA_IMAGE_TAG_TO_UPGRADE}"),
-                string(name: 'RANCHER_HELM_REPO', value: "${env.HA_HELM_REPO}"),
+                string(name: 'RANCHER_HELM_REPO', value: "${env.HA_HELM_REPO_TO_UPGRADE}"),
                 string(name: 'RANCHER_HELM_URL', value: "${env.HA_HELM_URL_TO_UPGRADE}"),
                 string(name: 'RANCHER_HA_CERT_OPTION', value: "${env.HA_CERT_OPTION}"),
                 string(name: 'RANCHER_HA_KUBECONFIG', value: "${env.HA_KUBECONFIG}"),


### PR DESCRIPTION
For prime releases, helm repo differs before and after upgrade. This is to make sure we are able to use the repo in ha upgrade pipeline

Note: Once approved, this requires a back port in 2.8 as well as 2.7