### PR TITLE
[v2.9] Update snapshot names to use S3 or local

### DIFF
--- a/tests/v2/validation/snapshot/README.md
+++ b/tests/v2/validation/snapshot/README.md
@@ -32,8 +32,8 @@ Additionally, S3 is a supported restore option. If you choose to use S3, then yo
 These tests utilize Go build tags. Due to this, see the below example on how to run the tests:
 
 ### Snapshot restore
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestore"` \
-`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestoreDynamicInput"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreETCDOnlyTestSuite/TestSnapshotRestoreETCDOnly"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreETCDOnlyTestSuite/TestSnapshotRestoreETCDOnlyDynamicInput"`
 
 ### Snapshot restore with K8s upgrade
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotRestoreK8sUpgradeTestSuite/TestSnapshotRestoreK8sUpgrade"` \

--- a/tests/v2/validation/snapshot/snapshot.go
+++ b/tests/v2/validation/snapshot/snapshot.go
@@ -362,14 +362,6 @@ func restoreV2Prov(t *testing.T, client *rancher.Client, v2prov initialSnapshotC
 		assert.Empty(t, podErrors)
 		require.Equal(t, v2prov.kubernetesVersion, clusterObject.Spec.KubernetesVersion)
 
-		steveclient, err := client.Steve.ProxyDownstream(clusterID)
-		require.NoError(t, err)
-
-		deploymentList, err := steveclient.SteveType(workloads.DeploymentSteveType).NamespacedSteveClient(defaultNamespace).List(nil)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(deploymentList.Data))
-		require.Equal(t, initialWorkloadName, deploymentList.Data[0].ObjectMeta.Name)
-
 		if etcdRestore.SnapshotRestore == kubernetesVersion || etcdRestore.SnapshotRestore == all {
 			clusterObject, _, err := clusters.GetProvisioningClusterByName(client, clusterName, namespace)
 			require.NoError(t, err)

--- a/tests/v2/validation/snapshot/snapshot_additional_test.go
+++ b/tests/v2/validation/snapshot/snapshot_additional_test.go
@@ -76,22 +76,41 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceWorkerNode() {
 	}
 
 	for _, tt := range tests {
-		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
-		require.NoError(s.T(), err)
+		clusterObject, _, _ := clusters.GetProvisioningClusterByName(tt.client, s.client.RancherConfig.ClusterName, namespace)
+		if clusterObject == nil {
+			clusterID, err := clusters.GetClusterIDByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
-		require.NoError(s.T(), err)
+			clusterResp, err := tt.client.Management.Cluster.ByID(clusterID)
+			require.NoError(s.T(), err)
 
-		updatedCluster := new(apisV1.Cluster)
-		err = v1.ConvertToK8sType(cluster, &updatedCluster)
-		require.NoError(s.T(), err)
-
-		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
-			tt.name = "RKE2 " + tt.name
-		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
-			tt.name = "K3S " + tt.name
+			if clusterResp.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig != nil {
+				tt.name = "RKE1 S3 " + tt.name
+			} else {
+				tt.name = "RKE1 Local " + tt.name
+			}
 		} else {
-			tt.name = "RKE1 " + tt.name
+			clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
+
+			cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+			require.NoError(s.T(), err)
+
+			updatedCluster := new(apisV1.Cluster)
+			err = v1.ConvertToK8sType(cluster, &updatedCluster)
+			require.NoError(s.T(), err)
+
+			if updatedCluster.Spec.RKEConfig.ETCD.S3 != nil {
+				tt.name = "S3 " + tt.name
+			} else {
+				tt.name = "Local " + tt.name
+			}
+
+			if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+				tt.name = "RKE2 " + tt.name
+			} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+				tt.name = "K3S " + tt.name
+			}
 		}
 
 		s.Run(tt.name, func() {
@@ -117,22 +136,41 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotRecurringRestores() {
 	}
 
 	for _, tt := range tests {
-		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
-		require.NoError(s.T(), err)
+		clusterObject, _, _ := clusters.GetProvisioningClusterByName(tt.client, s.client.RancherConfig.ClusterName, namespace)
+		if clusterObject == nil {
+			clusterID, err := clusters.GetClusterIDByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
-		require.NoError(s.T(), err)
+			clusterResp, err := tt.client.Management.Cluster.ByID(clusterID)
+			require.NoError(s.T(), err)
 
-		updatedCluster := new(apisV1.Cluster)
-		err = v1.ConvertToK8sType(cluster, &updatedCluster)
-		require.NoError(s.T(), err)
-
-		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
-			tt.name = "RKE2 " + tt.name
-		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
-			tt.name = "K3S " + tt.name
+			if clusterResp.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig != nil {
+				tt.name = "RKE1 S3 " + tt.name
+			} else {
+				tt.name = "RKE1 Local " + tt.name
+			}
 		} else {
-			tt.name = "RKE1 " + tt.name
+			clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
+
+			cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+			require.NoError(s.T(), err)
+
+			updatedCluster := new(apisV1.Cluster)
+			err = v1.ConvertToK8sType(cluster, &updatedCluster)
+			require.NoError(s.T(), err)
+
+			if updatedCluster.Spec.RKEConfig.ETCD.S3 != nil {
+				tt.name = "S3 " + tt.name
+			} else {
+				tt.name = "Local " + tt.name
+			}
+
+			if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+				tt.name = "RKE2 " + tt.name
+			} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+				tt.name = "K3S " + tt.name
+			}
 		}
 
 		s.Run(tt.name, func() {

--- a/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -68,22 +68,41 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 	}
 
 	for _, tt := range tests {
-		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
-		require.NoError(s.T(), err)
+		clusterObject, _, _ := clusters.GetProvisioningClusterByName(tt.client, s.client.RancherConfig.ClusterName, namespace)
+		if clusterObject == nil {
+			clusterID, err := clusters.GetClusterIDByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
-		require.NoError(s.T(), err)
+			clusterResp, err := tt.client.Management.Cluster.ByID(clusterID)
+			require.NoError(s.T(), err)
 
-		updatedCluster := new(apisV1.Cluster)
-		err = v1.ConvertToK8sType(cluster, &updatedCluster)
-		require.NoError(s.T(), err)
-
-		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
-			tt.name = "RKE2 " + tt.name
-		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
-			tt.name = "K3S " + tt.name
+			if clusterResp.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig != nil {
+				tt.name = "RKE1 S3 " + tt.name
+			} else {
+				tt.name = "RKE1 Local " + tt.name
+			}
 		} else {
-			tt.name = "RKE1 " + tt.name
+			clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
+
+			cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+			require.NoError(s.T(), err)
+
+			updatedCluster := new(apisV1.Cluster)
+			err = v1.ConvertToK8sType(cluster, &updatedCluster)
+			require.NoError(s.T(), err)
+
+			if updatedCluster.Spec.RKEConfig.ETCD.S3 != nil {
+				tt.name = "S3 " + tt.name
+			} else {
+				tt.name = "Local " + tt.name
+			}
+
+			if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+				tt.name = "RKE2 " + tt.name
+			} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+				tt.name = "K3S " + tt.name
+			}
 		}
 
 		s.Run(tt.name, func() {

--- a/tests/v2/validation/snapshot/snapshot_restore_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_test.go
@@ -60,22 +60,41 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 	}
 
 	for _, tt := range tests {
-		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
-		require.NoError(s.T(), err)
+		clusterObject, _, _ := clusters.GetProvisioningClusterByName(tt.client, s.client.RancherConfig.ClusterName, namespace)
+		if clusterObject == nil {
+			clusterID, err := clusters.GetClusterIDByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
-		require.NoError(s.T(), err)
+			clusterResp, err := tt.client.Management.Cluster.ByID(clusterID)
+			require.NoError(s.T(), err)
 
-		updatedCluster := new(apisV1.Cluster)
-		err = v1.ConvertToK8sType(cluster, &updatedCluster)
-		require.NoError(s.T(), err)
-
-		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
-			tt.name = "RKE2 " + tt.name
-		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
-			tt.name = "K3S " + tt.name
+			if clusterResp.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig != nil {
+				tt.name = "RKE1 S3 " + tt.name
+			} else {
+				tt.name = "RKE1 Local " + tt.name
+			}
 		} else {
-			tt.name = "RKE1 " + tt.name
+			clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
+
+			cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+			require.NoError(s.T(), err)
+
+			updatedCluster := new(apisV1.Cluster)
+			err = v1.ConvertToK8sType(cluster, &updatedCluster)
+			require.NoError(s.T(), err)
+
+			if updatedCluster.Spec.RKEConfig.ETCD.S3 != nil {
+				tt.name = "S3 " + tt.name
+			} else {
+				tt.name = "Local " + tt.name
+			}
+
+			if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+				tt.name = "RKE2 " + tt.name
+			} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+				tt.name = "K3S " + tt.name
+			}
 		}
 
 		s.Run(tt.name, func() {
@@ -94,6 +113,6 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnlyDynamicInput() {
 
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
-func TestSnapshotRestoreTestSuite(t *testing.T) {
+func TestSnapshotRestoreETCDOnlyTestSuite(t *testing.T) {
 	suite.Run(t, new(SnapshotRestoreTestSuite))
 }

--- a/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -76,22 +76,41 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 	}
 
 	for _, tt := range tests {
-		clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
-		require.NoError(s.T(), err)
+		clusterObject, _, _ := clusters.GetProvisioningClusterByName(tt.client, s.client.RancherConfig.ClusterName, namespace)
+		if clusterObject == nil {
+			clusterID, err := clusters.GetClusterIDByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
 
-		cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
-		require.NoError(s.T(), err)
+			clusterResp, err := tt.client.Management.Cluster.ByID(clusterID)
+			require.NoError(s.T(), err)
 
-		updatedCluster := new(apisV1.Cluster)
-		err = v1.ConvertToK8sType(cluster, &updatedCluster)
-		require.NoError(s.T(), err)
-
-		if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
-			tt.name = "RKE2 " + tt.name
-		} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
-			tt.name = "K3S " + tt.name
+			if clusterResp.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig != nil {
+				tt.name = "RKE1 S3 " + tt.name
+			} else {
+				tt.name = "RKE1 Local " + tt.name
+			}
 		} else {
-			tt.name = "RKE1 " + tt.name
+			clusterID, err := clusters.GetV1ProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName)
+			require.NoError(s.T(), err)
+
+			cluster, err := tt.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+			require.NoError(s.T(), err)
+
+			updatedCluster := new(apisV1.Cluster)
+			err = v1.ConvertToK8sType(cluster, &updatedCluster)
+			require.NoError(s.T(), err)
+
+			if updatedCluster.Spec.RKEConfig.ETCD.S3 != nil {
+				tt.name = "S3 " + tt.name
+			} else {
+				tt.name = "Local " + tt.name
+			}
+
+			if strings.Contains(updatedCluster.Spec.KubernetesVersion, "rke2") {
+				tt.name = "RKE2 " + tt.name
+			} else if strings.Contains(updatedCluster.Spec.KubernetesVersion, "k3s") {
+				tt.name = "K3S " + tt.name
+			}
 		}
 
 		s.Run(tt.name, func() {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In our `snapshot` package, we allow the support of local snapshots and s3 snapshots. However, we don't have a way to exactly know when we are testing which use-case.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the name to check if S3 is enabled in the cluster. If it is, then specify `S3` in the name. If not, then specify `local`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually tested RKE1/RKE2/K3S with snapshot restore ETCD only.

### Automated Testing
Jenkins jobs will be given offline to reviewers.