### PR TITLE
[v2.9] [Experimental] Resolve principals using external auth provider

### DIFF
--- a/pkg/auth/principals/handler.go
+++ b/pkg/auth/principals/handler.go
@@ -119,7 +119,8 @@ func (h *principalsHandler) list(apiContext *types.APIContext, next types.Reques
 		// get the group principals for that provider.
 		if extProvider := providers.GetEnabledExternalProvider(); extProvider != nil {
 			shouldGetGroupPrincipals = true
-			// We'll fake the token in this case.
+			// We'll fake the token in this case to pass the user id and auth provider,
+			// that are used to fetch user's group principals stored in the userattribute object.
 			getGroupPricipalsToken = &v32.Token{
 				UserID:       token.UserID,
 				AuthProvider: extProvider.GetName(),

--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -49,8 +49,8 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{},
 			},
@@ -87,13 +87,13 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{
-					providers.LocalProvider: map[string][]string{
-						common.UserAttributePrincipalID: []string{"local://user-abcde"},
-						common.UserAttributeUserName:    []string{"admin"},
+					providers.LocalProvider: {
+						common.UserAttributePrincipalID: {"local://user-abcde"},
+						common.UserAttributeUserName:    {"admin"},
 					},
 				},
 			},
@@ -130,13 +130,13 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{
-					providers.LocalProvider: map[string][]string{
-						common.UserAttributePrincipalID: []string{"local://user-abcde"},
-						common.UserAttributeUserName:    []string{"admin"},
+					providers.LocalProvider: {
+						common.UserAttributePrincipalID: {"local://user-abcde"},
+						common.UserAttributeUserName:    {"admin"},
 					},
 				},
 			},
@@ -173,8 +173,8 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{},
 			},
@@ -221,13 +221,13 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{
-					providers.LocalProvider: map[string][]string{
-						common.UserAttributePrincipalID: []string{"local://user-abcde"},
-						common.UserAttributeUserName:    []string{"admin"},
+					providers.LocalProvider: {
+						common.UserAttributePrincipalID: {"local://user-abcde"},
+						common.UserAttributeUserName:    {"admin"},
 					},
 				},
 			},
@@ -264,13 +264,13 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{
-					saml.ShibbolethName: map[string][]string{
-						common.UserAttributePrincipalID: []string{"shibboleth_user://user1"},
-						common.UserAttributeUserName:    []string{"user1"},
+					saml.ShibbolethName: {
+						common.UserAttributePrincipalID: {"shibboleth_user://user1"},
+						common.UserAttributeUserName:    {"user1"},
 					},
 				},
 			},
@@ -318,8 +318,8 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{},
 			},
@@ -370,13 +370,13 @@ func Test_refreshAttributes(t *testing.T) {
 			want: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
 				GroupPrincipals: map[string]v3.Principals{
-					"local":      v3.Principals{},
-					"shibboleth": v3.Principals{},
+					"local":      {},
+					"shibboleth": {},
 				},
 				ExtraByProvider: map[string]map[string][]string{
-					providers.LocalProvider: map[string][]string{
-						common.UserAttributePrincipalID: []string{"local://user-abcde"},
-						common.UserAttributeUserName:    []string{"admin"},
+					providers.LocalProvider: {
+						common.UserAttributePrincipalID: {"local://user-abcde"},
+						common.UserAttributeUserName:    {"admin"},
 					},
 				},
 			},
@@ -557,8 +557,8 @@ func (p *mockLocalProvider) CanAccessWithGroupProviders(userPrincipalID string, 
 
 func (p *mockLocalProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	return map[string][]string{
-		common.UserAttributePrincipalID: []string{userPrincipal.ExtraInfo[common.UserAttributePrincipalID]},
-		common.UserAttributeUserName:    []string{userPrincipal.ExtraInfo[common.UserAttributeUserName]},
+		common.UserAttributePrincipalID: {userPrincipal.ExtraInfo[common.UserAttributePrincipalID]},
+		common.UserAttributeUserName:    {userPrincipal.ExtraInfo[common.UserAttributeUserName]},
 	}
 }
 
@@ -609,8 +609,8 @@ func (p *mockShibbolethProvider) CanAccessWithGroupProviders(userPrincipalID str
 
 func (p *mockShibbolethProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	return map[string][]string{
-		common.UserAttributePrincipalID: []string{userPrincipal.ExtraInfo[common.UserAttributePrincipalID]},
-		common.UserAttributeUserName:    []string{userPrincipal.ExtraInfo[common.UserAttributeUserName]},
+		common.UserAttributePrincipalID: {userPrincipal.ExtraInfo[common.UserAttributePrincipalID]},
+		common.UserAttributeUserName:    {userPrincipal.ExtraInfo[common.UserAttributeUserName]},
 	}
 }
 

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -21,6 +21,7 @@ import (
 	publicclient "github.com/rancher/rancher/pkg/client/generated/management/v3public"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -173,7 +174,9 @@ func GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
 
 	disabled, err := provider.IsDisabledProvider()
 	if err != nil {
-		return v3.Principal{}, err
+		// Treat the error here the same way the provider refresher does.
+		logrus.Warnf("Unable to determine if provider %s was disabled, will assume that it isn't with error: %v", principalProvider, err)
+		disabled = false
 	}
 	if disabled {
 		return v3.Principal{}, fmt.Errorf("authProvider %s is disabled", principalProvider)

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -162,7 +162,11 @@ func AuthenticateUser(ctx context.Context, input interface{}, providerName strin
 }
 
 func GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
-	principalScheme, _, _ := strings.Cut(principalID, ":")
+	principalScheme, _, found := strings.Cut(principalID, ":")
+	if !found {
+		return v3.Principal{}, fmt.Errorf("invalid principalID %s", principalID)
+	}
+
 	principalProvider, _, _ := strings.Cut(principalScheme, "_")
 
 	// Try to use the provider of the principal rather then the one we used to authenticate.

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -164,7 +164,7 @@ func GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
 	principalScheme, _, _ := strings.Cut(principalID, ":")
 	principalProvider, _, _ := strings.Cut(principalScheme, "_")
 
-	// Try to use the provider of the pricipal rather then the one we used to authenticate.
+	// Try to use the provider of the principal rather then the one we used to authenticate.
 	// Make sure that it exists and is enabled.
 	provider := Providers[principalProvider]
 	if provider == nil {

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -234,32 +234,28 @@ func TestGetPrincipal(t *testing.T) {
 				name:     local.Name,
 				disabled: false,
 				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
-					return v3.Principal{
-						ObjectMeta:    metav1.ObjectMeta{Name: localPrincipalID},
-						Provider:      local.Name,
-						PrincipalType: "user",
-					}, nil
+					t.Error("Unexpected call to local provider")
+					return v3.Principal{}, nil
 				},
 			},
 			extProvider: &fakeProvider{
 				name:     activedirectory.Name,
 				disabled: false,
 				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
-					t.Error("Unexpected call to external provider")
-					return v3.Principal{}, nil
+					return v3.Principal{}, fmt.Errorf("not found")
 				},
 			},
 			searchPrincipalID: localPrincipalID,
-			wantProvider:      local.Name,
+			shoudErr:          true,
 		},
 		{
-			desc:              "Provider is not initialized",
+			desc:              "External provider is not initialized",
 			myToken:           localToken,
 			searchPrincipalID: extPrincipalID,
 			shoudErr:          true,
 		},
 		{
-			desc:    "Provider disabled",
+			desc:    "External provider is disabled",
 			myToken: localToken,
 			extProvider: &fakeProvider{
 				name:     activedirectory.Name,

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/activedirectory"
 	"github.com/rancher/rancher/pkg/auth/providers/azure"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/github"
+	"github.com/rancher/rancher/pkg/auth/providers/ldap"
+	"github.com/rancher/rancher/pkg/auth/providers/local"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,6 +108,310 @@ func TestProviderHasPerUserTokens(t *testing.T) {
 	assert.True(t, hasPerUserSecrets)
 }
 
+func TestGetEnabledExternalProvider(t *testing.T) {
+	t.Cleanup(cleanup)
+
+	Providers[local.Name] = fakeProvider{
+		name:     local.Name,
+		disabled: false,
+	}
+	Providers[ldap.OpenLdapName] = fakeProvider{
+		name:     ldap.OpenLdapName,
+		disabled: true,
+	}
+	Providers[activedirectory.Name] = fakeProvider{
+		name:     activedirectory.Name,
+		disabled: false,
+	}
+	Providers[github.Name] = fakeProvider{
+		name:     github.Name,
+		disabled: false,
+	}
+
+	t.Run("Enabled external provider is returned", func(t *testing.T) {
+		provider := GetEnabledExternalProvider()
+		require.NotNil(t, provider)
+		// Either one of the enabled ones is returned, but not the local.
+		assert.Contains(t, []string{activedirectory.Name, github.Name}, provider.GetName())
+	})
+
+	delete(Providers, github.Name)
+	delete(Providers, activedirectory.Name)
+
+	t.Run("No enabled external provider", func(t *testing.T) {
+		provider := GetEnabledExternalProvider()
+		require.Nil(t, provider)
+	})
+}
+
+func TestGetPrincipal(t *testing.T) {
+	localPrincipalID := "local://user2"
+	extPrincipalID := "activedirectory_user://CN=user2,OU=CN\\=test,DC=test-ad,DC=ad,DC=com"
+
+	localToken := v3.Token{AuthProvider: local.Name, UserID: "local://user1"}
+	extToken := v3.Token{AuthProvider: activedirectory.Name, UserID: "activedirectory_user://CN=user1,OU=CN\\=test,DC=test-ad,DC=ad,DC=com"}
+
+	tests := []struct {
+		desc              string
+		myToken           v3.Token
+		localProvider     common.AuthProvider
+		extProvider       common.AuthProvider
+		searchPrincipalID string
+		wantProvider      string
+		shoudErr          bool
+	}{
+		{
+			desc:    "Local user resolving local principal",
+			myToken: localToken,
+			localProvider: &fakeProvider{
+				name:     local.Name,
+				disabled: false,
+				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
+					return v3.Principal{
+						ObjectMeta:    metav1.ObjectMeta{Name: localPrincipalID},
+						Provider:      local.Name,
+						PrincipalType: "user",
+					}, nil
+				},
+			},
+			searchPrincipalID: localPrincipalID,
+			wantProvider:      local.Name,
+		},
+		{
+			desc:    "Local user resolving external principal",
+			myToken: localToken,
+			localProvider: &fakeProvider{
+				name:     local.Name,
+				disabled: false,
+				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
+					t.Error("Unexpected call to local provider")
+					return v3.Principal{}, nil
+				},
+			},
+			extProvider: &fakeProvider{
+				name:     activedirectory.Name,
+				disabled: false,
+				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
+					return v3.Principal{
+						ObjectMeta:    metav1.ObjectMeta{Name: extPrincipalID},
+						Provider:      activedirectory.Name,
+						PrincipalType: "user",
+					}, nil
+				},
+			},
+			searchPrincipalID: extPrincipalID,
+			wantProvider:      activedirectory.Name,
+		},
+		{
+			desc:    "External user resolving external principal",
+			myToken: extToken,
+			localProvider: &fakeProvider{
+				name:     local.Name,
+				disabled: false,
+				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
+					t.Error("Unexpected call to local provider")
+					return v3.Principal{}, nil
+				},
+			},
+			extProvider: &fakeProvider{
+				name:     activedirectory.Name,
+				disabled: false,
+				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
+					return v3.Principal{
+						ObjectMeta:    metav1.ObjectMeta{Name: extPrincipalID},
+						Provider:      activedirectory.Name,
+						PrincipalType: "user",
+					}, nil
+				},
+			},
+			searchPrincipalID: extPrincipalID,
+			wantProvider:      activedirectory.Name,
+		},
+		{
+			desc:    "External user resolving local principal",
+			myToken: extToken,
+			localProvider: &fakeProvider{
+				name:     local.Name,
+				disabled: false,
+				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
+					return v3.Principal{
+						ObjectMeta:    metav1.ObjectMeta{Name: localPrincipalID},
+						Provider:      local.Name,
+						PrincipalType: "user",
+					}, nil
+				},
+			},
+			extProvider: &fakeProvider{
+				name:     activedirectory.Name,
+				disabled: false,
+				getPrincipalFunc: func(string, v3.Token) (v3.Principal, error) {
+					t.Error("Unexpected call to external provider")
+					return v3.Principal{}, nil
+				},
+			},
+			searchPrincipalID: localPrincipalID,
+			wantProvider:      local.Name,
+		},
+		{
+			desc:              "Provider is not initialized",
+			myToken:           localToken,
+			searchPrincipalID: extPrincipalID,
+			shoudErr:          true,
+		},
+		{
+			desc:    "Provider disabled",
+			myToken: localToken,
+			extProvider: &fakeProvider{
+				name:     activedirectory.Name,
+				disabled: true,
+			},
+			searchPrincipalID: extPrincipalID,
+			shoudErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Cleanup(cleanup)
+
+			if tt.localProvider != nil {
+				Providers[local.Name] = tt.localProvider
+			}
+			if tt.extProvider != nil {
+				Providers[activedirectory.Name] = tt.extProvider
+			}
+
+			principal, err := GetPrincipal(tt.searchPrincipalID, tt.myToken)
+			if tt.shoudErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.searchPrincipalID, principal.Name)
+			assert.Equal(t, tt.wantProvider, principal.Provider)
+		})
+	}
+}
+
+func TestSearchPrincipals(t *testing.T) {
+	originalLocalSearch := searchLocalPrincipalsDedupe
+	t.Cleanup(func() {
+		searchLocalPrincipalsDedupe = originalLocalSearch
+		cleanup()
+	})
+
+	localPrincipalID := "local://user2"
+	extPrincipalID := "activedirectory_user://CN=user2,OU=CN\\=test,DC=test-ad,DC=ad,DC=com"
+
+	localToken := v3.Token{AuthProvider: local.Name, UserID: "local://user1"}
+	extToken := v3.Token{AuthProvider: activedirectory.Name, UserID: "activedirectory_user://CN=user1,OU=CN\\=test,DC=test-ad,DC=ad,DC=com"}
+
+	tests := []struct {
+		desc           string
+		myToken        v3.Token
+		localProvider  common.AuthProvider
+		extProvider    common.AuthProvider
+		localSearch    dedupeSearchFunc
+		wantPrincipals []string
+	}{
+		{
+			desc:    "Search as a local user",
+			myToken: localToken,
+			localProvider: &fakeProvider{
+				name:     local.Name,
+				disabled: false,
+			},
+			extProvider: &fakeProvider{
+				name:     activedirectory.Name,
+				disabled: false,
+				searchPrincipalsFunc: func(string, string, v3.Token) ([]v3.Principal, error) {
+					return []v3.Principal{{
+						ObjectMeta:    metav1.ObjectMeta{Name: extPrincipalID},
+						Provider:      activedirectory.Name,
+						PrincipalType: "user",
+					}}, nil
+				},
+			},
+			localSearch: func(string, string, v3.Token, []v3.Principal) ([]v3.Principal, error) {
+				return []v3.Principal{{
+					ObjectMeta:    metav1.ObjectMeta{Name: localPrincipalID},
+					Provider:      local.Name,
+					PrincipalType: "user",
+				}}, nil
+			},
+			wantPrincipals: []string{localPrincipalID, extPrincipalID},
+		},
+		{
+			desc:    "Search as an external user",
+			myToken: extToken,
+			localProvider: &fakeProvider{
+				name:     local.Name,
+				disabled: false,
+			},
+			extProvider: &fakeProvider{
+				name:     activedirectory.Name,
+				disabled: false,
+				searchPrincipalsFunc: func(string, string, v3.Token) ([]v3.Principal, error) {
+					return []v3.Principal{{
+						ObjectMeta:    metav1.ObjectMeta{Name: extPrincipalID},
+						Provider:      activedirectory.Name,
+						PrincipalType: "user",
+					}}, nil
+				},
+			},
+			localSearch: func(string, string, v3.Token, []v3.Principal) ([]v3.Principal, error) {
+				return []v3.Principal{{
+					ObjectMeta:    metav1.ObjectMeta{Name: localPrincipalID},
+					Provider:      local.Name,
+					PrincipalType: "user",
+				}}, nil
+			},
+			wantPrincipals: []string{localPrincipalID, extPrincipalID},
+		},
+		{
+			desc:    "Search only local provider",
+			myToken: extToken,
+			localProvider: &fakeProvider{
+				name:     local.Name,
+				disabled: false,
+			},
+			extProvider: &fakeProvider{
+				name:     activedirectory.Name,
+				disabled: true,
+			},
+			localSearch: func(string, string, v3.Token, []v3.Principal) ([]v3.Principal, error) {
+				return []v3.Principal{{
+					ObjectMeta:    metav1.ObjectMeta{Name: localPrincipalID},
+					Provider:      local.Name,
+					PrincipalType: "user",
+				}}, nil
+			},
+			wantPrincipals: []string{localPrincipalID},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if tt.localProvider != nil {
+				Providers[local.Name] = tt.localProvider
+			}
+			if tt.extProvider != nil {
+				Providers[activedirectory.Name] = tt.extProvider
+			}
+
+			searchLocalPrincipalsDedupe = tt.localSearch
+
+			found, err := SearchPrincipals("user", "", tt.myToken)
+			require.NoError(t, err)
+			assert.Len(t, found, len(tt.wantPrincipals))
+			for _, principal := range found {
+				assert.Contains(t, tt.wantPrincipals, principal.Name)
+			}
+		})
+	}
+}
+
 func cleanup() {
 	Providers = make(map[string]common.AuthProvider)
 	providersWithSecrets = make(map[string]bool)
@@ -132,14 +439,6 @@ func (m *mockUnstructuredGetter) Get(name string, _ metav1.GetOptions) (runtime.
 	return nil, fmt.Errorf("object %s not found", name)
 }
 
-func (m *mockUnstructuredGetter) addObject(name string, object runtime.Object) {
-	m.objects[name] = object
-}
-
-func (m *mockUnstructuredGetter) addErr(name string, err error) {
-	m.errObjects[name] = err
-}
-
 type mockUnstructured struct {
 	content map[string]interface{}
 }
@@ -153,44 +452,55 @@ func (m *mockUnstructured) EachListItemWithAlloc(func(runtime.Object) error) err
 func (m *mockUnstructured) GetObjectKind() schema.ObjectKind                       { return nil }
 func (m *mockUnstructured) DeepCopyObject() runtime.Object                         { return nil }
 
-type fakeProvider struct{}
+type fakeProvider struct {
+	name                 string
+	disabled             bool
+	searchPrincipalsFunc func(string, string, v3.Token) ([]v3.Principal, error)
+	getPrincipalFunc     func(string, v3.Token) (v3.Principal, error)
+}
 
 func (f fakeProvider) GetName() string {
+	return f.name
+}
+
+func (f fakeProvider) AuthenticateUser(context.Context, interface{}) (v3.Principal, []v3.Principal, string, error) {
 	panic("implement me")
 }
 
-func (f fakeProvider) AuthenticateUser(_ context.Context, _ interface{}) (v3.Principal, []v3.Principal, string, error) {
+func (f fakeProvider) SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Principal, error) {
+	if f.searchPrincipalsFunc != nil {
+		return f.searchPrincipalsFunc(name, principalType, myToken)
+	}
+	return nil, nil
+}
+
+func (f fakeProvider) GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
+	if f.getPrincipalFunc != nil {
+		return f.getPrincipalFunc(principalID, myToken)
+	}
+	return v3.Principal{}, nil
+}
+
+func (f fakeProvider) CustomizeSchema(*types.Schema) {
 	panic("implement me")
 }
 
