### PR TITLE
Adds automated support to test Init node cannot be deleted issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240425061024-5ce684a45887
-	github.com/rancher/shepherd v0.0.0-20240425212533-351f9be6d0c0
+	github.com/rancher/shepherd v0.0.0-20240502220002-2bcb20d8aa61
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1700,8 +1700,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.6.0-rc1 h1:4aYfGiG4gxL5k44M3jpDoKfQqI1lxdl4GAVPRMvKMj8=
 github.com/rancher/rke v1.6.0-rc1/go.mod h1:vojhOf8U8VCmw7y17OENWXSIfEFPEbXCMQcmI7xN7i8=
-github.com/rancher/shepherd v0.0.0-20240425212533-351f9be6d0c0 h1:BW9f3F/zcIGrYNpffWQz/zdqghVdmkwaYDdz9W++aGQ=
-github.com/rancher/shepherd v0.0.0-20240425212533-351f9be6d0c0/go.mod h1:Mpd+RsxaqTMaoKSdeiEvGoDEknAKS8hAWjdozi5mJxE=
+github.com/rancher/shepherd v0.0.0-20240502220002-2bcb20d8aa61 h1:w+zEBdP+7gGv+bKqqiSjeVjM6Mm5IjXN8tP1PGSJAS0=
+github.com/rancher/shepherd v0.0.0-20240502220002-2bcb20d8aa61/go.mod h1:Mpd+RsxaqTMaoKSdeiEvGoDEknAKS8hAWjdozi5mJxE=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/deleting/README.md
+++ b/tests/v2/validation/deleting/README.md
@@ -26,4 +26,9 @@ These tests utilize Go build tags. Due to this, see the below examples on how to
 ### RKE2 | K3S
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/deleting --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestClusterDeleteTestSuite/TestDeletingCluster"`
 
+### Delete Init Machine Suite (rke2/k3s)
+automated check to validate [this issue](https://github.com/rancher/rancher/issues/42709), where the "init node" machine for v2 prov clusters would hang in deletion state and fail to be removed.
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/deleting --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestDeleteInitMachineTestSuite/TestDeleteInitMachine"`
+
 If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/v2/validation/deleting/delete_init_machine.go
+++ b/tests/v2/validation/deleting/delete_init_machine.go
@@ -1,0 +1,33 @@
+package deleting
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/machinepools"
+	"github.com/rancher/shepherd/extensions/steve"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	machineSteveResourceType = "cluster.x-k8s.io.machine"
+)
+
+func deleteInitMachine(t *testing.T, client *rancher.Client, clusterID string) {
+	initMachine, err := machinepools.GetInitMachine(client, clusterID)
+	require.NoError(t, err)
+
+	err = client.Steve.SteveType(machineSteveResourceType).Delete(initMachine)
+	require.NoError(t, err)
+
+	logrus.Info("Awaiting machine deletion...")
+	err = steve.WaitForSteveResourceDeletion(client, defaults.FiveHundredMillisecondTimeout, defaults.TwoMinuteTimeout, machineSteveResourceType, initMachine.ID)
+	require.NoError(t, err)
+
+	logrus.Info("Awaiting machine replacement...")
+	err = clusters.WatchAndWaitForCluster(client, clusterID)
+	require.NoError(t, err)
+}

--- a/tests/v2/validation/deleting/delete_init_machine_test.go
+++ b/tests/v2/validation/deleting/delete_init_machine_test.go
@@ -1,0 +1,68 @@
+package deleting
+
+import (
+	"strings"
+	"testing"
+
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	ProvisioningSteveResourceType = "provisioning.cattle.io.cluster"
+)
+
+type DeleteInitMachineTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (d *DeleteInitMachineTestSuite) TearDownSuite() {
+	d.session.Cleanup()
+}
+
+func (d *DeleteInitMachineTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	d.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(d.T(), err)
+
+	d.client = client
+}
+
+func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
+	clusterID, err := clusters.GetV1ProvisioningClusterByName(d.client, d.client.RancherConfig.ClusterName)
+	require.NoError(d.T(), err)
+
+	cluster, err := d.client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+	require.NoError(d.T(), err)
+
+	updatedCluster := new(apisV1.Cluster)
+	err = v1.ConvertToK8sType(cluster, &updatedCluster)
+	require.NoError(d.T(), err)
+
+	name := "K3S"
+
+	if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+		name = "RKE2"
+	}
+	require.NotContains(d.T(), updatedCluster.Spec.KubernetesVersion, "-rancher")
+	require.NotEmpty(d.T(), updatedCluster.Spec.KubernetesVersion)
+
+	d.Run(name, func() {
+		deleteInitMachine(d.T(), d.client, clusterID)
+	})
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestDeleteInitMachineTestSuite(t *testing.T) {
+	suite.Run(t, new(DeleteInitMachineTestSuite))
+}


### PR DESCRIPTION
adds a test to delete the init node machine of a downstream rke2/k3s cluster, then verify successful deletion

Issue:
https://github.com/rancher/rancher/issues/42709

Link to previous PRs (draft) for additional context around requested changes:
https://github.com/rancher/rancher/pull/44155
https://github.com/rancher/rancher/pull/45113