### PR TITLE
[2.9] Clean up orphaned ClusterUserAttribute

### DIFF
--- a/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
@@ -5,6 +5,7 @@ import (
 
 	clusterv3 "github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3"
 	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +35,7 @@ func (h *clusterUserAttributeHandler) Sync(key string, clusterUserAttribute *clu
 					if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
 						return nil, fmt.Errorf("error deleting orphaned clusteruserattribute %s: %w", clusterUserAttribute.Name, err)
 					}
+					logrus.Infof("Deleted orphaned clusteruserattribute %s", clusterUserAttribute.Name)
 					return nil, nil
 				}
 				return nil, err

--- a/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
@@ -27,7 +27,7 @@ func (h *clusterUserAttributeHandler) Sync(key string, clusterUserAttribute *clu
 		// If the corresponding UserAttribute no longer exists, we need to clean up the ClusterUserAttribute.
 		if apierrors.IsNotFound(err) {
 			// There is a chance that it hasn't ended up in the cache yet so we try to get it afresh.
-			userAttribute, err = h.userAttribute.Get("", metav1.GetOptions{})
+			userAttribute, err = h.userAttribute.Get(clusterUserAttribute.Name, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					err = h.clusterUserAttribute.Delete(clusterUserAttribute.Name, &metav1.DeleteOptions{})

--- a/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
@@ -1,14 +1,19 @@
 package clusterauthtoken
 
 import (
+	"fmt"
+
 	clusterv3 "github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3"
 	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type clusterUserAttributeHandler struct {
-	userAttribute       managementv3.UserAttributeInterface
-	userAttributeLister managementv3.UserAttributeLister
+	userAttribute        managementv3.UserAttributeInterface
+	userAttributeLister  managementv3.UserAttributeLister
+	clusterUserAttribute clusterv3.ClusterUserAttributeInterface
 }
 
 // Sync clusterUserAttributes and userAttributes
@@ -17,15 +22,31 @@ func (h *clusterUserAttributeHandler) Sync(key string, clusterUserAttribute *clu
 		return nil, nil
 	}
 
+	userAttribute, err := h.userAttributeLister.Get("", clusterUserAttribute.Name)
+	if err != nil {
+		// If the corresponding UserAttribute no longer exists, we need to clean up the ClusterUserAttribute.
+		if apierrors.IsNotFound(err) {
+			// There is a chance that it hasn't ended up in the cache yet so we try to get it afresh.
+			userAttribute, err = h.userAttribute.Get("", metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					err = h.clusterUserAttribute.Delete(clusterUserAttribute.Name, &metav1.DeleteOptions{})
+					if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+						return nil, fmt.Errorf("error deleting orphaned clusteruserattribute %s: %w", clusterUserAttribute.Name, err)
+					}
+					return nil, nil
+				}
+				return nil, err
+			}
+			// The userAttribute exists, proceed.
+		} else {
+			return nil, err
+		}
+	}
+
 	if !clusterUserAttribute.NeedsRefresh {
 		return nil, nil
 	}
-
-	userAttribute, err := h.userAttributeLister.Get("", clusterUserAttribute.Name)
-	if err != nil {
-		return nil, err
-	}
-
 	if userAttribute.NeedsRefresh {
 		return nil, nil
 	}

--- a/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute_test.go
@@ -69,9 +69,9 @@ func TestClusterUserAttributeHandlerCleanup(t *testing.T) {
 }
 
 func TestClusterUserAttributeHandlerCleanupErrors(t *testing.T) {
-	name := "u-bdploclm4x"
+	attribName := "u-bdploclm4x"
 	someErr := fmt.Errorf("some error")
-	notFoundErr := apierrors.NewNotFound(managementv3.Resource("userattributes"), name)
+	notFoundErr := apierrors.NewNotFound(managementv3.Resource("userattributes"), attribName)
 
 	tests := []struct {
 		desc                          string
@@ -119,18 +119,27 @@ func TestClusterUserAttributeHandlerCleanupErrors(t *testing.T) {
 
 			userAttributes := &managementFakes.UserAttributeInterfaceMock{
 				GetFunc: func(name string, opts metav1.GetOptions) (*managementv3.UserAttribute, error) {
+					if name != attribName {
+						t.Errorf("Unexpected name in userAttributes.Get call: %s", name)
+					}
 					return nil, tt.userAttributeGetErr
 				},
 			}
 
 			userAttributeLister := &managementFakes.UserAttributeListerMock{
 				GetFunc: func(namespace string, name string) (*managementv3.UserAttribute, error) {
+					if name != attribName {
+						t.Errorf("Unexpected name in userAttributeLister.Get call: %s", name)
+					}
 					return nil, tt.userAttributeListerGetErr
 				},
 			}
 
 			clusterUserAttributes := &clusterFakes.ClusterUserAttributeInterfaceMock{
 				DeleteFunc: func(name string, opts *metav1.DeleteOptions) error {
+					if name != attribName {
+						t.Errorf("Unexpected name in clusterUserAttributes.Delete call: %s", name)
+					}
 					return tt.clusterUserAttributeDeleteErr
 				},
 			}
@@ -143,7 +152,7 @@ func TestClusterUserAttributeHandlerCleanupErrors(t *testing.T) {
 
 			_, err := handler.Sync("", &clusterv3.ClusterUserAttribute{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: attribName,
 				},
 			})
 			if tt.shouldErr {

--- a/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute_test.go
@@ -1,0 +1,164 @@
+package clusterauthtoken
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	clusterv3 "github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3"
+	clusterFakes "github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3/fakes"
+	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	managementFakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClusterUserAttributeHandlerCleanup(t *testing.T) {
+	clusterUserAttribute := &clusterv3.ClusterUserAttribute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "u-bdploclm4x",
+		},
+	}
+
+	var userAttributeGetCalledTimes int
+	userAttributes := &managementFakes.UserAttributeInterfaceMock{
+		GetFunc: func(name string, opts metav1.GetOptions) (*managementv3.UserAttribute, error) {
+			userAttributeGetCalledTimes++
+			return nil, apierrors.NewNotFound(managementv3.Resource("userattributes"), name)
+		},
+	}
+
+	var userAttributeListerGetCalledTimes int
+	userAttributeLister := &managementFakes.UserAttributeListerMock{
+		GetFunc: func(namespace string, name string) (*managementv3.UserAttribute, error) {
+			userAttributeListerGetCalledTimes++
+			return nil, apierrors.NewNotFound(managementv3.Resource("userattributes"), name)
+		},
+	}
+
+	var deleted bool
+	clusterUserAttributes := &clusterFakes.ClusterUserAttributeInterfaceMock{
+		DeleteFunc: func(name string, opts *metav1.DeleteOptions) error {
+			if name == clusterUserAttribute.Name {
+				deleted = true
+			}
+			return nil
+		},
+	}
+
+	handler := &clusterUserAttributeHandler{
+		userAttribute:        userAttributes,
+		userAttributeLister:  userAttributeLister,
+		clusterUserAttribute: clusterUserAttributes,
+	}
+
+	_, err := handler.Sync("", clusterUserAttribute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !deleted {
+		t.Error("Expected ClusterUserAttribute to be deleted")
+	}
+	if want, got := 1, userAttributeGetCalledTimes; want != got {
+		t.Errorf("Expected userAttributeGetCalledTimes %d got %d", want, got)
+	}
+	if want, got := 1, userAttributeListerGetCalledTimes; want != got {
+		t.Errorf("Expected userAttributeListerGetCalledTimes %d got %d", want, got)
+	}
+}
+
+func TestClusterUserAttributeHandlerCleanupErrors(t *testing.T) {
+	name := "u-bdploclm4x"
+	someErr := fmt.Errorf("some error")
+	notFoundErr := apierrors.NewNotFound(managementv3.Resource("userattributes"), name)
+
+	tests := []struct {
+		desc                          string
+		userAttributeGetErr           error
+		userAttributeListerGetErr     error
+		clusterUserAttributeDeleteErr error
+		shouldErr                     bool
+	}{
+		{
+			desc:                      "userAttributeListerGet error",
+			userAttributeListerGetErr: someErr,
+			shouldErr:                 true,
+		},
+		{
+			desc:                      "userAttributeGet error",
+			userAttributeListerGetErr: notFoundErr,
+			userAttributeGetErr:       someErr,
+			shouldErr:                 true,
+		},
+		{
+			desc:                          "userAttributeDelete error",
+			userAttributeGetErr:           notFoundErr,
+			userAttributeListerGetErr:     notFoundErr,
+			clusterUserAttributeDeleteErr: someErr,
+			shouldErr:                     true,
+		},
+		{
+			desc:                          "userAttributeDelete errors with NotFound",
+			userAttributeGetErr:           notFoundErr,
+			userAttributeListerGetErr:     notFoundErr,
+			clusterUserAttributeDeleteErr: notFoundErr,
+		},
+		{
+			desc:                          "userAttributeDelete errors with Gone",
+			userAttributeGetErr:           notFoundErr,
+			userAttributeListerGetErr:     notFoundErr,
+			clusterUserAttributeDeleteErr: apierrors.NewGone("gone"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			userAttributes := &managementFakes.UserAttributeInterfaceMock{
+				GetFunc: func(name string, opts metav1.GetOptions) (*managementv3.UserAttribute, error) {
+					return nil, tt.userAttributeGetErr
+				},
+			}
+
+			userAttributeLister := &managementFakes.UserAttributeListerMock{
+				GetFunc: func(namespace string, name string) (*managementv3.UserAttribute, error) {
+					return nil, tt.userAttributeListerGetErr
+				},
+			}
+
+			clusterUserAttributes := &clusterFakes.ClusterUserAttributeInterfaceMock{
+				DeleteFunc: func(name string, opts *metav1.DeleteOptions) error {
+					return tt.clusterUserAttributeDeleteErr
+				},
+			}
+
+			handler := &clusterUserAttributeHandler{
+				userAttribute:        userAttributes,
+				userAttributeLister:  userAttributeLister,
+				clusterUserAttribute: clusterUserAttributes,
+			}
+
+			_, err := handler.Sync("", &clusterv3.ClusterUserAttribute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			})
+			if tt.shouldErr {
+				if err == nil {
+					t.Fatal("Expected an error")
+				}
+
+				if !errors.Is(err, someErr) {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -93,6 +93,7 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext) {
 	cluster.Cluster.ClusterUserAttributes(namespace).AddHandler(ctx, "cat-cluster-user-attribute-controller", (&clusterUserAttributeHandler{
 		userAttribute,
 		userAttributeLister,
+		clusterUserAttribute,
 	}).Sync)
 }
 


### PR DESCRIPTION
Ref: https://github.com/rancher/rancher/issues/44914

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If the ClusterUserAttribute becomes orphaned the corresponding controller will spin not being able to find related UserAttribute.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Delete orphaned ClusterUserAttribute's. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A