### PR TITLE
UI: Allow separate banner settings to be fetched before login

### DIFF
--- a/pkg/data/dashboard/rbac.go
+++ b/pkg/data/dashboard/rbac.go
@@ -17,10 +17,12 @@ func addUnauthenticatedRoles(apply apply.Apply) error {
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
-						Verbs:         []string{"get"},
-						APIGroups:     []string{"management.cattle.io"},
-						Resources:     []string{"settings"},
-						ResourceNames: []string{"first-login", "ui-pl", "ui-banners", "ui-brand", "ui-favicon", "ui-login-background-light", "ui-login-background-dark", "ui-primary-color", "ui-link-color"},
+						Verbs:     []string{"get"},
+						APIGroups: []string{"management.cattle.io"},
+						Resources: []string{"settings"},
+						ResourceNames: []string{
+							"first-login", "ui-pl", "ui-banners", "ui-brand", "ui-favicon", "ui-login-background-light", "ui-login-background-dark", "ui-primary-color", "ui-link-color",
+							"ui-banner-header", "ui-banner-footer", "ui-banner-login-consent"},
 					},
 				},
 			},

--- a/pkg/data/dashboard/rbac.go
+++ b/pkg/data/dashboard/rbac.go
@@ -17,9 +17,9 @@ func addUnauthenticatedRoles(apply apply.Apply) error {
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
-						Verbs:         []string{"get"},
-						APIGroups:     []string{"management.cattle.io"},
-						Resources:     []string{"settings"},
+						Verbs:     []string{"get"},
+						APIGroups: []string{"management.cattle.io"},
+						Resources: []string{"settings"},
 						ResourceNames: []string{
 							"first-login", "ui-pl", "ui-banners", "ui-brand", "ui-favicon", "ui-login-background-light", "ui-login-background-dark", "ui-primary-color", "ui-link-color",
 							"ui-banner-header", "ui-banner-footer", "ui-banner-login-consent"},

--- a/pkg/data/dashboard/rbac.go
+++ b/pkg/data/dashboard/rbac.go
@@ -17,9 +17,9 @@ func addUnauthenticatedRoles(apply apply.Apply) error {
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
-						Verbs:     []string{"get"},
-						APIGroups: []string{"management.cattle.io"},
-						Resources: []string{"settings"},
+						Verbs:         []string{"get"},
+						APIGroups:     []string{"management.cattle.io"},
+						Resources:     []string{"settings"},
 						ResourceNames: []string{
 							"first-login", "ui-pl", "ui-banners", "ui-brand", "ui-favicon", "ui-login-background-light", "ui-login-background-dark", "ui-primary-color", "ui-link-color",
 							"ui-banner-header", "ui-banner-footer", "ui-banner-login-consent"},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

https://github.com/rancher/dashboard/issues/7366
 
## Problem

Presently, all banners are in a single setting as a single JSON blob - this makes it hard for users wishing to individually configure banners outside of the UI.
 
## Solution

Add optional individual banner settings that will be used if defined, rather than the single setting we currently have.

This is a follow-on to PR: https://github.com/rancher/rancher/pull/45528

That PR added the new settings.

This PR makes an update so that these new individual banner settings can be retrieved before login - this ensures if they are used, we can show the banners on the login screen.

Note that `ui-banners` is already exposed this way, and this is about allowing the same for the 3 new settings which specify the banners individually, rather than in a single setting.
 
## Testing

UI will add automated e2e tests to cover this feature and the correct operation of these  new settings.
