### PR TITLE
Unskip OCI Integration Test

### DIFF
--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -616,7 +616,6 @@ func (c *ClusterRepoTestSuite) test4xxErrors(params ClusterRepoParams) {
 
 // TestOCI tests creating an OCI clusterrepo and install a chart
 func (c *ClusterRepoTestSuite) TestOCIRepoChartInstallation() {
-	c.T().Skip()
 	//start registry
 	ts, err := StartRegistry()
 	assert.NoError(c.T(), err)


### PR DESCRIPTION
Please see the issue for more details 

### Summary 

- Unskip the OCI integration test which was skipped due to disk pressure. Now the disk pressure is solved.