### PR TITLE
Change timeout of icons to 2 seconds

### DIFF
--- a/pkg/catalogv2/http/download.go
+++ b/pkg/catalogv2/http/download.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 
@@ -26,6 +27,7 @@ func Icon(secret *corev1.Secret, repoURL string, caBundle []byte, insecureSkipTL
 	}
 
 	client, err := HelmClient(secret, caBundle, insecureSkipTLSVerify, disableSameOriginCheck, repoURL)
+	client.Timeout = 2 * time.Second
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
Please look into the issue for more details 

### Summary 
The timeout for icon loading in Charts page is changed from 30 seconds to 2 seconds since icons don't require such a huge timeout and also it helps in good user experience in http/1.1 browsers where requests are made 6 in a batch.