### PR TITLE
Fix the AuthConfig migrator for Shibboleth secrets.

### DIFF
--- a/pkg/controllers/management/secretmigrator/authconfig_test.go
+++ b/pkg/controllers/management/secretmigrator/authconfig_test.go
@@ -226,6 +226,22 @@ func TestShibbolethAuthConfigMigration(t *testing.T) {
 			wantSecretRef: fmt.Sprintf("cattle-global-data:shibbolethconfig-%s", strings.ToLower(serviceAccountPasswordFieldName)),
 		},
 		{
+			name: "test migrating existing Shibboleth config",
+			authConfig: newTestShibbolethConfig(func(ac *apimgmtv3.AuthConfig) {
+				ac.Status = apimgmtv3.AuthConfigStatus{
+					Conditions: []apimgmtv3.AuthConfigConditions{
+						apimgmtv3.AuthConfigConditions{
+							Type:           apimgmtv3.AuthConfigConditionSecretsMigrated,
+							Status:         "True",
+							LastUpdateTime: "2024-05-13T15:20:34+01:00",
+						},
+					},
+				}
+			}),
+			unstructuredAuthConfig: getUnstructuredShibbolethConfig(),
+			wantConditions:         []condition.Cond{},
+		},
+		{
 			name:                   "test migrating Shibboleth configuration without OpenLDAP",
 			authConfig:             newTestShibbolethConfig(),
 			unstructuredAuthConfig: getUnstructuredShibbolethConfig(),


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46187
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Enabling Shibboleth was causing a panic.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This was caused when we migrated the original secret and fixed the secret in a single reconciliation.

The second part got a struct that wasn't converted to a ShibbolethConfig

This fix ensures that we convert the Shibboleth struct before looking for the status.
 
**NOTE**: The tests should be improved further, while the code uses an `UnstructuredClient` the implementation in the test acts like an AuthConfig client, this can be done in a separate PR.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Enable Shibboleth.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_