### PR TITLE
[2.9] Add origin for `mirrored-sig-storage-csi-snapshotter`

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -206,6 +206,7 @@ var OriginMap = map[string]string{
 	"mirrored-sig-storage-csi-provisioner":                    "https://github.com/kubernetes-csi/external-provisioner",
 	"mirrored-sig-storage-csi-resizer":                        "https://github.com/kubernetes-csi/external-resizer",
 	"mirrored-sig-storage-livenessprobe":                      "https://github.com/kubernetes-csi/livenessprobe",
+	"mirrored-sig-storage-csi-snapshotter":                    "https://github.com/kubernetes-csi/external-snapshotter",
 	"mirrored-sig-storage-snapshot-controller":                "https://github.com/kubernetes-csi/external-snapshotter",
 	"mirrored-sig-storage-snapshot-validation-webhook":        "https://github.com/kubernetes-csi/external-snapshotter",
 	"mirrored-sigwindowstools-k8s-gmsa-webhook":               "https://github.com/kubernetes-sigs/windows-gmsa/tree/master/admission-webhook",


### PR DESCRIPTION
Charts PR https://github.com/rancher/charts/pull/3654 introduced a new image `mirrored-sig-storage-csi-snapshotter` which is not tracked in the origins list, resulting in https://drone-publish.rancher.io/rancher/rancher/11965/6/2. This PR adds the origin of that image. This will be backported to other release lines once merged 