### PR TITLE
Replace multierror.Append with errors.Join

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -22,7 +23,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-colorable"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/v3/pkg/signals"
@@ -69,15 +69,15 @@ func main() {
 			var bindingErr error
 			err = clean.DuplicateBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanCatalogBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = bindingErr
 		} else if os.Getenv("AD_GUID_CLEANUP") == "true" {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -66,20 +66,11 @@ func main() {
 		if os.Getenv("CLUSTER_CLEANUP") == "true" {
 			err = clean.Cluster()
 		} else if os.Getenv("BINDING_CLEANUP") == "true" {
-			var bindingErr error
-			err = clean.DuplicateBindings(nil)
-			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
-			}
-			err = clean.OrphanBindings(nil)
-			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
-			}
-			err = clean.OrphanCatalogBindings(nil)
-			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
-			}
-			err = bindingErr
+			err = errors.Join(
+				clean.DuplicateBindings(nil),
+				clean.OrphanBindings(nil),
+				clean.OrphanCatalogBindings(nil),
+			)
 		} else if os.Getenv("AD_GUID_CLEANUP") == "true" {
 			dryrun := os.Getenv("DRY_RUN") == "true"
 			deleteMissingUsers := os.Getenv("AD_DELETE_MISSING_GUID_USERS") == "true"

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,6 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/heptio/authenticator v0.0.0-20180409043135-d282f87a1972
 	github.com/mattn/go-colorable v0.1.13
@@ -236,6 +235,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect

--- a/pkg/agent/clean/dupe_bindings.go
+++ b/pkg/agent/clean/dupe_bindings.go
@@ -13,13 +13,13 @@ package clean
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
@@ -181,25 +181,25 @@ func (bc *dupeBindingsCleanup) cleanObjectDuplicates(bindingType string, newLabe
 
 			crbs, err := bc.clusterRoleBindings.List(metav1.ListOptions{LabelSelector: label})
 			if err != nil {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 			}
 
 			if len(crbs.Items) > 1 {
 				CRBduplicates += len(crbs.Items) - 1
 				if err := bc.dedupeCRB(crbs.Items); err != nil {
-					returnErr = multierror.Append(returnErr, err)
+					returnErr = errors.Join(returnErr, err)
 				}
 			}
 
 			roleBindings, err := bc.roleBindings.List("", metav1.ListOptions{LabelSelector: label})
 			if err != nil {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 			}
 
 			if len(roleBindings.Items) > 1 {
 				roleDuplicates, err := bc.dedupeRB(roleBindings.Items)
 				if err != nil {
-					returnErr = multierror.Append(returnErr, err)
+					returnErr = errors.Join(returnErr, err)
 				}
 				RBDupes += roleDuplicates
 			}

--- a/pkg/agent/clean/dupe_bindings.go
+++ b/pkg/agent/clean/dupe_bindings.go
@@ -180,27 +180,19 @@ func (bc *dupeBindingsCleanup) cleanObjectDuplicates(bindingType string, newLabe
 			var CRBduplicates, RBDupes int
 
 			crbs, err := bc.clusterRoleBindings.List(metav1.ListOptions{LabelSelector: label})
-			if err != nil {
-				returnErr = errors.Join(returnErr, err)
-			}
+			returnErr = errors.Join(returnErr, err)
 
 			if len(crbs.Items) > 1 {
 				CRBduplicates += len(crbs.Items) - 1
-				if err := bc.dedupeCRB(crbs.Items); err != nil {
-					returnErr = errors.Join(returnErr, err)
-				}
+				returnErr = errors.Join(returnErr, bc.dedupeCRB(crbs.Items))
 			}
 
 			roleBindings, err := bc.roleBindings.List("", metav1.ListOptions{LabelSelector: label})
-			if err != nil {
-				returnErr = errors.Join(returnErr, err)
-			}
+			returnErr = errors.Join(returnErr, err)
 
 			if len(roleBindings.Items) > 1 {
 				roleDuplicates, err := bc.dedupeRB(roleBindings.Items)
-				if err != nil {
-					returnErr = errors.Join(returnErr, err)
-				}
+				returnErr = errors.Join(returnErr, err)
 				RBDupes += roleDuplicates
 			}
 			if CRBduplicates > 0 || RBDupes > 0 {

--- a/pkg/agent/clean/orphan_bindings.go
+++ b/pkg/agent/clean/orphan_bindings.go
@@ -10,9 +10,9 @@ package clean
 
 import (
 	"context"
+	"errors"
 	"os"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/controllers/management/auth/globalroles"
 	mgmt "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
@@ -155,7 +155,7 @@ func (bc *orphanBindingsCleanup) cleanOrphans(dryRun bool) error {
 			logrus.Infof("[%v] deleting orphaned binding: %s/%s", orphanBindingsOperation, rb.Namespace, rb.Name)
 			err := bc.roleBindings.Delete(rb.Namespace, rb.Name, &metav1.DeleteOptions{})
 			if err != nil && !k8serrors.IsNotFound(err) {
-				returnErr = multierror.Append(returnErr, err)
+				returnErr = errors.Join(returnErr, err)
 			}
 		}
 	}

--- a/pkg/auth/api/secrets/cleanup.go
+++ b/pkg/auth/api/secrets/cleanup.go
@@ -34,9 +34,7 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 
 	if utils.Contains(tokens.PerUserCacheProviders, config.Name) {
 		err := CleanupOAuthTokens(secretInterface, config.Name)
-		if err != nil {
-			result = errors.Join(result, err)
-		}
+		result = errors.Join(result, err)
 	}
 
 	if fieldsMap, ok := SubTypeToFields[config.Type]; ok {

--- a/pkg/auth/api/secrets/cleanup.go
+++ b/pkg/auth/api/secrets/cleanup.go
@@ -1,9 +1,9 @@
 package secrets
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/catalog/utils"
@@ -28,14 +28,14 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 	for _, field := range fields {
 		err := common.DeleteSecret(secretInterface, config.Type, field)
 		if err != nil && !apierrors.IsNotFound(err) {
-			result = multierror.Append(result, err)
+			result = errors.Join(result, err)
 		}
 	}
 
 	if utils.Contains(tokens.PerUserCacheProviders, config.Name) {
 		err := CleanupOAuthTokens(secretInterface, config.Name)
 		if err != nil {
-			result = multierror.Append(result, err)
+			result = errors.Join(result, err)
 		}
 	}
 
@@ -44,7 +44,7 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 			for _, field := range slice {
 				err := common.DeleteSecret(secretInterface, config.Type, field)
 				if err != nil && !apierrors.IsNotFound(err) {
-					result = multierror.Append(result, err)
+					result = errors.Join(result, err)
 				}
 			}
 		}
@@ -53,7 +53,7 @@ func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.Aut
 	for _, secretName := range NameToFields[config.Name] {
 		err := common.DeleteSecret(secretInterface, config.Name, secretName)
 		if err != nil && !apierrors.IsNotFound(err) {
-			result = multierror.Append(result, err)
+			result = errors.Join(result, err)
 		}
 	}
 	return result
@@ -75,7 +75,7 @@ func CleanupOAuthTokens(secretInterface corev1.SecretInterface, key string) erro
 		if _, keyPresent := secret.Data[key]; keyPresent {
 			err := secretInterface.DeleteNamespaced(tokens.SecretNamespace, secret.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
-				result = multierror.Append(result, err)
+				result = errors.Join(result, err)
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -133,7 +133,7 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding)
 		return binding, nil
 	}
 
-	return nil, fmt.Errorf("Binding %v has no subject", binding.Name)
+	return nil, fmt.Errorf("ClusterRoleTemplateBinding %v has no subject", binding.Name)
 }
 
 // When a CRTB is created or updated, translate it into several k8s roles and bindings to actually enforce the RBAC
@@ -253,9 +253,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			_, err := c.crbClient.Update(crbToUpdate)
 			return err
 		})
-		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
-		}
+		returnErr = errors.Join(returnErr, retryErr)
 	}
 
 	set = map[string]string{string(binding.UID): CrtbInProjectBindingOwner}
