### PR TITLE
Bump rancher-webhook to v0.5.0-rc7

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 104.0.0+up0.5.0-rc6
+webhookVersion: 104.0.0+up0.5.0-rc7
 cspAdapterMinVersion: 103.0.0+up3.0.0
 defaultShellVersion: rancher/shell:v0.1.22
 fleetVersion: 104.0.0+up0.10.0-rc.4

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,5 +6,5 @@ const (
 	CspAdapterMinVersion = "103.0.0+up3.0.0"
 	DefaultShellVersion  = "rancher/shell:v0.1.22"
 	FleetVersion         = "104.0.0+up0.10.0-rc.4"
-	WebhookVersion       = "104.0.0+up0.5.0-rc6"
+	WebhookVersion       = "104.0.0+up0.5.0-rc7"
 )


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43728

Also includes the CAPI removal from https://github.com/rancher/rancher/issues/43619

## Problem

We want k8s 1.28 support, so needed to remove CAPI webhook from inside webhook and bump the dependencies