### PR TITLE
[v2.8] Fix flaky nodescaling test cases + specify cluster types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	github.com/containers/image/v5 v5.25.0
 	github.com/google/gnostic-models v0.6.8
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240213233515-935d309ebad4
-	github.com/rancher/shepherd v0.0.0-20240405212128-578908d4308a
+	github.com/rancher/shepherd v0.0.0-20240408151625-d0c3b8dbe5dd
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1641,8 +1641,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.7 h1:pCVziDwgulQc2WgRkisY6sEo3DFGgu1StE66UbkuF2c=
 github.com/rancher/rke v1.5.7/go.mod h1:vojhOf8U8VCmw7y17OENWXSIfEFPEbXCMQcmI7xN7i8=
-github.com/rancher/shepherd v0.0.0-20240405212128-578908d4308a h1:VV4AyNyCQrkPtvSVa1rQL69+A/gyWTYFgWSkjuR4JGQ=
-github.com/rancher/shepherd v0.0.0-20240405212128-578908d4308a/go.mod h1:LNI7nH1BptYMvJmuqsLgmkMytGBBTpW4jk4vAHCxfF4=
+github.com/rancher/shepherd v0.0.0-20240408151625-d0c3b8dbe5dd h1:Nog4ViMD04zg6GP+5IvsthOIWqps7m6mdMnhIwWkPxA=
+github.com/rancher/shepherd v0.0.0-20240408151625-d0c3b8dbe5dd/go.mod h1:LNI7nH1BptYMvJmuqsLgmkMytGBBTpW4jk4vAHCxfF4=
 github.com/rancher/steve v0.0.0-20240305150728-3943409601f1 h1:6wNYy3q9jget45syTN6K2uOLSYaptLYCHscY2WRmhDI=
 github.com/rancher/steve v0.0.0-20240305150728-3943409601f1/go.mod h1:o4vLBzMTKbHHhIiAcbgOiaN3aK1vIjL6ZTgaGxQYpsY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/deleting/delete_cluster_rke1_test.go
+++ b/tests/v2/validation/deleting/delete_cluster_rke1_test.go
@@ -34,11 +34,20 @@ func (c *RKE1ClusterDeleteTestSuite) SetupSuite() {
 }
 
 func (c *RKE1ClusterDeleteTestSuite) TestDeletingRKE1Cluster() {
-	clusterID, err := clusters.GetClusterIDByName(c.client, c.client.RancherConfig.ClusterName)
-	require.NoError(c.T(), err)
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"Deleting cluster", c.client},
+	}
 
-	clusters.DeleteRKE1Cluster(c.client, clusterID)
-	provisioning.VerifyDeleteRKE1Cluster(c.T(), c.client, clusterID)
+	for _, tt := range tests {
+		clusterID, err := clusters.GetClusterIDByName(c.client, c.client.RancherConfig.ClusterName)
+		require.NoError(c.T(), err)
+
+		clusters.DeleteRKE1Cluster(tt.client, clusterID)
+		provisioning.VerifyDeleteRKE1Cluster(c.T(), tt.client, clusterID)
+	}
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/tests/v2/validation/deleting/delete_cluster_test.go
+++ b/tests/v2/validation/deleting/delete_cluster_test.go
@@ -3,9 +3,12 @@
 package deleting
 
 import (
+	"strings"
 	"testing"
 
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/pkg/session"
@@ -34,11 +37,35 @@ func (c *ClusterDeleteTestSuite) SetupSuite() {
 }
 
 func (c *ClusterDeleteTestSuite) TestDeletingCluster() {
-	clusterID, err := clusters.GetV1ProvisioningClusterByName(c.client, c.client.RancherConfig.ClusterName)
-	require.NoError(c.T(), err)
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"cluster", c.client},
+	}
 
-	clusters.DeleteK3SRKE2Cluster(c.client, clusterID)
-	provisioning.VerifyDeleteRKE2K3SCluster(c.T(), c.client, clusterID)
+	for _, tt := range tests {
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(c.client, c.client.RancherConfig.ClusterName)
+		require.NoError(c.T(), err)
+
+		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		require.NoError(c.T(), err)
+
+		updatedCluster := new(apisV1.Cluster)
+		err = v1.ConvertToK8sType(cluster, &updatedCluster)
+		require.NoError(c.T(), err)
+
+		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+			tt.name = "Deleting RKE2 " + tt.name
+		} else {
+			tt.name = "Deleting K3S " + tt.name
+		}
+
+		c.Run(tt.name, func() {
+			clusters.DeleteK3SRKE2Cluster(tt.client, clusterID)
+			provisioning.VerifyDeleteRKE2K3SCluster(c.T(), tt.client, clusterID)
+		})
+	}
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/tests/v2/validation/nodescaling/scale_replace_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scale_replace_rke1_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	nodepools "github.com/rancher/shepherd/extensions/rke1/nodepools"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type NodeScaleRKE1DownAndUp struct {
+type RKE1NodeReplacingTestSuite struct {
 	suite.Suite
 	session        *session.Session
 	client         *rancher.Client
@@ -21,11 +22,11 @@ type NodeScaleRKE1DownAndUp struct {
 	clustersConfig *provisioninginput.Config
 }
 
-func (s *NodeScaleRKE1DownAndUp) TearDownSuite() {
+func (s *RKE1NodeReplacingTestSuite) TearDownSuite() {
 	s.session.Cleanup()
 }
 
-func (s *NodeScaleRKE1DownAndUp) SetupSuite() {
+func (s *RKE1NodeReplacingTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	s.session = testSession
 
@@ -40,22 +41,42 @@ func (s *NodeScaleRKE1DownAndUp) SetupSuite() {
 	s.client = client
 }
 
-func (s *NodeScaleRKE1DownAndUp) TestEtcdScaleDownAndUp() {
-	s.Run("rke1-etcd-node-scale-down-and-up", func() {
-		ReplaceRKE1Nodes(s.T(), s.client, s.client.RancherConfig.ClusterName, true, false, false)
-	})
-}
-func (s *NodeScaleRKE1DownAndUp) TestWorkerScaleDownAndUp() {
-	s.Run("rke1-worker-node-scale-down-and-up", func() {
-		ReplaceRKE1Nodes(s.T(), s.client, s.client.RancherConfig.ClusterName, false, false, true)
-	})
-}
-func (s *NodeScaleRKE1DownAndUp) TestControlPlaneScaleDownAndUp() {
-	s.Run("rke1-controlplane-node-scale-down-and-up", func() {
-		ReplaceRKE1Nodes(s.T(), s.client, s.client.RancherConfig.ClusterName, false, true, false)
-	})
+func (s *RKE1NodeReplacingTestSuite) TestReplacingRKE1Nodes() {
+	nodeRolesEtcd := nodepools.NodeRoles{
+		Etcd:         true,
+		ControlPlane: false,
+		Worker:       false,
+	}
+
+	nodeRolesControlPlane := nodepools.NodeRoles{
+		Etcd:         false,
+		ControlPlane: true,
+		Worker:       false,
+	}
+
+	nodeRolesWorker := nodepools.NodeRoles{
+		Etcd:         false,
+		ControlPlane: false,
+		Worker:       true,
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles nodepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"Replacing control plane nodes", nodeRolesControlPlane, s.client},
+		{"Replacing etcd nodes", nodeRolesEtcd, s.client},
+		{"Replacing worker nodes", nodeRolesWorker, s.client},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			ReplaceRKE1Nodes(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.nodeRoles.Etcd, tt.nodeRoles.ControlPlane, tt.nodeRoles.Worker)
+		})
+	}
 }
 
-func TestRKE1NodeScaleDownAndUp(t *testing.T) {
-	suite.Run(t, new(NodeScaleRKE1DownAndUp))
+func TestRKE1NodeReplacingTestSuite(t *testing.T) {
+	suite.Run(t, new(RKE1NodeReplacingTestSuite))
 }

--- a/tests/v2/validation/nodescaling/scaling_custom_cluster_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scaling_custom_cluster_rke1_test.go
@@ -71,11 +71,11 @@ func (s *RKE1CustomClusterNodeScalingTestSuite) TestScalingRKE1CustomClusterNode
 		nodeRoles nodepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling custom RKE1 control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling custom RKE1 etcd by 1", nodeRolesEtcd, s.client},
-		{"Scaling custom RKE1 etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
-		{"Scaling custom RKE1 worker by 1", nodeRolesWorker, s.client},
-		{"Scaling custom RKE1 worker by 2", nodeRolesTwoWorkers, s.client},
+		{"Scaling custom control plane by 1", nodeRolesControlPlane, s.client},
+		{"Scaling custom etcd by 1", nodeRolesEtcd, s.client},
+		{"Scaling custom etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
+		{"Scaling custom worker by 1", nodeRolesWorker, s.client},
+		{"Scaling custom worker by 2", nodeRolesTwoWorkers, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_node_driver_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_rke1_test.go
@@ -65,10 +65,10 @@ func (s *RKE1NodeScalingTestSuite) TestScalingRKE1NodePools() {
 		nodeRoles nodepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling RKE1 control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling RKE1 etcd node by 1", nodeRolesEtcd, s.client},
-		{"Scaling RKE1 worker by 1", nodeRolesWorker, s.client},
-		{"Scaling RKE1 worker node machine by 2", nodeRolesTwoWorkers, s.client},
+		{"Scaling control plane by 1", nodeRolesControlPlane, s.client},
+		{"Scaling etcd node by 1", nodeRolesEtcd, s.client},
+		{"Scaling worker by 1", nodeRolesWorker, s.client},
+		{"Scaling worker node machine by 2", nodeRolesTwoWorkers, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_nodepools.go
+++ b/tests/v2/validation/nodescaling/scaling_nodepools.go
@@ -30,10 +30,13 @@ func scalingRKE2K3SNodePools(t *testing.T, client *rancher.Client, clusterID str
 	clusterResp, err := machinepools.ScaleMachinePoolNodes(client, cluster, nodeRoles)
 	require.NoError(t, err)
 
-	pods.VerifyReadyDaemonsetPods(t, client, cluster)
+	pods.VerifyReadyDaemonsetPods(t, client, clusterResp)
+
+	updatedCluster, err := client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+	require.NoError(t, err)
 
 	nodeRoles.Quantity = -nodeRoles.Quantity
-	scaledClusterResp, err := machinepools.ScaleMachinePoolNodes(client, clusterResp, nodeRoles)
+	scaledClusterResp, err := machinepools.ScaleMachinePoolNodes(client, updatedCluster, nodeRoles)
 	require.NoError(t, err)
 
 	pods.VerifyReadyDaemonsetPods(t, client, scaledClusterResp)

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -122,10 +122,10 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster()
 		{"2 nodes - etcd|cp roles per 1 node " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesShared, false, c.client.Flags.GetValue(environmentflag.Short) || c.client.Flags.GetValue(environmentflag.Long)},
 		{"3 nodes - 1 role per node " + provisioninginput.AdminClientName.String(), c.client, nodeRolesDedicated, false, c.client.Flags.GetValue(environmentflag.Long)},
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, false, c.client.Flags.GetValue(environmentflag.Long)},
-		{"4 nodes - 1 role per node + 1 windows worker" + provisioninginput.AdminClientName.String(), c.client, nodeRolesDedicatedWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
-		{"4 nodes - 1 role per node + 1 windows worker" + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicatedWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
-		{"5 nodes - 1 role per node + 2 windows workers" + provisioninginput.AdminClientName.String(), c.client, nodeRolesDedicatedTwoWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
-		{"5 nodes - 1 role per node + 2 windows workers" + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicatedTwoWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
+		{"4 nodes - 1 role per node + 1 windows worker " + provisioninginput.AdminClientName.String(), c.client, nodeRolesDedicatedWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
+		{"4 nodes - 1 role per node + 1 windows worker " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicatedWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
+		{"5 nodes - 1 role per node + 2 windows workers " + provisioninginput.AdminClientName.String(), c.client, nodeRolesDedicatedTwoWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
+		{"5 nodes - 1 role per node + 2 windows workers " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicatedTwoWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
 		if !tt.runFlag {

--- a/tests/v2/validation/snapshot/snapshot_additional_test.go
+++ b/tests/v2/validation/snapshot/snapshot_additional_test.go
@@ -3,9 +3,13 @@
 package snapshot
 
 import (
+	"strings"
 	"testing"
 
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 
 	"github.com/rancher/shepherd/pkg/config"
@@ -72,6 +76,24 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceWorkerNode() {
 	}
 
 	for _, tt := range tests {
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+		require.NoError(s.T(), err)
+
+		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		require.NoError(s.T(), err)
+
+		updatedCluster := new(apisV1.Cluster)
+		err = v1.ConvertToK8sType(cluster, &updatedCluster)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+			tt.name = "RKE2 " + tt.name
+		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+			tt.name = "K3S " + tt.name
+		} else {
+			tt.name = "RKE1 " + tt.name
+		}
+
 		s.Run(tt.name, func() {
 			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
 		})
@@ -95,6 +117,24 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotRecurringRestores() {
 	}
 
 	for _, tt := range tests {
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+		require.NoError(s.T(), err)
+
+		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		require.NoError(s.T(), err)
+
+		updatedCluster := new(apisV1.Cluster)
+		err = v1.ConvertToK8sType(cluster, &updatedCluster)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+			tt.name = "RKE2 " + tt.name
+		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+			tt.name = "K3S " + tt.name
+		} else {
+			tt.name = "RKE1 " + tt.name
+		}
+
 		s.Run(tt.name, func() {
 			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
 		})

--- a/tests/v2/validation/snapshot/snapshot_restore_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_test.go
@@ -3,9 +3,13 @@
 package snapshot
 
 import (
+	"strings"
 	"testing"
 
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 
 	"github.com/rancher/shepherd/pkg/config"
@@ -56,6 +60,24 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 	}
 
 	for _, tt := range tests {
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+		require.NoError(s.T(), err)
+
+		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		require.NoError(s.T(), err)
+
+		updatedCluster := new(apisV1.Cluster)
+		err = v1.ConvertToK8sType(cluster, &updatedCluster)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+			tt.name = "RKE2 " + tt.name
+		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+			tt.name = "K3S " + tt.name
+		} else {
+			tt.name = "RKE1 " + tt.name
+		}
+
 		s.Run(tt.name, func() {
 			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
 		})

--- a/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -3,9 +3,13 @@
 package snapshot
 
 import (
+	"strings"
 	"testing"
 
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 
 	"github.com/rancher/shepherd/pkg/config"
@@ -72,6 +76,24 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 	}
 
 	for _, tt := range tests {
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+		require.NoError(s.T(), err)
+
+		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		require.NoError(s.T(), err)
+
+		updatedCluster := new(apisV1.Cluster)
+		err = v1.ConvertToK8sType(cluster, &updatedCluster)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+			tt.name = "RKE2 " + tt.name
+		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+			tt.name = "K3S " + tt.name
+		} else {
+			tt.name = "RKE1 " + tt.name
+		}
+
 		s.Run(tt.name, func() {
 			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot)
 		})


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Fix Flaky Scaling Tests](https://github.com/rancher/qa-tasks/issues/1113)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
During release testing, there were several issues seen with custom clusters and node driver for the `nodescaling` package. Additionally, there wasn't a way to see which cluster type is being ran for the `nodescaling` and `snapshot` package.

This makes it hard for Qase for reviewers to see exactly what cluster type was being ran against tests.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Addressed flakiness with nodescaling in counterpart shepherd PR with this
- Specified cluster types in test case names
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
- Ran against RKE1/RKE2/K3S for node scaling - custom cluster and node driver
- Ran snapshot test for each cluster type and made sure it is made clear in the test case header which cluster type is being used