### PR TITLE
[2.7] Implemented time out report to log cluster status and condition information to the provisioning tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/containers/image/v5 v5.25.0
 	github.com/rancher/cis-operator v1.0.11
-	github.com/rancher/shepherd v0.0.0-20240628195837-fce9bdc2bcf0
+	github.com/rancher/shepherd v0.0.0-20240715182543-4a96c602489d
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1044,8 +1044,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.20-rc1 h1:nbJNHtPM9mKiPu59cpRLAZ45eY2nHgazYLq4wKvT2Nk=
 github.com/rancher/rke v1.4.20-rc1/go.mod h1:UIc898udZbjJ+0616CEmjqY+eBQSkW/dQ30ZvL7bUcQ=
-github.com/rancher/shepherd v0.0.0-20240628195837-fce9bdc2bcf0 h1:RWeWFBDQcD4Cgvh/k+e9cKwhFrmCVAmlI5t1Co73yUY=
-github.com/rancher/shepherd v0.0.0-20240628195837-fce9bdc2bcf0/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
+github.com/rancher/shepherd v0.0.0-20240715182543-4a96c602489d h1:kmhcCpGRxgfQcPNSGTHzmxHNlg8xSDzIRjOVsnAe8dM=
+github.com/rancher/shepherd v0.0.0-20240715182543-4a96c602489d/go.mod h1:j4CkK2GNHGuuIIX/zcfoTd0hZx2Pvat0Ogvz+XdtuGc=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a h1:Mawv3TfevX5dbVDlB/+RPgqxMX1HZQimyhj05R/Ef7U=
 github.com/rancher/steve v0.0.0-20240305150731-02a6bd766b7a/go.mod h1:tfdVny3lVO6H0JyysFBZ1ce45kH9VgWLPa9z9TZVI+U=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	provisioning "github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/sirupsen/logrus"
@@ -110,11 +111,13 @@ func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningUpgradeAirGapK3SCustom
 	testConfig.KubernetesVersion = a.clustersConfig.K3SKubernetesVersions[0]
 	testConfig.CNI = a.clustersConfig.CNIs[0]
 	clusterObject, err := provisioning.CreateProvisioningAirgapCustomCluster(a.client, testConfig, a.corralPackage)
+	reports.TimeoutClusterReport(clusterObject, err)
 	require.NoError(a.T(), err)
 
 	provisioning.VerifyCluster(a.T(), a.client, testConfig, clusterObject)
 
 	upgradedCluster, err := provisioning.UpgradeClusterK8sVersion(a.client, &clusterObject.Name, &k3sVersions[numOfK3SVersions-1])
+	reports.TimeoutClusterReport(clusterObject, err)
 	require.NoError(a.T(), err)
 
 	provisioning.VerifyUpgrade(a.T(), upgradedCluster, k3sVersions[numOfK3SVersions-1])

--- a/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	provisioning "github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/sirupsen/logrus"
@@ -113,11 +114,13 @@ func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningUpgradeAirGapRKE1Cust
 	testConfig.KubernetesVersion = a.clustersConfig.RKE1KubernetesVersions[0]
 	testConfig.CNI = a.clustersConfig.CNIs[0]
 	clusterObject, err := provisioning.CreateProvisioningRKE1AirgapCustomCluster(a.client, testConfig, a.corralPackage)
+	reports.TimeoutRKEReport(clusterObject, err)
 	require.NoError(a.T(), err)
 
 	provisioning.VerifyRKE1Cluster(a.T(), a.client, testConfig, clusterObject)
 
 	upgradedCluster, err := provisioning.UpgradeClusterK8sVersion(a.client, &clusterObject.Name, &rke1Versions[numOfRKE1Versions-1])
+	reports.TimeoutRKEReport(clusterObject, err)
 	require.NoError(a.T(), err)
 
 	provisioning.VerifyUpgrade(a.T(), upgradedCluster, rke1Versions[numOfRKE1Versions-1])

--- a/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	provisioning "github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/sirupsen/logrus"
@@ -112,11 +113,13 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningAirGapUpgradeRKE2Cust
 	testConfig.KubernetesVersion = a.clustersConfig.RKE2KubernetesVersions[0]
 	testConfig.CNI = a.clustersConfig.CNIs[0]
 	clusterObject, err := provisioning.CreateProvisioningAirgapCustomCluster(a.client, testConfig, a.corralPackage)
+	reports.TimeoutClusterReport(clusterObject, err)
 	require.NoError(a.T(), err)
 
 	provisioning.VerifyCluster(a.T(), a.client, testConfig, clusterObject)
 
 	upgradedCluster, err := provisioning.UpgradeClusterK8sVersion(a.client, &clusterObject.Name, &rke2Versions[numOfRKE2Versions-1])
+	reports.TimeoutClusterReport(clusterObject, err)
 	require.NoError(a.T(), err)
 
 	provisioning.VerifyUpgrade(a.T(), upgradedCluster, rke2Versions[numOfRKE2Versions-1])