@@ -278,9 +276,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			_, err := c.rbClient.Update(rbToUpdate)
 			return err
 		})
-		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
-		}
+		returnErr = errors.Join(returnErr, retryErr)
 	}
 	if returnErr != nil {
 		return returnErr

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -1,11 +1,10 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/controllers/management/authprovisioningv2"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -134,7 +133,7 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding)
 		return binding, nil
 	}
 
-	return nil, errors.Errorf("Binding %v has no subject", binding.Name)
+	return nil, fmt.Errorf("Binding %v has no subject", binding.Name)
 }
 
 // When a CRTB is created or updated, translate it into several k8s roles and bindings to actually enforce the RBAC
@@ -153,7 +152,7 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 		return err
 	}
 	if cluster == nil {
-		return errors.Errorf("cannot create binding because cluster %v was not found", clusterName)
+		return fmt.Errorf("cannot create binding because cluster %v was not found", clusterName)
 	}
 	// if roletemplate is not builtin, check if it's inherited/cloned
 	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName, clusterContext, 0)
@@ -255,7 +254,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 
@@ -280,7 +279,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 	if returnErr != nil {

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -1,12 +1,11 @@
 package globalroles
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	mgmtconv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -99,27 +98,27 @@ func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (runtime.Object, error
 	// set GR status to "in progress" while the underlying roles get added
 	err := gr.setGRAsInProgress(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileGlobalRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileCatalogRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileNamespacedRoles(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.setGRAsCompleted(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	return obj, returnError
 }
@@ -136,27 +135,27 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 	// set GR status to "in progress" while the underlying roles get added
 	err := gr.setGRAsInProgress(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileGlobalRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileCatalogRole(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.reconcileNamespacedRoles(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	err = gr.setGRAsCompleted(obj)
 	if err != nil {
-		returnError = multierror.Append(returnError, err)
+		returnError = errors.Join(returnError, err)
 	}
 	return nil, returnError
 }
@@ -180,7 +179,7 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) er
 			logrus.Infof("[%v] Updating clusterRole %v. GlobalRole rules have changed. Have: %+v. Want: %+v", grController, clusterRole.Name, clusterRole.Rules, globalRole.Rules)
 			if _, err := gr.crClient.Update(clusterRole); err != nil {
 				addCondition(globalRole, condition, FailedToUpdateClusterRole, crName, err)
-				return errors.Wrapf(err, "couldn't update ClusterRole %v", clusterRole.Name)
+				return fmt.Errorf("couldn't update ClusterRole %v: %w", clusterRole.Name, err)
 			}
 		}
 		addCondition(globalRole, condition, ClusterRoleExists, crName, nil)
@@ -326,7 +325,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			addCondition(globalRole, condition, NamespaceNotFound, roleName, fmt.Errorf("namespace %s not found", ns))
 			continue
 		} else if err != nil {
-			returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't get namespace %s", ns))
+			returnError = errors.Join(returnError, fmt.Errorf("couldn't get namespace %s: %w", ns, err))
 			addCondition(globalRole, condition, FailedToGetNamespace, roleName, err)
 			continue
 		}
@@ -335,7 +334,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 		role, err := gr.rLister.Get(ns, roleName)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToGetRole, roleName, err)
 				continue
 			}
@@ -373,7 +372,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			}
 
 			if !apierrors.IsAlreadyExists(err) {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToCreateRole, roleName, err)
 				continue
 			}
