### PR TITLE
Replace multierror.Append with errors.Join

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -22,7 +23,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-colorable"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/v2/pkg/signals"
@@ -69,15 +69,15 @@ func main() {
 			var bindingErr error
 			err = clean.DuplicateBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanCatalogBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = bindingErr
 		} else if os.Getenv("AD_GUID_CLEANUP") == "true" {

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,6 @@ require (
 	github.com/google/go-containerregistry v0.15.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/heptio/authenticator v0.0.0-20180409043135-d282f87a1972
 	github.com/manicminer/hamilton v0.46.0
@@ -225,6 +224,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20210315223345-82c243799c99 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/fs v0.1.0 // indirect

--- a/pkg/agent/clean/dupe_bindings.go
+++ b/pkg/agent/clean/dupe_bindings.go
@@ -13,13 +13,13 @@ package clean
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
@@ -181,25 +181,25 @@ func (bc *dupeBindingsCleanup) cleanObjectDuplicates(bindingType string, newLabe
 
 			crbs, err := bc.clusterRoleBindings.List(metav1.ListOptions{LabelSelector: label})
 			if err != nil {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 			}
 
 			if len(crbs.Items) > 1 {
 				CRBduplicates += len(crbs.Items) - 1
 				if err := bc.dedupeCRB(crbs.Items); err != nil {
-					returnErr = multierror.Append(returnErr, err)
+					returnErr = errors.Join(returnErr, err)
 				}
 			}
 
 			roleBindings, err := bc.roleBindings.List("", metav1.ListOptions{LabelSelector: label})
 			if err != nil {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 			}
 
 			if len(roleBindings.Items) > 1 {
 				roleDuplicates, err := bc.dedupeRB(roleBindings.Items)
 				if err != nil {
-					returnErr = multierror.Append(returnErr, err)
+					returnErr = errors.Join(returnErr, err)
 				}
 				RBDupes += roleDuplicates
 			}

--- a/pkg/agent/clean/orphan_bindings.go
+++ b/pkg/agent/clean/orphan_bindings.go
@@ -10,9 +10,9 @@ package clean
 
 import (
 	"context"
+	"errors"
 	"os"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/controllers/management/auth/globalroles"
 	mgmt "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
@@ -155,7 +155,7 @@ func (bc *orphanBindingsCleanup) cleanOrphans(dryRun bool) error {
 			logrus.Infof("[%v] deleting orphaned binding: %s/%s", orphanBindingsOperation, rb.Namespace, rb.Name)
 			err := bc.roleBindings.Delete(rb.Namespace, rb.Name, &metav1.DeleteOptions{})
 			if err != nil && !k8serrors.IsNotFound(err) {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 			}
 		}
 	}

--- a/pkg/auth/api/secrets/cleanup.go
+++ b/pkg/auth/api/secrets/cleanup.go
@@ -1,9 +1,9 @@
 package secrets
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/catalog/utils"
@@ -28,14 +28,14 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 	for _, field := range fields {
 		err := common.DeleteSecret(secretInterface, config.Type, field)
 		if err != nil && !apierrors.IsNotFound(err) {
-			result = multierror.Append(result, err)
+			result = errors.Join(result, err)
 		}
 	}
 
 	if utils.Contains(tokens.PerUserCacheProviders, config.Name) {
 		err := CleanupOAuthTokens(secretInterface, config.Name)
 		if err != nil {
-			result = multierror.Append(result, err)
+			result = errors.Join(result, err)
 		}
 	}
 
@@ -44,7 +44,7 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 			for _, field := range slice {
 				err := common.DeleteSecret(secretInterface, config.Type, field)
 				if err != nil && !apierrors.IsNotFound(err) {
-					result = multierror.Append(result, err)
+					result = errors.Join(result, err)
 				}
 			}
 		}
@@ -53,7 +53,7 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 	for _, secretName := range NameToFields[config.Name] {
 		err := common.DeleteSecret(secretInterface, config.Name, secretName)
 		if err != nil && !apierrors.IsNotFound(err) {
-			result = multierror.Append(result, err)
+			result = errors.Join(result, err)
 		}
 	}
 	return result
@@ -75,7 +75,7 @@ func CleanupOAuthTokens(secretInterface corev1.SecretInterface, key string) erro
 		if _, keyPresent := secret.Data[key]; keyPresent {
 			err := secretInterface.DeleteNamespaced(tokens.SecretNamespace, secret.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
-				result = multierror.Append(result, err)
+				result = errors.Join(result, err)
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -1,11 +1,10 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/controllers/management/authprovisioningv2"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
@@ -125,7 +124,7 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding)
 		return binding, nil
 	}
 
-	return nil, errors.Errorf("Binding %v has no subject", binding.Name)
+	return nil, fmt.Errorf("Binding %v has no subject", binding.Name)
 }
 
 // When a CRTB is created or updated, translate it into several k8s roles and bindings to actually enforce the RBAC
@@ -144,7 +143,7 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 		return err
 	}
 	if cluster == nil {
-		return errors.Errorf("cannot create binding because cluster %v was not found", clusterName)
+		return fmt.Errorf("cannot create binding because cluster %v was not found", clusterName)
 	}
 	// if roletemplate is not builtin, check if it's inherited/cloned
 	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName, clusterContext, 0)
