### PR TITLE
Revert "Replace multierror.Append with errors.Join (#45344)"

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -23,6 +22,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-colorable"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/v2/pkg/signals"
@@ -69,15 +69,15 @@ func main() {
 			var bindingErr error
 			err = clean.DuplicateBindings(nil)
 			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
+				bindingErr = multierror.Append(bindingErr, err)
 			}
 			err = clean.OrphanBindings(nil)
 			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
+				bindingErr = multierror.Append(bindingErr, err)
 			}
 			err = clean.OrphanCatalogBindings(nil)
 			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
+				bindingErr = multierror.Append(bindingErr, err)
 			}
 			err = bindingErr
 		} else if os.Getenv("AD_GUID_CLEANUP") == "true" {

--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/google/go-containerregistry v0.15.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/heptio/authenticator v0.0.0-20180409043135-d282f87a1972
 	github.com/manicminer/hamilton v0.46.0
@@ -226,7 +227,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20210315223345-82c243799c99 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/fs v0.1.0 // indirect

--- a/pkg/agent/clean/dupe_bindings.go
+++ b/pkg/agent/clean/dupe_bindings.go
@@ -13,13 +13,13 @@ package clean
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/go-multierror"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
@@ -181,25 +181,25 @@ func (bc *dupeBindingsCleanup) cleanObjectDuplicates(bindingType string, newLabe
 
 			crbs, err := bc.clusterRoleBindings.List(metav1.ListOptions{LabelSelector: label})
 			if err != nil {
-				returnErr = errors.Join(returnErr, err)
+				returnErr = multierror.Append(returnErr, err)
 			}
 
 			if len(crbs.Items) > 1 {
 				CRBduplicates += len(crbs.Items) - 1
 				if err := bc.dedupeCRB(crbs.Items); err != nil {
-					returnErr = errors.Join(returnErr, err)
+					returnErr = multierror.Append(returnErr, err)
 				}
 			}
 
 			roleBindings, err := bc.roleBindings.List("", metav1.ListOptions{LabelSelector: label})
 			if err != nil {
-				returnErr = errors.Join(returnErr, err)
+				returnErr = multierror.Append(returnErr, err)
 			}
 
 			if len(roleBindings.Items) > 1 {
 				roleDuplicates, err := bc.dedupeRB(roleBindings.Items)
 				if err != nil {
-					returnErr = errors.Join(returnErr, err)
+					returnErr = multierror.Append(returnErr, err)
 				}
 				RBDupes += roleDuplicates
 			}

--- a/pkg/agent/clean/orphan_bindings.go
+++ b/pkg/agent/clean/orphan_bindings.go
@@ -10,9 +10,9 @@ package clean
 
 import (
 	"context"
-	"errors"
 	"os"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/controllers/management/auth/globalroles"
 	mgmt "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
@@ -155,7 +155,7 @@ func (bc *orphanBindingsCleanup) cleanOrphans(dryRun bool) error {
 			logrus.Infof("[%v] deleting orphaned binding: %s/%s", orphanBindingsOperation, rb.Namespace, rb.Name)
 			err := bc.roleBindings.Delete(rb.Namespace, rb.Name, &metav1.DeleteOptions{})
 			if err != nil && !k8serrors.IsNotFound(err) {
-				returnErr = errors.Join(returnErr, err)
+				returnErr = multierror.Append(returnErr, err)
 			}
 		}
 	}

--- a/pkg/auth/api/secrets/cleanup.go
+++ b/pkg/auth/api/secrets/cleanup.go
@@ -1,9 +1,9 @@
 package secrets
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/catalog/utils"
@@ -28,14 +28,14 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 	for _, field := range fields {
 		err := common.DeleteSecret(secretInterface, config.Type, field)
 		if err != nil && !apierrors.IsNotFound(err) {
-			result = errors.Join(result, err)
+			result = multierror.Append(result, err)
 		}
 	}
 
 	if utils.Contains(tokens.PerUserCacheProviders, config.Name) {
 		err := CleanupOAuthTokens(secretInterface, config.Name)
 		if err != nil {
-			result = errors.Join(result, err)
+			result = multierror.Append(result, err)
 		}
 	}
 
@@ -44,7 +44,7 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 			for _, field := range slice {
 				err := common.DeleteSecret(secretInterface, config.Type, field)
 				if err != nil && !apierrors.IsNotFound(err) {
-					result = errors.Join(result, err)
+					result = multierror.Append(result, err)
 				}
 			}
 		}
@@ -53,7 +53,7 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 	for _, secretName := range NameToFields[config.Name] {
 		err := common.DeleteSecret(secretInterface, config.Name, secretName)
 		if err != nil && !apierrors.IsNotFound(err) {
-			result = errors.Join(result, err)
+			result = multierror.Append(result, err)
 		}
 	}
 	return result
@@ -75,7 +75,7 @@ func CleanupOAuthTokens(secretInterface corev1.SecretInterface, key string) erro
 		if _, keyPresent := secret.Data[key]; keyPresent {
 			err := secretInterface.DeleteNamespaced(tokens.SecretNamespace, secret.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
-				result = errors.Join(result, err)
+				result = multierror.Append(result, err)
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -1,10 +1,11 @@
 package auth
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/controllers/management/authprovisioningv2"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -134,7 +135,7 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding)
 		return binding, nil
 	}
 
-	return nil, fmt.Errorf("Binding %v has no subject", binding.Name)
+	return nil, errors.Errorf("Binding %v has no subject", binding.Name)
 }
 
 // When a CRTB is created or updated, translate it into several k8s roles and bindings to actually enforce the RBAC
@@ -153,7 +154,7 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 		return err
 	}
 	if cluster == nil {
-		return fmt.Errorf("cannot create binding because cluster %v was not found", clusterName)
+		return errors.Errorf("cannot create binding because cluster %v was not found", clusterName)
 	}
 	// if roletemplate is not builtin, check if it's inherited/cloned
 	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName, clusterContext, 0)
