### PR TITLE
Add framework for global role integration tests

### DIFF
--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -58,7 +58,7 @@ type mcm struct {
 	startLock   sync.Mutex
 }
 
-func buildScaledContext(ctx context.Context, wranglerContext *wrangler.Context, cfg *Options) (*config.ScaledContext,
+func BuildScaledContext(ctx context.Context, wranglerContext *wrangler.Context, cfg *Options) (*config.ScaledContext,
 	*clustermanager.Manager, *mcmauthorizer.Authorizer, error) {
 	scaledContext, err := config.NewScaledContext(*wranglerContext.RESTConfig, &config.ScaleContextOptions{
 		ControllerFactory: wranglerContext.ControllerFactory,
@@ -105,7 +105,7 @@ func buildScaledContext(ctx context.Context, wranglerContext *wrangler.Context, 
 }
 
 func newMCM(ctx context.Context, wranglerContext *wrangler.Context, cfg *Options) (*mcm, error) {
-	scaledContext, clusterManager, tunnelAuthorizer, err := buildScaledContext(ctx, wranglerContext, cfg)
+	scaledContext, clusterManager, tunnelAuthorizer, err := BuildScaledContext(ctx, wranglerContext, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/controllers/README.md
+++ b/tests/controllers/README.md
@@ -21,7 +21,7 @@ All tests can be run with `make controller-test`. That runs the bash script [`ru
 
 After installing `setup-envtest`, export the environment variable `KUBEBUILDER_ASSETS` to point to where setup-envtest was installed using the following:
 ```
-export KUBEBUILDER_ASSETS=($setup-envtest use -p path)
+export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
 ```
 
 Note: You can add a k8s version to the export command if you want to test a specific version. Otherwise it will use the latest version installed.

--- a/tests/controllers/common/common.go
+++ b/tests/controllers/common/common.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func RegisterCRDs(t *testing.T, ctx context.Context, r *rest.Config, crds ...crd.CRD) {
+func RegisterCRDs(ctx context.Context, t *testing.T, r *rest.Config, crds ...crd.CRD) {
 	factory, err := crd.NewFactoryFromClient(r)
 	assert.NoError(t, err)
 
@@ -21,7 +21,7 @@ func RegisterCRDs(t *testing.T, ctx context.Context, r *rest.Config, crds ...crd
 	assert.NoError(t, err)
 }
 
-func StartNormanControllers(t *testing.T, ctx context.Context, m *config.ManagementContext, gvk ...schema.GroupVersionKind) {
+func StartNormanControllers(ctx context.Context, t *testing.T, m *config.ManagementContext, gvk ...schema.GroupVersionKind) {
 	controllers := []controller.SharedController{}
 	for _, g := range gvk {
 		c, err := m.ControllerFactory.ForKind(g)
@@ -34,7 +34,7 @@ func StartNormanControllers(t *testing.T, ctx context.Context, m *config.Managem
 	}
 }
 
-func StartWranglerCaches(t *testing.T, ctx context.Context, w *wrangler.Context, gvk ...schema.GroupVersionKind) {
+func StartWranglerCaches(ctx context.Context, t *testing.T, w *wrangler.Context, gvk ...schema.GroupVersionKind) {
 	for _, g := range gvk {
 		err := w.ControllerFactory.SharedCacheFactory().StartGVK(ctx, g)
 		assert.NoError(t, err)

--- a/tests/controllers/common/common.go
+++ b/tests/controllers/common/common.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rancher/lasso/pkg/controller"
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/wrangler/v2/pkg/crd"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+func RegisterCRDs(t *testing.T, ctx context.Context, r *rest.Config, crds ...crd.CRD) {
+	factory, err := crd.NewFactoryFromClient(r)
+	assert.NoError(t, err)
+
+	err = factory.BatchCreateCRDs(ctx, crds...).BatchWait()
+	assert.NoError(t, err)
+}
+
+func StartNormanControllers(t *testing.T, ctx context.Context, m *config.ManagementContext, gvk ...schema.GroupVersionKind) {
+	controllers := []controller.SharedController{}
+	for _, g := range gvk {
+		c, err := m.ControllerFactory.ForKind(g)
+		assert.NoError(t, err)
+		controllers = append(controllers, c)
+	}
+	for _, c := range controllers {
+		err := c.Start(ctx, 1)
+		assert.NoError(t, err)
+	}
+}
+
+func StartWranglerCaches(t *testing.T, ctx context.Context, w *wrangler.Context, gvk ...schema.GroupVersionKind) {
+	for _, g := range gvk {
+		err := w.ControllerFactory.SharedCacheFactory().StartGVK(ctx, g)
+		assert.NoError(t, err)
+	}
+}

--- a/tests/controllers/globalroles/globalrole_test.go
+++ b/tests/controllers/globalroles/globalrole_test.go
@@ -1,0 +1,177 @@
+package globalroles_integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/pkg/controllers/management/auth/globalroles"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/multiclustermanager"
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/rancher/tests/controllers/common"
+	"github.com/rancher/wrangler/v2/pkg/crd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+type GlobalRoleTestSuite struct {
+	suite.Suite
+	ctx               context.Context
+	cancel            context.CancelFunc
+	testEnv           *envtest.Environment
+	managementContext *config.ManagementContext
+}
+
+const (
+	tick     = 1 * time.Second
+	duration = 10 * time.Second
+)
+
+func (s *GlobalRoleTestSuite) SetupSuite() {
+	s.ctx, s.cancel = context.WithCancel(context.TODO())
+
+	// Start envtest
+	s.testEnv = &envtest.Environment{}
+	restCfg, err := s.testEnv.Start()
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), restCfg)
+
+	// Register CRDs
+	common.RegisterCRDs(s.T(), s.ctx, restCfg,
+		crd.CRD{
+			SchemaObject: v3.GlobalRole{},
+			NonNamespace: true,
+		},
+		crd.CRD{
+			SchemaObject: v3.GlobalRoleBinding{},
+			NonNamespace: true,
+		})
+
+	// Create wrangler context
+	wranglerContext, err := wrangler.NewContext(s.ctx, nil, restCfg)
+	assert.NoError(s.T(), err)
+
+	// Create management context
+	scaledContext, clusterManager, _, err := multiclustermanager.BuildScaledContext(s.ctx, wranglerContext, &multiclustermanager.Options{})
+	assert.NoError(s.T(), err)
+	s.managementContext, err = scaledContext.NewManagementContext()
+	assert.NoError(s.T(), err)
+
+	// Register controller
+	globalroles.Register(s.ctx, s.managementContext, clusterManager)
+
+	// Start controllers
+	common.StartNormanControllers(s.T(), s.ctx, s.managementContext,
+		schema.GroupVersionKind{
+			Group:   "management.cattle.io",
+			Version: "v3",
+			Kind:    "GlobalRoleBinding",
+		},
+		schema.GroupVersionKind{
+			Group:   "management.cattle.io",
+			Version: "v3",
+			Kind:    "GlobalRole",
+		})
+
+	// Start caches
+	common.StartWranglerCaches(s.T(), s.ctx, s.managementContext.Wrangler,
+		schema.GroupVersionKind{
+			Group:   "rbac.authorization.k8s.io",
+			Version: "v1",
+			Kind:    "ClusterRole",
+		},
+		schema.GroupVersionKind{
+			Group:   "rbac.authorization.k8s.io",
+			Version: "v1",
+			Kind:    "ClusterRoleBinding",
+		},
+		schema.GroupVersionKind{
+			Group:   "rbac.authorization.k8s.io",
+			Version: "v1",
+			Kind:    "Role",
+		},
+		schema.GroupVersionKind{
+			Group:   "rbac.authorization.k8s.io",
+			Version: "v1",
+			Kind:    "RoleBinding",
+		})
+}
+
+func (s *GlobalRoleTestSuite) TearDownSuite() {
+	s.cancel()
+	err := s.testEnv.Stop()
+	assert.NoError(s.T(), err)
+}
+
+func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
+	tests := []struct {
+		name         string
+		globalRole   v3.GlobalRole
+		roles        []rbacv1.Role
+		clusterRoles []rbacv1.ClusterRole
+	}{}
+	for _, test := range tests {
+		test := test
+		s.T().Run(test.name, func(t *testing.T) {
+			_, err := s.managementContext.Management.GlobalRoles("").Create(&test.globalRole)
+			assert.NoError(s.T(), err)
+
+			// Create Global Role
+			assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+				gr, err := s.managementContext.Management.GlobalRoles("").Get(test.globalRole.Name, metav1.GetOptions{})
+				assert.NoError(c, err)
+				assert.NotNil(c, gr)
+				assert.NotNil(c, gr.Status)
+
+				// Once status is completed, all necessary backing resources should have been created
+				assert.Equal(c, globalroles.SummaryCompleted, gr.Status.Summary)
+			}, duration, tick)
+
+			// Check created Roles
+			for _, r := range test.roles {
+				role, err := s.managementContext.RBAC.Roles(r.Namespace).Get(r.Name, metav1.GetOptions{})
+				assert.NoError(s.T(), err)
+				// Assert any desired role fields
+				assert.Equal(s.T(), test.globalRole.Name, role.OwnerReferences[0].Name)
+			}
+
+			// Check created Cluster Roles
+			for _, cr := range test.clusterRoles {
+				clusterRole, err := s.managementContext.RBAC.ClusterRoles("").Get(cr.Name, metav1.GetOptions{})
+				assert.NoError(s.T(), err)
+				// Assert any desired clusterRole fields
+				assert.Equal(s.T(), test.globalRole.Name, clusterRole.OwnerReferences[0].Name)
+			}
+
+			// Delete Global Role
+			assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+				err := s.managementContext.Management.GlobalRoles("").Delete(test.globalRole.Name, &metav1.DeleteOptions{})
+				assert.NoError(c, err)
+			}, duration, tick)
+
+			// Check that Roles get deleted
+			for _, r := range test.roles {
+				_, err = s.managementContext.RBAC.Roles(r.Namespace).Get(r.Name, metav1.GetOptions{})
+				assert.Error(s.T(), err)
+				// TODO make sure the error is a "NotFound"
+			}
+
+			// Check that Cluster Roles get deleted
+			for _, cr := range test.clusterRoles {
+				_, err = s.managementContext.RBAC.ClusterRoles("").Get(cr.Name, metav1.GetOptions{})
+				assert.Error(s.T(), err)
+				// TODO make sure the error is a "NotFound"
+			}
+		})
+	}
+}
+
+func TestGlobalRoleTestSuite(t *testing.T) {
+	suite.Run(t, new(GlobalRoleTestSuite))
+}

--- a/tests/controllers/globalroles/globalrole_test.go
+++ b/tests/controllers/globalroles/globalrole_test.go
@@ -66,7 +66,7 @@ func (s *GlobalRoleTestSuite) SetupSuite() {
 	assert.NotNil(s.T(), restCfg)
 
 	// Register CRDs
-	common.RegisterCRDs(s.T(), s.ctx, restCfg,
+	common.RegisterCRDs(s.ctx, s.T(), restCfg,
 		crd.CRD{
 			SchemaObject: v3.GlobalRole{},
 			NonNamespace: true,
@@ -91,7 +91,7 @@ func (s *GlobalRoleTestSuite) SetupSuite() {
 	globalroles.Register(s.ctx, s.managementContext, clusterManager)
 
 	// Start controllers
-	common.StartNormanControllers(s.T(), s.ctx, s.managementContext,
+	common.StartNormanControllers(s.ctx, s.T(), s.managementContext,
 		schema.GroupVersionKind{
 			Group:   "management.cattle.io",
 			Version: "v3",
@@ -104,7 +104,7 @@ func (s *GlobalRoleTestSuite) SetupSuite() {
 		})
 
 	// Start caches
-	common.StartWranglerCaches(s.T(), s.ctx, s.managementContext.Wrangler,
+	common.StartWranglerCaches(s.ctx, s.T(), s.managementContext.Wrangler,
 		schema.GroupVersionKind{
 			Group:   "rbac.authorization.k8s.io",
 			Version: "v1",


### PR DESCRIPTION
## Summary
This PR adds some initial integration tests to Global Roles. It covers 4 basic create cases
1. Testing that the cluster role gets created and uses generated name
2. Testing that the cluster role gets created and uses given name based on annotation
3. Creating a global role with namespaced rules creates the right roles in the right namespaces
4. Creating a global role with catalog rules (ie the resource `template`) creates a role in `cattle-global-data`

To make it as easy as possible to add new tests, I kept the tests very simple. The test is this structure
```
struct {
	name        string
	globalRole  v3.GlobalRole
	roles       []rbacv1.Role
	clusterRole rbacv1.ClusterRole
}
```
- name: name of the test
- globalRole: the created global role
- roles: expected roles to be created
- clusterRole: expected cluster role to be created

I also moved some logic to `tests/controllers/common/common.go` because I envision it being re-used by future integration tests.

## Limitations
This PR is meant to introduce the integration test framework. It is not comprehensive coverage of global roles. Some additional tests for future work:
- Testing update functionality
- Testing that roles with the wrong `GlobalRoleOwner` label get removed
- Any testing of failures/conditions

Another limitation is that `envtest` doesn't run the controllers that monitor `OwnerReferences` and do garbage collection. So when a global role is deleted, the cluster roles and roles that are owned by it don't get deleted. I added checks to make sure the `OwnerReference` of these are set to the global role, which indicates that they _would_ get deleted in a full scale kubernetes system.

Finally, in order to run the tests in parallel, each global role needs a unique name. Otherwise there are collisions and it causes the test to fail. Alternatively, the tests could be run sequentially, but the issue might still happen if the delete takes a long time to occur.