### PR TITLE
[2.9] Refactor components to avoid caching Secrets from downstream clusters

### DIFF
--- a/pkg/agent/cluster/cluster.go
+++ b/pkg/agent/cluster/cluster.go
@@ -74,7 +74,7 @@ func getTokenFromAPI() ([]byte, []byte, error) {
 		}
 		return secret.Data[coreV1.ServiceAccountRootCAKey], secret.Data[coreV1.ServiceAccountTokenKey], nil
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, k8s, sa)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, k8s.CoreV1(), sa)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to ensure secret for service account %s/%s: %w", namespace.System, "cattle", err)
 	}

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -295,7 +295,7 @@ func GetPlanServiceAccountTokenSecret(secretClient corecontrollers.SecretControl
 	if planSA == nil {
 		return nil, false, fmt.Errorf("planSA was nil")
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), secretClient.Cache(), k8s, planSA)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), secretClient.Cache(), k8s.CoreV1(), planSA)
 	if err != nil {
 		return nil, false, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", planSA.Namespace, planSA.Name, err)
 	}

--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -201,6 +202,7 @@ func (r *RemoteService) Handler() http.Handler {
 }
 
 func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
 	u, err := r.url()
 	if err != nil {
 		er.Error(rw, req, err)
@@ -229,18 +231,18 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if r.cluster.Spec.Internal && r.localAuth == "" {
 		req.Header.Del("Authorization")
 	} else {
-		userInfo, authed := request.UserFrom(req.Context())
+		userInfo, authed := request.UserFrom(ctx)
 		if !authed {
 			er.Error(rw, req, validation.Unauthorized)
 			return
 		}
 
-		if !authcontext.IsSAAuthenticated(req.Context()) {
+		if !authcontext.IsSAAuthenticated(ctx) {
 			// If the request is not authenticated as a service account,
 			// we need to use an impersonation token.
 			// This is because the impersonator service account does exist on the downstream cluster, and
 			// it has sufficient permissions to perform the TokenReview.
-			token, err := r.getImpersonatorAccountToken(userInfo)
+			token, err := r.getImpersonatorAccountToken(ctx, userInfo)
 			if err != nil && !strings.Contains(err.Error(), dialer2.ErrAgentDisconnected.Error()) {
 				er.Error(rw, req, fmt.Errorf("unable to create impersonator account: %w", err))
 				return
@@ -291,7 +293,7 @@ func (p *UpgradeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // getImpersonatorAccountToken creates, if not already present, a service account and role bindings
 // whose only permission is to impersonate the given user, and returns the bearer token for the account.
-func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, error) {
+func (r *RemoteService) getImpersonatorAccountToken(ctx context.Context, user user.Info) (string, error) {
 	clusterContext, err := r.clusterContextGetter.UserContext(r.cluster.Name)
 	if err != nil {
 		return "", err
@@ -302,11 +304,11 @@ func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, err
 		return "", fmt.Errorf("error creating impersonation for user %s: %w", user.GetUID(), err)
 	}
 
-	sa, err := i.SetUpImpersonation()
+	sa, err := i.SetUpImpersonation(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error setting up impersonation for user %s: %w", user.GetUID(), err)
 	}
-	saToken, err := i.GetToken(sa)
+	saToken, err := i.GetToken(ctx, sa)
 	if err != nil {
 		return "", fmt.Errorf("error getting service account token: %w", err)
 	}

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -120,7 +120,7 @@ func (h *handler) getBootstrapSecret(namespace, name string, envVars []corev1.En
 	if err != nil {
 		return nil, err
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), h.secretCache, h.k8s, sa)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), h.secretCache, h.k8s.CoreV1(), sa)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/dashboard/apiservice/apiservice.go
+++ b/pkg/controllers/dashboard/apiservice/apiservice.go
@@ -148,7 +148,7 @@ func (h *handler) getToken(sa *corev1.ServiceAccount) (string, error) {
 	}
 
 	// create a secret-based token for the service account if one does not exist
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(h.ctx, h.secretsCache, h.k8s, sa)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(h.ctx, h.secretsCache, h.k8s.CoreV1(), sa)
 	if err != nil {
 		return "", fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
 	}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -48,8 +48,6 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 
 	// register controller for API
 	cluster.APIAggregation.APIServices("").Controller()
-	// register secrets controller for impersonation
-	cluster.Core.Secrets("").Controller()
 
 	if clusterRec.Spec.LocalClusterAuthEndpoint.Enabled {
 		err := clusterauthtoken.CRDSetup(ctx, cluster.UserOnlyContext())
@@ -61,7 +59,6 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 
 	// Ensure these caches are started
 	cluster.Core.Namespaces("").Controller()
-	cluster.Core.Secrets("").Controller()
 	cluster.Core.ServiceAccounts("").Controller()
 
 	return managementuserlegacy.Register(ctx, mgmt, cluster, clusterRec, kubeConfigGetter)

--- a/pkg/controllers/managementuser/rbac/impersonation_handler.go
+++ b/pkg/controllers/managementuser/rbac/impersonation_handler.go
@@ -1,6 +1,8 @@
 package rbac
 
 import (
+	"context"
+
 	"github.com/rancher/rancher/pkg/impersonation"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,7 +20,7 @@ func (m *manager) ensureServiceAccountImpersonator(username string) error {
 	if err != nil {
 		return err
 	}
-	_, err = i.SetUpImpersonation()
+	_, err = i.SetUpImpersonation(context.TODO())
 	return err
 }
 

--- a/pkg/kontainer-engine/drivers/util/utils.go
+++ b/pkg/kontainer-engine/drivers/util/utils.go
@@ -95,7 +95,7 @@ func GenerateServiceAccountToken(clientset kubernetes.Interface) (string, error)
 	if serviceAccount, err = clientset.CoreV1().ServiceAccounts(cattleNamespace).Get(context.Background(), serviceAccount.Name, metav1.GetOptions{}); err != nil {
 		return "", fmt.Errorf("error getting service account: %w", err)
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, clientset, serviceAccount)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, clientset.CoreV1(), serviceAccount)
 	if err != nil {
 		return "", fmt.Errorf("error ensuring secret for service account: %w", err)
 	}

--- a/pkg/metrics/object_count.go
+++ b/pkg/metrics/object_count.go
@@ -1,0 +1,94 @@
+package metrics
+
+import (
+	"context"
+
+	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	projectv3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
+	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+type clusterObjectCounter interface {
+	ConfigMaps(context.Context) (int64, error)
+	Namespaces(context.Context) (int64, error)
+	Nodes(context.Context) (int64, error)
+	Secrets(context.Context) (int64, error)
+
+	AppRevisions(context.Context) (int64, error)
+
+	ClusterRoleBindings(context.Context) (int64, error)
+	RoleBindings(context.Context) (int64, error)
+
+	CatalogTemplateVersions(context.Context) (int64, error)
+	Projects(context.Context) (int64, error)
+}
+
+type clusterCountClient struct {
+	dynamic dynamic.Interface
+}
+
+func (h *metricsHandler) getClusterClient(clusterID string) (clusterObjectCounter, error) {
+	cluster, err := h.clusterManager.UserContext(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return &clusterCountClient{
+		dynamic: dynamic.New(cluster.UnversionedClient),
+	}, nil
+}
+
+func (c clusterCountClient) countAllObjects(ctx context.Context, gvr schema.GroupVersionResource) (int64, error) {
+	list, err := c.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	n := int64(len(list.Items))
+	if remaining := list.GetRemainingItemCount(); remaining != nil {
+		n += *remaining
+	}
+	return n, nil
+}
+
+func (c clusterCountClient) ConfigMaps(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, corev1.ConfigMapGroupVersionResource)
+}
+
+func (c clusterCountClient) Namespaces(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, corev1.NamespaceGroupVersionResource)
+}
+
+func (c clusterCountClient) Nodes(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, corev1.NodeGroupVersionResource)
+}
+
+func (c clusterCountClient) Secrets(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, corev1.SecretGroupVersionResource)
+}
+
+func (c clusterCountClient) AppRevisions(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, projectv3.AppRevisionGroupVersionResource)
+}
+
+func (c clusterCountClient) ClusterRoleBindings(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, rbacv1.ClusterRoleBindingGroupVersionResource)
+}
+
+func (c clusterCountClient) RoleBindings(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, rbacv1.RoleBindingGroupVersionResource)
+}
+
+func (c clusterCountClient) CatalogTemplateVersions(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, managementv3.CatalogTemplateVersionGroupVersionResource)
+}
+
+func (c clusterCountClient) Projects(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, managementv3.ProjectGroupVersionResource)
+}

