### PR TITLE
[v2.7] Convert flaky Python CLI tests to Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
-	github.com/rancher/shepherd v0.0.0-20240412143323-2c49f1e19a09
+	github.com/rancher/shepherd v0.0.0-20240418211337-2d2cdf4902d5
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1042,8 +1042,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.16 h1:TwhO68syETl4KAMM7zrueTamoMHWwGMzJfAShWBAC+4=
 github.com/rancher/rke v1.4.16/go.mod h1:UIc898udZbjJ+0616CEmjqY+eBQSkW/dQ30ZvL7bUcQ=
-github.com/rancher/shepherd v0.0.0-20240412143323-2c49f1e19a09 h1:3AoIDvX9USQpPWhsjK6vcxKcJg1+0Kejey+s+d0O8to=
-github.com/rancher/shepherd v0.0.0-20240412143323-2c49f1e19a09/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
+github.com/rancher/shepherd v0.0.0-20240418211337-2d2cdf4902d5 h1:Pprtz3Z3dmrlm5R0Ojko6uBlbyqv4j3fMrw0zlBw+VA=
+github.com/rancher/shepherd v0.0.0-20240418211337-2d2cdf4902d5/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a h1:Mawv3TfevX5dbVDlB/+RPgqxMX1HZQimyhj05R/Ef7U=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a/go.mod h1:tfdVny3lVO6H0JyysFBZ1ce45kH9VgWLPa9z9TZVI+U=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/Dockerfile.e2e
+++ b/tests/v2/validation/Dockerfile.e2e
@@ -29,3 +29,10 @@ RUN if [[ -z "$RKE_VERSION" ]] ; then echo installing latest version RKE && \
     curl -0Ls https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux-amd64 > rke; fi;
 RUN mv rke /bin/rke && \
     chmod +x /bin/rke
+
+ARG CLI_VERSION
+RUN if [[ -n "$CLI_VERSION" ]] ; then echo installing CLI version ${CLI_VERSION} && \
+    curl -LO https://github.com/rancher/cli/releases/download/${CLI_VERSION}/rancher-linux-amd64-${CLI_VERSION}.tar.gz ; fi;
+RUN tar -xf rancher-linux-amd64-${CLI_VERSION}.tar.gz && \
+    mv rancher-${CLI_VERSION}/rancher /bin/rancher && \
+    chmod +x /bin/rancher

--- a/tests/v2/validation/Dockerfile.validation
+++ b/tests/v2/validation/Dockerfile.validation
@@ -48,3 +48,10 @@ RUN if [[ -z "$RKE_VERSION" ]] ; then echo installing latest version RKE && \
     curl -0Ls https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux-amd64 > rke; fi;
 RUN mv rke /bin/rke && \
     chmod +x /bin/rke
+
+ARG CLI_VERSION
+RUN if [[ -n "$CLI_VERSION" ]] ; then echo installing CLI version ${CLI_VERSION} && \
+    curl -LO https://github.com/rancher/cli/releases/download/${CLI_VERSION}/rancher-linux-amd64-${CLI_VERSION}.tar.gz ; fi;
+RUN tar -xf rancher-linux-amd64-${CLI_VERSION}.tar.gz && \
+    mv rancher-${CLI_VERSION}/rancher /bin/rancher && \
+    chmod +x /bin/rancher

--- a/tests/v2/validation/build.sh
+++ b/tests/v2/validation/build.sh
@@ -4,6 +4,7 @@ set -x
 set -eu
 
 DEBUG="${DEBUG:-false}"
+CLI_VERSION="${CLI_VERSION}"
 EXTERNAL_ENCODED_VPN="${EXTERNAL_ENCODED_VPN:-1234}"
 VPN_ENCODED_LOGIN="${VPN_ENCODED_LOGIN:-5678}"
 
@@ -16,7 +17,7 @@ fi
 
 count=0
 while [[ 3 -gt $count ]]; do
-    docker build . -f tests/v2/validation/Dockerfile.validation --build-arg EXTERNAL_ENCODED_VPN="$EXTERNAL_ENCODED_VPN" --build-arg VPN_ENCODED_LOGIN="$VPN_ENCODED_LOGIN" -t rancher-validation-"${TRIM_JOB_NAME}""${BUILD_NUMBER}"   
+    docker build . -f tests/v2/validation/Dockerfile.validation --build-arg CLI_VERSION="$CLI_VERSION" --build-arg EXTERNAL_ENCODED_VPN="$EXTERNAL_ENCODED_VPN" --build-arg VPN_ENCODED_LOGIN="$VPN_ENCODED_LOGIN" -t rancher-validation-"${TRIM_JOB_NAME}""${BUILD_NUMBER}"   
 
     if [[ $? -eq 0 ]]; then break; fi
     count=$(($count + 1))

--- a/tests/v2/validation/cli/README.md
+++ b/tests/v2/validation/cli/README.md
@@ -1,0 +1,24 @@
+# CLI
+
+For CLI tests, the local cluster is used to perform each of the tests. It is important to note that you must have the Rancher CLI already installed and configured on your client machine before running this test.
+
+Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
+## Getting Started
+In your config file, set the following:
+```yaml
+rancher:
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: true/optional
+  rancherCLI: true
+```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/cli --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCLITestSuite$"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/v2/validation/cli/cli_test.go
+++ b/tests/v2/validation/cli/cli_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/cli"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CLITestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (c *CLITestSuite) TearDownSuite() {
+	c.session.Cleanup()
+}
+
+func (c *CLITestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	c.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(c.T(), err)
+
+	c.client = client
+}
+
+func (c *CLITestSuite) TestContext() {
+	err := cli.SwitchContext(c.client.CLI)
+	require.NoError(c.T(), err)
+}
+
+func (c *CLITestSuite) TestProjects() {
+	var projectName = namegen.AppendRandomString("projects")
+	var clusterName = namegen.AppendRandomString("cluster")
+
+	err := cli.CreateProjects(c.client.CLI, projectName, "local")
+	require.NoError(c.T(), err)
+
+	err = cli.CreateProjects(c.client.CLI, projectName, clusterName)
+	require.Error(c.T(), err)
+
+	err = cli.DeleteProjects(c.client.CLI, projectName)
+	require.NoError(c.T(), err)
+}
+
+func (c *CLITestSuite) TestNamespaces() {
+	var namespaceName = namegen.AppendRandomString("ns")
+	var projectName = namegen.AppendRandomString("projects")
+
+	err := cli.CreateNamespaces(c.client.CLI, namespaceName, projectName)
+	require.NoError(c.T(), err)
+
+	err = cli.DeleteNamespaces(c.client.CLI, namespaceName, projectName)
+	require.NoError(c.T(), err)
+}
+
+func (c *CLITestSuite) TestCatalog() {
+	var catalogName = namegen.AppendRandomString("catalog")
+
+	err := cli.CreateCatalogs(c.client.CLI, catalogName)
+	require.NoError(c.T(), err)
+
+	err = cli.DeleteCatalogs(c.client.CLI, catalogName)
+	require.NoError(c.T(), err)
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestCLITestSuite(t *testing.T) {
+	suite.Run(t, new(CLITestSuite))
+}


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/45049.