### PR TITLE
[2.7] Fix Response Body Reading in Charts Validation Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
-	github.com/rancher/shepherd v0.0.0-20240326230256-f1bfd6f04888
+	github.com/rancher/shepherd v0.0.0-20240401195510-172b6023257d
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1042,8 +1042,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.15 h1:awAzHDwIbKDMEImgt8/DAYpbZlUWPI8TbKgq9AJDdBM=
 github.com/rancher/rke v1.4.15/go.mod h1:UIc898udZbjJ+0616CEmjqY+eBQSkW/dQ30ZvL7bUcQ=
-github.com/rancher/shepherd v0.0.0-20240326230256-f1bfd6f04888 h1:B5cS3L7/PqOLRuLOA72DO8cFenhFGacmJQUPpS1esDA=
-github.com/rancher/shepherd v0.0.0-20240326230256-f1bfd6f04888/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
+github.com/rancher/shepherd v0.0.0-20240401195510-172b6023257d h1:OAo3awo1H8u29Oj3kggIA7rwJI/XmfHoUI3vo2vSV3E=
+github.com/rancher/shepherd v0.0.0-20240401195510-172b6023257d/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a h1:Mawv3TfevX5dbVDlB/+RPgqxMX1HZQimyhj05R/Ef7U=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a/go.mod h1:tfdVny3lVO6H0JyysFBZ1ce45kH9VgWLPa9z9TZVI+U=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/charts/gatekeeper.go
+++ b/tests/v2/validation/charts/gatekeeper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -31,8 +32,7 @@ func getAuditTimestamp(client *rancher.Client, project *management.Project) erro
 	if err != nil {
 		return err
 	}
-	return wait.Poll(1*time.Second, 5*time.Minute, func() (done bool, err error) {
-
+	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 5*time.Minute, true, func(context.Context) (done bool, err error) {
 		// get list of constraints
 		auditList, err := steveClient.SteveType(ConstraintResourceSteveType).List(nil)
 		if err != nil {
@@ -53,5 +53,4 @@ func getAuditTimestamp(client *rancher.Client, project *management.Project) erro
 		}
 		return true, nil
 	})
-
 }

--- a/tests/v2/validation/charts/webhook_test.go
+++ b/tests/v2/validation/charts/webhook_test.go
@@ -47,7 +47,6 @@ func (w *WebhookTestSuite) SetupSuite() {
 	w.clusterName = client.RancherConfig.ClusterName
 	w.chartVersion, err = client.Catalog.GetLatestChartVersion(charts.RancherWebhookName, catalog.RancherChartRepo)
 	require.NoError(w.T(), err)
-
 }
 
 func (w *WebhookTestSuite) TestWebhookChart() {
@@ -78,7 +77,6 @@ func (w *WebhookTestSuite) TestWebhookChart() {
 		})
 
 		w.Run("Verify webhook pod logs", func() {
-
 			steveClient, err := w.client.Steve.ProxyDownstream(clusterID)
 			require.NoError(w.T(), err)
 
@@ -106,10 +104,8 @@ func (w *WebhookTestSuite) TestWebhookChart() {
 			log.Info("Count of webhook obtained for the cluster: ", tt.cluster, " is ", len(webhookList))
 			listStr := strings.Join(webhookList, ", ")
 			log.WithField("", listStr).Info("List of webhooks obtained for the ", tt.cluster)
-
 		})
 	}
-
 }
 
 func (w *WebhookTestSuite) TestWebhookEscalationCheck() {
@@ -132,7 +128,6 @@ func (w *WebhookTestSuite) TestWebhookEscalationCheck() {
 		assert.Contains(w.T(), err.Error(), errMessage)
 	})
 }
-
 
 func TestWebhookTestSuite(t *testing.T) {
 	suite.Run(t, new(WebhookTestSuite))


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/1114
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The charts test became flaky after recent HTTP call updates in external ingress helpers. The root cause; the body is drained as it's closed. But it's not read or stored anywhere. The same drained response body is used on the Rancher validation side, but it happens too late to read the body.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added read body part to the function where the HTTP call happens. And now it returns the body as a string for further use of the same body.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Provided offline.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)