### PR TITLE
feat: Add `podLabels` key for additional Pod labels in Deployment

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       labels:
         app: {{ template "rancher.fullname" . }}
         release: {{ .Release.Name }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: {{ template "rancher.fullname" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -118,6 +118,9 @@ priorityClassName: rancher-critical
 # Set pod resource requests/limits for Rancher.
 resources: {}
 
+#Set new pod labels not included in the selector
+podLabels: {}
+
 #
 # tls
 #   Where to offload the TLS/SSL encryption


### PR DESCRIPTION
## Problem

In certain contexts of label standardization or events related to labels, it is necessary to add additional labels to the Pod template that are not directly relevant to the selector.

This is why it is common to add the `podLabels` key to the values file.

## Solution

Add a `podLabels` key that allows adding labels to the deployment.

## Engineering Testing
### Manual Testing
Install the chart with the default values and verify that the key exists in the pod.