### PR TITLE
Constants update 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher
 
-go 1.22
+go 1.22.0
+
+toolchain go1.22.2
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.27 // for compatibilty with docker 20.10.x
@@ -450,3 +452,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+replace github.com/rancher/shepherd => github.com/susesgartner/shepherd v0.0.0-20240426205906-5052bfd25d0b

--- a/go.sum
+++ b/go.sum
@@ -1700,8 +1700,6 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.6.0-rc1 h1:4aYfGiG4gxL5k44M3jpDoKfQqI1lxdl4GAVPRMvKMj8=
 github.com/rancher/rke v1.6.0-rc1/go.mod h1:vojhOf8U8VCmw7y17OENWXSIfEFPEbXCMQcmI7xN7i8=
-github.com/rancher/shepherd v0.0.0-20240425212533-351f9be6d0c0 h1:BW9f3F/zcIGrYNpffWQz/zdqghVdmkwaYDdz9W++aGQ=
-github.com/rancher/shepherd v0.0.0-20240425212533-351f9be6d0c0/go.mod h1:Mpd+RsxaqTMaoKSdeiEvGoDEknAKS8hAWjdozi5mJxE=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
@@ -1814,6 +1812,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/susesgartner/shepherd v0.0.0-20240426205906-5052bfd25d0b h1:2mElGNDoxDcJWrDYHZkqgHAMgI1pPBzEC3gfA/ZznCU=
+github.com/susesgartner/shepherd v0.0.0-20240426205906-5052bfd25d0b/go.mod h1:BVDG5SPBFCZqO+239c1N4oq1+zMsHBblme+L+E3jsw0=
 github.com/sylabs/sif/v2 v2.11.5 h1:7ssPH3epSonsTrzbS1YxeJ9KuqAN7ISlSM61a7j/mQM=
 github.com/sylabs/sif/v2 v2.11.5/go.mod h1:GBoZs9LU3e4yJH1dcZ3Akf/jsqYgy5SeguJQC+zd75Y=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=

--- a/tests/integration/pkg/defaults/defaults.go
+++ b/tests/integration/pkg/defaults/defaults.go
@@ -1,5 +1,0 @@
-package defaults
-
-var (
-	WatchTimeoutSeconds = int64(600) // 10 minutes.
-)

--- a/tests/v2/codecoverage/ranchercleanup/main.go
+++ b/tests/v2/codecoverage/ranchercleanup/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rancher/shepherd/clients/corral"
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
-	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/shepherd/pkg/wait"
 	"github.com/sirupsen/logrus"
