### PR TITLE
Fix build after ToRESTConfig signature change

### DIFF
--- a/pkg/auth/requests/service_account.go
+++ b/pkg/auth/requests/service_account.go
@@ -26,7 +26,7 @@ import (
 )
 
 type (
-	restConfigGetter  func(cluster *mgmtv3.Cluster, context *config.ScaledContext, secretLister corev1.SecretLister) (*rest.Config, error)
+	restConfigGetter  func(cluster *mgmtv3.Cluster, context *config.ScaledContext, secretLister corev1.SecretLister, tryReconnecting bool) (*rest.Config, error)
 	authClientCreator func(clusterID string) (kubernetes.Interface, error)
 )
 

--- a/pkg/auth/requests/service_account_test.go
+++ b/pkg/auth/requests/service_account_test.go
@@ -249,7 +249,7 @@ func TestAuthenticate(t *testing.T) {
 					},
 				},
 				secretLister: nil,
-				restConfigGetter: func(cluster *v3.Cluster, context *config.ScaledContext, secretLister corev1.SecretLister) (*rest.Config, error) {
+				restConfigGetter: func(cluster *v3.Cluster, context *config.ScaledContext, secretLister corev1.SecretLister, tryReconnecting bool) (*rest.Config, error) {
 					return &rest.Config{}, nil
 				},
 				authClientCreator: func(clusterID string) (kubernetes.Interface, error) {


### PR DESCRIPTION
## Problem

https://github.com/rancher/rancher/pull/44925 broke the build - for some reason it was not caught by CI.

```
+ go build -tags k8s -gcflags=all= -ldflags '-X github.com/rancher/rancher/pkg/version.Version=6cb38f2fa
   -X github.com/rancher/rancher/pkg/version.GitCommit=6cb38f2fa
   -X github.com/rancher/rancher/pkg/settings.InjectDefaults={"rke-version":"v1.5.3"} -extldflags -static -s' -o bin/rancher
...
...
# github.com/rancher/rancher/pkg/multiclustermanager
pkg/multiclustermanager/routes.go:97:76: cannot use clustermanager.ToRESTConfig (value of type func(cluster *"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3".Cluster, context *"github.com/rancher/rancher/pkg/types/config".ScaledContext, secretLister "github.com/rancher/rancher/pkg/generated/norman/core/v1".SecretLister, reconnect bool) (*"k8s.io/client-go/rest".Config, error)) as requests.restConfigGetter value in argument to requests.NewServiceAccountAuth
```

Fix is trivial - add a missing parameter.