--- a/pkg/serviceaccounttoken/secret_test.go
+++ b/pkg/serviceaccounttoken/secret_test.go
@@ -180,7 +180,7 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					return true, ret, nil
 				},
 			)
-			got, gotErr := EnsureSecretForServiceAccount(context.Background(), nil, k8sClient, tt.sa)
+			got, gotErr := EnsureSecretForServiceAccount(context.Background(), nil, k8sClient.CoreV1(), tt.sa)
 			if tt.wantErr {
 				assert.Error(t, gotErr)
 				return

--- a/pkg/tunnelserver/peermanager.go
+++ b/pkg/tunnelserver/peermanager.go
@@ -77,7 +77,7 @@ func getTokenFromToken(ctx context.Context, tokenBytes []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(ctx, nil, client, sa)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(ctx, nil, client.CoreV1(), sa)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41905

### TO-DO
 - [ ] If https://github.com/rancher/lasso/pull/69 and https://github.com/rancher/norman/pull/496 get approved and merged, use it in `pkg/metrics`.
 
## General Problem

Currently we are caching many objects for downstream clusters in the local cluster's rancher instance, involving at least 12 different Kubernetes kinds (see related issue). This effects rancher's ability to scale, since this not only incurs into a considerable amount of memory usage, but also network bandwidth required to populate and keep those caches up-to-date.

I am investigating how every of those Kinds is being used by the offending Rancher components, and reviewed how we could eventually get rid of some of them (if possible, where it makes sense).

## Concrete Problem being investigated in this PR
 
One of the Kinds that normally shows at the top during memory profiling is `v1.Secret`, which I've identified not to be extensively used. I believe the use of caches might not be justified.

## Solution

I identified 4 areas where secrets were cached (maybe inadvertently, since wrangler controllers implicitly start caching kinds on its constructor (see https://github.com/rancher/wrangler/blob/master/pkg/generic/controller.go#L195 and https://github.com/rancher/lasso/blob/master/pkg/controller/sharedcontrollerfactory.go#L183):
 - `pkg/metrics`
 - `pkg/impersonation`
 - `controllers/managementuser/certsexpiration`
 - `controllers/managementuser/secret`

I've split every component in a different commit and added a brief explanation.
 
## Testing

I've manually tested these changes, adding extra instrumentation to ensure that `Secret` do not get added to the shared caches. Also, I couldn't find any regression in the functionality of the components being modified.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_