### PR TITLE
[v2.9] Fix origin of `rancher-agent` image

### DIFF
--- a/pkg/api/steve/catalog/plugin_test.go
+++ b/pkg/api/steve/catalog/plugin_test.go
@@ -29,7 +29,7 @@ func TestProxyRequest_content_type(t *testing.T) {
 		t.Errorf("got StatusCode %v, want %v", resp.StatusCode, http.StatusOK)
 	}
 
-	wantContent := "application/javascript"
+	wantContent := "text/javascript; charset=utf-8"
 	if ct := resp.Header.Get("Content-Type"); ct != wantContent {
 		t.Errorf("got Content-Type %s, want %s", ct, wantContent)
 

--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -234,7 +234,7 @@ var OriginMap = map[string]string{
 	"pushprox-client":                                         "https://github.com/rancher/PushProx",
 	"pushprox-proxy":                                          "https://github.com/rancher/PushProx",
 	"rancher":                                                 "https://github.com/rancher/rancher",
-	"rancher-agent":                                           "https://github.com/rancher/rancher-agent",
+	"rancher-agent":                                           "https://github.com/rancher/rancher",
 	"rancher-csp-adapter":                                     "https://github.com/rancher/csp-adapter",
 	"rancher-webhook":                                         "https://github.com/rancher/webhook",
 	"rke-tools":                                               "https://github.com/rancher/rke-tools",

--- a/scripts/package
+++ b/scripts/package
@@ -67,7 +67,7 @@ fi
 
 if [ ${ARCH} == amd64 ]; then
     # Move this out of ARCH check for local dev on non-amd64 hardware.
-    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR $IMAGE $AGENT_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $WINS_AGENT_UPGRADE_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}
+    TAG=$TAG REPO=${REPO} CGO_ENABLED=0 go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR $IMAGE $AGENT_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $WINS_AGENT_UPGRADE_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}
 fi
 
 # Create components file used for pre-release notes

--- a/scripts/test
+++ b/scripts/test
@@ -23,7 +23,7 @@ fi
 cd $(dirname $0)/..
 
 echo Running unit tests
-go test -cover -tags=test ./pkg/...
+CGO_ENABLED=0 go test -cover -tags=test ./pkg/...
 
 if [ ${ARCH} == arm64 ] || [ ${ARCH} == s390x ]; then
     export ETCD_UNSUPPORTED_ARCH=${ARCH}
@@ -172,7 +172,7 @@ export CATTLE_TEST_CONFIG=$(pwd)/config.yaml # used by integration tests and tes
 }
 
 echo Running go integration tests
-go test -v -failfast -p 1 ./tests/v2/integration/... || {
+CGO_ENABLED=0 go test -v -failfast -p 1 ./tests/v2/integration/... || {
   dump_rancher_logs
   exit 1
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Apart from the problem listed below, due to an yet unidentified problem, we had to add `CGO_ENABLED=0` to some `go run/build` to solve a caching problem. Another solution would have been to clean the Go cache as tested in https://github.com/rancher/rancher/pull/46018, but not merged.

Additionally, this PR is also fixing an unrelated failing test, as approved by @rohitsakala.

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
It seems that we are wrongly tracking the origin of `rancher-agent` image to repo `rancher/rancher-agent` instead of [rancher/rancher](https://github.com/rancher/rancher). The `rancher-agent` image is made in https://github.com/rancher/rancher/blob/edd2985c2efde73c58fe39737962d0591b171b35/package/Dockerfile.agent and published in: https://github.com/rancher/rancher/blob/edd2985c2efde73c58fe39737962d0591b171b35/.drone.yml#L190-L204

The repo https://github.com/rancher/rancher-agent is a redirect to https://github.com/rancher/system-agent where a different image is built: https://github.com/rancher/rancher/blob/edd2985c2efde73c58fe39737962d0591b171b35/pkg/image/origins.go#L246

Ideally this is mostly a cosmetic fix, because this tracking is only for our own internal purpose. With the wrong information, some automations that we are developing internally will present the wrong results.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_