### PR TITLE
[v2.7] Fix delete init node for RKE2 clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
-	github.com/rancher/shepherd v0.0.0-20240502215946-0121532168a2
+	github.com/rancher/shepherd v0.0.0-20240513202644-fdbe0e62987e
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1042,8 +1042,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.18 h1:iifOL97QG/1xlc8/yks1Ik+QRsii+cXqigJYmKyFXfs=
 github.com/rancher/rke v1.4.18/go.mod h1:UIc898udZbjJ+0616CEmjqY+eBQSkW/dQ30ZvL7bUcQ=
-github.com/rancher/shepherd v0.0.0-20240502215946-0121532168a2 h1:IwfjZ9KMtz2pMOajFauq3BvAzW+QBb3rZW8azKrSX0c=
-github.com/rancher/shepherd v0.0.0-20240502215946-0121532168a2/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
+github.com/rancher/shepherd v0.0.0-20240513202644-fdbe0e62987e h1:6IC4+4mXDnmejpGZ6vMatBiit4QddshoLin+eB8AEnU=
+github.com/rancher/shepherd v0.0.0-20240513202644-fdbe0e62987e/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a h1:Mawv3TfevX5dbVDlB/+RPgqxMX1HZQimyhj05R/Ef7U=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a/go.mod h1:tfdVny3lVO6H0JyysFBZ1ce45kH9VgWLPa9z9TZVI+U=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/deleting/delete_init_machine.go
+++ b/tests/v2/validation/deleting/delete_init_machine.go
@@ -24,7 +24,7 @@ func deleteInitMachine(t *testing.T, client *rancher.Client, clusterID string) {
 	require.NoError(t, err)
 
 	logrus.Info("Awaiting machine deletion...")
-	err = steve.WaitForSteveResourceDeletion(client, defaults.FiveHundredMillisecondTimeout, defaults.FiveMinuteTimeout, machineSteveResourceType, initMachine.ID)
+	err = steve.WaitForSteveResourceDeletion(client, defaults.FiveHundredMillisecondTimeout, defaults.TenMinuteTimeout, machineSteveResourceType, initMachine.ID)
 	require.NoError(t, err)
 
 	logrus.Info("Awaiting machine replacement...")

--- a/tests/v2/validation/deleting/delete_init_machine_test.go
+++ b/tests/v2/validation/deleting/delete_init_machine_test.go
@@ -1,3 +1,5 @@
+//go:build (infra.rke2k3s || validation) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke1 && !stress && !sanity && !extended
+
 package deleting
 
 import (
@@ -53,6 +55,7 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 	if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
 		name = "RKE2"
 	}
+
 	require.NotContains(d.T(), updatedCluster.Spec.KubernetesVersion, "-rancher")
 	require.NotEmpty(d.T(), updatedCluster.Spec.KubernetesVersion)
 


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/45413.