### PR TITLE
Use correct version of K3s in provisioning-tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -61,7 +61,7 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
   if [ "$DIST" = "rke2" ]; then
     export SOME_K8S_VERSION="v1.27.10+rke2r1"
   else
-    export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.9/data/data.json | jq -r ".$DIST.channels[0].latest")
+    export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.9/data/data.json | jq -r ".$DIST.releases[-1].version")
   fi
 fi
 


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/45577
 
## Follow up of:
https://github.com/rancher/rancher/pull/45660

## Problem
An accidental usage of `.channels[0].latest` was introduced (which is a reversion to prior logic that was used for `provisioning-tests`) when we pinned RKE2 provisioning tests to `v1.27.10+rke2r1`.

## Solution
Revert the usage of `.channels[0].latest` to `.releases[-1].version`