-func (f fakeProvider) SearchPrincipals(_, _ string, _ v3.Token) ([]v3.Principal, error) {
+func (f fakeProvider) TransformToAuthProvider(map[string]interface{}) (map[string]interface{}, error) {
 	panic("implement me")
 }
 
-func (f fakeProvider) GetPrincipal(_ string, _ v3.Token) (v3.Principal, error) {
+func (f fakeProvider) RefetchGroupPrincipals(string, string) ([]v3.Principal, error) {
 	panic("implement me")
 }
 
-func (f fakeProvider) CustomizeSchema(_ *types.Schema) {
+func (f fakeProvider) CanAccessWithGroupProviders(string, []v3.Principal) (bool, error) {
 	panic("implement me")
 }
 
-func (f fakeProvider) TransformToAuthProvider(_ map[string]interface{}) (map[string]interface{}, error) {
-	panic("implement me")
-}
-
-func (f fakeProvider) RefetchGroupPrincipals(_ string, _ string) ([]v3.Principal, error) {
-	panic("implement me")
-}
-
-func (f fakeProvider) CanAccessWithGroupProviders(_ string, _ []v3.Principal) (bool, error) {
-	panic("implement me")
-}
-
-func (f fakeProvider) GetUserExtraAttributes(_ v3.Principal) map[string][]string {
+func (f fakeProvider) GetUserExtraAttributes(v3.Principal) map[string][]string {
 	panic("implement me")
 }
 
 func (f fakeProvider) IsDisabledProvider() (bool, error) {
-	panic("implement me")
+	return f.disabled, nil
 }

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -702,21 +702,18 @@ func (m *Manager) GetGroupsForTokenAuthProvider(token *v3.Token) []v3.Principal 
 
 	hitProvider := false
 	if attribs != nil {
-		for provider, y := range attribs.GroupPrincipals {
+		for provider, principals := range attribs.GroupPrincipals {
 			if provider == token.AuthProvider {
 				hitProvider = true
-				for _, principal := range y.Items {
-					groups = append(groups, principal)
-				}
+				groups = append(groups, principals.Items...)
+				break
 			}
 		}
 	}
 
 	// fallback to legacy token groupPrincipals
 	if !hitProvider {
-		for _, principal := range token.GroupPrincipals {
-			groups = append(groups, principal)
-		}
+		groups = append(groups, token.GroupPrincipals...)
 	}
 
 	return groups


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/36539
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a user is logged in using the local auth provider it's impossible to resolve, list or search for principals using configured external auth provider (e.g. active directory).

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

When resolving an external principal parse the principal ID to determine which provider to use.
When listing user's group principals or searching for principals use the first (if any) enabled external provider to do so.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Resolving, listing, searching for principals across all auth providers.

Existing / newly added automated tests that provide evidence there are no regressions:
N/A