### PR TITLE
Revert "[v2.7] feat: added capi label to kubeconfig secrets"

### DIFF
--- a/pkg/provisioningv2/kubeconfig/manager.go
+++ b/pkg/provisioningv2/kubeconfig/manager.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -252,7 +251,7 @@ func (m *Manager) GetCRTBForClusterOwner(cluster *v1.Cluster, status v1.ClusterS
 // kubeConfigValid accepts a kubeconfig and corresponding data, and validates that the kubeconfig is valid for the
 // cluster in question. It returns two booleans, the first of which is whether an error occurred parsing the kubeconfig
 // or retrieving information related to the kubeconfig, and the second which indicates whether the kubeconfig is valid.
-func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentServerURL, currentServerCA, currentManagementClusterName string, secretLabels map[string]string) (bool, bool) {
+func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentServerURL, currentServerCA, currentManagementClusterName string) (bool, bool) {
 	if len(kcData) == 0 {
 		return true, false
 	}
@@ -290,13 +289,6 @@ func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentSer
 		tokenMatches = err == nil
 	}
 
-	// Check if the required CAPI cluster label is present in the secretLabels map
-	capiClusterLabelValue, labelPresent := secretLabels[capi.ClusterLabelName]
-	if !labelPresent || capiClusterLabelValue != cluster.Name {
-		logrus.Tracef("[kubeconfigmanager] cluster %s/%s: kubeconfig secret failed validation due to missing or incorrect label", cluster.Namespace, cluster.Name)
-		return false, false
-	}
-
 	if serverURL != currentServerURL || !bytes.Equal([]byte(strings.TrimSpace(currentServerCA)), kc.Clusters["cluster"].CertificateAuthorityData) || managementCluster != currentManagementClusterName || !tokenMatches {
 		logrus.Tracef("[kubeconfigmanager] cluster %s/%s: kubeconfig secret failed validation, did not match provided data", cluster.Namespace, cluster.Name)
 		return false, false
@@ -313,7 +305,7 @@ func (m *Manager) getKubeConfigData(cluster *v1.Cluster, secretName, managementC
 
 	secret, err := m.secretCache.Get(cluster.Namespace, secretName)
 	if err == nil {
-		retrievalError, isValid := m.kubeConfigValid(secret.Data["value"], cluster, serverURL, cacert, managementClusterName, secret.Labels)
+		retrievalError, isValid := m.kubeConfigValid(secret.Data["value"], cluster, serverURL, cacert, managementClusterName)
 		if (!retrievalError && !isValid) || secret.Data == nil || secret.Data["token"] == nil || len(secret.OwnerReferences) == 0 {
 			logrus.Infof("[kubeconfigmanager] deleting kubeconfig secret for cluster %s/%s", cluster.Namespace, cluster.Name)
 			// Check if we require a new secret based on the token value and annotation(s). We delete the old secret since it may contain
@@ -376,9 +368,6 @@ func (m *Manager) getKubeConfigData(cluster *v1.Cluster, secretName, managementC
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			}},
-			Labels: map[string]string{
-				capi.ClusterLabelName: cluster.Name,
-			},
 		},
 		Data: map[string][]byte{
 			"value": data,

--- a/pkg/provisioningv2/kubeconfig/manager_test.go
+++ b/pkg/provisioningv2/kubeconfig/manager_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/pointer"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -65,12 +64,11 @@ func Test_kubeConfigValid(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		currentData  *kubeconfigData
-		wantData     *kubeconfigData
-		cluster      *v1.Cluster
-		storedToken  *v3.Token
-		secretLabels map[string]string
+		name        string
+		currentData *kubeconfigData
+		wantData    *kubeconfigData
+		cluster     *v1.Cluster
+		storedToken *v3.Token
 
 		invalidServerURL  bool
 		invalidKubeconfig bool
@@ -94,9 +92,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: false,
 			wantValid: true,
@@ -116,9 +111,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: hashToken(&token, false),
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: false,
 			wantValid: true,
@@ -138,9 +130,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: false,
 			wantValid: false,
@@ -160,9 +149,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: hashToken(&token, false),
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: false,
 			wantValid: false,
@@ -182,9 +168,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: false,
 			wantValid: false,
@@ -204,9 +187,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: false,
 			wantValid: false,
@@ -226,9 +206,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: false,
 			wantValid: false,
@@ -243,9 +220,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: true,
 			wantValid: false,
@@ -261,76 +235,8 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken:       &token,
 			cluster:           &cluster,
 			invalidKubeconfig: true,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: true,
-			wantValid: false,
-		},
-		{
-			name: "CAPI cluster label is set correctly",
-			currentData: &kubeconfigData{
-				serverURL:   "https://test.cluster.io",
-				serverCA:    "ABC",
-				clusterName: "c-1234xyz",
-				token:       fmt.Sprintf("%s:%s", token.Name, tokenKey),
-			},
-			wantData: &kubeconfigData{
-				serverURL:   "https://test.cluster.io",
-				serverCA:    "ABC",
-				clusterName: "c-1234xyz",
-			},
-			storedToken: &token,
-			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
-
-			wantError: false,
-			wantValid: true,
-		},
-		{
-			name: "CAPI cluster label is set incorrectly",
-			currentData: &kubeconfigData{
-				serverURL:   "https://test.cluster.io",
-				serverCA:    "ABC",
-				clusterName: "c-1234xyz",
-				token:       fmt.Sprintf("%s:%s", token.Name, tokenKey),
-			},
-			wantData: &kubeconfigData{
-				serverURL:   "https://test.cluster.io",
-				serverCA:    "ABC",
-				clusterName: "c-1234xyz",
-			},
-			storedToken: &token,
-			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "random-cluster-name",
-			},
-
-			wantError: false,
-			wantValid: false,
-		},
-		{
-			name: "CAPI cluster label is missing",
-			currentData: &kubeconfigData{
-				serverURL:   "https://test.cluster.io",
-				serverCA:    "ABC",
-				clusterName: "c-1234xyz",
-				token:       fmt.Sprintf("%s:%s", token.Name, tokenKey),
-			},
-			wantData: &kubeconfigData{
-				serverURL:   "https://test.cluster.io",
-				serverCA:    "ABC",
-				clusterName: "c-1234xyz",
-			},
-			storedToken:       &token,
-			cluster:           &cluster,
-			invalidKubeconfig: true,
-			secretLabels:      map[string]string{},
-
-			wantError: false,
 			wantValid: false,
 		},
 		{
@@ -348,9 +254,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken:      &token,
 			cluster:          &cluster,
 			invalidServerURL: true,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: true,
 			wantValid: false,
@@ -369,9 +272,6 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: hashToken(&token, true),
 			cluster:     &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
 
 			wantError: true,
 			wantValid: false,
@@ -388,10 +288,7 @@ func Test_kubeConfigValid(t *testing.T) {
 				serverCA:    "ABC",
 				clusterName: "c-1234abc",
 			},
-			cluster: &cluster,
-			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
-			},
+			cluster:         &cluster,
 			tokenCacheError: fmt.Errorf("server unavailable"),
 
 			wantError: true,
@@ -452,7 +349,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			m := Manager{
 				tokensCache: mockCache,
 			}
-			isError, isValid := m.kubeConfigValid(kcData, test.cluster, test.wantData.serverURL, test.wantData.serverCA, test.wantData.clusterName, test.secretLabels)
+			isError, isValid := m.kubeConfigValid(kcData, test.cluster, test.wantData.serverURL, test.wantData.serverCA, test.wantData.clusterName)
 			require.Equal(t, test.wantError, isError)
 			require.Equal(t, test.wantValid, isValid)
 		})


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/42402

Reverts rancher/rancher#42318

The PR needs to be rebased -- it was referring to constants that are undefined:
```
# github.com/rancher/rancher/pkg/provisioningv2/kubeconfig
pkg/provisioningv2/kubeconfig/manager.go:294:59: undefined: capi.ClusterLabelName
pkg/provisioningv2/kubeconfig/manager.go:380:10: undefined: capi.ClusterLabelName
```