### PR TITLE
[release/v2.8] fixing flakey unit test

### DIFF
--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -499,12 +499,7 @@ func (w *RancherManagedChartsTest) TestServeIcons() {
 	w.Require().NoError(err)
 	w.Assert().Equal("bundled", systemCatalogUpdated.Value)
 
-	// Fetch one icon with https:// scheme, it should return an empty object (i.e length of image equals 0) with nil error
-	imgLength, err := w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "fleet")
-	w.Require().NoError(err)
-	w.Assert().Equal(0, imgLength)
-
-	imgLength, err = w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "rancher-cis-benchmark")
+	imgLength, err := w.catalogClient.FetchChartIcon(smallForkClusterRepoName, "rancher-cis-benchmark")
 	w.Require().NoError(err)
 	w.Assert().Greater(imgLength, 0)
 


### PR DESCRIPTION
#### Problem

The check, in the integration test is not working correctly. 
It is for a Rancher bundled repo, and although the charts-small-fork is a simulated bundled repo, it will not pass the check for the test and will throw an error. 

### Solution

Remove that specific check. 
Keep the one for cis-benchmark ensuring the feature is tested. 

