### PR TITLE
[v2.9] Fix RKE1 nodetemplates to include cloud credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.26.0
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240425061024-5ce684a45887
-	github.com/rancher/shepherd v0.0.0-20240513202553-b237456b1927
+	github.com/rancher/shepherd v0.0.0-20240521170624-a0bc2ec1eda4
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1700,8 +1700,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.6.0-rc3 h1:AT4oRN8qyoampqhQ7zWZLPsXAoOXUsECC9Oh7gjWFFY=
 github.com/rancher/rke v1.6.0-rc3/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
-github.com/rancher/shepherd v0.0.0-20240513202553-b237456b1927 h1:4riXwztwQme5CiRcMqAuwDrhkTDeekIeXe1+c+I1SFo=
-github.com/rancher/shepherd v0.0.0-20240513202553-b237456b1927/go.mod h1:Mpd+RsxaqTMaoKSdeiEvGoDEknAKS8hAWjdozi5mJxE=
+github.com/rancher/shepherd v0.0.0-20240521170624-a0bc2ec1eda4 h1:l1PWzlIZ6km2IFTvlE6Fb9Zb1mTemyfFfL4oyEFNG48=
+github.com/rancher/shepherd v0.0.0-20240521170624-a0bc2ec1eda4/go.mod h1:Mpd+RsxaqTMaoKSdeiEvGoDEknAKS8hAWjdozi5mJxE=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49 h1:FVWzTCgR2bRcKIWqgJCa7L4s8J1S8HfCJMnqoSj99yg=
 github.com/rancher/steve v0.0.0-20240314145706-870824dc8f49/go.mod h1:+MET7wv8z6yycUt6NRDQzrd+h/j91tumImDg29w7eTw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -10,12 +10,13 @@ Please see below for more details for your config. Please note that the config c
 1. [Prerequisites](../README.md)
 2. [Configuring test flags](#Flags)
 3. [Define your test](#Provisioning-Input)
-4. [Configuring providers to use for Node Driver Clusters](#NodeTemplateConfigs)
-5. [Configuring Custom Clusters](#Custom-Cluster)
-6. [Static test cases](#static-test-cases)
-7. [Cloud Provider](#Cloud-Provider)
-8. [Advanced Cluster Settings](#advanced-settings)
-9. [Back to general provisioning](../README.md)
+4. [Cloud Credential](#cloud-credentials)
+5. [Configuring providers to use for Node Driver Clusters](#NodeTemplateConfigs)
+6. [Configuring Custom Clusters](#Custom-Cluster)
+7. [Static test cases](#static-test-cases)
+8. [Cloud Provider](#Cloud-Provider)
+9. [Advanced Cluster Settings](#advanced-settings)
+10. [Back to general provisioning](../README.md)
 
 
 ## Flags
@@ -68,6 +69,55 @@ provisioningInput:
     snapshot: false
 ```
 
+## Cloud Credentials
+These are the inputs needed for the different node provider cloud credentials, including linode, aws, harvester, azure, and google.
+
+### Digital Ocean
+```yaml
+digitalOceanCredentials:               
+  accessToken: ""                     #required
+```
+### Linode
+```yaml
+linodeCredentials:                   
+  token: ""                           #required
+```
+### Azure
+```yaml
+azureCredentials:                     
+  clientId: ""                        #required
+  clientSecret: ""                    #required
+  subscriptionId: ""                  #required
+  environment: "AzurePublicCloud"     #required
+```
+### AWS
+```yaml
+awsCredentials:                       
+  secretKey: ""                       #required
+  accessKey: ""                       #required
+  defaultRegion: ""                   #required
+```
+### Harvester
+```yaml
+harvesterCredentials:                 
+  clusterId: ""                       #required
+  clusterType: ""                     #required
+  kubeconfigContent: ""               #required
+```
+### Google
+```yaml
+googleCredentials:                    
+  authEncodedJson: ""                 #required
+```
+### VSphere
+```yaml
+vmwarevsphereCredentials:             
+  password: ""                        #required
+  username: ""                        #required
+  vcenter: ""                         #required
+  vcenterPort: ""                     #required
+```
+
 
 ## Cloud Provider
 Cloud Provider enables additional options through the cloud provider, like cloud persistent storage or cloud provisioned load balancers.
@@ -93,7 +143,6 @@ providers to work.
 ### AWS
 ```yaml
   awsNodeConfig:
-    accessKey: ""
     ami: ""
     blockDurationMinutes: "0"
     encryptEbsVolume: false
@@ -111,7 +160,6 @@ providers to work.
     requestSpotInstance: true
     retries: "5"
     rootSize: "16"
-    secretKey: ""
     securityGroup: ["open-all"]
     securityGroupReadonly: false
     sessionToken: ""
@@ -133,8 +181,6 @@ providers to work.
 ```yaml
 azureNodeConfig:
   availabilitySet: "docker-machine"
-  clientId: ""
-  clientSecret: ""
   customData: ""
   diskSize: "30"
   dns: ""
@@ -156,7 +202,6 @@ azureNodeConfig:
   subnet: "docker-machine"
   subnetPrefix: "192.168.0.0/16"
   subscriptionId: ""
-  tenantId: ""
   type: "azureConfig"
   updateDomainCount: "5"
   vnet: "docker-machine-vnet"
@@ -166,14 +211,11 @@ azureNodeConfig:
 ```yaml
 harvesterNodeConfig":
   cloudConfig: ""
-  clusterId: ""
-  clusterType: ""
   cpuCount: "2"
   diskBus: "virtio"
   diskSize: "40"
   imageName: "default/image-gchq8"
   keyPairName: ""
-  kubeconfigContent: ""
   memorySize: "4"
   networkData: ""
   networkModel: "virtio"
@@ -206,7 +248,6 @@ linodeNodeConfig:
   stackscriptData: ""
   swapSize: "512"
   tags: ""
-  token: ""
   type: "linodeConfig"
   uaPrefix: "Rancher"
 ```


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [RKE1 node templates are not being created using a cloud credential in the automation](https://github.com/rancher/qa-tasks/issues/1334)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
This is the rancher/rancher counterpart to shepherd PR https://github.com/rancher/shepherd/pull/194. Jenkins jobs will be given to reviewers offline.