### PR TITLE
Bump provisioning test wait to 45 minutes

### DIFF
--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -15,7 +15,7 @@ var (
 	DistroDataDir          = os.Getenv("V2PROV_DISTRO_DATA_DIR")
 	ProvisioningDataDir    = os.Getenv("V2PROV_PROVISIONING_DATA_DIR")
 	SystemAgentDataDir     = os.Getenv("V2PROV_SYSTEM_AGENT_DATA_DIR")
-	WatchTimeoutSeconds    = int64(900) // 15 minutes.
+	WatchTimeoutSeconds    = int64(2700) // 45 minutes.
 	CommonClusterConfig    = map[string]interface{}{
 		"service-cidr": "10.45.0.0/16",
 		"cluster-cidr": "10.44.0.0/16",


### PR DESCRIPTION
Bumping provisioning test wait timeout from 15 minutes to 45.