### PR TITLE
Retrigger if the clusterrepo oci spec changed.

### DIFF
--- a/pkg/catalogv2/oci/oci.go
+++ b/pkg/catalogv2/oci/oci.go
@@ -180,7 +180,7 @@ func GenerateIndex(URL string, credentialSecret *corev1.Secret,
 				}
 
 				if maxTag != nil {
-					ociClient.tag = maxTag.String()
+					ociClient.tag = maxTag.Original()
 
 					// fetch the chart.yaml for the latest tag and add it to the index.
 					err = addToHelmRepoIndex(*ociClient, indexFile, orasRepository)
@@ -221,7 +221,7 @@ func GenerateIndex(URL string, credentialSecret *corev1.Secret,
 		}
 
 		if maxTag != nil {
-			ociClient.tag = maxTag.String()
+			ociClient.tag = maxTag.Original()
 
 			// fetch the chart.yaml for the latest tag and add it to the index.
 			err = addToHelmRepoIndex(*ociClient, indexFile, orasRepository)


### PR DESCRIPTION
Please check issue for more information. 

#### Summary

When the clusterrepo spec is changed, it should retrigger the OCI handler for syncing with the registry.