### PR TITLE
Squelch github linter warnings about embedded structs without json tags.

### DIFF
--- a/pkg/apis/project.cattle.io/v3/app_types.go
+++ b/pkg/apis/project.cattle.io/v3/app_types.go
@@ -14,7 +14,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type App struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
@@ -86,7 +86,7 @@ type AppCondition struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type AppRevision struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/pkg/apis/project.cattle.io/v3/types.go
+++ b/pkg/apis/project.cattle.io/v3/types.go
@@ -10,7 +10,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type ServiceAccountToken struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -33,7 +33,7 @@ type NamespacedServiceAccountToken ServiceAccountToken
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type DockerCredential struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -61,7 +61,7 @@ type RegistryCredential struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Certificate struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -93,7 +93,7 @@ type NamespacedCertificate Certificate
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type BasicAuth struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -114,7 +114,7 @@ type NamespacedBasicAuth BasicAuth
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SSHAuth struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -153,7 +153,7 @@ type PublicEndpoint struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Workload struct {
-	types.Namespaced
+	types.Namespaced `json:"-"`
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 }


### PR DESCRIPTION
This looks like the proper way to denote fields that we don't want marshalled.