### PR TITLE
Remove external-rules feature flag

### DIFF
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -159,6 +159,12 @@ func InitializeFeatures(featuresClient managementv3.FeatureClient, featureArgs s
 		return
 	}
 
+	// external-rules feature flag was removed in 2.9. We need to delete it for users upgrading from 2.8.
+	err := featuresClient.Delete("external-rules", &metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		logrus.Errorf("unable to delete external-rules feature: %v", err)
+	}
+
 	// creates any features in map that do not exist, updates features with new default value
 	for key, f := range features {
 		featureState, err := featuresClient.Get(key, metav1.GetOptions{})

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -3,7 +3,12 @@ package features
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	managementv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var isDefFalse = newFeature("isfalse", "", false, false, true)
@@ -38,4 +43,28 @@ func TestInitializeNil(t *testing.T) {
 	assert.False(isDefFalse.Enabled())
 	InitializeFeatures(nil, "isfalse=true")
 	assert.True(isDefFalse.Enabled())
+}
+
+func TestInitializeFeatures(t *testing.T) {
+	tests := map[string]struct {
+		featureMock func() managementv3.FeatureClient
+		features    map[string]*Feature
+	}{
+		"delete external-rules feature is called": {
+			featureMock: func() managementv3.FeatureClient {
+				mock := fake.NewMockNonNamespacedControllerInterface[*v3.Feature, *v3.FeatureList](gomock.NewController(t))
+				mock.EXPECT().Delete("external-rules", &metav1.DeleteOptions{})
+
+				return mock
+			},
+			features: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			features = test.features // we can't run parallel tests if we modify this package var here. Code should be refactored to not use a package var if more tests cases are added.
+			InitializeFeatures(test.featureMock(), "")
+		})
+	}
 }


### PR DESCRIPTION
## Issue:  https://github.com/rancher/rancher/issues/46272
 
## Problem
`external-rules` flag was removed in 2.9. The problem is that is still present when upgrading from 2.8 to 2.9. 
 
## Solution
Remove the flag if present
 
