### PR TITLE
update nutanix node driver to v3.6.0

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -134,7 +134,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	if err := addMachineDriver(SoftLayerDriver, "local://", "", "", nil, false, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(NutanixDriver, "https://github.com/nutanix/docker-machine/releases/download/v3.4.0/docker-machine-driver-nutanix", "https://nutanix.github.io/rancher-ui-driver/v3.4.0/component.js", "65dbf92e2df2b4c6d1a6b1f77c542f2cb13a052a62f236eeee697a1151ede62c", []string{"nutanix.github.io"}, false, false, false, management); err != nil {
+	if err := addMachineDriver(NutanixDriver, "https://github.com/nutanix/docker-machine/releases/download/v3.6.0/docker-machine-driver-nutanix", "https://nutanix.github.io/rancher-ui-driver/v3.6.0/component.js", "d9710fe31a1357d1bbd57539a4b0b00e3ab3550fcaeffea18cbc145cb4e9b22f", []string{"nutanix.github.io"}, false, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(OutscaleDriver, "https://github.com/outscale/docker-machine-driver-outscale/releases/download/v0.2.0/docker-machine-driver-outscale_0.2.0_linux_amd64.zip", "https://oos.eu-west-2.outscale.com/rancher-ui-driver-outscale/v0.2.0/component.js", "bb539ed4e2b0f1a1083b29cbdbab59bde3efed0a3145fefc0b2f47026c48bfe0", []string{"oos.eu-west-2.outscale.com"}, false, false, false, management); err != nil {


### PR DESCRIPTION
## Issue: #44984 
 
update Nutanix node driver to v3.6.0

## Testing

manual installation of the node driver and cluster deployment with it


![image](https://github.com/rancher/rancher/assets/180613/913c98b3-6502-4724-96ac-3b5337febbc0)

Driver is activated

<img width="735" alt="image" src="https://github.com/rancher/rancher/assets/180613/31ce2090-290b-44d8-916f-7f600f90a785">

RKE2 & RKE1 install succesfull

![image](https://github.com/rancher/rancher/assets/180613/9128be47-e7b5-4723-af2c-6c282f0658c1)


