### PR TITLE
checking rancher settings are not empty

### DIFF
--- a/tests/v2/validation/charts/csp_test.go
+++ b/tests/v2/validation/charts/csp_test.go
@@ -1,0 +1,52 @@
+//go:build (infra.any || cluster.any || sanity || validation) && !stress && !extended
+
+package charts
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/kubectl"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+type CSPTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (c *CSPTestSuite) TearDownSuite() {
+	c.session.Cleanup()
+}
+
+func (c *CSPTestSuite) SetupSuite() {
+	c.session = session.NewSession()
+	client, err := rancher.NewClient("", c.session)
+	require.NoError(c.T(), err)
+	c.client = client
+}
+
+func (c *CSPTestSuite) TestCSPAdapterMinVersionNotEmpty() {
+	cmd := []string{"kubectl", "get", "setting", "csp-adapter-min-version", "-o", "yaml"}
+	resp, err := kubectl.Command(c.client, nil, localCluster, cmd, "")
+	require.NoError(c.T(), err)
+
+	var data map[string]interface{}
+	err = yaml.Unmarshal([]byte(resp), &data)
+	require.NoError(c.T(), err)
+
+	source, ok := data["source"].(string)
+	require.True(c.T(), ok, "source field should be a string")
+	require.Equal(c.T(), "env", source, "source field should be 'env'")
+
+	value, ok := data["value"].(string)
+	require.True(c.T(), ok, "value field should be a string")
+	require.NotEmpty(c.T(), value, "value field should not be empty")
+}
+
+func TestCSPTestSuite(t *testing.T) {
+	suite.Run(t, new(CSPTestSuite))
+}

--- a/tests/v2/validation/charts/fleet_test.go
+++ b/tests/v2/validation/charts/fleet_test.go
@@ -1,0 +1,52 @@
+//go:build (infra.any || cluster.any || sanity || validation) && !stress && !extended
+
+package charts
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/kubectl"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+type FleetTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (f *FleetTestSuite) TearDownSuite() {
+	f.session.Cleanup()
+}
+
+func (f *FleetTestSuite) SetupSuite() {
+	f.session = session.NewSession()
+	client, err := rancher.NewClient("", f.session)
+	require.NoError(f.T(), err)
+	f.client = client
+}
+
+func (f *FleetTestSuite) TestFleetVersionNotEmpty() {
+	cmd := []string{"kubectl", "get", "setting", "fleet-version", "-o", "yaml"}
+	resp, err := kubectl.Command(f.client, nil, localCluster, cmd, "")
+	require.NoError(f.T(), err)
+
+	var data map[string]interface{}
+	err = yaml.Unmarshal([]byte(resp), &data)
+	require.NoError(f.T(), err)
+
+	source, ok := data["source"].(string)
+	require.True(f.T(), ok, "source field should be a string")
+	require.Equal(f.T(), "env", source, "source field should be 'env'")
+
+	value, ok := data["value"].(string)
+	require.True(f.T(), ok, "value field should be a string")
+	require.NotEmpty(f.T(), value, "value field should not be empty")
+}
+
+func TestFleetTestSuite(t *testing.T) {
+	suite.Run(t, new(FleetTestSuite))
+}


### PR DESCRIPTION
## Issue: [#45418](https://github.com/rancher/rancher/issues/45418)

## Problem
In Rancher versions 2.8.3 the webhook version, fleet version, and CSP adapter version are not set in the settings or environment variables. This allows these components to be automatically upgraded to newer versions, which may cause unexpected behavior or compatibility issues.

## Solution
From a QA perspective, the solution involves adding automated tests to ensure that the versions for the webhook, fleet, and CSP adapter not empty. The tests will:
- Retrieve the settings for `rancher-webhook-version`, `fleet-version`, and `csp-adapter-min-version` using `kubectl` commands.
- Verify that the `source` field in the settings is set to `"env"`.
- Check that the `value` field in the settings is not empty.

These tests will be implemented using the Go testing framework and the Rancher Shepherd library to interact with Rancher and perform the necessary assertions.

## Testing
### Automated Testing
* Test types added/modified:
   * Validation (Go Framework)
Summary:
- Updated a test suite `WebhookTestSuite` with a new test case `TestWebhookPinnedVersion` to verify that the webhook version is pinned and not empty in the settings and environment variable.
- Added a test suite `CSPTestSuite` with a test case `TestCSPAdapterMinVersionNotEmpty` to ensure that the CSP adapter minimum version is set and not empty in the settings and environment variable.
- Added a test suite `FleetTestSuite` with a test case `TestFleetVersionNotEmpty` to check that the fleet version is specified and not empty in the settings and environment variable.