### PR TITLE
Add ACR validation check for OIDC auth

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -525,7 +525,7 @@ type OIDCConfig struct {
 	ClientSecret       string `json:"clientSecret,omitempty" norman:"required,type=password"`
 	RancherURL         string `json:"rancherUrl" norman:"required,notnullable"`
 	Issuer             string `json:"issuer" norman:"required,notnullable"`
-	AuthEndpoint       string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
+	AuthEndpoint       string `json:"authEndpoint,omitempty"`
 	TokenEndpoint      string `json:"tokenEndpoint,omitempty"`
 	UserInfoEndpoint   string `json:"userInfoEndpoint,omitempty"`
 	JWKSUrl            string `json:"jwksUrl,omitempty"`

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -535,6 +535,8 @@ type OIDCConfig struct {
 	GroupsClaim        string `json:"groupsClaim,omitempty"`
 	// Scopes is expected to be a space delimited list of scopes
 	Scopes string `json:"scope,omitempty"`
+	// AcrValue is expected to be string containing the required ACR value
+	AcrValue string `json:"acrValue,omitempty"`
 }
 
 type OIDCTestOutput struct {

--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -131,12 +131,18 @@ func (g *GenOIDCProvider) groupToPrincipal(groupName string) v3.Principal {
 func (g *GenOIDCProvider) getRedirectURL(config map[string]interface{}) string {
 	authURL, _ := baseoidc.FetchAuthURL(config)
 
-	return fmt.Sprintf(
+	redirectURL := fmt.Sprintf(
 		"%s?client_id=%s&response_type=code&redirect_uri=%s",
 		authURL,
 		config["clientId"],
 		config["rancherUrl"],
 	)
+
+	if config["acrValue"] != nil {
+		redirectURL += fmt.Sprintf("&acr_values=%s", config["acrValue"])
+	}
+
+	return redirectURL
 }
 
 // toPrincipalFromToken uses additional information about the principal found in the token, if available, to provide

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -1,6 +1,8 @@
 package oidc
 
 import (
+	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/golang-jwt/jwt"
@@ -35,6 +37,56 @@ func Test_validateACR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, isValidACR(tt.claimACR, tt.configuredACR), "isValidACR(%v, %v)", tt.claimACR, tt.configuredACR)
+		})
+	}
+}
+
+func TestParseACRFromAccessToken(t *testing.T) {
+	header := base64.URLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	validClaims := base64.URLEncoding.EncodeToString([]byte(`{"acr":"example_acr"}`))
+	invalidBase64Claims := "invalid_base64_claims"
+	noAcrClaims := base64.URLEncoding.EncodeToString([]byte(`{"sub":"1234567890"}`))
+
+	tests := []struct {
+		name        string
+		token       string
+		expectedACR string
+		wantError   bool
+	}{
+		{
+			name:        "valid token with ACR",
+			token:       fmt.Sprintf("%s.%s.", header, validClaims),
+			expectedACR: "example_acr",
+		},
+		{
+			name:        "invalid token format",
+			token:       "invalid.token",
+			expectedACR: "",
+			wantError:   true,
+		},
+		{
+			name:        "invalid base64 decoding",
+			token:       fmt.Sprintf("%s.%s.", header, invalidBase64Claims),
+			expectedACR: "",
+			wantError:   true,
+		},
+		{
+			name:        "valid token without ACR claim",
+			token:       fmt.Sprintf("%s.%s.", header, noAcrClaims),
+			expectedACR: "",
+			wantError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acr, err := parseACRFromAccessToken(tt.token)
+			if acr != tt.expectedACR {
+				t.Fatalf("expected acr to be '%s', got '%s'", tt.expectedACR, acr)
+			}
+			if (err != nil) != tt.wantError {
+				t.Fatalf("expected error: %v, got error: %v", tt.wantError, err)
+			}
 		})
 	}
 }

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -4,50 +4,37 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/oauth2"
 )
 
 func Test_validateACR(t *testing.T) {
 	tests := []struct {
-		name        string
-		oauth2Token *oauth2.Token
-		config      *v32.OIDCConfig
-		want        bool
+		name          string
+		claimACR      string
+		configuredACR string
+		want          bool
 	}{
 		{
-			name: "acr set in config and matches token",
-			config: &v32.OIDCConfig{
-				AcrValue: "level1",
-			},
-			oauth2Token: &oauth2.Token{
-				AccessToken: generateAccessToken("level1"),
-			},
-			want: true,
+			name:          "acr set in config and matches token",
+			configuredACR: "level1",
+			claimACR:      "level1",
+			want:          true,
 		},
 		{
-			name: "acr set in config and does not match token",
-			config: &v32.OIDCConfig{
-				AcrValue: "level1",
-			},
-			oauth2Token: &oauth2.Token{
-				AccessToken: generateAccessToken(""),
-			},
-			want: false,
+			name:          "acr set in config and does not match token",
+			configuredACR: "level1",
+			claimACR:      "",
+			want:          false,
 		},
 		{
-			name:   "acr not set in config",
-			config: &v32.OIDCConfig{},
-			oauth2Token: &oauth2.Token{
-				AccessToken: generateAccessToken(""),
-			},
-			want: true,
+			name:     "acr not set in config",
+			claimACR: "",
+			want:     true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, validateACR(tt.oauth2Token, tt.config), "validateACR(%v, %v)", tt.oauth2Token, tt.config)
+			assert.Equalf(t, tt.want, isValidACR(tt.claimACR, tt.configuredACR), "isValidACR(%v, %v)", tt.claimACR, tt.configuredACR)
 		})
 	}
 }

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -82,10 +82,10 @@ func TestParseACRFromAccessToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			acr, err := parseACRFromAccessToken(tt.token)
 			if acr != tt.expectedACR {
-				t.Fatalf("expected acr to be '%s', got '%s'", tt.expectedACR, acr)
+				t.Errorf("expected acr to be '%s', got '%s'", tt.expectedACR, acr)
 			}
 			if (err != nil) != tt.wantError {
-				t.Fatalf("expected error: %v, got error: %v", tt.wantError, err)
+				t.Errorf("expected error: %v, got error: %v", tt.wantError, err)
 			}
 		})
 	}

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -1,0 +1,63 @@
+package oidc
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+func Test_validateACR(t *testing.T) {
+	tests := []struct {
+		name        string
+		oauth2Token *oauth2.Token
+		config      *v32.OIDCConfig
+		want        bool
+	}{
+		{
+			name: "acr set in config and matches token",
+			config: &v32.OIDCConfig{
+				AcrValue: "level1",
+			},
+			oauth2Token: &oauth2.Token{
+				AccessToken: generateAccessToken("level1"),
+			},
+			want: true,
+		},
+		{
+			name: "acr set in config and does not match token",
+			config: &v32.OIDCConfig{
+				AcrValue: "level1",
+			},
+			oauth2Token: &oauth2.Token{
+				AccessToken: generateAccessToken(""),
+			},
+			want: false,
+		},
+		{
+			name:   "acr not set in config",
+			config: &v32.OIDCConfig{},
+			oauth2Token: &oauth2.Token{
+				AccessToken: generateAccessToken(""),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, validateACR(tt.oauth2Token, tt.config), "validateACR(%v, %v)", tt.oauth2Token, tt.config)
+		})
+	}
+}
+
+// generateAccessToken generates an access token with the specified acr.
+func generateAccessToken(acr string) string {
+	claims := jwt.MapClaims{
+		"acr": acr,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte("test_secret_key"))
+	return tokenString
+}

--- a/pkg/client/generated/management/v3/zz_generated_generic_oidcconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_generic_oidcconfig.go
@@ -3,6 +3,7 @@ package client
 const (
 	GenericOIDCConfigType                     = "genericOIDCConfig"
 	GenericOIDCConfigFieldAccessMode          = "accessMode"
+	GenericOIDCConfigFieldAcrValue            = "acrValue"
 	GenericOIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
 	GenericOIDCConfigFieldAnnotations         = "annotations"
 	GenericOIDCConfigFieldAuthEndpoint        = "authEndpoint"
@@ -32,6 +33,7 @@ const (
 
 type GenericOIDCConfig struct {
 	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AcrValue            string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
 	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
@@ -3,6 +3,7 @@ package client
 const (
 	KeyCloakOIDCConfigType                     = "keyCloakOIDCConfig"
 	KeyCloakOIDCConfigFieldAccessMode          = "accessMode"
+	KeyCloakOIDCConfigFieldAcrValue            = "acrValue"
 	KeyCloakOIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
 	KeyCloakOIDCConfigFieldAnnotations         = "annotations"
 	KeyCloakOIDCConfigFieldAuthEndpoint        = "authEndpoint"
@@ -32,6 +33,7 @@ const (
 
 type KeyCloakOIDCConfig struct {
 	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AcrValue            string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
 	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_oidc_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_oidc_config.go
@@ -3,6 +3,7 @@ package client
 const (
 	OIDCConfigType                     = "oidcConfig"
 	OIDCConfigFieldAccessMode          = "accessMode"
+	OIDCConfigFieldAcrValue            = "acrValue"
 	OIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
 	OIDCConfigFieldAnnotations         = "annotations"
 	OIDCConfigFieldAuthEndpoint        = "authEndpoint"
@@ -32,6 +33,7 @@ const (
 
 type OIDCConfig struct {
 	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AcrValue            string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
 	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/10053

## Problem
This PR adds a check for an ACR value, which is an optional configuration.  It piggybacks on https://github.com/rancher/rancher/pull/45366
Also includes a fix to allow an empty Authentication URL, which is ok now since it will just trigger "discovery".

 
## Solution
If a required ACR value is present in the authconfig (supplied when configuring the auth provider), verify that the correct value is present in the token when the user logs in.
 
## Testing
Unit tests added

## Engineering Testing
### Manual Testing
Configured Keycloak OIDC to provide an ACR value and then configured Rancher' authconfig to require it.  Logins with the correct ACR work while those without will fail.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit


## QA Testing Considerations
 
### Regressions Considerations
This is added for the new genericoidc implementation, so I would not expect any existing functionality to be affected.

Existing / newly added automated tests that provide evidence there are no regressions:
