### PR TITLE
Okta ldap password for release/v2.9

### DIFF
--- a/pkg/controllers/management/secretmigrator/authconfig.go
+++ b/pkg/controllers/management/secretmigrator/authconfig.go
@@ -24,25 +24,41 @@ const (
 
 // syncAuthConfig syncs the authentication config and removes/migrates secrets as needed.
 func (h *handler) syncAuthConfig(_ string, authConfig *apimgmtv3.AuthConfig) (runtime.Object, error) {
-	if authConfig == nil || !authConfig.Enabled || apimgmtv3.AuthConfigConditionSecretsMigrated.IsTrue(authConfig) {
+	if authConfig == nil || !authConfig.Enabled {
 		return authConfig, nil
 	}
 
-	if authConfig.Type != client.ShibbolethConfigType {
-		unstructuredConfig, err := getUnstructuredAuthConfig(h.authConfigs, authConfig)
-		if err != nil {
-			return nil, err
-		}
-		newUnstructuredConfig, err := setUnstructuredStatus(unstructuredConfig, apimgmtv3.AuthConfigConditionSecretsMigrated, "True")
-		if err != nil {
-			return nil, fmt.Errorf("failed to set the status on unstructured AuthConfig %s: %w", authConfig.Name, err)
-		}
+	switch authConfig.Type {
+	case client.ShibbolethConfigType:
+		return h.migrateShibbolethConfig(authConfig)
+	case client.OKTAConfigType:
+		return h.migrateOKTAConfig(authConfig)
+	default:
+		return h.migrateAuthConfig(authConfig)
+	}
 
-		updated, err := h.authConfigs.Update(authConfig.Name, newUnstructuredConfig)
-		if err != nil {
-			return nil, fmt.Errorf("unable to update migration status of authconfig: %w", err)
-		}
-		return updated, nil
+}
+
+func (h *handler) migrateAuthConfig(authConfig *apimgmtv3.AuthConfig) (runtime.Object, error) {
+	unstructuredConfig, err := getUnstructuredAuthConfig(h.authConfigs, authConfig)
+	if err != nil {
+		return nil, err
+	}
+	newUnstructuredConfig, err := setUnstructuredStatus(unstructuredConfig, apimgmtv3.AuthConfigConditionSecretsMigrated, "True")
+	if err != nil {
+		return nil, fmt.Errorf("failed to set the status on unstructured AuthConfig %s: %w", authConfig.Name, err)
+	}
+
+	updated, err := h.authConfigs.Update(authConfig.Name, newUnstructuredConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to update migration status of authconfig: %w", err)
+	}
+	return updated, nil
+}
+
+func (h *handler) migrateShibbolethConfig(authConfig *apimgmtv3.AuthConfig) (runtime.Object, error) {
+	if apimgmtv3.AuthConfigConditionSecretsMigrated.IsTrue(authConfig) {
+		return authConfig, nil
 	}
 
 	updated, err := apimgmtv3.AuthConfigConditionSecretsMigrated.DoUntilTrue(authConfig, func() (runtime.Object, error) {
@@ -61,6 +77,32 @@ func (h *handler) syncAuthConfig(_ string, authConfig *apimgmtv3.AuthConfig) (ru
 	if err != nil {
 		return nil, fmt.Errorf("failed to update AuthConfig %s: %w", authConfig.Name, err)
 	}
+
+	return updatedAuthConfig, nil
+}
+
+func (h *handler) migrateOKTAConfig(authConfig *apimgmtv3.AuthConfig) (runtime.Object, error) {
+	if apimgmtv3.AuthConfigConditionSecretsMigrated.IsTrue(authConfig) {
+		return authConfig, nil
+	}
+
+	updated, err := apimgmtv3.AuthConfigConditionSecretsMigrated.DoUntilTrue(authConfig, func() (runtime.Object, error) {
+		unstructuredConfig, err := getUnstructuredAuthConfig(h.authConfigs, authConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		return h.migrateOKTASecrets(unstructuredConfig.UnstructuredContent())
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update status for AuthConfig %s: %w", authConfig.Name, err)
+	}
+
+	updatedAuthConfig, err := h.authConfigs.Update(authConfig.Name, updated)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update AuthConfig %s: %w", authConfig.Name, err)
+	}
+
 	return updatedAuthConfig, nil
 }
 
@@ -75,6 +117,7 @@ func getUnstructuredAuthConfig(unstructuredClient objectclient.GenericClient, au
 	if !ok {
 		return nil, fmt.Errorf("failed to read unstructured data for AuthConfig")
 	}
+
 	return unstructured, nil
 }
 
@@ -114,6 +157,46 @@ func (h *handler) migrateShibbolethSecrets(unstructuredConfig map[string]any) (*
 	shibbConfig.OpenLdapConfig.ServiceAccountPassword = common.NameForSecret(secret)
 
 	return shibbConfig, nil
+}
+
+// migrateOKTASecrets effects the migration of secrets for the OKTA provider.
+func (h *handler) migrateOKTASecrets(unstructuredConfig map[string]any) (*apimgmtv3.OKTAConfig, error) {
+	oktaConfig := &apimgmtv3.OKTAConfig{}
+
+	err := common.Decode(unstructuredConfig, oktaConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode OKTAConfig: %w", err)
+	}
+
+	if oktaConfig.OpenLdapConfig.ServiceAccountPassword == "" {
+		// OpenLDAP is not configured, so nothing else is needed
+		return oktaConfig, nil
+	}
+
+	secretName := fmt.Sprintf("%s-%s", strings.ToLower(oktaConfig.Type), serviceAccountPasswordFieldName)
+	lowercaseFieldName := strings.ToLower(serviceAccountPasswordFieldName)
+
+	// cannot use createOrUpdateSecretForCredential because the credential is saved in the secret with a key of
+	// "credential", but our AuthProviders look for "serviceaccountpassword"
+	_, err = h.migrator.createOrUpdateSecret(
+		secretName,
+		namespace.GlobalNamespace,
+		map[string]string{
+			lowercaseFieldName: oktaConfig.OpenLdapConfig.ServiceAccountPassword,
+		},
+		nil,
+		oktaConfig,
+		authConfigKind,
+		lowercaseFieldName)
+	if err != nil {
+		return nil, err
+	}
+
+	lowerType := strings.ToLower(oktaConfig.Type)
+	fullSecretName := common.GetFullSecretName(lowerType, serviceAccountPasswordFieldName)
+	oktaConfig.OpenLdapConfig.ServiceAccountPassword = fullSecretName
+
+	return oktaConfig, nil
 }
 
 func setUnstructuredStatus(unstructured runtime.Unstructured, key condition.Cond, value corev1.ConditionStatus) (runtime.Unstructured, error) {

--- a/pkg/controllers/management/secretmigrator/authconfig.go
+++ b/pkg/controllers/management/secretmigrator/authconfig.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/rancher/norman/condition"
-	"github.com/rancher/norman/objectclient"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
@@ -198,7 +197,7 @@ func setUnstructuredStatus(unstructured runtime.Unstructured, key condition.Cond
 }
 
 // getUnstructuredAuthConfig attempts to get the unstructured AuthConfig for the AuthConfig that is passed in.
-func getUnstructuredAuthConfig(unstructuredClient objectclient.GenericClient, authConfig *apimgmtv3.AuthConfig) (runtime.Unstructured, error) {
+func getUnstructuredAuthConfig(unstructuredClient authConfigsClient, authConfig *apimgmtv3.AuthConfig) (runtime.Unstructured, error) {
 	unstructuredAuthConfig, err := unstructuredClient.Get(authConfig.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve unstructured data for AuthConfig from cluster: %w", err)

--- a/pkg/controllers/management/secretmigrator/authconfig_test.go
+++ b/pkg/controllers/management/secretmigrator/authconfig_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/rancher/norman/objectclient"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/saml"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
@@ -22,8 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 const (
@@ -511,7 +508,7 @@ type mockAuthConfigClient struct {
 	config map[string]any
 }
 
-func newMockAuthConfigClient(authConfig map[string]any) objectclient.GenericClient {
+func newMockAuthConfigClient(authConfig map[string]any) authConfigsClient {
 	return mockAuthConfigClient{config: authConfig}
 }
 
@@ -523,60 +520,4 @@ func (m mockAuthConfigClient) Get(name string, opts metav1.GetOptions) (runtime.
 
 func (m mockAuthConfigClient) Update(name string, o runtime.Object) (runtime.Object, error) {
 	return o, nil
-}
-
-func (m mockAuthConfigClient) UnstructuredClient() objectclient.GenericClient {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) GroupVersionKind() schema.GroupVersionKind {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) Create(o runtime.Object) (runtime.Object, error) {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) GetNamespaced(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) UpdateStatus(name string, o runtime.Object) (runtime.Object, error) {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) DeleteNamespaced(namespace, name string, opts *metav1.DeleteOptions) error {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) Delete(name string, opts *metav1.DeleteOptions) error {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) List(opts metav1.ListOptions) (runtime.Object, error) {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) ListNamespaced(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) Patch(name string, o runtime.Object, patchType types.PatchType, data []byte, subresources ...string) (runtime.Object, error) {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) ObjectFactory() objectclient.ObjectFactory {
-	panic("implement me")
-}
-
-func (m mockAuthConfigClient) ObjectClient() *objectclient.ObjectClient {
-	panic("implement me")
 }

--- a/pkg/controllers/management/secretmigrator/authconfig_test.go
+++ b/pkg/controllers/management/secretmigrator/authconfig_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/norman/objectclient"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/saml"
+	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	corefakes "github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -26,7 +27,7 @@ import (
 )
 
 const (
-	mockPass                = "testpass1234"
+	testPassword            = "testpass1234"
 	testCreationStampString = "2023-05-15T19:28:22Z"
 )
 
@@ -245,7 +246,7 @@ func TestShibbolethAuthConfigMigration(t *testing.T) {
 
 					assert.Equal(t, tt.expectedSecretName, secret.Name)
 					assert.Equal(t, namespace.GlobalNamespace, secret.Namespace)
-					assert.Equal(t, mockPass, secret.StringData[strings.ToLower(serviceAccountPasswordFieldName)])
+					assert.Equal(t, testPassword, secret.StringData[strings.ToLower(serviceAccountPasswordFieldName)])
 
 					return secret, nil
 				},
@@ -293,6 +294,116 @@ func TestShibbolethAuthConfigMigration(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NotNil(t, config)
+		})
+	}
+}
+
+func TestOKTAAuthConfigMigration(t *testing.T) {
+	timeStamp, _ := time.Parse(time.RFC3339, testCreationStampString)
+	testcases := []struct {
+		name                   string
+		unstructuredAuthConfig map[string]any
+		authConfig             apimgmtv3.AuthConfig
+		expectedLdapConfig     apimgmtv3.LdapFields
+		wantStringData         map[string]string
+		// wantMigration is true when we expect the migration to execute
+		wantMigration bool
+	}{
+		{
+			name:                   "test migrating OKTA configuration with openLDAP",
+			unstructuredAuthConfig: getUnstructuredOKTAWithOpenLDAP(),
+			authConfig: apimgmtv3.AuthConfig{
+				Type:    "oktaConfig",
+				Enabled: true,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "okta",
+					CreationTimestamp: metav1.NewTime(timeStamp),
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AuthConfig",
+					APIVersion: "management.cattle.io/v3",
+				},
+			},
+			expectedLdapConfig: apimgmtv3.LdapFields{
+				ServiceAccountPassword: "cattle-global-data:oktaconfig-serviceaccountpassword",
+			},
+			wantStringData: map[string]string{
+				"serviceaccountpassword": "testpass1234",
+			},
+			wantMigration: true,
+		},
+		{
+			name:                   "test migrating with existing migration",
+			unstructuredAuthConfig: getUnstructuredOKTAWithOpenLDAP(),
+			authConfig: apimgmtv3.AuthConfig{
+				Type:    "oktaConfig",
+				Enabled: true,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "okta",
+					CreationTimestamp: metav1.NewTime(timeStamp),
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AuthConfig",
+					APIVersion: "management.cattle.io/v3",
+				},
+				Status: apimgmtv3.AuthConfigStatus{
+					Conditions: []apimgmtv3.AuthConfigConditions{
+						apimgmtv3.AuthConfigConditions{
+							Type:               apimgmtv3.AuthConfigConditionSecretsMigrated,
+							Status:             "True",
+							LastUpdateTime:     "2024-05-13T15:20:34+01:00",
+							LastTransitionTime: "",
+							Reason:             "",
+							Message:            "",
+						},
+					},
+				},
+			},
+			expectedLdapConfig: apimgmtv3.LdapFields{
+				ServiceAccountPassword: "cattle-global-data:oktaconfig-serviceaccountpassword",
+			},
+			wantStringData: map[string]string{
+				"serviceaccountpassword": "testpass1234",
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newFakeHandler(
+				tt.unstructuredAuthConfig,
+				func(secret *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "oktaconfig-serviceaccountpassword", secret.Name)
+					assert.Equal(t, namespace.GlobalNamespace, secret.Namespace)
+					assert.Equal(t, tt.wantStringData, secret.StringData)
+
+					return secret, nil
+				},
+				func(secret *corev1.Secret) (*corev1.Secret, error) {
+					return nil, nil
+				},
+				func(namespace string, name string) (*corev1.Secret, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, name)
+				},
+			)
+
+			config, err := h.syncAuthConfig("test", &tt.authConfig)
+
+			assert.NotNil(t, config)
+			assert.NoError(t, err)
+
+			oktaConfig, ok := config.(*apimgmtv3.OKTAConfig)
+
+			assert.Equal(t, tt.wantMigration, ok)
+			if !tt.wantMigration {
+				return
+			}
+			assert.NotNil(t, oktaConfig)
+
+			assert.NotEmpty(t, oktaConfig.Status.Conditions)
+			assert.NotNil(t, oktaConfig.Status.Conditions[0])
+			assert.Equal(t, apimgmtv3.AuthConfigConditionSecretsMigrated, oktaConfig.Status.Conditions[0].Type)
+			assert.Equal(t, tt.expectedLdapConfig, oktaConfig.OpenLdapConfig)
 		})
 	}
 }
@@ -372,11 +483,27 @@ func getMockShibbolethWithOpenLDAP() map[string]any {
 		},
 		"kind":       "AuthConfig",
 		"apiVersion": "management.cattle.io/v3",
-		"type":       "shibbolethConfig",
+		"type":       client.ShibbolethConfigType,
 		"enabled":    true,
 		"openLdapConfig": map[string]any{
-			"serviceAccountPassword": mockPass,
+			"serviceAccountPassword": testPassword,
 		},
+	}
+}
+
+func getUnstructuredOKTAWithOpenLDAP() map[string]any {
+	timeStamp, _ := time.Parse(time.RFC3339, testCreationStampString)
+	createdTime := metav1.NewTime(timeStamp)
+	return map[string]any{
+		"metadata": map[string]any{
+			"name":              "okta",
+			"creationtimestamp": createdTime,
+		},
+		"kind":                   "AuthConfig",
+		"apiVersion":             "management.cattle.io/v3",
+		"type":                   client.OKTAConfigType,
+		"enabled":                true,
+		"serviceAccountPassword": testPassword,
 	}
 }
 

--- a/pkg/controllers/management/secretmigrator/register.go
+++ b/pkg/controllers/management/secretmigrator/register.go
@@ -3,16 +3,22 @@ package secretmigrator
 import (
 	"context"
 
-	"github.com/rancher/norman/objectclient"
 	provv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Migrator struct {
 	secretLister v1.SecretLister
 	secrets      v1.SecretInterface
+}
+
+type authConfigsClient interface {
+	Get(name string, opts metav1.GetOptions) (runtime.Object, error)
+	Update(name string, o runtime.Object) (runtime.Object, error)
 }
 
 type handler struct {
@@ -28,11 +34,11 @@ type handler struct {
 	projectCatalogLister     v3.ProjectCatalogLister
 	projectCatalogs          v3.ProjectCatalogInterface
 	projectLister            v3.ProjectLister
-	// Note the use of the GenericClient here. AuthConfigs contain internal-only fields that deal with
-	// various auth providers. Those fields are not present everywhere, nor are they defined in the CRD. Given
+	// AuthConfigs contain internal-only fields that deal with various auth providers.
+	// Those fields are not present everywhere, nor are they defined in the CRD. Given
 	// that, the regular client will "eat" those internal-only fields, so in this case, we use
 	// the unstructured client, losing some validation, but gaining the flexibility we require.
-	authConfigs objectclient.GenericClient
+	authConfigs authConfigsClient
 }
 
 func NewMigrator(secretLister v1.SecretLister, secrets v1.SecretInterface) *Migrator {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The secret for accessing OpenLDAP for lookups when using Okta is stored inside the `AuthConfig`, this should be migrated (as happened for the Shibboleth config) to a separate `Secret` resource.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Very similar to the fix for Shibboleth, this includes a `Migration` which splits the password to a `Secret` and updates the `AuthConfig` to reference the `Secret`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Configure Okta and OpenLDAP, the password should not be stored in the `AuthConfig` and the password field should point to a `Secret` which contains the password.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Configured OpenLDAP and confirmed that the secret is not stored in the `AuthConfig` resource.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
This shouldn't cause regressions.

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_