### PR TITLE
[Backport v2.8] Reduce reliance on Git Mirror for CI tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -39,6 +39,7 @@ RUNARG="-run ${V2PROV_TEST_RUN_REGEX}"
 export DIST=${V2PROV_TEST_DIST}
 export SOME_K8S_VERSION=${SOME_K8S_VERSION}
 export TB_ORG=${TB_ORG}
+export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 
 eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
@@ -52,6 +53,12 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
 # here for simplicity's sake, as it requires semver parsing & matching. The last release should
 # be good enough for our needs.
 export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.8/data/data.json | jq -r ".$DIST.releases[-1].version")
+fi
+
+if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
+# If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so GitHub is used instead of
+# the default `https://git.rancher.io/charts` to reduce the reliance and load on our Git mirror
+export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts
 fi
 
 echo "Starting rancher server for provisioning-tests using $SOME_K8S_VERSION"

--- a/scripts/test
+++ b/scripts/test
@@ -42,6 +42,7 @@ fi
 export DIST=${TEST_DIST}
 export SOME_K8S_VERSION=${SOME_K8S_VERSION}
 export TB_ORG=${TB_ORG}
+export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 
 # Tell Rancher to use the recently-built Rancher cluster agent image. This image is built as part of CI and will be
 # copied to the in-cluster registry during test setup below.
@@ -61,6 +62,12 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
 # here for simplicity's sake, as it requires semver parsing & matching. The last release should
 # be good enough for our needs.
 export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.8/data/data.json | jq -r ".$DIST.releases[-1].version")
+fi
+
+if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
+# If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so GitHub is used instead of
+# the default `https://git.rancher.io/charts` to reduce the reliance and load on our Git mirror
+export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts
 fi
 
 echo Starting rancher server for test


### PR DESCRIPTION
(cherry picked from commit c8097db7b89900f9cbd11fd3178094a27e8ea071)

## Issue: https://github.com/rancher/rancher/issues/45677

Direct cherry-pick of https://github.com/rancher/rancher/pull/45681 (the same description applies)