### PR TITLE
Remove git worktree files to decrease image size

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -117,7 +117,12 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     # Revert the previous change in git.rancher.io from .gitconfig
     rm "${HOME}/.gitconfig" && \
     git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library && \
-    git clone -b master --depth 1 https://github.com/rancher/helm3-charts /var/lib/rancher-data/local-catalogs/helm3-library
+    git clone -b master --depth 1 https://github.com/rancher/helm3-charts /var/lib/rancher-data/local-catalogs/helm3-library && \
+    # Remove files from the worktree to avoid unnecessarily increasing the image size. This process is reverted at entrypoint.
+    rm -rf /var/lib/rancher-data/local-catalogs/{helm3-,system-,}library/[!.git]* && \
+    rm -rf /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9/[!.git]* && \
+    rm -rf /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974/[!.git]* && \
+    rm -rf /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/[!.git]*
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -7,6 +7,20 @@ if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; the
     exit 1
 fi
 
+git_dirs=(
+  /var/lib/rancher-data/local-catalogs/system-library
+  /var/lib/rancher-data/local-catalogs/helm3-library
+  /var/lib/rancher-data/local-catalogs/library
+  /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9/
+  /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974/
+  /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/
+)
+echo "Restoring git repositories: "
+for dir in ${git_dirs[@]}; do
+  echo "- ${dir}"
+  cd "${dir}" && git restore .
+done
+
 #########################################################################################################################################
 # DISCLAIMER                                                                                                                            #
 # Copied from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37                              #


### PR DESCRIPTION
The worktree files are not needed until the container is started, therefore avoid the duplication of content (specially for chart binaries) and restore the worktrees as part of the entry-point script.

The changes made the container image to drop over 300mb in size for amd64. Similar gains are expected across all supported architectures.

```
dive rancher/rancher:v2.9-head -> Total Image size: 2.0 GB
dive rancher/rancher:dev -> Total Image size: 1.6 GB
```