### PR TITLE
Check if the provider is enabled when authenticating

### DIFF
--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -131,12 +131,12 @@ func (a *tokenAuthenticator) Authenticate(req *http.Request) (*AuthenticatorResp
 
 	attribs, err := a.userAttributeLister.Get("", token.UserID)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
+		return nil, errors.Wrapf(ErrMustAuthenticate, "failed to retrieve userattribute %s: %v", token.UserID, err)
 	}
 
 	authUser, err := a.userLister.Get("", token.UserID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(ErrMustAuthenticate, "failed to retrieve user %s: %v", token.UserID, err)
 	}
 
 	if authUser.Enabled != nil && !*authUser.Enabled {

--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -161,7 +161,7 @@ func (a *tokenAuthenticator) Authenticate(req *http.Request) (*AuthenticatorResp
 	}
 	groups = append(groups, user.AllAuthenticated, "system:cattle:authenticated")
 
-	if !authUser.IsSystem() {
+	if !authUser.IsSystem() || !strings.HasPrefix(token.UserID, "system:") {
 		go a.userAuthRefresher.TriggerUserRefresh(token.UserID, false)
 	}
 

--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -161,7 +161,7 @@ func (a *tokenAuthenticator) Authenticate(req *http.Request) (*AuthenticatorResp
 	}
 	groups = append(groups, user.AllAuthenticated, "system:cattle:authenticated")
 
-	if !authUser.IsSystem() || !strings.HasPrefix(token.UserID, "system:") {
+	if !(authUser.IsSystem() || strings.HasPrefix(token.UserID, "system:")) {
 		go a.userAuthRefresher.TriggerUserRefresh(token.UserID, false)
 	}
 

--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -116,7 +116,7 @@ func (a *tokenAuthenticator) Authenticate(req *http.Request) (*AuthenticatorResp
 	if token.AuthProvider != "" {
 		disabled, err := providers.IsDisabledProvider(token.AuthProvider)
 		if err != nil {
-			return nil, errors.Wrapf(ErrMustAuthenticate, "provider %s doesn't exist", token.AuthProvider)
+			return nil, errors.Wrapf(ErrMustAuthenticate, "error checking if provider %s is disabled: %v", token.AuthProvider, err)
 		}
 		if disabled {
 			return nil, errors.Wrapf(ErrMustAuthenticate, "provider %s is disabled", token.AuthProvider)

--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -54,10 +54,7 @@ func ToAuthMiddleware(a Authenticator) auth.Middleware {
 	return auth.ToMiddleware(auth.AuthenticatorFunc(f))
 }
 
-type (
-	ClusterRouter func(req *http.Request) string
-	userRefresher func(string, bool)
-)
+type ClusterRouter func(req *http.Request) string
 
 func NewAuthenticator(ctx context.Context, clusterRouter ClusterRouter, mgmtCtx *config.ScaledContext) Authenticator {
 	tokenInformer := mgmtCtx.Management.Tokens("").Controller().Informer()
@@ -86,7 +83,7 @@ type tokenAuthenticator struct {
 	userAttributeLister v3.UserAttributeLister
 	userLister          v3.UserLister
 	clusterRouter       ClusterRouter
-	refreshUser         userRefresher
+	refreshUser         func(userID string, force bool)
 }
 
 const (

--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -215,9 +215,12 @@ func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 			return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
 		}
 
+		refresher.calledTimes.Store(0)
+
 		resp, err := authenticator.Authenticate(req)
 		require.NoError(t, err)
 		<-refresher.done // Wait for the provider refresh to finish.
+		assert.Equal(t, int32(1), refresher.calledTimes.Load())
 
 		require.NotNil(t, resp)
 		assert.True(t, resp.IsAuthed)
@@ -232,9 +235,7 @@ func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 
 		resp, err := authenticator.Authenticate(req)
 		require.NoError(t, err)
-
-		refresherCalledTimes := refresher.calledTimes.Load()
-		assert.Equal(t, int32(0), refresherCalledTimes)
+		assert.Equal(t, int32(0), refresher.calledTimes.Load())
 
 		require.NotNil(t, resp)
 		assert.True(t, resp.IsAuthed)
@@ -259,9 +260,7 @@ func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 
 		resp, err := authenticator.Authenticate(req)
 		require.NoError(t, err)
-
-		refresherCalledTimes := refresher.calledTimes.Load()
-		assert.Equal(t, int32(0), refresherCalledTimes)
+		assert.Equal(t, int32(0), refresher.calledTimes.Load())
 
 		require.NotNil(t, resp)
 		assert.True(t, resp.IsAuthed)

--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -203,8 +203,8 @@ func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 
 		resp, err := authenticator.Authenticate(req)
 		require.NoError(t, err)
-		refresherArgs := <-refresher.done                       // Wait for refresher to finish.
-		assert.Equal(t, int32(1), refresher.calledTimes.Load()) // Refresh was called once.
+		refresherArgs := <-refresher.done // Wait for the provider refresh to finish.
+		assert.Equal(t, int32(1), refresher.calledTimes.Load())
 
 		require.NotNil(t, resp)
 		assert.True(t, resp.IsAuthed)
@@ -248,13 +248,9 @@ func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 			}, nil
 		}
 
-		oldTokenUserID := token.UserID
-		defer func() { token.UserID = oldTokenUserID }()
-		token.UserID = "system://provisioning/fleet-local/local"
-
 		resp, err := authenticator.Authenticate(req)
 		require.NoError(t, err)
-		assert.Equal(t, int32(0), refresher.calledTimes.Load()) // Refresh was called once.
+		assert.Equal(t, int32(0), refresher.calledTimes.Load())
 
 		require.NotNil(t, resp)
 		assert.True(t, resp.IsAuthed)

--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -1,0 +1,333 @@
+package requests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/types"
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	mgmtFakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+)
+
+type fakeUserAuthRefresherArgs struct {
+	userID string
+	force  bool
+}
+type fakeUserAuthRefresher struct {
+	calledTimes atomic.Int32
+	done        chan fakeUserAuthRefresherArgs
+}
+
+func (*fakeUserAuthRefresher) TriggerAllUserRefresh() {}
+func (r *fakeUserAuthRefresher) TriggerUserRefresh(userID string, force bool) {
+	r.calledTimes.Add(1)
+	if r.done != nil {
+		r.done <- fakeUserAuthRefresherArgs{
+			userID: userID,
+			force:  force,
+		}
+	}
+}
+
+type fakeProvider struct {
+	Name                   string
+	IsDisabledProviderFunc func() (bool, error)
+}
+
+func (p *fakeProvider) IsDisabledProvider() (bool, error) {
+	if p.IsDisabledProviderFunc != nil {
+		return p.IsDisabledProviderFunc()
+	}
+	return false, nil
+}
+
+func (p *fakeProvider) GetName() string {
+	return p.Name
+}
+
+func (p *fakeProvider) AuthenticateUser(ctx context.Context, input interface{}) (v3.Principal, []v3.Principal, string, error) {
+	panic("not implemented")
+}
+
+func (p *fakeProvider) SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Principal, error) {
+	panic("not implemented")
+}
+
+func (p *fakeProvider) GetPrincipal(principalID string, token v3.Token) (v3.Principal, error) {
+	panic("not implemented")
+}
+
+func (p *fakeProvider) CustomizeSchema(schema *types.Schema) {
+	panic("not implemented")
+}
+
+func (p *fakeProvider) TransformToAuthProvider(authConfig map[string]interface{}) (map[string]interface{}, error) {
+	panic("not implemented")
+}
+
+func (p *fakeProvider) RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error) {
+	panic("not implemented")
+}
+
+func (p *fakeProvider) CanAccessWithGroupProviders(userPrincipalID string, groups []v3.Principal) (bool, error) {
+	panic("not implemented")
+}
+
+func (p *fakeProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
+	return map[string][]string{
+		common.UserAttributePrincipalID: {userPrincipal.ExtraInfo[common.UserAttributePrincipalID]},
+		common.UserAttributeUserName:    {userPrincipal.ExtraInfo[common.UserAttributeUserName]},
+	}
+}
+
+func (p *fakeProvider) CleanupResources(*v3.AuthConfig) error {
+	return nil
+}
+
+func TestTokenAuthenticatorAuthenticate(t *testing.T) {
+	existingProviders := providers.Providers
+	defer func() {
+		providers.Providers = existingProviders
+	}()
+
+	fakeProvider := &fakeProvider{
+		Name: "fake",
+	}
+
+	providers.Providers = map[string]common.AuthProvider{
+		fakeProvider.Name: fakeProvider,
+	}
+
+	now := time.Now()
+	userID := "u-abcdef"
+	token := &v3.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "token-v2rcx",
+			CreationTimestamp: metav1.NewTime(now),
+		},
+		Token:        "jnb9tksmnctvgbn92ngbkptblcjwg4pmfp98wqj29wk5kv85ktg59s",
+		AuthProvider: fakeProvider.Name,
+		TTLMillis:    57600000,
+		UserID:       userID,
+		UserPrincipal: v3.Principal{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: userID,
+			},
+		},
+	}
+
+	mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	mockIndexer.AddIndexers(cache.Indexers{tokenKeyIndex: tokenKeyIndexer})
+	mockIndexer.Add(token)
+
+	userAttributeLister := &mgmtFakes.UserAttributeListerMock{
+		GetFunc: func(namespace, name string) (*v3.UserAttribute, error) {
+			return &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: userID,
+				},
+				GroupPrincipals: map[string]apiv3.Principals{
+					fakeProvider.Name: {
+						Items: []apiv3.Principal{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: fakeProvider.Name + "_group://56789",
+								},
+								MemberOf:      true,
+								LoginName:     "rancher",
+								DisplayName:   "rancher",
+								PrincipalType: "group",
+								Provider:      fakeProvider.Name,
+							},
+						},
+					},
+				},
+				ExtraByProvider: map[string]map[string][]string{
+					fakeProvider.Name: {
+						common.UserAttributePrincipalID: {fakeProvider.Name + "_user://12345"},
+						common.UserAttributeUserName:    {"fake-user"},
+					},
+					providers.LocalProvider: {
+						common.UserAttributePrincipalID: {"local://" + userID},
+						common.UserAttributeUserName:    {"local-user"},
+					},
+				},
+			}, nil
+		},
+	}
+
+	userLister := &mgmtFakes.UserListerMock{
+		GetFunc: func(namespace, name string) (*v3.User, error) {
+			return &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: userID,
+				},
+			}, nil
+		},
+	}
+
+	refresher := &fakeUserAuthRefresher{}
+
+	authenticator := tokenAuthenticator{
+		ctx:                 context.Background(),
+		tokenIndexer:        mockIndexer,
+		userAttributeLister: userAttributeLister,
+		userLister:          userLister,
+		userAuthRefresher:   refresher,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/namespaces", nil)
+	req.Header.Set("Authorization", "Bearer "+token.Name+":"+token.Token)
+
+	t.Run("authenticated", func(t *testing.T) {
+		refresher.done = make(chan fakeUserAuthRefresherArgs)
+		refresher.calledTimes.Store(0)
+		defer func() {
+			refresher.done = nil
+		}()
+
+		resp, err := authenticator.Authenticate(req)
+		require.NoError(t, err)
+		refresherArgs := <-refresher.done                       // Wait for refresher to finish.
+		assert.Equal(t, int32(1), refresher.calledTimes.Load()) // Refresh was called once.
+
+		require.NotNil(t, resp)
+		assert.True(t, resp.IsAuthed)
+		assert.Equal(t, userID, resp.User)
+		assert.Equal(t, userID, resp.UserPrincipal)
+		assert.Equal(t, userID, refresherArgs.userID)
+		assert.False(t, refresherArgs.force)
+		assert.Contains(t, resp.Groups, fakeProvider.Name+"_group://56789")
+		assert.Contains(t, resp.Groups, "system:cattle:authenticated")
+		assert.Contains(t, resp.Extras[common.UserAttributePrincipalID], fakeProvider.Name+"_user://12345")
+		assert.Contains(t, resp.Extras[common.UserAttributeUserName], "fake-user")
+	})
+
+	t.Run("authenticated if userattribute doesn't exist", func(t *testing.T) {
+		oldGetUserAttributeFunc := userAttributeLister.GetFunc
+		defer func() { userAttributeLister.GetFunc = oldGetUserAttributeFunc }()
+		userAttributeLister.GetFunc = func(namespace, name string) (*v3.UserAttribute, error) {
+			return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+		}
+
+		resp, err := authenticator.Authenticate(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, resp.IsAuthed)
+	})
+
+	t.Run("provider refresh is not called for system users", func(t *testing.T) {
+		refresher.calledTimes.Store(0)
+
+		oldGetUserFunc := userLister.GetFunc
+		defer func() { userLister.GetFunc = oldGetUserFunc }()
+		userLister.GetFunc = func(namespace, name string) (*v3.User, error) {
+			return &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: userID,
+				},
+				PrincipalIDs: []string{
+					"system://provisioning/fleet-local/local",
+					"local://" + userID,
+				},
+			}, nil
+		}
+
+		oldTokenUserID := token.UserID
+		defer func() { token.UserID = oldTokenUserID }()
+		token.UserID = "system://provisioning/fleet-local/local"
+
+		resp, err := authenticator.Authenticate(req)
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), refresher.calledTimes.Load()) // Refresh was called once.
+
+		require.NotNil(t, resp)
+		assert.True(t, resp.IsAuthed)
+	})
+
+	t.Run("token disabled", func(t *testing.T) {
+		oldTokenEnabled := token.Enabled
+		defer func() { token.Enabled = oldTokenEnabled }()
+		token.Enabled = pointer.BoolPtr(false)
+
+		resp, err := authenticator.Authenticate(req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+
+	t.Run("user doesn't exist", func(t *testing.T) {
+		oldGetUserFunc := userLister.GetFunc
+		defer func() { userLister.GetFunc = oldGetUserFunc }()
+		userLister.GetFunc = func(namespace, name string) (*v3.User, error) {
+			return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+		}
+
+		resp, err := authenticator.Authenticate(req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+
+	t.Run("user disabled", func(t *testing.T) {
+		oldGetUserFunc := userLister.GetFunc
+		defer func() { userLister.GetFunc = oldGetUserFunc }()
+		userLister.GetFunc = func(namespace, name string) (*v3.User, error) {
+			return &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: userID,
+				},
+				Enabled: pointer.BoolPtr(false),
+			}, nil
+		}
+
+		resp, err := authenticator.Authenticate(req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+
+	t.Run("error getting userattribute", func(t *testing.T) {
+		oldGetUserAttributeFunc := userAttributeLister.GetFunc
+		defer func() { userAttributeLister.GetFunc = oldGetUserAttributeFunc }()
+		userAttributeLister.GetFunc = func(namespace, name string) (*v3.UserAttribute, error) {
+			return nil, fmt.Errorf("some error")
+		}
+
+		resp, err := authenticator.Authenticate(req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+
+	t.Run("auth provider disabled", func(t *testing.T) {
+		oldIsDisabledProviderFunc := fakeProvider.IsDisabledProviderFunc
+		defer func() { fakeProvider.IsDisabledProviderFunc = oldIsDisabledProviderFunc }()
+		fakeProvider.IsDisabledProviderFunc = func() (bool, error) { return true, nil }
+
+		resp, err := authenticator.Authenticate(req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+
+	t.Run("auth provider doesn't exist", func(t *testing.T) {
+		oldProvider := token.AuthProvider
+		token.AuthProvider = "foo"
+		defer func() { token.AuthProvider = oldProvider }()
+
+		resp, err := authenticator.Authenticate(req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+}

--- a/pkg/auth/requests/service_account_test.go
+++ b/pkg/auth/requests/service_account_test.go
@@ -67,7 +67,7 @@ func TestIsTokenExpired(t *testing.T) {
 	}
 }
 
-func TestAuthenticate(t *testing.T) {
+func TestServiceAccountAuthAuthenticate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name                  string
@@ -298,7 +298,7 @@ func TestAuthenticate(t *testing.T) {
 }
 
 func generateDownstreamRequest(method string, path string) *http.Request {
-	req, _ := http.NewRequest("GET", proxyPrefix+path, nil)
+	req, _ := http.NewRequest(method, proxyPrefix+path, nil)
 	return req
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When rancher authenticates a request using a token it doesn't check if the token auth provider exists or is enabled. Therefore if the auth provider was disabled and tokens weren't cleaned up they can still be used to authenticate with rancher.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

If the auth provider is set in the token check that the provider exists or enabled and reject the request if the check fails.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

### Existing / newly added automated tests that provide evidence there are no regressions:
N/A