### PR TITLE
Bumping steve

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.3.2
 	github.com/rancher/rke v1.6.0-rc7
-	github.com/rancher/steve v0.0.0-20240611175428-d0f58fc91895
+	github.com/rancher/steve v0.0.0-20240617145219-9ac9be9c0e21
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler/v3 v3.0.0-rc2
 	github.com/robfig/cron v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1887,8 +1887,8 @@ github.com/rancher/rke v1.6.0-rc7 h1:AfKugPEJtZrjgbcr5zGTwTuv18GJAUUMOMKaXUbT8TU
 github.com/rancher/rke v1.6.0-rc7/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
 github.com/rancher/shepherd v0.0.0-20240625175629-3df3551442ba h1:d6xp+xJjRBD2mkVAXaQ2T1jKjz3KHtn0hODPcBCPiFA=
 github.com/rancher/shepherd v0.0.0-20240625175629-3df3551442ba/go.mod h1:u9MIIECvfn+aLZPYi6+JPnH2qmgE88NIJGQ2UwVsC3w=
-github.com/rancher/steve v0.0.0-20240611175428-d0f58fc91895 h1:VWGXpF5QauJ5bpeLJZqbS5l1/0C8dS//te2O8fHl5S0=
-github.com/rancher/steve v0.0.0-20240611175428-d0f58fc91895/go.mod h1:fFT7pNgAQA+ZPVwT2NqO6B6bLuOmReHpCKxkg0pKUqE=
+github.com/rancher/steve v0.0.0-20240617145219-9ac9be9c0e21 h1:nS4q/uzKNlyK7qUh2oOKYwGfQ+aA5pLobBE07UTOuXk=
+github.com/rancher/steve v0.0.0-20240617145219-9ac9be9c0e21/go.mod h1:fFT7pNgAQA+ZPVwT2NqO6B6bLuOmReHpCKxkg0pKUqE=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=


### PR DESCRIPTION
Bumps steve to include 1.30 support and fixes for schema definitions

## Issue: <!-- link the issue or issues this PR resolves here -->
#45157 
 
## Problem
CRD fields which weren't included in openapi/v2 endpoints weren't included in the schema definitions. See #45157 and rancher/steve#215 for more.
 
## Solution
Steve was bumped. See rancher/steve#215 for more details on the full solution.
 
## Testing
N/A - see the steve PR.