### PR TITLE
[v2.8] Bump dynamic listener to `v0.4.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/rancher/aks-operator v1.2.1
 	github.com/rancher/apiserver v0.0.0-20240207153744-69b3c2b56f3f
 	github.com/rancher/channelserver v0.6.1-0.20240212155841-07630c8295da
-	github.com/rancher/dynamiclistener v0.4.0-rc2
+	github.com/rancher/dynamiclistener v0.4.0
 	github.com/rancher/eks-operator v1.3.1
 	github.com/rancher/fleet/pkg/apis v0.9.1-rc.2.0.20240213164401-2c6b1019687c
 	github.com/rancher/gke-operator v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1615,8 +1615,8 @@ github.com/rancher/channelserver v0.6.1-0.20240212155841-07630c8295da h1:M7p9bmF
 github.com/rancher/channelserver v0.6.1-0.20240212155841-07630c8295da/go.mod h1:DuOeweH+bHP22OVq7mgQwDMVJjMmPNn8WzF1IHAU39U=
 github.com/rancher/client-go v1.28.6-rancher1 h1:nSoGKs12BuPviZtzemO7wTX8jxABaLqfYKFLRBV8MI0=
 github.com/rancher/client-go v1.28.6-rancher1/go.mod h1:+nu0Yp21Oeo/cBCsprNVXB2BfJTV51lFfe5tXl2rUL8=
-github.com/rancher/dynamiclistener v0.4.0-rc2 h1:tgBtNnQ2cQIsjBvto2BYmwP8NGpyg3N4Mp6zFyoGx9E=
-github.com/rancher/dynamiclistener v0.4.0-rc2/go.mod h1:Y+VdjQH9KQGE97uMwYEWqNN6puFQ17aBemIjVLYdlD8=
+github.com/rancher/dynamiclistener v0.4.0 h1:1bOlH4uzD5BPQ8fo2FeiWxiMp87ppwmyc2uYxN2z1kc=
+github.com/rancher/dynamiclistener v0.4.0/go.mod h1:Y+VdjQH9KQGE97uMwYEWqNN6puFQ17aBemIjVLYdlD8=
 github.com/rancher/eks-operator v1.3.1 h1:G7wcT8WuuCWPHWVu84d8W1/mLkxKhCUIljMzMKMTsJg=
 github.com/rancher/eks-operator v1.3.1/go.mod h1:CKOicULKDa3SxRdocK5bYEE0TZ4sgDFfIyfue7VZtZg=
 github.com/rancher/fleet/pkg/apis v0.9.1-rc.2.0.20240213164401-2c6b1019687c h1:Oza71YDPN+jE9WY8xRVthD3MYkVYHHgsTOAxGSb9OLs=


### PR DESCRIPTION
## Problem
`release/v2.8` is still using an RC version of the `dynamiclistener` dependency 
 
## Solution
Update `go.mod` to point to the non-rc `v0.4.0` tag of dynamic listener 
 
## Testing
The `v0.4.0` tag of dynamic listener uses the same commit as `v0.4.0-rc2`, so this bump does not change any functionality or invalidate any prior testing. 

## Engineering Testing
### Manual Testing

### Automated Testing

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->


Existing / newly added automated tests that provide evidence there are no regressions:
