### PR TITLE
Add new UI Settings for page banners

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -275,9 +275,9 @@ var (
 	UIBannerDark  = NewSetting("ui-banner-dark", "")
 
 	// UI Settings for allowing seperate configuration of page banners
-	UIBannerDark  = NewSetting("ui-banner-header", "")
-	UIBannerDark  = NewSetting("ui-banner-footer", "")
-	UIBannerDark  = NewSetting("ui-banner-login-consent", "")
+	UIBannerHeader  = NewSetting("ui-banner-header", "")
+	UIBannerFooter  = NewSetting("ui-banner-footer", "")
+	UIBannerLoginConsent  = NewSetting("ui-banner-login-consent", "")
 
 	// UIPreferred Ensure that the new Dashboard is the default UI.
 	UIPreferred = NewSetting("ui-preferred", "vue")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -274,6 +274,11 @@ var (
 	UIBannerLight = NewSetting("ui-banner-light", "")
 	UIBannerDark  = NewSetting("ui-banner-dark", "")
 
+	// UI Settings for allowing seperate configuration of page banners
+	UIBannerDark  = NewSetting("ui-banner-header", "")
+	UIBannerDark  = NewSetting("ui-banner-footer", "")
+	UIBannerDark  = NewSetting("ui-banner-login-consent", "")
+
 	// UIPreferred Ensure that the new Dashboard is the default UI.
 	UIPreferred = NewSetting("ui-preferred", "vue")
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -275,9 +275,9 @@ var (
 	UIBannerDark  = NewSetting("ui-banner-dark", "")
 
 	// UI Settings for allowing separate configuration of page banners
-	UIBannerHeader        = NewSetting("ui-banner-header", "")
-	UIBannerFooter        = NewSetting("ui-banner-footer", "")
-	UIBannerLoginConsent  = NewSetting("ui-banner-login-consent", "")
+	UIBannerHeader       = NewSetting("ui-banner-header", "")
+	UIBannerFooter       = NewSetting("ui-banner-footer", "")
+	UIBannerLoginConsent = NewSetting("ui-banner-login-consent", "")
 
 	// UIPreferred Ensure that the new Dashboard is the default UI.
 	UIPreferred = NewSetting("ui-preferred", "vue")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -274,7 +274,7 @@ var (
 	UIBannerLight = NewSetting("ui-banner-light", "")
 	UIBannerDark  = NewSetting("ui-banner-dark", "")
 
-	// UI Settings for allowing seperate configuration of page banners
+	// UI Settings for allowing separate configuration of page banners
 	UIBannerHeader        = NewSetting("ui-banner-header", "")
 	UIBannerFooter        = NewSetting("ui-banner-footer", "")
 	UIBannerLoginConsent  = NewSetting("ui-banner-login-consent", "")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -275,8 +275,8 @@ var (
 	UIBannerDark  = NewSetting("ui-banner-dark", "")
 
 	// UI Settings for allowing seperate configuration of page banners
-	UIBannerHeader  = NewSetting("ui-banner-header", "")
-	UIBannerFooter  = NewSetting("ui-banner-footer", "")
+	UIBannerHeader        = NewSetting("ui-banner-header", "")
+	UIBannerFooter        = NewSetting("ui-banner-footer", "")
 	UIBannerLoginConsent  = NewSetting("ui-banner-login-consent", "")
 
 	// UIPreferred Ensure that the new Dashboard is the default UI.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

https://github.com/rancher/dashboard/issues/7366
 
## Problem

Presently, all banners are in a single setting as a single JSON blob - this makes it hard for users wishing to individually configure banners outside of the UI.
 
## Solution

Add optional individual banner settings that will be used if defined, rather than the single setting we currently have.
 
## Testing

UI will add automated e2e tests to cover this feature and the correct operation of these  new settings.
