### PR TITLE
Reduce reliance on Git Mirror for CI tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -39,6 +39,7 @@ RUNARG="-run ${V2PROV_TEST_RUN_REGEX}"
 export DIST=${V2PROV_TEST_DIST}
 export SOME_K8S_VERSION=${SOME_K8S_VERSION}
 export TB_ORG=${TB_ORG}
+export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 
 eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
@@ -62,6 +63,12 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
   else
     export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.9/data/data.json | jq -r ".$DIST.channels[0].latest")
   fi
+fi
+
+if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
+# If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so GitHub is used instead of
+# the default `https://git.rancher.io/charts` to reduce the reliance and load on our Git mirror
+export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts
 fi
 
 echo "Starting rancher server for provisioning-tests using $SOME_K8S_VERSION"

--- a/scripts/test
+++ b/scripts/test
@@ -65,8 +65,8 @@ export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kon
 fi
 
 if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
-# If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so its used instead of default
-# `https://git.rancher.io/charts` to reduce reliance and load on our Git mirror
+# If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so GitHub is used instead of
+# the default `https://git.rancher.io/charts` to reduce the reliance and load on our Git mirror
 export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -42,6 +42,7 @@ fi
 export DIST=${TEST_DIST}
 export SOME_K8S_VERSION=${SOME_K8S_VERSION}
 export TB_ORG=${TB_ORG}
+export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 
 # Tell Rancher to use the recently-built Rancher cluster agent image. This image is built as part of CI and will be
 # copied to the in-cluster registry during test setup below.
@@ -61,6 +62,12 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
 # here for simplicity's sake, as it requires semver parsing & matching. The last release should
 # be good enough for our needs.
 export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.9/data/data.json | jq -r ".$DIST.releases[-1].version")
+fi
+
+if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
+# If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so its used instead of default
+# `https://git.rancher.io/charts` to reduce reliance and load on our Git mirror
+export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts-deliberately-broken-for-tests
 fi
 
 echo Starting rancher server for test

--- a/scripts/test
+++ b/scripts/test
@@ -67,7 +67,7 @@ fi
 if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
 # If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so its used instead of default
 # `https://git.rancher.io/charts` to reduce reliance and load on our Git mirror
-export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts-deliberately-broken-for-tests
+export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts
 fi
 
 echo Starting rancher server for test


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45676
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
As per the linked issue, integration and v2prov tests run Rancher which deploys certain charts like `rancher-webhook` making it dependent on and producing additional load for our Git mirror https://git.rancher.io/charts - so when it's down/unstable CI fails blocking merging of PRs etc.
 
## Solution
Leverage `ChartDefaultURL` setting introduced in https://github.com/rancher/rancher/pull/43530 via `CATTLE_CHART_DEFAULT_URL` to pull Rancher charts from https://github.com/rancher/charts instead.
Note: Commits will be squashed on merge
 
## Testing
No testing is required, part of CI

## Engineering Testing
### Manual Testing
Initial commit had `CATTLE_CHART_DEFAULT_URL` set to invalid URL and the related build has failed due to failure to deploy webhook - https://drone-pr.rancher.io/rancher/rancher/39661/6/2
Then the setting was changed to `https://github.com/rancher/charts` and the build has passed essentially confirming that charts are pulled from GitHub now - https://drone-pr.rancher.io/rancher/rancher/39662/6/2
Ideally we want to test this while our Git mirror https://git.rancher.io/charts is down but it's not feasible to do so.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change

## QA Testing Considerations
None
 
### Regressions Considerations
None

Existing / newly added automated tests that provide evidence there are no regressions:
N/A