### PR TITLE
[2.9] Backup/Restore P0 Test Case

### DIFF
--- a/tests/v2/validation/charts/backup_restore/README.md
+++ b/tests/v2/validation/charts/backup_restore/README.md
@@ -1,0 +1,30 @@
+# Backup Restore Operator (BRO)
+Backup Restore Operator (BRO for short) is a disaster recovery chart that can be installed on the local cluster only, and is used to create backups of Rancher resources contained in the `rancher-resource-set`. The resource set becomes available after the chart is installed and can be edited as a user needs. Once a backup is created and stored in either a local volume or in an S3 storage location (such as AWS S3 or Minio S3), a restore operation can be created to restore Rancher back to the backed up version of the Rancher resources.
+
+## Pre-requisites
+- Downstream RKE1 and RKE2 clusters are required before running the test(s)
+- All tests require configs pulled in from the broInput parameter.
+
+## Test Setup
+In your config file, set the following:
+```
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  userToken: "rancher_user_token"
+  insecure: True
+  cleanup: True
+  clusterName: "downstream_cluster_name"
+backupRestoreInput:
+  backupName: ""
+  s3BucketName: ""
+  s3FolderName: ""
+  s3Region: ""
+  s3Endpoint: ""
+  volumeName: ""
+  credentialSecretNamespace: ""
+  prune: true/false
+  resourceSetName: ""
+  accessKey: ""
+  secretKey: ""
+```

