### PR TITLE
[v2.8] bump default shell version to v0.1.24

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
 webhookVersion: 103.0.3+up0.4.4-rc1
 cspAdapterMinVersion: 103.0.1+up3.0.1
-defaultShellVersion: rancher/shell:v0.1.24-rc1
+defaultShellVersion: rancher/shell:v0.1.24
 fleetVersion: 103.1.4+up0.9.4

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion = "103.0.1+up3.0.1"
-	DefaultShellVersion  = "rancher/shell:v0.1.24-rc1"
+	DefaultShellVersion  = "rancher/shell:v0.1.24"
 	FleetVersion         = "103.1.4+up0.9.4"
 	WebhookVersion       = "103.0.3+up0.4.4-rc1"
 )


### PR DESCRIPTION
Awaiting QA to promote `*-rc1` to stable - preparing draft in advance.
(This PR will be squash merged; or just as likely rebased before undrafted.)