### PR TITLE
[v2.9] Prevent set password of external users

### DIFF
--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -41,15 +41,15 @@ type Handler struct {
 func (h *Handler) Actions(actionName string, action *types.Action, apiContext *types.APIContext) error {
 	switch actionName {
 	case "changepassword":
-		if err := h.changePassword(actionName, action, apiContext); err != nil {
+		if err := h.changePassword(apiContext); err != nil {
 			return err
 		}
 	case "setpassword":
-		if err := h.setPassword(actionName, action, apiContext); err != nil {
+		if err := h.setPassword(apiContext); err != nil {
 			return err
 		}
 	case "refreshauthprovideraccess":
-		if err := h.refreshAttributes(actionName, action, apiContext); err != nil {
+		if err := h.refreshAttributes(apiContext); err != nil {
 			return err
 		}
 	default:
@@ -64,7 +64,7 @@ func (h *Handler) Actions(actionName string, action *types.Action, apiContext *t
 	return nil
 }
 
-func (h *Handler) changePassword(actionName string, action *types.Action, request *types.APIContext) error {
+func (h *Handler) changePassword(request *types.APIContext) error {
 	actionInput, err := parse.ReadBody(request.Request)
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func (h *Handler) changePassword(actionName string, action *types.Action, reques
 	return nil
 }
 
-func (h *Handler) setPassword(actionName string, action *types.Action, request *types.APIContext) error {
+func (h *Handler) setPassword(request *types.APIContext) error {
 	actionInput, err := parse.ReadBody(request.Request)
 	if err != nil {
 		return err
@@ -167,7 +167,7 @@ func (h *Handler) setPassword(actionName string, action *types.Action, request *
 	return nil
 }
 
-func (h *Handler) refreshAttributes(actionName string, action *types.Action, request *types.APIContext) error {
+func (h *Handler) refreshAttributes(request *types.APIContext) error {
 	canRefresh := h.userCanRefresh(request)
 
 	if !canRefresh {

--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -139,7 +139,12 @@ func (h *Handler) setPassword(actionName string, action *types.Action, request *
 		return errors.New("Invalid password")
 	}
 
-	username := userData[client.UserFieldUsername].(string)
+	// if the username is not set the user is an external one
+	usernameInt, found := userData[client.UserFieldUsername]
+	if !found {
+		return errors.New("Cannot set password of non-local user")
+	}
+	username, _ := usernameInt.(string)
 
 	// passing empty currentPass to validator since, this api call doesn't assume an existing password
 	if err := validatePassword(username, "", newPass, settings.PasswordMinLength.GetInt()); err != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Panic setting password to Azure AD (Entra ID) user: https://github.com/rancher/rancher/issues/45451
 
## Problem
Setting the password of an external user will cause a panic. This is not related only to AD users.
 
## Solution
We are discouraging the use of the local provider, or local users. Also an external user doesn't have a username that can be used to login. So the set password is useless, without a manual workaround, like setting manually a `username` field.

This PR will prevent the set password for users without a `username`:

![image](https://github.com/user-attachments/assets/b267bf95-9401-45a2-ac81-bc88094b4e22)

It also removes the unused `actionName string` and `action *types.Action` arguments from the func signatures.