### PR TITLE
[2.7] Fix Slice Package Dependency in Tests

### DIFF
--- a/tests/v2/validation/provisioning/rke2/provisioning_cloud_provider_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_cloud_provider_test.go
@@ -3,9 +3,9 @@
 package rke2
 
 import (
-	"slices"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/catalog/utils"
 	"github.com/rancher/rancher/tests/v2/validation/provisioning/permutations"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -84,7 +84,7 @@ func (r *RKE2CloudProviderTestSuite) TestAWSCloudProviderCluster() {
 		{"OutOfTree" + provisioninginput.StandardClientName.String(), nodeRolesDedicated, r.standardUserClient, r.client.Flags.GetValue(environmentflag.Long)},
 	}
 
-	if !slices.Contains(r.provisioningConfig.Providers, "aws") {
+	if !utils.Contains(r.provisioningConfig.Providers, "aws") {
 		r.T().Skip("AWS Cloud Provider test requires access to aws.")
 	}
 
@@ -116,7 +116,7 @@ func (r *RKE2CloudProviderTestSuite) TestVsphereCloudProviderCluster() {
 		{"OutOfTree" + provisioninginput.StandardClientName.String(), nodeRolesDedicated, r.standardUserClient, r.client.Flags.GetValue(environmentflag.Long)},
 	}
 
-	if !slices.Contains(r.provisioningConfig.Providers, "vsphere") {
+	if !utils.Contains(r.provisioningConfig.Providers, "vsphere") {
 		r.T().Skip("Vsphere Cloud Provider test requires access to vsphere.")
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 jenkins was failing on 2.7 for this test due to go 1.20 not supporting slice package
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 wrote my own slice.contains function. 