### PR TITLE
[v2.7] Added proxied rancher provisioning tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/imdario/mergo v0.3.15
 	github.com/rancher/cis-operator v1.0.11
-	github.com/rancher/shepherd v0.0.0-20240912175837-499d22f27ced
+	github.com/rancher/shepherd v0.0.0-20240927150412-cc8e26d7c6b3
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.20-rc1 h1:nbJNHtPM9mKiPu59cpRLAZ45eY2nHgazYLq4wKvT2Nk=
 github.com/rancher/rke v1.4.20-rc1/go.mod h1:UIc898udZbjJ+0616CEmjqY+eBQSkW/dQ30ZvL7bUcQ=
-github.com/rancher/shepherd v0.0.0-20240912175837-499d22f27ced h1:/WquyFdUmt7sJiudk+2giIHV3P9y0J3LdMjjmWucd9M=
-github.com/rancher/shepherd v0.0.0-20240912175837-499d22f27ced/go.mod h1:NqJtQg0JiPfl6hKvSw1JkRBUcg9s1EpffjXsdxbSEu0=
+github.com/rancher/shepherd v0.0.0-20240927150412-cc8e26d7c6b3 h1:1gXG96LoE8ifd5Q9oJL76Ao80lzfH4c+1RZxq6H12yc=
+github.com/rancher/shepherd v0.0.0-20240927150412-cc8e26d7c6b3/go.mod h1:NqJtQg0JiPfl6hKvSw1JkRBUcg9s1EpffjXsdxbSEu0=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a h1:Mawv3TfevX5dbVDlB/+RPgqxMX1HZQimyhj05R/Ef7U=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a/go.mod h1:tfdVny3lVO6H0JyysFBZ1ce45kH9VgWLPa9z9TZVI+U=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/actions/clusters/clusterconfig.go
+++ b/tests/v2/actions/clusters/clusterconfig.go
@@ -18,8 +18,8 @@ type ClusterConfig struct {
 	NodeProviders                  *[]string                                         `json:"nodeProviders" yaml:"nodeProviders"`
 	Hardened                       bool                                              `json:"hardened" yaml:"hardened"`
 	AddOnConfig                    *provisioningInput.AddOnConfig                    `json:"addonConfig" yaml:"addonConfig"`
-	AgentEnvVars                   *[]rkev1.EnvVar                                   `json:"agentEnvVars" yaml:"agentEnvVars"`
-	AgentEnvVarsRKE1               *[]management.EnvVar                              `json:"agentEnvVarsRKE1" yaml:"agentEnvVarsRKE1"`
+	AgentEnvVars                   []rkev1.EnvVar                                    `json:"agentEnvVars" yaml:"agentEnvVars"`
+	AgentEnvVarsRKE1               []management.EnvVar                               `json:"agentEnvVarsRKE1" yaml:"agentEnvVarsRKE1"`
 	ClusterAgent                   *management.AgentDeploymentCustomization          `json:"clusterAgent" yaml:"clusterAgent"`
 	FleetAgent                     *management.AgentDeploymentCustomization          `json:"fleetAgent" yaml:"fleetAgent"`
 	ETCD                           *rkev1.ETCD                                       `json:"etcd" yaml:"etcd"`
@@ -41,6 +41,7 @@ func ConvertConfigToClusterConfig(provisioningConfig *provisioningInput.Config) 
 	newConfig.MachinePools = provisioningConfig.MachinePools
 	newConfig.NodePools = provisioningConfig.NodePools
 	newConfig.AgentEnvVars = provisioningConfig.AgentEnvVars
+	newConfig.AgentEnvVarsRKE1 = provisioningConfig.AgentEnvVarsRKE1
 	newConfig.Networking = provisioningConfig.Networking
 	newConfig.Advanced = provisioningConfig.Advanced
 	newConfig.Providers = &provisioningConfig.Providers

--- a/tests/v2/actions/clusters/clusters.go
+++ b/tests/v2/actions/clusters/clusters.go
@@ -145,6 +145,7 @@ func NewRKE1ClusterConfig(clusterName string, client *rancher.Client, clustersCo
 	}
 	newConfig.ClusterAgentDeploymentCustomization = clustersConfig.ClusterAgent
 	newConfig.FleetAgentDeploymentCustomization = clustersConfig.FleetAgent
+	newConfig.AgentEnvVars = clustersConfig.AgentEnvVarsRKE1
 
 	if clustersConfig.Registries != nil {
 		if clustersConfig.Registries.RKE1Registries != nil {
@@ -183,6 +184,10 @@ func NewRKE1ClusterConfig(clusterName string, client *rancher.Client, clustersCo
 		newConfig.DefaultPodSecurityAdmissionConfigurationTemplateName = clustersConfig.PSACT
 	}
 
+	if clustersConfig.AgentEnvVars != nil {
+		newConfig.AgentEnvVars = clustersConfig.AgentEnvVarsRKE1
+	}
+
 	return newConfig
 }
 
@@ -200,6 +205,7 @@ func UpdateRKE1ClusterConfig(clusterName string, client *rancher.Client, cluster
 
 	newConfig.ClusterAgentDeploymentCustomization = clustersConfig.ClusterAgent
 	newConfig.FleetAgentDeploymentCustomization = clustersConfig.FleetAgent
+	newConfig.AgentEnvVars = clustersConfig.AgentEnvVarsRKE1
 
 	if clustersConfig.Registries != nil {
 		if clustersConfig.Registries.RKE1Registries != nil {
@@ -233,6 +239,10 @@ func UpdateRKE1ClusterConfig(clusterName string, client *rancher.Client, cluster
 
 	if clustersConfig.ETCDRKE1 != nil {
 		newConfig.RancherKubernetesEngineConfig.Services.Etcd = clustersConfig.ETCDRKE1
+	}
+
+	if clustersConfig.AgentEnvVars != nil {
+		newConfig.AgentEnvVars = clustersConfig.AgentEnvVarsRKE1
 	}
 
 	if clustersConfig.PSACT != "" {
@@ -384,6 +394,8 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace string, clustersConfig *Clus
 		MachinePools:         machinePools,
 	}
 
+	agentEnvVars := []rkev1.EnvVar{}
+
 	spec := apisV1.ClusterSpec{
 		CloudCredentialSecretName:           cloudCredentialSecretName,
 		KubernetesVersion:                   clustersConfig.KubernetesVersion,
@@ -391,6 +403,11 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace string, clustersConfig *Clus
 		RKEConfig:                           rkeConfig,
 		ClusterAgentDeploymentCustomization: clusterAgentDeploymentCustomization,
 		FleetAgentDeploymentCustomization:   fleetAgentDeploymentCustomization,
+		AgentEnvVars:                        agentEnvVars,
+	}
+
+	if clustersConfig.AgentEnvVars != nil {
+		spec.AgentEnvVars = clustersConfig.AgentEnvVars
 	}
 
 	if clustersConfig.PSACT != "" {
@@ -505,6 +522,10 @@ func UpdateK3SRKE2ClusterConfig(cluster *v1.SteveAPIObject, clustersConfig *Clus
 			},
 				nil),
 		)
+	}
+
+	if clustersConfig.AgentEnvVars != nil {
+		clusterSpec.AgentEnvVars = clustersConfig.AgentEnvVars
 	}
 
 	if clustersConfig.PSACT != "" {

--- a/tests/v2/actions/provisioning/creates.go
+++ b/tests/v2/actions/provisioning/creates.go
@@ -624,7 +624,9 @@ func CreateProvisioningAirgapCustomCluster(client *rancher.Client, clustersConfi
 			return nil, err
 		}
 
-		command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, roles)
+		// environment variables must be escaped inside original registration command
+		temp := strings.Replace(token.InsecureNodeCommand, "\"", "\\\"", -1)
+		command := fmt.Sprintf("%s %s", temp, roles)
 		logrus.Infof("registration command is %s", command)
 		err = corral.UpdateCorralConfig("registration_command", command)
 		if err != nil {
@@ -703,7 +705,9 @@ func CreateProvisioningRKE1AirgapCustomCluster(client *rancher.Client, clustersC
 			return nil, err
 		}
 
-		command := fmt.Sprintf("%s %s", token.NodeCommand, roles)
+		// environment variables must be escaped inside original registration command
+		temp := strings.Replace(token.NodeCommand, "\"", "\\\"", -1)
+		command := fmt.Sprintf("%s %s", temp, roles)
 		logrus.Infof("registration command is %s", command)
 		err = corral.UpdateCorralConfig("registration_command", command)
 		if err != nil {

--- a/tests/v2/actions/provisioninginput/config.go
+++ b/tests/v2/actions/provisioninginput/config.go
@@ -214,8 +214,8 @@ type Config struct {
 	CNIs                           []string                                 `json:"cni,omitempty" yaml:"cni,omitempty"`
 	PSACT                          string                                   `json:"psact,omitempty" yaml:"psact,omitempty"`
 	PNI                            bool                                     `json:"pni,omitempty" yaml:"pni,omitempty"`
-	AgentEnvVars                   *[]rkev1.EnvVar                          `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
-	AgentEnvVarsRKE1               *[]management.EnvVar                     `json:"agentEnvVarsRKE1,omitempty" yaml:"agentEnvVarsRKE1,omitempty"`
+	AgentEnvVars                   []rkev1.EnvVar                           `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
+	AgentEnvVarsRKE1               []management.EnvVar                      `json:"agentEnvVarsRKE1,omitempty" yaml:"agentEnvVarsRKE1,omitempty"`
 	ClusterAgent                   *management.AgentDeploymentCustomization `json:"clusterAgent,omitempty" yaml:"clusterAgent,omitempty"`
 	FleetAgent                     *management.AgentDeploymentCustomization `json:"fleetAgent,omitempty" yaml:"fleetAgent,omitempty"`
 	ETCD                           *rkev1.ETCD                              `json:"etcd,omitempty" yaml:"etcd,omitempty"`

--- a/tests/v2/validation/provisioning/proxy/README.md
+++ b/tests/v2/validation/provisioning/proxy/README.md
@@ -1,0 +1,65 @@
+
+# Proxy Provisioning Configs
+
+Please refer to [RKE1 Provisioning](../rke1/README.md) and [RKE2 Provisioning](../rke2/README.md) to build config file with basic `provisioningInput` parameters.
+
+Your GO test_package should be set to `provisioning/proxy`.
+Your GO suite should be set to `-run ^TestRKE2ProxyTestSuite$`.
+Please see below for more details for your proxy config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+For provisioning tests, include the following parameters into `agentEnvVars` and/or `agentEnvVarsRKE1` inside your `provisioningInput` 
+
+```yaml
+provisioningInput:
+  agentEnvVars:
+  - name: HTTPS_PROXY
+    value: #proxy server internal ip address:port
+  - name: HTTP_PROXY
+    value: #proxy server internal ip address:port
+  - name: NO_PROXY
+    value: localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,cattle-system.svc
+  agentEnvVarsRKE1:
+  - name: HTTPS_PROXY
+    value: #proxy server internal ip address:port
+  - name: HTTP_PROXY
+    value: #proxy server internal ip address:port
+  - name: NO_PROXY
+    value: localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,cattle-system.svc
+```
+
+You should have a basic understanding of Corral before running the custom cluster tests. 
+In your config file, set the following:
+```yaml
+corralPackages:
+  corralPackageImages:
+    airgapCustomCluster: "/dist/aws-rancher-custom-cluster-false-true"
+    rancherHA: "/dist/aws-aws-proxy-standalone-rke2-rancher-proxy-calico-true-2.15.1-1.11.0" # the name of the corral rancher is configurable with config entry above
+    ...
+  hasDebug: <bool, default=false>
+  hasCleanup: <bool, default=true>
+corralConfigs:
+  corralConfigUser: <string, default="jenkauto">
+  corralConfigVars:
+    <var1>: <string, "val1"> # for now only aws is supported, so use the appropriate aws vars
+    registry_ip: <addr> # if the proxied rancher instance is created beforehand (not in the same job) set this to the registry public IP, otherwise it is automatically done in the job. 
+    registry_private_ip: <addr> # if the proxied rancher instance is created beforehand (not in the same job) set this to the registry private IP, otherwise it is automatically done in the job.
+    rancher_chart_repo: <val> #  
+    rancher_version: <val> #
+    kubernetes_version: <val> #
+    corral_private_key: <val> # only set this if you have created the proxied rancher instance beforehand. By doing `corral vars <corral> corral_private_key`
+    corral_public_key: <val> # only set this if you have created the proxied rancher instance beforehand. By doing `corral vars <corral> corral_private_key`
+    ...
+  corralSSHPath: <string, optional, mostly for local testing>
+corralRancherHA:
+  name: rancherha # this is the name of your aigap corral package if it hasn't been created beforehand
+```
+
+Note: `corralConfigUser` will be the prefix for all resources created in your provider. 
+From there, your `corralConfigVars` should contain the parameters necessary to run the test. You can see what variables need to be set by navigating to your corral package folder and checking the `manifest.yaml` variables.
+
+In order to run the entire proxy package set the package to `proxy/...` Your GO suite should be set to blank. 
+
+Formatting `corral_private_key`:
+1. Output key to file `corral vars <corral> corral_private_key > temp`
+2. Copy single line version of key `awk -v ORS='\\n' '1' temp | pbcopy`
+3. Paste into config (example yaml format `corral_private_key: '"<key>"'`)

--- a/tests/v2/validation/provisioning/proxy/k3s_proxy_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/proxy/k3s_proxy_custom_cluster_test.go
@@ -1,0 +1,137 @@
+package proxy
+
+import (
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProxyK3SCustomClusterTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	session            *session.Session
+	corralPackage      *corral.Packages
+	clustersConfig     *provisioninginput.Config
+	EnvVar             rkev1.EnvVar
+	corralImage        string
+	corralAutoCleanup  bool
+}
+
+func (k *ProxyK3SCustomClusterTestSuite) TearDownSuite() {
+	k.session.Cleanup()
+}
+
+func (k *ProxyK3SCustomClusterTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	k.session = testSession
+
+	corralRancherHA := new(corralha.CorralRancherHA)
+	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
+
+	k.clustersConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.clustersConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(k.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(k.T(), err)
+
+	k.standardUserClient = standardUserClient
+
+	k.clustersConfig.K3SKubernetesVersions, err = kubernetesversions.Default(
+		k.client, clusters.K3SClusterType.String(), k.clustersConfig.K3SKubernetesVersions)
+	require.NoError(k.T(), err)
+
+	listOfCorrals, err := corral.ListCorral()
+	require.NoError(k.T(), err)
+
+	corralConfig := corral.Configurations()
+	err = corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	require.NoError(k.T(), err)
+
+	k.corralPackage = corral.PackagesConfig()
+	k.corralImage = k.corralPackage.CorralPackageImages[corralPackageAirgapCustomClusterName]
+	k.corralAutoCleanup = k.corralPackage.HasCleanup
+
+	_, corralExist := listOfCorrals[corralRancherHA.Name]
+	if corralExist {
+		bastionIP, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryPrivateIP)
+		require.NoError(k.T(), err)
+
+		k.EnvVar.Name = "HTTP_PROXY"
+		k.EnvVar.Value = bastionIP + ":3219"
+		k.clustersConfig.AgentEnvVars = append(k.clustersConfig.AgentEnvVars, k.EnvVar)
+
+		k.EnvVar.Name = "HTTPS_PROXY"
+		k.EnvVar.Value = bastionIP + ":3219"
+		k.clustersConfig.AgentEnvVars = append(k.clustersConfig.AgentEnvVars, k.EnvVar)
+
+		k.EnvVar.Name = "NO_PROXY"
+		k.EnvVar.Value = "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc"
+		k.clustersConfig.AgentEnvVars = append(k.clustersConfig.AgentEnvVars, k.EnvVar)
+
+		err = corral.SetCorralSSHKeys(corralRancherHA.Name)
+		require.NoError(k.T(), err)
+
+		err = corral.SetCorralBastion(corralRancherHA.Name)
+		require.NoError(k.T(), err)
+	} else {
+		k.T().Logf("Using AgentEnvVars from config: %v", k.clustersConfig.AgentEnvVars)
+	}
+
+}
+
+func (k *ProxyK3SCustomClusterTestSuite) TestProxyK3SCustomClusterProvisioning() {
+	k.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+
+	tests := []struct {
+		name    string
+		client  *rancher.Client
+		runFlag bool
+	}{
+		{provisioninginput.StandardClientName.String() + "-" + permutations.K3SAirgapCluster + "-", k.standardUserClient, k.standardUserClient.Flags.GetValue(environmentflag.Short)},
+	}
+	for _, tt := range tests {
+		provisioningConfig := *k.clustersConfig
+		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig, permutations.K3SAirgapCluster, nil, k.corralPackage)
+	}
+}
+
+func TestProxyK3SCustomClusterTestSuite(t *testing.T) {
+	suite.Run(t, new(ProxyK3SCustomClusterTestSuite))
+}

--- a/tests/v2/validation/provisioning/proxy/k3s_proxy_node_driver_test.go
+++ b/tests/v2/validation/provisioning/proxy/k3s_proxy_node_driver_test.go
@@ -1,0 +1,125 @@
+package proxy
+
+import (
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProxyK3SProvisioningTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	session            *session.Session
+	clustersConfig     *provisioninginput.Config
+	EnvVar             rkev1.EnvVar
+}
+
+func (k *ProxyK3SProvisioningTestSuite) TearDownSuite() {
+	k.session.Cleanup()
+}
+
+func (k *ProxyK3SProvisioningTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	k.session = testSession
+
+	corralRancherHA := new(corralha.CorralRancherHA)
+	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
+
+	k.clustersConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.clustersConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(k.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(k.T(), err)
+
+	k.standardUserClient = standardUserClient
+
+	k.clustersConfig.K3SKubernetesVersions, err = kubernetesversions.Default(
+		k.client, clusters.K3SClusterType.String(), k.clustersConfig.K3SKubernetesVersions)
+	require.NoError(k.T(), err)
+
+	listOfCorrals, err := corral.ListCorral()
+	require.NoError(k.T(), err)
+
+	_, corralExist := listOfCorrals[corralRancherHA.Name]
+	if corralExist {
+		bastionIP, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryPrivateIP)
+		require.NoError(k.T(), err)
+
+		k.EnvVar.Name = "HTTP_PROXY"
+		k.EnvVar.Value = bastionIP + ":3219"
+		k.clustersConfig.AgentEnvVars = append(k.clustersConfig.AgentEnvVars, k.EnvVar)
+
+		k.EnvVar.Name = "HTTPS_PROXY"
+		k.EnvVar.Value = bastionIP + ":3219"
+		k.clustersConfig.AgentEnvVars = append(k.clustersConfig.AgentEnvVars, k.EnvVar)
+
+		k.EnvVar.Name = "NO_PROXY"
+		k.EnvVar.Value = "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc"
+		k.clustersConfig.AgentEnvVars = append(k.clustersConfig.AgentEnvVars, k.EnvVar)
+	} else {
+		k.T().Logf("Using AgentEnvVars from config: %v", k.clustersConfig.AgentEnvVars)
+	}
+}
+
+func (k *ProxyK3SProvisioningTestSuite) TestProxyK3SClusterProvisioning() {
+	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		client       *rancher.Client
+		runFlag      bool
+	}{
+		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRolesAll, k.standardUserClient, k.standardUserClient.Flags.GetValue(environmentflag.Short)},
+	}
+
+	for _, tt := range tests {
+		if !tt.runFlag {
+			k.T().Logf("SKIPPED")
+			continue
+		}
+		provisioningConfig := *k.clustersConfig
+		provisioningConfig.MachinePools = tt.machinePools
+		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+	}
+}
+
+func TestProxyK3SProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(ProxyK3SProvisioningTestSuite))
+}

--- a/tests/v2/validation/provisioning/proxy/proxy.go
+++ b/tests/v2/validation/provisioning/proxy/proxy.go
@@ -1,0 +1,10 @@
+package proxy
+
+const (
+	//corralPackageProxyCustomClusterName = "proxyCustomCluster"
+	corralPackageAirgapCustomClusterName = "airgapCustomCluster"
+	corralBastionIP                      = "bastion_ip"
+	corralRegistryIP                     = "registry_ip"
+	corralRegistryPrivateIP              = "registry_private_ip"
+	logMessageKubernetesVersion          = "Validating the current version is the upgraded one"
+)

--- a/tests/v2/validation/provisioning/proxy/rke1_proxy_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/proxy/rke1_proxy_custom_cluster_test.go
@@ -1,0 +1,130 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProxyRKE1CustomClusterTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	session            *session.Session
+	corralPackage      *corral.Packages
+	clustersConfig     *provisioninginput.Config
+	EnvVar             management.EnvVar
+	corralImage        string
+	corralAutoCleanup  bool
+}
+
+func (r *ProxyRKE1CustomClusterTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *ProxyRKE1CustomClusterTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	r.session = testSession
+
+	corralRancherHA := new(corralha.CorralRancherHA)
+	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
+
+	r.clustersConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.clustersConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+
+	listOfCorrals, err := corral.ListCorral()
+	require.NoError(r.T(), err)
+
+	corralConfig := corral.Configurations()
+	err = corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	require.NoError(r.T(), err)
+
+	r.corralPackage = corral.PackagesConfig()
+	r.corralImage = r.corralPackage.CorralPackageImages[corralPackageAirgapCustomClusterName]
+	r.corralAutoCleanup = r.corralPackage.HasCleanup
+
+	_, corralExist := listOfCorrals[corralRancherHA.Name]
+	if corralExist {
+		bastionIP, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryPrivateIP)
+		require.NoError(r.T(), err)
+
+		r.EnvVar.Name = "HTTP_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.clustersConfig.AgentEnvVarsRKE1 = append(r.clustersConfig.AgentEnvVarsRKE1, r.EnvVar)
+
+		r.EnvVar.Name = "HTTPS_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.clustersConfig.AgentEnvVarsRKE1 = append(r.clustersConfig.AgentEnvVarsRKE1, r.EnvVar)
+
+		r.EnvVar.Name = "NO_PROXY"
+		r.EnvVar.Value = "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc"
+		r.clustersConfig.AgentEnvVarsRKE1 = append(r.clustersConfig.AgentEnvVarsRKE1, r.EnvVar)
+
+		err = corral.SetCorralSSHKeys(corralRancherHA.Name)
+		require.NoError(r.T(), err)
+
+		err = corral.SetCorralBastion(corralRancherHA.Name)
+		require.NoError(r.T(), err)
+	} else {
+		r.T().Logf("Using AgentEnvVarsRKE1 from config: %v", r.clustersConfig.AgentEnvVarsRKE1)
+	}
+}
+
+func (r *ProxyRKE1CustomClusterTestSuite) TestProxyRKE1CustomCluster() {
+	r.clustersConfig.NodePools = []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
+
+	tests := []struct {
+		name    string
+		client  *rancher.Client
+		runFlag bool
+	}{
+		{provisioninginput.StandardClientName.String() + "-" + permutations.RKE1AirgapCluster + "-", r.standardUserClient, r.standardUserClient.Flags.GetValue(environmentflag.Short)},
+	}
+	for _, tt := range tests {
+		provisioningConfig := *r.clustersConfig
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1AirgapCluster, nil, r.corralPackage)
+	}
+
+}
+
+func TestProxyRKE1CustomClusterTestSuite(t *testing.T) {
+	suite.Run(t, new(ProxyRKE1CustomClusterTestSuite))
+}

