### PR TITLE
Updated cspadapter version 4.0.0-rc9

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 104.0.0+up0.5.0-rc10
 provisioningCAPIVersion: 104.0.0+up0.3.0-rc.1
-cspAdapterMinVersion: 104.0.0+up4.0.0-rc8
+cspAdapterMinVersion: 104.0.0+up4.0.0-rc9
 defaultShellVersion: rancher/shell:v0.2.1-rc.5
 fleetVersion: 104.0.0+up0.10.0-rc.18

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion    = "104.0.0+up4.0.0-rc8"
+	CspAdapterMinVersion    = "104.0.0+up4.0.0-rc9"
 	DefaultShellVersion     = "rancher/shell:v0.2.1-rc.5"
 	FleetVersion            = "104.0.0+up0.10.0-rc.18"
 	ProvisioningCAPIVersion = "104.0.0+up0.3.0-rc.1"


### PR DESCRIPTION
rancher/rancher#45744

Problem
Support k8s 1.30

Testing
scenario 1 (Fresh Install):

On an EKS cluster, install locally built rancher with cspAdapterMinVersion: 104.0.0+up4.0.0-rc9.
Start with an EKS cluster (k8s version 1.28), install rancher 2.8.4 with csp-adapter 3.0.1.
Upgrade rancher to locally built rancher with cspAdapterMinVersion: 104.0.0+up4.0.0-rc9
Update charts url repo/branch and upgrade csp-adapter version to 104.0.0+up4.0.0-rc9
Upgrade Management and compute node to K8s 1.30. Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.