### PR TITLE
bump shell rc version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 104.0.0+up0.5.0-rc8
 provisioningCAPIVersion: 104.0.0+up0.2.0
 cspAdapterMinVersion: 104.0.0+up4.0.0-rc1
-defaultShellVersion: rancher/shell:v0.2.1-rc.2
+defaultShellVersion: rancher/shell:v0.2.1-rc.4
 fleetVersion: 104.0.0+up0.10.0-rc.14

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion    = "104.0.0+up4.0.0-rc1"
-	DefaultShellVersion     = "rancher/shell:v0.2.1-rc.2"
+	DefaultShellVersion     = "rancher/shell:v0.2.1-rc.4"
 	FleetVersion            = "104.0.0+up0.10.0-rc.14"
 	ProvisioningCAPIVersion = "104.0.0+up0.2.0"
 	WebhookVersion          = "104.0.0+up0.5.0-rc8"


### PR DESCRIPTION
Bump shell version for new RC - increments kubectl to more appropriate version for Rancher 2.9.

- PR bumping shell kubectl to 1.28: https://github.com/rancher/shell/pull/237
- bump helm to v3.15.1-rancher2: https://github.com/rancher/shell/pull/241