### PR TITLE
Add new setting for UI Extension configuration

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -277,7 +277,7 @@ var (
 	// UIExtensions - setting for configuring UI Extensions (e.g. allow users to enable/disable extensions)
 	UIExtensions = NewSetting("ui-extensions", "")
 
-  	// UI Settings for allowing separate configuration of page banners
+	// UI Settings for allowing separate configuration of page banners
 	UIBannerHeader       = NewSetting("ui-banner-header", "")
 	UIBannerFooter       = NewSetting("ui-banner-footer", "")
 	UIBannerLoginConsent = NewSetting("ui-banner-login-consent", "")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -275,7 +275,7 @@ var (
 	UIBannerDark  = NewSetting("ui-banner-dark", "")
 
 	// UIExtensions - setting for configuring UI Extensions (e.g. allow users to enable/disable extensions)
-	UIExtenstions = NewSetting("ui-extensions", "")
+	UIExtensions = NewSetting("ui-extensions", "")
 
   	// UI Settings for allowing separate configuration of page banners
 	UIBannerHeader       = NewSetting("ui-banner-header", "")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -277,7 +277,7 @@ var (
 	// UIExtensions - setting for configuring UI Extensions (e.g. allow users to enable/disable extensions)
 	UIExtenstions = NewSetting("ui-extensions", "")
 
-  // UI Settings for allowing separate configuration of page banners
+  	// UI Settings for allowing separate configuration of page banners
 	UIBannerHeader       = NewSetting("ui-banner-header", "")
 	UIBannerFooter       = NewSetting("ui-banner-footer", "")
 	UIBannerLoginConsent = NewSetting("ui-banner-login-consent", "")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -274,6 +274,9 @@ var (
 	UIBannerLight = NewSetting("ui-banner-light", "")
 	UIBannerDark  = NewSetting("ui-banner-dark", "")
 
+	// UIExtensions - setting for configuring UI Extensions (e.g. allow users to enable/disable extensions)
+	UIExtenstions = NewSetting("ui-extensions", "")
+
 	// UIPreferred Ensure that the new Dashboard is the default UI.
 	UIPreferred = NewSetting("ui-preferred", "vue")
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

https://github.com/rancher/dashboard/issues/11047
 
## Problem

Need a way to more easily enable/disable extensions without install/uninstall - especially useful for built-in extensions that we might want to allow the user to disable.

## Solution

Add a new setting `ui-extensions` that can be used to store the required configuration.
 
## Testing

Testing will be covered by end-to-end and unit tests in the relating UI work.
