### PR TITLE
Handle redaction errors in audit log

### DIFF
--- a/pkg/auth/audit/audit.go
+++ b/pkg/auth/audit/audit.go
@@ -191,7 +191,6 @@ func (a *auditLog) write(userInfo *User, reqHeaders, resHeaders http.Header, res
 	var compactBuffer bytes.Buffer
 	err = json.Compact(&compactBuffer, buffer.Bytes())
 	if err != nil {
-
 		return fmt.Errorf("failed to compact audit log: %w", err)
 	}
 
@@ -282,14 +281,14 @@ func isExist(array []string, key string) bool {
 	return false
 }
 
-func redactedBodyError(auditErr error) []byte {
+func redactedBodyWithErr(auditErr error) []byte {
 	m := map[string]string{
 		auditLogErrKey: auditErr.Error(),
 	}
 
 	body, err := json.Marshal(m)
 	if err != nil {
-		logrus.Debugf("auditLog: failed to generate audit log error body: %v", err)
+		logrus.Debugf("auditLog: recevied invalid json: %v", err)
 		return []byte("{}")
 	}
 
@@ -299,7 +298,7 @@ func redactedBodyError(auditErr error) []byte {
 func (a *auditLog) redactSensitiveData(requestURI string, body []byte) []byte {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
-		return redactedBodyError(err)
+		return redactedBodyWithErr(err)
 	}
 
 	var changed bool
@@ -320,7 +319,7 @@ func (a *auditLog) redactSensitiveData(requestURI string, body []byte) []byte {
 
 	newBody, err := json.Marshal(m)
 	if err != nil {
-		return redactedBodyError(err)
+		return redactedBodyWithErr(err)
 	}
 
 	return newBody

--- a/pkg/auth/audit/audit_test.go
+++ b/pkg/auth/audit/audit_test.go
@@ -204,6 +204,11 @@ func (a *AuditTest) TestRedactSensitiveData() {
 			input: []byte(`{"credentials": "{'fakeCredName': 'fakeCred'}", "applicationSecret": "fakeAppSecret", "oauthCredential": "fakeOauth", "serviceAccountCredential": "fakeSACred", "spKey": "fakeSPKey", "spCert": "fakeSPCERT", "certificate": "fakeCert", "privateKey": "fakeKey"}`),
 			want:  []byte(fmt.Sprintf(`{"credentials": "%s", "applicationSecret": "%[1]s", "oauthCredential": "%[1]s", "serviceAccountCredential": "%[1]s", "spKey": "%[1]s", "spCert": "%[1]s", "certificate": "%[1]s", "privateKey": "%[1]s"}`, redacted)),
 		},
+		{
+			name:  "With malformed input",
+			input: []byte(`{"key": "value", "response":}`),
+			want:  []byte(fmt.Sprintf(`{"%s": "invalid character '}' looking for beginning of value"}`, auditLogErrKey)),
+		},
 	}
 	for i := range tests {
 		test := tests[i]

--- a/pkg/auth/audit/audit_test.go
+++ b/pkg/auth/audit/audit_test.go
@@ -346,18 +346,18 @@ func (a *AuditTest) TestCompression() {
 			level:      LevelRequestResponse,
 		},
 		{
-			name:       "invalid json gzip response",
-			respHeader: http.Header{"Content-Type": []string{"application/json"}, "Content-Encoding": []string{"gzip"}},
-			respBody:   a.gzip(""),
-			Error:      &json.SyntaxError{},
-			level:      LevelRequestResponse,
+			name:             "invalid json gzip response",
+			respHeader:       http.Header{"Content-Type": []string{"application/json"}, "Content-Encoding": []string{"gzip"}},
+			respBody:         a.gzip(""),
+			expectedRespBody: `{"auditLogError":"unexpected end of JSON input"}`,
+			level:            LevelRequestResponse,
 		},
 		{
-			name:       "invalid json deflate response",
-			respHeader: http.Header{"Content-Type": []string{"application/json"}, "Content-Encoding": []string{"deflate"}},
-			respBody:   a.deflate("Bad Data[]}"),
-			Error:      &json.SyntaxError{},
-			level:      LevelRequestResponse,
+			name:             "invalid json deflate response",
+			respHeader:       http.Header{"Content-Type": []string{"application/json"}, "Content-Encoding": []string{"deflate"}},
+			respBody:         a.deflate("Bad Data[]}"),
+			expectedRespBody: `{"auditLogError":"invalid character 'B' looking for beginning of value"}`,
+			level:            LevelRequestResponse,
 		},
 	}
 
@@ -387,7 +387,6 @@ func (a *AuditTest) TestCompression() {
 			a.JSONEqf(expectedData, a.drain(tmpPath), "Incorrect JSON stored.")
 		})
 	}
-
 }
 
 func (a *AuditTest) TestFilterSensitiveHeader() {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/44359

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If the audit log handler attempts to redact info from data that is not valid json it returns invalid json, which later causes errors when compacting the full audit log json.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Return valid json, while exposing the errors that occur while handling response and request bodies.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Steps in the issue are valid. Was not able to reproduce locally, but testing in EKS works as described.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

1. Deploy rancher in EKS
2. Deploy / Modify / Scale workloads via rancher UI
3. View audit logs for values at `.responseBody` for error content

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Add unit test(s) to test for invalid json

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
