### PR TITLE
Refactor global role functions to use Wrangler Backport 2.8

### DIFF
--- a/tests/v2/validation/rbac/globalrolesv2/globalroles_v2.go
+++ b/tests/v2/validation/rbac/globalrolesv2/globalroles_v2.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
-
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/kubeapi/rbac"
@@ -60,10 +59,10 @@ var globalRoleBinding = &v3.GlobalRoleBinding{
 	UserName:       "",
 }
 
-func createGlobalRoleWithInheritedClusterRoles(client *rancher.Client, inheritedRoles []string) (*v3.GlobalRole, error) {
+func createGlobalRoleWithInheritedClusterRolesWrangler(client *rancher.Client, inheritedRoles []string) (*v3.GlobalRole, error) {
 	globalRole.Name = namegen.AppendRandomString("testgr")
 	globalRole.InheritedClusterRoles = inheritedRoles
-	createdGlobalRole, err := rbac.CreateGlobalRole(client, &globalRole)
+	createdGlobalRole, err := client.WranglerContext.Mgmt.GlobalRole().Create(&globalRole)
 	if err != nil {
 		return nil, err
 	}
@@ -71,9 +70,8 @@ func createGlobalRoleWithInheritedClusterRoles(client *rancher.Client, inherited
 	return createdGlobalRole, nil
 }
 
-func getGlobalRoleBindingForUser(client *rancher.Client, userID string) (string, error) {
-	grblist, err := rbac.ListGlobalRoleBindings(client, metav1.ListOptions{})
-
+func getGlobalRoleBindingForUserWrangler(client *rancher.Client, userID string) (string, error) {
+	grblist, err := client.WranglerContext.Mgmt.GlobalRoleBinding().List(metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -44,11 +44,12 @@ func (gr *GlobalRolesV2TestSuite) SetupSuite() {
 	require.NoError(gr.T(), err)
 
 	gr.client = client
+
 }
 
 func (gr *GlobalRolesV2TestSuite) validateRBACResources(createdUser *management.User, inheritedRoles []string) (string, int) {
 	log.Info("Verify that the global role binding is created for the user.")
-	grbOwner, err := getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+	grbOwner, err := getGlobalRoleBindingForUserWrangler(gr.client, createdUser.ID)
 	require.NoError(gr.T(), err)
 	require.NotEmpty(gr.T(), grbOwner, "Global Role Binding not found for the user")
 	grbName := grbOwner
@@ -85,7 +86,7 @@ func (gr *GlobalRolesV2TestSuite) TestCreateUserWithInheritedClusterRoles() {
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleOwner}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -101,7 +102,7 @@ func (gr *GlobalRolesV2TestSuite) TestCreateUserWithMultipleInheritedClusterRole
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleCrtbView, roleProjectsCreate, roleProjectsView}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -126,7 +127,7 @@ func (gr *GlobalRolesV2TestSuite) TestCreateUserWithInheritedCustomClusterRole()
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{inheritedRoleTemplate.ID}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -150,7 +151,7 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleMember}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -184,7 +185,7 @@ func (gr *GlobalRolesV2TestSuite) TestUpdateExistingUserWithCustomGlobalRoleInhe
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleOwner}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user.")
@@ -215,7 +216,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserDeletionAndResourceCleanupWithInherite
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleOwner}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -239,7 +240,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserDeletionAndResourceCleanupWithInherite
 	log.Infof("Verify that the global role binding %s is deleted for the user.", grbName)
 	var grbOwner string
 	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.TenSecondTimeout, func() (done bool, pollErr error) {
-		grbOwner, pollErr = getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+		grbOwner, pollErr = getGlobalRoleBindingForUserWrangler(gr.client, createdUser.ID)
 		if pollErr != nil {
 			return false, pollErr
 		}
@@ -277,7 +278,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromDel
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleOwner}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -307,7 +308,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromDel
 	require.NotEmpty(gr.T(), grList, "Global Role does not exist.")
 
 	log.Info("Verify that the global role binding is deleted for the user.")
-	grbOwner, err := getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+	grbOwner, err := getGlobalRoleBindingForUserWrangler(gr.client, createdUser.ID)
 	require.NoError(gr.T(), err)
 	require.Empty(gr.T(), grbOwner, "Global Role Binding exists for the user.")
 
@@ -343,7 +344,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromDel
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleMember}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -380,7 +381,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromDel
 
 	for _, user := range users {
 		log.Infof("Verify that the global role binding is not deleted for user %s.", user.ID)
-		grbOwner, err := getGlobalRoleBindingForUser(gr.client, user.ID)
+		grbOwner, err := getGlobalRoleBindingForUserWrangler(gr.client, user.ID)
 		require.NoError(gr.T(), err)
 		require.NotEmpty(gr.T(), grbOwner, "Global Role Binding does not exist for user %s", user.ID)
 
@@ -423,7 +424,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClu
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{roleOwner}
-	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRoles(gr.client, inheritedClusterRoles)
+	createdGlobalRole, err := createGlobalRoleWithInheritedClusterRolesWrangler(gr.client, inheritedClusterRoles)
 	require.NoError(gr.T(), err)
 
 	log.Info("Create a user with global role standard user and custom global role.")
@@ -441,7 +442,8 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClu
 	require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", expectedClusterCount, actualClusterCount)
 
 	log.Info("Delete the RKE2 downstream cluster.")
-	clusters.DeleteK3SRKE2Cluster(userClient, rke2SteveObject.ID)
+	err = clusters.DeleteK3SRKE2Cluster(userClient, rke2SteveObject.ID)
+	require.NoError(gr.T(), err)
 
 	log.Info("Verify that the global role is not deleted.")
 	listOpt := metav1.ListOptions{
@@ -452,7 +454,7 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClu
 	require.NotEmpty(gr.T(), grList, "Global Role does not exist.")
 
 	log.Info("Verify that the global role binding is not deleted for the user.")
-	grbOwner, err := getGlobalRoleBindingForUser(gr.client, createdUser.ID)
+	grbOwner, err := getGlobalRoleBindingForUserWrangler(gr.client, createdUser.ID)
 	require.NoError(gr.T(), err)
 	require.NotEmpty(gr.T(), grbOwner, "Global Role Binding does not exist for the user.")
 

--- a/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
+++ b/tests/v2/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
@@ -59,7 +59,7 @@ func (grw *GlobalRolesV2WebhookTestSuite) SetupSuite() {
 
 func getCRTBFromGRBOwner(t *testing.T, client *rancher.Client, user *management.User, expectedCrtbCount int) (*v3.ClusterRoleTemplateBindingList, error, string) {
 	log.Info("Verify that the global role binding is created for the user.")
-	grbOwner, err := getGlobalRoleBindingForUser(client, user.ID)
+	grbOwner, err := getGlobalRoleBindingForUserWrangler(client, user.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, grbOwner, "Global Role Binding not found for the user")
 


### PR DESCRIPTION
Updated the RBAC global role functions to use Wrangler in the GlobalRolesV2 test suite. This includes the functions for creating global roles and getting global role bindings for a user. Also, minor changes are included in globalroles_v2_webhook_test.go file to align with the new function names.

Backport of https://github.com/rancher/rancher/pull/45131