### PR TITLE
[SURE-6353]fix: Reconcile ACE

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -179,8 +179,13 @@ func (p *Provisioner) Remove(cluster *apimgmtv3.Cluster) (runtime.Object, error)
 }
 
 func (p *Provisioner) Updated(cluster *apimgmtv3.Cluster) (runtime.Object, error) {
-	if skipOperatorCluster("update", cluster) || imported.IsAdministratedByProvisioningCluster(cluster) {
+	if skipOperatorCluster("update", cluster) {
 		return cluster, nil
+	}
+
+	if imported.IsAdministratedByProvisioningCluster(cluster) {
+		reconcileACE(cluster)
+		return p.Clusters.Update(cluster)
 	}
 
 	obj, err := apimgmtv3.ClusterConditionUpdated.Do(cluster, func() (runtime.Object, error) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/41832
[SURE-6353](https://jira.suse.com/browse/SURE-6353)
 
## Problem
The issue is that enabling ACE on an RKE2 downstream cluster is not functioning as anticipated. While the kube-api-auth pod starts successfully and the kube-apiserver flags are set correctly, the controller within the kube-api-auth pod fails to start. As a result, the necessary Custom Resource Definitions (CRDs) are not created on the downstream cluster, leading to the absence of tokens.
 
## Solution
The solution to the aforementioned problem was identified through troubleshooting. It was observed that there was a discrepancy between the `appliedSpec` and `Spec` fields:

```
spec:
  desiredAgentImage: rancher/rancher-agent:v2.7.3
  desiredAuthImage: rancher/kube-api-auth:v0.1.8
  localClusterAuthEndpoint:
    enabled: true
------------
status:
  appliedSpec:
    localClusterAuthEndpoint:
      enabled: false 
```

Further investigation revealed that the ACE was not being reconciled upon updates. As a result, the `status.appliedSpec.localClusterAuthEndpoint.enabled` was not updated, preventing the controller from triggering the installation of the necessary CRDs on the downstream cluster. To address this issue, this PR introduces code to reconcile ACE, ensuring that the `status.appliedSpec.localClusterAuthEndpoint.enabled` is updated appropriately.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Followed repro steps from JIRA issue SURE-6353

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_