### PR TITLE
[2.9] Fixes for Shell automation

### DIFF
--- a/tests/v2/validation/shell/README.md
+++ b/tests/v2/validation/shell/README.md
@@ -4,12 +4,11 @@ Your GO test_package should be set to shell. Your GO suite should be set to -run
 
 In your config file, set the following:
 
-"rancher": { 
-  "host": "rancher_server_address",
-  "adminToken": "rancher_admin_token",
-  "insecure": true/optional,
-  "cleanup": true/optional,
-  "shellImage" : "rancher/shell:<Version>""
-}
+rancher:
+  host: "rancher_server_address" 
+  adminToken: "rancher_admin_token"
+  insecure: true/optional
+  cleanup: true/optional
+  shellImage : "rancher/shell:<Version>"
 
 While validating the shell P0 checks, set the shellImage version to the latest version. We validate the shell latest image that is available to that of the image we have on our rancher server.

--- a/tests/v2/validation/shell/shell_test.go
+++ b/tests/v2/validation/shell/shell_test.go
@@ -22,13 +22,13 @@ import (
 const (
 	cattleSystemNameSpace = "cattle-system"
 	shellName             = "shell-image"
+	clusterName           = "local"
 )
 
 type ShellTestSuite struct {
 	suite.Suite
-	client      *rancher.Client
-	session     *session.Session
-	clusterName string
+	client  *rancher.Client
+	session *session.Session
 }
 
 func (s *ShellTestSuite) TearDownSuite() {
@@ -43,11 +43,6 @@ func (s *ShellTestSuite) SetupSuite() {
 	require.NoError(s.T(), err)
 
 	s.client = client
-
-	// Get clusterName from config yaml
-	s.clusterName = client.RancherConfig.ClusterName
-	require.NoError(s.T(), err)
-
 }
 
 func (s *ShellTestSuite) TestShell() {
@@ -55,7 +50,7 @@ func (s *ShellTestSuite) TestShell() {
 	defer subSession.Cleanup()
 
 	s.Run("Verify the version of shell on local cluster", func() {
-		shellImage, err := settings.ShellVersion(s.client, s.clusterName, shellName)
+		shellImage, err := settings.ShellVersion(s.client, clusterName, shellName)
 		require.NoError(s.T(), err)
 		assert.Equal(s.T(), shellImage, s.client.RancherConfig.ShellImage)
 	})


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The existing Shell automation is pulling the cluster name from the config file, but these tests are only ever run on the local cluster. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
I've updated the `s.clusterName` to now be the string `"local"`

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)

Summary: Updated automation to use local cluster only