### PR TITLE
[2.7] Honor agent TLS mode when installing Fleet

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -65,7 +65,8 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 
 	if setting.Name != settings.ServerURL.Name &&
 		setting.Name != settings.CACerts.Name &&
-		setting.Name != settings.SystemDefaultRegistry.Name {
+		setting.Name != settings.SystemDefaultRegistry.Name &&
+		setting.Name != settings.AgentTLSMode.Name {
 		return setting, nil
 	}
 
@@ -88,6 +89,7 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	}
 
 	fleetChartValues := map[string]interface{}{
+		"agentTLSMode": settings.AgentTLSMode.Get(),
 		"apiServerURL": settings.ServerURL.Get(),
 		"apiServerCA":  settings.CACerts.Get(),
 		"global":       systemGlobalRegistry,

--- a/pkg/controllers/dashboard/fleetcharts/controller_test.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller_test.go
@@ -50,6 +50,7 @@ func Test_ChartInstallation(t *testing.T) {
 				settings.ConfigMapName.Set("pass")
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{
@@ -99,6 +100,7 @@ func Test_ChartInstallation(t *testing.T) {
 				settings.ConfigMapName.Set("fail")
 				manager := fake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
 					"apiServerURL": settings.ServerURL.Get(),
 					"apiServerCA":  settings.CACerts.Get(),
 					"global": map[string]interface{}{


### PR DESCRIPTION
Backport of #45842 to 2.7.
Depends on [fleet#2596](https://github.com/rancher/fleet/pull/2596).

## Testing

## Engineering Testing
### Manual Testing
1. (locally) cherry-picked [this commit](https://github.com/rancher/rancher/commit/62e6a3f7f901c4ae426f6641544b29a29a614dd1) to enable Rancher to use a custom charts repository URL
2. Installed Rancher via Helm, built locally using `dev-script/build-local.sh`:
```
$ helm upgrade --install rancher rancher-latest/rancher --devel \
    --namespace cattle-system --create-namespace \
    --set bootstrapPassword=admin \
    --set replicas=1 \
    --set hostname=172.17.0.2.sslip.io \
    --set rancherImageTag=2.7-test-strict-tls \
    --set extraEnv[0].name=CATTLE_CHART_DEFAULT_BRANCH \
    --set extraEnv[0].value=fleetci-dev-v2.7-20240704155138 \
    --set extraEnv[1].name=CATTLE_CHART_DEFAULT_URL \
    --set extraEnv[1].value=https://github.com/fleetrepoci/charts \
    --set extraEnv[2].name=CATTLE_FLEET_VERSION \
    --set extraEnv[2].value=999.9.9+up9.9.9
```
(whereby the Fleet version and charts branch were set by [this workflow](https://github.com/rancher/fleet/actions/runs/9797111050/job/27053002761))

3. Found configmaps `fleet-agent` and `fleet-controller`, in namespaces `cattle-fleet-local-system` and `cattle-fleet-system` respectively, to contain the key/value pair `"agentTLSMode": "system-store"`

4. Repeated the Helm install step in 2. with the following additional arguments:
```
    --set extraEnv[3].name=CATTLE_AGENT_TLS_MODE \
    --set extraEnv[3].value=strict
```

5. Found configmaps `fleet-agent` and `fleet-controller`, in namespaces `cattle-fleet-local-system` and `cattle-fleet-system` respectively, to contain the key/value pair `"agentTLSMode": "strict"`

### Automated Testing
N/A

## QA Testing Considerations
I did not manage to test reinstalling the Fleet agent by updating config map `rancher-config`, neither for the agent TLS mode nor even for the server URL.
 
### Regressions Considerations
N/A