### PR TITLE
Improve standard user default permissions

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -119,6 +119,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("get", "list", "watch")
 
+	userRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create")
+
 	rb.addRole("User Base", "user-base").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").
@@ -438,7 +440,6 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 
 func addUserRules(role *roleBuilder) *roleBuilder {
 	role.
-		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -92,6 +92,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	// restricted-admin will get cluster admin access to all downstream clusters but limited access to the local cluster
 	restrictedAdminRole := addUserRules(rb.addRole("Restricted Admin", "restricted-admin"))
 	restrictedAdminRole.
+		addRule().apiGroups("").resources("secret").verbs("create").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplaterevisions").verbs("*").
@@ -461,7 +462,6 @@ func addUserRules(role *roleBuilder) *roleBuilder {
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch")
-
 	return role
 }
 

--- a/pkg/data/management/rolebuilder.go
+++ b/pkg/data/management/rolebuilder.go
@@ -110,6 +110,10 @@ func (rb *roleBuilder) policyRules() []rbacv1.PolicyRule {
 }
 
 func (rb *roleBuilder) namespacedPolicyRules() map[string][]rbacv1.PolicyRule {
+	if len(rb.namespacedRules) == 0 {
+		return nil
+	}
+
 	nsRules := map[string][]rbacv1.PolicyRule{}
 	for _, n := range rb.namespacedRules {
 		var prs []rbacv1.PolicyRule
@@ -305,10 +309,11 @@ func (rb *roleBuilder) reconcileGlobalRoles(grClient wranglerv3.GlobalRoleClient
 
 	compareAndMod := func(haveGR *v3.GlobalRole, wantGR *v3.GlobalRole) (bool, *v3.GlobalRole, error) {
 		builtin := haveGR.Builtin == wantGR.Builtin
-		equal := builtin && haveGR.DisplayName == wantGR.DisplayName && reflect.DeepEqual(haveGR.Rules, wantGR.Rules)
+		equal := builtin && haveGR.DisplayName == wantGR.DisplayName && reflect.DeepEqual(haveGR.Rules, wantGR.Rules) && reflect.DeepEqual(haveGR.NamespacedRules, wantGR.NamespacedRules)
 
 		haveGR.DisplayName = wantGR.DisplayName
 		haveGR.Rules = wantGR.Rules
+		haveGR.NamespacedRules = wantGR.NamespacedRules
 		haveGR.Builtin = wantGR.Builtin
 
 		return equal, haveGR, nil

--- a/pkg/data/management/rolebuilder.go
+++ b/pkg/data/management/rolebuilder.go
@@ -31,6 +31,7 @@ type roleBuilder struct {
 	administrative    bool
 	roleTemplateNames []string
 	rules             []*ruleBuilder
+	namespacedRules   []*namespacedRuleBuilder
 }
 
 func (rb *roleBuilder) String() string {
@@ -78,6 +79,16 @@ func (rb *roleBuilder) addRule() *ruleBuilder {
 	return r
 }
 
+func (rb *roleBuilder) addNamespacedRule(namespace string) *namespacedRuleBuilder {
+	n := &namespacedRuleBuilder{
+		rb:         rb,
+		rules:      []*ruleBuilder{},
+		_namespace: namespace,
+	}
+	rb.namespacedRules = append(rb.namespacedRules, n)
+	return n
+}
+
 func (rb *roleBuilder) setRoleTemplateNames(names ...string) *roleBuilder {
 	rb.roleTemplateNames = names
 	return rb
@@ -96,6 +107,18 @@ func (rb *roleBuilder) policyRules() []rbacv1.PolicyRule {
 		prs = append(prs, r.toPolicyRule())
 	}
 	return prs
+}
+
+func (rb *roleBuilder) namespacedPolicyRules() map[string][]rbacv1.PolicyRule {
+	nsRules := map[string][]rbacv1.PolicyRule{}
+	for _, n := range rb.namespacedRules {
+		var prs []rbacv1.PolicyRule
+		for _, r := range n.rules {
+			prs = append(prs, r.toPolicyRule())
+		}
+		nsRules[n._namespace] = prs
+	}
+	return nsRules
 }
 
 type ruleBuilder struct {
@@ -170,6 +193,24 @@ func (r *ruleBuilder) toPolicyRule() rbacv1.PolicyRule {
 	}
 }
 
+type namespacedRuleBuilder struct {
+	rb         *roleBuilder
+	rules      []*ruleBuilder
+	_namespace string
+}
+
+func (n *namespacedRuleBuilder) String() string {
+	return fmt.Sprintf("namespace: %v, rules: %v", n._namespace, n.rules)
+}
+
+func (n *namespacedRuleBuilder) addRule() *ruleBuilder {
+	r := &ruleBuilder{
+		rb: n.rb,
+	}
+	n.rules = append(n.rules, r)
+	return r
+}
+
 // buildFnc takes in a roleBuilder and returns desired runtime.Objects.
 type buildFnc[T runtime.Object] func(thisRB *roleBuilder) (name string, object T)
 
@@ -239,9 +280,10 @@ func (rb *roleBuilder) reconcileGlobalRoles(grClient wranglerv3.GlobalRoleClient
 				Name:   current.name,
 				Labels: defaultGRLabel,
 			},
-			DisplayName: current.displayName,
-			Rules:       current.policyRules(),
-			Builtin:     current.builtin,
+			DisplayName:     current.displayName,
+			Rules:           current.policyRules(),
+			Builtin:         current.builtin,
+			NamespacedRules: current.namespacedPolicyRules(),
 		}
 		return gr.Name, gr
 	}

--- a/pkg/data/management/rolebuilder_test.go
+++ b/pkg/data/management/rolebuilder_test.go
@@ -69,6 +69,16 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 		Rules:       []rbacv1.PolicyRule{ruleReadPods},
 		Builtin:     true,
 	}
+	namespacedGR := &v3.GlobalRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "namespaced-gr",
+		},
+		DisplayName: "Namespaced GR",
+		NamespacedRules: map[string][]rbacv1.PolicyRule{
+			"namespace1": []rbacv1.PolicyRule{ruleReadPods},
+		},
+		Builtin: true,
+	}
 	tests := []struct {
 		name        string
 		grsToCreate []*v3.GlobalRole
@@ -76,7 +86,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "Create new GRB with no preexisting",
+			name:        "Create new GR with no preexisting",
 			grsToCreate: []*v3.GlobalRole{basicGR},
 			setup: func(mocks testMocks) {
 
@@ -93,7 +103,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:        "Create new GRB and append to existing",
+			name:        "Create new GR and append to existing",
 			grsToCreate: []*v3.GlobalRole{basicGR, adminGR},
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
@@ -110,7 +120,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:        "Create multiple new GRBs",
+			name:        "Create multiple new GRs",
 			grsToCreate: []*v3.GlobalRole{basicGR, readGR, adminGR},
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
@@ -134,9 +144,24 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 				)
 			},
 		},
