### PR TITLE
[2.9] Add build system's values to Drone's targets via build-args

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -347,6 +347,12 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
+      - CATTLE_CSP_ADAPTER_MIN_VERSION
+      - CATTLE_FLEET_VERSION
     build_args:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
@@ -396,6 +402,10 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
     build_args:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
@@ -421,6 +431,12 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
+      - CATTLE_CSP_ADAPTER_MIN_VERSION
+      - CATTLE_FLEET_VERSION
     build_args:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
@@ -462,6 +478,10 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
     build_args:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
@@ -605,6 +625,12 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
+      - CATTLE_CSP_ADAPTER_MIN_VERSION
+      - CATTLE_FLEET_VERSION
     build_args:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
@@ -654,6 +680,10 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
     build_args:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
@@ -679,6 +709,12 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
+      - CATTLE_CSP_ADAPTER_MIN_VERSION
+      - CATTLE_FLEET_VERSION
     build_args:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"
@@ -720,6 +756,10 @@ steps:
   image: plugins/docker
   settings:
     purge: false
+    commands:
+      - source ../scripts/export-config
+    build_args_from_env:
+      - CATTLE_RANCHER_WEBHOOK_VERSION
     build_args:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"

--- a/.drone.yml
+++ b/.drone.yml
@@ -350,6 +350,9 @@ steps:
     build_args:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
+    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
+    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -400,6 +403,7 @@ steps:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -424,6 +428,9 @@ steps:
     build_args:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
+    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
+    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -466,6 +473,7 @@ steps:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-amd64"
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -608,6 +616,9 @@ steps:
     build_args:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
+    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
+    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -658,6 +669,7 @@ steps:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -682,6 +694,9 @@ steps:
     build_args:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
+    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
+    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -724,6 +739,7 @@ steps:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-arm64"
+    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -817,6 +833,7 @@ steps:
         - SERVERCORE_VERSION=1809
         - ARCH=amd64
         - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
@@ -845,6 +862,7 @@ steps:
         - SERVERCORE_VERSION=1809
         - ARCH=amd64
         - "VERSION=${DRONE_TAG}"
+        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
@@ -942,6 +960,7 @@ steps:
         - SERVERCORE_VERSION=ltsc2022
         - ARCH=amd64
         - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
+        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
@@ -970,6 +989,7 @@ steps:
         - SERVERCORE_VERSION=ltsc2022
         - ARCH=amd64
         - "VERSION=${DRONE_TAG}"
+        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent

--- a/.drone.yml
+++ b/.drone.yml
@@ -350,9 +350,6 @@ steps:
     build_args:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
-    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
-    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -403,7 +400,6 @@ steps:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-amd64
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -428,9 +424,6 @@ steps:
     build_args:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
-    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
-    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -473,7 +466,6 @@ steps:
     - ARCH=amd64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-amd64"
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -616,9 +608,6 @@ steps:
     build_args:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
-    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
-    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -669,7 +658,6 @@ steps:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
     - RANCHER_TAG=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-linux-arm64
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -694,9 +682,6 @@ steps:
     build_args:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
-    - CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0
-    - CATTLE_FLEET_VERSION=104.0.0+up0.10.0-rc.13
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -739,7 +724,6 @@ steps:
     - ARCH=arm64
     - "VERSION=${DRONE_TAG}"
     - "RANCHER_TAG=${DRONE_TAG}-linux-arm64"
-    - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -833,7 +817,6 @@ steps:
         - SERVERCORE_VERSION=1809
         - ARCH=amd64
         - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
@@ -862,7 +845,6 @@ steps:
         - SERVERCORE_VERSION=1809
         - ARCH=amd64
         - "VERSION=${DRONE_TAG}"
-        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
@@ -960,7 +942,6 @@ steps:
         - SERVERCORE_VERSION=ltsc2022
         - ARCH=amd64
         - VERSION=${DRONE_BRANCH/release\//}-${DRONE_COMMIT}-head
-        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
@@ -989,7 +970,6 @@ steps:
         - SERVERCORE_VERSION=ltsc2022
         - ARCH=amd64
         - "VERSION=${DRONE_TAG}"
-        - CATTLE_RANCHER_WEBHOOK_VERSION=104.0.0+up0.5.0-rc8
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45418
 
## Problem

Currently, Drone doesn't run all the scripts intended to be run on release. Specifically, it doesn't run `ci` in all its targets. Because of this, images built by Drone and pushed to registries don't run some of the necessary scripts and thus don't have some of the environment variables needed for Rancher at run time.
 
## Solution

Because Drone will soon be removed in favor of GitHub Actions, this commit simply adds the environment variables as build-args inline, instead of fixing the Drone pipeline steps and the ensuing it runs the script populating the environment variables defined by the build system.
 
## Testing
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_