### PR TITLE
[2.9] Making the OCI cluster repo handler take care of retries instead of using the oras library

### DIFF
--- a/pkg/apis/catalog.cattle.io/v1/types.go
+++ b/pkg/apis/catalog.cattle.io/v1/types.go
@@ -111,6 +111,9 @@ type RepoStatus struct {
 	Commit string `json:"commit,omitempty"`
 
 	Conditions []genericcondition.GenericCondition `json:"conditions,omitempty"`
+
+	NumberOfRetries int         `json:"numberOfRetries,omitempty"`
+	NextRetryAt     metav1.Time `json:"nextRetryAt,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/catalog.cattle.io/v1/types.go
+++ b/pkg/apis/catalog.cattle.io/v1/types.go
@@ -112,8 +112,14 @@ type RepoStatus struct {
 
 	Conditions []genericcondition.GenericCondition `json:"conditions,omitempty"`
 
-	NumberOfRetries int         `json:"numberOfRetries,omitempty"`
-	NextRetryAt     metav1.Time `json:"nextRetryAt,omitempty"`
+	// Number of times the handler will retry if it gets a 429 error
+	NumberOfRetries int `json:"numberOfRetries,omitempty"`
+
+	// The time the next retry will happen
+	NextRetryAt metav1.Time `json:"nextRetryAt,omitempty"`
+
+	// If the handler should be skipped or not
+	ShouldNotSkip bool `json:"shouldNotSkip,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/catalog.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/catalog.cattle.io/v1/zz_generated_deepcopy.go
@@ -468,6 +468,7 @@ func (in *RepoStatus) DeepCopyInto(out *RepoStatus) {
 		*out = make([]genericcondition.GenericCondition, len(*in))
 		copy(*out, *in)
 	}
+	in.NextRetryAt.DeepCopyInto(&out.NextRetryAt)
 	return
 }
 