@@ -381,7 +380,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 			// In the case that the role already exists, we get it and check that the rules are correct
 			role, err = gr.rLister.Get(ns, roleName)
 			if err != nil {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToGetRole, roleName, err)
 				continue
 			}
@@ -404,7 +403,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 
 			_, err := gr.rClient.Update(newRole)
 			if err != nil {
-				returnError = multierror.Append(returnError, err)
+				returnError = errors.Join(returnError, err)
 				addCondition(globalRole, condition, FailedToUpdateRole, roleName, err)
 				continue
 			}
@@ -415,12 +414,12 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 	// get all the roles claiming to be owned by this GR and remove any that shouldn't exist
 	r, err := labels.NewRequirement(grOwnerLabel, selection.Equals, []string{globalRoleName})
 	if err != nil {
-		return multierror.Append(returnError, errors.Wrapf(err, "couldn't create label: %s", grOwnerLabel))
+		return errors.Join(returnError, fmt.Errorf("couldn't create label: %s: %w", grOwnerLabel, err))
 	}
 
 	roles, err := gr.rLister.List("", labels.NewSelector().Add(*r))
 	if err != nil {
-		return multierror.Append(returnError, errors.Wrapf(err, "couldn't list roles with label %s : %s", grOwnerLabel, globalRoleName))
+		return errors.Join(returnError, fmt.Errorf("couldn't list roles with label %s : %s: %w", grOwnerLabel, globalRoleName, err))
 	}
 
 	// After creating/updating all Roles, if the number of RBs with the grOwnerLabel is the same as
