### PR TITLE
[v2.7] Update nodescaling names for RKE1 and v2prov clusters

### DIFF
--- a/tests/v2/validation/nodescaling/scaling_custom_cluster_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scaling_custom_cluster_rke1_test.go
@@ -71,11 +71,11 @@ func (s *RKE1CustomClusterNodeScalingTestSuite) TestScalingRKE1CustomClusterNode
 		nodeRoles nodepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling etcd by 1", nodeRolesEtcd, s.client},
-		{"Scaling etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
-		{"Scaling worker by 1", nodeRolesWorker, s.client},
-		{"Scaling worker by 2", nodeRolesTwoWorkers, s.client},
+		{"Scaling custom RKE1 control plane by 1", nodeRolesControlPlane, s.client},
+		{"Scaling custom RKE1 etcd by 1", nodeRolesEtcd, s.client},
+		{"Scaling custom RKE1 etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
+		{"Scaling custom RKE1 worker by 1", nodeRolesWorker, s.client},
+		{"Scaling custom RKE1 worker by 2", nodeRolesTwoWorkers, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_custom_cluster_test.go
+++ b/tests/v2/validation/nodescaling/scaling_custom_cluster_test.go
@@ -3,9 +3,12 @@
 package nodescaling
 
 import (
+	"strings"
 	"testing"
 
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/machinepools"
 	"github.com/rancher/shepherd/extensions/scalinginput"
@@ -71,16 +74,29 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 		nodeRoles machinepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling custom control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling custom etcd by 1", nodeRolesEtcd, s.client},
-		{"Scaling custom etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
-		{"Scaling custom worker by 1", nodeRolesWorker, s.client},
-		{"Scaling custom worker by 2", nodeRolesTwoWorkers, s.client},
+		{"control plane by 1", nodeRolesControlPlane, s.client},
+		{"etcd by 1", nodeRolesEtcd, s.client},
+		{"etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
+		{"worker by 1", nodeRolesWorker, s.client},
+		{"worker by 2", nodeRolesTwoWorkers, s.client},
 	}
 
 	for _, tt := range tests {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
+
+		cluster, err := tt.client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+		require.NoError(s.T(), err)
+
+		updatedCluster := new(apisV1.Cluster)
+		err = v1.ConvertToK8sType(cluster, &updatedCluster)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+			tt.name = "Scaling custom RKE2 " + tt.name
+		} else {
+			tt.name = "Scaling custom K3S " + tt.name
+		}
 
 		s.Run(tt.name, func() {
 			scalingRKE2K3SCustomClusterPools(s.T(), s.client, clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles)

--- a/tests/v2/validation/nodescaling/scaling_custom_cluster_test.go
+++ b/tests/v2/validation/nodescaling/scaling_custom_cluster_test.go
@@ -71,11 +71,11 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 		nodeRoles machinepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling etcd by 1", nodeRolesEtcd, s.client},
-		{"Scaling etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
-		{"Scaling worker by 1", nodeRolesWorker, s.client},
-		{"Scaling worker by 2", nodeRolesTwoWorkers, s.client},
+		{"Scaling custom control plane by 1", nodeRolesControlPlane, s.client},
+		{"Scaling custom etcd by 1", nodeRolesEtcd, s.client},
+		{"Scaling custom etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
+		{"Scaling custom worker by 1", nodeRolesWorker, s.client},
+		{"Scaling custom worker by 2", nodeRolesTwoWorkers, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_node_driver_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_rke1_test.go
@@ -65,10 +65,10 @@ func (s *RKE1NodeScalingTestSuite) TestScalingRKE1NodePools() {
 		nodeRoles nodepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling etcd node by 1", nodeRolesEtcd, s.client},
-		{"Scaling worker by 1", nodeRolesWorker, s.client},
-		{"Scaling worker by 2", nodeRolesTwoWorkers, s.client},
+		{"Scaling RKE1 control plane by 1", nodeRolesControlPlane, s.client},
+		{"Scaling RKE1 etcd node by 1", nodeRolesEtcd, s.client},
+		{"Scaling RKE1 worker by 1", nodeRolesWorker, s.client},
+		{"Scaling RKE1 worker node machine by 2", nodeRolesTwoWorkers, s.client},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In Qase, nodescaling for RKE1 and v2 prov is not being reported in its own section. This is because the test case name is the exact same. So the Qase parser is unable to distinguish between the appropriate test cases.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the node driver and custom cluster's test case names so that the Qase parser can properly distinguish between the test cases.