### PR TITLE
adding custom tolerations to helm operations pod

### DIFF
--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -21,6 +21,7 @@ package types
 
 import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,15 +34,16 @@ type ChartInstall struct {
 	Annotations map[string]string     `json:"annotations,omitempty"`
 }
 
+// ChartInstallAction represents the input received when installing the charts received in the charts field
 type ChartInstallAction struct {
-	Timeout                  *metav1.Duration `json:"timeout,omitempty"`
-	Wait                     bool             `json:"wait,omitempty"`
-	DisableHooks             bool             `json:"noHooks,omitempty"`
-	DisableOpenAPIValidation bool             `json:"disableOpenAPIValidation,omitempty"`
-	Namespace                string           `json:"namespace,omitempty"`
-	ProjectID                string           `json:"projectId,omitempty"`
-
-	Charts []ChartInstall `json:"charts,omitempty"`
+	Timeout                  *metav1.Duration    `json:"timeout,omitempty"`
+	Wait                     bool                `json:"wait,omitempty"`
+	DisableHooks             bool                `json:"noHooks,omitempty"`
+	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	Namespace                string              `json:"namespace,omitempty"`
+	ProjectID                string              `json:"projectId,omitempty"`
+	OperationTolerations     []corev1.Toleration `json:"operationTolerations,omitempty"`
+	Charts                   []ChartInstall      `json:"charts,omitempty"`
 }
 
 type ChartInfo struct {
@@ -52,26 +54,30 @@ type ChartInfo struct {
 	Chart     v3.MapStringInterface `json:"chart,omitempty"`
 }
 
+// ChartUninstallAction represents the input received when uninstalling a chart
 type ChartUninstallAction struct {
-	DisableHooks bool             `json:"noHooks,omitempty"`
-	DryRun       bool             `json:"dryRun,omitempty"`
-	KeepHistory  bool             `json:"keepHistory,omitempty"`
-	Timeout      *metav1.Duration `json:"timeout,omitempty"`
-	Description  string           `json:"description,omitempty"`
+	DisableHooks         bool                `json:"noHooks,omitempty"`
+	DryRun               bool                `json:"dryRun,omitempty"`
+	KeepHistory          bool                `json:"keepHistory,omitempty"`
+	Timeout              *metav1.Duration    `json:"timeout,omitempty"`
+	Description          string              `json:"description,omitempty"`
+	OperationTolerations []corev1.Toleration `json:"operationTolerations,omitempty"`
 }
 
+// ChartUpgradeAction represents the input received when upgrading the charts received in the charts field
 type ChartUpgradeAction struct {
-	Timeout                  *metav1.Duration `json:"timeout,omitempty"`
-	Wait                     bool             `json:"wait,omitempty"`
-	DisableHooks             bool             `json:"noHooks,omitempty"`
-	DisableOpenAPIValidation bool             `json:"disableOpenAPIValidation,omitempty"`
-	Force                    bool             `json:"force,omitempty"`
-	TakeOwnership            bool             `json:"takeOwnership,omitempty"`
-	MaxHistory               int              `json:"historyMax,omitempty"`
-	Install                  bool             `json:"install,omitempty"`
-	Namespace                string           `json:"namespace,omitempty"`
-	CleanupOnFail            bool             `json:"cleanupOnFail,omitempty"`
-	Charts                   []ChartUpgrade   `json:"charts,omitempty"`
+	Timeout                  *metav1.Duration    `json:"timeout,omitempty"`
+	Wait                     bool                `json:"wait,omitempty"`
+	DisableHooks             bool                `json:"noHooks,omitempty"`
+	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	Force                    bool                `json:"force,omitempty"`
+	TakeOwnership            bool                `json:"takeOwnership,omitempty"`
+	MaxHistory               int                 `json:"historyMax,omitempty"`
+	Install                  bool                `json:"install,omitempty"`
+	Namespace                string              `json:"namespace,omitempty"`
+	CleanupOnFail            bool                `json:"cleanupOnFail,omitempty"`
+	Charts                   []ChartUpgrade      `json:"charts,omitempty"`
+	OperationTolerations     []corev1.Toleration `json:"operationTolerations,omitempty"`
 }
 
 type ChartUpgrade struct {

--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -43,6 +43,7 @@ type ChartInstallAction struct {
 	Namespace                string              `json:"namespace,omitempty"`
 	ProjectID                string              `json:"projectId,omitempty"`
 	OperationTolerations     []corev1.Toleration `json:"operationTolerations,omitempty"`
+	AutomaticCPTolerations   bool                `json:"automaticCPTolerations,omitempty"`
 	Charts                   []ChartInstall      `json:"charts,omitempty"`
 }
 
@@ -56,12 +57,13 @@ type ChartInfo struct {
 
 // ChartUninstallAction represents the input received when uninstalling a chart
 type ChartUninstallAction struct {
-	DisableHooks         bool                `json:"noHooks,omitempty"`
-	DryRun               bool                `json:"dryRun,omitempty"`
-	KeepHistory          bool                `json:"keepHistory,omitempty"`
-	Timeout              *metav1.Duration    `json:"timeout,omitempty"`
-	Description          string              `json:"description,omitempty"`
-	OperationTolerations []corev1.Toleration `json:"operationTolerations,omitempty"`
+	DisableHooks           bool                `json:"noHooks,omitempty"`
+	DryRun                 bool                `json:"dryRun,omitempty"`
+	KeepHistory            bool                `json:"keepHistory,omitempty"`
+	Timeout                *metav1.Duration    `json:"timeout,omitempty"`
+	Description            string              `json:"description,omitempty"`
+	OperationTolerations   []corev1.Toleration `json:"operationTolerations,omitempty"`
+	AutomaticCPTolerations bool                `json:"automaticCPTolerations,omitempty"`
 }
 
 // ChartUpgradeAction represents the input received when upgrading the charts received in the charts field
@@ -78,6 +80,7 @@ type ChartUpgradeAction struct {
 	CleanupOnFail            bool                `json:"cleanupOnFail,omitempty"`
 	Charts                   []ChartUpgrade      `json:"charts,omitempty"`
 	OperationTolerations     []corev1.Toleration `json:"operationTolerations,omitempty"`
+	AutomaticCPTolerations   bool                `json:"automaticCPTolerations,omitempty"`
 }
 
 type ChartUpgrade struct {

--- a/pkg/apis/catalog.cattle.io/v1/types.go
+++ b/pkg/apis/catalog.cattle.io/v1/types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -132,6 +133,7 @@ type Operation struct {
 	Status            OperationStatus `json:"status"`
 }
 
+// OperationStatus represents the status of a helm operation that's going to be created
 type OperationStatus struct {
 	ObservedGeneration int64                               `json:"observedGeneration"`
 	Action             string                              `json:"action,omitempty"`
@@ -146,4 +148,5 @@ type OperationStatus struct {
 	PodNamespace       string                              `json:"podNamespace,omitempty"`
 	PodCreated         bool                                `json:"podCreated,omitempty"`
 	Conditions         []genericcondition.GenericCondition `json:"conditions,omitempty"`
+	Tolerations        []corev1.Toleration                 `json:"tolerations,omitempty"`
 }

--- a/pkg/apis/catalog.cattle.io/v1/types.go
+++ b/pkg/apis/catalog.cattle.io/v1/types.go
@@ -135,18 +135,19 @@ type Operation struct {
 
 // OperationStatus represents the status of a helm operation that's going to be created
 type OperationStatus struct {
-	ObservedGeneration int64                               `json:"observedGeneration"`
-	Action             string                              `json:"action,omitempty"`
-	Chart              string                              `json:"chart,omitempty"`
-	Version            string                              `json:"version,omitempty"`
-	Release            string                              `json:"releaseName,omitempty"`
-	Namespace          string                              `json:"namespace,omitempty"`
-	ProjectID          string                              `json:"projectId,omitempty"`
-	Token              string                              `json:"token,omitempty"`
-	Command            []string                            `json:"command,omitempty"`
-	PodName            string                              `json:"podName,omitempty"`
-	PodNamespace       string                              `json:"podNamespace,omitempty"`
-	PodCreated         bool                                `json:"podCreated,omitempty"`
-	Conditions         []genericcondition.GenericCondition `json:"conditions,omitempty"`
-	Tolerations        []corev1.Toleration                 `json:"tolerations,omitempty"`
+	ObservedGeneration     int64                               `json:"observedGeneration"`
+	Action                 string                              `json:"action,omitempty"`
+	Chart                  string                              `json:"chart,omitempty"`
+	Version                string                              `json:"version,omitempty"`
+	Release                string                              `json:"releaseName,omitempty"`
+	Namespace              string                              `json:"namespace,omitempty"`
+	ProjectID              string                              `json:"projectId,omitempty"`
+	Token                  string                              `json:"token,omitempty"`
+	Command                []string                            `json:"command,omitempty"`
+	PodName                string                              `json:"podName,omitempty"`
+	PodNamespace           string                              `json:"podNamespace,omitempty"`
+	PodCreated             bool                                `json:"podCreated,omitempty"`
+	Conditions             []genericcondition.GenericCondition `json:"conditions,omitempty"`
+	AutomaticCPTolerations bool                                `json:"automaticCPTolerations,omitempty"`
+	Tolerations            []corev1.Toleration                 `json:"tolerations,omitempty"`
 }

--- a/pkg/apis/catalog.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/catalog.cattle.io/v1/zz_generated_deepcopy.go
@@ -23,6 +23,7 @@ package v1
 
 import (
 	genericcondition "github.com/rancher/wrangler/v3/pkg/genericcondition"
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -340,6 +341,13 @@ func (in *OperationStatus) DeepCopyInto(out *OperationStatus) {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]genericcondition.GenericCondition, len(*in))
 		copy(*out, *in)
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/catalogv2/helmop/operation_test.go
+++ b/pkg/catalogv2/helmop/operation_test.go
@@ -2,6 +2,8 @@ package helmop
 
 import (
 	"fmt"
+	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"testing"
 
@@ -12,6 +14,24 @@ type testCase struct {
 	commands Commands
 	expected map[string][]byte
 	failMsg  string
+}
+
+type createPodTestCase struct {
+	name          string
+	operation     Operations
+	expected      *corev1.Pod
+	failMsg       string
+	secretData    map[string][]byte
+	kustomize     bool
+	imageOverride string
+	tolerations   []corev1.Toleration
+}
+
+type mergeTolerationsTestCase struct {
+	name           string
+	tolerations    []corev1.Toleration
+	newTolerations []corev1.Toleration
+	expected       []corev1.Toleration
 }
 
 func Test_Render(t *testing.T) {
@@ -103,10 +123,203 @@ func Test_Render(t *testing.T) {
 			},
 			failMsg: "uninstall test case failed",
 		},
+		{
+			commands: Commands{
+				Command{
+					Operation:   "upgrade",
+					ChartFile:   "test-chart-v1.1.0.tgz",
+					Chart:       []byte("test-chart"),
+					Kustomize:   true,
+					ReleaseName: "test6",
+					ArgObjects: []interface{}{types.ChartInstallAction{
+						OperationTolerations: []corev1.Toleration{
+							{
+								Key:      "foo",
+								Operator: "equals",
+								Value:    "bar",
+								Effect:   "NoSchedule",
+							},
+							{
+								Key:      "foo2",
+								Operator: "equals",
+								Value:    "bar2",
+								Effect:   "NoSchedule",
+							}},
+					}},
+				},
+			},
+			expected: map[string][]byte{
+				"operation000":          []byte(strings.Join([]string{"upgrade", "--post-renderer=/home/shell/kustomize.sh", "test6", "/home/shell/helm-run/test-chart-v1.1.0.tgz"}, "\x00")),
+				"kustomization000.yaml": []byte(fmt.Sprintf(kustomization, "000")),
+				"transform000.yaml":     []byte(fmt.Sprintf(transform, "test6")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "operation toleration test case failed",
+		},
 	}
+
 	for _, testCase := range testCases {
 		actual, err := testCase.commands.Render()
 		asserts.Nil(err, "error encountered: %v", err)
 		asserts.Equal(testCase.expected, actual, testCase.failMsg)
+	}
+}
+
+// Test_CreatePod function to run tests for the createPod method
+func Test_CreatePod(t *testing.T) {
+	asserts := assert.New(t)
+	defaultTolerations := []corev1.Toleration{
+		{
+			Key:      "cattle.io/os",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "linux",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/controlplane",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/etcd",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   "NoExecute",
+		},
+		{
+			Key:      "node.cloudprovider.kubernetes.io/uninitialized",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   "NoSchedule",
+		},
+	}
+	testCases := []createPodTestCase{
+		{
+			name: "Created pod should have custom toleration",
+			operation: Operations{
+				namespace: "test-ns",
+			},
+			expected: &corev1.Pod{
+				Spec: corev1.PodSpec{Tolerations: append(defaultTolerations, corev1.Toleration{
+					Key:      "foo",
+					Operator: "Equals",
+					Value:    "bar",
+					Effect:   "NoSchedule",
+				})},
+			},
+			tolerations: []corev1.Toleration{{
+				Key:      "foo",
+				Operator: "Equals",
+				Value:    "bar",
+				Effect:   "NoSchedule",
+			}},
+			failMsg: "Pod should be created with toleration",
+		},
+		{
+			name: "Created pod should have custom tolerations",
+			operation: Operations{
+				namespace: "test-ns",
+			},
+			expected: &corev1.Pod{
+				Spec: corev1.PodSpec{Tolerations: append(defaultTolerations, corev1.Toleration{
+					Key:      "foo",
+					Operator: "Equals",
+					Value:    "bar",
+					Effect:   "NoSchedule",
+				}, corev1.Toleration{
+					Key:   "foo2",
+					Value: "bar2",
+				})},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Equals",
+					Value:    "bar",
+					Effect:   "NoSchedule",
+				},
+				{
+					Key:   "foo2",
+					Value: "bar2",
+				}},
+			failMsg: "Pod should be created with all custom tolerations",
+		},
+		{
+			name: "Created pod should have only the default tolerations",
+			operation: Operations{
+				namespace: "test-ns",
+			},
+			expected: &corev1.Pod{
+				Spec: corev1.PodSpec{Tolerations: defaultTolerations},
+			},
+			tolerations: nil,
+			failMsg:     "Pod should be created with only the default tolerations",
+		},
+	}
+	for _, testCase := range testCases {
+		actual, _ := testCase.operation.createPod(testCase.secretData, testCase.kustomize, testCase.imageOverride, testCase.tolerations)
+		asserts.ElementsMatch(testCase.expected.Spec.Tolerations, actual.Spec.Tolerations, testCase.failMsg)
+	}
+}
+
+func Test_mergeTolerations(t *testing.T) {
+	asserts := assert.New(t)
+	testCases := []mergeTolerationsTestCase{
+		{
+			name: "Shouldn't duplicate tolerations",
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Equals",
+					Value:    "bar",
+					Effect:   "NoSchedule",
+				},
+				{
+					Key:   "foo2",
+					Value: "bar2",
+				},
+			},
+			newTolerations: []corev1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Equals",
+					Value:    "bar",
+					Effect:   "NoSchedule",
+				},
+				{
+					Key:   "foo3",
+					Value: "bar3",
+				},
+				{
+					Key:   "foo2",
+					Value: "bar20",
+				},
+			},
+			expected: []corev1.Toleration{
+				{
+					Key:      "foo",
+					Operator: "Equals",
+					Value:    "bar",
+					Effect:   "NoSchedule",
+				},
+				{
+					Key:   "foo2",
+					Value: "bar2",
+				},
+				{
+					Key:   "foo3",
+					Value: "bar3",
+				},
+				{
+					Key:   "foo2",
+					Value: "bar20",
+				},
+			},
+		},
+	}
+	for _, t := range testCases {
+		resp := mergeTolerations(t.tolerations, t.newTolerations)
+		asserts.ElementsMatch(resp, t.expected, t.name)
 	}
 }

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -375,7 +375,8 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		helm.Catalog().V1(),
 		rbac.Rbac().V1(),
 		content,
-		core.Core().V1().Pod())
+		core.Core().V1().Pod(),
+		core.Core().V1().Node())
 
 	cache := memory.NewMemCacheClient(k8s.Discovery())
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cache)

