### PR TITLE
setting content type header for successful proxied requests

### DIFF
--- a/pkg/api/steve/catalog/plugin_test.go
+++ b/pkg/api/steve/catalog/plugin_test.go
@@ -1,0 +1,40 @@
+package catalog
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxyRequest_content_type(t *testing.T) {
+	response := "var http = require('http');\n        var url = require('url');\n        var number = 0;"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Disposition", "attachment; filename=testing.js")
+		if _, err := w.Write([]byte(response)); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer ts.Close()
+	denyFunc := func(string) bool { return false }
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	w := httptest.NewRecorder()
+
+	proxyRequest(ts.URL, "/testing.js", w, req, denyFunc)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("got StatusCode %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	wantContent := "application/javascript"
+	if ct := resp.Header.Get("Content-Type"); ct != wantContent {
+		t.Errorf("got Content-Type %s, want %s", ct, wantContent)
+
+	}
+	if string(body) != response {
+		t.Errorf("read body: %s", body)
+	}
+}


### PR DESCRIPTION
This PR uses `mime.TypeByExtension` to set the `Content-Type` header of proxied extension requests. If it fails to get the type, we use the one returned by the request.