### PR TITLE
[v2.8] Bump `rancher/cli` to v2.8.6-rc4

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -180,7 +180,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.8.6-alpha2
 ENV CATTLE_DASHBOARD_UI_VERSION v2.8.6-alpha2
-ENV CATTLE_CLI_VERSION v2.8.6-rc1
+ENV CATTLE_CLI_VERSION v2.8.6-rc4
 
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -177,7 +177,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.8.0
 ENV CATTLE_DASHBOARD_UI_VERSION v2.8.6-alpha1
-ENV CATTLE_CLI_VERSION v2.8.6-rc1
+ENV CATTLE_CLI_VERSION v2.8.6-rc4
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=


### PR DESCRIPTION
Bump `rancher/cli` to v2.8.6-rc4.

Contains fix for: https://github.com/rancher/rancher/issues/46068

Now releases are available also on GCS:
- https://releases.rancher.com/cli2/v2.8.6-rc4/sha256sum.txt