--- a/pkg/catalogv2/oci/client_test.go
+++ b/pkg/catalogv2/oci/client_test.go
@@ -14,15 +14,13 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/repo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"oras.land/oras-go/v2/registry/remote/auth"
-	"oras.land/oras-go/v2/registry/remote/retry"
-
-	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 )
 
 func spinRegistry(layerSize int, chartMediaType, helmManifest bool, testcaseName string, t *testing.T) *httptest.Server {
@@ -368,41 +366,25 @@ func TestFetchChart(t *testing.T) {
 
 func TestGetOrasRegistry(t *testing.T) {
 	testCases := []struct {
-		name                     string
-		expectedErr              error
-		insecurePlainHTTP        bool
-		exponentialBackOffValues *v1.ExponentialBackOffValues
+		name              string
+		expectedErr       error
+		insecurePlainHTTP bool
 	}{
 		{
-			name:              "retry policy values are set correctly in oras auth client",
+			name:              "fetching oras registry works fine without auth",
+			expectedErr:       nil,
+			insecurePlainHTTP: false,
+		},
+		{
+			name:              "fetching oras repository works fine with plainHTTP",
 			expectedErr:       nil,
 			insecurePlainHTTP: true,
-			exponentialBackOffValues: &v1.ExponentialBackOffValues{
-				MaxRetries: 5,
-				MaxWait:    "5s",
-				MinWait:    "5s",
-			},
-		},
-		{
-			name:                     "fetching oras registry works fine without auth",
-			expectedErr:              nil,
-			insecurePlainHTTP:        false,
-			exponentialBackOffValues: nil,
-		},
-		{
-			name:                     "fetching oras repository works fine with plainHTTP",
-			expectedErr:              nil,
-			insecurePlainHTTP:        true,
-			exponentialBackOffValues: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		repoSpec := v1.RepoSpec{
 			InsecurePlainHTTP: tc.insecurePlainHTTP,
-		}
-		if tc.exponentialBackOffValues != nil {
-			repoSpec.ExponentialBackOffValues = tc.exponentialBackOffValues
 		}
 
 		ociClient, err := NewClient("oci://example.com/charts/test:1.2.2", repoSpec, nil)
@@ -411,13 +393,6 @@ func TestGetOrasRegistry(t *testing.T) {
 		orasRegistry, err := ociClient.GetOrasRegistry()
 		assert.Nil(t, orasRegistry.Client.(*auth.Client).Cache)
 		assert.Equal(t, orasRegistry.PlainHTTP, tc.insecurePlainHTTP)
-		policy := orasRegistry.Client.(*auth.Client).Client.Transport.(*retry.Transport).Policy().(*retry.GenericPolicy)
-
-		if tc.exponentialBackOffValues != nil {
-			assert.Equal(t, policy.MaxRetry, 5)
-			assert.Equal(t, policy.MinWait, time.Duration(5*time.Second))
-			assert.Equal(t, policy.MaxWait, time.Duration(5*time.Second))
-		}
 
 		if tc.expectedErr != nil {
 			assert.ErrorContains(t, err, tc.expectedErr.Error())

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -76,6 +76,9 @@ func RegisterReposForFollowers(ctx context.Context,
 }
 
 func (r *repoHandler) ClusterRepoDownloadEnsureStatusHandler(repo *catalog.ClusterRepo, status catalog.RepoStatus) (catalog.RepoStatus, error) {
+	if registry.IsOCI(repo.Spec.URL) {
+		return status, nil
+	}
 	r.clusterRepos.EnqueueAfter(repo.Name, interval)
 	return r.ensure(&repo.Spec, status, &repo.ObjectMeta)
 }

--- a/pkg/controllers/dashboard/helm/repo_oci.go
+++ b/pkg/controllers/dashboard/helm/repo_oci.go
@@ -7,7 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/maphash"
 	"io"
+	"math"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -29,11 +32,24 @@ import (
 	"oras.land/oras-go/v2/registry/remote/errcode"
 )
 
+var timeNow = time.Now
+
 type OCIRepohandler struct {
 	clusterRepoController catalogcontrollers.ClusterRepoController
 	configMapController   corev1controllers.ConfigMapController
 	secretCacheController corev1controllers.SecretCache
 	apply                 apply.Apply
+}
+
+type retryPolicy struct {
+	// MinWait is the minimum duration to wait before retrying.
+	MinWait time.Duration
+
+	// MaxWait is the maximum duration to wait before retrying.
+	MaxWait time.Duration
+
+	// MaxRetry is the maximum number of retries.
+	MaxRetry int
 }
 
 func RegisterOCIRepo(ctx context.Context,
@@ -61,9 +77,29 @@ func (o *OCIRepohandler) onClusterRepoChange(key string, clusterRepo *catalog.Cl
 	if clusterRepo == nil {
 		return nil, nil
 	}
-
 	// Ignore non OCI ClusterRepos
 	if !registry.IsOCI(clusterRepo.Spec.URL) {
+		return clusterRepo, nil
+	}
+
+	// this is to prevent the handler from making calls when the crd is outdated.
+	updatedRepo, err := o.clusterRepoController.Get(key, metav1.GetOptions{})
+	if err == nil && updatedRepo.ResourceVersion != clusterRepo.ResourceVersion {
+		return clusterRepo, nil
+	}
+
+	if shouldResetRetries(clusterRepo) {
+		clusterRepo.Status.NumberOfRetries = 0
+		clusterRepo.Status.NextRetryAt = metav1.Time{}
+	}
+
+	if !clusterRepo.Status.NextRetryAt.IsZero() && clusterRepo.Status.NextRetryAt.Time.After(timeNow()) {
+		return clusterRepo, nil
+	}
+
+	retryPolicy := getRetryPolicy(clusterRepo)
+
+	if clusterRepo.Status.NumberOfRetries > retryPolicy.MaxRetry {
 		return clusterRepo, nil
 	}
 
@@ -72,7 +108,7 @@ func (o *OCIRepohandler) onClusterRepoChange(key string, clusterRepo *catalog.Cl
 	logrus.Debugf("OCIRepoHandler triggered for clusterrepo %s", clusterRepo.Name)
 	var index *repo.IndexFile
 
-	err := ensureIndexConfigMap(clusterRepo, originalStatus, o.configMapController)
+	err = ensureIndexConfigMap(clusterRepo, originalStatus, o.configMapController)
 	if err != nil {
 		return o.setErrorCondition(clusterRepo, err, originalStatus)
 	}
@@ -109,7 +145,7 @@ func (o *OCIRepohandler) onClusterRepoChange(key string, clusterRepo *catalog.Cl
 			return o.set4xxCondition(clusterRepo, errResp, originalStatus)
 		}
 
-		// If there is 429 error code, then we don't reconcile further and wait for 6 hours interval
+		// If there is 429 error code and max retry is reached, then we don't reconcile further and wait for 6 hours interval,
 		// but we also create the configmap for future usecases.
 		if errResp.StatusCode == http.StatusTooManyRequests {
 			if index != nil && len(index.Entries) > 0 {
@@ -119,11 +155,24 @@ func (o *OCIRepohandler) onClusterRepoChange(key string, clusterRepo *catalog.Cl
 				_, err := createOrUpdateMap(clusterRepo.Namespace, index, owner, o.apply)
 				if err != nil {
 					logrus.Debugf("failed to create/udpate the configmap incase of 4xx statuscode for %s", clusterRepo.Name)
-					return o.set4xxCondition(clusterRepo, errResp, originalStatus)
 				}
 			}
 
-			return o.set4xxCondition(clusterRepo, errResp, originalStatus)
+			clusterRepo.Status.NumberOfRetries++
+			if clusterRepo.Status.NumberOfRetries > retryPolicy.MaxRetry {
+				return o.set4xxCondition(clusterRepo, errResp, originalStatus)
+			}
+
+			backoff := calculateBackoff(clusterRepo, retryPolicy)
+
+			clusterRepo.Status.NextRetryAt = metav1.Time{Time: timeNow().Add(backoff)}
+			//updating the status triggers the handler again
+			status, err := o.clusterRepoController.UpdateStatus(clusterRepo)
+			if err != nil {
+				return clusterRepo, err
+			}
+			o.clusterRepoController.EnqueueAfter(clusterRepo.Name, backoff)
+			return status, nil
 		}
 	}
 	if err != nil {
@@ -138,7 +187,6 @@ func (o *OCIRepohandler) onClusterRepoChange(key string, clusterRepo *catalog.Cl
 	if err != nil {
 		return o.setErrorCondition(clusterRepo, err, originalStatus)
 	}
-
 	// Only update, if the index got updated
 	if !bytes.Equal(originalIndexBytes, newIndexBytes) {
 		index.SortEntries()
@@ -152,15 +200,18 @@ func (o *OCIRepohandler) onClusterRepoChange(key string, clusterRepo *catalog.Cl
 		originalStatus.IndexConfigMapNamespace = cm.Namespace
 		originalStatus.IndexConfigMapResourceVersion = cm.ResourceVersion
 		originalStatus.DownloadTime = downloadTime
+		originalStatus.NumberOfRetries = 0
 	}
 
 	return o.setErrorCondition(clusterRepo, err, originalStatus)
 }
 
-// setErrorCondition is only called when error happens in the handler and
+// setErrorCondition is only called when error happens in the handler, and
 // we need to depend on wrangler to reenqueue the handler
 func (o *OCIRepohandler) setErrorCondition(clusterRepo *catalog.ClusterRepo, err error, originalStatus *catalog.RepoStatus) (*catalog.ClusterRepo, error) {
 	var statusErr error
+	originalStatus.NumberOfRetries = 0
+	originalStatus.NextRetryAt = metav1.Time{}
 
 	ociDownloaded := condition.Cond(catalog.OCIDownloaded)
 	if apierrors.IsConflict(err) {
@@ -189,7 +240,6 @@ func (o *OCIRepohandler) setErrorCondition(clusterRepo *catalog.ClusterRepo, err
 // we need to wait for 6 hours to reenqueue.
 func (o *OCIRepohandler) set4xxCondition(clusterRepo *catalog.ClusterRepo, err *errcode.ErrorResponse, originalStatus *catalog.RepoStatus) (*catalog.ClusterRepo, error) {
 	err.Errors = append(err.Errors, errcode.Error{Message: fmt.Sprintf(" will retry will after %s", interval)})
-
 	ociDownloaded := condition.Cond(catalog.OCIDownloaded)
 	if apierrors.IsConflict(err) {
 		ociDownloaded.SetError(originalStatus, "", nil)
@@ -201,7 +251,9 @@ func (o *OCIRepohandler) set4xxCondition(clusterRepo *catalog.ClusterRepo, err *
 		// Since status has changed, update the lastUpdatedTime
 		ociDownloaded.LastUpdated(originalStatus, time.Now().UTC().Format(time.RFC3339))
 
+		originalStatus.NumberOfRetries = clusterRepo.Status.NumberOfRetries
 		clusterRepo.Status = *originalStatus
+
 		return o.clusterRepoController.UpdateStatus(clusterRepo)
 	}
 
@@ -220,7 +272,6 @@ func getIndexfile(clusterRepoStatus catalog.RepoStatus,
 	indexFile := repo.NewIndexFile()
 	var configMap *corev1.ConfigMap
 	var err error
-
 	if clusterRepoSpec.URL != clusterRepoStatus.URL {
 		return indexFile, nil
 	}
@@ -285,4 +336,69 @@ func readBytes(configMapCache corev1controllers.ConfigMapClient, cm *corev1.Conf
 	}
 
 	return bytes, nil
+}
+
+// calculateBackoff gets the amount of time to wait for the next call.
+// Reference: https://github.com/oras-project/oras-go/blob/main/registry/remote/retry/policy.go#L95
+func calculateBackoff(clusterRepo *catalog.ClusterRepo, policy retryPolicy) time.Duration {
+	var h maphash.Hash
+	h.SetSeed(maphash.MakeSeed())
+	rand := rand.New(rand.NewSource(int64(h.Sum64())))
+	temp := float64(policy.MinWait) * math.Pow(2, float64(clusterRepo.Status.NumberOfRetries))
+	backoff := time.Duration(temp*(1-0.2)) + time.Duration(rand.Int63n(int64(2*0.2*temp)))
+	if backoff < policy.MinWait {
+		return policy.MinWait
+	}
+	if backoff > policy.MaxWait {
+		return policy.MaxWait
+	}
+	return backoff
+}
+
+// getRetryPolicy returns the retry policy for the repository using the values present in the spec
+// or, if they aren't present, the default values
+func getRetryPolicy(clusterRepo *catalog.ClusterRepo) retryPolicy {
+	// Default Values for exponentialBackOff function which is used
+	// to retry an HTTP call when 429 response code is hit.
+	var retryPolicy = retryPolicy{
+		MinWait:  1 * time.Second,
+		MaxWait:  5 * time.Second,
+		MaxRetry: 5,
+	}
+
+	if clusterRepo.Spec.ExponentialBackOffValues != nil {
+		if clusterRepo.Spec.ExponentialBackOffValues.MaxRetries > 0 {
+			retryPolicy.MaxRetry = clusterRepo.Spec.ExponentialBackOffValues.MaxRetries
+		}
+		if clusterRepo.Spec.ExponentialBackOffValues.MaxWait != "" {
+			maxWait, err := time.ParseDuration(clusterRepo.Spec.ExponentialBackOffValues.MaxWait)
+			if err == nil {
+				retryPolicy.MaxWait = maxWait
+			}
+		}
+		if clusterRepo.Spec.ExponentialBackOffValues.MinWait != "" {
+			minWait, err := time.ParseDuration(clusterRepo.Spec.ExponentialBackOffValues.MinWait)
+			if err == nil {
+				retryPolicy.MinWait = minWait
+			}
+		}
+	}
+	return retryPolicy
+}
+
+// shouldResetRetries checks to see if the interval has passed or if we need to do a force update
+func shouldResetRetries(clusterRepo *catalog.ClusterRepo) bool {
+	var lastStatusUpdate time.Time
+	for _, field := range clusterRepo.ManagedFields {
+		if field.Operation == metav1.ManagedFieldsOperationUpdate && field.Subresource == "status" {
+			lastStatusUpdate = field.Time.Time.UTC()
+		}
+	}
+	ociDownloaded := condition.Cond(catalog.OCIDownloaded)
+	ociDownloadedTime, _ := time.Parse(time.RFC3339, ociDownloaded.GetLastUpdated(clusterRepo))
+	// interval has passed. lastStatusUpdate will always be greater than zero if the ociDownloaded Condition exists
+	if !ociDownloadedTime.IsZero() && ociDownloadedTime.Add(interval).Before(timeNow().UTC()) && ociDownloadedTime.Add(interval).After(lastStatusUpdate) {
+		return true
+	}
+	return false
 }

--- a/pkg/controllers/dashboard/helm/repo_oci_test.go
+++ b/pkg/controllers/dashboard/helm/repo_oci_test.go
@@ -334,70 +334,157 @@ func TestGetRetryPolicy(t *testing.T) {
 	}
 }
 
-func TestShouldResetRetries(t *testing.T) {
+func TestShouldSkip(t *testing.T) {
 	interval = 1 * time.Hour
 	testCases := []struct {
-		name               string
-		ociDownloadedTime  time.Time
-		lastStatusUpdate   *metav1.Time
-		forceUpdate        *metav1.Time
-		timeNow            func() time.Time
-		generation         int64
-		observedGeneration int64
-		expected           bool
+		name                     string
+		ociDownloadedTime        time.Time
+		timeNow                  func() time.Time
+		nextRetryAt              metav1.Time
+		newClusterRepoController func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList]
+		generation               int64
+		observedGeneration       int64
+		maxRetries               int
+		numberOfRetries          int
+		shouldNotSkip            bool
+		expected                 bool
 	}{
 		{
-			name:              "Should reset retries if interval has passed and status was not updated after the interval",
-			ociDownloadedTime: time.Date(2024, 04, 23, 9, 0, 0, 0, time.UTC),
-			lastStatusUpdate:  &metav1.Time{Time: time.Date(2024, 04, 23, 9, 0, 0, 0, time.UTC)},
-			forceUpdate:       nil,
-			timeNow: func() time.Time {
-				return time.Date(2024, 04, 23, 10, 1, 0, 0, time.UTC)
+			name: "Should skip if resourceVersion don't match",
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}}, nil)
+				return mockController
 			},
 			expected: true,
 		},
 		{
-			name:              "Should NOT reset retries if interval has passed but status was updated after the interval",
-			ociDownloadedTime: time.Date(2024, 04, 23, 10, 0, 0, 0, time.UTC),
-			lastStatusUpdate:  &metav1.Time{Time: time.Date(2024, 04, 23, 11, 1, 0, 0, time.UTC)},
-			forceUpdate:       nil,
+			name: "Should skip if nextRetryAt is after time.now()",
 			timeNow: func() time.Time {
 				return time.Date(2024, 04, 23, 10, 1, 0, 0, time.UTC)
 			},
-			expected: false,
+			nextRetryAt: metav1.NewTime(time.Date(2024, 04, 23, 10, 2, 0, 0, time.UTC)),
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}, nil)
+				return mockController
+			},
+			expected: true,
 		},
 		{
-			name:              "Should reset retries if generation has changed",
-			ociDownloadedTime: time.Date(2024, 04, 23, 10, 0, 0, 0, time.UTC),
-			lastStatusUpdate:  &metav1.Time{Time: time.Date(2024, 04, 23, 11, 1, 0, 0, time.UTC)},
-			forceUpdate:       nil,
+			name: "Should NOT skip if status.ShouldNotSkip is true",
 			timeNow: func() time.Time {
 				return time.Date(2024, 04, 23, 10, 1, 0, 0, time.UTC)
 			},
-			generation:         3,
-			observedGeneration: 2,
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}, nil)
+				return mockController
+			},
+			shouldNotSkip: true,
+			expected:      false,
+		},
+		{
+			name: "Should NOT skip if the handler is retrying",
+			timeNow: func() time.Time {
+				return time.Date(2024, 04, 23, 10, 1, 0, 0, time.UTC)
+			},
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}, nil)
+				return mockController
+			},
+			maxRetries:      5,
+			numberOfRetries: 1,
+			expected:        false,
+		},
+		{
+			name: "Should NOT skip if generation has changed",
+			timeNow: func() time.Time {
+				return time.Date(2024, 04, 23, 10, 1, 0, 0, time.UTC)
+			},
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}, nil)
+				return mockController
+			},
+			generation:         1,
+			observedGeneration: 0,
+			maxRetries:         5,
+			numberOfRetries:    0,
+			expected:           false,
+		},
+		{
+			name:              "Should NOT skip if interval has not passed",
+			ociDownloadedTime: time.Date(2024, 04, 23, 10, 0, 0, 0, time.UTC),
+			timeNow: func() time.Time {
+				return time.Date(2024, 04, 23, 10, 1, 0, 0, time.UTC)
+			},
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}, nil)
+				return mockController
+			},
+			generation:         1,
+			observedGeneration: 0,
+			maxRetries:         5,
+			numberOfRetries:    0,
+			expected:           false,
+		},
+		{
+			name:              "Should skip if handler is done retrying, generation didn't change and interval has not passed",
+			ociDownloadedTime: time.Date(2024, 04, 23, 10, 0, 0, 0, time.UTC),
+			timeNow: func() time.Time {
+				return time.Date(2024, 04, 23, 10, 5, 0, 0, time.UTC)
+			},
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}, nil)
+				mockController.EXPECT().EnqueueAfter("", interval).Return()
+				return mockController
+			},
+			generation:         1,
+			observedGeneration: 1,
+			maxRetries:         5,
+			numberOfRetries:    6,
 			expected:           true,
