### PR TITLE
[2.9] adding an import test to the go framework

### DIFF
--- a/tests/v2/validation/provisioning/import/README.md
+++ b/tests/v2/validation/provisioning/import/README.md
@@ -1,0 +1,58 @@
+# Import Provisioning Config
+
+For your config, you will need everything in the Prerequisites section on the previous readme, [Define your test](#provisioning-input), and a corral config that points to a package that builds a functional cluster and has a `kubeconfig` var once the corral has built successfully. This test is setup to run the k3s corral-package, but technically as long as the corral is successful and finishes with a valid `kubeconfig`, the cluster import job will still operate properly and successfully. 
+
+Your GO test_package should be set to `provisioning/import`.
+Your GO suite should be set to `-run ^TestImportProvisioningTestSuite$`.
+Please see below for more details for your config. 
+
+
+## Table of Contents
+1. [Prerequisites](../README.md)
+2. [Configuring test flags](#Flags)
+3. [Define your Corral](#corral-input)
+4. [Back to general provisioning](../README.md)
+
+## Flags
+Flags are used to determine which static table tests are run (has no effect on dynamic tests) 
+`Long` Will run the long version of the table tests (usually all of them)
+`Short` Will run the subset of table tests with the short flag.
+
+```yaml
+flags:
+  desiredflags: "Long"   #required (static tests only)
+```
+
+## Corral Input
+
+```yaml
+
+corralConfigs:
+    corralConfigVars:
+        agent_count: 0
+        aws_access_key: "your_key"
+        aws_ami: "your_ami"
+        aws_hostname_prefix: autoimport
+        aws_region: us-west-1
+        aws_route53_zone: "your_zone"
+        aws_secret_key: "your_secret_key"
+        aws_security_group: "your_security_group"
+        aws_ssh_user: "your_user"
+        aws_subnet: "your_subnet"
+        aws_volume_size: 50
+        aws_volume_type: gp3
+        hostname: "your_hostname(should match the prefix + route_53 zone)"
+        aws_vpc: "your_vpc"
+        instance_type: t3a.medium
+        # kubernetes_version: not supported with suggested package
+        node_count: 3
+        server_count: 3
+
+    corralSSHPath: "/root/go/src/github.com/rancher/rancher/tests/v2/validation/.ssh/<your_ssh_key>"
+corralPackages:
+    corralPackageImages:
+        # NOTE: k3sToImport is the **Required** package name. It can point to any path, as long as the package name is k3sToImport.
+        k3sToImport: /root/go/src/github.com/rancherlabs/corral-packages/dist/aws-k3s-v1.26.8-k3s1
+```
+
+**k3sToImport is the **Required** package name. It can point to any path, as long as the package name is k3sToImport.**

--- a/tests/v2/validation/provisioning/import/import_cluster_test.go
+++ b/tests/v2/validation/provisioning/import/import_cluster_test.go
@@ -1,0 +1,186 @@
+//go:build (validation || extended) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !cluster.any && !cluster.custom && !cluster.nodedriver && !sanity && !stress
+
+package imported
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/extensions/workloads/pods"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	k3sImportPackageName = "k3sToImport"
+)
+
+type ImportProvisioningTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	provisioningConfig *provisioninginput.Config
+}
+
+func (r *ImportProvisioningTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *ImportProvisioningTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	r.session = testSession
+
+	r.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+
+	corralConfig := corral.Configurations()
+	err = corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	require.NoError(r.T(), err, "error reading corral configs")
+}
+
+func (r *ImportProvisioningTestSuite) TestProvisioningImportK3SCluster() {
+	corralPackage := corral.PackagesConfig()
+
+	if corralPackage.HasCustomRepo != "" {
+		err := corral.SetCustomRepo(corralPackage.HasCustomRepo)
+		require.Nil(r.T(), err, "error setting remote repo")
+	}
+
+	newPackages := []string{}
+	if len(corralPackage.CorralPackageImages) == 0 {
+		r.T().Error("No Corral Packages to Test")
+	}
+
+	_, ok := corralPackage.CorralPackageImages[k3sImportPackageName]
+	require.True(r.T(), ok, "Please ensure %s package is in corralPackageImages", k3sImportPackageName)
+
+	var importPackageName string
+
+	for packageName, packageImage := range corralPackage.CorralPackageImages {
+		newPackageName := namegen.AppendRandomString(packageName)
+		if packageName == k3sImportPackageName {
+			importPackageName = newPackageName
+		}
+
+		newPackages = append(newPackages, newPackageName)
+
+		corralRun, err := corral.CreateCorral(r.session, newPackageName, packageImage, corralPackage.HasDebug, corralPackage.HasDebug)
+		require.NoError(r.T(), err, "error creating corral %v", packageName)
+
+		r.T().Logf("Corral %v created successfully", packageName)
+		require.NotNil(r.T(), corralRun, "corral run had no restConfig")
+	}
+
+	importCluster := apiv1.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      namegen.AppendRandomString("auto-import"),
+			Namespace: "fleet-default",
+		},
+	}
+
+	decodedKubeConfig, err := corral.GetKubeConfig(importPackageName)
+	require.NoError(r.T(), err)
+
+	config, err := clientcmd.RESTConfigFromKubeConfig(decodedKubeConfig)
+	require.NoError(r.T(), err)
+
+	_, err = clusters.CreateK3SRKE2Cluster(r.client, &importCluster)
+	require.NoError(r.T(), err)
+
+	backoff := wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.1,
+		Jitter:   0.1,
+		Steps:    10,
+	}
+
+	updatedCluster := new(apiv1.Cluster)
+
+	err = wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		updatedCluster, _, err = clusters.GetProvisioningClusterByName(r.client, importCluster.Name, importCluster.Namespace)
+		require.NoError(r.T(), err)
+
+		if updatedCluster.Status.ClusterName != "" {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(r.T(), err)
+
+	logrus.Info(updatedCluster.Status.ClusterName)
+	err = clusters.ImportCluster(r.client, updatedCluster, config)
+	require.NoError(r.T(), err)
+
+	backoff = wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.1,
+		Jitter:   0.1,
+		Steps:    100,
+	}
+
+	err = wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		updatedCluster, _, err = clusters.GetProvisioningClusterByName(r.client, importCluster.Name, importCluster.Namespace)
+		require.NoError(r.T(), err)
+
+		if updatedCluster.Status.Ready {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(r.T(), err)
+
+	podErrors := pods.StatusPods(r.client, updatedCluster.Status.ClusterName)
+	require.Empty(r.T(), podErrors)
+
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestImportProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(ImportProvisioningTestSuite))
+}

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -107,7 +107,10 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomClusterDyn
 			break
 		}
 	}
