### PR TITLE
Add helm value to specify pod securityContext

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms: {{ include "linux-node-selector-terms" . | nindent 14 }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}
@@ -172,6 +174,8 @@ spec:
           failureThreshold: {{.Values.readinessProbe.failureThreshold }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         volumeMounts:
 {{- if .Values.additionalTrustedCAs }}
         - mountPath: /etc/pki/trust/anchors/ca-additional.pem

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -115,6 +115,12 @@ replicas: 3
 # Set priorityClassName to avoid eviction
 priorityClassName: rancher-critical
 
+# Set security context for the Rancher pod.
+podSecurityContext: {}
+
+# Set security context for the Rancher container.
+securityContext: {}
+
 # Set pod resource requests/limits for Rancher.
 resources: {}
 


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/45698
https://github.com/rancher/rancher/issues/27160
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Rancher requires the MKNOD capability, which is not available in the default configuration of cri-o, making rancher unable to start. A known workaround is to adjust cri-o's configuration to grant the capability by default to all pods.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
I added a `securityContext` and `podSecurityContext` value to the helm chart, to allow modification of the securityContext on the pod and rancher container level respectively, including but not limited to adding the capability required for usage with cri-o.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
/

## Engineering Testing
### Manual Testing
Verified that the values are passed to the pods correctly, and verified installation in a cluster using cri-o with default configuration is possible when specifying the appropriate values.

### Automated Testing
n/a
## QA Testing Considerations
n/a
 
### Regressions Considerations
n/a
