### PR TITLE
[2.9] Add new setting agent-tls-mode

### DIFF
--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -196,6 +196,8 @@ func (s *settingsProvider) cleanupUnknownSettings(settingsMap map[string]setting
 	return nil
 }
 
+// anySettingsInstalled tries to find out if at least one setting is installed as a resource in the cluster.
+// It is used as a way to know if Rancher has been started for the first time.
 func (s *settingsProvider) anySettingsInstalled() (bool, error) {
 	list, err := s.settings.List(metav1.ListOptions{})
 	if err != nil {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -55,7 +55,7 @@ var (
 	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.9-head")
 	AgentRolloutTimeout                 = NewSetting("agent-rollout-timeout", "300s")
 	AgentRolloutWait                    = NewSetting("agent-rollout-wait", "true")
-	AgentTLSMode                        = NewSettingWithDefaultOnUpgrade("agent-tls-mode", "strict", "system-store")
+	AgentTLSMode                        = NewSetting("agent-tls-mode", "strict").WithDefaultOnUpgrade("system-store")
 	AuthImage                           = NewSetting("auth-image", v32.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)
 	AuthorizationCacheTTLSeconds        = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds    = NewSetting("authorization-deny-cache-ttl-seconds", "10")
@@ -347,8 +347,8 @@ type Setting struct {
 	// Default represents a value to be used in the absence of an actual Value stored in etcd on the Setting resource.
 	Default string
 	// DefaultOnUpgrade represents a desired Default value that the setting should have on upgrade from a previous minor
-	// or major version of Rancher. This is used for special cases where, on upgrades, the Default value of a setting
-	// changes, and, instead of accepting the new value, Rancher chooses DefaultOnUpgrade as the Default.
+	// or major version of Rancher. This is used for special cases where the value of the setting must stay the same
+	// on upgraded setups but use a new value for fresh installations for backward compatibility.
 	DefaultOnUpgrade string
 	ReadOnly         bool
 }
@@ -420,14 +420,9 @@ func NewSetting(name, def string) Setting {
 	return s
 }
 
-// NewSettingWithDefaultOnUpgrade creates a new server setting, taking into account a regular Default value
-// and a Default value to be used on upgrades.
-func NewSettingWithDefaultOnUpgrade(name, def, defOnUpgrade string) Setting {
-	s := Setting{
-		Name:             name,
-		Default:          def,
-		DefaultOnUpgrade: defOnUpgrade,
-	}
+// WithDefaultOnUpgrade takes a setting and returns a new setting with the default value on upgrade set.
+func (s Setting) WithDefaultOnUpgrade(defOnUpgrade string) Setting {
+	s.DefaultOnUpgrade = defOnUpgrade
 	settings[s.Name] = s
 	return s
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -9,12 +9,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	authsettings "github.com/rancher/rancher/pkg/auth/settings"
 	"github.com/rancher/rancher/pkg/buildconfig"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
-	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
 )
 
 const RancherVersionDev = "2.9.99"
@@ -54,6 +55,7 @@ var (
 	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.9-head")
 	AgentRolloutTimeout                 = NewSetting("agent-rollout-timeout", "300s")
 	AgentRolloutWait                    = NewSetting("agent-rollout-wait", "true")
+	AgentTLSMode                        = NewSettingWithDefaultOnUpgrade("agent-tls-mode", "strict", "system-store")
 	AuthImage                           = NewSetting("auth-image", v32.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)
 	AuthorizationCacheTTLSeconds        = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds    = NewSetting("authorization-deny-cache-ttl-seconds", "10")
@@ -341,9 +343,14 @@ type Provider interface {
 
 // Setting stores information about a specific server setting.
 type Setting struct {
-	Name     string
-	Default  string
-	ReadOnly bool
+	Name string
+	// Default represents a value to be used in the absence of an actual Value stored in etcd on the Setting resource.
+	Default string
+	// DefaultOnUpgrade represents a desired Default value that the setting should have on upgrade from a previous minor
+	// or major version of Rancher. This is used for special cases where, on upgrades, the Default value of a setting
+	// changes, and, instead of accepting the new value, Rancher chooses DefaultOnUpgrade as the Default.
+	DefaultOnUpgrade string
+	ReadOnly         bool
 }
 
 // SetIfUnset will store the given value of the setting if it was not already stored.
@@ -408,6 +415,18 @@ func NewSetting(name, def string) Setting {
 	s := Setting{
 		Name:    name,
 		Default: def,
+	}
+	settings[s.Name] = s
+	return s
+}
+
+// NewSettingWithDefaultOnUpgrade creates a new server setting, taking into account a regular Default value
+// and a Default value to be used on upgrades.
+func NewSettingWithDefaultOnUpgrade(name, def, defOnUpgrade string) Setting {
+	s := Setting{
+		Name:             name,
+		Default:          def,
+		DefaultOnUpgrade: defOnUpgrade,
 	}
 	settings[s.Name] = s
 	return s


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45628
 
## Problem

Rancher needs a new setting for specifying the TLS mode to be used by agent. In 2.9, the Default value is `strict`. Rancher needs to keep the existing `system-store` Default value (from 2.7 and 2.8) for upgrades to 2.9. Only for new installations of 2.9 should Rancher use the new `strict` Default value.
 
## Solution

Add a new setting. And implement functionality that allows to add a special `DefaultOnUpgrade` value to any setting. Rancher will then be more reserved about accepting the new Default value on upgrades, if it has changed. Some settings' Default may need to be the same on upgrades for backward compatibility.

To do so, augment the Setting struct type with a new `DefaultOnUpgrade` field. 

DefaultOnUpgrade represents a desired Default value that the setting should have on upgrade from a previous minor
or major version of Rancher. This is used for special cases where, on upgrades, the Default value of a setting
changes, and, instead of accepting the new value, Rancher chooses DefaultOnUpgrade as the Default.

Adjust the logic of setting registration in K8s by supporting the following scenarios:

1. Start with 2.9.0, ensure the Default value of the setting is `strict`.
2. Start with 2.8.x, with a setting (Default value is `system-store`). Upgrade to 2.9.0 and ensure the Default value of the setting is still `system-store`.
3. Start with an older version of 2.8, one that doesn't have the new setting. Upgrade to 2.9.0 and ensure the Default value of the setting is `system-store`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Tried all three scenarios by hand.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_