@@ -428,7 +427,7 @@ func (gr *globalRoleLifecycle) reconcileNamespacedRoles(globalRole *v3.GlobalRol
 	if len(roleUIDs) != len(roles) {
 		err = gr.purgeInvalidNamespacedRoles(roles, roleUIDs)
 		if err != nil {
-			returnError = multierror.Append(returnError, err)
+			returnError = errors.Join(returnError, err)
 		}
 	}
 	return returnError
@@ -441,7 +440,7 @@ func (gr *globalRoleLifecycle) purgeInvalidNamespacedRoles(roles []*v1.Role, uid
 		if _, ok := uids[r.UID]; !ok {
 			err := gr.rClient.DeleteNamespaced(r.Namespace, r.Name, &metav1.DeleteOptions{})
 			if err != nil {
-				returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't delete role %s", r.Name))
+				returnError = errors.Join(returnError, fmt.Errorf("couldn't delete role %s: %w", r.Name, err))
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -87,76 +87,39 @@ type globalRoleLifecycle struct {
 }
 
 func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (runtime.Object, error) {
-	var returnError error
-
 	// ObjectMeta.Generation does not get updated when the Status is updated.
 	// If only the status has been updated and we have finished updating the status (status.Summary != "InProgress")
 	// we don't need to perform a reconcile as nothing has changed.
 	if obj.Status.ObservedGeneration == obj.ObjectMeta.Generation && obj.Status.Summary != SummaryInProgress {
 		return obj, nil
 	}
-	// set GR status to "in progress" while the underlying roles get added
-	err := gr.setGRAsInProgress(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.reconcileGlobalRole(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.reconcileCatalogRole(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.reconcileNamespacedRoles(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.setGRAsCompleted(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
+	returnError := errors.Join(
+		gr.setGRAsInProgress(obj), // set GR status to "in progress" while the underlying roles get added
+		gr.reconcileGlobalRole(obj),
+		gr.reconcileCatalogRole(obj),
+		gr.reconcileNamespacedRoles(obj),
+		gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj),
+		gr.setGRAsCompleted(obj),
+	)
 	return obj, returnError
 }
 
 func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, error) {
-	var returnError error
-
 	// ObjectMeta.Generation does not get updated when the Status is updated.
 	// If only the status has been updated and we have finished updating the status (status.Summary != "InProgress")
 	// we don't need to perform a reconcile as nothing has changed.
 	if obj.Status.ObservedGeneration == obj.ObjectMeta.Generation && obj.Status.Summary != SummaryInProgress {
 		return obj, nil
 	}
-	// set GR status to "in progress" while the underlying roles get added
-	err := gr.setGRAsInProgress(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.reconcileGlobalRole(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.reconcileCatalogRole(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.reconcileNamespacedRoles(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = gr.setGRAsCompleted(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
+
+	returnError := errors.Join(
+		gr.setGRAsInProgress(obj), // set GR status to "in progress" while the underlying roles get added
+		gr.reconcileGlobalRole(obj),
+		gr.reconcileCatalogRole(obj),
+		gr.reconcileNamespacedRoles(obj),
+		gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj),
+		gr.setGRAsCompleted(obj),
+	)
 	return nil, returnError
 }
 

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -103,44 +103,22 @@ type globalRoleBindingLifecycle struct {
 }
 
 func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
-	var returnError error
-	err := grb.reconcileClusterPermissions(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = grb.reconcileGlobalRoleBinding(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = grb.reconcileNamespacedRoleBindings(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = grb.fleetPermissionsHandler.reconcileFleetWorkspacePermissionsBindings(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
+	returnError := errors.Join(
+		grb.reconcileClusterPermissions(obj),
+		grb.reconcileGlobalRoleBinding(obj),
+		grb.reconcileNamespacedRoleBindings(obj),
+		grb.fleetPermissionsHandler.reconcileFleetWorkspacePermissionsBindings(obj),
+	)
 	return obj, returnError
 }
 
 func (grb *globalRoleBindingLifecycle) Updated(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
-	var returnError error
-	err := grb.reconcileClusterPermissions(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = grb.reconcileGlobalRoleBinding(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = grb.reconcileNamespacedRoleBindings(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
-	err = grb.fleetPermissionsHandler.reconcileFleetWorkspacePermissionsBindings(obj)
-	if err != nil {
-		returnError = errors.Join(returnError, err)
-	}
+	returnError := errors.Join(
+		grb.reconcileClusterPermissions(obj),
+		grb.reconcileGlobalRoleBinding(obj),
+		grb.reconcileNamespacedRoleBindings(obj),
+		grb.fleetPermissionsHandler.reconcileFleetWorkspacePermissionsBindings(obj),
+	)
 	return obj, returnError
 }
 

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -1,12 +1,11 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac"
@@ -460,7 +459,7 @@ func (m *manager) removeAuthV2Permissions(setID string, owner runtime.Object) er
 		err := m.rbClient.DeleteNamespaced(binding.Namespace, binding.Name, &metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			// Combine all errors so we try our best to delete everything in the first run
-			returnErr = multierror.Append(returnErr, err)
+			returnErr = errors.Join(returnErr, err)
 		}
 	}
 
@@ -718,7 +717,7 @@ func (m *manager) reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs m
 	// If the namespace is terminating don't create RoleBindings
 	ns, err := m.nsLister.Get("", namespace)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't get namespace %v", namespace)
+		return fmt.Errorf("couldn't get namespace %v: %w", namespace, err)
 	}
 	if ns.Status.Phase == corev1.NamespaceTerminating {
 		logrus.Warnf("[%v] Namespace %v is terminating, not creating roleBindings", m.controller, namespace)
@@ -827,7 +826,7 @@ func (m *manager) reconcileManagementPlaneRole(namespace string, resourceToVerbs
 	// If the namespace is terminating, don't create a Role in it
 	ns, err := m.nsLister.Get("", namespace)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't get namespace %v", namespace)
+		return fmt.Errorf("couldn't get namespace %v: %w", namespace, err)
 	}
 	if ns.Status.Phase == corev1.NamespaceTerminating {
 		logrus.Warnf("[%v] Namespace %v is terminating, not creating role", m.controller, namespace)
@@ -847,7 +846,7 @@ func (m *manager) reconcileManagementPlaneRole(namespace string, resourceToVerbs
 		Rules: rules,
 	})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return errors.Wrapf(err, "couldn't create role %v", rt.Name)
+		return fmt.Errorf("couldn't create role %v: %w", rt.Name, err)
 	}
 
 	return nil
@@ -859,10 +858,10 @@ func (m *manager) gatherRoleTemplates(rt *v3.RoleTemplate, roleTemplates map[str
 	for _, rtName := range rt.RoleTemplateNames {
 		subRT, err := m.rtLister.Get("", rtName)
 		if err != nil {
-			return errors.Wrapf(err, "couldn't get RoleTemplate %s", rtName)
+			return fmt.Errorf("couldn't get RoleTemplate %s: %w", rtName, err)
 		}
 		if err := m.gatherRoleTemplates(subRT, roleTemplates); err != nil {
-			return errors.Wrapf(err, "couldn't gather RoleTemplate %s", rtName)
+			return fmt.Errorf("couldn't gather RoleTemplate %s: %w", rtName, err)
 		}
 	}
 

--- a/pkg/controllers/management/auth/project_cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster_handler.go
@@ -149,19 +149,14 @@ func (l *projectLifecycle) Remove(obj *apisv3.Project) (runtime.Object, error) {
 	var returnErr error
 	set := labels.Set{rbac.RestrictedAdminProjectRoleBinding: "true"}
 	rbs, err := l.mgr.rbLister.List(obj.Name, labels.SelectorFromSet(set))
-	if err != nil {
-		returnErr = errors.Join(returnErr, err)
-	}
+	returnErr = errors.Join(returnErr, err)
+
 	for _, rb := range rbs {
 		err := l.mgr.roleBindings.DeleteNamespaced(obj.Name, rb.Name, &v1.DeleteOptions{})
-		if err != nil {
-			returnErr = errors.Join(returnErr, err)
-		}
-	}
-	err = l.mgr.deleteNamespace(obj, projectRemoveController)
-	if err != nil {
 		returnErr = errors.Join(returnErr, err)
 	}
+	err = l.mgr.deleteNamespace(obj, projectRemoveController)
+	returnErr = errors.Join(returnErr, err)
 	return obj, returnErr
 }
 
@@ -239,23 +234,16 @@ func (l *clusterLifecycle) Remove(obj *apisv3.Cluster) (runtime.Object, error) {
 	var returnErr error
 	set := labels.Set{rbac.RestrictedAdminClusterRoleBinding: "true"}
 	rbs, err := l.mgr.rbLister.List(obj.Name, labels.SelectorFromSet(set))
-	if err != nil {
-		returnErr = errors.Join(returnErr, err)
-	}
+	returnErr = errors.Join(returnErr, err)
+
 	for _, rb := range rbs {
 		err := l.mgr.roleBindings.DeleteNamespaced(obj.Name, rb.Name, &v1.DeleteOptions{})
-		if err != nil {
-			returnErr = errors.Join(returnErr, err)
-		}
-	}
-	err = l.mgr.deleteSystemProject(obj, clusterRemoveController)
-	if err != nil {
 		returnErr = errors.Join(returnErr, err)
 	}
-	err = l.mgr.deleteNamespace(obj, clusterRemoveController)
-	if err != nil {
-		returnErr = errors.Join(returnErr, err)
-	}
+	returnErr = errors.Join(
+		l.mgr.deleteSystemProject(obj, clusterRemoveController),
+		l.mgr.deleteNamespace(obj, clusterRemoveController),
+	)
 	return obj, returnErr
 }
 

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -269,9 +269,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 			_, err := p.crbClient.Update(crbToUpdate)
 			return err
 		})
-		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
-		}
+		returnErr = errors.Join(returnErr, retryErr)
 	}
 
 	for _, prtbLabel := range []string{MembershipBindingOwner, PrtbInClusterBindingOwner} {
@@ -294,9 +292,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 				_, err := p.rbClient.Update(rbToUpdate)
 				return err
 			})
-			if retryErr != nil {
-				returnErr = errors.Join(returnErr, retryErr)
-			}
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 	if returnErr != nil {

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -1,11 +1,10 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/controllers/management/authprovisioningv2"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -88,7 +87,7 @@ func (p *prtbLifecycle) Updated(obj *v3.ProjectRoleTemplateBinding) (runtime.Obj
 func (p *prtbLifecycle) Remove(obj *v3.ProjectRoleTemplateBinding) (runtime.Object, error) {
 	parts := strings.SplitN(obj.ProjectName, ":", 2)
 	if len(parts) < 2 {
-		return nil, errors.Errorf("cannot determine project and cluster from %v", obj.ProjectName)
+		return nil, fmt.Errorf("cannot determine project and cluster from %v", obj.ProjectName)
 	}
 	clusterName := parts[0]
 	rtbNsAndName := pkgrbac.GetRTBLabel(obj.ObjectMeta)
@@ -139,7 +138,7 @@ func (p *prtbLifecycle) reconcileSubject(binding *v3.ProjectRoleTemplateBinding)
 		return binding, nil
 	}
 
-	return nil, errors.Errorf("Binding %v has no subject", binding.Name)
+	return nil, fmt.Errorf("Binding %v has no subject", binding.Name)
 }
 
 // When a PRTB is created or updated, translate it into several k8s roles and bindings to actually enforce the RBAC.
@@ -154,7 +153,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 
 	parts := strings.SplitN(binding.ProjectName, ":", 2)
 	if len(parts) < 2 {
-		return errors.Errorf("cannot determine project and cluster from %v", binding.ProjectName)
+		return fmt.Errorf("cannot determine project and cluster from %v", binding.ProjectName)
 	}
 
 	clusterName := parts[0]
@@ -164,7 +163,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 		return err
 	}
 	if proj == nil {
-		return errors.Errorf("cannot create binding because project %v was not found", projectName)
+		return fmt.Errorf("cannot create binding because project %v was not found", projectName)
 	}
 
 	cluster, err := p.clusterLister.Get("", clusterName)
@@ -172,7 +171,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 		return err
 	}
 	if cluster == nil {
-		return errors.Errorf("cannot create binding because cluster %v was not found", clusterName)
+		return fmt.Errorf("cannot create binding because cluster %v was not found", clusterName)
 	}
 
 	roleName := strings.ToLower(fmt.Sprintf("%v-clustermember", clusterName))
@@ -271,7 +270,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 
@@ -296,7 +295,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 				return err
 			})
 			if retryErr != nil {
-				returnErr = multierror.Append(returnErr, retryErr)
+				returnErr = errors.Join(returnErr, retryErr)
 			}
 		}
 	}

--- a/pkg/controllers/management/auth/role_template_lifecycle.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle.go
@@ -1,9 +1,9 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -134,7 +134,7 @@ func (rtl *roleTemplateLifecycle) removeAuthV2Roles(roleTemplate *v3.RoleTemplat
 		err := rtl.roles.DeleteNamespaced(role.Namespace, role.Name, &metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			// Combine all errors so we try our best to delete everything in the first run
-			returnErr = multierror.Append(returnErr, err)
+			returnErr = errors.Join(returnErr, err)
 		}
 	}
 

--- a/pkg/controllers/management/restrictedadminrbac/cluster.go
+++ b/pkg/controllers/management/restrictedadminrbac/cluster.go
@@ -1,9 +1,9 @@
 package restrictedadminrbac
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/v3/pkg/name"
@@ -32,7 +32,7 @@ func (r *rbaccontroller) clusterOwnerSync(_ string, grb *v3.GlobalRoleBinding) (
 		crtbName := name.SafeConcatName(rbac.GetGRBTargetKey(grb), "restricted-admin", "cluster-owner")
 		_, err := r.crtbCache.Get(cluster.Name, crtbName)
 		if err != nil && !apierrors.IsNotFound(err) {
-			retError = multierror.Append(retError, fmt.Errorf("failed to get CRTB '%s' from cache: %w", crtbName, err))
+			retError = errors.Join(retError, fmt.Errorf("failed to get CRTB '%s' from cache: %w", crtbName, err))
 			continue
 		}
 		if err == nil {
@@ -72,7 +72,7 @@ func (r *rbaccontroller) clusterOwnerSync(_ string, grb *v3.GlobalRoleBinding) (
 
 		_, err = r.crtbCtrl.Create(&crtb)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
-			retError = multierror.Append(retError, fmt.Errorf("failed to create a CRTB '%s': %w", crtbName, err))
+			retError = errors.Join(retError, fmt.Errorf("failed to create a CRTB '%s': %w", crtbName, err))
 			continue
 		}
 	}

--- a/pkg/controllers/management/restrictedadminrbac/fleet.go
+++ b/pkg/controllers/management/restrictedadminrbac/fleet.go
@@ -43,9 +43,8 @@ func (r *rbaccontroller) ensureRestricedAdminForFleet(key string, obj *v3.Global
 		if fw.Name == fleetconst.ClustersLocalNamespace {
 			continue
 		}
-		if err := r.ensureRolebinding(fw.Name, rbac.GetGRBSubject(obj), obj); err != nil {
-			finalError = errors.Join(finalError, err)
-		}
+		err := r.ensureRolebinding(fw.Name, rbac.GetGRBSubject(obj), obj)
+		finalError = errors.Join(finalError, err)
 	}
 	return obj, finalError
 }

--- a/pkg/controllers/management/restrictedadminrbac/fleet.go
+++ b/pkg/controllers/management/restrictedadminrbac/fleet.go
@@ -1,10 +1,10 @@
 package restrictedadminrbac
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
-	"github.com/hashicorp/go-multierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	"github.com/rancher/rancher/pkg/rbac"
@@ -44,7 +44,7 @@ func (r *rbaccontroller) ensureRestricedAdminForFleet(key string, obj *v3.Global
 			continue
 		}
 		if err := r.ensureRolebinding(fw.Name, rbac.GetGRBSubject(obj), obj); err != nil {
-			finalError = multierror.Append(finalError, err)
+			finalError = errors.Join(finalError, err)
 		}
 	}
 	return obj, finalError

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -151,9 +151,7 @@ func (c *crtbLifecycle) reconcileCRTBUserClusterLabels(binding *v3.ClusterRoleTe
 			_, err := c.crbClient.Update(crbToUpdate)
 			return err
 		})
-		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
-		}
+		returnErr = errors.Join(returnErr, retryErr)
 	}
 	if returnErr != nil {
 		return returnErr

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -1,8 +1,9 @@
 package rbac
 
 import (
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
+
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
@@ -64,7 +65,7 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 
 	rt, err := c.rtLister.Get("", binding.RoleTemplateName)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't get role template %v", binding.RoleTemplateName)
+		return fmt.Errorf("couldn't get role template %v: %w", binding.RoleTemplateName, err)
 	}
 
 	roles := map[string]*v3.RoleTemplate{}
@@ -73,16 +74,16 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 	}
 
 	if err := c.m.ensureRoles(roles); err != nil {
-		return errors.Wrap(err, "couldn't ensure roles")
+		return fmt.Errorf("couldn't ensure roles: %w", err)
 	}
 
 	if err := c.m.ensureClusterBindings(roles, binding); err != nil {
-		return errors.Wrapf(err, "couldn't ensure cluster bindings %v", binding)
+		return fmt.Errorf("couldn't ensure cluster bindings %v: %w", binding, err)
 	}
 
 	if binding.UserName != "" {
 		if err := c.m.ensureServiceAccountImpersonator(binding.UserName); err != nil {
-			return errors.Wrapf(err, "couldn't ensure service account impersonator")
+			return fmt.Errorf("couldn't ensure service account impersonator: %w", err)
 		}
 	}
 
@@ -93,19 +94,19 @@ func (c *crtbLifecycle) ensureCRTBDelete(binding *v3.ClusterRoleTemplateBinding)
 	set := labels.Set(map[string]string{rtbOwnerLabel: pkgrbac.GetRTBLabel(binding.ObjectMeta)})
 	rbs, err := c.crbLister.List("", set.AsSelector())
 	if err != nil {
-		return errors.Wrapf(err, "couldn't list clusterrolebindings with selector %s", set.AsSelector())
+		return fmt.Errorf("couldn't list clusterrolebindings with selector %s: %w", set.AsSelector(), err)
 	}
 
 	for _, rb := range rbs {
 		if err := c.crbClient.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
-				return errors.Wrapf(err, "error deleting clusterrolebinding %v", rb.Name)
+				return fmt.Errorf("error deleting clusterrolebinding %v: %w", rb.Name, err)
 			}
 		}
 	}
 
 	if err := c.m.deleteServiceAccountImpersonator(binding.UserName); err != nil {
-		return errors.Wrap(err, "error deleting service account impersonator")
+		return fmt.Errorf("error deleting service account impersonator: %w", err)
 	}
 
 	return nil
@@ -151,7 +152,7 @@ func (c *crtbLifecycle) reconcileCRTBUserClusterLabels(binding *v3.ClusterRoleTe
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 	if returnErr != nil {

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -460,9 +460,7 @@ func (p *prtbLifecycle) reconcilePRTBUserClusterLabels(binding *v3.ProjectRoleTe
 			_, err := p.crbClient.Update(crbToUpdate)
 			return err
 		})
-		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
-		}
+		returnErr = errors.Join(returnErr, retryErr)
 	}
 
 	reqUpdatedOwnerLabel, err := labels.NewRequirement(rtbOwnerLabel, selection.DoesNotExist, []string{})
@@ -488,9 +486,7 @@ func (p *prtbLifecycle) reconcilePRTBUserClusterLabels(binding *v3.ProjectRoleTe
 			_, err := p.rbClient.Update(rbToUpdate)
 			return err
 		})
-		if retryErr != nil {
-			returnErr = errors.Join(returnErr, retryErr)
-		}
+		returnErr = errors.Join(returnErr, retryErr)
 	}
 
 	if returnErr != nil {

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -1,12 +1,11 @@
 package rbac
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/slice"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -127,7 +126,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 	}
 
 	if err := p.m.ensureRoles(roles); err != nil {
-		return errors.Wrap(err, "couldn't ensure roles")
+		return fmt.Errorf("couldn't ensure roles: %w", err)
 	}
 
 	for _, n := range namespaces {
@@ -174,7 +173,7 @@ func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding)
 	}
 
 	if err := p.m.deleteServiceAccountImpersonator(binding.UserName); err != nil {
-		return errors.Wrap(err, "error deleting service account impersonator")
+		return fmt.Errorf("error deleting service account impersonator: %w", err)
 	}
 
 	return p.reconcileProjectAccessToGlobalResourcesForDelete(binding)
