### PR TITLE
[v2.8] Fix delete init node for RKE2 clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -167,7 +167,7 @@ require (
 	github.com/containers/image/v5 v5.25.0
 	github.com/google/gnostic-models v0.6.8
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240213233515-935d309ebad4
-	github.com/rancher/shepherd v0.0.0-20240502215958-8fae4da148d2
+	github.com/rancher/shepherd v0.0.0-20240513202648-b64563872c50
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1641,8 +1641,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.9 h1:sCD2vWtkUQEQmNWyne7akZXuu4gZw+3vZVf8VRALXOE=
 github.com/rancher/rke v1.5.9/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
-github.com/rancher/shepherd v0.0.0-20240502215958-8fae4da148d2 h1:N3OA0j2z63fUUYyrNB6VgfHD3aM5KnCAUnVmitZ/d0E=
-github.com/rancher/shepherd v0.0.0-20240502215958-8fae4da148d2/go.mod h1:aF+34m7gi1PkHYqMd0kCcPJMyr4blVCsj0RgijAyXPg=
+github.com/rancher/shepherd v0.0.0-20240513202648-b64563872c50 h1:O+MNWD2g9E73NMLliqbz6VHuC6Bo6dXGWxVm0gispUk=
+github.com/rancher/shepherd v0.0.0-20240513202648-b64563872c50/go.mod h1:aF+34m7gi1PkHYqMd0kCcPJMyr4blVCsj0RgijAyXPg=
 github.com/rancher/steve v0.0.0-20240411162517-a80bf83f76b4 h1:aN7muy+rU1aCB1Pjcy8V2cD5Qm/l96S/+qiukBr/fE0=
 github.com/rancher/steve v0.0.0-20240411162517-a80bf83f76b4/go.mod h1:o4vLBzMTKbHHhIiAcbgOiaN3aK1vIjL6ZTgaGxQYpsY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/deleting/delete_init_machine.go
+++ b/tests/v2/validation/deleting/delete_init_machine.go
@@ -24,7 +24,7 @@ func deleteInitMachine(t *testing.T, client *rancher.Client, clusterID string) {
 	require.NoError(t, err)
 
 	logrus.Info("Awaiting machine deletion...")
-	err = steve.WaitForSteveResourceDeletion(client, defaults.FiveHundredMillisecondTimeout, defaults.TwoMinuteTimeout, machineSteveResourceType, initMachine.ID)
+	err = steve.WaitForSteveResourceDeletion(client, defaults.FiveHundredMillisecondTimeout, defaults.TenMinuteTimeout, machineSteveResourceType, initMachine.ID)
 	require.NoError(t, err)
 
 	logrus.Info("Awaiting machine replacement...")

--- a/tests/v2/validation/deleting/delete_init_machine_test.go
+++ b/tests/v2/validation/deleting/delete_init_machine_test.go
@@ -1,3 +1,5 @@
+//go:build (infra.rke2k3s || validation) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke1 && !stress && !sanity && !extended
+
 package deleting
 
 import (
@@ -53,6 +55,7 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 	if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
 		name = "RKE2"
 	}
+
 	require.NotContains(d.T(), updatedCluster.Spec.KubernetesVersion, "-rancher")
 	require.NotEmpty(d.T(), updatedCluster.Spec.KubernetesVersion)
 


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/45413.