### PR TITLE
Fix local ha upgrade job failures

### DIFF
--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -52,6 +52,10 @@ func (u *UpgradeWorkloadTestSuite) SetupSuite() {
 
 func (u *UpgradeWorkloadTestSuite) TestWorkloadPreUpgrade() {
 	for _, cluster := range u.clusters {
+		if cluster.Name == "local" {
+			u.T().Skip()
+		}
+
 		cluster := cluster
 		names := newNames()
 		u.Run(cluster.Name, func() {
@@ -62,6 +66,10 @@ func (u *UpgradeWorkloadTestSuite) TestWorkloadPreUpgrade() {
 
 func (u *UpgradeWorkloadTestSuite) TestWorkloadPostUpgrade() {
 	for _, cluster := range u.clusters {
+		if cluster.Name == "local" {
+			u.T().Skip()
+		}
+
 		cluster := cluster
 		names := newNames()
 		u.Run(cluster.Name, func() {


### PR DESCRIPTION
local ha upgrade job is failing, due to running workloadPreUpgrade and workloadPostUpgrade checks against the local cluster, which were intended for downstream clusters only.  Local cluster should only be upgraded, and pre/post workload checks should occur on downstream clusters only.

Solution:
- add validation to skip workloadPreUpgrade/workloadPostUpgrade if the targeted cluster is "local"