### PR TITLE
Steve SQLite cache: propagate setting downstream

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -17,7 +17,6 @@ import (
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/healthsyncer"
-	"github.com/rancher/rancher/pkg/features"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
@@ -272,17 +271,6 @@ func redeployAgent(cluster *apimgmtv3.Cluster, desiredAgent, desiredAuth string,
 	logrus.Tracef("clusterDeploy: redeployAgent: returning false for redeployAgent")
 
 	return false
-}
-
-func (cd *clusterDeploy) getDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
-	return map[string]bool{
-		features.MCM.Name():                false,
-		features.MCMAgent.Name():           true,
-		features.Fleet.Name():              false,
-		features.RKE2.Name():               false,
-		features.ProvisioningV2.Name():     false,
-		features.EmbeddedClusterAPI.Name(): false,
-	}
 }
 
 func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -154,6 +154,7 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 		features.RKE2.Name():               false,
 		features.ProvisioningV2.Name():     false,
 		features.EmbeddedClusterAPI.Name(): false,
+		features.UISQLCache.Name():         features.UISQLCache.Enabled(),
 	}
 }
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45635

Ensure cached backed API is available in downstream clusters without manually applying feature setting in downstream clusters.
 
## Problem
Currently separate steps are needed to enable the feature upstream and downstream: https://confluence.suse.com/display/RANQA/Rancher+Setup+with+Vai+Cache+Setup
 
## Solution
Propagate the feature setting from upstream to downstream on activation.
 
## Testing
1. Check that feature is off. From a machine with a kubeconfig pointing to any downstream cluster:

```sh
pod=$(kubectl -n cattle-system get pods -l app=cattle-cluster-agent --no-headers -o custom-columns=name:.metadata.name) 
kubectl exec -n cattle-system ${pod} -- ls | grep .db
```

Output should be empty.

2. Turn on the feature flag upstream
   1. In the upper left corner, click **☰ > Global Settings > Feature Flags**.
   1. Go to **`ui-sql-cache`** and click **⋮ > Activate > Activate**.
   1. Wait for Rancher to restart. That will also redeploy all cattle-cluster-agents in all downstream clusters.

3. Check that feature is now on. From a machine with a kubeconfig pointing to any downstream cluster:

```sh
pod=$(kubectl -n cattle-system get pods -l app=cattle-cluster-agent --no-headers -o custom-columns=name:.metadata.name) 
kubectl exec -n cattle-system ${pod} -- ls | grep .db
```

Output should list some files.

## Engineering Testing
### Manual Testing
Followed the same procedure above on an image based on this PR.

## QA Testing Considerations
Covered by the Vai test plan.