--- a/tests/v2/validation/provisioning/proxy/rke1_proxy_node_driver_test.go
+++ b/tests/v2/validation/provisioning/proxy/rke1_proxy_node_driver_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProxyRKE1ProvisioningTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	session            *session.Session
+	provisioningConfig *provisioninginput.Config
+	EnvVar             management.EnvVar
+}
+
+func (r *ProxyRKE1ProvisioningTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *ProxyRKE1ProvisioningTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	r.session = testSession
+
+	corralRancherHA := new(corralha.CorralRancherHA)
+	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
+
+	r.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	r.provisioningConfig.RKE1KubernetesVersions, err = kubernetesversions.Default(
+		r.client, clusters.RKE1ClusterType.String(), r.provisioningConfig.RKE1KubernetesVersions)
+	require.NoError(r.T(), err)
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+
+	listOfCorrals, err := corral.ListCorral()
+	require.NoError(r.T(), err)
+
+	_, corralExist := listOfCorrals[corralRancherHA.Name]
+	if corralExist {
+		bastionIP, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryPrivateIP)
+		require.NoError(r.T(), err)
+
+		r.EnvVar.Name = "HTTP_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.provisioningConfig.AgentEnvVarsRKE1 = append(r.provisioningConfig.AgentEnvVarsRKE1, r.EnvVar)
+
+		r.EnvVar.Name = "HTTPS_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.provisioningConfig.AgentEnvVarsRKE1 = append(r.provisioningConfig.AgentEnvVarsRKE1, r.EnvVar)
+
+		r.EnvVar.Name = "NO_PROXY"
+		r.EnvVar.Value = "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc"
+		r.provisioningConfig.AgentEnvVarsRKE1 = append(r.provisioningConfig.AgentEnvVarsRKE1, r.EnvVar)
+	} else {
+		r.T().Logf("Using AgentEnvVarsRKE1 from config: %v", r.provisioningConfig.AgentEnvVarsRKE1)
+	}
+}
+
+func (r *ProxyRKE1ProvisioningTestSuite) TestProxyRKE1ClusterProvisioning() {
+	nodeRolesAll := []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
+
+	tests := []struct {
+		name      string
+		nodePools []provisioninginput.NodePools
+		client    *rancher.Client
+		runFlag   bool
+	}{
+		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRolesAll, r.standardUserClient, r.standardUserClient.Flags.GetValue(environmentflag.Short)},
+	}
+	for _, tt := range tests {
+		if !tt.runFlag {
+			r.T().Logf("SKIPPED")
+			continue
+		}
+		provisioningConfig := *r.provisioningConfig
+		provisioningConfig.NodePools = tt.nodePools
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+	}
+}
+
+func TestProxyRKE1ProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(ProxyRKE1ProvisioningTestSuite))
+}