--- a/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/aks"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
@@ -75,6 +76,7 @@ func (h *HostedAKSClusterProvisioningTestSuite) TestProvisioningHostedAKS() {
 		config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, &aksClusterConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningAKSHostedCluster(tt.client, aksClusterConfig)
+		reports.TimeoutClusterReport(clusterObject, err)
 		require.NoError(h.T(), err)
 
 		provisioning.VerifyHostedCluster(h.T(), tt.client, clusterObject)

--- a/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/eks"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
@@ -74,6 +75,7 @@ func (h *HostedEKSClusterProvisioningTestSuite) TestProvisioningHostedEKS() {
 		config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &eksClusterConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningEKSHostedCluster(tt.client, eksClusterConfig)
+		reports.TimeoutRKEReport(clusterObject, err)
 		require.NoError(h.T(), err)
 
 		provisioning.VerifyHostedCluster(h.T(), tt.client, clusterObject)

--- a/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/gke"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
@@ -73,6 +74,7 @@ func (h *HostedGKEClusterProvisioningTestSuite) TestProvisioningHostedGKE() {
 		var gkeClusterConfig gke.ClusterConfig
 		config.LoadConfig(gke.GKEClusterConfigConfigurationFileKey, &gkeClusterConfig)
 		clusterObject, err := provisioning.CreateProvisioningGKEHostedCluster(tt.client, gkeClusterConfig)
+		reports.TimeoutRKEReport(clusterObject, err)
 		require.NoError(h.T(), err)
 
 		provisioning.VerifyHostedCluster(h.T(), tt.client, clusterObject)

--- a/tests/v2/validation/provisioning/hostnametruncation/hostname_truncation_test.go
+++ b/tests/v2/validation/provisioning/hostnametruncation/hostname_truncation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/shepherd/extensions/machinepools"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/pkg/config"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
@@ -104,6 +105,7 @@ func (r *HostnameTruncationTestSuite) TestProvisioningRKE2ClusterTruncation() {
 				rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], r.clustersConfig)
 
 				clusterObject, err := provisioning.CreateProvisioningCluster(r.client, *rke2Provider, testConfig, hostnamePools)
+				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(r.T(), err)
 
 				provisioning.VerifyCluster(r.T(), r.client, testConfig, clusterObject)

--- a/tests/v2/validation/provisioning/k3s/hardened_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/hardened_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
@@ -100,17 +101,20 @@ func (c *HardenedK3SClusterProvisioningTestSuite) TestProvisioningK3SHardenedClu
 			testConfig.KubernetesVersion = c.provisioningConfig.K3SKubernetesVersions[0]
 
 			clusterObject, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, testConfig)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			provisioning.VerifyCluster(c.T(), tt.client, testConfig, clusterObject)
 
 			cluster, err := clusters.NewClusterMeta(tt.client, clusterObject.Name)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			latestCISBenchmarkVersion, err := tt.client.Catalog.GetLatestChartVersion(charts.CISBenchmarkName, catalog.RancherChartRepo)
 			require.NoError(c.T(), err)
 
 			project, err := projects.GetProjectByName(tt.client, cluster.ID, cis.System)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			c.project = project

--- a/tests/v2/validation/provisioning/permutations/permutations.go
+++ b/tests/v2/validation/provisioning/permutations/permutations.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/rke1/componentchecks"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
 	"github.com/rancher/shepherd/extensions/services"
@@ -127,6 +128,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 					case RKE2ProvisionCluster, K3SProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
 						clusterObject, err = provisioning.CreateProvisioningCluster(client, *nodeProvider, testClusterConfig, hostnameTruncation)
+						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
@@ -142,6 +144,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						}
 
 						rke1ClusterObject, err = provisioning.CreateProvisioningRKE1Cluster(client, *rke1Provider, testClusterConfig, nodeTemplate)
+						reports.TimeoutRKEReport(rke1ClusterObject, err)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, rke1ClusterObject)
@@ -150,6 +153,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						testClusterConfig.KubernetesVersion = kubeVersion
 
 						clusterObject, err = provisioning.CreateProvisioningCustomCluster(client, customProvider, testClusterConfig)
+						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
@@ -163,6 +167,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						}
 
 						rke1ClusterObject, nodes, err := provisioning.CreateProvisioningRKE1CustomCluster(client, customProvider, testClusterConfig)
+						reports.TimeoutRKEReport(rke1ClusterObject, err)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, rke1ClusterObject)
@@ -174,6 +179,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 					case RKE2AirgapCluster, K3SAirgapCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
 						clusterObject, err = provisioning.CreateProvisioningAirgapCustomCluster(client, testClusterConfig, corralPackages)
+						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
@@ -187,6 +193,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						}
 
 						clusterObject, err := provisioning.CreateProvisioningRKE1AirgapCustomCluster(client, testClusterConfig, corralPackages)