+		},
+		{
+			name:              "Should NOT skip if handler is done retrying, generation didn't change but interval has passed",
+			ociDownloadedTime: time.Date(2024, 04, 23, 10, 0, 0, 0, time.UTC),
+			timeNow: func() time.Time {
+				return time.Date(2024, 04, 24, 11, 0, 0, 0, time.UTC)
+			},
+			newClusterRepoController: func(ctrl *gomock.Controller) *fake.MockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList] {
+				mockController := fake.NewMockNonNamespacedControllerInterface[*catalog.ClusterRepo, *catalog.ClusterRepoList](ctrl)
+				mockController.EXPECT().Get("clusterRepo", metav1.GetOptions{}).Return(&catalog.ClusterRepo{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}, nil)
+				return mockController
+			},
+			generation:         1,
+			observedGeneration: 1,
+			maxRetries:         5,
+			numberOfRetries:    5,
+			expected:           false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			policy := retryPolicy{MaxRetry: testCase.maxRetries}
+			ctrl := gomock.NewController(t)
+			mockController := testCase.newClusterRepoController(ctrl)
+			handler := OCIRepohandler{clusterRepoController: mockController}
 			timeNow = testCase.timeNow
 			clusterRepo := &catalog.ClusterRepo{
 				ObjectMeta: metav1.ObjectMeta{
-					Generation: testCase.generation,
-					ManagedFields: []metav1.ManagedFieldsEntry{
-						{
-							Subresource: "status",
-							Operation:   metav1.ManagedFieldsOperationUpdate,
-							Time:        testCase.lastStatusUpdate,
-						},
-					}},
-				Spec: catalog.RepoSpec{
-					ForceUpdate: testCase.forceUpdate,
+					Generation:      testCase.generation,
+					ResourceVersion: "1",
 				},
 				Status: catalog.RepoStatus{
 					ObservedGeneration: testCase.observedGeneration,
+					NumberOfRetries:    testCase.numberOfRetries,
+					NextRetryAt:        testCase.nextRetryAt,
+					ShouldNotSkip:      testCase.shouldNotSkip,
 					Conditions: []genericcondition.GenericCondition{
 						{
 							Type:           string(catalog.OCIDownloaded),
@@ -405,7 +492,7 @@ func TestShouldResetRetries(t *testing.T) {
 						},
 					}},
 			}
-			assert.Equal(t, testCase.expected, shouldResetRetries(clusterRepo))
+			assert.Equal(t, testCase.expected, handler.shouldSkip(clusterRepo, policy, "clusterRepo"))
 		})
 	}
 }

