### PR TITLE
[2.9] feat(helm-letsencrypt): adding dns01 challenge types to letsencrypt

### DIFF
--- a/chart/templates/issuer-letsEncrypt.yaml
+++ b/chart/templates/issuer-letsEncrypt.yaml
@@ -29,9 +29,17 @@ spec:
     http01: {}
     {{- else }}
     solvers:
+    {{- if .Values.letsEncrypt.solver.dns01 }}
+    - selector:
+        dnsZones:
+          - {{ .Values.hostname }}
+      dns01:
+{{ toYaml .Values.letsEncrypt.solver.dns01 | indent 8}}
+    {{- else }}
     - http01:
         ingress:
           class: {{ .Values.letsEncrypt.ingress.class }}
+    {{- end }}
     {{- end }}
   {{- end -}}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,6 +84,17 @@ service:
 letsEncrypt:
   # email: none@example.com
   environment: production
+  # http01 default or dns01 for extended support in CSPs
+  solver: 
+    http01:
+    #dns01:
+      #route53:
+        #accessKeyID: ""
+        #hostedZoneID: ""
+        #region: ""
+        #secretAccessKeySecretRef:
+          #key: ""
+          #name: ""
   ingress:
     # options: traefik, nginx
     class: ""


### PR DESCRIPTION
Adding dns01 open-ended config to the helm-charts to allow systems that cant do port 80 challenges with letsenrypt.
 Allows agnostic accepting of dns01 challenge types to include support for route53/azuredns/etc

## Problem
Many environments are locking down port 80 communication. These environments may not have proxies, but it means it limits the ability to use the LetsEncrypt Cert Manager to create the certs because we have only http01 hardcoded and cant use more flexibly acceptable challenge types like dns01 which has more cloud specific support
 
## Solution
Add support for dns01 challenge type (still defaults to http01 for behavior consistency) which will then inject the provided values configuration to support any type of sub dns01 challenge
