### PR TITLE
[v2.8] Add `mirrored-sig-storage-csi-snapshotter` origin

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -208,6 +208,7 @@ var OriginMap = map[string]string{
 	"mirrored-sig-storage-csi-provisioner":                    "https://github.com/kubernetes-csi/external-provisioner",
 	"mirrored-sig-storage-csi-resizer":                        "https://github.com/kubernetes-csi/external-resizer",
 	"mirrored-sig-storage-livenessprobe":                      "https://github.com/kubernetes-csi/livenessprobe",
+	"mirrored-sig-storage-csi-snapshotter":                    "https://github.com/kubernetes-csi/external-snapshotter",
 	"mirrored-sig-storage-snapshot-controller":                "https://github.com/kubernetes-csi/external-snapshotter",
 	"mirrored-sig-storage-snapshot-validation-webhook":        "https://github.com/kubernetes-csi/external-snapshotter",
 	"mirrored-sigwindowstools-k8s-gmsa-webhook":               "https://github.com/kubernetes-sigs/windows-gmsa/tree/master/admission-webhook",


### PR DESCRIPTION
backport of https://github.com/rancher/rancher/pull/45048