### PR TITLE
Release rancher-webhook v0.4.5

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 103.0.4+up0.4.5-rc2
+webhookVersion: 103.0.4+up0.4.5
 cspAdapterMinVersion: 103.0.1+up3.0.1
 defaultShellVersion: rancher/shell:v0.1.24
 fleetVersion: 103.1.4+up0.9.4

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,5 +6,5 @@ const (
 	CspAdapterMinVersion = "103.0.1+up3.0.1"
 	DefaultShellVersion  = "rancher/shell:v0.1.24"
 	FleetVersion         = "103.1.4+up0.9.4"
-	WebhookVersion       = "103.0.4+up0.4.5-rc2"
+	WebhookVersion       = "103.0.4+up0.4.5"
 )


### PR DESCRIPTION
Releases rancher-webhook to v0.4.5 for to 2.8.