### PR TITLE
[v2.9] Make eula-agreed setting known to Rancher

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -275,6 +275,8 @@ var (
 	// This setting is for development purposes only.
 	SkipHostedClusterChartInstallation = NewSetting("skip-hosted-cluster-chart-installation", os.Getenv("CATTLE_SKIP_HOSTED_CLUSTER_CHART_INSTALLATION"))
 	MachineProvisionImagePullPolicy    = NewSetting("machine-provision-image-pull-policy", string(v1.PullAlways))
+	// EULAAgreed is used only by the UI, but needs to be known to Rancher so that it's not removed.
+	EULAAgreed = NewSetting("eula-agreed", "")
 )
 
 // FullShellImage returns the full private registry name of the rancher shell image.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/43103
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Since rancher v2.8 we mark (#43989) unknown settings with a label and remove (#44070) them in v2.9.
`eula-agreed` settings is used by UI but is not known to the rancher and therefore will be removed in v2.9.

```
2024/04/10 15:40:10 [WARNING] Unknown setting eula-agreed
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add this setting so that rancher knows about it.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A