### PR TITLE
Add support for updating builtin PSACTs

### DIFF
--- a/pkg/controllers/management/clusterconnected/clusterconnected.go
+++ b/pkg/controllers/management/clusterconnected/clusterconnected.go
@@ -118,6 +118,7 @@ func (c *checker) updateClusterConnectedCondition(cluster *v3.Cluster, connected
 			v3.ClusterConditionReady.Reason(cluster, "Disconnected")
 			v3.ClusterConditionReady.Message(cluster, "Cluster agent is not connected")
 		}
+		logrus.Tracef("[clusterConnectedCondition] update cluster %v", cluster.Name)
 		_, err := c.clusters.Update(cluster)
 		if apierror.IsConflict(err) {
 			cluster, err = c.clusters.Get(cluster.Name, metav1.GetOptions{})

--- a/pkg/controllers/managementuser/healthsyncer/healthsyncer.go
+++ b/pkg/controllers/managementuser/healthsyncer/healthsyncer.go
@@ -178,6 +178,7 @@ func (h *HealthSyncer) updateClusterHealth() error {
 	}
 
 	if !reflect.DeepEqual(oldCluster, newObj) {
+		logrus.Tracef("[healthSyncer] update cluster %s", cluster.Name)
 		if _, err := h.clusters.Update(newObj.(*v3.Cluster)); err != nil {
 			return errors.Wrapf(err, "[updateClusterHealth] Failed to update cluster [%s]", cluster.Name)
 		}

--- a/pkg/data/management/podadmissionconfigurationtemplate_data_test.go
+++ b/pkg/data/management/podadmissionconfigurationtemplate_data_test.go
@@ -1,0 +1,117 @@
+package management
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	example1 = &v3.PodSecurityAdmissionConfigurationTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-example1",
+		},
+		Description: "This is an example for testing",
+		Configuration: v3.PodSecurityAdmissionConfigurationTemplateSpec{
+			Defaults: v3.PodSecurityAdmissionConfigurationTemplateDefaults{
+				Enforce:        "restricted",
+				EnforceVersion: "latest",
+				Audit:          "restricted",
+				AuditVersion:   "latest",
+				Warn:           "restricted",
+				WarnVersion:    "latest",
+			},
+			Exemptions: v3.PodSecurityAdmissionConfigurationTemplateExemptions{
+				Usernames:      []string{"user-a", "user-b", "user-c"},
+				RuntimeClasses: []string{"runtime-a", "runtime-b", "runtime-c"},
+				Namespaces:     []string{"ns-a", "ns-b", "ns-c"},
+			},
+		},
+	}
+	example2 = &v3.PodSecurityAdmissionConfigurationTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "another-example",
+		},
+		Description: "This is another example for testing",
+		Configuration: v3.PodSecurityAdmissionConfigurationTemplateSpec{
+			Exemptions: v3.PodSecurityAdmissionConfigurationTemplateExemptions{
+				Usernames:      []string{"user-a", "user-1", "user-2", "user-3"},
+				RuntimeClasses: []string{"runtime-1", "runtime-2", "runtime-3"},
+				Namespaces:     []string{"ns-1", "ns-2", "ns-3"},
+			},
+		},
+	}
+	example1plug2 = &v3.PodSecurityAdmissionConfigurationTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-example1",
+		},
+		Description: "This is an example for testing",
+		Configuration: v3.PodSecurityAdmissionConfigurationTemplateSpec{
+			Defaults: v3.PodSecurityAdmissionConfigurationTemplateDefaults{
+				Enforce:        "restricted",
+				EnforceVersion: "latest",
+				Audit:          "restricted",
+				AuditVersion:   "latest",
+				Warn:           "restricted",
+				WarnVersion:    "latest",
+			},
+			Exemptions: v3.PodSecurityAdmissionConfigurationTemplateExemptions{
+				Usernames:      []string{"user-1", "user-2", "user-3", "user-a", "user-b", "user-c"},
+				RuntimeClasses: []string{"runtime-1", "runtime-2", "runtime-3", "runtime-a", "runtime-b", "runtime-c"},
+				Namespaces:     []string{"ns-1", "ns-2", "ns-3", "ns-a", "ns-b", "ns-c"},
+			},
+		},
+	}
+)
+
+func Test_merge(t *testing.T) {
+	type args struct {
+		base       *v3.PodSecurityAdmissionConfigurationTemplate
+		additional *v3.PodSecurityAdmissionConfigurationTemplate
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v3.PodSecurityAdmissionConfigurationTemplate
+	}{
+		{
+			name: "base is empty",
+			args: args{
+				base:       nil,
+				additional: example1,
+			},
+			want: example1,
+		},
+		{
+			name: "additional is empty",
+			args: args{
+				base:       example1,
+				additional: nil,
+			},
+			want: example1,
+		},
+		{
+			name: "both are empty",
+			args: args{
+				base:       nil,
+				additional: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "addition contains different exceptions",
+			args: args{
+				base:       example1,
+				additional: example2,
+			},
+			want: example1plug2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, mergeExemptions(tt.args.base, tt.args.additional), "mergeExemptions(%v, %v)", tt.args.base, tt.args.additional)
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/43150
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Rancher can create two built-on PSACTs (`rancher-prviledge` and `rancher-restricted`) on start-up but does not have the ability to update them if they already exist. It becomes a problem that any update on the built-in PSACT templates (in the newer version of Rancher) will not be applied to the existing PSACT after upgrading Rancher. 
 
The chance of users modifying the built-in PSACTs is low, normally they would/should create a new one based on the built-in ones and make any customization they need there. But we need to handle the possible situation to minimize any negative impact on user experience.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This PR is to add support for updating the built-in PSACTs on Rancher's start-up.

With this PR, Rancher will update the built-in PSACTs such that it preserves the user's additions to the exemptions and merges everything from the built-in template into the existing one, which means that any value that is from the built-in template but removed by users will be added back. This is to make sure Rancher and its components work properly. 



The same logic is applied to all three fields under the `.Configuration.Exemptions`: Namespaces, Usernames, and RuntimeClasses.  Currently, the PSACT `rancher-restricted` utilizes only Namespace.  


Miscellaneous:
- This PR also adds some tracing-level logging messages which I found helpful for debugging in general during the development.  
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Steps:
- build and run Rnacher from this branch in the developing environment
- notice that two built-in PSACTs are created
- modify the PSACT rancher-restricted to remove some entries and add some new ones to the exemption namespace list via Rancher UI  
- add some new entries to the built-in template in the code base
- rebuild and run Rancher

Results:
- The PSACT rancher-restricted is updated to contain all namespace from the built-in template (including the ones that are removed by me and added in the new template) and the ones added by me

### Automated Testing
 
Unit tests are added for the newly-added function `mergeExemptions`. 


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

On installing Rancher, the builtin PSACTs should be created successfully;
on upgrading Rancher, those PSACTs should be updated to match the built-in template and also preserve the user's addition. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

The creation of PSACTs on Rancher's start-up should work. 

Existing / newly added automated tests that provide evidence there are no regressions:

n/a 