-
 		{
-			name:        "Update existing GRB DisplayName",
+			name:        "Create GR with NamespacedRules",
+			grsToCreate: []*v3.GlobalRole{namespacedGR},
+			setup: func(mocks testMocks) {
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(&v3.GlobalRoleList{}, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
+				mocks.grClientMock.EXPECT().Create(ObjectMatcher(namespacedGR)).DoAndReturn(
+					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
+						require.EqualValues(mocks.t, namespacedGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, namespacedGR.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, namespacedGR.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, namespacedGR.NamespacedRules, toCreate.NamespacedRules, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing GR DisplayName",
 			grsToCreate: []*v3.GlobalRole{adminGR},
 			setup: func(mocks testMocks) {
 				oldAdmin := adminGR.DeepCopy()
@@ -153,7 +178,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:        "Update existing GRB Rules",
+			name:        "Update existing GR Rules",
 			grsToCreate: []*v3.GlobalRole{adminGR},
 			setup: func(mocks testMocks) {
 				oldAdmin := adminGR.DeepCopy()
@@ -170,7 +195,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:        "Delete existing GRB Rules",
+			name:        "Delete existing GR Rules",
 			grsToCreate: nil,
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
@@ -180,7 +205,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:    "Fail to delete existing GRB Rules",
+			name:    "Fail to delete existing GR Rules",
 			wantErr: true,
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
@@ -190,7 +215,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:    "Fail to list existing GRB Rules",
+			name:    "Fail to list existing GR Rules",
 			wantErr: true,
 			setup: func(mocks testMocks) {
 				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
@@ -198,7 +223,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:        "Fail to create new GRB",
+			name:        "Fail to create new GR",
 			grsToCreate: []*v3.GlobalRole{basicGR},
 			wantErr:     true,
 			setup: func(mocks testMocks) {
@@ -208,7 +233,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			},
 		},
 		{
-			name:        "Fail to update existing GRB",
+			name:        "Fail to update existing GR",
 			grsToCreate: []*v3.GlobalRole{adminGR},
 			wantErr:     true,
 			setup: func(mocks testMocks) {
@@ -553,10 +578,9 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 
 func addGlobalRole(builder *roleBuilder, roles ...*v3.GlobalRole) {
 	for _, gr := range roles {
-		addRules(
-			builder.addRole(gr.DisplayName, gr.Name),
-			gr.Rules...,
-		)
+		r := builder.addRole(gr.DisplayName, gr.Name)
+		addRules(r, gr.Rules...)
+		addNamespacedRules(builder, gr.NamespacedRules)
 	}
 }
 func addRoleTemplates(builder *roleBuilder, templates ...*v3.RoleTemplate) {
@@ -577,6 +601,19 @@ func addRules(builder *roleBuilder, rules ...rbacv1.PolicyRule) {
 		rb.resources(rule.Resources...)
 		rb.resourceNames(rule.ResourceNames...)
 		rb.nonResourceURLs(rule.NonResourceURLs...)
+	}
+}
+func addNamespacedRules(builder *roleBuilder, nsRules map[string][]rbacv1.PolicyRule) {
+	for ns, rules := range nsRules {
+		nsrb := builder.addNamespacedRule(ns)
+		for _, r := range rules {
+			rb := nsrb.addRule()
+			rb.verbs(r.Verbs...)
+			rb.apiGroups(r.APIGroups...)
+			rb.resources(r.Resources...)
+			rb.resourceNames(r.ResourceNames...)
+			rb.nonResourceURLs(r.NonResourceURLs...)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Standard users are able to create secrets in any namespace. While a collision is unlikely, a user could preempt where secrets get created and make one themselves, which could lead to some unexpected/undefined behaviour. However, they do need to be able to create secrets in the cattle-global-data namespace for cloud credentials.

## Solution

Using the new GlobalRole NamespacedRules field, I've moved the ability to create secrets from all namespaces, to just within the cattle-global-data namespace. That way they can't create secrets in any other namespace.

I chose not to add an opt-out flag. I think if a system would like their users to create secrets in any namespace, that should be added as an additional permission, not be granted by default. A release note will be added for this informing users of this change, but I personally think a standard user should only have enough permissions to do basic operations. Anything extra should be explicitly required.

## Testing

- Tested upgrading from an older version to a version with my change. It changes the global role immediately.
- Added more unit tests to ensure NamespacedRules get added/updated
- Ensured that restricted-admin rules remained the same.
