### PR TITLE
[v2.8] Add charts url setting (#43530)

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -116,8 +116,6 @@ var (
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
 	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.8")
 	SystemManagedChartsOperationTimeout = NewSetting("system-managed-charts-operation-timeout", "300s")
-	PartnerChartDefaultBranch           = NewSetting("partner-chart-default-branch", "main")
-	RKE2ChartDefaultBranch              = NewSetting("rke2-chart-default-branch", "main")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none
 	ShellImage                          = NewSetting("shell-image", buildconfig.DefaultShellVersion)
 	IgnoreNodeName                      = NewSetting("ignore-node-name", "") // nodes to ignore when syncing v1.node to v3.node
@@ -145,6 +143,10 @@ var (
 	// AuthUserSessionTTLMinutes represents the time to live for tokens used for login sessions in minutes.
 	AuthUserSessionTTLMinutes = NewSetting("auth-user-session-ttl-minutes", "960") // 16 hours
 
+	// ChartDefaultURL represents the default URL for the system charts repo. It should only be set for test or
+	// debug purposes.
+	ChartDefaultURL = NewSetting("chart-default-url", "https://git.rancher.io/")
+
 	// ConfigMapName name of the configmap that stores rancher configuration information.
 	// Deprecated: to be removed in 2.8.0
 	ConfigMapName = NewSetting("config-map-name", "rancher-config")
@@ -168,8 +170,22 @@ var (
 	// If set to false the kubeconfig will contain a command to login to Rancher.
 	KubeconfigGenerateToken = NewSetting("kubeconfig-generate-token", "true")
 
+	// PartnerChartDefaultBranch represents the default branch for the partner charts repo.
+	PartnerChartDefaultBranch = NewSetting("partner-chart-default-branch", "main")
+
+	// PartnerChartDefaultURL represents the default URL for the partner charts repo. It should only be set for test
+	// or debug purposes.
+	PartnerChartDefaultURL = NewSetting("partner-chart-default-url", "https://git.rancher.io/")
+
 	// RancherWebhookVersion is the exact version of the webhook that Rancher will install.
 	RancherWebhookVersion = NewSetting("rancher-webhook-version", "")
+
+	// RKE2ChartDefaultBranch represents the default branch for the RKE2 charts repo.
+	RKE2ChartDefaultBranch = NewSetting("rke2-chart-default-branch", "main")
+
+	// RKE2ChartDefaultURL represents the default URL for the RKE2 charts repo. It should only be set for test or
+	// debug purposes.
+	RKE2ChartDefaultURL = NewSetting("rke2-chart-default-url", "https://git.rancher.io/")
 
 	// SystemDefaultRegistry is the default contrainer registry used for images.
 	// The environmental variable "CATTLE_BASE_REGISTRY" controls the default value of this setting.


### PR DESCRIPTION
Backport of #43530 to `release/v2.8`.
Refers to #45677.

* Add default chart URL setting

This adds new settings to control the origin of system, partner and RKE2 charts, which can now be tested with custom versions prior to releasing corresponding RCs to their respective repositories:
* `ChartDefaultURL` (`rancher/charts`)
* `PartnerChartDefaultURL` (`rancher/partner- charts`)
* `RKE2ChartDefaultURL` (`rancher/rke2- charts`)

These options are intended for internal use only. When in use, Rancher issues a warning suggesting to unset them should any issues be encountered when fetching charts.

* Group settings by repo type

This moves each default branch setting, for the partner and RKE2 charts repositories, next to the default URL settings for the respective repository, to make configuration easier and improve documentation.