### PR TITLE
Add origin for mirrored-prometheus-windows-exporter

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -201,6 +201,7 @@ var OriginMap = map[string]string{
 	"mirrored-prometheus-operator-prometheus-config-reloader": "https://github.com/prometheus-operator/prometheus-operator/pkgs/container/prometheus-config-reloader",
 	"mirrored-prometheus-operator-prometheus-operator":        "https://github.com/prometheus-operator/prometheus-operator",
 	"mirrored-prometheus-prometheus":                          "https://github.com/prometheus/prometheus",
+	"mirrored-prometheus-windows-exporter":                    "https://github.com/prometheus-community/windows_exporter",
 	"mirrored-pstauffer-curl":                                 "https://github.com/pstauffer/docker-curl",
 	"mirrored-s3gw-s3gw":                                      "https://github.com/aquarist-labs/s3gw",
 	"mirrored-sig-storage-csi-attacher":                       "https://github.com/kubernetes-csi/external-attacher",


### PR DESCRIPTION
## Issue: https://github.com/rancher/windows/issues/234
#### Relates to: https://github.com/rancher/charts/pull/3607

## Problem
The windows exporter sub-chart of the rancher monitoring chart is transitioning from a complete reimplementation to simply patching the upstream chart. As a part of this, we will no longer need to use the custom windows_exporter image produced from https://github.com/rancher/windows_exporter-package, and will instead used the mirrored image `mirrored-prometheus-windows-exporter`
 
## Solution
We need to track the new image before it is added to a chart consumed by rancher. This does not need to be back ported as this image will only be used in 2.9+. 
 
## Testing

## Engineering Testing
### Manual Testing


### Automated Testing

## QA Testing Considerations

 
### Regressions Considerations


Existing / newly added automated tests that provide evidence there are no regressions:
