### PR TITLE
[2.9] Bump RKE to v1.6.0-rc6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.3.2
-	github.com/rancher/rke v1.6.0-rc5
+	github.com/rancher/rke v1.6.0-rc6
 	github.com/rancher/steve v0.0.0-20240605141712-7a84620e8bc1
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler/v2 v2.2.0-rc6

--- a/go.sum
+++ b/go.sum
@@ -1882,8 +1882,8 @@ github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVf
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa/go.mod h1:NP3xboG+t2p+XMnrcrJ/L384Ki0Cp3Pww/X+vm5Jcy0=
 github.com/rancher/remotedialer v0.3.2 h1:kstZbRwPS5gPWpGg8VjEHT2poHtArs+Fc317YM8JCzU=
 github.com/rancher/remotedialer v0.3.2/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
-github.com/rancher/rke v1.6.0-rc5 h1:SY2w9o7JRQMxVUncRDkAis7kaGE6DmcH3tliETV1Vfw=
-github.com/rancher/rke v1.6.0-rc5/go.mod h1:zvrJLRt+84/OMOUO0AggVqW6a2RSsTjqSW8bDHvKgME=
+github.com/rancher/rke v1.6.0-rc6 h1:FUZvy/RHpHcT84rWlrl9VrO//mp5sKXsbbvEm5JdM8A=
+github.com/rancher/rke v1.6.0-rc6/go.mod h1:6ruRFiHrhT1KQvbmKycjKh8OIa2PG6fshP2Q5CLUyR4=
 github.com/rancher/shepherd v0.0.0-20240531204216-65735fd062c1 h1:n3vLfDGyfgc2caVQ9zdul38/7iqdagg72+rVEPoe1Hg=
 github.com/rancher/shepherd v0.0.0-20240531204216-65735fd062c1/go.mod h1:+1bFZ/XBf8QOu0WLJIJ+2K2x/GIjHgKXKCUfm7PnCz4=
 github.com/rancher/steve v0.0.0-20240605141712-7a84620e8bc1 h1:3qZw5UjtFFMHARNeYi0kki0wnRzeLSnoF1tk0Mb95FQ=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20231017140638-93432f288e79
 	github.com/rancher/gke-operator v1.9.0-rc.4
 	github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b
-	github.com/rancher/rke v1.6.0-rc5
+	github.com/rancher/rke v1.6.0-rc6
 	github.com/rancher/wrangler/v2 v2.2.0-rc6
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.29.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -100,8 +100,8 @@ github.com/rancher/lasso v0.0.0-20240424194130-d87ec407d941 h1:1SvuoeyfANRvKVJUS
 github.com/rancher/lasso v0.0.0-20240424194130-d87ec407d941/go.mod h1:pYKOe2r/5O0w3ypoc7xHQF8LvWCp5PsNRea1Jpq3vBU=
 github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b h1:9k8VOhRi6ZIZ8rBlQG8ON9eG+ukqThNeXJ2e6CzZO78=
 github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b/go.mod h1:xJ0CLJUG9SvtyuPzPA8ATh2SjwiqXGfE+pPh7uVhJzQ=
-github.com/rancher/rke v1.6.0-rc5 h1:SY2w9o7JRQMxVUncRDkAis7kaGE6DmcH3tliETV1Vfw=
-github.com/rancher/rke v1.6.0-rc5/go.mod h1:zvrJLRt+84/OMOUO0AggVqW6a2RSsTjqSW8bDHvKgME=
+github.com/rancher/rke v1.6.0-rc6 h1:FUZvy/RHpHcT84rWlrl9VrO//mp5sKXsbbvEm5JdM8A=
+github.com/rancher/rke v1.6.0-rc6/go.mod h1:6ruRFiHrhT1KQvbmKycjKh8OIa2PG6fshP2Q5CLUyR4=
 github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=
 github.com/rancher/wrangler v1.1.1/go.mod h1:ioVbKupzcBOdzsl55MvEDN0R1wdGggj8iNCYGFI5JvM=
 github.com/rancher/wrangler/v2 v2.2.0-rc6 h1:jMsuOVl7nBuQ5QJqdNkR2yHEf1+rYiyd1gN+mQzIcag=


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/45645

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The bug was reported in the standalone RKE cluster (https://github.com/rancher/rke/issues/3587),  but it is possible to be triggered in Rancher as well.  


If we provision or edit an RKE1 node-driver cluster and set the `extra_env` for the `kube-api` server, Rancher will fail to create or update the cluster with an error message like below 

`cluster health check failed: Failed to communicate with AP| server during namespace check: Get "https://xxx.xxx.xxx.xxx:6443/api/v1/namespaces/kube-system?timeout=45s": dial tcp xxx.xxx.xxx.xxx:6443: connect: connection refused:[controlPlanel
Failed to upgrade Control Plane: [[Failed to create [kube-apiserver] container on host [xxx.xxx.xxx.xxx]: Failed to create Docker container [kube-apiserver] on host [xxx.xxx.xxx.xxx]: Error response from daemon: invalid environment`

As a result, it is impossible to set the `extra_env` for the `kube-api` server. 

It happens because we declared the Env slice with the size of the `c.Services.KubeAPI.ExtraEnv` field, which leads to empty strings at the beginning of the Env slice because we use Golang's append function to add new elements, and Docker is not happy with that. 




## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
The fix is implemented in RKE, please check [this PR](https://github.com/rancher/rke/pull/3597) for details. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The test was done on the RKE side, please check the mentioned PR in RKE.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

cluster provisioning and upgrading when we set the `extra_env` for the `kube-api` server. 


Existing / newly added automated tests that provide evidence there are no regressions:
 