### PR TITLE
Improve hamilton error handling

### DIFF
--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
@@ -44,8 +45,9 @@ func (c azureMSGraphClient) MarshalTokenJSON() (string, error) {
 func (c azureMSGraphClient) GetUser(id string) (v3.Principal, error) {
 	user, _, err := c.userClient.Get(context.Background(), id, odata.Query{})
 	if err != nil {
-		return v3.Principal{}, err
+		return v3.Principal{}, fmt.Errorf("failed to get user from Azure: %w", err)
 	}
+
 	return c.userToPrincipal(*user)
 }
 
@@ -202,7 +204,7 @@ type AccessTokenCache struct {
 }
 
 // Replace fetches the access token from a secret in Kubernetes.
-func (c AccessTokenCache) Replace(cache cache.Unmarshaler, key string) {
+func (c AccessTokenCache) Replace(unmarshaler cache.Unmarshaler, key string) {
 	secretName := fmt.Sprintf("%s:%s", common.SecretsNamespace, AccessTokenSecretName)
 	secret, err := common.ReadFromSecret(c.Secrets, secretName, "access-token")
 	if err != nil {
@@ -210,7 +212,7 @@ func (c AccessTokenCache) Replace(cache cache.Unmarshaler, key string) {
 		return
 	}
 
-	err = cache.Unmarshal([]byte(secret))
+	err = unmarshaler.Unmarshal([]byte(secret))
 	if err != nil {
 		logrus.Errorf("[%s] failed to unmarshal the access token: %v", cacheLogPrefix, err)
 	}
@@ -235,18 +237,19 @@ func (c AccessTokenCache) Export(cache cache.Marshaler, key string) {
 // If that fails, it tries to acquire it directly from the auth provider with the credential (application secret in Azure).
 // It also checks that the access token has the necessary permissions.
 func NewMSGraphClient(config *v32.AzureADConfig, secrets corev1.SecretInterface) (AzureClient, error) {
-	c := &azureMSGraphClient{}
 	cred, err := confidential.NewCredFromSecret(config.ApplicationSecret)
 	if err != nil {
 		return nil, fmt.Errorf("could not create a cred from a secret: %w", err)
 	}
+
 	tokenCache := AccessTokenCache{Secrets: secrets}
 	confidentialClientApp, err := confidential.New(config.ApplicationID, cred,
 		confidential.WithAccessor(tokenCache),
 		confidential.WithAuthority(fmt.Sprintf("%s%s", config.Endpoint, config.TenantID)))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create Azure client: %w", err)
 	}
+
 	scope := fmt.Sprintf("%s/%s", config.GraphEndpoint, ".default")
 
 	var ar confidential.AuthResult
@@ -260,6 +263,10 @@ func NewMSGraphClient(config *v32.AzureADConfig, secrets corev1.SecretInterface)
 		}
 	}
 
+	return newMSGraphClient(config, ar), nil
+}
+
+func newMSGraphClient(config *v32.AzureADConfig, ar confidential.AuthResult) *azureMSGraphClient {
 	authResult := getCustomAuthResult(&ar)
 	authorizer := authorizer{authResult: authResult}
 
@@ -268,17 +275,28 @@ func NewMSGraphClient(config *v32.AzureADConfig, secrets corev1.SecretInterface)
 	userClient.BaseClient.Authorizer = &authorizer
 	userClient.BaseClient.ApiVersion = msgraph.Version10
 	userClient.BaseClient.DisableRetries = true
+	userClient.BaseClient.RetryableClient.ErrorHandler = retryableErrorHandler
 
 	groupClient := msgraph.NewGroupsClient(config.TenantID)
 	groupClient.BaseClient.Endpoint = environments.ApiEndpoint(config.GraphEndpoint)
 	groupClient.BaseClient.Authorizer = &authorizer
 	groupClient.BaseClient.ApiVersion = msgraph.Version10
 	groupClient.BaseClient.DisableRetries = true
+	groupClient.BaseClient.RetryableClient.ErrorHandler = retryableErrorHandler
 
-	c.authResult = authResult
-	c.userClient = userClient
-	c.groupClient = groupClient
-	return c, err
+	return &azureMSGraphClient{
+		authResult:  authResult,
+		userClient:  userClient,
+		groupClient: groupClient,
+	}
+}
+
+func retryableErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	if resp == nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func getCustomAuthResult(result *confidential.AuthResult) *customAuthResult {

--- a/pkg/auth/providers/azure/clients/ms_graph_client_test.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client_test.go
@@ -1,0 +1,174 @@
+package clients
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+)
+
+func TestAzureClient_connection_failures(t *testing.T) {
+	// This creates a listener on a random available port.
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	config := &mgmtv3.AzureADConfig{
+		GraphEndpoint: fmt.Sprintf("https://localhost:%d/", port),
+		TenantID:      "test-tenant",
+	}
+
+	connectionTests := []struct {
+		name string
+		call func(client AzureClient) error
+	}{
+		{
+			name: "GetUser()",
+			call: func(client AzureClient) error {
+				_, err := client.GetUser("test-user-id")
+				return err
+			},
+		},
+		{
+			name: "ListUsers()",
+			call: func(client AzureClient) error {
+				_, err := client.ListUsers("LastName eq 'Smith'")
+				return err
+			},
+		},
+		{
+			name: "GetGroup()",
+			call: func(client AzureClient) error {
+				_, err := client.GetGroup("testing-group")
+				return err
+			},
+		},
+		{
+			name: "ListGroups()",
+			call: func(client AzureClient) error {
+				_, err := client.ListGroups("mailEnabled eq true")
+				return err
+			},
+		},
+		{
+			name: "ListGroupMemberships()",
+			call: func(client AzureClient) error {
+				_, err := client.ListGroupMemberships("test-user-id")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range connectionTests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMSGraphClient(config, confidential.AuthResult{
+				AccessToken: "test-token",
+			})
+			client.userClient.BaseClient.RetryableClient.RetryMax = 1
+			client.groupClient.BaseClient.RetryableClient.RetryMax = 1
+
+			err := tt.call(client)
+
+			if err == nil {
+				t.Error("expected to get an error, got nil")
+			}
+
+			if msg := err.Error(); !strings.Contains(msg, "connect: connection refused") {
+				t.Errorf("got %s, want message with 'connection refused'", msg)
+			}
+		})
+	}
+}
+
+func TestAzureClient_invalid_responses(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths := []string{
+			"/v1.0/test-tenant/users/test-user-id",
+			"/v1.0/test-tenant/users",
+			"/v1.0/test-tenant/groups/testing-group",
+			"/v1.0/test-tenant/groups",
+			"/v1.0/test-tenant/users/test-user-id/transitiveMemberOf",
+		}
+		if slices.Contains(paths, r.URL.Path) {
+			fmt.Fprintln(w, `{ "`+strings.Repeat("a", 513)+`" 1 }`)
+			return
+		}
+		http.Error(w, fmt.Sprintf("didn't match: %s", r.URL.Path), http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	config := &mgmtv3.AzureADConfig{
+		GraphEndpoint: ts.URL,
+		TenantID:      "test-tenant",
+	}
+
+	connectionTests := []struct {
+		name string
+		call func(client AzureClient) error
+	}{
+		{
+			name: "GetUser()",
+			call: func(client AzureClient) error {
+				_, err := client.GetUser("test-user-id")
+				return err
+			},
+		},
+		{
+			name: "ListUsers()",
+			call: func(client AzureClient) error {
+				_, err := client.ListUsers("LastName eq 'Smith'")
+				return err
+			},
+		},
+		{
+			name: "GetGroup()",
+			call: func(client AzureClient) error {
+				_, err := client.GetGroup("testing-group")
+				return err
+			},
+		},
+		{
+			name: "ListGroups()",
+			call: func(client AzureClient) error {
+				_, err := client.ListGroups("mailEnabled eq true")
+				return err
+			},
+		},
+		{
+			name: "ListGroupMemberships()",
+			call: func(client AzureClient) error {
+				_, err := client.ListGroupMemberships("test-user-id")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range connectionTests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMSGraphClient(config, confidential.AuthResult{
+				AccessToken: "test-token",
+			})
+			client.userClient.BaseClient.RetryableClient.RetryMax = 1
+			client.groupClient.BaseClient.RetryableClient.RetryMax = 1
+
+			err := tt.call(client)
+
+			if err == nil {
+				t.Error("expected to get an error, got nil")
+			}
+
+			if msg := err.Error(); !strings.Contains(msg, "invalid character") {
+				t.Errorf("got %s, want message with 'invalid character'", msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes: #45010
Fixes: #45005

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The upstream package (github.com/manicminer/hamilton) was dropping errors from the underlying Go HTTP Transport, this was being reported by the Go HTTP Client as an error, and the original error was lost, for example, if you had egress rules that prevented access, any "connection" errors would be lost.,

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This changes the behaviour of our use of the hamilton msgraph client to return errors when connecting which will pass the message through.
    
This is a reimplementation of the fix that was upstreamed here https://github.com/manicminer/hamilton/pull/280

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

This would require blocking of access to Azure's endpoints, or a misconfiguration of the Graph API custom endpoint, see https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-azure-ad "custom endpoints" to point to an endpoint that could not be connected with.

Without the fix, you will get a message `http: RoundTripper implementation (*retryablehttp.RoundTripper) returned a nil *Response with a nil error` with the fix, if you have a custom endpoint that is invalid, you will get...`Get "https://localhost/v1.0/test-tenant/users/test-user-id": dial tcp [::1]:80: connect: connection refused` or something similar.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
See above.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_