### PR TITLE
Restricted Admins can't create Standard Users due to typo in rules

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -89,7 +89,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	// restricted-admin will get cluster admin access to all downstream clusters but limited access to the local cluster
 	restrictedAdminRole := addUserRules(rb.addRole("Restricted Admin", "restricted-admin"))
 	restrictedAdminRole.
-		addRule().apiGroups("").resources("secret").verbs("create").
+		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplaterevisions").verbs("*").


### PR DESCRIPTION
## Issue: 
## Problem
Restricted Admins are not able to create Standard Users. They get the following error:
```
admission webhook "rancher.cattle.io.globalrolebindings.management.cattle.io" denied the request: errors due to escalation: user "u-pvmqd" (groups=["system:authenticated" "system:cattle:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["secrets"], Verbs:["create"]}
```
 
## Solution
The Restricted Admin permission specified `secret` when it should be `secrets`.
 
## Testing
- Create a Restricted Admin user without Standard User as well
- Login as the Restricted Admin
- Create a Standard User
- Before the change, failure. After, success