### PR TITLE
[v2.8]Expose rancherversion while mcm disabled

### DIFF
--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -33,7 +33,6 @@ import (
 	"github.com/rancher/rancher/pkg/telemetry"
 	"github.com/rancher/rancher/pkg/tunnelserver/mcmauthorizer"
 	"github.com/rancher/rancher/pkg/types/config"
-	"github.com/rancher/rancher/pkg/version"
 	"github.com/rancher/steve/pkg/auth"
 )
 
@@ -86,7 +85,6 @@ func router(ctx context.Context, localClusterEnabled bool, tunnelAuthorizer *mcm
 	unauthed.Handle("/v3/settings/ui-pl", managementAPI).MatcherFunc(onlyGet)
 	unauthed.Handle("/v3/settings/ui-brand", managementAPI).MatcherFunc(onlyGet)
 	unauthed.Handle("/v3/settings/ui-default-landing", managementAPI).MatcherFunc(onlyGet)
-	unauthed.Handle("/rancherversion", version.NewVersionHandler())
 	unauthed.PathPrefix("/v1-{prefix}-release/channel").Handler(channelserver)
 	unauthed.PathPrefix("/v1-{prefix}-release/release").Handler(channelserver)
 	unauthed.PathPrefix("/v1-saml").Handler(saml.AuthHandler())

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -38,6 +38,7 @@ import (
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/tls"
 	"github.com/rancher/rancher/pkg/ui"
+	"github.com/rancher/rancher/pkg/version"
 	"github.com/rancher/rancher/pkg/websocket"
 	"github.com/rancher/rancher/pkg/wrangler"
 	aggregation2 "github.com/rancher/steve/pkg/aggregation"
@@ -247,7 +248,8 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 			wranglerContext.MultiClusterManager.Middleware,
 			authServer.Management,
 			additionalAPI,
-			requests.NewRequireAuthenticatedFilter("/v1/", "/v1/management.cattle.io.setting"),
+			requests.NewRequireAuthenticatedFilter("/v1/", "/v1/management.cattle.io.setting", "/rancherversion"),
+			version.NewVersionMiddleware,
 		}.Handler(steve),
 		Wrangler:   wranglerContext,
 		Steve:      steve,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+
+	"github.com/gorilla/mux"
 )
 
 var (
@@ -30,6 +32,13 @@ func FriendlyVersion() string {
 
 type versionHandler struct {
 	info Info
+}
+
+func NewVersionMiddleware(next http.Handler) http.Handler {
+	router := mux.NewRouter()
+	router.Handle("/rancherversion", NewVersionHandler())
+	router.NotFoundHandler = next
+	return router
 }
 
 // NewVersionHandler checks the runtime environment for the RANCHER_PRIME environment variable


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44940
 
## Problem
Unable to enable extensions in the mcm disabled setup. The root cause is that `/rancherversion` URI is not available when mcm disabled.
 
## Solution
Expose this URI whether the mcm is enabled or not.
 
## Testing
Tested manually

## Engineering Testing
### Manual Testing
Run Rancher without mcm enabled, and enable extension. And the Extensions page works properly.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: the origin URI can be accessed without auth, and it's changed in this PR.

* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_