--- a/pkg/controllers/dashboard/helm/repo_oci_test.go
+++ b/pkg/controllers/dashboard/helm/repo_oci_test.go
@@ -374,9 +374,9 @@ func TestShouldResetRetries(t *testing.T) {
 			timeNow: func() time.Time {
 				return time.Date(2024, 04, 23, 10, 1, 0, 0, time.UTC)
 			},
-			generation:         2,
-			observedGeneration: 3,
-			expected:           false,
+			generation:         3,
+			observedGeneration: 2,
+			expected:           true,
 		},
 	}
 

--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -213,7 +213,7 @@ func Start429Registry(t assert.TestingT) (*url.URL, error) {
 	manifestCount := 1
 	timerStart := false
 
-	// Create a OCI Registry Server
+	// Create an OCI Registry Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		switch r.URL.Path {
@@ -382,7 +382,7 @@ func (c *ClusterRepoTestSuite) TestOCIRepo2() {
 	})
 }
 
-// TestOCIRepo3 tests 4xx response codes recieved from the registry
+// TestOCIRepo3 tests 4xx response codes received from the registry
 func (c *ClusterRepoTestSuite) TestOCIRepo3() {
 	statusCodes := [3]int{404, 401, 403}
 	for _, statusCode := range statusCodes {
@@ -438,6 +438,7 @@ func (c *ClusterRepoTestSuite) test429Error(params ClusterRepoParams) {
 		return false, nil
 	})
 	assert.NoError(c.T(), err)
+	assert.Equal(c.T(), clusterRepo.Status.NumberOfRetries, expoValues.MaxRetries+1, "Number of retries should be max+1")
 
 	configMap, err := c.corev1.ConfigMaps(helm.GetConfigMapNamespace(clusterRepo.Namespace)).Get(context.TODO(), helm.GenerateConfigMapName(clusterRepo.Name, 0, clusterRepo.UID), metav1.GetOptions{})
 	assert.NoError(c.T(), err)
@@ -480,6 +481,7 @@ func (c *ClusterRepoTestSuite) test429Error(params ClusterRepoParams) {
 
 	clusterRepo, err = c.catalogClient.ClusterRepos().Get(context.TODO(), params.Name, metav1.GetOptions{})
 	assert.NoError(c.T(), err)
+	assert.Equal(c.T(), clusterRepo.Status.NumberOfRetries, 0, "Number of retries should be 0 since there were no 429s")
 	configMap, err = c.corev1.ConfigMaps(clusterRepo.Status.IndexConfigMapNamespace).Get(context.TODO(), clusterRepo.Status.IndexConfigMapName, metav1.GetOptions{})
 	assert.NoError(c.T(), err)
 
@@ -540,7 +542,7 @@ func (c *ClusterRepoTestSuite) test4xxErrors(params ClusterRepoParams) {
 	assert.Error(c.T(), err)
 }
 
-// TestOCI tests creating a OCI clusterrepo and install a chart
+// TestOCI tests creating an OCI clusterrepo and install a chart
 func (c *ClusterRepoTestSuite) TestOCIRepoChartInstallation() {
 	//start registry
 	u, err := StartRegistry()

--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -398,7 +398,7 @@ func (c *ClusterRepoTestSuite) TestOCIRepo3() {
 	}
 }
 
-// TestOCIRepo4 tests 429 response code recieved from the registry
+// TestOCIRepo4 tests 429 response code received from the registry
 func (c *ClusterRepoTestSuite) TestOCIRepo4() {
 	u, err := Start429Registry(c.T())
 	assert.NoError(c.T(), err)
@@ -431,14 +431,13 @@ func (c *ClusterRepoTestSuite) test429Error(params ClusterRepoParams) {
 
 		for _, condition := range clusterRepo.Status.Conditions {
 			if v1.RepoCondition(condition.Type) == v1.OCIDownloaded {
-				return condition.Status == corev1.ConditionFalse, nil
+				return condition.Status == corev1.ConditionFalse && clusterRepo.Status.NumberOfRetries == 0, nil
 			}
 		}
 
 		return false, nil
 	})
 	assert.NoError(c.T(), err)
-	assert.Equal(c.T(), clusterRepo.Status.NumberOfRetries, expoValues.MaxRetries+1, "Number of retries should be max+1")
 
 	configMap, err := c.corev1.ConfigMaps(helm.GetConfigMapNamespace(clusterRepo.Namespace)).Get(context.TODO(), helm.GenerateConfigMapName(clusterRepo.Name, 0, clusterRepo.UID), metav1.GetOptions{})
 	assert.NoError(c.T(), err)


### PR DESCRIPTION
Previously, the retries were handled by the oras library, and because of that, the handler would get stuck while waiting for it. This PR implements changes that make the handler itself handle the retries, instead of the oras library.