-	require.False(c.T(), isWindows, "Windows nodes are not supported for k3s Clusters")
+	if isWindows {
+		c.T().Skip("Skipping Windows tests, not supported on k3s")
+	}
+
 	if len(c.provisioningConfig.MachinePools) == 0 {
 		c.T().Skip()
 	}

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_go_provisioing_sanity
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_go_provisioing_sanity
@@ -81,6 +81,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                             string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
                             string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
                             string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                            string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: 'RANCHER_LINODE_ACCESSKEY'),
                             string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')]) {
 
             println "Branch: ${branch}"
@@ -125,7 +126,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                     currentBuild.result = 'FAILURE'
                   }
                 }
-
+                
                 // AWS_USER and AWS_AMI are currently not set in the environmental variables.
                 def GO_CATTLE_TEST_URL = env.CATTLE_TEST_URL.replace('https://', '')
                 env.CONFIG = env.CONFIG.replace('${CATTLE_TEST_URL}', "${GO_CATTLE_TEST_URL}")
@@ -141,13 +142,12 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                 env.CONFIG = env.CONFIG.replace('${AWS_VPC}', env.AWS_VPC)
                 env.CONFIG = env.CONFIG.replace('${AWS_SECURITY_GROUPS}', env.AWS_SECURITY_GROUPS)
                 env.CONFIG = env.CONFIG.replace('${AWS_SSH_PEM_KEY}', env.AWS_SSH_KEY_NAME)
-                env.CONFIG = env.CONFIG.replace('${RANCHER_LINODE_TOKEN}', env.RANCHER_LINODE_TOKEN)
-
+                env.CONFIG = env.CONFIG.replace('${RANCHER_LINODE_ACCESSKEY}', env.RANCHER_LINODE_ACCESSKEY)
                 stage('Execute subjobs') {
                   try {
                       jobs = [:]
                       println "Branch: ${branch}"
-
+                      
                       goParams = [ string(name: 'TIMEOUT', value: "${TIMEOUT}"),
                                   text(name: 'CONFIG', value: "${env.CONFIG}"),
                                   string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
@@ -155,8 +155,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                                   string(name: 'TEST_PACKAGE', value: "provisioning/..."),
                                   string(name: 'GOTEST_TESTCASE', value: "${env.GOTEST_TESTCASE}") ]
 
-                      // Rancher server 1 is used to test RKE1, RKE2 and K3s clusters.
-                      jobs["go-provisioning"] = { build job: 'rancher_ontag_go_certification', parameters: goParams }                        
+                      jobs["go-provisioning"] = { build job: 'rancher_qa/rancher_go-provisioning', parameters: goParams }                        
 
                       parallel jobs
                     } catch(err) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/1263
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 currently, there's no end to end provisioning test that imports a cluster into rancher

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 add a solution that works with Corral to import a cluster. 
Also addressed some changes to the sanity job. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested locally, jenkins jobs upon request. 
