### PR TITLE
[v2.9] Add `util-linux` `ca-certificates-mozilla`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-    git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small \
+    git-core curl util-linux ca-certificates ca-certificates-mozilla unzip xz gzip sed tar shadow gawk vim-small \
     netcat-openbsd mkisofs openssh-clients && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
@@ -19,6 +19,13 @@ FROM final
 
 # Copy binaries and configuration files from builder to micro
 COPY --from=builder /chroot/ /
+
+# Test that some of the dependency binaries were copied
+# and are working on the target image.
+RUN /usr/bin/unshare --version && \
+    /usr/bin/mount --version && \
+    /usr/bin/umount --version && \
+    /usr/bin/nsenter --version
 
 RUN useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -13,7 +13,7 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-    curl ca-certificates jq git-core hostname iproute2 vim-small less \
+    curl util-linux ca-certificates ca-certificates-mozilla jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
@@ -23,11 +23,13 @@ FROM final
 
 # Copy binaries and configuration files from builder to micro
 COPY --from=builder /chroot/ /
-COPY --from=builder \
-    /usr/bin/unshare \
-    /usr/bin/mount \
-    /usr/bin/umount \
-    /usr/bin/
+
+# Test that some of the dependency binaries were copied
+# and are working on the target image.
+RUN /usr/bin/unshare --version && \
+    /usr/bin/mount --version && \
+    /usr/bin/umount --version && \
+    /usr/bin/nsenter --version
 
 ARG ARCH=amd64
 ENV KUBECTL_VERSION v1.27.10

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-    git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small \
+    git-core curl util-linux ca-certificates ca-certificates-mozilla unzip xz gzip sed tar shadow gawk vim-small \
     netcat-openbsd mkisofs openssh-clients && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
@@ -19,6 +19,13 @@ FROM final
 
 # Copy binaries and configuration files from builder to micro
 COPY --from=builder /chroot/ /
+
+# Test that some of the dependency binaries were copied
+# and are working on the target image.
+RUN /usr/bin/unshare --version && \
+    /usr/bin/mount --version && \
+    /usr/bin/umount --version && \
+    /usr/bin/nsenter --version
 
 RUN useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -13,7 +13,7 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-    curl ca-certificates jq git-core hostname iproute2 vim-small less \
+    curl util-linux ca-certificates ca-certificates-mozilla jq git-core hostname iproute2 vim-small less \
 	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
@@ -23,11 +23,13 @@ FROM final
 
 # Copy binaries and configuration files from builder to micro
 COPY --from=builder /chroot/ /
-COPY --from=builder \
-    /usr/bin/unshare \
-    /usr/bin/mount \
-    /usr/bin/umount \
-    /usr/bin/
+
+# Test that some of the dependency binaries were copied
+# and are working on the target image.
+RUN /usr/bin/unshare --version && \
+    /usr/bin/mount --version && \
+    /usr/bin/umount --version && \
+    /usr/bin/nsenter --version
 
 ARG ARCH=amd64
 ENV KUBECTL_VERSION v1.27.10


### PR DESCRIPTION
Both packages needed to be added after the transition from `bci-base` to `bci-micro` (#44348). The former contains key Linux utilities such as `mount` and `umount`, which are needed by upstream dependencies. The latter contain static certificate files which are needed for the `update-ca-certificates` operation that takes place at `entrypoint.sh`.

Fixes https://github.com/rancher/rancher/issues/45199.
Potentially linked to https://github.com/rancher/rancher/issues/45199.