### PR TITLE
[2.8] Honor agent TLS mode when installing Fleet

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -39,6 +39,7 @@ var (
 		settings.SystemDefaultRegistry.Name: {},
 		settings.FleetMinVersion.Name:       {},
 		settings.FleetVersion.Name:          {},
+		settings.AgentTLSMode.Name:          {},
 	}
 )
 
@@ -108,6 +109,7 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	}
 
 	fleetChartValues := map[string]interface{}{
+		"agentTLSMode": settings.AgentTLSMode.Get(),
 		"apiServerURL": settings.ServerURL.Get(),
 		"apiServerCA":  settings.CACerts.Get(),
 		"global":       systemGlobalRegistry,

--- a/pkg/controllers/dashboard/fleetcharts/controller_test.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller_test.go
@@ -56,6 +56,7 @@ func Test_ChartInstallation(t *testing.T) {
 
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{
@@ -109,6 +110,7 @@ func Test_ChartInstallation(t *testing.T) {
 				settings.ConfigMapName.Set("pass")
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{
@@ -166,6 +168,7 @@ func Test_ChartInstallation(t *testing.T) {
 
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{
@@ -222,6 +225,7 @@ gitjob:
 
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{


### PR DESCRIPTION
Backport of [rancher#45842](https://github.com/rancher/rancher/pull/45842) to 2.8.

Depends on [fleet#2577](https://github.com/rancher/fleet/pull/2577).

## Testing

## Engineering Testing
### Manual Testing
1. Installed Rancher via Helm, built locally using `dev-script/build-local.sh`:
```
$ helm upgrade --install rancher rancher-latest/rancher --devel \
    --namespace cattle-system --create-namespace \
    --set bootstrapPassword=admin \
    --set replicas=1 \
    --set hostname=172.17.0.2.sslip.io \
    --set rancherImageTag=2.8-test-strict-tls \
    --set extraEnv[0].name=CATTLE_CHART_DEFAULT_BRANCH \
    --set extraEnv[0].value=fleetci-dev-v2.8-20240703115101 \
    --set extraEnv[1].name=CATTLE_CHART_DEFAULT_URL \
    --set extraEnv[1].value=https://github.com/fleetrepoci/charts \
    --set extraEnv[2].name=CATTLE_FLEET_VERSION \
    --set extraEnv[2].value=999.9.9+up9.9.9
```
(whereby the Fleet version and charts branch were set by [this workflow](https://github.com/rancher/fleet/actions/runs/9777258631/job/26991537435))

2. Found configmaps `fleet-agent` and `fleet-controller`, in namespaces `cattle-fleet-local-system` and `cattle-fleet-system` respectively, to contain the key/value pair `"agentTLSMode": "system-store"`

3. Navigated the Rancher UI at `https://172.17.0.2.sslip.io/dashboard/c/local/explorer/configmap` and edited config map `rancher-config`, adding a `fleet` field with value `{"agentTLSMode": "strict"}`

4. Could see the `fleet-agent` pod being re-created, and config maps `fleet-controller` and `fleet-agent` being updated with the new `agentTLSMode` value.

### Automated Testing
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
N/A