### PR TITLE
[v2.9] csp adapter 4.0.0-rc8

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 104.0.0+up0.5.0-rc8
 provisioningCAPIVersion: 104.0.0+up0.2.0
-cspAdapterMinVersion: 104.0.0+up4.0.0-rc1
+cspAdapterMinVersion: 104.0.0+up4.0.0-rc8
 defaultShellVersion: rancher/shell:v0.2.1-rc.4
 fleetVersion: 104.0.0+up0.10.0-rc.14

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion    = "104.0.0+up4.0.0-rc1"
+	CspAdapterMinVersion    = "104.0.0+up4.0.0-rc8"
 	DefaultShellVersion     = "rancher/shell:v0.2.1-rc.4"
 	FleetVersion            = "104.0.0+up0.10.0-rc.14"
 	ProvisioningCAPIVersion = "104.0.0+up0.2.0"


### PR DESCRIPTION
##Issue: 
rancher/rancher#45461

##Problem:
Support k8s 1.29

##Testing:

scenario 1 (fresh install):

    On an EKS cluster, install locally built rancher with cspAdapterMinVersion: 104.0.0+up4.0.0-rc8
    Validated the support config and license entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.

scenario 2 (upgrade scenario):

    Start with an EKS cluster (k8s version 1.28), install rancher 2.8.4 with csp-adapter 3.0.1
    Upgrade rancher to locally built rancher with cspAdapterMinVersion: 104.0.0+up4.0.0-rc8
    Update charts url repo/branch and upgrade csp-adapter version to 104.0.0+up4.0.0-rc8
    Validated the support config and license entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.