@@ -246,7 +245,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 
@@ -271,7 +270,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 	if returnErr != nil {

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -1,12 +1,11 @@
 package globalroles
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	mgmtconv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -92,23 +91,23 @@ func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (runtime.Object, error
 	// set GR status to "in progress" while the underlying roles get added
 	err := gr.setGRAsInProgress(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileGlobalRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileCatalogRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileNamespacedRoles(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.setGRAsCompleted(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	return obj, returnError
 }
@@ -125,23 +124,23 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 	// set GR status to "in progress" while the underlying roles get added
 	err := gr.setGRAsInProgress(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileGlobalRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileCatalogRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileNamespacedRoles(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.setGRAsCompleted(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	return nil, returnError
 }
@@ -164,7 +163,7 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) er
 			logrus.Infof("[%v] Updating clusterRole %v. GlobalRole rules have changed. Have: %+v. Want: %+v", grController, clusterRole.Name, clusterRole.Rules, globalRole.Rules)
 			if _, err := gr.crClient.Update(clusterRole); err != nil {
 				addCondition(globalRole, condition, FailedToUpdateClusterRole, crName, err)
-				return errors.Wrapf(err, "couldn't update ClusterRole %v", clusterRole.Name)
+				return fmt.Errorf("couldn't update ClusterRole %v: %w", clusterRole.Name, err)
 			}
 		}
 		addCondition(globalRole, condition, ClusterRoleExists, crName, nil)
@@ -310,7 +309,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			addCondition(globalRole, condition, NamespaceNotFound, roleName, fmt.Errorf("namespace %s not found", ns))
 			continue
 		} else if err != nil {
-			returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't get namespace %s", ns))
+			returnError = errors.Join(returnError, fmt.Errorf("couldn't get namespace %s: %w", ns, err))
 			addCondition(globalRole, condition, FailedToGetNamespace, roleName, err)
 			continue
 		}
@@ -319,7 +318,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 		role, err := gr.rLister.Get(ns, roleName)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToGetRole, roleName, err)
 				continue
 			}
@@ -357,7 +356,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			}
 
 			if !apierrors.IsAlreadyExists(err) {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToCreateRole, roleName, err)
 				continue
 			}
@@ -365,7 +364,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			// In the case that the role already exists, we get it and check that the rules are correct
 			role, err = gr.rLister.Get(ns, roleName)
 			if err != nil {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToGetRole, roleName, err)
 				continue
 			}
@@ -388,7 +387,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 
 			_, err := gr.rClient.Update(newRole)
 			if err != nil {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToUpdateRole, roleName, err)
 				continue
 			}
@@ -399,12 +398,12 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 	// get all the roles claiming to be owned by this GR and remove any that shouldn't exist
 	r, err := labels.NewRequirement(grOwnerLabel, selection.Equals, []string{globalRoleName})
 	if err != nil {
-		return multierror.Append(returnError, errors.Wrapf(err, "couldn't create label: %s", grOwnerLabel))
+		return errors.Join(returnError, fmt.Errorf("couldn't create label: %s: %w", grOwnerLabel, err))
 	}
 
 	roles, err := gr.rLister.List("", labels.NewSelector().Add(*r))
 	if err != nil {
-		return multierror.Append(returnError, errors.Wrapf(err, "couldn't list roles with label %s : %s", grOwnerLabel, globalRoleName))
+		return errors.Join(returnError, fmt.Errorf("couldn't list roles with label %s : %s: %w", grOwnerLabel, globalRoleName, err))
 	}
 
 	// After creating/updating all Roles, if the number of RBs with the grOwnerLabel is the same as
