### PR TITLE
[v2.9] Fix delete init node for RKE2 clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240425061024-5ce684a45887
-	github.com/rancher/shepherd v0.0.0-20240502220002-2bcb20d8aa61
+	github.com/rancher/shepherd v0.0.0-20240513202553-b237456b1927
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1700,8 +1700,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.6.0-rc1 h1:4aYfGiG4gxL5k44M3jpDoKfQqI1lxdl4GAVPRMvKMj8=
 github.com/rancher/rke v1.6.0-rc1/go.mod h1:vojhOf8U8VCmw7y17OENWXSIfEFPEbXCMQcmI7xN7i8=
-github.com/rancher/shepherd v0.0.0-20240502220002-2bcb20d8aa61 h1:w+zEBdP+7gGv+bKqqiSjeVjM6Mm5IjXN8tP1PGSJAS0=
-github.com/rancher/shepherd v0.0.0-20240502220002-2bcb20d8aa61/go.mod h1:Mpd+RsxaqTMaoKSdeiEvGoDEknAKS8hAWjdozi5mJxE=
+github.com/rancher/shepherd v0.0.0-20240513202553-b237456b1927 h1:4riXwztwQme5CiRcMqAuwDrhkTDeekIeXe1+c+I1SFo=
+github.com/rancher/shepherd v0.0.0-20240513202553-b237456b1927/go.mod h1:Mpd+RsxaqTMaoKSdeiEvGoDEknAKS8hAWjdozi5mJxE=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/deleting/delete_init_machine.go
+++ b/tests/v2/validation/deleting/delete_init_machine.go
@@ -24,7 +24,7 @@ func deleteInitMachine(t *testing.T, client *rancher.Client, clusterID string) {
 	require.NoError(t, err)
 
 	logrus.Info("Awaiting machine deletion...")
-	err = steve.WaitForSteveResourceDeletion(client, defaults.FiveHundredMillisecondTimeout, defaults.TwoMinuteTimeout, machineSteveResourceType, initMachine.ID)
+	err = steve.WaitForSteveResourceDeletion(client, defaults.FiveHundredMillisecondTimeout, defaults.TenMinuteTimeout, machineSteveResourceType, initMachine.ID)
 	require.NoError(t, err)
 
 	logrus.Info("Awaiting machine replacement...")

--- a/tests/v2/validation/deleting/delete_init_machine_test.go
+++ b/tests/v2/validation/deleting/delete_init_machine_test.go
@@ -1,3 +1,5 @@
+//go:build (infra.rke2k3s || validation) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke1 && !stress && !sanity && !extended
+
 package deleting
 
 import (
@@ -53,6 +55,7 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 	if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
 		name = "RKE2"
 	}
+
 	require.NotContains(d.T(), updatedCluster.Spec.KubernetesVersion, "-rancher")
 	require.NotEmpty(d.T(), updatedCluster.Spec.KubernetesVersion)
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->[delete_init_machine_test.go is failing for RKE2 clusters but works for K3s clusters]( https://github.com/rancher/qa-tasks/issues/1313)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Rancher PR for shepherd PR https://github.com/rancher/shepherd/pull/181.