### PR TITLE
Include metering archive in support config

### DIFF
--- a/pkg/api/steve/supportconfigs/generator.go
+++ b/pkg/api/steve/supportconfigs/generator.go
@@ -30,8 +30,11 @@ const (
 	// Pay-As-You-Go (PAYG) offerings. However, they will be in different namespaces to avoid
 	// clashing.
 	cspAdapterConfigmap = "csp-config"
-	tarContentType      = "application/x-tar"
-	logPrefix           = "support-config-generator"
+	// Metering archive for CSP marketplace Pay-As-You-Go (PAYG
+	// offerings. Used for auditing purposes.
+	cspMeteringArchiveConfigmap = "metering-archive"
+	tarContentType              = "application/x-tar"
+	logPrefix                   = "support-config-generator"
 )
 
 var errNotFound = errors.New("not implemented")
@@ -56,6 +59,24 @@ func NewHandler(scaledContext *config.ScaledContext) Handler {
 	}
 }
 
+// Check to see if user have access to the configmaps needed to create
+// the supportconfig tarball. Return false if user is not authorize or error
+// in checking authorization, true otherwise.
+func (h *Handler) checkAuthorization(cspNamespace string, cspConfigmap string, writer http.ResponseWriter, request *http.Request) bool {
+	authorized, err := h.authorize(cspNamespace, cspConfigmap, request)
+	if err != nil {
+		util.ReturnHTTPError(writer, request, http.StatusForbidden, http.StatusText(http.StatusForbidden))
+		logrus.Errorf("[%s] Failed to authorize user with error: %s", logPrefix, err.Error())
+		return false
+	}
+	if !authorized {
+		util.ReturnHTTPError(writer, request, http.StatusForbidden, http.StatusText(http.StatusForbidden))
+		return false
+	}
+
+	return true
+}
+
 // ServerHTTP implements http.Handler - attempts to authenticate/authorize the user. Returns a tar of support information
 // if the user can get the backing configmap in the adapter namespace
 func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -66,22 +87,18 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		// if usePAYG query parameter exist that means we are using the new Pay-As-You-Go offering CSP billing adapter
 		cspChartNamespace = cspadapter.PAYGChartNamespace
 		cspChartName = cspadapter.PAYGChartName
+		if !h.checkAuthorization(cspChartNamespace, cspMeteringArchiveConfigmap, writer, request) {
+			return
+		}
 	} else {
 		// if userPAYG query parameter does exist that means we are using the old Managed License offering CSP adapter
 		cspChartNamespace = cspadapter.MLOChartNamespace
 		cspChartName = cspadapter.MLOChartName
 	}
