### PR TITLE
[2.8] Add RBAC for statefulsets/scale for the Manage Workloads RoleTemplate

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -352,7 +352,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("").resources("pods", "pods/attach", "pods/exec", "pods/portforward", "pods/proxy", "replicationcontrollers",
 		"replicationcontrollers/scale").verbs("*").
 		addRule().apiGroups("apps").resources("daemonsets", "deployments", "deployments/rollback", "deployments/scale", "replicasets",
-		"replicasets/scale", "statefulsets").verbs("*").
+		"replicasets/scale", "statefulsets", "statefulsets/scale").verbs("*").
 		addRule().apiGroups("autoscaling").resources("horizontalpodautoscalers").verbs("*").
 		addRule().apiGroups("batch").resources("cronjobs", "jobs").verbs("*").
 		addRule().apiGroups("").resources("limitranges", "pods/log", "pods/status", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status", "bindings").verbs("get", "list", "watch").


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

https://github.com/rancher/rancher/issues/44918 which is the backport issue for https://github.com/rancher/rancher/issues/40303

 
## Problem
User unable to scale statefulsets when given "manage workloads"
 
## Solution
Add RBAC to allow the manage workloads role to have scale on statefulsets
 
## Testing
To test this:
Start up a Rancher instance (issue is 2.5, but you can certainly use something more modern, 2.7.x or 2.8.x).
Create standard user
Create a downstream cluster, project, and namespace.
Assign the user from above "manage workloads" permission in that project.
Create a statefulset inside that project/namespace.
Login as the standard user for which you have granted the manage workload permissions.
Navigate to the statefulset you created inside the project/namespace.
In the UI, the scale buttons will work.
If you try via kubectl (get a kubeconfig for the standard user): kubectl scale statefulset.apps/ -n --replicas=1 it will fail because no RBAC exists that grants those permissions.

Upgrade to a Rancher version that includes this fix.
The upgrade will patch-up the RBAC to include permission for scaling statefulsets for the "manage workloads" role.
After upgrade, the UI should have scale buttons that will still work.
Also, the kubectl command from above will also work since the RBAC now allows that operation.