### PR TITLE
[46362] Add CATTLE_AGENT_VAR_DIR to mgmt cluster env vars

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/norman/types/convert"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/features"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
@@ -317,6 +318,15 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 			Name:  env.Name,
 			Value: env.Value,
 		})
+	}
+
+	if cluster.Spec.RKEConfig != nil {
+		if dir := cluster.Spec.RKEConfig.DataDirectories.SystemAgent; dir != "" {
+			spec.AgentEnvVars = append(spec.AgentEnvVars, corev1.EnvVar{
+				Name:  capr.SystemAgentDataDirEnvVar,
+				Value: dir,
+			})
+		}
 	}
 
 	if cluster.Spec.ClusterAgentDeploymentCustomization != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #46362 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When creating a custom cluster with a system agent data directory, the custom cluster registration command does not include the `CATTLE_AGENT_VAR_DIR` env var.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

When generating a mgmt cluster from a prov cluster, insert the `CATTLE_AGENT_VAR_DIR` env var if the system agent data dir is configured.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, webhook only validates the provisioning cluster env vars so there is no issue adding it into the mgmt cluster object, and confirmed the clsuter registration token which populates the registration command in the UI was formatted correctly (confirmed in backend & frontend).

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Would be a good idea to test all cluster registration commands for RKE2/K3s clusters, so confirm linx+windows, and insecure/secure commands.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A