### PR TITLE
[v2.8] Add missing endpointslice dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ replace (
 	k8s.io/cri-api => k8s.io/cri-api v0.28.6
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.28.6
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.28.6
+	k8s.io/endpointslice => k8s.io/endpointslice v0.28.6
 	k8s.io/kms => k8s.io/kms v0.28.6
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.28.6
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.28.6

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -15,6 +15,7 @@ replace (
 	k8s.io/cri-api => k8s.io/cri-api v0.28.6
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.28.6
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.28.6
+	k8s.io/endpointslice => k8s.io/endpointslice v0.28.6
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.28.6
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.28.6
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.28.6


### PR DESCRIPTION
## Issue: 
* https://github.com/rancher/rancher/issues/45152

## Update:
* Added missing endpointslice dependency overwrite in `go.mod` and `pkg/apis/go.mod`