### PR TITLE
[2.9] configmap CRUD tests

### DIFF
--- a/tests/v2/validation/configmaps/configmaps.go
+++ b/tests/v2/validation/configmaps/configmaps.go
@@ -1,0 +1,47 @@
+package configmaps
+
+import (
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+
+	"github.com/rancher/shepherd/extensions/kubeapi/configmaps"
+)
+
+const (
+	namespace = "default"
+	labelKey  = "label1"
+	labelVal  = "autoLabel"
+	dataKey   = "foo"
+	dataVal   = "bar"
+	annoKey   = "anno1"
+	annoVal   = "automated annotation"
+	descKey   = "field.cattle.io/description"
+	descVal   = "automated configmap description"
+	cmName    = "steve-configmap"
+)
+
+func createConfigmap(client v1.SteveClient, name, namespace string, annotations, labels, data map[string]string) (v1.SteveAPIObject, error) {
+	configmapTemplate := configmaps.NewConfigmapTemplate(name, namespace, annotations, labels, data)
+	configMapObj, err := client.Create(configmapTemplate)
+
+	return *configMapObj, err
+}
+
+func updateConfigmapAnnotations(configMapClient v1.SteveClient, configmapObj v1.SteveAPIObject, newAnnotations map[string]string) (*v1.SteveAPIObject, error) {
+	newConfigmap := configmapObj
+	newConfigmap.ObjectMeta.Annotations = newAnnotations
+	updatedConfigMapObj, err := configMapClient.Update(&configmapObj, newConfigmap)
+
+	return updatedConfigMapObj, err
+}
+
+func getConfigMapLabelsAndAnnotations(actualResources map[string]string) map[string]string {
+	expectedResources := map[string]string{}
+
+	for resource := range actualResources {
+		if _, found := actualResources[resource]; found {
+			expectedResources[resource] = actualResources[resource]
+		}
+	}
+
+	return expectedResources
+}

--- a/tests/v2/validation/configmaps/configmaps_test.go
+++ b/tests/v2/validation/configmaps/configmaps_test.go
@@ -1,0 +1,112 @@
+package configmaps
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/configmaps"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigmapTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (cm *ConfigmapTestSuite) TearDownSuite() {
+	cm.session.Cleanup()
+}
+
+func (cm *ConfigmapTestSuite) SetupSuite() {
+	cm.session = session.NewSession()
+
+	client, err := rancher.NewClient("", cm.session)
+	require.NoError(cm.T(), err)
+	cm.client = client
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(cm.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(cm.client, clusterName)
+	require.NoError(cm.T(), err, "Error getting cluster ID")
+	cm.cluster, err = cm.client.Management.Cluster.ByID(clusterID)
+	require.NoError(cm.T(), err)
+}
+
+func (cm *ConfigmapTestSuite) TestConfigMapCreate() {
+	subSession := cm.session.NewSession()
+	defer subSession.Cleanup()
+
+	configMapClient := cm.client.Steve.SteveType(configmaps.ConfigMapSteveType)
+	configmapLabels := map[string]string{labelKey: labelVal}
+	configmapData := map[string]string{dataKey: dataVal}
+
+	log.Info("Creating a configmap")
+	configmapName := namegenerator.AppendRandomString(cmName)
+	configmapObj, err := createConfigmap(*configMapClient, configmapName, namespace, nil, configmapLabels, configmapData)
+	require.NoError(cm.T(), err)
+
+	log.Info("Validating configmap was created with correct resource values")
+	labels := getConfigMapLabelsAndAnnotations(configmapObj.ObjectMeta.Labels)
+	assert.Contains(cm.T(), configmapObj.Name, configmapName)
+	assert.Equal(cm.T(), labels, configmapLabels)
+}
+
+func (cm *ConfigmapTestSuite) TestConfigMapUpdate() {
+	subSession := cm.session.NewSession()
+	defer subSession.Cleanup()
+
+	configMapClient := cm.client.Steve.SteveType(configmaps.ConfigMapSteveType)
+	configmapLabels := map[string]string{labelKey: labelVal}
+	configmapData := map[string]string{dataKey: dataVal}
+	actualAnnotations := map[string]string{annoKey: annoVal, descKey: descVal}
+
+	log.Info(("Creating a configmap"))
+	configmapName := namegenerator.AppendRandomString(cmName)
+	configmapObj, err := createConfigmap(*configMapClient, configmapName, namespace, nil, configmapLabels, configmapData)
+	require.NoError(cm.T(), err)
+
+	log.Info("Updating the configmap")
+	updatedConfigMapObj, err := updateConfigmapAnnotations(*configMapClient, configmapObj, actualAnnotations)
+	require.NoError(cm.T(), err)
+
+	log.Info("Validating configmap was properly updated")
+	expectedAnnotations := getConfigMapLabelsAndAnnotations(updatedConfigMapObj.ObjectMeta.Annotations)
+	assert.Equal(cm.T(), expectedAnnotations, actualAnnotations)
+}
+
+func (cm *ConfigmapTestSuite) TestConfigmapDelete() {
+	subSession := cm.session.NewSession()
+	defer subSession.Cleanup()
+
+	configMapClient := cm.client.Steve.SteveType(configmaps.ConfigMapSteveType)
+	configmapLabels := map[string]string{labelKey: labelVal}
+	configmapData := map[string]string{dataKey: dataVal}
+
+	log.Info("Creating a configmap")
+	configmapName := namegenerator.AppendRandomString(cmName)
+	configmapObj, err := createConfigmap(*configMapClient, configmapName, namespace, nil, configmapLabels, configmapData)
+	require.NoError(cm.T(), err)
+
+	log.Info("Deleting the configmap")
+	err = configMapClient.Delete(&configmapObj)
+	require.NoError(cm.T(), err)
+
+	log.Info("Validating configmap was deleted")
+	configmapByID, err := configMapClient.ByID(configmapObj.ID)
+	require.Error(cm.T(), err)
+	assert.Nil(cm.T(), configmapByID)
+	assert.ErrorContains(cm.T(), err, "not found")
+}
+
+func TestConfigMapsSuite(t *testing.T) {
+	suite.Run(t, new(ConfigmapTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- resolves https://github.com/rancher/qa-tasks/issues/395
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The need for validation tests of configmap operations
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Created a new configmap_test file and added a function that runs through the CRUD operations for configmaps
create -> validate creation -> update -> validate update -> delete -> validate deletion

## Engineering Testing
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration (Go Framework)

Summary: Added test for configmap CRUD operations