### PR TITLE
Add controller integration tests to the CI

### DIFF
--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -1,0 +1,31 @@
+name: Controller Integration Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+    - 'release/*'
+
+env:
+  MAIN_BRANCH: origin/master
+  GOARCH: amd64
+  CGO_ENABLED: 0
+  SETUP_GO_VERSION: '1.22.*'
+
+jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        name: Run Integration Tests
+        run: ./tests/controllers/run_controller_tests.sh

--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -8,7 +8,6 @@ on:
     - 'release/*'
 
 env:
-  MAIN_BRANCH: origin/master
   GOARCH: amd64
   CGO_ENABLED: 0
   SETUP_GO_VERSION: '1.22.*'
@@ -28,4 +27,6 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
       -
         name: Run Integration Tests
+        env:
+          ENVTEST_K8S_VERSION: 1.30
         run: ./tests/controllers/run_controller_tests.sh

--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -14,7 +14,7 @@ env:
   SETUP_GO_VERSION: '1.22.*'
 
 jobs:
-  check-changes:
+  run-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -28,5 +28,5 @@ jobs:
       -
         name: Run Integration Tests
         env:
-          ENVTEST_K8S_VERSION: 1.30
+          ENVTEST_K8S_VERSION: "1.30"
         run: ./tests/controllers/run_controller_tests.sh

--- a/tests/controllers/README.md
+++ b/tests/controllers/README.md
@@ -16,6 +16,7 @@ go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 ### Makefile
 All tests can be run with `make controller-test`. That runs the bash script [`run_controller_tests.sh`](./run_controller_tests.sh).
+To specify a k8s version, set the environment variable `ENVTEST_K8S_VERSION`. Otherwise it will use the latest version available.
 
 ### Manually
 
@@ -25,6 +26,8 @@ export KUBEBUILDER_ASSETS=$(setup-envtest use -p path)
 ```
 
 Note: You can add a k8s version to the export command if you want to test a specific version. Otherwise it will use the latest version installed.
+
+ex. `export KUBEBUILDER_ASSETS=$(setup-envtest use -p path 1.30)`
 
 After setting the environment variable, running the tests is the same as any other go test and can be run with `go test`.
 

--- a/tests/controllers/run_controller_tests.sh
+++ b/tests/controllers/run_controller_tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION-1.28.3}
-
 if ! command -v setup-envtest &> /dev/null
 then
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
@@ -9,8 +7,8 @@ fi
 
 if [ -z "$KUBEBUILDER_ASSETS" ];
 then 
-    KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path $ENVTEST_K8S_VERSION)
+    KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path)
     export KUBEBUILDER_ASSETS
 fi
 
-go test ./...
+go test -v $(dirname "$0")/...

--- a/tests/controllers/run_controller_tests.sh
+++ b/tests/controllers/run_controller_tests.sh
@@ -7,7 +7,7 @@ fi
 
 if [ -z "$KUBEBUILDER_ASSETS" ];
 then 
-    KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path)
+    KUBEBUILDER_ASSETS=$(setup-envtest use --use-env -p path $ENVTEST_K8S_VERSION)
     export KUBEBUILDER_ASSETS
 fi
 


### PR DESCRIPTION
## Summary

Added a new step to the CI to run the controller tests. I used `verify-generated-code-changes.yml` as a reference.

I also updated the `run_controller_tests.sh` script to remove an unused environment variable and to run in the right directory.