@@ -412,7 +411,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 	if len(roleUIDs) != len(roles) {
 		err = gr.purgeInvalidNamespacedRoles(roles, roleUIDs)
 		if err != nil {
-			returnError = multierror.Append(returnError, err)
+			returnError = errors.Join(returnError, err)
 		}
 	}
 	return returnError
@@ -425,7 +424,7 @@ func (gr *globalRoleLifecycle) purgeInvalidNamespacedRoles(roles []*v1.Role, uid
 		if _, ok := uids[r.UID]; !ok {
 			err := gr.rClient.DeleteNamespaced(r.Namespace, r.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't delete role %s", r.Name))
+				returnError = errors.Join(returnError, fmt.Errorf("couldn't delete role %s: %w", r.Name, err))
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -1,11 +1,10 @@
 package globalroles
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers"
 	mgmtcontroller "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -100,15 +99,15 @@ func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (runtim
 	var returnError error
 	err := grb.reconcileClusterPermissions(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = grb.reconcileGlobalRoleBinding(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = grb.reconcileNamespacedRoleBindings(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	return obj, returnError
 }
@@ -117,15 +116,15 @@ func (grb *globalRoleBindingLifecycle) Updated(obj *v3.GlobalRoleBinding) (runti
 	var returnError error
 	err := grb.reconcileClusterPermissions(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = grb.reconcileGlobalRoleBinding(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = grb.reconcileNamespacedRoleBindings(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	return obj, returnError
 }
@@ -291,7 +290,7 @@ func (grb *globalRoleBindingLifecycle) purgeCorruptRoles(wantRTs []string, clust
 				// failure to delete one crtb does not prevent our ability to delete other crtbs, or to determine
 				// which rts we want to remove
 				crtbErr := fmt.Errorf("unable to delete backing crtb %s for globalRoleBinding %s: %w", crtb.Name, binding.Name, err)
-				deleteErr = multierror.Append(deleteErr, crtbErr)
+				deleteErr = errors.Join(deleteErr, crtbErr)
 			}
 		} else {
 			seenRTs[crtb.RoleTemplateName] = struct{}{}
@@ -363,7 +362,7 @@ func (grb *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBind
 			crb.Subjects = subjects
 			logrus.Infof("[%v] Updating clusterRoleBinding %v for globalRoleBinding %v user %v", grbController, crb.Name, globalRoleBinding.Name, globalRoleBinding.UserName)
 			if _, err := grb.crbClient.Update(crb); err != nil {
-				return errors.Wrapf(err, "couldn't update ClusterRoleBinding %v", crb.Name)
+				return fmt.Errorf("couldn't update ClusterRoleBinding %v: %w", crb.Name, err)
 			}
 		}
 		return grb.addRulesForTemplateAndTemplateVersions(globalRoleBinding, subject)
@@ -490,7 +489,7 @@ func (grb *globalRoleBindingLifecycle) createRestrictedAdminCRBsForUserClusters(
 		crbName := clusterName + rbac.RestrictedAdminCRBForClusters + globalRoleBinding.Name
 		crb, err := grb.crbLister.Get("", crbName)
 		if err != nil && !apierrors.IsNotFound(err) {
-			returnErr = multierror.Append(returnErr, err)
+			returnErr = errors.Join(returnErr, err)
 			continue
 		}
 		if crb != nil {
@@ -508,7 +507,7 @@ func (grb *globalRoleBindingLifecycle) createRestrictedAdminCRBsForUserClusters(
 			Subjects: []v1.Subject{subject},
 		})
 		if err != nil && !apierrors.IsAlreadyExists(err) {
-			returnErr = multierror.Append(returnErr, err)
+			returnErr = errors.Join(returnErr, err)
 		}
 	}
 	return returnErr
@@ -528,7 +527,7 @@ func (grb *globalRoleBindingLifecycle) grantRestrictedAdminUserClusterPermission
 		_, err := grb.roleBindingLister.Get(cluster.Name, rbName)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 				continue
 			}
 			_, err := grb.roleBindings.Create(&v1.RoleBinding{
@@ -551,14 +550,14 @@ func (grb *globalRoleBindingLifecycle) grantRestrictedAdminUserClusterPermission
 				Subjects: []v1.Subject{subject},
 			})
 			if err != nil && !apierrors.IsAlreadyExists(err) {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 				continue
 			}
 		}
 
 		projects, err := grb.projectLister.List(cluster.Name, labels.NewSelector())
 		if err != nil {
-			returnErr = multierror.Append(returnErr, err)
+			returnErr = errors.Join(returnErr, err)
 			continue
 		}
 
@@ -587,10 +586,10 @@ func (grb *globalRoleBindingLifecycle) grantRestrictedAdminUserClusterPermission
 						Subjects: []v1.Subject{subject},
 					})
 					if err != nil && !apierrors.IsAlreadyExists(err) {
-						returnErr = multierror.Append(returnErr, err)
+						returnErr = errors.Join(returnErr, err)
 					}
 				} else {
-					returnErr = multierror.Append(returnErr, err)
+					returnErr = errors.Join(returnErr, err)
 				}
 			}
 		}
@@ -617,7 +616,7 @@ func (grb *globalRoleBindingLifecycle) reconcileNamespacedRoleBindings(globalRol
 			logrus.Warnf("[%v] Namespace %s not found. Not re-enqueueing GlobalRoleBinding %s", grController, ns, globalRoleBinding.Name)
 			continue
 		} else if err != nil {
-			returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't get namespace %s", ns))
+			returnError = errors.Join(returnError, fmt.Errorf("couldn't get namespace %s: %w", ns, err))
 			continue
 		}
 
@@ -639,11 +638,11 @@ func (grb *globalRoleBindingLifecycle) reconcileNamespacedRoleBindings(globalRol
 			// Since roleRef is immutable, we have to delete and recreate the RB
 			err = grb.roleBindings.DeleteNamespaced(roleBinding.Namespace, roleBinding.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				continue
 			}
 		} else if !apierrors.IsNotFound(err) {
-			returnError = multierror.Append(returnError, err)
+			returnError = errors.Join(returnError, err)
 			continue
 		}
 
@@ -676,7 +675,7 @@ func (grb *globalRoleBindingLifecycle) reconcileNamespacedRoleBindings(globalRol
 
 		createdRB, err := grb.roleBindings.Create(newRoleBinding)
 		if err != nil {
-			returnError = multierror.Append(returnError, err)
+			returnError = errors.Join(returnError, err)
 			continue
 		}
 		roleBindingUIDs[createdRB.UID] = struct{}{}
@@ -685,13 +684,13 @@ func (grb *globalRoleBindingLifecycle) reconcileNamespacedRoleBindings(globalRol
 	// get all the roleBindings claiming to be owned by this GRB and remove any that shouldn't exist
 	r, err := labels.NewRequirement(grbOwnerLabel, selection.Equals, []string{grbName})
 	if err != nil {
-		return multierror.Append(returnError, errors.Wrapf(err, "couldn't create label: %s", grOwnerLabel))
+		return errors.Join(returnError, fmt.Errorf("couldn't create label: %s: %w", grOwnerLabel, err))
 	}
 
 	rbs, err := grb.roleBindingLister.List("", labels.NewSelector().Add(*r))
 	if err != nil {
-		return multierror.Append(returnError,
-			errors.Wrapf(err, "couldn't list roleBindings with label %s : %s", grbOwnerLabel, grbName))
+		return errors.Join(returnError,
+			fmt.Errorf("couldn't list roleBindings with label %s : %s: %w", grbOwnerLabel, grbName, err))
 	}
 
 	// After creating/updating all RBs, if the number of RBs with the grbOwnerLabel is the same as
@@ -699,7 +698,7 @@ func (grb *globalRoleBindingLifecycle) reconcileNamespacedRoleBindings(globalRol
 	if len(rbs) != len(roleBindingUIDs) {
 		err = grb.purgeInvalidNamespacedRBs(rbs, roleBindingUIDs)
 		if err != nil {
-			returnError = multierror.Append(returnError, err)
+			returnError = errors.Join(returnError, err)
 		}
 	}
 	return returnError
@@ -712,7 +711,7 @@ func (grb *globalRoleBindingLifecycle) purgeInvalidNamespacedRBs(rbs []*v1.RoleB
 		if _, ok := uids[rb.UID]; !ok {
 			err := grb.roleBindings.DeleteNamespaced(rb.Namespace, rb.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't delete roleBinding %s", rb.Name))
+				returnError = errors.Join(returnError, fmt.Errorf("couldn't delete roleBinding %s: %w", rb.Name, err))
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/role_template_lifecycle.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle.go
@@ -1,9 +1,9 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -134,7 +134,7 @@ func (rtl *roleTemplateLifecycle) removeAuthV2Roles(roleTemplate *v3.RoleTemplat
 		err := rtl.roles.DeleteNamespaced(role.Namespace, role.Name, &metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			// Combine all errors so we try our best to delete everything in the first run
-			returnErr = multierror.Append(returnErr, err)
+			returnErr = errors.Join(returnErr, err)
 		}
 	}
 

--- a/pkg/controllers/management/restrictedadminrbac/cluster.go
+++ b/pkg/controllers/management/restrictedadminrbac/cluster.go
@@ -1,9 +1,9 @@
 package restrictedadminrbac
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/v2/pkg/name"
@@ -32,7 +32,7 @@ func (r *rbaccontroller) clusterOwnerSync(_ string, grb *v3.GlobalRoleBinding) (
 		crtbName := name.SafeConcatName(rbac.GetGRBTargetKey(grb), "restricted-admin", "cluster-owner")
 		_, err := r.crtbCache.Get(cluster.Name, crtbName)
 		if err != nil && !apierrors.IsNotFound(err) {
-			retError = multierror.Append(retError, fmt.Errorf("failed to get CRTB '%s' from cache: %w", crtbName, err))
+			retError = errors.Join(retError, fmt.Errorf("failed to get CRTB '%s' from cache: %w", crtbName, err))
 			continue
 		}
 		if err == nil {
@@ -72,7 +72,7 @@ func (r *rbaccontroller) clusterOwnerSync(_ string, grb *v3.GlobalRoleBinding) (
 
 		_, err = r.crtbCtrl.Create(&crtb)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
-			retError = multierror.Append(retError, fmt.Errorf("failed to create a CRTB '%s': %w", crtbName, err))
+			retError = errors.Join(retError, fmt.Errorf("failed to create a CRTB '%s': %w", crtbName, err))
 			continue
 		}
 	}

--- a/pkg/controllers/management/restrictedadminrbac/fleet.go
+++ b/pkg/controllers/management/restrictedadminrbac/fleet.go
@@ -1,10 +1,10 @@
 package restrictedadminrbac
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
-	"github.com/hashicorp/go-multierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	"github.com/rancher/rancher/pkg/rbac"
@@ -44,7 +44,7 @@ func (r *rbaccontroller) ensureRestricedAdminForFleet(key string, obj *v3.Global
 			continue
 		}
 		if err := r.ensureRolebinding(fw.Name, rbac.GetGRBSubject(obj), obj); err != nil {
-			finalError = multierror.Append(finalError, err)
+			finalError = errors.Join(finalError, err)
 		}
 	}
 	return obj, finalError

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -2,12 +2,12 @@ package management
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"sort"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/rbac"
@@ -134,7 +134,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	// TODO enable when groups are "in". they need to be self-service
 
 	if err := rb.reconcileGlobalRoles(wrangler.Mgmt.GlobalRole()); err != nil {
-		return "", errors.Wrap(err, "problem reconciling global roles")
+		return "", fmt.Errorf("problem reconciling global roles: %w", err)
 	}
 
 	// RoleTemplates to be used inside of clusters
@@ -424,7 +424,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	//	addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch")
 
 	if err := rb.reconcileRoleTemplates(wrangler.Mgmt.RoleTemplate()); err != nil {
-		return "", errors.Wrap(err, "problem reconciling role templates")
+		return "", fmt.Errorf("problem reconciling role templates: %w", err)
 	}
 
 	adminName, err := BootstrapAdmin(wrangler)
@@ -506,7 +506,7 @@ func BootstrapAdmin(management *wrangler.Context) (string, error) {
 		// Config map does not exist and no users, attempt to create the default admin user
 		bootstrapPassword, bootstrapPasswordIsGenerated, err := GetBootstrapPassword(context.TODO(), management.K8s.CoreV1().Secrets(cattleNamespace))
 		if err != nil {
-			return "", errors.Wrap(err, "failed to retrieve bootstrap password")
+			return "", fmt.Errorf("failed to retrieve bootstrap password: %w", err)
 		}
 
 		bootstrapPasswordHash, _ := bcrypt.GenerateFromPassword([]byte(bootstrapPassword), bcrypt.DefaultCost)
@@ -522,7 +522,7 @@ func BootstrapAdmin(management *wrangler.Context) (string, error) {
 			MustChangePassword: bootstrapPasswordIsGenerated || bootstrapPassword == "admin",
 		})
 		if err != nil && !apierrors.IsAlreadyExists(err) {
-			return "", errors.Wrap(err, "can not ensure admin user exists")
+			return "", fmt.Errorf("can not ensure admin user exists: %w", err)
 		}
 		if err == nil {
 			var serverURL string
@@ -700,7 +700,7 @@ func addClusterRoleForNamespacedCRDs(management *config.ManagementContext) error
 		},
 	}
 	if err := createOrUpdateClusterRole(management, cr); err != nil {
-		returnErr = multierror.Append(returnErr, err)
+		returnErr = errors.Join(returnErr, err)
 	}
 
 	// ProjectCRDsClusterRole is a CR containing rules for granting restricted-admins access to all CRDs that can be created in a
@@ -723,7 +723,7 @@ func addClusterRoleForNamespacedCRDs(management *config.ManagementContext) error
 		},
 	}
 	if err := createOrUpdateClusterRole(management, cr); err != nil {
-		returnErr = multierror.Append(returnErr, err)
+		returnErr = errors.Join(returnErr, err)
 	}
 	return returnErr
 }

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -3,6 +3,7 @@ package rancher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -10,8 +11,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	responsewriter "github.com/rancher/apiserver/pkg/middleware"
 	"github.com/rancher/rancher/pkg/api/norman/customization/kontainerdriver"
 	"github.com/rancher/rancher/pkg/api/norman/customization/podsecuritypolicytemplate"
@@ -564,13 +563,13 @@ func migrateEncryptionConfig(ctx context.Context, restConfig *rest.Config) error
 
 			clusterBytes, err := rawDynamicCluster.MarshalJSON()
 			if err != nil {
-				return false, errors.Wrap(err, "error trying to Marshal dynamic cluster")
+				return false, fmt.Errorf("error trying to Marshal dynamic cluster: %w", err)
 			}
 
 			var cluster *v3.Cluster
 
 			if err := json.Unmarshal(clusterBytes, &cluster); err != nil {
-				return false, errors.Wrap(err, "error trying to Unmarshal dynamicCluster into v3 cluster")
+				return false, fmt.Errorf("error trying to Unmarshal dynamicCluster into v3 cluster: %w", err)
 			}
 
 			if cluster.Annotations == nil {
@@ -593,7 +592,7 @@ func migrateEncryptionConfig(ctx context.Context, restConfig *rest.Config) error
 			return false, err
 		})
 		if err != nil {
-			allErrors = multierror.Append(err, allErrors)
+			allErrors = errors.Join(err, allErrors)
 		}
 	}
 	return allErrors

--- a/tests/v2/codecoverage/agent/main.go
+++ b/tests/v2/codecoverage/agent/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-colorable"
 	"github.com/rancher/rancher/pkg/agent/clean"
 	"github.com/rancher/rancher/pkg/agent/cluster"
@@ -80,15 +80,15 @@ func runAgent(ctx context.Context) {
 			var bindingErr error
 			err = clean.DuplicateBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanCatalogBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = bindingErr
 		} else {


### PR DESCRIPTION
## Issue: 
 
## Problem
The package `go-multierror` from [here](https://github.com/hashicorp/go-multierror) uses the MPL 2.0 license, which is considered an incompatible license in rancher.  
 
## Solution
Multierrors can be replaced with `errors.Join` and get similar results. Multierror is formatted a little nicer, but both combine errors and can be checked for the existence of specific errors.

Here is an example of the formatting difference:
https://go.dev/play/p/qYefpBQ81GL

While I was working on removing `multierror`, I also replaced `https://github.com/pkg/errors` with the `errors` standard library. Specifically, I replaced instances of `errors.Wrap(err, "message")` with `fmt.Errorf("message: %w", err)`. Both wrap the error and create the same error message. The motivation behind this is that `https://github.com/pkg/errors` has been archived and hasn't received updates since 2020. In a future PR it should be completely removed from rancher.

It's still imported as an indirect requirement, but rancher no longer makes use of it directly.

## Testing
The existing unit tests pass. This does not change functionality, just how the errors are handled.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_