@@ -34,7 +34,7 @@ func main() {
 	var clusterList *v1.SteveCollection
 	err = kwait.Poll(500*time.Millisecond, 10*time.Minute, func() (done bool, err error) {
 		//clean up clusters
-		resp, err := client.Steve.SteveType(clusters.ProvisioningSteveResourceType).List(nil)
+		resp, err := client.Steve.SteveType(stevetypes.Provisioning).List(nil)
 		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
 			return false, err
 		} else if resp != nil {
@@ -51,7 +51,7 @@ func main() {
 	deleteTimeout := timeout
 	for _, cluster := range clusterList.Data {
 		if cluster.ObjectMeta.Name != "local" {
-			err := client.Steve.SteveType(clusters.ProvisioningSteveResourceType).Delete(&cluster)
+			err := client.Steve.SteveType(stevetypes.Provisioning).Delete(&cluster)
 			if err != nil {
 				logrus.Errorf("error deleting cluster: %v", err)
 			}

--- a/tests/v2/codecoverage/setuprancher/main.go
+++ b/tests/v2/codecoverage/setuprancher/main.go
@@ -11,8 +11,8 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/clusters"
-	"github.com/rancher/shepherd/extensions/defaults"
-	"github.com/rancher/shepherd/extensions/kubeapi/workloads/deployments"
+	"github.com/rancher/shepherd/extensions/defaults/schema/groupversionresources"
+	"github.com/rancher/shepherd/extensions/defaults/timeouts"
 	"github.com/rancher/shepherd/extensions/pipeline"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	nodepools "github.com/rancher/shepherd/extensions/rke1/nodepools"
@@ -197,7 +197,7 @@ func updateRancherDeployment(kubeconfig []byte) error {
 		return err
 	}
 
-	deploymentResource := dynamicClient.Resource(deployments.DeploymentGroupVersionResource)
+	deploymentResource := dynamicClient.Resource(groupversionresources.Deployment())
 
 	cattleSystemDeploymentResource := deploymentResource.Namespace(namespace)
 	unstructuredDeployment, err := cattleSystemDeploymentResource.Get(context.TODO(), deploymentName, metav1.GetOptions{})
@@ -305,7 +305,7 @@ func createTestCluster(client, adminClient *rancher.Client, numClusters int, clu
 
 		opts := metav1.ListOptions{
 			FieldSelector:  "metadata.name=" + clusterResp.ID,
-			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+			TimeoutSeconds: timeouts.ThirtyMinuteWatch(),
 		}
 		watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, opts)
 		if err != nil {

--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher/catalog"
 	client "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	stevev1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/kubeconfig"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/sirupsen/logrus"
@@ -404,7 +405,7 @@ func (w *RancherManagedChartsTest) resetManagementCluster() {
 
 func (w *RancherManagedChartsTest) updateSetting(name, value string) error {
 	// Use the Steve client instead of the main one to be able to set a setting's value to an empty string.
-	existing, err := w.client.Steve.SteveType("management.cattle.io.setting").ByID(name)
+	existing, err := w.client.Steve.SteveType(stevetypes.ManagementSetting).ByID(name)
 	if err != nil {
 		return err
 	}
@@ -415,7 +416,7 @@ func (w *RancherManagedChartsTest) updateSetting(name, value string) error {
 	}
 
 	s.Value = value
-	_, err = w.client.Steve.SteveType("management.cattle.io.setting").Update(existing, s)
+	_, err = w.client.Steve.SteveType(stevetypes.ManagementSetting).Update(existing, s)
 	return err
 }
 
@@ -476,7 +477,7 @@ func (w *RancherManagedChartsTest) TestServeIcons() {
 			},
 		},
 	)
-	_, err := w.client.Steve.SteveType(catalog.ClusterRepoSteveResourceType).Create(clusterRepoToCreate)
+	_, err := w.client.Steve.SteveType(stevetypes.ClusterRepo).Create(clusterRepoToCreate)
 	w.Require().NoError(err)
 	time.Sleep(1 * time.Second)
 

--- a/tests/v2/integration/projects/resource_quota_test.go
+++ b/tests/v2/integration/projects/resource_quota_test.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/schema/groupversionresources"
+	"github.com/rancher/shepherd/extensions/defaults/timeouts"
 	"github.com/rancher/shepherd/extensions/kubeapi/resourcequotas"
 	"github.com/rancher/shepherd/extensions/namespaces"
 	steveResourceQuotas "github.com/rancher/shepherd/extensions/resourcequotas"
@@ -241,9 +242,9 @@ func (s *ResourceQuotaSuite) TestRemoveQuotaFromProjectWithNamespacePropagation(
 	testProject.ResourceQuota.Limit.ConfigMaps = ""
 	testProject.NamespaceDefaultResourceQuota.Limit.ConfigMaps = ""
 
-	watchInterface, err := dynamicClient.Resource(resourcequotas.ResourceQuotaGroupVersionResource).Watch(context.TODO(), metav1.ListOptions{
+	watchInterface, err := dynamicClient.Resource(groupversionresources.ResourceQuota()).Watch(context.TODO(), metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + quotaName,
-		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		TimeoutSeconds: timeouts.ThirtyMinuteWatch(),
 	})
 	s.Require().NoError(err)
 

--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -19,6 +19,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	clientv1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/schema/groupversionresources"
 	kubenamespaces "github.com/rancher/shepherd/extensions/kubeapi/namespaces"
 	"github.com/rancher/shepherd/extensions/kubeapi/rbac"
 	"github.com/rancher/shepherd/extensions/kubeapi/secrets"
@@ -314,7 +315,7 @@ func (s *steveAPITestSuite) setupSuite(clusterName string) {
 		}
 		dynamicClient, err := client.GetDownStreamClusterClient(s.clusterID)
 		require.NoError(s.T(), err)
-		namespaceResource := dynamicClient.Resource(kubenamespaces.NamespaceGroupVersionResource)
+		namespaceResource := dynamicClient.Resource(groupversionresources.Namespace())
 		resp, err := namespaceResource.Create(context.TODO(), unstructured.MustToUnstructured(ns), metav1.CreateOptions{})
 		require.NoError(s.T(), err)
 		s.client.Session.RegisterCleanupFunc(func() error {

--- a/tests/v2/validation/certrotation/cert_rotation_test.go
+++ b/tests/v2/validation/certrotation/cert_rotation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
@@ -45,7 +46,7 @@ func (r *V2ProvCertRotationTestSuite) TestCertRotation() {
 	id, err := clusters.GetV1ProvisioningClusterByName(r.client, r.client.RancherConfig.ClusterName)
 	require.NoError(r.T(), err)
 
-	cluster, err := r.client.Steve.SteveType(provisioningSteveResourceType).ByID(id)
+	cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(id)
 	require.NoError(r.T(), err)
 
 	spec := &provv1.ClusterSpec{}

--- a/tests/v2/validation/charts/istio_test.go
+++ b/tests/v2/validation/charts/istio_test.go
@@ -17,6 +17,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/clusters"
+	defaultAnnotations "github.com/rancher/shepherd/extensions/defaults/annotations"
 	"github.com/rancher/shepherd/extensions/ingresses"
 	"github.com/rancher/shepherd/extensions/namespaces"
 	"github.com/rancher/shepherd/pkg/session"
@@ -192,7 +193,7 @@ func (i *IstioTestSuite) TestIstioChart() {
 	require.NoError(i.T(), err)
 	workerNodePublicIPs := []string{}
 	for _, node := range nodeCollection.Data {
-		workerNodePublicIPs = append(workerNodePublicIPs, node.Annotations["rke.cattle.io/external-ip"])
+		workerNodePublicIPs = append(workerNodePublicIPs, node.Annotations[defaultAnnotations.ExternalIp])
 	}
 	randWorkerNodePublicIP := workerNodePublicIPs[rand.Intn(len(workerNodePublicIPs))]
 	istioGatewayHost := randWorkerNodePublicIP + ":" + exampleAppPort

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/clusters"
+	defaultAnnotations "github.com/rancher/shepherd/extensions/defaults/annotations"
 	"github.com/rancher/shepherd/extensions/ingresses"
 	"github.com/rancher/shepherd/extensions/namespaces"
 	"github.com/rancher/shepherd/extensions/projects"
@@ -189,7 +190,7 @@ func (m *MonitoringTestSuite) TestMonitoringChart() {
 	require.NoError(m.T(), err)
 	workerNodePublicIPs := []string{}
 	for _, node := range nodeCollection.Data {
-		workerNodePublicIPs = append(workerNodePublicIPs, node.Annotations["rke.cattle.io/external-ip"])
+		workerNodePublicIPs = append(workerNodePublicIPs, node.Annotations[defaultAnnotations.ExternalIp])
 	}
 	randWorkerNodePublicIP := workerNodePublicIPs[rand.Intn(len(workerNodePublicIPs))]
 

--- a/tests/v2/validation/deleting/delete_cluster_test.go
+++ b/tests/v2/validation/deleting/delete_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func (c *ClusterDeleteTestSuite) TestDeletingCluster() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(c.client, c.client.RancherConfig.ClusterName)
 		require.NoError(c.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(c.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/nodescaling/auto_replace_test.go
+++ b/tests/v2/validation/nodescaling/auto_replace_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 const (
-	fleetNamespace        = "fleet-default"
-	deletingState         = "deleting"
-	machineNameAnnotation = "cluster.x-k8s.io/machine"
+	deletingState = "deleting"
 )
 
 type AutoReplaceSuite struct {

--- a/tests/v2/validation/nodescaling/scale_replace_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scale_replace_rke1_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	nodepools "github.com/rancher/shepherd/extensions/rke1/nodepools"
 	"github.com/rancher/shepherd/pkg/config"
@@ -30,7 +31,7 @@ func (s *RKE1NodeReplacingTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	s.session = testSession
 
-	s.ns = provisioninginput.Namespace
+	s.ns = namespaces.Fleet
 
 	s.clustersConfig = new(provisioninginput.Config)
 	config.LoadConfig(provisioninginput.ConfigurationFileKey, s.clustersConfig)

--- a/tests/v2/validation/nodescaling/scale_replace_test.go
+++ b/tests/v2/validation/nodescaling/scale_replace_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/machinepools"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	"github.com/rancher/shepherd/pkg/config"
@@ -34,7 +36,7 @@ func (s *NodeReplacingTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	s.session = testSession
 
-	s.ns = provisioninginput.Namespace
+	s.ns = namespaces.Fleet
 
 	s.clustersConfig = new(provisioninginput.Config)
 	config.LoadConfig(provisioninginput.ConfigurationFileKey, s.clustersConfig)
@@ -78,7 +80,7 @@ func (s *NodeReplacingTestSuite) TestReplacingNodes() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/nodescaling/scaling_custom_cluster_test.go
+++ b/tests/v2/validation/nodescaling/scaling_custom_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/machinepools"
 	"github.com/rancher/shepherd/extensions/scalinginput"
 	"github.com/rancher/shepherd/pkg/config"
@@ -85,7 +86,7 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/nodescaling/scaling_node_driver_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/machinepools"
 	"github.com/rancher/shepherd/extensions/scalinginput"
 	"github.com/rancher/shepherd/pkg/config"
@@ -78,7 +79,7 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/nodescaling/scaling_nodepools.go
+++ b/tests/v2/validation/nodescaling/scaling_nodepools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/aks"
 	"github.com/rancher/shepherd/extensions/clusters/eks"
 	"github.com/rancher/shepherd/extensions/clusters/gke"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/machinepools"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	rke1 "github.com/rancher/shepherd/extensions/rke1/nodepools"
@@ -15,16 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	ProvisioningSteveResourceType = "provisioning.cattle.io.cluster"
-	defaultNamespace              = "fleet-default"
-)
-
 var oneNode int64 = 1
 var twoNodes int64 = 2
 
 func scalingRKE2K3SNodePools(t *testing.T, client *rancher.Client, clusterID string, nodeRoles machinepools.NodeRoles) {
-	cluster, err := client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 	require.NoError(t, err)
 
 	clusterResp, err := machinepools.ScaleMachinePoolNodes(client, cluster, nodeRoles)
@@ -32,7 +28,7 @@ func scalingRKE2K3SNodePools(t *testing.T, client *rancher.Client, clusterID str
 
 	pods.VerifyReadyDaemonsetPods(t, client, clusterResp)
 
-	updatedCluster, err := client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+	updatedCluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 	require.NoError(t, err)
 
 	nodeRoles.Quantity = -nodeRoles.Quantity
@@ -73,7 +69,7 @@ func scalingRKE2K3SCustomClusterPools(t *testing.T, client *rancher.Client, clus
 	nodes, err := externalNodeProvider.NodeCreationFunc(client, rolesPerPool, quantityPerPool)
 	require.NoError(t, err)
 
-	cluster, err := client.Steve.SteveType(ProvisioningSteveResourceType).ByID(clusterID)
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 	require.NoError(t, err)
 
 	err = provisioning.AddRKE2K3SCustomClusterNodes(client, cluster, nodes, rolesPerNode)

--- a/tests/v2/validation/pipeline/downstreamcleanup/main.go
+++ b/tests/v2/validation/pipeline/downstreamcleanup/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/timeouts"
 	"github.com/rancher/shepherd/extensions/token"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/file"
@@ -90,7 +90,7 @@ func main() {
 		if !isLocalCluster {
 			opts := metav1.ListOptions{
 				FieldSelector:  "metadata.name=" + c.ID,
-				TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+				TimeoutSeconds: timeouts.ThirtyMinuteWatch(),
 			}
 
 			err := client.Management.Cluster.Delete(&c)

--- a/tests/v2/validation/pipeline/ranchercleanup/main.go
+++ b/tests/v2/validation/pipeline/ranchercleanup/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rancher/shepherd/clients/corral"
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
-	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/shepherd/pkg/wait"
 	"github.com/sirupsen/logrus"
@@ -33,7 +33,7 @@ func main() {
 		var clusterList *v1.SteveCollection
 		err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
 			//clean up clusters
-			resp, err := client.Steve.SteveType(clusters.ProvisioningSteveResourceType).List(nil)
+			resp, err := client.Steve.SteveType(stevetypes.Provisioning).List(nil)
 			if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
 				return false, err
 			} else if resp != nil {
@@ -50,7 +50,7 @@ func main() {
 		deleteTimeout := timeout
 		for _, cluster := range clusterList.Data {
 			if cluster.ObjectMeta.Name != "local" {
-				err := client.Steve.SteveType(clusters.ProvisioningSteveResourceType).Delete(&cluster)
+				err := client.Steve.SteveType(stevetypes.Provisioning).Delete(&cluster)
 				if err != nil {
 					logrus.Errorf("error deleting cluster: %v", err)
 				}

--- a/tests/v2/validation/projects/projects.go
+++ b/tests/v2/validation/projects/projects.go
@@ -10,7 +10,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/timeouts"
 	projectsApi "github.com/rancher/shepherd/extensions/kubeapi/projects"
 	rbacApi "github.com/rancher/shepherd/extensions/kubeapi/rbac"
 	"github.com/rancher/shepherd/extensions/kubeconfig"
@@ -75,7 +75,7 @@ func createProjectRoleTemplateBinding(client *rancher.Client, user *management.U
 }
 
 func waitForFinalizerToUpdate(client *rancher.Client, projectName string, projectNamespace string, finalizerCount int) error {
-	err := kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.TenSecondTimeout, func() (done bool, pollErr error) {
+	err := kwait.Poll(timeouts.FiveHundredMillisecond, timeouts.TenSecond, func() (done bool, pollErr error) {
 		project, pollErr := projectsApi.ListProjects(client, project.Namespace, metav1.ListOptions{
 			FieldSelector: "metadata.name=" + project.Name,
 		})
@@ -104,7 +104,7 @@ func checkPodLogsForErrors(client *rancher.Client, cluster string, podName strin
 
 	var errorMessage string
 
-	kwait.Poll(defaults.TenSecondTimeout, defaults.TwoMinuteTimeout, func() (bool, error) {
+	kwait.Poll(timeouts.TenSecond, timeouts.TwoMinute, func() (bool, error) {
 		podLogs, err := kubeconfig.GetPodLogs(client, cluster, podName, namespace, "")
 		if err != nil {
 			return false, err

--- a/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
@@ -82,7 +82,7 @@ func (a *AirGapK3SCustomClusterTestSuite) SetupSuite() {
 }
 
 func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningAirGapK3SCustomCluster() {
-	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	a.clustersConfig.MachinePools = provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
 
 	tests := []struct {
 		name   string
@@ -97,7 +97,7 @@ func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningAirGapK3SCustomCluster
 }
 
 func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningUpgradeAirGapK3SCustomCluster() {
-	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	a.clustersConfig.MachinePools = provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
 
 	k3sVersions, err := kubernetesversions.ListK3SAllVersions(a.client)
 	require.NoError(a.T(), err)

--- a/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
@@ -83,7 +83,7 @@ func (a *AirGapRKE1CustomClusterTestSuite) SetupSuite() {
 }
 
 func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningAirGapRKE1CustomCluster() {
-	a.clustersConfig.NodePools = []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
+	a.clustersConfig.NodePools = provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlaneWorker"})
 
 	tests := []struct {
 		name   string
@@ -98,7 +98,7 @@ func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningAirGapRKE1CustomClust
 }
 
 func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningUpgradeAirGapRKE1CustomCluster() {
-	a.clustersConfig.NodePools = []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
+	a.clustersConfig.NodePools = provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlaneWorker"})
 
 	rke1Versions, err := kubernetesversions.ListRKE1AllVersions(a.client)
 	require.NoError(a.T(), err)

--- a/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
@@ -82,7 +82,7 @@ func (a *AirGapRKE2CustomClusterTestSuite) SetupSuite() {
 }
 
 func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningAirGapRKE2CustomCluster() {
-	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	a.clustersConfig.MachinePools = provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
 
 	tests := []struct {
 		name   string
@@ -97,7 +97,7 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningAirGapRKE2CustomClust
 }
 
 func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningAirGapUpgradeRKE2CustomCluster() {
-	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	a.clustersConfig.MachinePools = provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
 
 	rke2Versions, err := kubernetesversions.ListRKE2AllVersions(a.client)
 	require.NoError(a.T(), err)

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -70,9 +70,9 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() {
-	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
-	nodeRolesShared := []provisioninginput.MachinePools{provisioninginput.EtcdControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesAll := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
+	nodeRolesShared := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker", "worker"})
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name         string

--- a/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
@@ -24,10 +25,6 @@ type KdmChecksTestSuite struct {
 	provisioningConfig *provisioninginput.Config
 }
 
-const (
-	defaultNamespace = "default"
-)
-
 func (k *KdmChecksTestSuite) TearDownSuite() {
 	k.session.Cleanup()
 }
@@ -36,7 +33,7 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	k.session = testSession
 
-	k.ns = defaultNamespace
+	k.ns = namespaces.Default
 
 	k.provisioningConfig = new(provisioninginput.Config)
 	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.provisioningConfig)

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -71,9 +71,9 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 }
 
 func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
-	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
-	nodeRolesShared := []provisioninginput.MachinePools{provisioninginput.EtcdControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesAll := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
+	nodeRolesShared := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlane", "worker"})
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name         string

--- a/tests/v2/validation/provisioning/k3s/psact_test.go
+++ b/tests/v2/validation/provisioning/k3s/psact_test.go
@@ -70,11 +70,7 @@ func (k *K3SPSACTTestSuite) SetupSuite() {
 }
 
 func (k *K3SPSACTTestSuite) TestK3SPSACTNodeDriverCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name         string
@@ -112,11 +108,7 @@ func (k *K3SPSACTTestSuite) TestK3SPSACTNodeDriverCluster() {
 }
 
 func (k *K3SPSACTTestSuite) TestK3SPSACTCustomCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name         string

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -70,9 +70,9 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster() {
-	nodeRolesAll := []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
-	nodeRolesShared := []provisioninginput.NodePools{provisioninginput.EtcdControlPlaneNodePool, provisioninginput.WorkerNodePool}
-	nodeRolesDedicated := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+	nodeRolesAll := provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlaneWorker"})
+	nodeRolesShared := provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlane", "worker"})
+	nodeRolesDedicated := provisioninginput.GetNodePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	require.GreaterOrEqual(c.T(), len(c.provisioningConfig.CNIs), 1)
 

--- a/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
@@ -25,8 +25,7 @@ type KdmChecksTestSuite struct {
 }
 
 const (
-	defaultNamespace             = "default"
-	ProvisioningSteveResouceType = "provisioning.cattle.io.cluster"
+	defaultNamespace = "default"
 )
 
 func (k *KdmChecksTestSuite) TearDownSuite() {

--- a/tests/v2/validation/provisioning/rke1/provisioning_cloud_provider_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_cloud_provider_test.go
@@ -72,7 +72,7 @@ func (r *RKE1CloudProviderTestSuite) SetupSuite() {
 }
 
 func (r *RKE1CloudProviderTestSuite) TestAWSCloudProviderRKE1Cluster() {
-	nodeRolesDedicated := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+	nodeRolesDedicated := provisioninginput.GetNodePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 	nodeRolesDedicated[0].NodeRoles.Quantity = 3
 	nodeRolesDedicated[1].NodeRoles.Quantity = 2
 	nodeRolesDedicated[2].NodeRoles.Quantity = 2
@@ -103,7 +103,7 @@ func (r *RKE1CloudProviderTestSuite) TestAWSCloudProviderRKE1Cluster() {
 }
 
 func (r *RKE1CloudProviderTestSuite) TestVsphereCloudProviderRKE1Cluster() {
-	nodeRolesDedicated := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+	nodeRolesDedicated := provisioninginput.GetNodePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 	nodeRolesDedicated[0].NodeRoles.Quantity = 3
 	nodeRolesDedicated[1].NodeRoles.Quantity = 2
 	nodeRolesDedicated[2].NodeRoles.Quantity = 2

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -71,9 +71,9 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 }
 
 func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1Cluster() {
-	nodeRolesAll := []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
-	nodeRolesShared := []provisioninginput.NodePools{provisioninginput.EtcdControlPlaneNodePool, provisioninginput.WorkerNodePool}
-	nodeRolesDedicated := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+	nodeRolesAll := provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlaneWorker"})
+	nodeRolesShared := provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlane", "worker"})
+	nodeRolesDedicated := provisioninginput.GetNodePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 	tests := []struct {
 		name      string
 		nodePools []provisioninginput.NodePools

--- a/tests/v2/validation/provisioning/rke1/psact_test.go
+++ b/tests/v2/validation/provisioning/rke1/psact_test.go
@@ -70,11 +70,7 @@ func (r *RKE1PSACTTestSuite) SetupSuite() {
 }
 
 func (r *RKE1PSACTTestSuite) TestRKE1PSACTNodeDriverCluster() {
-	nodeRolesDedicated := []provisioninginput.NodePools{
-		provisioninginput.EtcdNodePool,
-		provisioninginput.ControlPlaneNodePool,
-		provisioninginput.WorkerNodePool,
-	}
+	nodeRolesDedicated := provisioninginput.GetNodePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name      string
@@ -112,11 +108,7 @@ func (r *RKE1PSACTTestSuite) TestRKE1PSACTNodeDriverCluster() {
 }
 
 func (r *RKE1PSACTTestSuite) TestRKE1PSACTCustomCluster() {
-	nodeRolesDedicated := []provisioninginput.NodePools{
-		provisioninginput.EtcdNodePool,
-		provisioninginput.ControlPlaneNodePool,
-		provisioninginput.WorkerNodePool,
-	}
+	nodeRolesDedicated := provisioninginput.GetNodePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	require.GreaterOrEqual(r.T(), len(r.provisioningConfig.CNIs), 1)
 

--- a/tests/v2/validation/provisioning/rke2/agent_customization_test.go
+++ b/tests/v2/validation/provisioning/rke2/agent_customization_test.go
@@ -65,7 +65,7 @@ func (r *RKE2AgentCustomizationTestSuite) SetupSuite() {
 }
 
 func (r *RKE2AgentCustomizationTestSuite) TestProvisioningRKE2ClusterAgentCustomization() {
-	productionPool := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	productionPool := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 	productionPool[0].MachinePoolConfig.Quantity = 3
 	productionPool[1].MachinePoolConfig.Quantity = 2
 	productionPool[2].MachinePoolConfig.Quantity = 2
@@ -140,7 +140,7 @@ func (r *RKE2AgentCustomizationTestSuite) TestProvisioningRKE2ClusterAgentCustom
 }
 
 func (r *RKE2AgentCustomizationTestSuite) TestFailureProvisioningRKE2ClusterAgentCustomization() {
-	productionPool := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	productionPool := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 	productionPool[0].MachinePoolConfig.Quantity = 3
 	productionPool[1].MachinePoolConfig.Quantity = 2
 	productionPool[2].MachinePoolConfig.Quantity = 2

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -79,35 +79,15 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster() {
-	nodeRolesAll := []provisioninginput.MachinePools{
-		provisioninginput.AllRolesMachinePool,
-	}
+	nodeRolesAll := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
 
-	nodeRolesShared := []provisioninginput.MachinePools{
-		provisioninginput.EtcdControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesShared := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlane", "worker"})
 
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
-	nodeRolesDedicatedWindows := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-		provisioninginput.WindowsMachinePool,
-	}
+	nodeRolesDedicatedWindows := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker", "windows"})
 
-	nodeRolesDedicatedTwoWindows := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-		provisioninginput.WindowsMachinePool,
-		provisioninginput.WindowsMachinePool,
-	}
+	nodeRolesDedicatedTwoWindows := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker", "windows", "windows"})
 
 	tests := []struct {
 		name         string

--- a/tests/v2/validation/provisioning/rke2/provisioning_cloud_provider_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_cloud_provider_test.go
@@ -70,7 +70,7 @@ func (r *RKE2CloudProviderTestSuite) SetupSuite() {
 }
 
 func (r *RKE2CloudProviderTestSuite) TestAWSCloudProviderCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 	nodeRolesDedicated[0].MachinePoolConfig.Quantity = 3
 	nodeRolesDedicated[1].MachinePoolConfig.Quantity = 2
 	nodeRolesDedicated[2].MachinePoolConfig.Quantity = 2
@@ -102,7 +102,7 @@ func (r *RKE2CloudProviderTestSuite) TestAWSCloudProviderCluster() {
 }
 
 func (r *RKE2CloudProviderTestSuite) TestVsphereCloudProviderCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 	nodeRolesDedicated[0].MachinePoolConfig.Quantity = 3
 	nodeRolesDedicated[1].MachinePoolConfig.Quantity = 2
 	nodeRolesDedicated[2].MachinePoolConfig.Quantity = 2

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -69,9 +69,9 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
-	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
-	nodeRolesShared := []provisioninginput.MachinePools{provisioninginput.EtcdControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesAll := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
+	nodeRolesShared := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlane", "worker"})
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name         string

--- a/tests/v2/validation/provisioning/rke2/psact_test.go
+++ b/tests/v2/validation/provisioning/rke2/psact_test.go
@@ -70,11 +70,7 @@ func (r *RKE2PSACTTestSuite) SetupSuite() {
 }
 
 func (r *RKE2PSACTTestSuite) TestRKE2PSACTNodeDriverCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name         string
@@ -112,11 +108,7 @@ func (r *RKE2PSACTTestSuite) TestRKE2PSACTNodeDriverCluster() {
 }
 
 func (r *RKE2PSACTTestSuite) TestRKE2PSACTCustomCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesDedicated := provisioninginput.GetMachinePoolConfigs([]string{"etcd", "controlPlane", "worker"})
 
 	tests := []struct {
 		name         string

--- a/tests/v2/validation/rbac/globalrolesv2/globalroles_v2.go
+++ b/tests/v2/validation/rbac/globalrolesv2/globalroles_v2.go
@@ -15,7 +15,7 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 
 	"github.com/rancher/shepherd/extensions/clusters"
-	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/timeouts"
 	"github.com/rancher/shepherd/extensions/kubeapi/rbac"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
@@ -98,7 +98,7 @@ func listClusterRoleTemplateBindingsForInheritedClusterRoles(client *rancher.Cli
 
 	var crtbs *v3.ClusterRoleTemplateBindingList
 
-	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.OneMinuteTimeout, func() (done bool, pollErr error) {
+	err = kwait.Poll(timeouts.FiveHundredMillisecond, timeouts.OneMinute, func() (done bool, pollErr error) {
 		crtbs, pollErr = rbac.ListClusterRoleTemplateBindings(client, metav1.ListOptions{
 			LabelSelector: selector.String(),
 		})
@@ -192,16 +192,12 @@ func createDownstreamCluster(client *rancher.Client, clusterType string) (*manag
 
 	switch clusterType {
 	case "RKE1":
-		nodeAndRoles := []provisioninginput.NodePools{
-			provisioninginput.AllRolesNodePool,
-		}
+		nodeAndRoles := provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlaneWorker"})
 		testClusterConfig.NodePools = nodeAndRoles
 		testClusterConfig.KubernetesVersion = provisioningConfig.RKE1KubernetesVersions[0]
 		clusterObject, _, err = provisioning.CreateProvisioningRKE1CustomCluster(client, &externalNodeProvider, testClusterConfig)
 	case "RKE2":
-		nodeAndRoles := []provisioninginput.MachinePools{
-			provisioninginput.AllRolesMachinePool,
-		}
+		nodeAndRoles := provisioninginput.GetMachinePoolConfigs([]string{"etcdControlPlaneWorker"})
 		testClusterConfig.MachinePools = nodeAndRoles
 		testClusterConfig.KubernetesVersion = provisioningConfig.RKE2KubernetesVersions[0]
 		steveObject, err = provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, testClusterConfig)
@@ -238,10 +234,10 @@ func createGlobalRoleAndUser(client *rancher.Client, inheritedClusterrole []stri
 }
 
 func crtbStatus(client *rancher.Client, crtbName string, selector labels.Selector) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaults.TwoMinuteTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeouts.TwoMinute)
 	defer cancel()
 
-	err := kwait.PollUntilContextCancel(ctx, defaults.FiveHundredMillisecondTimeout, false, func(ctx context.Context) (done bool, err error) {
+	err := kwait.PollUntilContextCancel(ctx, timeouts.FiveHundredMillisecond, false, func(ctx context.Context) (done bool, err error) {
 		crtbs, err := rbac.ListClusterRoleTemplateBindings(client, metav1.ListOptions{
 			LabelSelector: selector.String(),
 		})

--- a/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -17,7 +17,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 
 	"github.com/rancher/shepherd/extensions/clusters"
-	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/timeouts"
 	"github.com/rancher/shepherd/extensions/kubeapi/rbac"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/users"
@@ -238,7 +238,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserDeletionAndResourceCleanupWithInherite
 
 	log.Infof("Verify that the global role binding %s is deleted for the user.", grbName)
 	var grbOwner string
-	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.TenSecondTimeout, func() (done bool, pollErr error) {
+	err = kwait.Poll(timeouts.FiveHundredMillisecond, timeouts.TenSecond, func() (done bool, pollErr error) {
 		grbOwner, pollErr = getGlobalRoleBindingForUser(gr.client, createdUser.ID)
 		if pollErr != nil {
 			return false, pollErr

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -11,6 +11,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/namespaces"
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/workloads"
@@ -168,7 +169,7 @@ func convertSetting(globalSetting *v1.SteveAPIObject) (*v3.Setting, error) {
 }
 
 func listGlobalSettings(steveclient *v1.Client) ([]string, error) {
-	globalSettings, err := steveclient.SteveType("management.cattle.io.setting").List(nil)
+	globalSettings, err := steveclient.SteveType(stevetypes.ManagementSetting).List(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func editGlobalSettings(steveclient *v1.Client, globalSetting *v1.SteveAPIObject
 	}
 
 	updateSetting.Value = value
-	updateGlobalSetting, err := steveclient.SteveType("management.cattle.io.setting").Update(globalSetting, updateSetting)
+	updateGlobalSetting, err := steveclient.SteveType(stevetypes.ManagementSetting).Update(globalSetting, updateSetting)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/v2/validation/rbac/rbac_additional_test.go
+++ b/tests/v2/validation/rbac/rbac_additional_test.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/kubeapi/rbac"
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/provisioning"
@@ -89,7 +90,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddMemberAsClusterRoles() {
 	require.NoError(rb.T(), err)
 	rb.additionalUserClient = additionalUserClient
 
-	clusterList, err := rb.additionalUserClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
+	clusterList, err := rb.additionalUserClient.Steve.SteveType(stevetypes.Provisioning).ListAll(nil)
 	require.NoError(rb.T(), err)
 	assert.Equal(rb.T(), 1, len(clusterList.Data))
 
@@ -107,7 +108,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddCMAsProjectOwner() {
 	require.NoError(rb.T(), err)
 	rb.additionalUserClient = additionalUserClient
 
-	clusterList, err := rb.standardUserClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
+	clusterList, err := rb.standardUserClient.Steve.SteveType(stevetypes.Provisioning).ListAll(nil)
 	require.NoError(rb.T(), err)
 	assert.Equal(rb.T(), 1, len(clusterList.Data))
 
@@ -197,7 +198,7 @@ func (rb *RBACAdditionalTestSuite) ValidateListGlobalSettings() {
 }
 
 func (rb *RBACAdditionalTestSuite) ValidateEditGlobalSettings() {
-	kubeConfigTokenSetting, err := rb.steveStdUserclient.SteveType("management.cattle.io.setting").ByID(kubeConfigTokenSettingID)
+	kubeConfigTokenSetting, err := rb.steveStdUserclient.SteveType(stevetypes.ManagementSetting).ByID(kubeConfigTokenSettingID)
 	require.NoError(rb.T(), err)
 
 	_, err = editGlobalSettings(rb.steveStdUserclient, kubeConfigTokenSetting, "3")
@@ -279,9 +280,7 @@ func (rb *RBACAdditionalTestSuite) TestRBACAdditional() {
 				userConfig := new(provisioninginput.Config)
 				config.LoadConfig(provisioninginput.ConfigurationFileKey, userConfig)
 				nodeProviders := userConfig.NodeProviders[0]
-				nodeAndRoles := []provisioninginput.NodePools{
-					provisioninginput.AllRolesNodePool,
-				}
+				nodeAndRoles := provisioninginput.GetNodePoolConfigs([]string{"etcdControlPlaneWorker"})
 				externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviders)
 				clusterConfig := clusters.ConvertConfigToClusterConfig(userConfig)
 				clusterConfig.NodePools = nodeAndRoles

--- a/tests/v2/validation/shell/shell_test.go
+++ b/tests/v2/validation/shell/shell_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/settings"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
 	"github.com/stretchr/testify/assert"
@@ -20,9 +21,8 @@ import (
 )
 
 const (
-	cattleSystemNameSpace = "cattle-system"
-	shellName             = "shell-image"
-	clusterName           = "local"
+	shellName   = "shell-image"
+	clusterName = "local"
 )
 
 type ShellTestSuite struct {
@@ -57,7 +57,7 @@ func (s *ShellTestSuite) TestShell() {
 
 	s.Run("Verify the helm operations for the shell succeeded", func() {
 		steveClient := s.client.Steve
-		pods, err := steveClient.SteveType(pods.PodResourceSteveType).NamespacedSteveClient(cattleSystemNameSpace).List(nil)
+		pods, err := steveClient.SteveType(pods.PodResourceSteveType).NamespacedSteveClient(namespaces.CattleSystem).List(nil)
 		require.NoError(s.T(), err)
 
 		for _, pod := range pods.Data {

--- a/tests/v2/validation/snapshot/snapshot_additional_test.go
+++ b/tests/v2/validation/snapshot/snapshot_additional_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 
 	"github.com/rancher/shepherd/pkg/config"
@@ -79,7 +80,7 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceWorkerNode() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)
@@ -120,7 +121,7 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotRecurringRestores() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 
 	"github.com/rancher/shepherd/pkg/config"
@@ -71,7 +72,7 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/snapshot/snapshot_restore_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 
 	"github.com/rancher/shepherd/pkg/config"
@@ -63,7 +64,7 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/etcdsnapshot"
 
 	"github.com/rancher/shepherd/pkg/config"
@@ -79,7 +80,7 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		cluster, err := tt.client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		require.NoError(s.T(), err)
 
 		updatedCluster := new(apisV1.Cluster)

--- a/tests/v2/validation/upgrade/cloud_provider_aws_migration.go
+++ b/tests/v2/validation/upgrade/cloud_provider_aws_migration.go
@@ -11,6 +11,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/kubectl"
 	"github.com/rancher/shepherd/extensions/services"
 	"github.com/rancher/shepherd/extensions/workloads"
@@ -231,7 +232,7 @@ func rke2AWSCloudProviderMigration(t *testing.T, client *rancher.Client, steveCl
 	newSteveCluster.Spec = spec
 
 	steveClusterObject, err = client.Steve.SteveType(
-		clusters.ProvisioningSteveResourceType).Update(steveClusterObject, newSteveCluster)
+		stevetypes.Provisioning).Update(steveClusterObject, newSteveCluster)
 	require.NoError(t, err)
 
 	err = clusters.WaitClusterToBeUpgraded(client, status.ClusterName)
@@ -268,7 +269,7 @@ func rke2AWSCloudProviderMigration(t *testing.T, client *rancher.Client, steveCl
 	newSteveCluster.Spec = spec
 
 	steveClusterObject, err = client.Steve.SteveType(
-		clusters.ProvisioningSteveResourceType).Update(steveClusterObject, newSteveCluster)
+		stevetypes.Provisioning).Update(steveClusterObject, newSteveCluster)
 	require.NoError(t, err)
 
 	err = clusters.WaitClusterToBeUpgraded(client, status.ClusterName)

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/bundledclusters"
-	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/timeouts"
 	nodestat "github.com/rancher/shepherd/extensions/nodes"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	psadeploy "github.com/rancher/shepherd/extensions/psact"
@@ -134,9 +134,9 @@ func (u *UpgradeKubernetesTestSuite) testUpgradeSingleCluster(clusterName, versi
 	}
 
 	if strings.Contains(versionToUpgrade, rke1KubeVersionCheck) {
-		err = nodestat.AllManagementNodeReady(client, clusterMeta.ID, defaults.ThirtyMinuteTimeout)
+		err = nodestat.AllManagementNodeReady(client, clusterMeta.ID, timeouts.ThirtyMinute)
 	} else if strings.Contains(versionToUpgrade, rke2KubeVersionCheck) || strings.Contains(versionToUpgrade, k3sKubeVersionCheck) {
-		err = nodestat.AllMachineReady(client, clusterMeta.ID, defaults.TenMinuteTimeout)
+		err = nodestat.AllMachineReady(client, clusterMeta.ID, timeouts.TenMinute)
 	}
 	require.NoError(u.T(), err)
 

--- a/tests/v2/validation/upgrade/workload.go
+++ b/tests/v2/validation/upgrade/workload.go
@@ -13,8 +13,8 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/schema/groupversionresources"
 	"github.com/rancher/shepherd/extensions/ingresses"
-	kubeingress "github.com/rancher/shepherd/extensions/kubeapi/ingresses"
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/services"
 	"github.com/rancher/shepherd/extensions/workloads"
@@ -193,7 +193,7 @@ func waitUntilIngressHostnameUpdates(client *rancher.Client, clusterID, namespac
 	if err != nil {
 		return err
 	}
-	adminIngressResource := adminDynamicClient.Resource(kubeingress.IngressesGroupVersionResource).Namespace(namespace)
+	adminIngressResource := adminDynamicClient.Resource(groupversionresources.Ingress()).Namespace(namespace)
 
 	watchAppInterface, err := adminIngressResource.Watch(context.TODO(), metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + ingressName,


### PR DESCRIPTION
QA task:  https://github.com/rancher/qa-tasks/issues/1266
Shepherd PR: https://github.com/rancher/shepherd/pull/107

## Problem
Constants are redeclared all over the framework and on the rancher side. When some of these constants get updated it requires that we update in all of the places that use that old constant. 
 
## Solution
Rework the defaults directory in shepherd to house commonly used constants as well as constants that have a tendency to change i.e Annotations/Labels. In addition all global variables have been cleaned so we can use a new sub-linter in our golangci-linter.
 
## Testing
Since there are no logical changes on the rancher side I have run `go build ./...` to verify that nothing has changed. 

##Additional Notes:
When reviewing this PR please keep any eye out for any logic changes (there should be none) since this PR should only be swapping 1 constant for another and then cleaning up unused constants.