### PR TITLE
fix cluster name and description cannot be updated

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -302,6 +302,13 @@ func mgmtClusterName() (string, error) {
 func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus, spec v3.ClusterSpec) ([]runtime.Object, v1.ClusterStatus, error) {
 	spec.DisplayName = cluster.Name
 	spec.Description = cluster.Annotations["field.cattle.io/description"]
+
+	mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
+	if err == nil {
+		spec.DisplayName = mgmtCluster.Spec.DisplayName
+		spec.Description = mgmtCluster.Spec.Description
+	}
+
 	spec.DefaultPodSecurityPolicyTemplateName = cluster.Spec.DefaultPodSecurityPolicyTemplateName
 	spec.DefaultPodSecurityAdmissionConfigurationTemplateName = cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
 	spec.DefaultClusterRoleForProjectMembers = cluster.Spec.DefaultClusterRoleForProjectMembers


### PR DESCRIPTION
## [[BUG] - Updating existing cluster name does not work](https://github.com/rancher/rancher/issues/41029)
 
## Problem
User cannot rename imported cluster or cluster description. Because the clusters.provisioning.cattle.io/v1's hook cluster create will overwrite the change.
 
## Solution
check if the mgmtCluster exist, if exist using the exist display name and description instead of overwriting them. 
