### PR TITLE
[2.7] Bump Shepherd Version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
 	github.com/rancher/cis-operator v1.0.11
-	github.com/rancher/shepherd v0.0.0-20240625175636-3b9cd408533b
+	github.com/rancher/shepherd v0.0.0-20240628195837-fce9bdc2bcf0
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1044,8 +1044,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.19 h1:KONBA00oZFcY8A87g7yKtbk0u+IkXswy/db9XvfSXD4=
 github.com/rancher/rke v1.4.19/go.mod h1:UIc898udZbjJ+0616CEmjqY+eBQSkW/dQ30ZvL7bUcQ=
-github.com/rancher/shepherd v0.0.0-20240625175636-3b9cd408533b h1:uFVAMyNZXNaOsm65fE5RYjKdGnBd9St44hNhT/VK2jQ=
-github.com/rancher/shepherd v0.0.0-20240625175636-3b9cd408533b/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
+github.com/rancher/shepherd v0.0.0-20240628195837-fce9bdc2bcf0 h1:RWeWFBDQcD4Cgvh/k+e9cKwhFrmCVAmlI5t1Co73yUY=
+github.com/rancher/shepherd v0.0.0-20240628195837-fce9bdc2bcf0/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a h1:Mawv3TfevX5dbVDlB/+RPgqxMX1HZQimyhj05R/Ef7U=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a/go.mod h1:tfdVny3lVO6H0JyysFBZ1ce45kH9VgWLPa9z9TZVI+U=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=


### PR DESCRIPTION
Bumps Shepherd version to `v0.0.0-20240628195837-fce9bdc2bcf0`