-	authorized, err := h.authorize(cspChartNamespace, request)
-	if err != nil {
-		util.ReturnHTTPError(writer, request, http.StatusForbidden, http.StatusText(http.StatusForbidden))
-		logrus.Errorf("[%s] Failed to authorize user with error: %s", logPrefix, err.Error())
+	if !h.checkAuthorization(cspChartNamespace, cspAdapterConfigmap, writer, request) {
 		return
 	}
-	if !authorized {
-		util.ReturnHTTPError(writer, request, http.StatusForbidden, http.StatusText(http.StatusForbidden))
-		return
-	}
-	_, err = h.adapterUtil.GetRelease(cspChartNamespace, cspChartName)
+	_, err := h.adapterUtil.GetRelease(cspChartNamespace, cspChartName)
 	if err != nil {
 		if errors.Is(err, cspadapter.ErrNotFound) {
 			// If neither adapter is installed, return a 501, so the
@@ -116,9 +133,9 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	logrus.Debugf("[%s] wrote %v bytes in archive response", logPrefix, n)
 }
 
-// authorize checks to see if the user can get the csp adapter configmap. Returns a bool (if the user is authorized)
+// authorize checks to see if the user can get the given csp adapter configmap. Returns a bool (if the user is authorized)
 // and optionally an error
-func (h *Handler) authorize(cspNamespace string, r *http.Request) (bool, error) {
+func (h *Handler) authorize(cspNamespace string, cspConfigmap string, r *http.Request) (bool, error) {
 	userInfo, ok := request.UserFrom(r.Context())
 	if !ok {
 		return false, fmt.Errorf("unable to extract user info from context")
@@ -128,7 +145,7 @@ func (h *Handler) authorize(cspNamespace string, r *http.Request) (bool, error) 
 			ResourceAttributes: &authzv1.ResourceAttributes{
 				Resource:  "configmap",
 				Verb:      "get",
-				Name:      cspAdapterConfigmap,
+				Name:      cspConfigmap,
 				Namespace: cspNamespace,
 			},
 			User:   userInfo.GetName(),
@@ -165,6 +182,25 @@ func (h *Handler) getCSPConfig(cspNamespace string) (map[string]interface{}, err
 	return retVal, nil
 }
 
+// getMeteringArchive gets th metering-archive configmap produced by CSP billing adapter returns an error if not able to produce the map. Will return
+// an errNotFound if the map is not found at all
+func (h *Handler) getMeteringArchive(cspNamespace string) ([]interface{}, error) {
+	cspMeteringArchive, err := h.ConfigMaps.GetNamespaced(cspNamespace, cspMeteringArchiveConfigmap, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errNotFound
+		}
+		return nil, err
+	}
+	var retVal []interface{}
+	err = json.Unmarshal([]byte(cspMeteringArchive.Data["archive"]), &retVal)
+	if err != nil {
+		return nil, err
+	}
+
+	return retVal, nil
+}
+
 // generateSupportConfig produces an io.Reader with the supportconfig ready to be returned using a http.ResponseWriter
 // Returns an err if it can't get the support config
 func (h *Handler) generateSupportConfig(cspNamespace string) (io.Reader, error) {
@@ -183,6 +219,26 @@ func (h *Handler) generateSupportConfig(cspNamespace string) (io.Reader, error) 
 
 	files := map[string][]byte{
 		"rancher/config.json": configData,
+	}
+
+	if cspNamespace == cspadapter.PAYGChartNamespace {
+		// For PAYG we also need to include the metering archive
+		// for auditing purposes
+		cspMeteringArchive, err := h.getMeteringArchive(cspNamespace)
+
+		// NOTE: metering archive may not have generated yet so don't include it
+		// if not found
+		if err == nil {
+			meteringArchiveData, err := json.MarshalIndent(cspMeteringArchive, "", "  ")
+			if err != nil {
+				return nil, err
+			}
+			files["rancher/metering_archive.json"] = meteringArchiveData
+		} else {
+			if !errors.Is(err, errNotFound) {
+				return nil, err
+			}
+		}
 	}
 
 	for name, body := range files {


### PR DESCRIPTION
for CSP billing auditing purposes

## Issue: https://github.com/rancher/rancher/issues/45142
 
## Problem
The csp-adapter functionality for Rancher PAYG instances is being enhanced with an archive of the previous billing data so that customers and support can validate what was submitted to AWS/Azure to generate their bill. Currently this data only exists in a configmap on the customer system, which makes it difficult to access for either the customer or support.
 
## Solution
Include the metering archive in the supportconfig tarball.
 
## Testing

Scenario 1: Metering archive is not available
1. Deploy Rancher Prime (with CSP Adapter, the BOYL version) in AWS.
2. Generate a supportconfig tarball
3. Verify that the supportconfig tarball contains `config.json` only.

Scenario 2: Metering archive is available
1. Deploy Rancher Prime (with CSP Adapter, the PAYG version) in AWS.
2. Generate a supportconfig tarball
3. Verify that the supportconfig tarball contains both `config.json` and `metering_archive.json`

## Engineering Testing
### Manual Testing
Scenario 1: Metering archive is not available
1. Deploy Rancher Prime (with CSP Adapter, the BOYL version) in AWS.
2. Generate a supportconfig tarball
3. Verify that the supportconfig tarball contains `config.json` only.

Scenario 2: Metering archive is available
1. Deploy Rancher Prime (with CSP Adapter, the PAYG version) in AWS.
2. Generate a supportconfig tarball
3. Verify that the supportconfig tarball contains both `config.json` and `metering_archive.json`

### Automated Testing
Making sure the existing unit tests does not break as the scenario is covered by the existing unit test.

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_