### PR TITLE
changing integration test to use new version of uk-locale

### DIFF
--- a/tests/v2/integration/catalogv2/ui_plugin_test.go
+++ b/tests/v2/integration/catalogv2/ui_plugin_test.go
@@ -176,7 +176,7 @@ func (w *UIPluginTest) TestGetSingleExtensionUnauthenticated() {
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}
-	res, _ := client.Get("https://localhost:8443/v1/uiplugins/uk-locale/0.1.0/plugin/uk-locale-0.1.0.umd.min.js")
+	res, _ := client.Get("https://localhost:8443/v1/uiplugins/uk-locale/0.1.1/plugin/uk-locale-0.1.1.umd.min.js")
 
 	w.Require().Equal(res.StatusCode, http.StatusOK)
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45159
 
## Problem
Some [changes](https://github.com/rancher/ui-plugin-examples/pull/38) in the chart caused the tests to break due to [this](https://github.com/rancher/rancher/blob/82aab25da503e4a2c70976585495ae76020391c8/pkg/controllers/dashboard/plugin/fscache.go#L72) check
 
## Solution
New [changes](https://github.com/rancher/ui-plugin-examples/pull/39) were made to the chart and the url used in the test is updated
 
## Testing
Manual and CI/CD