--- a/tests/v2/integration/catalogv2/charts_test.go
+++ b/tests/v2/integration/catalogv2/charts_test.go
@@ -1,0 +1,693 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/client-go/util/retry"
+	"sort"
+
+	"testing"
+	"time"
+
+	rv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	"github.com/rancher/shepherd/extensions/kubeconfig"
+	"github.com/rancher/shepherd/pkg/api/steve/catalog/types"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"helm.sh/helm/v3/pkg/action"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/kubernetes/pkg/util/taints"
+)
+
+type ChartsTest struct {
+	suite.Suite
+	client           *rancher.Client
+	session          *session.Session
+	restClientGetter genericclioptions.RESTClientGetter
+	catalogClient    *catalog.Client
+	corev1           corev1.CoreV1Interface
+	backoff          kwait.Backoff
+}
+
+func (w *ChartsTest) TearDownSuite() {
+	w.Require().NoError(w.catalogClient.ClusterRepos().Delete(context.Background(), "charts-small-fork", metav1.DeleteOptions{PropagationPolicy: &propagation}))
+	taint := v1.Taint{
+		Key:    "testTaint",
+		Value:  "testValue",
+		Effect: v1.TaintEffectPreferNoSchedule,
+	}
+	w.updateTaintOnNode(context.Background(), taint, taints.RemoveTaint)
+	w.session.Cleanup()
+
+}
+
+func (w *ChartsTest) SetupSuite() {
+	var err error
+	testSession := session.NewSession()
+	w.session = testSession
+	w.client, err = rancher.NewClient("", testSession)
+	require.NoError(w.T(), err)
+	insecure := true
+	w.client.RancherConfig.Insecure = &insecure
+	w.catalogClient, err = w.client.GetClusterCatalogClient("local")
+	require.NoError(w.T(), err)
+
+	kubeConfig, err := kubeconfig.GetKubeconfig(w.client, "local")
+	require.NoError(w.T(), err)
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	require.NoError(w.T(), err)
+	cset, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(w.T(), err)
+	w.corev1 = cset.CoreV1()
+
+	w.restClientGetter, err = kubeconfig.NewRestGetter(restConfig, *kubeConfig)
+	require.NoError(w.T(), err)
+	_, err = w.catalogClient.ClusterRepos().Create(context.Background(), &rv1.ClusterRepo{
+		ObjectMeta: metav1.ObjectMeta{Name: "charts-small-fork"},
+		Spec:       rv1.RepoSpec{GitRepo: "https://github.com/rancher/charts-small-fork", GitBranch: "aks-integration-test-working-charts"},
+	}, metav1.CreateOptions{})
+	w.Require().NoError(err)
+	w.Require().NoError(w.pollUntilDownloaded("charts-small-fork", metav1.Time{}))
+
+	w.backoff = kwait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Jitter:   0.2,
+		Factor:   2,
+		Steps:    10,
+		Cap:      60 * time.Second,
+	}
+}
+
+func TestChartsTestSuite(t *testing.T) {
+	suite.Run(t, new(ChartsTest))
+}
+
+// TestInstallChartWithAutomaticTolerationOnTaintedCPNode tests the installation of a chart with automatic CP toleration on a tainted control plane node
+func (w *ChartsTest) TestInstallChartWithAutomaticTolerationOnTaintedCPNode() {
+	ctx := context.Background()
+	taint := v1.Taint{
+		Key:    "testTaint",
+		Value:  "testValue",
+		Effect: v1.TaintEffectPreferNoSchedule,
+	}
+
+	w.updateTaintOnNode(ctx, taint, taints.AddOrUpdateTaint)
+
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   true,
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err := w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found := false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	w.Require().NoError(w.uninstallApp(namespace.System, "rancher-aks-operator-crd"))
+
+	w.updateTaintOnNode(ctx, taint, taints.RemoveTaint)
+}
+
+// TestInstallChartWithCustomTolerationOnTaintedCPNode tests the installation of a chart with custom toleration on a tainted control plane node
+func (w *ChartsTest) TestInstallChartWithCustomTolerationOnTaintedCPNode() {
+	ctx := context.Background()
+	taint := v1.Taint{
+		Key:    "testTaint",
+		Value:  "testValue",
+		Effect: v1.TaintEffectPreferNoSchedule,
+	}
+
+	w.updateTaintOnNode(ctx, taint, taints.AddOrUpdateTaint)
+
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   false,
+		OperationTolerations:     []v1.Toleration{{Key: "testTaint", Effect: v1.TaintEffectNoSchedule, Value: "testValue"}},
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err := w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found := false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	w.Require().NoError(w.uninstallApp(namespace.System, "rancher-aks-operator-crd"))
+
+	w.updateTaintOnNode(ctx, taint, taints.RemoveTaint)
+}
+
+// TestUpgradeChartWithCustomTolerationOnTaintedCPNode tests the upgrade of a chart with custom toleration on a tainted control plane node
+func (w *ChartsTest) TestUpgradeChartWithCustomTolerationOnTaintedCPNode() {
+	ctx := context.Background()
+	taint := v1.Taint{
+		Key:    "testTaint",
+		Value:  "testValue",
+		Effect: v1.TaintEffectPreferNoSchedule,
+	}
+
+	w.updateTaintOnNode(ctx, taint, taints.AddOrUpdateTaint)
+
+	//install chart
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   false,
+		OperationTolerations:     []v1.Toleration{{Key: "testTaint", Effect: v1.TaintEffectNoSchedule, Value: "testValue"}},
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.1+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err := w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found := false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//upgrade chart
+	w.Require().NoError(w.catalogClient.UpgradeChart(&types.ChartUpgradeAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   false,
+		OperationTolerations:     []v1.Toleration{{Key: "testTaint", Effect: v1.TaintEffectNoSchedule, Value: "testValue"}},
+		Charts: []types.ChartUpgrade{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 1))
+
+	operationList, err = w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err = w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found = false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//cleanup
+	w.Require().NoError(w.uninstallApp(namespace.System, "rancher-aks-operator-crd"))
+
+	w.updateTaintOnNode(ctx, taint, taints.RemoveTaint)
+}
+
+// TestUpgradeChartWithAutomaticTolerationOnTaintedCPNode tests the upgrade of a chart with automatic CP toleration on a tainted control plane node
+func (w *ChartsTest) TestUpgradeChartWithAutomaticTolerationOnTaintedCPNode() {
+	ctx := context.Background()
+	taint := v1.Taint{
+		Key:    "testTaint",
+		Value:  "testValue",
+		Effect: v1.TaintEffectPreferNoSchedule,
+	}
+
+	w.updateTaintOnNode(ctx, taint, taints.AddOrUpdateTaint)
+
+	//install chart
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   false,
+		OperationTolerations:     []v1.Toleration{{Key: "testTaint", Effect: v1.TaintEffectNoSchedule, Value: "testValue"}},
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.1+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err := w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found := false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//upgrade chart
+	w.Require().NoError(w.catalogClient.UpgradeChart(&types.ChartUpgradeAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   true,
+		Charts: []types.ChartUpgrade{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 1))
+
+	operationList, err = w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err = w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found = false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//cleanup
+	w.Require().NoError(w.uninstallApp(namespace.System, "rancher-aks-operator-crd"))
+
+	w.updateTaintOnNode(ctx, taint, taints.RemoveTaint)
+}
+
+// TestUninstallChartWithAutomaticTolerationOnTaintedCPNode tests the uninstallation of a chart with automatic CP toleration on a tainted control plane node
+func (w *ChartsTest) TestUninstallChartWithAutomaticTolerationOnTaintedCPNode() {
+	ctx := context.Background()
+	taint := v1.Taint{
+		Key:    "testTaint",
+		Value:  "testValue",
+		Effect: v1.TaintEffectPreferNoSchedule,
+	}
+
+	w.updateTaintOnNode(ctx, taint, taints.AddOrUpdateTaint)
+
+	//install chart
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   false,
+		OperationTolerations:     []v1.Toleration{{Key: "testTaint", Effect: v1.TaintEffectNoSchedule, Value: "testValue"}},
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err := w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found := false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//uninstall chart
+	w.Require().NoError(w.catalogClient.UninstallChart("rancher-aks-operator-crd", namespace.System, &types.ChartUninstallAction{
+		DisableHooks:           false,
+		Timeout:                &metav1.Duration{Duration: 60 * time.Second},
+		AutomaticCPTolerations: true,
+	}))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusUninstalled, "rancher-aks-operator-crd", 1))
+
+	operationList, err = w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err = w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found = false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//cleanup
+	w.updateTaintOnNode(ctx, taint, taints.RemoveTaint)
+}
+
+// TestUninstallChartWithCustomTolerationOnTaintedCPNode tests the uninstallation of a chart with custom toleration on a tainted control plane node
+func (w *ChartsTest) TestUninstallChartWithCustomTolerationOnTaintedCPNode() {
+	ctx := context.Background()
+	taint := v1.Taint{
+		Key:    "testTaint",
+		Value:  "testValue",
+		Effect: v1.TaintEffectPreferNoSchedule,
+	}
+
+	w.updateTaintOnNode(ctx, taint, taints.AddOrUpdateTaint)
+
+	//install chart
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		AutomaticCPTolerations:   false,
+		OperationTolerations:     []v1.Toleration{{Key: "testTaint", Effect: v1.TaintEffectNoSchedule, Value: "testValue"}},
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err := w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found := false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//uninstall chart
+	w.Require().NoError(w.catalogClient.UninstallChart("rancher-aks-operator-crd", namespace.System, &types.ChartUninstallAction{
+		DisableHooks:           false,
+		Timeout:                &metav1.Duration{Duration: 60 * time.Second},
+		AutomaticCPTolerations: false,
+		OperationTolerations:   []v1.Toleration{{Key: "testTaint", Effect: v1.TaintEffectNoSchedule, Value: "testValue"}},
+	}))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusUninstalled, "rancher-aks-operator-crd", 1))
+
+	operationList, err = w.catalogClient.Operations(namespace.System).List(context.Background(), metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	pod, err = w.corev1.Pods(op.Status.PodNamespace).Get(ctx, op.Status.PodName, metav1.GetOptions{})
+	w.Require().NoError(err)
+	found = false
+	for _, t := range pod.Spec.Tolerations {
+		if t.Key == "testTaint" {
+			found = true
+			break
+		}
+	}
+	w.Require().True(found)
+
+	//cleanup
+	w.updateTaintOnNode(ctx, taint, taints.RemoveTaint)
+}
+
+func (w *ChartsTest) waitForChart(status rv1.Status, name string, previousVersion int) error {
+	var app *rv1.App
+	err := kwait.Poll(500*time.Millisecond, 360*time.Second, func() (done bool, err error) {
+		app, err = w.catalogClient.Apps(namespace.System).Get(context.TODO(), name, metav1.GetOptions{})
+		e, ok := err.(*errors.StatusError)
+		if ok && errors.IsNotFound(e) {
+			if status == rv1.StatusUninstalled {
+				return true, nil
+			}
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if app.Spec.Info.Status == status && app.Spec.Version > previousVersion {
+			return true, nil
+		}
+		return false, nil
+	})
+	w.Require().NoError(err)
+	return nil
+}
+
+func (w *ChartsTest) uninstallApp(namespace, chartName string) error {
+	var cfg action.Configuration
+	if err := cfg.Init(w.restClientGetter, namespace, "", logrus.Infof); err != nil {
+		return err
+	}
+	l := action.NewList(&cfg)
+	l.All = true
+	l.SetStateMask()
+	releases, err := l.Run()
+	if err != nil {
+		return fmt.Errorf("failed to fetch all releases in the %s namespace: %w", namespace, err)
+	}
+	for _, r := range releases {
+		if r.Chart.Name() == chartName {
+			err = kwait.Poll(10*time.Second, time.Minute, func() (done bool, err error) {
+				act := action.NewUninstall(&cfg)
+				act.Wait = true
+				act.Timeout = time.Minute
+				if _, err = act.Run(r.Name); err != nil {
+					return false, nil
+				}
+				return true, nil
+			})
+			w.Require().NoError(err)
+		}
+	}
+	return nil
+}
+
+// pollUntilDownloaded Polls until the ClusterRepo of the given name has been downloaded (by comparing prevDownloadTime against the current DownloadTime)
+func (w *ChartsTest) pollUntilDownloaded(ClusterRepoName string, prevDownloadTime metav1.Time) error {
+	err := kwait.Poll(PollInterval, time.Minute, func() (done bool, err error) {
+		clusterRepo, err := w.catalogClient.ClusterRepos().Get(context.TODO(), ClusterRepoName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		w.Require().NoError(err)
+
+		return clusterRepo.Status.DownloadTime != prevDownloadTime, nil
+	})
+	return err
+}
+
+// updateTaintOnNode updates the taint on the control plane node according to the taintFunc received
+func (w *ChartsTest) updateTaintOnNode(ctx context.Context, taint v1.Taint, taintFunc func(node *v1.Node, taint *v1.Taint) (*v1.Node, bool, error)) {
+	w.Require().NoError(retry.RetryOnConflict(w.backoff, func() error {
+		list, err := w.corev1.Nodes().List(ctx, metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/control-plane=true"})
+		if err != nil {
+			return err
+		}
+		w.Require().Greater(len(list.Items), 0)
+		node := list.Items[0]
+		n, b, err := taintFunc(&node, &taint)
+		if err != nil {
+			return err
+		}
+		if b {
+			_, err = w.corev1.Nodes().Update(ctx, n, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}


### PR DESCRIPTION
This PR adds two fields to the input of requests for installing, upgrading, or uninstalling charts:

- automaticCPTolerations: Automatically adds toleration for all taints of a CP node
- operationTolerations: An array of toleration to add to the helm operation pod
