### PR TITLE
[v2.9] Remove PSP checks from SUC charts and it's upgrade process

### DIFF
--- a/pkg/controllers/capr/managesystemagent/managesystemagentplan_test.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagentplan_test.go
@@ -21,7 +21,6 @@ func TestManageSystemAgent_syncSystemUpgradeControllerStatusConditionManipulatio
 		controlPlaneName      string
 		controlPlaneNamespace string
 		kubernetesVersion     string
-		pspEnabled            bool
 		changeExpected        bool
 		bs                    fleetv1alpha1.BundleSummary
 	}
@@ -43,34 +42,6 @@ func TestManageSystemAgent_syncSystemUpgradeControllerStatusConditionManipulatio
 			},
 		},
 		{
-			name: "test for PSPs still enabled on 1.26",
-			args: args{
-				controlPlaneName:      "lol",
-				controlPlaneNamespace: "lol",
-				kubernetesVersion:     "v1.26.5+k3s1",
-				bs: fleetv1alpha1.BundleSummary{
-					DesiredReady: 1,
-					Ready:        1,
-				},
-				pspEnabled:     true,
-				changeExpected: true,
-			},
-		},
-		{
-			name: "test for PSPs disabled on 1.26",
-			args: args{
-				controlPlaneName:      "lol",
-				controlPlaneNamespace: "lol",
-				kubernetesVersion:     "v1.26.5+k3s1",
-				bs: fleetv1alpha1.BundleSummary{
-					DesiredReady: 1,
-					Ready:        1,
-				},
-				pspEnabled:     false,
-				changeExpected: false,
-			},
-		},
-		{
 			name: "test for super long controlplane name",
 			args: args{
 				controlPlaneName:      "ayyhxrojzehfiqampacgkqbqyewdjxwvhjowpikqqtxbkjqpegqaovgfehehkfg",
@@ -80,7 +51,6 @@ func TestManageSystemAgent_syncSystemUpgradeControllerStatusConditionManipulatio
 					DesiredReady: 1,
 					Ready:        1,
 				},
-				pspEnabled:     false,
 				changeExpected: false,
 			},
 		},
@@ -107,7 +77,7 @@ func TestManageSystemAgent_syncSystemUpgradeControllerStatusConditionManipulatio
 			}
 
 			capr.SystemUpgradeControllerReady.True(&mockControlPlane.Status)
-
+			capr.SystemUpgradeControllerReady.Message(&mockControlPlane.Status, "")
 			// Set the "last updated time" to the start of time, because RFC3339 only provides granularity at seconds and the test can run in less than a second (thus ensuring the timestamp is mutated when we expect it to be mutated)
 			capr.SystemUpgradeControllerReady.LastUpdated(&mockControlPlane.Status, time.Time{}.UTC().Format(time.RFC3339))
 			lu := capr.SystemUpgradeControllerReady.GetLastUpdated(&mockControlPlane.Status)
@@ -133,11 +103,7 @@ func TestManageSystemAgent_syncSystemUpgradeControllerStatusConditionManipulatio
 							Values: &fleetv1alpha1.GenericMap{
 								Data: map[string]interface{}{
 									"global": map[string]interface{}{
-										"cattle": map[string]interface{}{
-											"psp": map[string]interface{}{
-												"enabled": tt.args.pspEnabled,
-											},
-										},
+										"cattle": map[string]interface{}{},
 									},
 								},
 							},


### PR DESCRIPTION
## Issue
* https://github.com/rancher/rancher/issues/44922
 
## Problem
* PSP is completely removed from k8s 1.29 onwards

## TODO
* [x] Update SUC chart version in dockerfile once the charts PR is merged.
* * [x] https://github.com/rancher/system-charts/pull/606
* * [x] https://github.com/rancher/charts/pull/3951

## Solution
* Remove PSP checks from SUC charts and it's upgrade process
 
## Engineering Testing
### Manual Testing
* Created a rancher server with `v2.8.3`. Deployed rke2 1.28 k8s downstream cluster.
* Upgraded rancher server to custom image with the PSP checks removed.
* Rancher server and SUC chart upgrade went successful, PSP was removed from the `values.yaml` of SUC chart.
![Screenshot from 2024-05-08 18-04-31](https://github.com/rancher/rancher/assets/32087475/22801393-1401-488a-9dfa-08fd9a2ba0a5)


