### PR TITLE
Replace loglevel binary with small shell script

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -118,7 +118,6 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     git clone -b master --depth 1 https://github.com/rancher/helm3-charts /var/lib/rancher-data/local-catalogs/helm3-library
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
-    curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -LO https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-amd64.zip && \
     unzip docker-machine-driver-linode_linux-amd64.zip -d /opt/drivers/management-state/bin && \
     mkdir -p /usr/share/rancher/ui/assets/ && \
@@ -257,7 +256,7 @@ ENV CATTLE_CLI_URL_WINDOWS https://releases.rancher.com/cli2/${CATTLE_CLI_VERSIO
 
 ARG VERSION=dev
 ENV CATTLE_SERVER_VERSION ${VERSION}
-COPY entrypoint.sh rancher /usr/bin/
+COPY entrypoint.sh rancher loglevel /usr/bin/
 COPY kustomize.sh /usr/bin/
 COPY jailer.sh /usr/bin/
 COPY k3s-airgap-images.tar /var/lib/rancher/k3s/agent/images/

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -39,8 +39,6 @@ RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECT
 
 ENV LOGLEVEL_VERSION v0.1.5
 
-RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
-
 ARG VERSION=dev
 LABEL io.cattle.agent true
 ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
@@ -50,6 +48,6 @@ ENV CATTLE_RANCHER_WEBHOOK_VERSION=$CATTLE_RANCHER_WEBHOOK_VERSION
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
 COPY --from=rancher /usr/bin/tini /usr/bin/
-COPY agent run.sh kubectl-shell.sh shell-setup.sh /usr/bin/
+COPY agent loglevel run.sh kubectl-shell.sh shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
 ENTRYPOINT ["run.sh"]

--- a/package/loglevel
+++ b/package/loglevel
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+socket_location="${LOG_SOCKET_LOCATION:-/tmp/log.sock}"
+curl_args=""
+
+while true; do
+  case "$1" in
+    --set )
+      curl_args="--data level=$2"
+      shift 2
+      ;;
+    --socket-location )
+      socket_location="$2"
+      shift 2
+      ;;
+    -* )
+      echo "Invalid flag $1"
+      exit 1
+      ;;
+    * )
+      break
+      ;;
+  esac
+done
+
+set -x
+curl --no-progress-meter --fail-with-body --proxy "" --unix-socket "${socket_location}" http://unix/v1/loglevel $curl_args

--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -19,7 +19,6 @@ RUN $URL = 'https://dl.k8s.io/v1.25.12/kubernetes-client-windows-amd64.tar.gz'; 
     tar.exe -xzvf c:\kubernetes.tar.gz; \
     \
     Write-Host 'Complete.'
-# Need to support loglevel & kube-prompt
 # Move for PATH to work
 RUN Copy-Item -Path /wins.exe -Destination /Windows/
 RUN Copy-Item -Path /kubernetes/client/bin/kubectl.exe -Destination /Windows/

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -117,7 +117,6 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     git clone -b master --depth 1 https://github.com/rancher/helm3-charts /var/lib/rancher-data/local-catalogs/helm3-library
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
-    curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -LO https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-amd64.zip && \
     unzip docker-machine-driver-linode_linux-amd64.zip -d /opt/drivers/management-state/bin && \
     mkdir -p /usr/share/rancher/ui/assets/ && \
@@ -256,7 +255,7 @@ ENV CATTLE_CLI_URL_WINDOWS https://releases.rancher.com/cli2/${CATTLE_CLI_VERSIO
 
 ARG VERSION=dev
 ENV CATTLE_SERVER_VERSION ${VERSION}
-COPY run_rancher.sh rancher /usr/bin/
+COPY run_rancher.sh rancher loglevel /usr/bin/
 COPY kustomize.sh /usr/bin/
 COPY jailer.sh /usr/bin/
 COPY k3s-airgap-images.tar /var/lib/rancher/k3s/agent/images/

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -39,8 +39,6 @@ RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECT
 
 ENV LOGLEVEL_VERSION v0.1.5
 
-RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
-
 ARG VERSION=dev
 LABEL io.cattle.agent true
 ENV AGENT_IMAGE ${RANCHER_REPO}/rancher-agent:${VERSION}
@@ -49,6 +47,6 @@ ARG CATTLE_RANCHER_WEBHOOK_VERSION
 ENV CATTLE_RANCHER_WEBHOOK_VERSION=$CATTLE_RANCHER_WEBHOOK_VERSION
 COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
 COPY --from=rancher /usr/bin/tini /usr/bin/
-COPY agent run_agent.sh kubectl-shell.sh shell-setup.sh /usr/bin/
+COPY agent loglevel run_agent.sh kubectl-shell.sh shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
 ENTRYPOINT ["run_agent.sh"]


### PR DESCRIPTION
## Issue: SURE-8512
 
## Problem
The loglevel binary is built from a separate project that is essentially unmaintained: https://github.com/rancher/loglevel/blob/master/main.go

It serves very little purpose and is just a thin wrapper around a HTTP API presented via unix socket within the rancher container.
 
## Solution
Replace project and binary with shell script. Shell script should support the same CLI flags and env vars as the binary.
 
## Testing

Covered by tests

## Engineering Testing

### Manual Testing

Ran the script myself, seems to work

### Automated Testing
* Test types added/modified:
    * Integration (Go Framework)

## QA Testing Considerations
 
### Regressions Considerations

Existing / newly added automated tests that provide evidence there are no regressions:
