### PR TITLE
[2.7] Add validation tests to enable and disable Open LDAP

### DIFF
--- a/tests/v2/validation/auth/openldap.go
+++ b/tests/v2/validation/auth/openldap.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v3 "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	passwordSecretID                     = "cattle-global-data/openldapconfig-serviceaccountpassword"
+	authProvCleanupAnnotationKey         = "management.cattle.io/auth-provider-cleanup"
+	authProvCleanupAnnotationValLocked   = "rancher-locked"
+	authProvCleanupAnnotationValUnlocked = "unlocked"
+)
+
+func waitUntilAnnotationIsUpdated(client *rancher.Client) (*v3.AuthConfig, error) {
+	ldapConfig, err := client.Management.AuthConfig.ByID("openldap")
+	if err != nil {
+		return nil, err
+	}
+
+	err = kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, 2*time.Minute, true, func(context.Context) (bool, error) {
+		newLDAPConfig, err := client.Management.AuthConfig.ByID("openldap")
+		if err != nil {
+			return false, nil
+		}
+
+		if ldapConfig.Annotations[authProvCleanupAnnotationKey] != newLDAPConfig.Annotations[authProvCleanupAnnotationKey] {
+			ldapConfig = newLDAPConfig
+			return true, nil
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ldapConfig, err
+}

--- a/tests/v2/validation/auth/openldap_test.go
+++ b/tests/v2/validation/auth/openldap_test.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/auth"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type OLDAPTestSuite struct {
+	suite.Suite
+	session *session.Session
+	client  *rancher.Client
+}
+
+func (o *OLDAPTestSuite) TearDownSuite() {
+	o.session.Cleanup()
+}
+
+func (o *OLDAPTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	o.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(o.T(), err)
+
+	o.client = client
+}
+
+func (o *OLDAPTestSuite) TestEnableOLDAP() {
+	subSession := o.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := o.client.WithSession(subSession)
+	require.NoError(o.T(), err)
+
+	a, err := auth.NewAuth(client, subSession)
+	require.NoError(o.T(), err)
+
+	err = a.OLDAP.Enable()
+	require.NoError(o.T(), err)
+
+	ldapConfig, err := client.Management.AuthConfig.ByID("openldap")
+	require.NoError(o.T(), err)
+
+	assert.Truef(o.T(), ldapConfig.Enabled, "Checking if Open LDAP is enabled")
+
+	assert.Equalf(o.T(), authProvCleanupAnnotationValUnlocked, ldapConfig.Annotations[authProvCleanupAnnotationKey], "Checking if annotation set to unlocked for LDAP Auth Config")
+
+	passwordSecretResp, err := client.Steve.SteveType("secret").ByID(passwordSecretID)
+	assert.NoErrorf(o.T(), err, "Checking open LDAP config secret for service account password exists")
+
+	passwordSecret := &corev1.Secret{}
+	err = v1.ConvertToK8sType(passwordSecretResp.JSONResp, passwordSecret)
+	require.NoError(o.T(), err)
+
+	assert.Equal(o.T(), a.OLDAP.Config.ServiceAccount.Password, string(passwordSecret.Data["serviceaccountpassword"]), "Checking if serviceaccountpassword value is equal to the given")
+}
+
+func (o *OLDAPTestSuite) TestDisableOLDAP() {
+	subSession := o.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := o.client.WithSession(subSession)
+	require.NoError(o.T(), err)
+
+	a, err := auth.NewAuth(client, subSession)
+	require.NoError(o.T(), err)
+
+	err = a.OLDAP.Disable()
+	require.NoError(o.T(), err)
+
+	ldapConfig, err := waitUntilAnnotationIsUpdated(client)
+	require.NoError(o.T(), err)
+
+	assert.Falsef(o.T(), ldapConfig.Enabled, "Checking if Open LDAP is disabled")
+
+	assert.Equalf(o.T(), authProvCleanupAnnotationValLocked, ldapConfig.Annotations[authProvCleanupAnnotationKey], "Checking if annotation set to locked for LDAP Auth Config")
+
+	_, err = client.Steve.SteveType("secret").ByID(passwordSecretID)
+	assert.Errorf(o.T(), err, "Checking open LDAP config secret for service account password does not exist")
+	assert.Containsf(o.T(), err.Error(), "404", "Checking open LDAP config secret for service account password error returns 404")
+}
+
+func TestOLDAPSuite(t *testing.T) {
+	suite.Run(t, new(OLDAPTestSuite))
+}


### PR DESCRIPTION
## Issue:  https://github.com/rancher/qa-tasks/issues/1283
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Open LDAP enabling and disabling happen manually.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Adds initial Open LDAP test cases that enable and disable the auth.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)
