### PR TITLE
[v2.9] LDAP utils cleanup

### DIFF
--- a/pkg/agent/clean/adunmigration/ldap.go
+++ b/pkg/agent/clean/adunmigration/ldap.go
@@ -147,10 +147,17 @@ func escapeUUID(s string) string {
 }
 
 func findLdapUser(guid string, lConn *ldapv3.Conn, adConfig *v3.ActiveDirectoryConfig) (string, *v3.Principal, error) {
-	query := fmt.Sprintf("(&(%v=%v)(%v=%v))", AttributeObjectClass, adConfig.UserObjectClass, AttributeObjectGUID, escapeUUID(guid))
-	search := ldapv3.NewSearchRequest(adConfig.UserSearchBase, ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases,
-		0, 0, false,
-		query, adConfig.GetUserSearchAttributes("memberOf", "objectClass"), nil)
+	query := fmt.Sprintf(
+		"(&(%v=%v)(%v=%v))",
+		AttributeObjectClass, adConfig.UserObjectClass,
+		AttributeObjectGUID, escapeUUID(guid),
+	)
+
+	search := ldap.NewSearchRequest(
+		adConfig.UserSearchBase,
+		query,
+		adConfig.GetUserSearchAttributes("memberOf", "objectClass"),
+	)
 
 	result, err := lConn.Search(search)
 	if err != nil {

--- a/pkg/agent/clean/adunmigration/ldap.go
+++ b/pkg/agent/clean/adunmigration/ldap.go
@@ -150,7 +150,7 @@ func findLdapUser(guid string, lConn *ldapv3.Conn, adConfig *v3.ActiveDirectoryC
 	query := fmt.Sprintf("(&(%v=%v)(%v=%v))", AttributeObjectClass, adConfig.UserObjectClass, AttributeObjectGUID, escapeUUID(guid))
 	search := ldapv3.NewSearchRequest(adConfig.UserSearchBase, ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases,
 		0, 0, false,
-		query, ldap.GetUserSearchAttributes("memberOf", "objectClass", adConfig), nil)
+		query, adConfig.GetUserSearchAttributes("memberOf", "objectClass"), nil)
 
 	result, err := lConn.Search(search)
 	if err != nil {

--- a/pkg/agent/clean/adunmigration/ldap.go
+++ b/pkg/agent/clean/adunmigration/ldap.go
@@ -153,7 +153,7 @@ func findLdapUser(guid string, lConn *ldapv3.Conn, adConfig *v3.ActiveDirectoryC
 		AttributeObjectGUID, escapeUUID(guid),
 	)
 
-	search := ldap.NewSearchRequest(
+	search := ldap.NewWholeSubtreeSearchRequest(
 		adConfig.UserSearchBase,
 		query,
 		adConfig.GetUserSearchAttributes("memberOf", "objectClass"),

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -334,6 +334,26 @@ type ActiveDirectoryConfig struct {
 	NestedGroupMembershipEnabled *bool    `json:"nestedGroupMembershipEnabled,omitempty" norman:"default=false"`
 }
 
+func (c *ActiveDirectoryConfig) GetUserSearchAttributes(searchAttributes ...string) []string {
+	userSearchAttributes := []string{
+		c.UserObjectClass,
+		c.UserLoginAttribute,
+		c.UserNameAttribute,
+		c.UserEnabledAttribute,
+	}
+	return append(userSearchAttributes, searchAttributes...)
+}
+
+func (c *ActiveDirectoryConfig) GetGroupSearchAttributes(searchAttributes ...string) []string {
+	groupSeachAttributes := []string{
+		c.GroupObjectClass,
+		c.UserLoginAttribute,
+		c.GroupNameAttribute,
+		c.GroupSearchAttribute,
+	}
+	return append(groupSeachAttributes, searchAttributes...)
+}
+
 type ActiveDirectoryTestAndApplyInput struct {
 	ActiveDirectoryConfig ActiveDirectoryConfig `json:"activeDirectoryConfig,omitempty"`
 	Username              string                `json:"username"`
@@ -375,6 +395,29 @@ type LdapFields struct {
 type LdapConfig struct {
 	AuthConfig `json:",inline" mapstructure:",squash"`
 	LdapFields `json:",inline" mapstructure:",squash"`
+}
+
+func (c *LdapConfig) GetUserSearchAttributes(searchAttributes ...string) []string {
+	userSearchAttributes := []string{
+		"dn",
+		c.UserMemberAttribute,
+		c.UserObjectClass,
+		c.UserLoginAttribute,
+		c.UserNameAttribute,
+		c.UserEnabledAttribute,
+	}
+	return append(userSearchAttributes, searchAttributes...)
+}
+
+func (c *LdapConfig) GetGroupSearchAttributes(searchAttributes ...string) []string {
+	groupSeachAttributes := []string{
+		c.GroupMemberUserAttribute,
+		c.GroupObjectClass,
+		c.UserLoginAttribute,
+		c.GroupNameAttribute,
+		c.GroupSearchAttribute,
+	}
+	return append(groupSeachAttributes, searchAttributes...)
 }
 
 type LdapTestAndApplyInput struct {

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -56,12 +56,15 @@ func (p *adProvider) loginUser(adCredential *v32.BasicLogin, config *v32.ActiveD
 	if strings.Contains(username, `\`) {
 		samName = strings.SplitN(username, `\`, 2)[1]
 	}
+
 	query := fmt.Sprintf("(%v=%v)", config.UserLoginAttribute, ldapv3.EscapeFilter(samName))
 	logrus.Debugf("LDAP Search query: {%s}", query)
-	search := ldapv3.NewSearchRequest(config.UserSearchBase,
-		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
+
+	search := ldap.NewSearchRequest(
+		config.UserSearchBase,
 		query,
-		config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass), nil)
+		config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass),
+	)
 
 	result, err := lConn.Search(search)
 	if err != nil {
@@ -261,10 +264,11 @@ func (p *adProvider) getGroupPrincipalsFromSearch(searchBase string, filter stri
 	var groupPrincipals []v3.Principal
 	var nilPrincipal []v3.Principal
 
-	search := ldapv3.NewSearchRequest(searchBase,
-		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
+	search := ldap.NewSearchRequest(
+		searchBase,
 		filter,
-		config.GetGroupSearchAttributes(ObjectClass), nil)
+		config.GetGroupSearchAttributes(ObjectClass),
+	)
 
 	serviceAccountUsername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
 	err := lConn.Bind(serviceAccountUsername, config.ServiceAccountPassword)
@@ -460,18 +464,20 @@ func (p *adProvider) searchLdap(query string, scope string, config *v32.ActiveDi
 
 	searchDomain := config.UserSearchBase
 	if strings.EqualFold(UserScope, scope) {
-		search = ldapv3.NewSearchRequest(searchDomain,
-			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
+		search = ldap.NewSearchRequest(
+			searchDomain,
 			query,
-			config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass), nil)
+			config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass),
+		)
 	} else {
 		if config.GroupSearchBase != "" {
 			searchDomain = config.GroupSearchBase
 		}
-		search = ldapv3.NewSearchRequest(searchDomain,
-			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
+		search = ldap.NewSearchRequest(
+			searchDomain,
 			query,
-			config.GetGroupSearchAttributes(MemberOfAttribute, ObjectClass), nil)
+			config.GetGroupSearchAttributes(MemberOfAttribute, ObjectClass),
+		)
 	}
 
 	// Bind before query

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -191,7 +191,7 @@ func (p *adProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult, 
 
 	if len(memberOf) != 0 {
 		for i := 0; i < len(memberOf); i += 50 {
-			batch := memberOf[i:ldap.Min(i+50, len(memberOf))]
+			batch := memberOf[i:min(i+50, len(memberOf))]
 			filter := fmt.Sprintf("(%v=%v)", ObjectClass, config.GroupObjectClass)
 			query := "(|"
 			for _, attrib := range batch {

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -61,7 +61,7 @@ func (p *adProvider) loginUser(adCredential *v32.BasicLogin, config *v32.ActiveD
 	search := ldapv3.NewSearchRequest(config.UserSearchBase,
 		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
 		query,
-		ldap.GetUserSearchAttributes(MemberOfAttribute, ObjectClass, config), nil)
+		config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass), nil)
 
 	result, err := lConn.Search(search)
 	if err != nil {
@@ -127,7 +127,7 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 		0,
 		false,
 		fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass),
-		ldap.GetUserSearchAttributes(MemberOfAttribute, ObjectClass, config),
+		config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass),
 		nil,
 	)
 
@@ -264,7 +264,7 @@ func (p *adProvider) getGroupPrincipalsFromSearch(searchBase string, filter stri
 	search := ldapv3.NewSearchRequest(searchBase,
 		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
 		filter,
-		ldap.GetGroupSearchAttributes(config, ObjectClass), nil)
+		config.GetGroupSearchAttributes(ObjectClass), nil)
 
 	serviceAccountUsername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
 	err := lConn.Bind(serviceAccountUsername, config.ServiceAccountPassword)
@@ -375,12 +375,12 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 		search = ldapv3.NewSearchRequest(distinguishedName,
 			ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 0, 0, false,
 			filter,
-			ldap.GetUserSearchAttributes(MemberOfAttribute, ObjectClass, config), nil)
+			config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass), nil)
 	} else {
 		search = ldapv3.NewSearchRequest(distinguishedName,
 			ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 0, 0, false,
 			filter,
-			ldap.GetGroupSearchAttributes(config, MemberOfAttribute, ObjectClass), nil)
+			config.GetGroupSearchAttributes(MemberOfAttribute, ObjectClass), nil)
 	}
 
 	result, err := lConn.Search(search)
@@ -463,7 +463,7 @@ func (p *adProvider) searchLdap(query string, scope string, config *v32.ActiveDi
 		search = ldapv3.NewSearchRequest(searchDomain,
 			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
 			query,
-			ldap.GetUserSearchAttributes(MemberOfAttribute, ObjectClass, config), nil)
+			config.GetUserSearchAttributes(MemberOfAttribute, ObjectClass), nil)
 	} else {
 		if config.GroupSearchBase != "" {
 			searchDomain = config.GroupSearchBase
@@ -471,7 +471,7 @@ func (p *adProvider) searchLdap(query string, scope string, config *v32.ActiveDi
 		search = ldapv3.NewSearchRequest(searchDomain,
 			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
 			query,
-			ldap.GetGroupSearchAttributes(config, MemberOfAttribute, ObjectClass), nil)
+			config.GetGroupSearchAttributes(MemberOfAttribute, ObjectClass), nil)
 	}
 
 	// Bind before query

--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -266,13 +266,6 @@ func FindNonDuplicateBetweenGroupPrincipals(newGroupPrincipals []v3.Principal, g
 	return nonDupGroupPrincipals
 }
 
-func Min(a int, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func NewCAPool(cert string) (*x509.CertPool, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {

--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -221,7 +221,7 @@ func GatherParentGroups(groupPrincipal v3.Principal, searchDomain string, groupS
 		config.ObjectClass, config.GroupObjectClass,
 	)
 
-	searchGroup := NewSearchRequest(
+	searchGroup := NewWholeSubtreeSearchRequest(
 		searchDomain,
 		filter,
 		searchAttributes,
@@ -283,17 +283,26 @@ func NewCAPool(cert string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-// NewSearchRequest will return a new *ldapv3.SearchRequest based on some fixed common arguments:
-// - Scope (ScopeWholeSubtree)
+// NewWholeSubtreeSearchRequest will return a NewDefaultSearchRequest with a ScopeWholeSubtree scope
+func NewWholeSubtreeSearchRequest(baseDN, filter string, attributes []string) *ldapv3.SearchRequest {
+	return NewDefaultSearchRequest(baseDN, filter, ldapv3.ScopeWholeSubtree, attributes)
+}
+
+// NewBaseObjectSearchRequest will return a NewDefaultSearchRequest with a ScopeBaseObject scope
+func NewBaseObjectSearchRequest(baseDN, filter string, attributes []string) *ldapv3.SearchRequest {
+	return NewDefaultSearchRequest(baseDN, filter, ldapv3.ScopeBaseObject, attributes)
+}
+
+// NewDefaultSearchRequest will return a new *ldapv3.SearchRequest based on some fixed common arguments:
 // - DerefAliases (NeverDerefAliases)
 // - SizeLimit (0)
 // - TimeLimit (0)
 // - TypesOnly (false)
 // - Controls (nil)
-func NewSearchRequest(baseDN, filter string, attributes []string) *ldapv3.SearchRequest {
+func NewDefaultSearchRequest(baseDN, filter string, scope int, attributes []string) *ldapv3.SearchRequest {
 	return ldapv3.NewSearchRequest(
 		baseDN,                   // BaseDN
-		ldapv3.ScopeWholeSubtree, // Scope
+		scope,                    // Scope
 		ldapv3.NeverDerefAliases, // DerefAliases
 		0,                        // SizeLimit
 		0,                        // TimeLimit

--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -11,7 +11,6 @@ import (
 	ldapv3 "github.com/go-ldap/ldap/v3"
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/httperror"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,46 +127,6 @@ func GetAttributeValuesByName(search []*ldapv3.EntryAttribute, attributeName str
 		}
 	}
 	return []string{}
-}
-
-func GetUserSearchAttributes(memberOfAttribute, ObjectClass string, config *v32.ActiveDirectoryConfig) []string {
-	userSearchAttributes := []string{memberOfAttribute,
-		ObjectClass,
-		config.UserObjectClass,
-		config.UserLoginAttribute,
-		config.UserNameAttribute,
-		config.UserEnabledAttribute}
-	return userSearchAttributes
-}
-
-func GetGroupSearchAttributes(config *v32.ActiveDirectoryConfig, searchAttributes ...string) []string {
-	groupSeachAttributes := []string{
-		config.GroupObjectClass,
-		config.UserLoginAttribute,
-		config.GroupNameAttribute,
-		config.GroupSearchAttribute}
-	groupSeachAttributes = append(groupSeachAttributes, searchAttributes...)
-	return groupSeachAttributes
-}
-
-func GetUserSearchAttributesForLDAP(ObjectClass string, config *v3.LdapConfig) []string {
-	userSearchAttributes := []string{"dn", config.UserMemberAttribute,
-		ObjectClass,
-		config.UserObjectClass,
-		config.UserLoginAttribute,
-		config.UserNameAttribute,
-		config.UserEnabledAttribute}
-	return userSearchAttributes
-}
-
-func GetGroupSearchAttributesForLDAP(ObjectClass string, config *v3.LdapConfig) []string {
-	groupSeachAttributes := []string{config.GroupMemberUserAttribute,
-		ObjectClass,
-		config.GroupObjectClass,
-		config.UserLoginAttribute,
-		config.GroupNameAttribute,
-		config.GroupSearchAttribute}
-	return groupSeachAttributes
 }
 
 func AuthenticateServiceAccountUser(serviceAccountPassword string, serviceAccountUsername string, defaultLoginDomain string, lConn ldapv3.Client) error {

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -134,7 +134,7 @@ func (p *ldapProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult
 
 	if len(userMemberAttribute) > 0 {
 		for i := 0; i < len(userMemberAttribute); i += 50 {
-			batchGroupDN := userMemberAttribute[i:ldap.Min(i+50, len(userMemberAttribute))]
+			batchGroupDN := userMemberAttribute[i:min(i+50, len(userMemberAttribute))]
 			filter := fmt.Sprintf("(%v=%v)", ObjectClass, config.GroupObjectClass)
 			query := "(|"
 			for _, gdn := range batchGroupDN {

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -41,7 +41,7 @@ func (p *ldapProvider) loginUser(lConn ldapv3.Client, credential *v32.BasicLogin
 	searchRequest := ldapv3.NewSearchRequest(config.UserSearchBase,
 		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
 		fmt.Sprintf("(&(%v=%v)(%v=%v))", ObjectClass, config.UserObjectClass, config.UserLoginAttribute, ldapv3.EscapeFilter(username)),
-		ldap.GetUserSearchAttributesForLDAP(ObjectClass, config), nil)
+		config.GetUserSearchAttributes(ObjectClass), nil)
 	result, err := lConn.Search(searchRequest)
 	if err != nil {
 		return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed") // need to reload this error
@@ -295,12 +295,12 @@ func (p *ldapProvider) getPrincipal(distinguishedName string, scope string, conf
 		search = ldapv3.NewSearchRequest(distinguishedName,
 			ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 0, 0, false,
 			filter,
-			ldap.GetUserSearchAttributesForLDAP(ObjectClass, config), nil)
+			config.GetUserSearchAttributes(ObjectClass), nil)
 	} else {
 		search = ldapv3.NewSearchRequest(distinguishedName,
 			ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 0, 0, false,
 			filter,
-			ldap.GetGroupSearchAttributesForLDAP(ObjectClass, config), nil)
+			config.GetGroupSearchAttributes(ObjectClass), nil)
 	}
 
 	result, err := lConn.Search(search)
@@ -395,7 +395,7 @@ func (p *ldapProvider) searchLdap(query string, scope string, config *v3.LdapCon
 		search = ldapv3.NewSearchRequest(searchDomain,
 			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
 			query,
-			ldap.GetUserSearchAttributesForLDAP(ObjectClass, config), nil)
+			config.GetUserSearchAttributes(ObjectClass), nil)
 	} else {
 		if config.GroupSearchBase != "" {
 			searchDomain = config.GroupSearchBase
@@ -403,7 +403,7 @@ func (p *ldapProvider) searchLdap(query string, scope string, config *v3.LdapCon
 		search = ldapv3.NewSearchRequest(searchDomain,
 			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
 			query,
-			ldap.GetGroupSearchAttributesForLDAP(ObjectClass, config), nil)
+			config.GetGroupSearchAttributes(ObjectClass), nil)
 	}
 
 	// Bind before query
@@ -496,7 +496,7 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 		0,
 		false,
 		fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass),
-		ldap.GetUserSearchAttributesForLDAP(ObjectClass, config),
+		config.GetUserSearchAttributes(ObjectClass),
 		nil,
 	)
 

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -341,17 +341,29 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 	var searchRequest *ldapv3.SearchRequest
 	var filter string
 	if scope == p.userScope {
-		filter = fmt.Sprintf("(&(%v=%v)(%v=%v))",
-			ObjectClass, config.UserObjectClass, config.UserLoginAttribute, ldapv3.EscapeFilter(externalID))
-		searchRequest = ldapv3.NewSearchRequest(config.UserSearchBase,
-			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
-			filter, config.GetUserSearchAttributes(ObjectClass), nil)
+		filter = fmt.Sprintf(
+			"(&(%v=%v)(%v=%v))",
+			ObjectClass, config.UserObjectClass,
+			config.UserLoginAttribute, ldapv3.EscapeFilter(externalID),
+		)
+
+		searchRequest = ldap.NewSearchRequest(
+			config.UserSearchBase,
+			filter,
+			config.GetUserSearchAttributes(ObjectClass),
+		)
 	} else {
-		filter = fmt.Sprintf("(&(%v=%v)(%v=%v))",
-			ObjectClass, config.GroupObjectClass, config.GroupDNAttribute, ldapv3.EscapeFilter(externalID))
-		searchRequest = ldapv3.NewSearchRequest(config.GroupSearchBase,
-			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
-			filter, config.GetGroupSearchAttributes(ObjectClass), nil)
+		filter = fmt.Sprintf(
+			"(&(%v=%v)(%v=%v))",
+			ObjectClass, config.GroupObjectClass,
+			config.GroupDNAttribute, ldapv3.EscapeFilter(externalID),
+		)
+
+		searchRequest = ldap.NewSearchRequest(
+			config.GroupSearchBase,
+			filter,
+			config.GetGroupSearchAttributes(ObjectClass),
+		)
 	}
 
 	result, err := lConn.Search(searchRequest)

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -339,9 +339,9 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 	}
 
 	var searchRequest *ldapv3.SearchRequest
-	var filter string
+
 	if scope == p.userScope {
-		filter = fmt.Sprintf(
+		filter := fmt.Sprintf(
 			"(&(%v=%v)(%v=%v))",
 			ObjectClass, config.UserObjectClass,
 			config.UserLoginAttribute, ldapv3.EscapeFilter(externalID),
@@ -353,7 +353,7 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 			config.GetUserSearchAttributes(ObjectClass),
 		)
 	} else {
-		filter = fmt.Sprintf(
+		filter := fmt.Sprintf(
 			"(&(%v=%v)(%v=%v))",
 			ObjectClass, config.GroupObjectClass,
 			config.GroupDNAttribute, ldapv3.EscapeFilter(externalID),

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -347,7 +347,7 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 			config.UserLoginAttribute, ldapv3.EscapeFilter(externalID),
 		)
 
-		searchRequest = ldap.NewSearchRequest(
+		searchRequest = ldap.NewWholeSubtreeSearchRequest(
 			config.UserSearchBase,
 			filter,
 			config.GetUserSearchAttributes(ObjectClass),
@@ -359,7 +359,7 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 			config.GroupDNAttribute, ldapv3.EscapeFilter(externalID),
 		)
 
-		searchRequest = ldap.NewSearchRequest(
+		searchRequest = ldap.NewWholeSubtreeSearchRequest(
 			config.GroupSearchBase,
 			filter,
 			config.GetGroupSearchAttributes(ObjectClass),

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -345,13 +345,13 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 			ObjectClass, config.UserObjectClass, config.UserLoginAttribute, ldapv3.EscapeFilter(externalID))
 		searchRequest = ldapv3.NewSearchRequest(config.UserSearchBase,
 			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
-			filter, ldap.GetUserSearchAttributesForLDAP(ObjectClass, config), nil)
+			filter, config.GetUserSearchAttributes(ObjectClass), nil)
 	} else {
 		filter = fmt.Sprintf("(&(%v=%v)(%v=%v))",
 			ObjectClass, config.GroupObjectClass, config.GroupDNAttribute, ldapv3.EscapeFilter(externalID))
 		searchRequest = ldapv3.NewSearchRequest(config.GroupSearchBase,
 			ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 0, 0, false,
-			filter, ldap.GetGroupSearchAttributesForLDAP(ObjectClass, config), nil)
+			filter, config.GetGroupSearchAttributes(ObjectClass), nil)
 	}
 
 	result, err := lConn.Search(searchRequest)


### PR DESCRIPTION
During the investigation and WIP for https://github.com/rancher/rancher/issues/37994 I did some cleanup that can be safely merged in the codebase.

(updated description based on requested changes)

### NewDefaultSearchRequest / NewWholeSubtreeSearchRequest/ NewBaseObjectSearchRequest

In the past we had an issue performing an LDAP search request, because of a wrong scope. To avoid this issue this small PR adds a `NewWholeSubtreeSearchRequest` and a `NewBaseObjectSearchRequest` func in the ldap_util, in order to create a specific search request with some parameters already set to some defaults:

```go
// NewWholeSubtreeSearchRequest will return a NewDefaultSearchRequest with a ScopeWholeSubtree scope
func NewWholeSubtreeSearchRequest(baseDN, filter string, attributes []string) *ldapv3.SearchRequest {
	return NewDefaultSearchRequest(baseDN, filter, ldapv3.ScopeWholeSubtree, attributes)
}

// NewBaseObjectSearchRequest will return a NewDefaultSearchRequest with a ScopeBaseObject scope
func NewBaseObjectSearchRequest(baseDN, filter string, attributes []string) *ldapv3.SearchRequest {
	return NewDefaultSearchRequest(baseDN, filter, ldapv3.ScopeBaseObject, attributes)
}

// NewDefaultSearchRequest will return a new *ldapv3.SearchRequest based on some fixed common arguments:
// - DerefAliases (NeverDerefAliases)
// - SizeLimit (0)
// - TimeLimit (0)
// - TypesOnly (false)
// - Controls (nil)
func NewSearchRequest(baseDN, filter string, attributes []string) *ldapv3.SearchRequest {
	return ldapv3.NewSearchRequest(
		baseDN,                   // BaseDN
		ldapv3.ScopeWholeSubtree, // Scope
		ldapv3.NeverDerefAliases, // DerefAliases
		0,                        // SizeLimit
		0,                        // TimeLimit
		false,                    // TypesOnly
		filter,                   // Filter
		attributes,               // Attributes
		nil,                      // Controls
	)
}
```

All the old `NewSearchRequest` called that were using this configuration were updated accordingly.

### GetXXXSearchAttributes from func to method

The `ActiveDirectoryConfig` and the  `LdapConfig` were using two different functions to get some search attributes (`GetUserSearchAttributes`, `GetGroupsSearchAttributes`, `GetUserSearchAttributesForLDAP`, `GetGroupSearchAttributesForLDAP`). These funcs were moved as methods of the configurations, with the same signature. This could help having the same interface that can be used in some tests.

### Cleanup

Also an unused `ValidateLdapConfig` was deleted, and the `ldap.Min` func was deleted to use the now `min` func provided by the stdlib.

This PR is not introducing any functional changes.