### PR TITLE
Add auth config field that allows Rancher to use the service account to search for users

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -416,6 +416,7 @@ type LdapFields struct {
 	GroupMemberMappingAttribute     string   `json:"groupMemberMappingAttribute,omitempty"     norman:"default=member,notnullable,required"`
 	ConnectionTimeout               int64    `json:"connectionTimeout,omitempty"               norman:"default=5000,notnullable,required"`
 	NestedGroupMembershipEnabled    bool     `json:"nestedGroupMembershipEnabled"              norman:"default=false"`
+	SearchUsingServiceAccount       bool     `json:"searchUsingServiceAccount,omitempty"       norman:"default=false"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -70,6 +70,13 @@ func (p *ldapProvider) loginUser(lConn ldapv3.Client, credential *v32.BasicLogin
 		return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.ServerError, "server error while authenticating")
 	}
 
+	if config.SearchUsingServiceAccount {
+		err = ldap.AuthenticateServiceAccountUser(serviceAccountPassword, serviceAccountUserName, "", lConn)
+		if err != nil {
+			return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")
+		}
+	}
+
 	searchOpRequest := ldap.NewWholeSubtreeSearchRequest(
 		userDN,
 		fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass),


### PR DESCRIPTION
## Issue: #43064
 
## Problem
Users on certain LDAP setups do not have the permissions to search as their user. This lead to the error outlined in the issue (Result code 32), since Rancher attempted to bind as their user to perform searches (in order to show the user only the groups/users that they could see as part of their auth configs).
 
## Solution
The solution is to expose a field on the auth config (search_using_service_account, a bool) which will cause Rancher to always use the service account (and never the user) to search for users/groups. This value will default to false, to keep Rancher's current behavior for our existing consumers.

## Engineering Testing
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: Lack of the framework capable of testing this fix/change

Summary: No tests are modified or added.
 
### Regressions Considerations
Existing / newly added automated tests that provide evidence there are no regressions:
* None