### PR TITLE
Update Jenkinsfiles to use env vars in config for sensitive params

### DIFF
--- a/tests/v2/validation/Jenkinsfile
+++ b/tests/v2/validation/Jenkinsfile
@@ -14,6 +14,7 @@ node {
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
     def branch = "release/v2.8"
+    def config = env.CONFIG
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }
@@ -94,6 +95,14 @@ node {
           dir ("./") {
             try {
               stage('Configure and Build') {
+                config = config.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)
+                config = config.replace('${AWS_ACCESS_KEY_ID}', env.AWS_ACCESS_KEY_ID)
+                config = config.replace('${AWS_IAM_PROFILE}', env.AWS_IAM_PROFILE)
+                config = config.replace('${AWS_REGION}', env.AWS_REGION)
+                config = config.replace('${AWS_VPC}', env.AWS_VPC)
+                config = config.replace('${AWS_SECURITY_GROUPS}', env.AWS_SECURITY_GROUPS)
+                config = config.replace('${ADMIN_PASSWORD}', env.ADMIN_PASSWORD)
+
                 if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
                   dir("./tests/v2/validation/.ssh") {
                     def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
@@ -103,9 +112,8 @@ node {
 
                 dir("./tests/v2/validation") {
                   def filename = "config.yaml"
-                  def configContents = env.CONFIG
 
-                  writeFile file: filename, text: configContents
+                  writeFile file: filename, text: config
                   env.CATTLE_TEST_CONFIG = rootPath+filename
                 }
 

--- a/tests/v2/validation/Jenkinsfile.e2e
+++ b/tests/v2/validation/Jenkinsfile.e2e
@@ -19,6 +19,7 @@ node {
     def rancherConfig = "rancher_env.config"
     def branch = "release/v2.8"
     def corralBranch = "main"
+    def config = env.CONFIG
     def cleanup = env.RANCHER_CLEANUP.toLowerCase()
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
@@ -103,6 +104,14 @@ node {
           }
           dir ("./") {
             stage('Configure and Build') {
+              config = config.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)
+              config = config.replace('${AWS_ACCESS_KEY_ID}', env.AWS_ACCESS_KEY_ID)
+              config = config.replace('${AWS_IAM_PROFILE}', env.AWS_IAM_PROFILE)
+              config = config.replace('${AWS_REGION}', env.AWS_REGION)
+              config = config.replace('${AWS_VPC}', env.AWS_VPC)
+              config = config.replace('${AWS_SECURITY_GROUPS}', env.AWS_SECURITY_GROUPS)
+              config = config.replace('${ADMIN_PASSWORD}', env.ADMIN_PASSWORD)
+
               if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
                 dir("./rancher/tests/v2/validation/.ssh") {
                   def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
@@ -111,9 +120,8 @@ node {
               }
               dir("./rancher/tests/v2/validation") {
                 def filename = "config.yaml"
-                def configContents = env.CONFIG
 
-                writeFile file: filename, text: configContents
+                writeFile file: filename, text: config
                 env.CATTLE_TEST_CONFIG = "${workPath}"+filename
               }
               dir ("./") {

--- a/tests/v2/validation/Jenkinsfile_pre_post_upgrade
+++ b/tests/v2/validation/Jenkinsfile_pre_post_upgrade
@@ -17,6 +17,7 @@ node {
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
     def branch = "release/v2.8"
+    def config = env.CONFIG
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }
@@ -97,6 +98,14 @@ node {
           dir ("./") {
             try {
               stage('Configure and Build') {
+                config = config.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)
+                config = config.replace('${AWS_ACCESS_KEY_ID}', env.AWS_ACCESS_KEY_ID)
+                config = config.replace('${AWS_IAM_PROFILE}', env.AWS_IAM_PROFILE)
+                config = config.replace('${AWS_REGION}', env.AWS_REGION)
+                config = config.replace('${AWS_VPC}', env.AWS_VPC)
+                config = config.replace('${AWS_SECURITY_GROUPS}', env.AWS_SECURITY_GROUPS)
+                config = config.replace('${ADMIN_PASSWORD}', env.ADMIN_PASSWORD)
+
                 if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
                   dir("./tests/v2/validation/.ssh") {
                     def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
@@ -106,9 +115,8 @@ node {
 
                 dir("./tests/v2/validation") {
                   def filename = "config.yaml"
-                  def configContents = env.CONFIG
 
-                  writeFile file: filename, text: configContents
+                  writeFile file: filename, text: config
                   env.CATTLE_TEST_CONFIG = "/go/src/github.com/rancher/rancher/tests/v2/validation/"+filename
                 }
 

--- a/tests/v2/validation/Jenkinsfile_vpn
+++ b/tests/v2/validation/Jenkinsfile_vpn
@@ -13,6 +13,7 @@ node {
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
     def branch = "release/v2.8"
+    def config = env.CONFIG
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }
@@ -93,6 +94,14 @@ node {
       dir ("./") {
         try {
           stage('Configure and Build') {
+            config = config.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)
+            config = config.replace('${AWS_ACCESS_KEY_ID}', env.AWS_ACCESS_KEY_ID)
+            config = config.replace('${AWS_IAM_PROFILE}', env.AWS_IAM_PROFILE)
+            config = config.replace('${AWS_REGION}', env.AWS_REGION)
+            config = config.replace('${AWS_VPC}', env.AWS_VPC)
+            config = config.replace('${AWS_SECURITY_GROUPS}', env.AWS_SECURITY_GROUPS)
+            config = config.replace('${ADMIN_PASSWORD}', env.ADMIN_PASSWORD)
+
             if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
               dir("./tests/v2/validation/.ssh") {
                 def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
@@ -102,9 +111,8 @@ node {
 
             dir("./tests/v2/validation") {
               def filename = "config.yaml"
-              def configContents = env.CONFIG
 
-              writeFile file: filename, text: configContents
+              writeFile file: filename, text: config
               env.CATTLE_TEST_CONFIG = rootPath+filename
             }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
N/A
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The way these Jenkinsfiles are defined requires passing in things like your own AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, which could be a security risk as those would be in plaintext. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This updates Jenkinsfiles to use the method already defined in `Jenkinsfile.recurring`
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Jenkinsfile.recurring has been working, so did not perform any additional testing.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
None -- I would've had to modify jobs that use these manually. I don't have as much of the domain expertise to be able to do this quickly/efficiently for this small change where that level of manual testing felt unnecessary.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: This affects multiple automated tests that are run in Jenkins.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Run tests in Jenkins
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Things could fail in Jenkins.

Existing / newly added automated tests that provide evidence there are no regressions:
Jenkinsfile.recurring