### PR TITLE
Honor agent TLS mode when installing Fleet

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -39,6 +39,7 @@ var (
 		settings.SystemDefaultRegistry.Name: {},
 		settings.FleetMinVersion.Name:       {},
 		settings.FleetVersion.Name:          {},
+		settings.AgentTLSMode.Name:          {},
 	}
 )
 
@@ -108,6 +109,7 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	}
 
 	fleetChartValues := map[string]interface{}{
+		"agentTLSMode": settings.AgentTLSMode.Get(),
 		"apiServerURL": settings.ServerURL.Get(),
 		"apiServerCA":  settings.CACerts.Get(),
 		"global":       systemGlobalRegistry,

--- a/pkg/controllers/dashboard/fleetcharts/controller_test.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller_test.go
@@ -56,6 +56,7 @@ func Test_ChartInstallation(t *testing.T) {
 
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{
@@ -109,6 +110,7 @@ func Test_ChartInstallation(t *testing.T) {
 				settings.ConfigMapName.Set("pass")
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{
@@ -166,6 +168,7 @@ func Test_ChartInstallation(t *testing.T) {
 
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{
@@ -222,6 +225,7 @@ gitjob:
 
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{


### PR DESCRIPTION
This ensures that Fleet is installed with Rancher's configured agent TLS mode, and that any change to that setting leads to Fleet being reinstalled.

## Issue: #45630

Depends on [fleet#2507](https://github.com/rancher/fleet/pull/2507).
 
## Problem
The new `agent-tls-mode` setting was not taken into account when installing Fleet.
 
## Solution
Included that setting in values used to install the `fleet` chart.
 
## Testing

## Engineering Testing
### Manual Testing
1. Installed Rancher via Helm, built locally using `dev-script/build-local.sh`:
```
$ helm upgrade --install rancher rancher-latest/rancher --devel \
    --namespace cattle-system --create-namespace \
    --set bootstrapPassword=admin \
    --set replicas=1 \
    --set hostname=172.17.0.2.sslip.io \
    --set rancherImageTag=test-strict-tls \
    --set extraEnv[0].name=CATTLE_CHART_DEFAULT_BRANCH \
    --set extraEnv[0].value=fleetci-dev-v2.9-20240617102132 \
    --set extraEnv[1].name=CATTLE_CHART_DEFAULT_URL \
    --set extraEnv[1].value=https://github.com/fleetrepoci/charts \
    --set extraEnv[2].name=CATTLE_FLEET_VERSION \
    --set extraEnv[2].value=999.9.9+up9.9.9
```
(whereby the Fleet version and charts branch were set by [this workflow](https://github.com/rancher/fleet/actions/runs/9545984221/job/26307910961))

2. Found configmaps `fleet-agent` and `fleet-controller`, in namespaces `cattle-fleet-local-system` and `cattle-fleet-system` respectively, to contain the key/value pair `"agentTLSMode": "strict"`

3. Ran the above `helm` command again, this time with the following additional arguments:
```
 --set extraEnv[3].name=CATTLE_AGENT_TLS_MODE --set extraEnv[3].value=system-store
```

4. Repeated step 2. and found value `system-store` instead of `strict`.

**Open question**: how to refresh Rancher configuration? Is there a better way than triggering a reinstall, especially as this new setting does not seem to be visible in the Rancher web UI?

### Automated Testing
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
N/A