### PR TITLE
Bump rancher-webhook to v0.5.0-rc10

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 104.0.0+up0.5.0-rc9
+webhookVersion: 104.0.0+up0.5.0-rc10
 provisioningCAPIVersion: 104.0.0+up0.3.0-rc.1
 cspAdapterMinVersion: 104.0.0+up4.0.0-rc8
 defaultShellVersion: rancher/shell:v0.2.1-rc.4

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,5 +7,5 @@ const (
 	DefaultShellVersion     = "rancher/shell:v0.2.1-rc.4"
 	FleetVersion            = "104.0.0+up0.10.0-rc.18"
 	ProvisioningCAPIVersion = "104.0.0+up0.3.0-rc.1"
-	WebhookVersion          = "104.0.0+up0.5.0-rc9"
+	WebhookVersion          = "104.0.0+up0.5.0-rc10"
 )


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45331

## Problem

We need 1.30 k8s support in webhook


## Solution

- Bumps webhook to a version that supports k8s 1.30

## CheckList

- [ ] Test
  <!-- 
  Docs: 
   If you are updating or creating a mutator or validator, you will also need to update or create the markdown that documents validator's or mutator's behavior.
   For more info on how docs work, see: https://github.com/rancher/webhook#docs
  -->
- [ ] Docs