### PR TITLE
Fix the storage of Okta Config passwords.

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -15,6 +15,10 @@ const (
 	// AuthConfigConditionShibbolethSecretFixed is applied to an AuthConfig when the
 	// incorrect name for the shibboleth OpenLDAP secret has been fixed.
 	AuthConfigConditionShibbolethSecretFixed condition.Cond = "ShibbolethSecretFixed"
+
+	// AuthConfigOKTAPasswordMigrated is applied when an Okta password has been
+	// moved to a Secret.
+	AuthConfigOKTAPasswordMigrated condition.Cond = "OktaPasswordMigrated"
 )
 
 // +genclient
@@ -504,7 +508,7 @@ type KeyCloakConfig struct {
 
 type OKTAConfig struct {
 	SamlConfig     `json:",inline" mapstructure:",squash"`
-	OpenLdapConfig LdapFields `json:"openLdapConfig" mapstructure:",squash"`
+	OpenLdapConfig LdapFields `json:"openLdapConfig"`
 }
 
 type ShibbolethConfig struct {

--- a/pkg/controllers/management/secretmigrator/authconfig.go
+++ b/pkg/controllers/management/secretmigrator/authconfig.go
@@ -29,13 +29,16 @@ func (h *handler) syncAuthConfig(_ string, authConfig *apimgmtv3.AuthConfig) (ru
 
 	switch authConfig.Type {
 	case client.ShibbolethConfigType:
-		obj, err := h.migrateAuthConfigPasswordToSecret(authConfig, h.migrateShibbolethSecrets)
+		obj, err := h.migrateAuthConfigPasswordToSecret(authConfig,
+			apimgmtv3.AuthConfigConditionSecretsMigrated, h.migrateShibbolethSecrets)
 		if err != nil {
 			return obj, err
 		}
 		return h.fixShibbolethSecretReference(obj)
 	case client.OKTAConfigType:
-		return h.migrateAuthConfigPasswordToSecret(authConfig, h.migrateOKTASecrets)
+		return h.migrateAuthConfigPasswordToSecret(authConfig,
+			apimgmtv3.AuthConfigOKTAPasswordMigrated,
+			h.migrateOKTASecrets)
 	default:
 		return h.migrateAuthConfig(authConfig)
 	}
@@ -58,12 +61,12 @@ func (h *handler) migrateAuthConfig(authConfig *apimgmtv3.AuthConfig) (runtime.O
 	return updated, nil
 }
 
-func (h *handler) migrateAuthConfigPasswordToSecret(authConfig *apimgmtv3.AuthConfig, f func(map[string]any) (runtime.Object, error)) (runtime.Object, error) {
-	if apimgmtv3.AuthConfigConditionSecretsMigrated.IsTrue(authConfig) {
+func (h *handler) migrateAuthConfigPasswordToSecret(authConfig *apimgmtv3.AuthConfig, cond condition.Cond, f func(map[string]any) (runtime.Object, error)) (runtime.Object, error) {
+	if cond.IsTrue(authConfig) {
 		return authConfig, nil
 	}
 
-	updated, err := apimgmtv3.AuthConfigConditionSecretsMigrated.DoUntilTrue(authConfig, func() (runtime.Object, error) {
+	updated, err := cond.DoUntilTrue(authConfig, func() (runtime.Object, error) {
 		unstructuredConfig, err := getUnstructuredAuthConfigByName(h.authConfigs, authConfig.Name)
 		if err != nil {
 			return nil, err
@@ -171,12 +174,10 @@ func (h *handler) migrateOKTASecrets(unstructuredConfig map[string]any) (runtime
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode OKTAConfig: %w", err)
 	}
-
 	if oktaConfig.OpenLdapConfig.ServiceAccountPassword == "" {
 		// OpenLDAP is not configured, so nothing else is needed
 		return oktaConfig, nil
 	}
-
 	secretName := fmt.Sprintf("%s-%s", strings.ToLower(oktaConfig.Type), serviceAccountPasswordFieldName)
 	lowercaseFieldName := strings.ToLower(serviceAccountPasswordFieldName)
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

This ensures that when Okta is used with OpenLDAP and the password is stored in the AuthConfig, it will be split out into a separate secret. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This adds an additional migration condition and splits the secret out using the same logic as is used for Shibboleth.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Configure Okta with OpenLDAP and the password will appear in the authconfig/okta resource.

Upgrading to code with this fix will split it out and a secret is created `serviceAccountPassword: cattle-global-data:oktaconfig-serviceaccountpassword` with a new condition `OktaPasswordMigrated`.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_