--- a/tests/v2/validation/charts/backup_restore/backup_restore.go
+++ b/tests/v2/validation/charts/backup_restore/backup_restore.go
@@ -1,0 +1,339 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/projects"
+	"github.com/rancher/shepherd/extensions/secrets"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/sirupsen/logrus"
+
+	bv1 "github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	backupName          = namegen.AppendRandomString("backup")
+	secretName          = namegen.AppendRandomString("brosecretname")
+	roleName            = namegen.AppendRandomString("broRole")
+	backupRestoreConfig = new(charts.BackupRestoreConfig)
+
+	rules = []management.PolicyRule{
+		{
+			APIGroups: []string{"management.cattle.io"},
+			Resources: []string{"projects"},
+			Verbs:     []string{backupRole},
+		},
+	}
+)
+
+const (
+	backupEnabled        = true
+	backupChartNamespace = "cattle-resources-system"
+	backupChartName      = "rancher-backup"
+	backupSteveType      = "resources.cattle.io.backup"
+	restoreSteveType     = "resources.cattle.io.restore"
+	backupRole           = "backupRole"
+	clusterRoleContext   = "cluster"
+	systemProject        = "System"
+	localCluster         = "local"
+	globalUserRole       = "user"
+)
+
+func setBackupObject() bv1.Backup {
+	broConfig := backupRestoreConfig
+	config.LoadConfig(charts.BackupRestoreConfigurationFileKey, broConfig)
+
+	backup := bv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: backupName,
+		},
+		Spec: bv1.BackupSpec{
+			ResourceSetName: broConfig.ResourceSetName,
+		},
+	}
+	return backup
+}
+
+func setRestoreObject() bv1.Restore {
+	broConfig := backupRestoreConfig
+	config.LoadConfig(charts.BackupRestoreConfigurationFileKey, broConfig)
+
+	restore := bv1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "restore-",
+		},
+		Spec: bv1.RestoreSpec{
+			BackupFilename: backupName,
+			Prune:          &broConfig.Prune,
+		},
+	}
+	return restore
+}
+
+func installBroChart(client *rancher.Client) error {
+	project, err := projects.GetProjectByName(client, localCluster, systemProject)
+	if err != nil {
+		return err
+	}
+
+	// Get clusterName from config yaml
+	clusterName := client.RancherConfig.ClusterName
+
+	// Get cluster meta
+	cluster, err := clusters.NewClusterMeta(client, clusterName)
+	if err != nil {
+		return err
+	}
+
+	// Get latest version of Rancher Backup chart
+	latestBackupVersion, err := client.Catalog.GetLatestChartVersion(backupChartName, catalog.RancherChartRepo)
+	if err != nil {
+		return err
+	}
+
+	broConfig := backupRestoreConfig
+	config.LoadConfig(charts.BackupRestoreConfigurationFileKey, broConfig)
+
+	chartInstallOptions := &charts.InstallOptions{
+		Cluster:   cluster,
+		Version:   latestBackupVersion,
+		ProjectID: project.ID,
+	}
+	chartFeatureOptions := &charts.RancherBackupOpts{
+		VolumeName:                broConfig.VolumeName,
+		BucketName:                broConfig.S3BucketName,
+		CredentialSecretName:      secretName,
+		CredentialSecretNamespace: broConfig.CredentialSecretNamespace,
+		Enabled:                   backupEnabled,
+		Endpoint:                  broConfig.S3Endpoint,
+		Folder:                    broConfig.S3FolderName,
+		Region:                    broConfig.S3Region,
+	}
+
+	_, err = createOpaqueS3Secret(client.Steve)
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Installing backup chart")
+	err = charts.InstallRancherBackupChart(client, chartInstallOptions, chartFeatureOptions, true)
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Waiting for backup chart deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, project.ClusterID, backupChartNamespace, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Waiting for backup chart DaemonSets to have expected number of available nodes")
+	err = charts.WatchAndWaitDaemonSets(client, project.ClusterID, backupChartNamespace, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Waiting for backup chart StatefulSets to have expected number of ready replicas")
+	err = charts.WatchAndWaitStatefulSets(client, project.ClusterID, backupChartNamespace, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func createOpaqueS3Secret(steveClient *v1.Client) (string, error) {
+	broConfig := backupRestoreConfig
+	config.LoadConfig(charts.BackupRestoreConfigurationFileKey, broConfig)
+
+	logrus.Infof("Creating an opaque secret with name: %v", secretName)
+	secretTemplate := secrets.NewSecretTemplate(secretName, broConfig.CredentialSecretNamespace, map[string][]byte{"accessKey": []byte(broConfig.AccessKey), "secretKey": []byte(broConfig.SecretKey)}, corev1.SecretTypeOpaque)
+	createdSecret, err := steveClient.SteveType(secrets.SecretSteveType).Create(secretTemplate)
+
+	return createdSecret.Name, err
+}
+
+func createProject(client *rancher.Client, clusterID string) (*management.Project, error) {
+	projectConfig := &management.Project{
+		ClusterID: clusterID,
+		Name:      systemProject,
+	}
+	createProject, err := client.Management.Project.Create(projectConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return createProject, nil
+}
+
+func createRole(client *rancher.Client, context string, roleName string, rules []management.PolicyRule) (role *management.RoleTemplate, err error) {
+	role, err = client.Management.RoleTemplate.Create(
+		&management.RoleTemplate{
+			Context: context,
+			Name:    roleName,
+			Rules:   rules,
+		})
+
+	return
+}
+
+func createRancherResources(client *rancher.Client, resourceCount int, clusterID string) ([]*management.User, []*management.Project, []*management.RoleTemplate, error) {
+	userList := []*management.User{}
+	projList := []*management.Project{}
+	roleList := []*management.RoleTemplate{}
+
+	for i := 0; i < resourceCount; i++ {
+		u, err := users.CreateUserWithRole(client, users.UserConfig(), globalUserRole)
+		if err != nil {
+			return userList, projList, roleList, err
+		}
+		userList = append(userList, u)
+
+		p, err := createProject(client, clusterID)
+		if err != nil {
+			return userList, projList, roleList, err
+		}
+		projList = append(projList, p)
+
+		rt, err := createRole(client, clusterRoleContext, roleName, rules)
+		if err != nil {
+			return userList, projList, roleList, err
+		}
+		roleList = append(roleList, rt)
+	}
+
+	return userList, projList, roleList, nil
+}
+
+func createBackup(client *rancher.Client, name string) (*v1.SteveAPIObject, error) {
+	backup := setBackupObject()
+	backupTemplate := bv1.NewBackup("", name, backup)
+	completedBackup, err := client.Steve.SteveType(backupSteveType).Create(backupTemplate)
+
+	return completedBackup, err
+}
+
+func createRestore(client *rancher.Client, fileName string) (*v1.SteveAPIObject, error) {
+	restore := setRestoreObject()
+	restoreTemplate := bv1.NewRestore("", "", restore)
+	restoreTemplate.Spec.BackupFilename = fileName
+	completedRestore, err := client.Steve.SteveType(restoreSteveType).Create(restoreTemplate)
+
+	return completedRestore, err
+}
+
+func validateAWSS3BackupExists(bucket string, folder string, key string) (bool, error) {
+	if len(folder) > 0 {
+		folder += key
+		isPresent, err := checkAWSS3Object(bucket, folder)
+		return isPresent, err
+	}
+	isPresent, err := checkAWSS3Object(bucket, key)
+	return isPresent, err
+}
+
+func checkAWSS3Object(bucket string, key string) (bool, error) {
+	sdkConfig, err := awsConfig.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return false, err
+	}
+
+	s3Client := s3.NewFromConfig(sdkConfig)
+	_, err = s3Client.HeadObject(context.TODO(), &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "NotFound":
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func deleteAWSBackup(bucket string, folder string, key string) error {
+	sdkConfig, err := awsConfig.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return err
+	}
+	svc := s3.NewFromConfig(sdkConfig)
+
+	input := &s3.DeleteObjectInput{}
+
+	input = &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+	if len(folder) > 0 {
+		folder += key
+		input = &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(folder),
+		}
+	}
+
+	_, err = svc.DeleteObject(context.TODO(), input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			fmt.Println(err.Error())
+		}
+		return err
+	}
+
+	return err
+}
+
+func verifyRancherResources(client *rancher.Client, userList []*management.User, projList []*management.Project, roleList []*management.RoleTemplate) error {
+	logrus.Info("Verifying user resources...")
+	for i := range userList {
+		_, err := users.GetUserIDByName(client, userList[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	logrus.Info("Verifying project resources...")
+	for i := range projList {
+		_, err := client.Management.Project.ByID(projList[i].ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	logrus.Info("Verifying role resources...")
+	for i := range roleList {
+		_, err := client.Management.RoleTemplate.ByID(roleList[i].ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tests/v2/validation/charts/backup_restore/backup_restore_test.go
+++ b/tests/v2/validation/charts/backup_restore/backup_restore_test.go
@@ -1,0 +1,136 @@
+package charts
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	bv1 "github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/sirupsen/logrus"
+
+	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/projects"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type BackupTestSuite struct {
+	suite.Suite
+	client   *rancher.Client
+	session  *session.Session
+	project  *management.Project
+	S3Client *s3.Client
+}
+
+func (b *BackupTestSuite) TearDownSuite() {
+	b.session.Cleanup()
+}
+
+func (b *BackupTestSuite) SetupSuite() {
+	b.session = session.NewSession()
+
+	client, err := rancher.NewClient("", b.session)
+	require.NoError(b.T(), err)
+
+	b.client = client
+
+	subSession := b.session.NewSession()
+	defer subSession.Cleanup()
+}
+
+func (b *BackupTestSuite) TestBackupChart() {
+	subSession := b.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := b.client.WithSession(subSession)
+	require.NoError(b.T(), err)
+
+	b.client = client
+
+	broConfig := backupRestoreConfig
+	config.LoadConfig(charts.BackupRestoreConfigurationFileKey, broConfig)
+
+	project, err := projects.GetProjectByName(b.client, localCluster, systemProject)
+	require.NoError(b.T(), err)
+
+	b.project = project
+
+	logrus.Info("Checking if the backup chart is already installed...")
+	initialBackupChart, err := charts.GetChartStatus(b.client, b.project.ClusterID, backupChartNamespace, backupChartName)
+	require.NoError(b.T(), err)
+
+	if !initialBackupChart.IsAlreadyInstalled {
+		installBroChart(b.client)
+	}
+
+	client, err = b.client.ReLogin()
+	require.NoError(b.T(), err)
+
+	logrus.Info("Creating two users, projects, and role templates...")
+	userList, projList, roleList, err := createRancherResources(client, 2, b.project.ClusterID)
+	require.NoError(b.T(), err)
+
+	logrus.Info("Creating a backup of the local cluster...")
+	firstBackup, err := createBackup(client, backupName)
+	require.NoError(b.T(), err)
+	charts.VerifyBackupCompleted(client, backupSteveType, firstBackup)
+
+	backupObj, err := client.Steve.SteveType(backupSteveType).ByID(backupName)
+	require.NoError(b.T(), err)
+	backupK8Obj := &bv1.Backup{}
+	error := v1.ConvertToK8sType(backupObj.JSONResp, backupK8Obj)
+	require.NoError(b.T(), error)
+	backupFileName := backupK8Obj.Status.Filename
+
+	logrus.Info("Validating backup file is in AWS S3...")
+	backupPresent, err := validateAWSS3BackupExists(broConfig.S3BucketName, broConfig.S3FolderName, backupFileName)
+	require.NoError(b.T(), err)
+	assert.True(b.T(), backupPresent)
+
+	userListPostBackup, projListPostBackup, roleListPostBackup, err := createRancherResources(client, 2, b.project.ClusterID)
+	require.NoError(b.T(), err)
+
+	logrus.Infof("Creating a restore using backup file: %v", backupFileName)
+	completedRestore, err := createRestore(client, backupFileName)
+	require.NoError(b.T(), err)
+	restoreObj, err := client.Steve.SteveType(restoreSteveType).ByID(completedRestore.ID)
+	require.NoError(b.T(), err)
+	charts.VerifyRestoreCompleted(client, restoreSteveType, restoreObj)
+
+	logrus.Info("Restore complete, validating Rancher resources...")
+	err = verifyRancherResources(client, userList, projList, roleList)
+	require.NoError(b.T(), err)
+
+	err = verifyRancherResources(client, userListPostBackup, projListPostBackup, roleListPostBackup)
+	assert.Error(b.T(), err)
+
+	logrus.Info("Validating downstream clusters are in an Active status...")
+	rke1ClusterID, err := clusters.GetClusterIDByName(client, broConfig.Rke1ClusterName)
+	require.NoError(b.T(), err)
+	rke2ClusterID, err := clusters.GetClusterIDByName(client, broConfig.Rke2ClusterName)
+	require.NoError(b.T(), err)
+
+	// Note: The function name mentions upgrade, but it's waiting for the cluster to become active
+	// and it logs the cluster status while waiting, therefore it's still useful for post-restore checks
+	err = clusters.WaitClusterUntilUpgrade(client, rke1ClusterID)
+	require.NoError(b.T(), err)
+	err = clusters.WaitClusterUntilUpgrade(client, rke2ClusterID)
+	require.NoError(b.T(), err)
+
+	logrus.Info("Validations complete, deleting backup from S3 bucket...")
+	err = deleteAWSBackup(broConfig.S3BucketName, broConfig.S3FolderName, backupFileName)
+	require.NoError(b.T(), err)
+	backupDeleted, err := validateAWSS3BackupExists(broConfig.S3BucketName, broConfig.S3FolderName, backupFileName)
+	assert.ErrorContains(b.T(), err, "404")
+	assert.False(b.T(), backupDeleted)
+}
+
+func TestBackupTestSuite(t *testing.T) {
+	suite.Run(t, new(BackupTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- resolves https://github.com/rancher/qa-tasks/issues/999
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The need for automated validation tests of backup and restore operator functions. This PR specifically tests the in-place restore P0 test case.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Created new files and functions to install the Rancher Backups chart with or without storage configured on install as well as creating an opaque secret with S3 creds for use in the chart install. The test creates new Rancher resources, provisions a downstream RKE1 and RKE2 cluster, performs a backup, creates more resources, takes another backup, performs a restore using the first backup file, and then validates that the expected resources are present.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)

Summary: Added automation for Rancher Backups P0 in-place restore test case

Associated Shepherd PR for BRO Extensions: https://github.com/rancher/shepherd/pull/140