### PR TITLE
Automate P0 tests for GH41301

### DIFF
--- a/tests/v2/validation/schemas/README.md
+++ b/tests/v2/validation/schemas/README.md
@@ -1,0 +1,20 @@
+# Schemas
+
+## Pre-requisites
+
+- Ensure you have an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, create one first before running this test.
+
+## Test Setup
+
+Your GO suite should be set to `-run ^TestSchemaChangesTestSuite$`.
+
+In your config file, set the following:
+
+```yaml
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True #optional
+  cleanup: True #optional
+  clusterName: "downstream_cluster_name"
+```

--- a/tests/v2/validation/schemas/resources/crd_create.yaml
+++ b/tests/v2/validation/schemas/resources/crd_create.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+    - name: v2
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                newField1:
+                  type: integer
+                newField2:
+                  type: number
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+    shortNames:
+    - ct

--- a/tests/v2/validation/schemas/schemas.go
+++ b/tests/v2/validation/schemas/schemas.go
@@ -1,0 +1,289 @@
+package schemas
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/kubectl"
+)
+
+const (
+	schema              = "schema"
+	schemaDefinition    = "schemaDefinition"
+	apiGroupEndpoint    = "apigroup"
+	localCluster        = "local"
+	projectSchemaID     = "management.cattle.io.project"
+	namespaceSchemaID   = "namespace"
+	autoscalingSchemaID = "autoscaling.horizontalpodautoscaler"
+	customSchemaID      = "stable.example.com.crontab"
+	customCrdName       = "crontabs.stable.example.com"
+	crdCreateFilePath   = "./resources/crd_create.yaml"
+	twoSecondTimeout    = 2 * time.Second
+)
+
+var exceptionMap = map[string]bool{
+	"applyOutput":              true,
+	"applyInput":               true,
+	"apiRoot":                  true,
+	"chartActionOutput":        true,
+	"chartInstall":             true,
+	"chartInstallAction":       true,
+	"chartUpgrade":             true,
+	"chartUpgradeAction":       true,
+	"chartUninstallAction":     true,
+	"count":                    true,
+	"generateKubeconfigOutput": true,
+	"schema":                   true,
+	"schemaDefinition":         true,
+	"subscribe":                true,
+	"userpreference":           true,
+}
+
+func getSchemaByID(client *rancher.Client, clusterID, existingSchemaID string) (map[string]interface{}, error) {
+	return getJSONResponse(client, clusterID, schema, existingSchemaID)
+}
+
+func getSchemaDefinitionByID(client *rancher.Client, clusterID, existingSchemaID string) (map[string]interface{}, error) {
+	return getJSONResponse(client, clusterID, schemaDefinition, existingSchemaID)
+}
+
+func getAPIGroupInfoByAPIGroupName(client *rancher.Client, clusterID, apiGroupName string) (map[string]interface{}, error) {
+	return getJSONResponse(client, clusterID, apiGroupEndpoint, apiGroupName)
+}
+
+func accessSchemaDefinitionForEachSchema(client *rancher.Client, schemasCollection *v1.SteveCollection, clusterID string) ([]string, error) {
+	var failedSchemaDefinitions []string
+	var err error
+	var schemaID string
+
+	for _, schema := range schemasCollection.Data {
+		schemaID = schema.JSONResp["id"].(string)
+
+		if _, exists := exceptionMap[schemaID]; !exists {
+			_, err = getSchemaByID(client, clusterID, schemaID)
+			if err != nil {
+				return nil, err
+			}
+			_, err = getSchemaDefinitionByID(client, clusterID, schemaID)
+			if err != nil {
+				failedSchemaDefinitions = append(failedSchemaDefinitions, schemaID)
+			}
+		}
+	}
+	return failedSchemaDefinitions, nil
+}
+
+func checkPreferredVersion(client *rancher.Client, schemasCollection *v1.SteveCollection, clusterID string) ([][]string, error) {
+	var failedSchemaPreferredVersionCheck [][]string
+
+	for _, schema := range schemasCollection.Data {
+		schemaID := schema.JSONResp["id"].(string)
+
+		if _, exists := exceptionMap[schemaID]; !exists {
+			schemaInfo, err := getSchemaByID(client, clusterID, schemaID)
+			if err != nil {
+				return nil, err
+			}
+			schemaVersion := schemaInfo["attributes"].(map[string]interface{})["version"].(string)
+
+			apiGroupName := schemaInfo["attributes"].(map[string]interface{})["group"].(string)
+			if apiGroupName == "" {
+				continue
+			}
+			apiGroupInfo, err := getAPIGroupInfoByAPIGroupName(client, clusterID, apiGroupName)
+			if err != nil {
+				return nil, err
+			}
+			preferredVersion := apiGroupInfo["preferredVersion"].(map[string]interface{})["version"].(string)
+
+			if schemaVersion != preferredVersion {
+				failedSchemaPreferredVersionCheck = append(failedSchemaPreferredVersionCheck, []string{
+					"Schema ID: " + schemaID + ",",
+					"Schema Version: " + schemaVersion + ";",
+					"API Group Name: " + apiGroupName + ",",
+					"API Group Version: " + preferredVersion,
+				})
+			}
+		}
+	}
+	return failedSchemaPreferredVersionCheck, nil
+}
+
+func getJSONResponse(client *rancher.Client, clusterID, endpointType, existingID string) (map[string]interface{}, error) {
+	rancherURL := client.RancherConfig.Host
+	token := client.RancherConfig.AdminToken
+
+	baseURL := fmt.Sprintf("https://%s", rancherURL)
+	if clusterID != localCluster {
+		baseURL = fmt.Sprintf("%s/k8s/clusters/%s", baseURL, clusterID)
+	}
+
+	var httpURL string
+	if endpointType == apiGroupEndpoint {
+		httpURL = fmt.Sprintf("%s/apis/%s", baseURL, existingID)
+	} else {
+		httpURL = fmt.Sprintf("%s/v1/%s/%s", baseURL, endpointType, existingID)
+	}
+
+	req, err := http.NewRequest("GET", httpURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	byteObject, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var jsonObject map[string]interface{}
+	if err := json.Unmarshal(byteObject, &jsonObject); err != nil {
+		return nil, err
+	}
+
+	return jsonObject, nil
+}
+
+func checkSchemaFields(schemasCollection *v1.SteveCollection) error {
+	for _, schema := range schemasCollection.Data {
+		schemaID := schema.JSONResp["id"].(string)
+		if !exceptionMap[schemaID] {
+			if schema.JSONResp["resourceFields"] != nil {
+				return errors.New("resourceFields should be null for schema " + schemaID)
+			}
+
+			if match, _ := regexp.MatchString(`\.[vV][0-9]+`, schemaID); match {
+				return errors.New("child schema should not be listed")
+			}
+		}
+	}
+	return nil
+}
+
+func checkChildSchemasNotListed(client *rancher.Client, clusterID string, childSchemas map[string]bool, schemaResponse map[string]interface{}) error {
+	for childSchemaID := range childSchemas {
+		if _, found := schemaResponse[childSchemaID]; found {
+			return errors.New("child schema should not be listed")
+		}
+
+		_, err := getSchemaByID(client, clusterID, childSchemaID)
+		if err == nil {
+			return errors.New("expected an error when fetching child schema")
+		}
+		errStatus := strings.Split(err.Error(), ": ")[1]
+		if errStatus != "404" {
+			return errors.New("unexpected error status: " + errStatus)
+		}
+	}
+	return nil
+}
+
+func checkExpectedDefinitions(expectedDefinitions map[string]bool, schemaResponse map[string]interface{}) error {
+	for definitionID := range expectedDefinitions {
+		definitionData, exists := schemaResponse["definitions"].(map[string]interface{})[definitionID]
+		if !exists {
+			return fmt.Errorf("Expected definition %s not found in schemaResponse", definitionID)
+		}
+
+		resourceFields, resourceFieldsExist := definitionData.(map[string]interface{})["resourceFields"]
+		if !resourceFieldsExist || resourceFields == nil {
+			return fmt.Errorf("ResourceFields are nil for definition %s", definitionID)
+		}
+
+		_, resourceMethodsExist := definitionData.(map[string]interface{})["resourceMethods"]
+		if resourceMethodsExist {
+			return fmt.Errorf("ResourceMethods field exists for definition %s", definitionID)
+		}
+
+		_, collectionMethodsExist := definitionData.(map[string]interface{})["collectionMethods"]
+		if collectionMethodsExist {
+			return fmt.Errorf("CollectionMethods field exists for definition %s", definitionID)
+		}
+
+		for fieldName, fieldData := range resourceFields.(map[string]interface{}) {
+			fieldType := fieldData.(map[string]interface{})["type"].(string)
+			if fieldType == "integer" || fieldType == "number" {
+				return fmt.Errorf("field %s should not be of type %s in definition %s", fieldName, fieldType, definitionID)
+			}
+		}
+	}
+	return nil
+}
+
+func getChildSchemasForProject() map[string]bool {
+	return map[string]bool{
+		"io.cattle.management.v3.Project":                                          true,
+		"io.cattle.management.v3.Project.spec":                                     true,
+		"io.cattle.management.v3.Project.spec.resourceQuota":                       true,
+		"io.cattle.management.v3.Project.spec.resourceQuota.usedLimit":             true,
+		"io.cattle.management.v3.Project.spec.resourceQuota.limit":                 true,
+		"io.cattle.management.v3.Project.spec.namespaceDefaultResourceQuota":       true,
+		"io.cattle.management.v3.Project.spec.namespaceDefaultResourceQuota.limit": true,
+		"io.cattle.management.v3.Project.spec.containerDefaultResourceLimit":       true,
+		"io.cattle.management.v3.Project.status":                                   true,
+		"io.cattle.management.v3.Project.status.conditions":                        true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry":                  true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta":                          true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference":                      true,
+	}
+}
+
+func getChildSchemasForNamespace() map[string]bool {
+	return map[string]bool{
+		"io.k8s.api.core.v1.NamespaceCondition":                   true,
+		"io.k8s.api.core.v1.NamespaceSpec":                        true,
+		"io.k8s.api.core.v1.NamespaceStatus":                      true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta":         true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference":     true,
+	}
+}
+
+func getChildSchemasForCronTab() map[string]bool {
+	return map[string]bool{
+		"com.example.stable.v2.CronTab":                           true,
+		"com.example.stable.v2.CronTab.spec":                      true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta":         true,
+		"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference":     true,
+	}
+}
+
+func createCRD(client *rancher.Client, crdCreateFilePath string) error {
+	crdYAML, err := os.ReadFile(crdCreateFilePath)
+	if err != nil {
+		return err
+	}
+
+	yamlInput := &management.ImportClusterYamlInput{
+		YAML: string(crdYAML),
+	}
+	apply := []string{"kubectl", "apply", "-f", "/root/.kube/my-pod.yaml"}
+	_, err = kubectl.Command(client, yamlInput, localCluster, apply, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/v2/validation/schemas/schemas_test.go
+++ b/tests/v2/validation/schemas/schemas_test.go
@@ -1,0 +1,340 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+
+package schemas
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/kubeapi/customresourcedefinitions"
+	"github.com/rancher/shepherd/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+type SchemaChangesTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (sc *SchemaChangesTestSuite) TearDownSuite() {
+	sc.session.Cleanup()
+}
+
+func (sc *SchemaChangesTestSuite) SetupSuite() {
+	sc.session = session.NewSession()
+
+	client, err := rancher.NewClient("", sc.session)
+	require.NoError(sc.T(), err)
+
+	sc.client = client
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(sc.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(sc.client, clusterName)
+	require.NoError(sc.T(), err, "Error getting cluster ID")
+	sc.cluster, err = sc.client.Management.Cluster.ByID(clusterID)
+	require.NoError(sc.T(), err)
+}
+
+func (sc *SchemaChangesTestSuite) TestSchemaEndpointLocalCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access the schemas endpoint on the local cluster and verify that it can be accessed successfully without any errors.")
+	schemasCollection, err := sc.client.Steve.SteveType(schema).List(nil)
+	require.NoError(sc.T(), err)
+	log.Infof("Number of schemas: %d", len(schemasCollection.Data))
+
+	log.Info("Verify that each listed schema's resourceFields are set to null and ensure the schemas endpoint exclusively lists top-level types without including child schemas for resources.")
+	err = checkSchemaFields(schemasCollection)
+	require.NoError(sc.T(), err)
+}
+
+func (sc *SchemaChangesTestSuite) TestSchemaEndpointDownstreamCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	steveAdminClient, err := sc.client.Steve.ProxyDownstream(sc.cluster.ID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Access the schemas endpoint on the downstream cluster and verify that it can be accessed successfully without any errors.")
+	schemasCollection, err := steveAdminClient.SteveType(schema).List(nil)
+	require.NoError(sc.T(), err)
+	log.Infof("Number of schemas: %d", len(schemasCollection.Data))
+
+	log.Info("Verify that each listed schema's resourceFields are set to null and ensure the schemas endpoint exclusively lists top-level types without including child schemas for resources.")
+	err = checkSchemaFields(schemasCollection)
+	require.NoError(sc.T(), err)
+}
+
+func (sc *SchemaChangesTestSuite) TestExistingSchemaLocalCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access an existing schema on the local cluster and verify that it can be accessed successfully without any errors.")
+	schemaResponse, err := getSchemaByID(sc.client, localCluster, projectSchemaID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify that the schema's resourceFields field is set to null.")
+	id := schemaResponse["id"].(string)
+	require.Nil(sc.T(), schemaResponse["resourceFields"], "ResourceFields should be null for schema "+id)
+
+	log.Info("Verify that the schemas endpoint for Project does not list the child schemas and trying to access any of the child schemas results in a '404 Not Found' error.")
+	childSchemas := getChildSchemasForProject()
+	err = checkChildSchemasNotListed(sc.client, localCluster, childSchemas, schemaResponse)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify that the data returned from the schemas endpoint has the resourceMethods and collectionMethods fields.")
+	require.NotNil(sc.T(), schemaResponse["resourceMethods"], "resourceMethods should be present in this schema")
+	require.NotNil(sc.T(), schemaResponse["collectionMethods"], "collectionMethods should be present in this schema")
+}
+
+func (sc *SchemaChangesTestSuite) TestExistingSchemaDownstreamCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access an existing schema on the downstream cluster and verify that it can be accessed successfully without any errors.")
+	schemaResponse, err := getSchemaByID(sc.client, sc.cluster.ID, namespaceSchemaID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify that the schema's resourceFields field is set to null.")
+	id := schemaResponse["id"].(string)
+	require.Nil(sc.T(), schemaResponse["resourceFields"], "ResourceFields should be null for schema "+id)
+
+	log.Info("Verify that the schemas endpoint for Namespace does not list the child schemas and trying to access any of the child schemas results in a '404 Not Found' error.")
+	childSchemas := getChildSchemasForNamespace()
+	err = checkChildSchemasNotListed(sc.client, sc.cluster.ID, childSchemas, schemaResponse)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify that the data returned from the schemas endpoint has the resourceMethods and collectionMethods fields.")
+	require.NotNil(sc.T(), schemaResponse["resourceMethods"], "resourceMethods should be present in this schema")
+	require.NotNil(sc.T(), schemaResponse["collectionMethods"], "collectionMethods should be present in this schema")
+}
+
+func (sc *SchemaChangesTestSuite) TestSchemaDefinitionsEndpointLocalCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access schemadefinitions endpoint on the local cluster without providing the schema and verify that it fails with an error.")
+	_, err := sc.client.Steve.SteveType(schemaDefinition).List(nil)
+	require.Error(sc.T(), err)
+	errMessage := strings.Split(err.Error(), ":")[0]
+	require.Equal(sc.T(), "Resource type [schemaDefinition] has no method GET", errMessage)
+}
+
+func (sc *SchemaChangesTestSuite) TestSchemaDefinitionsEndpointDownstreamCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	steveAdminClient, err := sc.client.Steve.ProxyDownstream(sc.cluster.ID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Access schemadefinitions endpoint on the downstream cluster without providing the schema and verify that it fails with an error.")
+	_, err = steveAdminClient.SteveType(schemaDefinition).List(nil)
+	require.Error(sc.T(), err)
+	errMessage := strings.Split(err.Error(), ":")[0]
+	require.Equal(sc.T(), "Resource type [schemaDefinition] has no method GET", errMessage)
+}
+
+func (sc *SchemaChangesTestSuite) TestExistingSchemaDefinitionLocalCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access the schema definition for an existing schema on the local cluster and verify that it can be accessed successfully without any errors.")
+	schemaResponse, err := getSchemaDefinitionByID(sc.client, localCluster, projectSchemaID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify data returned has definitions with resourceFields for each definition type.")
+	expectedDefinitions := getChildSchemasForProject()
+	err = checkExpectedDefinitions(expectedDefinitions, schemaResponse)
+	require.NoError(sc.T(), err)
+}
+
+func (sc *SchemaChangesTestSuite) TestExistingSchemaDefinitionDownstreamCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access the schema definition for an existing schema on the downstream cluster and verify that it can be accessed successfully without any errors.")
+	schemaResponse, err := getSchemaDefinitionByID(sc.client, sc.cluster.ID, namespaceSchemaID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify data returned has definitions with resourceFields for each definition type.")
+	expectedDefinitions := getChildSchemasForNamespace()
+	err = checkExpectedDefinitions(expectedDefinitions, schemaResponse)
+	require.NoError(sc.T(), err)
+}
+
+func (sc *SchemaChangesTestSuite) TestSchemaDefinitionsExistenceForSchemaLocalCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access the schemas and schema definition endpoint on the local cluster and verify that it can be accessed successfully without any errors.")
+	schemasCollection, err := sc.client.Steve.SteveType(schema).List(nil)
+	require.NoError(sc.T(), err)
+	log.Infof("Number of schemas: %d", len(schemasCollection.Data))
+
+	log.Info("Access the schema definition for each schema in the list using the schemadefinitions endpoint.")
+	failedSchemaDefinitions, err := accessSchemaDefinitionForEachSchema(sc.client, schemasCollection, localCluster)
+	require.NoError(sc.T(), err)
+	require.Emptyf(sc.T(), failedSchemaDefinitions, "Failed to access schema definitions for schemas: %s", strings.Join(failedSchemaDefinitions, ", "))
+}
+
+func (sc *SchemaChangesTestSuite) TestSchemaDefinitionsExistenceForSchemaDownstreamCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	steveAdminClient, err := sc.client.Steve.ProxyDownstream(sc.cluster.ID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Access the schemas endpoint on the downstream cluster and verify that it can be accessed successfully without any errors.")
+	schemasCollection, err := steveAdminClient.SteveType(schema).List(nil)
+	require.NoError(sc.T(), err)
+	log.Infof("Number of schemas: %d", len(schemasCollection.Data))
+
+	log.Info("Access the schema definition for each schema in the list using the schemadefinitions endpoint.")
+	failedSchemaDefinitions, err := accessSchemaDefinitionForEachSchema(sc.client, schemasCollection, sc.cluster.ID)
+	require.NoError(sc.T(), err)
+	require.Emptyf(sc.T(), failedSchemaDefinitions, "Failed to access schema definitions for schemas: %s", strings.Join(failedSchemaDefinitions, ", "))
+}
+
+func (sc *SchemaChangesTestSuite) TestPreferredVersionCheckLocalCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Access the schemas endpoint on the local cluster and verify that it can be accessed successfully without any errors.")
+	schemasCollection, err := sc.client.Steve.SteveType(schema).List(nil)
+	require.NoError(sc.T(), err)
+	log.Infof("Number of schemas: %d", len(schemasCollection.Data))
+
+	log.Info("Verify that the version in each schema is the preferred version.")
+	failedSchemaPreferredVersionCheck, err := checkPreferredVersion(sc.client, schemasCollection, localCluster)
+	require.NoError(sc.T(), err)
+	require.Emptyf(sc.T(), failedSchemaPreferredVersionCheck, "Failed preferred version checks: %v", failedSchemaPreferredVersionCheck)
+}
+
+func (sc *SchemaChangesTestSuite) TestPreferredVersionCheckDownstreamCluster() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	steveAdminClient, err := sc.client.Steve.ProxyDownstream(sc.cluster.ID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Access the schemas endpoint on the downstream cluster and verify that it can be accessed successfully without any errors.")
+	schemasCollection, err := steveAdminClient.SteveType(schema).List(nil)
+	require.NoError(sc.T(), err)
+	log.Infof("Number of schemas: %d", len(schemasCollection.Data))
+
+	log.Info("Verify that the version in each schema is the preferred version.")
+	failedSchemaPreferredVersionCheck, err := checkPreferredVersion(sc.client, schemasCollection, sc.cluster.ID)
+	require.NoError(sc.T(), err)
+	require.Emptyf(sc.T(), failedSchemaPreferredVersionCheck, "Failed preferred version checks: %v", failedSchemaPreferredVersionCheck)
+}
+
+func (sc *SchemaChangesTestSuite) TestCRDCreateOperation() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a new Custom Resource Definition (CRD).")
+	err := createCRD(sc.client, crdCreateFilePath)
+	require.NoError(sc.T(), err)
+
+	log.Info("Access the schemas endpoint for the newly created CRD and verify that it can be accessed successfully without any errors.")
+	err = kwait.PollUntilContextTimeout(context.Background(), twoSecondTimeout, defaults.FiveSecondTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+		_, pollErr = getSchemaByID(sc.client, localCluster, customSchemaID)
+		if pollErr != nil {
+			return false, pollErr
+		}
+		return true, nil
+	})
+	schemaResponse, err := getSchemaByID(sc.client, localCluster, customSchemaID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify that the schema's resourceFields field is set to null.")
+	id := schemaResponse["id"].(string)
+	require.Nil(sc.T(), schemaResponse["resourceFields"], "ResourceFields should be null for schema "+id)
+
+	log.Info("Verify that the schemas endpoint for the new CRD does not list the child schemas.")
+	childSchemas := getChildSchemasForCronTab()
+	err = checkChildSchemasNotListed(sc.client, localCluster, childSchemas, schemaResponse)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify that the data returned from the schemas endpoint has the resourceMethods and collectionMethods fields.")
+	require.NotNil(sc.T(), schemaResponse["resourceMethods"], "resourceMethods should be present in this schema")
+	require.NotNil(sc.T(), schemaResponse["collectionMethods"], "collectionMethods should be present in this schema")
+
+	log.Info("Access the schema definition for the new CRD and verify that it can be accessed successfully without any errors.")
+	err = kwait.PollUntilContextTimeout(context.Background(), twoSecondTimeout, defaults.FiveSecondTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+		_, pollErr = getSchemaDefinitionByID(sc.client, localCluster, customSchemaID)
+		if pollErr != nil {
+			return false, pollErr
+		}
+		return true, nil
+	})
+	schemaResponse, err = getSchemaDefinitionByID(sc.client, localCluster, customSchemaID)
+	require.NoError(sc.T(), err)
+
+	log.Info("Verify that the data returned has definitions with resourceFields for each definition type, and the resourceMethods and collectionMethods fields are present.")
+	expectedDefinitions := getChildSchemasForCronTab()
+	err = checkExpectedDefinitions(expectedDefinitions, schemaResponse)
+	require.NoError(sc.T(), err)
+}
+
+func (sc *SchemaChangesTestSuite) TestCRDDeleteOperation() {
+	subSession := sc.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a new Custom Resource Definition (CRD).")
+	err := createCRD(sc.client, crdCreateFilePath)
+	require.NoError(sc.T(), err)
+
+	log.Info("Access the schemas endpoint for the newly created CRD and verify that it can be accessed successfully without any errors.")
+	err = kwait.PollUntilContextTimeout(context.Background(), twoSecondTimeout, defaults.FiveSecondTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+		_, pollErr = getSchemaByID(sc.client, localCluster, customSchemaID)
+		if pollErr != nil {
+			return false, pollErr
+		}
+		return true, nil
+	})
+
+	log.Info("Delete the CRD.")
+	err = customresourcedefinitions.DeleteCustomResourceDefinition(sc.client, localCluster, "", customCrdName)
+	require.NoError(sc.T(), err)
+
+	log.Info("Access the schemas endpoint for the CRD and verify that it fails with a 404 error.")
+	err = kwait.PollUntilContextTimeout(context.Background(), twoSecondTimeout, defaults.OneMinuteTimeout, true, func(ctx context.Context) (done bool, pollErr error) {
+		_, pollErr = getSchemaByID(sc.client, localCluster, customSchemaID)
+		if pollErr != nil {
+			return true, pollErr
+		}
+		return false, nil
+	})
+	require.Error(sc.T(), err)
+	errStatus := strings.Split(err.Error(), ": ")[1]
+	require.Equal(sc.T(), "404", errStatus)
+
+	log.Info("Access the schema definition for the CRD and verify that it fails with a 404 error.")
+	err = kwait.PollUntilContextTimeout(context.Background(), twoSecondTimeout, defaults.OneMinuteTimeout, true, func(ctx context.Context) (done bool, pollErr error) {
+		_, pollErr = getSchemaDefinitionByID(sc.client, localCluster, customSchemaID)
+		if pollErr != nil {
+			return true, pollErr
+		}
+		return false, nil
+	})
+	require.Error(sc.T(), err)
+	errStatus = strings.Split(err.Error(), ": ")[1]
+	require.Equal(sc.T(), "404", errStatus)
+}
+
+func TestSchemaChangesTestSuite(t *testing.T) {
+	suite.Run(t, new(SchemaChangesTestSuite))
+}


### PR DESCRIPTION
QA Task: https://github.com/rancher/qa-tasks/issues/1277

Following P0 tests have been automated in this PR:
- [x] Schemas Endpoint Validation - Local Cluster
- [x] Schemas Endpoint Validation - Downstream Cluster
- [x] Existing Schema - Local Cluster
- [x] Existing Schema - Downstream Cluster
- [x] Schemadefinitions Endpoint Error Validation - Local Cluster
- [x] Schemadefinitions Endpoint Error Validation - Downstream Cluster
- [x] Schemadefinitions Endpoint Validation for existing schema - Local Cluster
- [x] Schemadefinitions Endpoint Validation for existing schema - Downstream Cluster
- [x] Verify Schema Definitions Exists For Each Schema - Local Cluster
- [x] Verify Schema Definitions Exists For Each Schema - Downstream Cluster
- [x] Create and Delete a CRD - verify schemas and schemadefinition
- [x] Preferred Version Check for Schemas - Local Cluster
- [x] Preferred Version Check for Schemas - Downstream Cluster

Note:
- This is applicable only for 2.9 so no backports will be created.