@@ -255,7 +256,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
+			returnErr = multierror.Append(returnErr, retryErr)
 		}
 	}
 
@@ -280,7 +281,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
+			returnErr = multierror.Append(returnErr, retryErr)
 		}
 	}
 	if returnErr != nil {

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -1,11 +1,12 @@
 package globalroles
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	mgmtconv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -97,19 +98,19 @@ func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (runtime.Object, error
 	// set GR status to "in progress" while the underlying roles get added
 	err := gr.setGRAsInProgress(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.reconcileGlobalRole(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.reconcileCatalogRole(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.reconcileNamespacedRoles(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj)
 	if err != nil {
@@ -117,7 +118,7 @@ func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (runtime.Object, error
 	}
 	err = gr.setGRAsCompleted(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	return obj, returnError
 }
@@ -134,19 +135,19 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 	// set GR status to "in progress" while the underlying roles get added
 	err := gr.setGRAsInProgress(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.reconcileGlobalRole(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.reconcileCatalogRole(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.reconcileNamespacedRoles(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	err = gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj)
 	if err != nil {
@@ -154,7 +155,7 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 	}
 	err = gr.setGRAsCompleted(obj)
 	if err != nil {
-		returnError = errors.Join(returnError, err)
+		returnError = multierror.Append(returnError, err)
 	}
 	return nil, returnError
 }
@@ -177,7 +178,7 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) er
 			logrus.Infof("[%v] Updating clusterRole %v. GlobalRole rules have changed. Have: %+v. Want: %+v", grController, clusterRole.Name, clusterRole.Rules, globalRole.Rules)
 			if _, err := gr.crClient.Update(clusterRole); err != nil {
 				addCondition(globalRole, condition, FailedToUpdateClusterRole, crName, err)
-				return fmt.Errorf("couldn't update ClusterRole %v: %w", clusterRole.Name, err)
+				return errors.Wrapf(err, "couldn't update ClusterRole %v", clusterRole.Name)
 			}
 		}
 		addCondition(globalRole, condition, ClusterRoleExists, crName, nil)
@@ -323,7 +324,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			addCondition(globalRole, condition, NamespaceNotFound, roleName, fmt.Errorf("namespace %s not found", ns))
 			continue
 		} else if err != nil {
-			returnError = errors.Join(returnError, fmt.Errorf("couldn't get namespace %s: %w", ns, err))
+			returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't get namespace %s", ns))
 			addCondition(globalRole, condition, FailedToGetNamespace, roleName, err)
 			continue
 		}
@@ -332,7 +333,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 		role, err := gr.rLister.Get(ns, roleName)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				returnError = errors.Join(returnError, err)
+				returnError = multierror.Append(returnError, err)
 				addCondition(globalRole, condition, FailedToGetRole, roleName, err)
 				continue
 			}
@@ -370,7 +371,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			}
 
 			if !apierrors.IsAlreadyExists(err) {
-				returnError = errors.Join(returnError, err)
+				returnError = multierror.Append(returnError, err)
 				addCondition(globalRole, condition, FailedToCreateRole, roleName, err)
 				continue
 			}
@@ -378,7 +379,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			// In the case that the role already exists, we get it and check that the rules are correct
 			role, err = gr.rLister.Get(ns, roleName)
 			if err != nil {
-				returnError = errors.Join(returnError, err)
+				returnError = multierror.Append(returnError, err)
 				addCondition(globalRole, condition, FailedToGetRole, roleName, err)
 				continue
 			}
@@ -401,7 +402,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 
 			_, err := gr.rClient.Update(newRole)
 			if err != nil {
-				returnError = errors.Join(returnError, err)
+				returnError = multierror.Append(returnError, err)
 				addCondition(globalRole, condition, FailedToUpdateRole, roleName, err)
 				continue
 			}
@@ -412,12 +413,12 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 	// get all the roles claiming to be owned by this GR and remove any that shouldn't exist
 	r, err := labels.NewRequirement(grOwnerLabel, selection.Equals, []string{globalRoleName})
 	if err != nil {
-		return errors.Join(returnError, fmt.Errorf("couldn't create label: %s: %w", grOwnerLabel, err))
+		return multierror.Append(returnError, errors.Wrapf(err, "couldn't create label: %s", grOwnerLabel))
 	}
 
 	roles, err := gr.rLister.List("", labels.NewSelector().Add(*r))
 	if err != nil {
-		return errors.Join(returnError, fmt.Errorf("couldn't list roles with label %s : %s: %w", grOwnerLabel, globalRoleName, err))
+		return multierror.Append(returnError, errors.Wrapf(err, "couldn't list roles with label %s : %s", grOwnerLabel, globalRoleName))
 	}
 
 	// After creating/updating all Roles, if the number of RBs with the grOwnerLabel is the same as
@@ -425,7 +426,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 	if len(roleUIDs) != len(roles) {
 		err = gr.purgeInvalidNamespacedRoles(roles, roleUIDs)
 		if err != nil {
-			returnError = errors.Join(returnError, err)
+			returnError = multierror.Append(returnError, err)
 		}
 	}
 	return returnError
@@ -438,7 +439,7 @@ func (gr *globalRoleLifecycle) purgeInvalidNamespacedRoles(roles []*v1.Role, uid
 		if _, ok := uids[r.UID]; !ok {
 			err := gr.rClient.DeleteNamespaced(r.Namespace, r.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				returnError = errors.Join(returnError, fmt.Errorf("couldn't delete role %s: %w", r.Name, err))
+				returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't delete role %s", r.Name))
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/project_cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster_handler.go
@@ -3,12 +3,13 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	"github.com/rancher/norman/condition"
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -150,17 +151,17 @@ func (l *projectLifecycle) Remove(obj *apisv3.Project) (runtime.Object, error) {
 	set := labels.Set{rbac.RestrictedAdminProjectRoleBinding: "true"}
 	rbs, err := l.mgr.rbLister.List(obj.Name, labels.SelectorFromSet(set))
 	if err != nil {
-		returnErr = errors.Join(returnErr, err)
+		returnErr = multierror.Append(returnErr, err)
 	}
 	for _, rb := range rbs {
 		err := l.mgr.roleBindings.DeleteNamespaced(obj.Name, rb.Name, &v1.DeleteOptions{})
 		if err != nil {
-			returnErr = errors.Join(returnErr, err)
+			returnErr = multierror.Append(returnErr, err)
 		}
 	}
 	err = l.mgr.deleteNamespace(obj, projectRemoveController)
 	if err != nil {
-		returnErr = errors.Join(returnErr, err)
+		returnErr = multierror.Append(returnErr, err)
 	}
 	return obj, returnErr
 }
@@ -240,21 +241,21 @@ func (l *clusterLifecycle) Remove(obj *apisv3.Cluster) (runtime.Object, error) {
 	set := labels.Set{rbac.RestrictedAdminClusterRoleBinding: "true"}
 	rbs, err := l.mgr.rbLister.List(obj.Name, labels.SelectorFromSet(set))
 	if err != nil {
-		returnErr = errors.Join(returnErr, err)
+		returnErr = multierror.Append(returnErr, err)
 	}
 	for _, rb := range rbs {
 		err := l.mgr.roleBindings.DeleteNamespaced(obj.Name, rb.Name, &v1.DeleteOptions{})
 		if err != nil {
-			returnErr = errors.Join(returnErr, err)
+			returnErr = multierror.Append(returnErr, err)
 		}
 	}
 	err = l.mgr.deleteSystemProject(obj, clusterRemoveController)
 	if err != nil {
-		returnErr = errors.Join(returnErr, err)
+		returnErr = multierror.Append(returnErr, err)
 	}
 	err = l.mgr.deleteNamespace(obj, clusterRemoveController)
 	if err != nil {
-		returnErr = errors.Join(returnErr, err)
+		returnErr = multierror.Append(returnErr, err)
 	}
 	return obj, returnErr
 }
@@ -358,7 +359,7 @@ func (m *mgr) deleteSystemProject(cluster *apisv3.Cluster, controller string) er
 		logrus.Infof("[%s] Deleting project %s", controller, p.Name)
 		err = bypassClient.Delete(p.Namespace, p.Name, nil)
 		if err != nil {
-			deleteError = errors.Join(deleteError, fmt.Errorf("[%s] failed to delete project '%s/%s': %w", controller, p.Namespace, p.Name, err))
+			deleteError = multierror.Append(deleteError, fmt.Errorf("[%s] failed to delete project '%s/%s': %w", controller, p.Namespace, p.Name, err))
 		}
 	}
 	return deleteError
@@ -564,7 +565,7 @@ func (m *mgr) reconcileResourceToNamespace(obj runtime.Object, controller string
 				},
 			}, v1.CreateOptions{})
 			if err != nil {
-				return obj, condition.Error("NamespaceCreationFailure", fmt.Errorf("failed to create namespace for %v %v: %w", t.GetKind(), o.GetName(), err))
+				return obj, condition.Error("NamespaceCreationFailure", errors.Wrapf(err, "failed to create namespace for %v %v", t.GetKind(), o.GetName()))
 			}
 		}
 

--- a/pkg/controllers/management/auth/role_template_lifecycle.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle.go
@@ -1,9 +1,9 @@
 package auth
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -134,7 +134,7 @@ func (rtl *roleTemplateLifecycle) removeAuthV2Roles(roleTemplate *v3.RoleTemplat
 		err := rtl.roles.DeleteNamespaced(role.Namespace, role.Name, &metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			// Combine all errors so we try our best to delete everything in the first run
-			returnErr = errors.Join(returnErr, err)
+			returnErr = multierror.Append(returnErr, err)
 		}
 	}
 

--- a/pkg/controllers/management/restrictedadminrbac/cluster.go
+++ b/pkg/controllers/management/restrictedadminrbac/cluster.go
@@ -1,9 +1,9 @@
 package restrictedadminrbac
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/v2/pkg/name"
@@ -32,7 +32,7 @@ func (r *rbaccontroller) clusterOwnerSync(_ string, grb *v3.GlobalRoleBinding) (
 		crtbName := name.SafeConcatName(rbac.GetGRBTargetKey(grb), "restricted-admin", "cluster-owner")
 		_, err := r.crtbCache.Get(cluster.Name, crtbName)
 		if err != nil && !apierrors.IsNotFound(err) {
-			retError = errors.Join(retError, fmt.Errorf("failed to get CRTB '%s' from cache: %w", crtbName, err))
+			retError = multierror.Append(retError, fmt.Errorf("failed to get CRTB '%s' from cache: %w", crtbName, err))
 			continue
 		}
 		if err == nil {
@@ -72,7 +72,7 @@ func (r *rbaccontroller) clusterOwnerSync(_ string, grb *v3.GlobalRoleBinding) (
 
 		_, err = r.crtbCtrl.Create(&crtb)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
-			retError = errors.Join(retError, fmt.Errorf("failed to create a CRTB '%s': %w", crtbName, err))
+			retError = multierror.Append(retError, fmt.Errorf("failed to create a CRTB '%s': %w", crtbName, err))
 			continue
 		}
 	}

--- a/pkg/controllers/management/restrictedadminrbac/fleet.go
+++ b/pkg/controllers/management/restrictedadminrbac/fleet.go
@@ -1,10 +1,10 @@
 package restrictedadminrbac
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
+	"github.com/hashicorp/go-multierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	"github.com/rancher/rancher/pkg/rbac"
@@ -44,7 +44,7 @@ func (r *rbaccontroller) ensureRestricedAdminForFleet(key string, obj *v3.Global
 			continue
 		}
 		if err := r.ensureRolebinding(fw.Name, rbac.GetGRBSubject(obj), obj); err != nil {
-			finalError = errors.Join(finalError, err)
+			finalError = multierror.Append(finalError, err)
 		}
 	}
 	return obj, finalError

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -2,12 +2,12 @@ package management
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"reflect"
 	"sort"
 	"sync"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/rbac"
@@ -134,7 +134,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	// TODO enable when groups are "in". they need to be self-service
 
 	if err := rb.reconcileGlobalRoles(wrangler.Mgmt.GlobalRole()); err != nil {
-		return "", fmt.Errorf("problem reconciling global roles: %w", err)
+		return "", errors.Wrap(err, "problem reconciling global roles")
 	}
 
 	// RoleTemplates to be used inside of clusters
@@ -424,7 +424,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	//	addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch")
 
 	if err := rb.reconcileRoleTemplates(wrangler.Mgmt.RoleTemplate()); err != nil {
-		return "", fmt.Errorf("problem reconciling role templates: %w", err)
+		return "", errors.Wrap(err, "problem reconciling role templates")
 	}
 
 	adminName, err := BootstrapAdmin(wrangler)
@@ -506,7 +506,7 @@ func BootstrapAdmin(management *wrangler.Context) (string, error) {
 		// Config map does not exist and no users, attempt to create the default admin user
 		bootstrapPassword, bootstrapPasswordIsGenerated, err := GetBootstrapPassword(context.TODO(), management.K8s.CoreV1().Secrets(cattleNamespace))
 		if err != nil {
-			return "", fmt.Errorf("failed to retrieve bootstrap password: %w", err)
+			return "", errors.Wrap(err, "failed to retrieve bootstrap password")
 		}
 
 		bootstrapPasswordHash, _ := bcrypt.GenerateFromPassword([]byte(bootstrapPassword), bcrypt.DefaultCost)
@@ -522,7 +522,7 @@ func BootstrapAdmin(management *wrangler.Context) (string, error) {
 			MustChangePassword: bootstrapPasswordIsGenerated || bootstrapPassword == "admin",
 		})
 		if err != nil && !apierrors.IsAlreadyExists(err) {
-			return "", fmt.Errorf("can not ensure admin user exists: %w", err)
+			return "", errors.Wrap(err, "can not ensure admin user exists")
 		}
 		if err == nil {
 			var serverURL string
@@ -700,7 +700,7 @@ func addClusterRoleForNamespacedCRDs(management *config.ManagementContext) error
 		},
 	}
 	if err := createOrUpdateClusterRole(management, cr); err != nil {
-		returnErr = errors.Join(returnErr, err)
+		returnErr = multierror.Append(returnErr, err)
 	}
 
 	// ProjectCRDsClusterRole is a CR containing rules for granting restricted-admins access to all CRDs that can be created in a
@@ -723,7 +723,7 @@ func addClusterRoleForNamespacedCRDs(management *config.ManagementContext) error
 		},
 	}
 	if err := createOrUpdateClusterRole(management, cr); err != nil {
-		returnErr = errors.Join(returnErr, err)
+		returnErr = multierror.Append(returnErr, err)
 	}
 	return returnErr
 }

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -3,7 +3,6 @@ package rancher
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	responsewriter "github.com/rancher/apiserver/pkg/middleware"
 	"github.com/rancher/rancher/pkg/api/norman/customization/kontainerdriver"
 	"github.com/rancher/rancher/pkg/api/norman/customization/podsecuritypolicytemplate"