@@ -302,7 +301,7 @@ func (m *manager) checkForGlobalResourceRules(role *v3.RoleTemplate, resource st
 // The roleName is used to find and create/update the relevant '<roleName>-promoted' ClusterRole.
 func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string, roleName string, newVerbs sets.Set[string], baseRule rbacv1.PolicyRule) (string, error) {
 	if roleName == "" {
-		return "", errors.New("cannot reconcile Role: missing roleName")
+		return "", fmt.Errorf("cannot reconcile Role: missing roleName")
 	}
 	roleName = roleName + "-promoted"
 
@@ -462,7 +461,7 @@ func (p *prtbLifecycle) reconcilePRTBUserClusterLabels(binding *v3.ProjectRoleTe
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 
@@ -490,7 +489,7 @@ func (p *prtbLifecycle) reconcilePRTBUserClusterLabels(binding *v3.ProjectRoleTe
 			return err
 		})
 		if retryErr != nil {
-			returnErr = multierror.Append(returnErr, retryErr)
+			returnErr = errors.Join(returnErr, retryErr)
 		}
 	}
 

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -711,9 +711,8 @@ func addClusterRoleForNamespacedCRDs(management *config.ManagementContext) error
 			},
 		},
 	}
-	if err := createOrUpdateClusterRole(management, cr); err != nil {
-		returnErr = errors.Join(returnErr, err)
-	}
+	err := createOrUpdateClusterRole(management, cr)
+	returnErr = errors.Join(returnErr, err)
 
 	// ProjectCRDsClusterRole is a CR containing rules for granting restricted-admins access to all CRDs that can be created in a
 	// v3.Cluster and v3.Project's namespace
