### PR TITLE
[v2.10] Add GUID search support

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -195,7 +195,7 @@ func getUsernameFromObjectGUID(lConn *ldapv3.Conn, config *v32.ActiveDirectoryCo
 	if len(result.Entries) == 0 {
 		return "", errors.New("LDAP search of user by objectGUID returned no results")
 	} else if len(result.Entries) > 1 {
-		return "", fmt.Errorf("LDAP search of user by objectGUID returned no results")
+		return "", fmt.Errorf("LDAP search of user by objectGUID returned more than 1 result")
 	}
 
 	// if found we can continue the login flow with the login attribute of the user

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -170,7 +170,7 @@ func getUsernameFromObjectGUID(lConn *ldapv3.Conn, config *v32.ActiveDirectoryCo
 
 	parsedGUID, err := guid.Parse(uuid)
 	if err != nil {
-		return "", fmt.Errorf("cannot parsing UUID: %w", err)
+		return "", fmt.Errorf("parsing objectGUID to get the username: %w", err)
 	}
 
 	// search the user by its objectGUID
@@ -194,11 +194,12 @@ func getUsernameFromObjectGUID(lConn *ldapv3.Conn, config *v32.ActiveDirectoryCo
 
 	if len(result.Entries) == 0 {
 		return "", errors.New("LDAP search of user by objectGUID returned no results")
+	} else if len(result.Entries) > 1 {
+		return "", fmt.Errorf("LDAP search of user by objectGUID returned no results")
 	}
 
 	// if found we can continue the login flow with the login attribute of the user
-	username = result.Entries[0].GetAttributeValue(config.UserLoginAttribute)
-	return username, nil
+	return result.Entries[0].GetAttributeValue(config.UserLoginAttribute), nil
 }
 
 func (p *adProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult, config *v32.ActiveDirectoryConfig, lConn *ldapv3.Conn) (v3.Principal, []v3.Principal, error) {

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -30,6 +30,7 @@ const (
 	UserScope                          = Name + "_user"
 	GroupScope                         = Name + "_group"
 	ObjectClass                        = "objectClass"
+	ObjectGUIDAttribute                = "objectGUID"
 	MemberOfAttribute                  = "memberOf"
 	StatusConfigMapName                = "ad-guid-migration"
 	StatusConfigMapNamespace           = "cattle-system"

--- a/pkg/auth/providers/activedirectory/guid/guid.go
+++ b/pkg/auth/providers/activedirectory/guid/guid.go
@@ -45,9 +45,7 @@ func (g GUID) UUID() string {
 		return ""
 	}
 
-	u := make([]byte, len(g))
-	copy(u, g)
-	swap(u)
+	u := swap(g)
 
 	return fmt.Sprintf(
 		"%x-%x-%x-%x-%x",
@@ -87,8 +85,7 @@ func Parse(uuid string) (GUID, error) {
 		return nil, fmt.Errorf("cannot decode uuid string '%s' to hex: %w", uuid, err)
 	}
 
-	swap(uuidBytes)
-	return GUID(uuidBytes), nil
+	return GUID(swap(uuidBytes)), nil
 }
 
 // Escape returns an escaped string format of the objectGUID that can be safely used
@@ -107,14 +104,18 @@ func Escape(guid GUID) string {
 	return builder.String()
 }
 
-func swap(u []byte) {
+// swap will return a new array with the first three "bytes blocks" reversed
+func swap(u []byte) []byte {
 	if len(u) != 16 {
-		return
+		return u
 	}
 
-	u[0], u[1], u[2], u[3] = u[3], u[2], u[1], u[0]
-	u[4], u[5] = u[5], u[4]
-	u[6], u[7] = u[7], u[6]
+	return []byte{
+		u[3], u[2], u[1], u[0], // reverse 0-4
+		u[5], u[4], // reverse 4-5
+		u[7], u[6], // reverse 6-7
+		u[8], u[9], u[10], u[11], u[12], u[13], u[14], u[15], // keep 8-15
+	}
 }
 
 // hexes returns a string array of the hex decoded values
@@ -122,8 +123,7 @@ func hexes(bytes []byte) []string {
 	var hexes []string
 
 	for _, b := range bytes {
-		hex := fmt.Sprintf("%02x", b)
-		hexes = append(hexes, hex)
+		hexes = append(hexes, fmt.Sprintf("%02x", b))
 	}
 
 	return hexes

--- a/pkg/auth/providers/activedirectory/guid/guid.go
+++ b/pkg/auth/providers/activedirectory/guid/guid.go
@@ -1,0 +1,130 @@
+// Package guid is used to handle the non-standard UUID from the Microsoft Active Directory.
+// The objectGUID is following the DSP0134 specification, described in the
+// DMTF System Management BIOS (SMBIOS) Reference Specification document:
+//
+//   - https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf
+//
+// According to this spec the bytes for the time_low, time_mid and time_hi_and_version
+// values follow the little endian format.
+//
+// The standard RFC4122 encoding for the UUID "00112233-4455-6677-8899-AABBCCDDEEFF" is:
+//
+//	00 11 22 33 44 55 66 77 88 99 AA BB CC DD EE FF
+//
+// The encoding specified in DSP0134 is:
+//
+//	33 22 11 00 55 44 77 66 88 99 AA BB CC DD EE FF
+package guid
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var uuidRegex = regexp.MustCompile("(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+// GUID represent the UUID in the DSP0134 spec
+type GUID []byte
+
+// Bytes returns the underlying bytes value
+func (g GUID) Bytes() []byte {
+	return g
+}
+
+// String returns UUID string representation
+func (g GUID) String() string {
+	return g.UUID()
+}
+
+// UUID returns the UUID string representation: "00112233-4455-6677-8899-AABBCCDDEEFF"
+func (g GUID) UUID() string {
+	if len(g) != 16 {
+		return ""
+	}
+
+	u := make([]byte, len(g))
+	copy(u, g)
+	swap(u)
+
+	return fmt.Sprintf(
+		"%x-%x-%x-%x-%x",
+		u[:4], u[4:6], u[6:8], u[8:10], u[10:],
+	)
+}
+
+// Hex returns the Hex string representation: "33 22 11 00 55 44 77 66 88 99 AA BB CC DD EE FF"
+func (g GUID) Hex() string {
+	hexesArr := hexes(g.Bytes())
+
+	for i := range hexesArr {
+		hexesArr[i] = strings.ToUpper(hexesArr[i])
+	}
+
+	return strings.Join(hexesArr, " ")
+}
+
+// New returns a GUID object
+func New(encoded []byte) (GUID, error) {
+	if len(encoded) != 16 {
+		return nil, errors.New("invalid length")
+	}
+
+	return GUID(encoded), nil
+}
+
+// Parse returns a GUID object from a RFC4122 UUID string
+func Parse(uuid string) (GUID, error) {
+	if !uuidRegex.MatchString(uuid) {
+		return nil, errors.New("cannot parse UUID to objectGUID: invalid format")
+	}
+
+	uuid = strings.ReplaceAll(uuid, "-", "")
+	uuidBytes, err := hex.DecodeString(uuid)
+	if err != nil {
+		return nil, err
+	}
+
+	swap(uuidBytes)
+	return GUID(uuidBytes), nil
+}
+
+// Escape returns an escaped string format of the objectGUID that can be safely used
+// through the LDAP search. Every byte has to be encoded in an hex string,
+// and prefixed with the '\' character. If a byte has a hex encoded string of
+// length 1 then it will be prefixed with a '0'.
+func Escape(guid GUID) string {
+	builder := strings.Builder{}
+
+	hexArray := hexes(guid.Bytes())
+	for _, hex := range hexArray {
+		builder.WriteString(`\`)
+		builder.WriteString(hex)
+	}
+
+	return builder.String()
+}
+
+func swap(u []byte) {
+	if len(u) != 16 {
+		return
+	}
+
+	u[0], u[1], u[2], u[3] = u[3], u[2], u[1], u[0]
+	u[4], u[5] = u[5], u[4]
+	u[6], u[7] = u[7], u[6]
+}
+
+// hexes returns a string array of the hex decoded values
+func hexes(bytes []byte) []string {
+	var hexes []string
+
+	for _, b := range bytes {
+		hex := fmt.Sprintf("%02x", b)
+		hexes = append(hexes, hex)
+	}
+
+	return hexes
+}

--- a/pkg/auth/providers/activedirectory/guid/guid.go
+++ b/pkg/auth/providers/activedirectory/guid/guid.go
@@ -69,7 +69,7 @@ func (g GUID) Hex() string {
 // New returns a GUID object
 func New(encoded []byte) (GUID, error) {
 	if len(encoded) != 16 {
-		return nil, errors.New("invalid length")
+		return nil, errors.New("cannot create GUID from encoded bytes: invalid length")
 	}
 
 	return GUID(encoded), nil
@@ -84,7 +84,7 @@ func Parse(uuid string) (GUID, error) {
 	uuid = strings.ReplaceAll(uuid, "-", "")
 	uuidBytes, err := hex.DecodeString(uuid)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot decode uuid string '%s' to hex: %w", uuid, err)
 	}
 
 	swap(uuidBytes)

--- a/pkg/auth/providers/activedirectory/guid/guid_test.go
+++ b/pkg/auth/providers/activedirectory/guid/guid_test.go
@@ -1,0 +1,179 @@
+package guid_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher/rancher/pkg/auth/providers/activedirectory/guid"
+)
+
+func TestDecodings(t *testing.T) {
+	tt := []struct {
+		name         string
+		encoded      []byte
+		expectedUUID string
+		expectedHex  string
+		expectedErr  string
+	}{
+		{
+			name:         "valid objectGUID 1",
+			encoded:      []byte("\xaf\xf6\x0e=[\x96\xe3D\x8f\xea\xb2:}:\xa6\xcb"),
+			expectedUUID: "3d0ef6af-965b-44e3-8fea-b23a7d3aa6cb",
+			expectedHex:  "AF F6 0E 3D 5B 96 E3 44 8F EA B2 3A 7D 3A A6 CB",
+		},
+		{
+			name:         "valid objectGUID 2",
+			encoded:      []byte("\xbf?Yu\xd1WUL\x87-\x93r\xef\x0f\xdd\x15"),
+			expectedUUID: "75593fbf-57d1-4c55-872d-9372ef0fdd15",
+			expectedHex:  "BF 3F 59 75 D1 57 55 4C 87 2D 93 72 EF 0F DD 15",
+		},
+		{
+			name:         "valid objectGUID 3",
+			encoded:      []byte("\x36\xf4\x21\x9b\xf9\x8a\x54\x48\x95\x3d\xc6\x36\x99\x90\xe0\xa0"),
+			expectedUUID: "9b21f436-8af9-4854-953d-c6369990e0a0",
+			expectedHex:  "36 F4 21 9B F9 8A 54 48 95 3D C6 36 99 90 E0 A0",
+		},
+		{
+			name:         "valid objectGUID with N char",
+			encoded:      []byte("\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e"),
+			expectedUUID: "4e4e4e4e-4e4e-4e4e-4e4e-4e4e4e4e4e4e",
+			expectedHex:  "4E 4E 4E 4E 4E 4E 4E 4E 4E 4E 4E 4E 4E 4E 4E 4E",
+		},
+		{
+			name:        "objectGUID with invalid length",
+			encoded:     []byte("\xaf\xf6\x0e\x96\xe3"),
+			expectedErr: "invalid length",
+		},
+		{
+			// This test data was taken from the following MS example:
+			// https://learn.microsoft.com/en-us/dotnet/api/system.guid.tobytearray?view=net-8.0
+			name:         "Microsoft GUID",
+			encoded:      []byte("\xC9\x8B\x91\x35\x6D\x19\xEA\x40\x97\x79\x88\x9D\x79\xB7\x53\xF0"),
+			expectedUUID: "35918bc9-196d-40ea-9779-889d79b753f0",
+			expectedHex:  "C9 8B 91 35 6D 19 EA 40 97 79 88 9D 79 B7 53 F0",
+		},
+		{
+			name:         "nil GUID",
+			encoded:      nil,
+			expectedUUID: "",
+			expectedHex:  "",
+			expectedErr:  "invalid length",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			parsedGUID, err := guid.New(tc.encoded)
+
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expectedUUID, parsedGUID.UUID())
+				assert.Equal(t, tc.expectedHex, parsedGUID.Hex())
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tt := []struct {
+		name         string
+		uuid         string
+		expectedGUID []byte
+		expectedErr  string
+	}{
+		{
+			name:         "valid uuid 1",
+			uuid:         "3d0ef6af-965b-44e3-8fea-b23a7d3aa6cb",
+			expectedGUID: []byte("\xaf\xf6\x0e=[\x96\xe3D\x8f\xea\xb2:}:\xa6\xcb"),
+		},
+		{
+			name:         "valid uuid 2",
+			uuid:         "75593fbf-57d1-4c55-872d-9372ef0fdd15",
+			expectedGUID: []byte("\xbf?Yu\xd1WUL\x87-\x93r\xef\x0f\xdd\x15"),
+		},
+		{
+			name:         "valid uuid 3",
+			uuid:         "9b21f436-8af9-4854-953d-c6369990e0a0",
+			expectedGUID: []byte("\x36\xf4\x21\x9b\xf9\x8a\x54\x48\x95\x3d\xc6\x36\x99\x90\xe0\xa0"),
+		},
+		{
+			name:         "valid uuid with N char",
+			uuid:         "4e4e4e4e-4e4e-4e4e-4e4e-4e4e4e4e4e4e",
+			expectedGUID: []byte("\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e"),
+		},
+		{
+			name:        "invalid uuid",
+			uuid:        "75593fbf",
+			expectedErr: "invalid format",
+		},
+		{
+			name:        "empty uuid",
+			uuid:        "",
+			expectedErr: "invalid format",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			objectGUID, err := guid.Parse(tc.uuid)
+
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expectedGUID, objectGUID.Bytes())
+			}
+		})
+	}
+}
+
+func TestEscape(t *testing.T) {
+	tt := []struct {
+		name        string
+		objectGUID  guid.GUID
+		escapedGUID string
+	}{
+		{
+			name:        "valid objectGUID 1",
+			objectGUID:  guid.GUID([]byte("\xaf\xf6\x0e=[\x96\xe3D\x8f\xea\xb2:}:\xa6\xcb")),
+			escapedGUID: "\\af\\f6\\0e\\3d\\5b\\96\\e3\\44\\8f\\ea\\b2\\3a\\7d\\3a\\a6\\cb",
+		},
+		{
+			name:        "valid objectGUID 2",
+			objectGUID:  guid.GUID([]byte("\xbf?Yu\xd1WUL\x87-\x93r\xef\x0f\xdd\x15")),
+			escapedGUID: "\\bf\\3f\\59\\75\\d1\\57\\55\\4c\\87\\2d\\93\\72\\ef\\0f\\dd\\15",
+		},
+		{
+			name:        "valid objectGUID with N char",
+			objectGUID:  guid.GUID([]byte("\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e\x4e")),
+			escapedGUID: "\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e\\4e",
+		},
+		{
+			name:        "short objectGUID",
+			objectGUID:  guid.GUID([]byte("a")),
+			escapedGUID: "\\61",
+		},
+		{
+			name:        "empty objectGUID",
+			objectGUID:  guid.GUID([]byte("")),
+			escapedGUID: "",
+		},
+		{
+			name:        "nil objectGUID",
+			escapedGUID: "",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			escaped := guid.Escape(tc.objectGUID)
+			assert.Equal(t, tc.escapedGUID, escaped)
+		})
+	}
+}


### PR DESCRIPTION
## Issue:  https://github.com/rancher/rancher/issues/44916
Rancher is missing a way to perform a search in ActiveDirectory though the `objectGUID` attribute.

## Problem
In order to fix the issue https://github.com/rancher/rancher/issues/37994 we need a way to fetch the `objectGUID` attribute from ActiveDirectory.
 
## Solution
This PR adds the `guid` package (with tests). This package can be used to create a GUID object from the raw bytes, following the DSP0134 specification for the UUID used as objectGUID in ActiveDirectory.

 
## Testing

## Engineering Testing

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
No regressions expected.
