### PR TITLE
[v2.8] Update hosted clusters nodescaling test case names

### DIFF
--- a/tests/v2/validation/nodescaling/scaling_node_driver_aks_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_aks_test.go
@@ -53,8 +53,8 @@ func (s *AKSNodeScalingTestSuite) TestScalingAKSNodePools() {
 		aksNodes aks.NodePool
 		client   *rancher.Client
 	}{
-		{"Scaling agentpool by 1", scaleOneNode, s.client},
-		{"Scaling agentpool by 2", scaleTwoNodes, s.client},
+		{"Scaling AKS agentpool by 1", scaleOneNode, s.client},
+		{"Scaling AKS agentpool by 2", scaleTwoNodes, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_node_driver_eks_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_eks_test.go
@@ -53,8 +53,8 @@ func (s *EKSNodeScalingTestSuite) TestScalingEKSNodePools() {
 		eksNodes eks.NodeGroupConfig
 		client   *rancher.Client
 	}{
-		{"Scaling node group by 1", scaleOneNode, s.client},
-		{"Scaling node group by 2", scaleTwoNodes, s.client},
+		{"Scaling EKS node group by 1", scaleOneNode, s.client},
+		{"Scaling EKS node group by 2", scaleTwoNodes, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_node_driver_gke_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_gke_test.go
@@ -53,8 +53,8 @@ func (s *GKENodeScalingTestSuite) TestScalingGKENodePools() {
 		gkeNodes gke.NodePool
 		client   *rancher.Client
 	}{
-		{"Scaling node group by 1", scaleOneNode, s.client},
-		{"Scaling node group by 2", scaleTwoNodes, s.client},
+		{"Scaling GKE node group by 1", scaleOneNode, s.client},
+		{"Scaling GKE node group by 2", scaleTwoNodes, s.client},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In Qase, GKE is not being reported in its own section. In fact, it is being reported as an additional run under the EKS section. This is because the test case name is the exact same.

So the Qase parser is unable to distinguish between the two.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the hosted cluster's test case names so that the Qase parser can properly distinguish between the two.