+						reports.TimeoutRKEReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, clusterObject)
@@ -240,6 +247,7 @@ func RunPostClusterCloudProviderChecks(t *testing.T, client *rancher.Client, clu
 				config.LoadConfig(charts.ConfigurationFileKey, chartConfig)
 
 				err := charts.InstallVsphereOutOfTreeCharts(client, catalog.RancherChartRepo, rke1ClusterObject.Name, !chartConfig.IsUpgradable)
+				reports.TimeoutRKEReport(rke1ClusterObject, err)
 				require.NoError(t, err)
 
 				podErrors := pods.StatusPods(client, rke1ClusterObject.ID)

--- a/tests/v2/validation/provisioning/registries/registry_test.go
+++ b/tests/v2/validation/provisioning/registries/registry_test.go
@@ -14,6 +14,7 @@ import (
 	provisioning "github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
 	"github.com/rancher/shepherd/extensions/registries"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/environmentflag"
@@ -233,6 +234,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE() {
 			nodeTemplate, err := rke1Provider.NodeTemplateFunc(subClient)
 			require.NoError(rt.T(), err)
 			clusterObject, err := provisioning.CreateProvisioningRKE1Cluster(subClient, *rke1Provider, testConfig, nodeTemplate)
+			reports.TimeoutRKEReport(clusterObject, err)
 			require.NoError(rt.T(), err)
 
 			provisioning.VerifyRKE1Cluster(rt.T(), subClient, testConfig, clusterObject)
@@ -250,6 +252,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE() {
 		require.NoError(rt.T(), err)
 
 		clusterObject, err := provisioning.CreateProvisioningRKE1Cluster(subClient, *rke1Provider, testConfig, nodeTemplate)
+		reports.TimeoutRKEReport(clusterObject, err)
 		require.NoError(rt.T(), err)
 
 		provisioning.VerifyRKE1Cluster(rt.T(), subClient, testConfig, clusterObject)
@@ -283,6 +286,7 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 			testConfig = rt.configureRKE2K3SRegistry(tt.registry, testConfig)
 			k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 			clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, testConfig, nil)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(rt.T(), err)
 
 			provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
@@ -298,6 +302,7 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 		k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, testConfig, nil)
+		reports.TimeoutClusterReport(clusterObject, err)
 		require.NoError(rt.T(), err)
 
 		provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
@@ -332,6 +337,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 			rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 			clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, testConfig, nil)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(rt.T(), err)
 
 			provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
@@ -346,6 +352,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 		rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, testConfig, nil)
+		reports.TimeoutClusterReport(clusterObject, err)
 		require.NoError(rt.T(), err)
 
 		provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)

--- a/tests/v2/validation/provisioning/rke1/hardened_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/hardened_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
@@ -100,17 +101,20 @@ func (c *HardenedRKE1ClusterProvisioningTestSuite) TestProvisioningRKE1HardenedC
 			testConfig.KubernetesVersion = c.provisioningConfig.RKE1KubernetesVersions[0]
 
 			clusterObject, _, err := provisioning.CreateProvisioningRKE1CustomCluster(tt.client, &externalNodeProvider, testConfig)
+			reports.TimeoutRKEReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			provisioning.VerifyRKE1Cluster(c.T(), tt.client, testConfig, clusterObject)
 
 			cluster, err := clusters.NewClusterMeta(tt.client, clusterObject.Name)
+			reports.TimeoutRKEReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			latestCISBenchmarkVersion, err := tt.client.Catalog.GetLatestChartVersion(charts.CISBenchmarkName, catalog.RancherChartRepo)
 			require.NoError(c.T(), err)
 
 			project, err := projects.GetProjectByName(tt.client, cluster.ID, cis.System)
+			reports.TimeoutRKEReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			c.project = project

--- a/tests/v2/validation/provisioning/rke2/hardened_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/hardened_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
@@ -100,17 +101,20 @@ func (c *HardenedRKE2ClusterProvisioningTestSuite) TestProvisioningRKE2HardenedC
 			testConfig.KubernetesVersion = c.provisioningConfig.RKE2KubernetesVersions[0]
 
 			clusterObject, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, testConfig)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			provisioning.VerifyCluster(c.T(), tt.client, testConfig, clusterObject)
 
 			cluster, err := clusters.NewClusterMeta(tt.client, clusterObject.Name)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			latestCISBenchmarkVersion, err := tt.client.Catalog.GetLatestChartVersion(charts.CISBenchmarkName, catalog.RancherChartRepo)
 			require.NoError(c.T(), err)
 
 			project, err := projects.GetProjectByName(tt.client, cluster.ID, cis.System)
+			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
 			c.project = project

--- a/tests/v2/validation/provisioning/rke2/template_test.go
+++ b/tests/v2/validation/provisioning/rke2/template_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/provisioning"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
+	"github.com/rancher/shepherd/extensions/reports"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/namegenerator"
@@ -71,6 +72,7 @@ func (r *ClusterTemplateTestSuite) TestProvisionRKE2TemplateCluster() {
 	require.NoError(r.T(), err)
 
 	_, cluster, err := clusters.GetProvisioningClusterByName(r.client, clusterName, fleetNamespace)
+	reports.TimeoutClusterReport(cluster, err)
 	require.NoError(r.T(), err)
 
 	provisioning.VerifyCluster(r.T(), r.client, nil, cluster)


### PR DESCRIPTION
- Changed provisioning tests to use TimeoutRKEReport and TimeoutClusterReport