@@ -734,9 +733,9 @@ func addClusterRoleForNamespacedCRDs(management *config.ManagementContext) error
 			},
 		},
 	}
-	if err := createOrUpdateClusterRole(management, cr); err != nil {
-		returnErr = errors.Join(returnErr, err)
-	}
+	err = createOrUpdateClusterRole(management, cr)
+	returnErr = errors.Join(returnErr, err)
+
 	return returnErr
 }
 

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -590,9 +590,7 @@ func migrateEncryptionConfig(ctx context.Context, restConfig *rest.Config) error
 			}
 			return false, err
 		})
-		if err != nil {
-			allErrors = errors.Join(err, allErrors)
-		}
+		allErrors = errors.Join(err, allErrors)
 	}
 	return allErrors
 }

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -3,6 +3,7 @@ package rancher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -10,8 +11,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	responsewriter "github.com/rancher/apiserver/pkg/middleware"
 	"github.com/rancher/rancher/pkg/api/norman/customization/kontainerdriver"
 	steveapi "github.com/rancher/rancher/pkg/api/steve"
@@ -563,13 +562,13 @@ func migrateEncryptionConfig(ctx context.Context, restConfig *rest.Config) error
 
 			clusterBytes, err := rawDynamicCluster.MarshalJSON()
 			if err != nil {
-				return false, errors.Wrap(err, "error trying to Marshal dynamic cluster")
+				return false, fmt.Errorf("error trying to Marshal dynamic cluster: %w", err)
 			}
 
 			var cluster *v3.Cluster
 
 			if err := json.Unmarshal(clusterBytes, &cluster); err != nil {
-				return false, errors.Wrap(err, "error trying to Unmarshal dynamicCluster into v3 cluster")
+				return false, fmt.Errorf("error trying to Unmarshal dynamicCluster into v3 cluster: %w", err)
 			}
 
 			if cluster.Annotations == nil {
@@ -592,7 +591,7 @@ func migrateEncryptionConfig(ctx context.Context, restConfig *rest.Config) error
 			return false, err
 		})
 		if err != nil {
-			allErrors = multierror.Append(err, allErrors)
+			allErrors = errors.Join(err, allErrors)
 		}
 	}
 	return allErrors

