### PR TITLE
Fix local ha upgrade jenkins job failures

### DIFF
--- a/tests/v2/validation/upgrade/workload.go
+++ b/tests/v2/validation/upgrade/workload.go
@@ -244,16 +244,21 @@ func checkPrefix(name string, prefix string) bool {
 	return strings.HasPrefix(name, prefix)
 }
 
-// validateDaemonset checks daemonset available number is equal to the number of workers in the cluster
+// validateDaemonset checks that the available number of daemonsets equals the number of workers in a downstream cluster or the number of nodes in the local cluster
 func validateDaemonset(t *testing.T, client *rancher.Client, clusterID, namespaceName, daemonsetName string) {
 	t.Helper()
 
-	workerNodesCollection, err := client.Management.Node.List(&types.ListOpts{
+	listFilter := &types.ListOpts{
 		Filters: map[string]interface{}{
 			"clusterId": clusterID,
-			"worker":    true,
 		},
-	})
+	}
+
+	if clusterID != local {
+		listFilter.Filters["worker"] = true
+	}
+
+	nodesCollection, err := client.Management.Node.List(listFilter)
 	require.NoError(t, err)
 
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)
@@ -267,7 +272,8 @@ func validateDaemonset(t *testing.T, client *rancher.Client, clusterID, namespac
 	err = v1.ConvertToK8sType(daemonsetResp.Status, daemonsetStatus)
 	require.NoError(t, err)
 
-	assert.Equalf(t, int(daemonsetStatus.NumberAvailable), len(workerNodesCollection.Data), "Daemonset %v doesn't have the required ready", daemonsetName)
+	assert.Equalf(t, int(daemonsetStatus.NumberAvailable), len(nodesCollection.Data), "Daemonset %v doesn't have the required ready", daemonsetName)
+
 }
 
 // newNames returns a new resourceNames struct


### PR DESCRIPTION
**Issue**
local ha upgrade job was failing workload checks for `daemonSets` in the local cluster due to `worker` node filtering.  For example, if 3 `server_nodes` are requested for the local cluster with no `agent_nodes`, the daemonSets are deployed on the `server_nodes`, and the validation check filters out `server_nodes` to explicitly target the `workers` (agent_nodes). So in this example, the test will fail, expecting 3 replicas, and only finding 0.

**Solution**:
enhance job to check `daemonSets` against the total number of nodes, for the local cluster.  This will function as expected now, regardless of the number of `server_nodes` and `agent_nodes` requested for the local cluster. 

So, with the fix: 
- if 3 `server_nodes` are requested as the local cluster, validation will ensure 3 `daemonSets` are found in the local cluster.  
- If 3 `server_nodes` and 3 `agent_nodes` are requested as the local cluster, validation will ensure 6 `daemonSets` are found for the local cluster.

Also, this change does not affect the previous behavior w/ downstream testing.  Only changes the validation logic for the local cluster