### PR TITLE
[v2.8] Bump provisioning test wait to 45 minutes

### DIFF
--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -12,7 +12,7 @@ var (
 	ObjectStoreServerImage = "rancher/mirrored-minio-minio:RELEASE.2022-12-12T19-27-27Z"
 	ObjectStoreUtilImage   = "rancher/mirrored-minio-mc:RELEASE.2022-12-13T00-23-28Z"
 	SomeK8sVersion         = os.Getenv("SOME_K8S_VERSION")
-	WatchTimeoutSeconds    = int64(900) // 15 minutes.
+	WatchTimeoutSeconds    = int64(2700) // 45 minutes.
 	CommonClusterConfig    = map[string]interface{}{
 		"service-cidr": "10.45.0.0/16",
 		"cluster-cidr": "10.44.0.0/16",


### PR DESCRIPTION
backport of https://github.com/rancher/rancher/pull/45996