### PR TITLE
Flatten conditionals in ClusterUserAttribute controller

### DIFF
--- a/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/cluster_user_attribute.go
@@ -26,24 +26,26 @@ func (h *clusterUserAttributeHandler) Sync(key string, clusterUserAttribute *clu
 	userAttribute, err := h.userAttributeLister.Get("", clusterUserAttribute.Name)
 	if err != nil {
 		// If the corresponding UserAttribute no longer exists, we need to clean up the ClusterUserAttribute.
-		if apierrors.IsNotFound(err) {
-			// There is a chance that it hasn't ended up in the cache yet so we try to get it afresh.
-			userAttribute, err = h.userAttribute.Get(clusterUserAttribute.Name, metav1.GetOptions{})
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					err = h.clusterUserAttribute.Delete(clusterUserAttribute.Name, &metav1.DeleteOptions{})
-					if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
-						return nil, fmt.Errorf("error deleting orphaned clusteruserattribute %s: %w", clusterUserAttribute.Name, err)
-					}
-					logrus.Infof("Deleted orphaned clusteruserattribute %s", clusterUserAttribute.Name)
-					return nil, nil
-				}
-				return nil, err
-			}
-			// The userAttribute exists, proceed.
-		} else {
+		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
+
+		// There is a chance that it hasn't ended up in the cache yet so we try to get it afresh.
+		userAttribute, err = h.userAttribute.Get(clusterUserAttribute.Name, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, err
+			}
+
+			err = h.clusterUserAttribute.Delete(clusterUserAttribute.Name, &metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+				return nil, fmt.Errorf("error deleting orphaned clusteruserattribute %s: %w", clusterUserAttribute.Name, err)
+			}
+
+			logrus.Infof("Deleted orphaned clusteruserattribute %s", clusterUserAttribute.Name)
+			return nil, nil
+		}
+		// The userAttribute exists, proceed.
 	}
 
 	if !clusterUserAttribute.NeedsRefresh {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

This is a forward port of d0d4b45317efa3e63ba24b57dada651811270f69 from #44990 that minimizes the code indentation in ClusterUserAttribute controller.

Original issue https://github.com/rancher/rancher/issues/44914

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A