### PR TITLE
[v2.9] Tag update for May patches 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.3.2
-	github.com/rancher/rke v1.6.0-rc4
+	github.com/rancher/rke v1.6.0-rc5
 	github.com/rancher/steve v0.0.0-20240510175329-a9bf8c7e9cad
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler/v2 v2.2.0-rc6

--- a/go.sum
+++ b/go.sum
@@ -1876,8 +1876,8 @@ github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVf
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa/go.mod h1:NP3xboG+t2p+XMnrcrJ/L384Ki0Cp3Pww/X+vm5Jcy0=
 github.com/rancher/remotedialer v0.3.2 h1:kstZbRwPS5gPWpGg8VjEHT2poHtArs+Fc317YM8JCzU=
 github.com/rancher/remotedialer v0.3.2/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
-github.com/rancher/rke v1.6.0-rc4 h1:5ytUakGjIGGwtG0uB6bnwMqbRoK8ZPiOAUPl6V12Vcw=
-github.com/rancher/rke v1.6.0-rc4/go.mod h1:zvrJLRt+84/OMOUO0AggVqW6a2RSsTjqSW8bDHvKgME=
+github.com/rancher/rke v1.6.0-rc5 h1:SY2w9o7JRQMxVUncRDkAis7kaGE6DmcH3tliETV1Vfw=
+github.com/rancher/rke v1.6.0-rc5/go.mod h1:zvrJLRt+84/OMOUO0AggVqW6a2RSsTjqSW8bDHvKgME=
 github.com/rancher/shepherd v0.0.0-20240531204216-65735fd062c1 h1:n3vLfDGyfgc2caVQ9zdul38/7iqdagg72+rVEPoe1Hg=
 github.com/rancher/shepherd v0.0.0-20240531204216-65735fd062c1/go.mod h1:+1bFZ/XBf8QOu0WLJIJ+2K2x/GIjHgKXKCUfm7PnCz4=
 github.com/rancher/steve v0.0.0-20240510175329-a9bf8c7e9cad h1:vlLNRXBJXQL5HAPzYpZc/w43mqfMnp2w+KX/4KrudqA=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20231017140638-93432f288e79
 	github.com/rancher/gke-operator v1.9.0-rc.4
 	github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b
-	github.com/rancher/rke v1.6.0-rc4
+	github.com/rancher/rke v1.6.0-rc5
 	github.com/rancher/wrangler/v2 v2.2.0-rc6
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.29.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -100,8 +100,8 @@ github.com/rancher/lasso v0.0.0-20240424194130-d87ec407d941 h1:1SvuoeyfANRvKVJUS
 github.com/rancher/lasso v0.0.0-20240424194130-d87ec407d941/go.mod h1:pYKOe2r/5O0w3ypoc7xHQF8LvWCp5PsNRea1Jpq3vBU=
 github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b h1:9k8VOhRi6ZIZ8rBlQG8ON9eG+ukqThNeXJ2e6CzZO78=
 github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b/go.mod h1:xJ0CLJUG9SvtyuPzPA8ATh2SjwiqXGfE+pPh7uVhJzQ=
-github.com/rancher/rke v1.6.0-rc4 h1:5ytUakGjIGGwtG0uB6bnwMqbRoK8ZPiOAUPl6V12Vcw=
-github.com/rancher/rke v1.6.0-rc4/go.mod h1:zvrJLRt+84/OMOUO0AggVqW6a2RSsTjqSW8bDHvKgME=
+github.com/rancher/rke v1.6.0-rc5 h1:SY2w9o7JRQMxVUncRDkAis7kaGE6DmcH3tliETV1Vfw=
+github.com/rancher/rke v1.6.0-rc5/go.mod h1:zvrJLRt+84/OMOUO0AggVqW6a2RSsTjqSW8bDHvKgME=
 github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=
 github.com/rancher/wrangler v1.1.1/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
 github.com/rancher/wrangler/v2 v2.2.0-rc6 h1:jMsuOVl7nBuQ5QJqdNkR2yHEf1+rYiyd1gN+mQzIcag=


### PR DESCRIPTION
### Updates

- Update rke tag from `v1.6.0-rc4` to `v1.6.0-rc5`


### Related
- https://github.com/rancher/rancher/issues/45567