### PR TITLE
Fix a bug related to minwait being greated than maxwait even with valid inputs

### DIFF
--- a/pkg/controllers/dashboard/helm/repo_oci.go
+++ b/pkg/controllers/dashboard/helm/repo_oci.go
@@ -376,30 +376,37 @@ func calculateBackoff(clusterRepo *catalog.ClusterRepo, policy retryPolicy) time
 func getRetryPolicy(clusterRepo *catalog.ClusterRepo) (retryPolicy, error) {
 	// Default Values for exponentialBackOff function which is used
 	// to retry an HTTP call when 429 response code is hit.
-	var retryPolicy = retryPolicy{
+	defaultRetryPolicy := retryPolicy{
 		MinWait:  1 * time.Second,
 		MaxWait:  5 * time.Second,
 		MaxRetry: 5,
 	}
-	if clusterRepo.Spec.ExponentialBackOffValues != nil {
-		if clusterRepo.Spec.ExponentialBackOffValues.MaxRetries > 0 {
-			retryPolicy.MaxRetry = clusterRepo.Spec.ExponentialBackOffValues.MaxRetries
-		}
-		if clusterRepo.Spec.ExponentialBackOffValues.MinWait >= 0 {
-			if clusterRepo.Spec.ExponentialBackOffValues.MinWait < 1 {
-				return retryPolicy, errors.New("minWait should be at least 1 second")
-			}
 
-			retryPolicy.MinWait = time.Duration(clusterRepo.Spec.ExponentialBackOffValues.MinWait) * time.Second
+	if clusterRepo.Spec.ExponentialBackOffValues != nil {
+		// Set MaxRetry if specified and valid
+		if clusterRepo.Spec.ExponentialBackOffValues.MaxRetries > 0 {
+			defaultRetryPolicy.MaxRetry = clusterRepo.Spec.ExponentialBackOffValues.MaxRetries
 		}
+
+		// Set MinWait if specified and valid
+		if clusterRepo.Spec.ExponentialBackOffValues.MinWait >= 1 {
+			defaultRetryPolicy.MinWait = time.Duration(clusterRepo.Spec.ExponentialBackOffValues.MinWait) * time.Second
+		} else if clusterRepo.Spec.ExponentialBackOffValues.MinWait != 0 {
+			return defaultRetryPolicy, errors.New("minWait must be at least 1 second")
+		}
+
+		// Set MaxWait if specified and valid
 		if clusterRepo.Spec.ExponentialBackOffValues.MaxWait > 0 {
-			retryPolicy.MaxWait = time.Duration(clusterRepo.Spec.ExponentialBackOffValues.MaxWait) * time.Second
-		}
-		if clusterRepo.Spec.ExponentialBackOffValues.MaxWait < clusterRepo.Spec.ExponentialBackOffValues.MinWait {
-			return retryPolicy, errors.New("maxWait should be greater than minWait")
+			defaultRetryPolicy.MaxWait = time.Duration(clusterRepo.Spec.ExponentialBackOffValues.MaxWait) * time.Second
 		}
 	}
-	return retryPolicy, nil
+
+	// Ensure MaxWait is not less than MinWait
+	if defaultRetryPolicy.MaxWait < defaultRetryPolicy.MinWait {
+		return defaultRetryPolicy, errors.New("maxWait must be greater than or equal to minWait")
+	}
+
+	return defaultRetryPolicy, nil
 }
 
 // shouldSkip checks certain conditions to see if the handler should be skipped.

--- a/pkg/controllers/dashboard/helm/repo_oci_test.go
+++ b/pkg/controllers/dashboard/helm/repo_oci_test.go
@@ -257,6 +257,16 @@ func TestGetRetryPolicy(t *testing.T) {
 		expectedErr         string
 	}{
 		{
+			name:          "Should return default values if exponentailBackOffValues is empty",
+			backOffValues: &catalog.ExponentialBackOffValues{},
+			expectedRetryPolicy: retryPolicy{
+				MinWait:  1 * time.Second,
+				MaxWait:  5 * time.Second,
+				MaxRetry: 5,
+			},
+			expectedErr: "",
+		},
+		{
 			name:          "Should return default values if values are not present",
 			backOffValues: nil,
 			expectedRetryPolicy: retryPolicy{
@@ -309,7 +319,7 @@ func TestGetRetryPolicy(t *testing.T) {
 		{
 			name: "minWait should be atleast 1 second",
 			backOffValues: &catalog.ExponentialBackOffValues{
-				MinWait: 0,
+				MinWait: -1,
 				MaxWait: 5,
 			},
 			expectedRetryPolicy: retryPolicy{
@@ -317,7 +327,7 @@ func TestGetRetryPolicy(t *testing.T) {
 				MaxWait:  5 * time.Second,
 				MaxRetry: 5,
 			},
-			expectedErr: "minWait should be at least 1 second",
+			expectedErr: "minWait must be at least 1 second",
 		},
 		{
 			name: "maxWait cant be less than minWait",
@@ -330,7 +340,7 @@ func TestGetRetryPolicy(t *testing.T) {
 				MaxWait:  20 * time.Second,
 				MaxRetry: 5,
 			},
-			expectedErr: "maxWait should be greater than minWait",
+			expectedErr: "maxWait must be greater than or equal to minWait",
 		},
 	}
 


### PR DESCRIPTION
Please see the issue for more details 

### Summary 

- There was a bug identified by the UI team when sending only Minwait as 1 in exponentialbackoff values is causing error whereas ideally it shouldn't