### PR TITLE
[v2.9] Use the Transitive membership when listing groups.

### DIFF
--- a/pkg/auth/providers/azure/clients/ms_graph_client_test.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client_test.go
@@ -63,7 +63,7 @@ func TestMSGraphClient_ListUsers(t *testing.T) {
 		displayNames = append(displayNames, v.DisplayName)
 	}
 
-	assert.Len(t, users, 38)
+	assert.Len(t, users, 41)
 }
 
 func TestMSGraphClient_ListUsers_with_filter(t *testing.T) {
@@ -131,7 +131,24 @@ func TestMSGraphClient_ListGroupMemberships(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, []string{"15f6a947-9d67-4e7f-b1d0-f5f52145fed3", "bf881716-8d6d-456f-b234-2b143dfd5cf0"}, groups)
+	assert.Equal(t, []string{
+		"15f6a947-9d67-4e7f-b1d0-f5f52145fed3",
+		"748274fd-3ec7-40d1-b08b-775c1a8ec1af",
+		"bf881716-8d6d-456f-b234-2b143dfd5cf0"}, groups)
+}
+
+func TestMSGraphClient_ListGroupMemberships_nested_groups(t *testing.T) {
+	client := newTestClient(t)
+
+	groups, err := client.ListGroupMemberships("anunesteduser1@ranchertest.onmicrosoft.com", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, []string{
+		"95469c9b-7f7f-48c4-82f2-a4c1eacf454b",
+		"bf6fa98e-9d06-46ed-bd62-5d8eee196265",
+	}, groups)
 }
 
 func TestMSGraphClient_ListGroupMemberships_with_filter(t *testing.T) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46169
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When fetching the list of groups a user is a member of, the query was not fetching the transitive groups.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This switches to using the TransitiveMemberOf mechanism for listing the groups a user is a member of

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_