--- a/tests/v2/validation/provisioning/proxy/rke2_proxy_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/proxy/rke2_proxy_custom_cluster_test.go
@@ -1,0 +1,137 @@
+package proxy
+
+import (
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProxyRKE2CustomClusterTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	session            *session.Session
+	corralPackage      *corral.Packages
+	clustersConfig     *provisioninginput.Config
+	EnvVar             rkev1.EnvVar
+	corralImage        string
+	corralAutoCleanup  bool
+}
+
+func (r *ProxyRKE2CustomClusterTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *ProxyRKE2CustomClusterTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	r.session = testSession
+
+	corralRancherHA := new(corralha.CorralRancherHA)
+	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
+
+	r.clustersConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.clustersConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	r.clustersConfig.RKE2KubernetesVersions, err = kubernetesversions.Default(
+		r.client, clusters.RKE2ClusterType.String(), r.clustersConfig.RKE2KubernetesVersions)
+	require.NoError(r.T(), err)
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+
+	listOfCorrals, err := corral.ListCorral()
+	require.NoError(r.T(), err)
+
+	corralConfig := corral.Configurations()
+	err = corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	require.NoError(r.T(), err)
+
+	r.corralPackage = corral.PackagesConfig()
+	r.corralImage = r.corralPackage.CorralPackageImages[corralPackageAirgapCustomClusterName]
+	r.corralAutoCleanup = r.corralPackage.HasCleanup
+
+	_, corralExist := listOfCorrals[corralRancherHA.Name]
+	if corralExist {
+		bastionIP, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryPrivateIP)
+		require.NoError(r.T(), err)
+
+		r.EnvVar.Name = "HTTP_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.clustersConfig.AgentEnvVars = append(r.clustersConfig.AgentEnvVars, r.EnvVar)
+
+		r.EnvVar.Name = "HTTPS_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.clustersConfig.AgentEnvVars = append(r.clustersConfig.AgentEnvVars, r.EnvVar)
+
+		r.EnvVar.Name = "NO_PROXY"
+		r.EnvVar.Value = "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc"
+		r.clustersConfig.AgentEnvVars = append(r.clustersConfig.AgentEnvVars, r.EnvVar)
+
+		err = corral.SetCorralSSHKeys(corralRancherHA.Name)
+		require.NoError(r.T(), err)
+
+		err = corral.SetCorralBastion(corralRancherHA.Name)
+		require.NoError(r.T(), err)
+	} else {
+		r.T().Logf("Using AgentEnvVars from config: %v", r.clustersConfig.AgentEnvVars)
+	}
+
+}
+
+func (r *ProxyRKE2CustomClusterTestSuite) TestProxyRKE2CustomClusterProvisioning() {
+	r.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+
+	tests := []struct {
+		name    string
+		client  *rancher.Client
+		runFlag bool
+	}{
+		{provisioninginput.StandardClientName.String() + "-" + permutations.RKE2AirgapCluster + "-", r.standardUserClient, r.standardUserClient.Flags.GetValue(environmentflag.Short)},
+	}
+	for _, tt := range tests {
+		provisioningConfig := *r.clustersConfig
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE2AirgapCluster, nil, r.corralPackage)
+	}
+}
+
+func TestProxyRKE2CustomClusterTestSuite(t *testing.T) {
+	suite.Run(t, new(ProxyRKE2CustomClusterTestSuite))
+}

