### PR TITLE
Remove external-rules feature flag

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac"
-	"github.com/rancher/rancher/pkg/features"
 	v13 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -741,7 +740,7 @@ func (m *manager) reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs m
 func (m *manager) checkForManagementPlaneRules(role *v3.RoleTemplate, managementPlaneResource string, apiGroup string) (map[string]string, error) {
 	var rules []v1.PolicyRule
 	if role.External {
-		if features.ExternalRules.Enabled() && role.ExternalRules != nil {
+		if role.ExternalRules != nil {
 			rules = append(rules, role.ExternalRules...)
 		} else {
 			externalRole, err := m.crLister.Get("", role.Name)

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -113,12 +113,6 @@ var (
 		false,
 		false,
 		true)
-	ExternalRules = newFeature(
-		"external-rules",
-		"Enable externalRules for RoleTemplates",
-		true,
-		true,
-		true)
 	UIExtension = newFeature(
 		"uiextension",
 		"Enable UI Extensions when starting Rancher",


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45863
 
## Problem
`external-rules` feature flag was added in Rancher v2.7 and v2.8 to help admins with the transition of the new `RoleTemplate` field `ExternalRules`. That's no longer needed in Rancher v2.9
 
## Solution
Remove `external-rules` feature flag. It will work as it is always enabled, and can't be disabled. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_