@@ -563,13 +564,13 @@ func migrateEncryptionConfig(ctx context.Context, restConfig *rest.Config) error
 
 			clusterBytes, err := rawDynamicCluster.MarshalJSON()
 			if err != nil {
-				return false, fmt.Errorf("error trying to Marshal dynamic cluster: %w", err)
+				return false, errors.Wrap(err, "error trying to Marshal dynamic cluster")
 			}
 
 			var cluster *v3.Cluster
 
 			if err := json.Unmarshal(clusterBytes, &cluster); err != nil {
-				return false, fmt.Errorf("error trying to Unmarshal dynamicCluster into v3 cluster: %w", err)
+				return false, errors.Wrap(err, "error trying to Unmarshal dynamicCluster into v3 cluster")
 			}
 
 			if cluster.Annotations == nil {
@@ -592,7 +593,7 @@ func migrateEncryptionConfig(ctx context.Context, restConfig *rest.Config) error
 			return false, err
 		})
 		if err != nil {
-			allErrors = errors.Join(err, allErrors)
+			allErrors = multierror.Append(err, allErrors)
 		}
 	}
 	return allErrors

--- a/tests/v2/codecoverage/agent/main.go
+++ b/tests/v2/codecoverage/agent/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -22,6 +21,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-colorable"
 	"github.com/rancher/rancher/pkg/agent/clean"
 	"github.com/rancher/rancher/pkg/agent/cluster"
@@ -80,15 +80,15 @@ func runAgent(ctx context.Context) {
 			var bindingErr error
 			err = clean.DuplicateBindings(nil)
 			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
+				bindingErr = multierror.Append(bindingErr, err)
 			}
 			err = clean.OrphanBindings(nil)
 			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
+				bindingErr = multierror.Append(bindingErr, err)
 			}
 			err = clean.OrphanCatalogBindings(nil)
 			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
+				bindingErr = multierror.Append(bindingErr, err)
 			}
 			err = bindingErr
 		} else {


### PR DESCRIPTION
Issue:
CI is failing across the v2.9 PRs. after https://github.com/rancher/rancher/pull/45344 was merged much after CI has passed on it and incompatible changes got into `release/v2.9` between CI pass and actual merge time.

Solution
This reverts commit https://github.com/rancher/rancher/commit/e7fe01a32, reversing changes made to https://github.com/rancher/rancher/commit/60d17a338ccfbe0ca9a7c45d40aa51bb734ac0a7.