### PR TITLE
Allow GenericOIDC SearchPrincipals to return groups as needed

### DIFF
--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -46,25 +46,33 @@ func (g *GenOIDCProvider) GetName() string {
 	return Name
 }
 
-// SearchPrincipals will return a principal of the requested principalType with a displayName and loginName
-// that match the searchValue.  This is done because OIDC does not have a proper lookup mechanism.  In order
+// SearchPrincipals will return a principal of the requested principalType with a displayName
+// that matches the searchValue.  If principalType is empty, both a user principal and a group principal will
+// be returned.  This is done because OIDC does not have a proper lookup mechanism.  In order
 // to provide some degree of functionality that allows manual entry for users/groups, this is the compromise.
 func (g *GenOIDCProvider) SearchPrincipals(searchValue, principalType string, _ v3.Token) ([]v3.Principal, error) {
 	var principals []v3.Principal
 
-	if principalType == "" {
-		principalType = UserType
+	if principalType != GroupType {
+		p := v3.Principal{
+			ObjectMeta:    metav1.ObjectMeta{Name: g.Name + "_" + UserType + "://" + searchValue},
+			DisplayName:   searchValue,
+			LoginName:     searchValue,
+			PrincipalType: UserType,
+			Provider:      g.Name,
+		}
+		principals = append(principals, p)
 	}
 
-	p := v3.Principal{
-		ObjectMeta:    metav1.ObjectMeta{Name: g.Name + "_" + principalType + "://" + searchValue},
-		DisplayName:   searchValue,
-		LoginName:     searchValue,
-		PrincipalType: principalType,
-		Provider:      g.Name,
+	if principalType != UserType {
+		gp := v3.Principal{
+			ObjectMeta:    metav1.ObjectMeta{Name: g.Name + "_" + GroupType + "://" + searchValue},
+			DisplayName:   searchValue,
+			PrincipalType: GroupType,
+			Provider:      g.Name,
+		}
+		principals = append(principals, gp)
 	}
-
-	principals = append(principals, p)
 	return principals, nil
 }
 

--- a/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
@@ -150,6 +150,12 @@ func TestGenOIDCProvider_SearchPrincipals(t *testing.T) {
 					PrincipalType: UserType,
 					Provider:      Name,
 				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_group://user1"},
+					DisplayName:   "user1",
+					PrincipalType: GroupType,
+					Provider:      Name,
+				},
 			},
 		},
 		{
@@ -158,6 +164,11 @@ func TestGenOIDCProvider_SearchPrincipals(t *testing.T) {
 				{
 					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://"},
 					PrincipalType: UserType,
+					Provider:      Name,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_group://"},
+					PrincipalType: GroupType,
 					Provider:      Name,
 				},
 			},
@@ -170,7 +181,6 @@ func TestGenOIDCProvider_SearchPrincipals(t *testing.T) {
 				{
 					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_group://group1"},
 					DisplayName:   "group1",
-					LoginName:     "group1",
 					PrincipalType: GroupType,
 					Provider:      Name,
 				},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/10053
 
## Problem
Searching principals only returns user principals when the principalType was empty. 
 
## Solution
Change the SearchPrincipals function to return both User and Group principals when the principalType is empty
 
## Engineering Testing
### Manual Testing
Tested by adding both users and groups as cluster member/owner via the search interface in the UI.

### Automated Testing
Unit tests added

## QA Testing Considerations
You should notice that the search box when adding cluster/project members will now display a user entry as well as a group entry.  
 
### Regressions Considerations
None: new feature

Existing / newly added automated tests that provide evidence there are no regressions:
Existing unit tests adjusted to expect users/groups as intended