### PR TITLE
[2.8] Use patched hamilton library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v20.10.25+incompatible // rancher-machine requires a repalce is set
 
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
+	github.com/manicminer/hamilton v0.46.0 => github.com/rancher/hamilton v0.0.0-20240507075902-326692ab84f7
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77
 	github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.1.0-rc2 // needed for containers/image/v5
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -1373,8 +1373,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/manicminer/hamilton v0.46.0 h1:ag0xqWnALt9uQSfrrrXuQvm6puV8y+LghJQD32lzW+M=
-github.com/manicminer/hamilton v0.46.0/go.mod h1:lbVyngC+/nCWuDp8UhC6Bw+bh7jcP/E+YwqzHTmzemk=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/markbates/errx v1.1.0 h1:QDFeR+UP95dO12JgW+tgi2UVfo0V8YBHiUIOaeBPiEI=
 github.com/markbates/errx v1.1.0/go.mod h1:PLa46Oex9KNbVDZhKel8v1OT7hD5JZ2eI7AHhA0wswc=
@@ -1625,6 +1623,8 @@ github.com/rancher/fleet/pkg/apis v0.9.1-rc.2.0.20240213164401-2c6b1019687c h1:O
 github.com/rancher/fleet/pkg/apis v0.9.1-rc.2.0.20240213164401-2c6b1019687c/go.mod h1:KNDEr0BQU33vw4UEYR0v33HwIcyrykcI5UksJwJOmpM=
 github.com/rancher/gke-operator v1.2.2-rc.2 h1:XgmdrV74cabXvUHSWQM4xDvLR2nBB4jmqecHMOqHU98=
 github.com/rancher/gke-operator v1.2.2-rc.2/go.mod h1:CNdldUK2fKZyN9jxhbnaTMigWA+rVZVzbnWfCvnhPJU=
+github.com/rancher/hamilton v0.0.0-20240507075902-326692ab84f7 h1:P2F98Jn851vBRNVyU+M35rhawhdWeOZTy3Vls0xClj4=
+github.com/rancher/hamilton v0.0.0-20240507075902-326692ab84f7/go.mod h1:lbVyngC+/nCWuDp8UhC6Bw+bh7jcP/E+YwqzHTmzemk=
 github.com/rancher/helm/v3 v3.13.3-rancher1 h1:iDVShnxFHtz66CzAlS0wktsEZ13cb3Em+W7g4RviC4w=
 github.com/rancher/helm/v3 v3.13.3-rancher1/go.mod h1:3OKO33yI3p4YEXtTITN2+4oScsHeQe71KuzhlZ+aPfg=
 github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM7QmfO4OedvFE3QwXiH60I=


### PR DESCRIPTION
## Issue: #45543
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem

We observed high memory and CPU usage due to this dependency.
 
## Solution

We agreed on temporarily use a fork of this library in order to include performance fixes, while working on a permanent solution for 2.9. This is based on the current `0.46.0` version being used plus this patch: https://github.com/manicminer/hamilton/pull/271

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Changes have been testes both locally and using debug builds.