--- a/tests/v2/validation/provisioning/proxy/rke2_proxy_node_driver_test.go
+++ b/tests/v2/validation/provisioning/proxy/rke2_proxy_node_driver_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProxyRKE2ProvisioningTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	clustersConfig     *provisioninginput.Config
+	standardUserClient *rancher.Client
+	EnvVar             rkev1.EnvVar
+}
+
+func (r *ProxyRKE2ProvisioningTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *ProxyRKE2ProvisioningTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	r.session = testSession
+
+	corralRancherHA := new(corralha.CorralRancherHA)
+	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
+
+	r.clustersConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.clustersConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	r.clustersConfig.RKE2KubernetesVersions, err = kubernetesversions.Default(
+		r.client, clusters.RKE2ClusterType.String(), r.clustersConfig.RKE2KubernetesVersions)
+	require.NoError(r.T(), err)
+
+	listOfCorrals, err := corral.ListCorral()
+	require.NoError(r.T(), err)
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+
+	_, corralExist := listOfCorrals[corralRancherHA.Name]
+	if corralExist {
+		bastionIP, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryPrivateIP)
+		require.NoError(r.T(), err)
+
+		r.EnvVar.Name = "HTTP_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.clustersConfig.AgentEnvVars = append(r.clustersConfig.AgentEnvVars, r.EnvVar)
+
+		r.EnvVar.Name = "HTTPS_PROXY"
+		r.EnvVar.Value = bastionIP + ":3219"
+		r.clustersConfig.AgentEnvVars = append(r.clustersConfig.AgentEnvVars, r.EnvVar)
+
+		r.EnvVar.Name = "NO_PROXY"
+		r.EnvVar.Value = "localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc"
+		r.clustersConfig.AgentEnvVars = append(r.clustersConfig.AgentEnvVars, r.EnvVar)
+	} else {
+		r.T().Logf("Using AgentEnvVars from config: %v", r.clustersConfig.AgentEnvVars)
+	}
+}
+
+func (r *ProxyRKE2ProvisioningTestSuite) TestProxyRKE2ClusterProvisioning() {
+	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		client       *rancher.Client
+		runFlag      bool
+	}{
+		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRolesAll, r.standardUserClient, r.standardUserClient.Flags.GetValue(environmentflag.Short)},
+	}
+	for _, tt := range tests {
+		if !tt.runFlag {
+			r.T().Logf("SKIPPED")
+			continue
+		}
+		provisioningConfig := *r.clustersConfig
+		provisioningConfig.MachinePools = tt.machinePools
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+	}
+}
+
+func TestProxyRKE2ProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(ProxyRKE2ProvisioningTestSuite))
+}


### PR DESCRIPTION
## Issue:
Added proxied rancher provisioning tests for https://github.com/rancher/qa-tasks/issues/479
Port: https://github.com/rancher/rancher/pull/45266

Tests added:

- rke1 node driver
- rke1 custom clusters
- rke2 node driver
- rke2 custom clusters
- k3s node driver
- k3s custom cluster

## QA Testing Considerations
Runs in Jenkins