--- a/tests/v2/codecoverage/agent/main.go
+++ b/tests/v2/codecoverage/agent/main.go
@@ -77,12 +77,11 @@ func runAgent(ctx context.Context) {
 		if os.Getenv("CLUSTER_CLEANUP") == "true" {
 			err = clean.Cluster()
 		} else if os.Getenv("BINDING_CLEANUP") == "true" {
-			bindingErr := errors.Join(
+			err = errors.Join(
 				clean.DuplicateBindings(nil),
 				clean.OrphanBindings(nil),
 				clean.OrphanCatalogBindings(nil),
 			)
-			err = bindingErr
 		} else {
 			err = run(ctx)
 		}

--- a/tests/v2/codecoverage/agent/main.go
+++ b/tests/v2/codecoverage/agent/main.go
@@ -77,19 +77,11 @@ func runAgent(ctx context.Context) {
 		if os.Getenv("CLUSTER_CLEANUP") == "true" {
 			err = clean.Cluster()
 		} else if os.Getenv("BINDING_CLEANUP") == "true" {
-			var bindingErr error
-			err = clean.DuplicateBindings(nil)
-			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
-			}
-			err = clean.OrphanBindings(nil)
-			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
-			}
-			err = clean.OrphanCatalogBindings(nil)
-			if err != nil {
-				bindingErr = errors.Join(bindingErr, err)
-			}
+			bindingErr := errors.Join(
+				clean.DuplicateBindings(nil),
+				clean.OrphanBindings(nil),
+				clean.OrphanCatalogBindings(nil),
+			)
 			err = bindingErr
 		} else {
 			err = run(ctx)

--- a/tests/v2/codecoverage/agent/main.go
+++ b/tests/v2/codecoverage/agent/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-colorable"
 	"github.com/rancher/rancher/pkg/agent/clean"
 	"github.com/rancher/rancher/pkg/agent/cluster"
@@ -80,15 +80,15 @@ func runAgent(ctx context.Context) {
 			var bindingErr error
 			err = clean.DuplicateBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = clean.OrphanCatalogBindings(nil)
 			if err != nil {
-				bindingErr = multierror.Append(bindingErr, err)
+				bindingErr = errors.Join(bindingErr, err)
 			}
 			err = bindingErr
 		} else {


### PR DESCRIPTION
## Issue: redoes the work done in #45344 since that caused issues in the CI
 
## Problem
The package `go-multierror` from [here](https://github.com/hashicorp/go-multierror) uses the MPL 2.0 license, which is considered an incompatible license in rancher.  
 
## Solution
Multierrors can be replaced with `errors.Join` and get similar results. Multierror is formatted a little nicer, but both combine errors and can be checked for the existence of specific errors.

Here is an example of the formatting difference:
https://go.dev/play/p/qYefpBQ81GL

While I was working on removing `multierror`, I also replaced `https://github.com/pkg/errors` with the `errors` standard library. Specifically, I replaced instances of `errors.Wrap(err, "message")` with `fmt.Errorf("message: %w", err)`. Both wrap the error and create the same error message. The motivation behind this is that `https://github.com/pkg/errors` has been archived and hasn't received updates since 2020. In a future PR it should be completely removed from rancher.

It's still imported as an indirect requirement, but rancher no longer makes use of it directly.

## Testing
The existing unit tests pass. This does not change functionality, just how the errors are handled.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_