### PR TITLE
[v2.9] bump shell RC version to newest

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 104.0.0+up0.5.0-rc10
 provisioningCAPIVersion: 104.0.0+up0.3.0-rc.1
 cspAdapterMinVersion: 104.0.0+up4.0.0-rc8
-defaultShellVersion: rancher/shell:v0.2.1-rc.4
+defaultShellVersion: rancher/shell:v0.2.1-rc.5
 fleetVersion: 104.0.0+up0.10.0-rc.18

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion    = "104.0.0+up4.0.0-rc8"
-	DefaultShellVersion     = "rancher/shell:v0.2.1-rc.4"
+	DefaultShellVersion     = "rancher/shell:v0.2.1-rc.5"
 	FleetVersion            = "104.0.0+up0.10.0-rc.18"
 	ProvisioningCAPIVersion = "104.0.0+up0.3.0-rc.1"
 	WebhookVersion          = "104.0.0+up0.5.0-rc10"


### PR DESCRIPTION
per title, this just ensures that Rancher RCs/alphas are using the newest Shell RC.