### PR TITLE
Enqueue CRTBs for rke clusters to recreate RoleBindings

### DIFF
--- a/pkg/controllers/dashboard/kubernetesprovider/kubernetesprovider.go
+++ b/pkg/controllers/dashboard/kubernetesprovider/kubernetesprovider.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	providerKey = "provider.cattle.io"
+	ProviderKey = "provider.cattle.io"
 )
 
 type handler struct {
@@ -36,7 +36,7 @@ func Register(ctx context.Context,
 }
 
 func (h *handler) OnChange(key string, cluster *v3.Cluster) (*v3.Cluster, error) {
-	if cluster == nil || (cluster.Status.Provider != "" && cluster.Labels[providerKey] != "") {
+	if cluster == nil || (cluster.Status.Provider != "" && cluster.Labels[ProviderKey] != "") {
 		// if cluster has windows enabled and provider is not rke.windows, continue to detect if it has windows nodes
 		if cluster == nil || !cluster.Spec.WindowsPreferedCluster || cluster.Status.Provider == "rke.windows" {
 			return cluster, nil
@@ -72,7 +72,7 @@ func (h *handler) OnChange(key string, cluster *v3.Cluster) (*v3.Cluster, error)
 	if cluster.Labels == nil {
 		cluster.Labels = map[string]string{}
 	}
-	cluster.Labels[providerKey] = provider
+	cluster.Labels[ProviderKey] = provider
 	cluster.Status.Provider = provider
 	return h.clusters.Update(cluster)
 }

--- a/pkg/controllers/management/authprovisioningv2/cluster_test.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster_test.go
@@ -1,0 +1,123 @@
+package authprovisioningv2
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rancher/kubernetes-provider-detector/providers"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/controllers/dashboard/kubernetesprovider"
+	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestOnCluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	crtbs := []*v3.ClusterRoleTemplateBinding{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "crtb1",
+				Namespace: "ns1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "crtb2",
+				Namespace: "ns2",
+			},
+		},
+	}
+	err := errors.NewBadRequest("error")
+
+	tests := map[string]struct {
+		cluster       *v1.Cluster
+		crtbCacheMock func(string) mgmtcontrollers.ClusterRoleTemplateBindingCache
+		crtbMock      func() mgmtcontrollers.ClusterRoleTemplateBindingController
+		expectedErr   error
+	}{
+		"no rke doesn't enqueue CRTBs": {
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						kubernetesprovider.ProviderKey: providers.K3s,
+					},
+				},
+			},
+			crtbCacheMock: func(_ string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
+				return fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+			},
+			crtbMock: func() mgmtcontrollers.ClusterRoleTemplateBindingController {
+				return fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
+			},
+			expectedErr: nil,
+		},
+		"rke enqueue CRTBs": {
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						kubernetesprovider.ProviderKey: providers.RKE,
+					},
+				},
+			},
+			crtbCacheMock: func(clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
+				mock := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+				mock.EXPECT().List(clusterName, labels.Everything()).Return(crtbs, nil)
+				return mock
+			},
+			crtbMock: func() mgmtcontrollers.ClusterRoleTemplateBindingController {
+				mock := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
+				for _, crtb := range crtbs {
+					mock.EXPECT().Enqueue(crtb.Namespace, crtb.Name)
+				}
+				return mock
+			},
+			expectedErr: nil,
+		},
+		"rke enqueue CRTBs error": {
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						kubernetesprovider.ProviderKey: providers.RKE,
+					},
+				},
+			},
+			crtbCacheMock: func(clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
+				mock := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+				mock.EXPECT().List(clusterName, labels.Everything()).Return(nil, err)
+				return mock
+			},
+			crtbMock: func() mgmtcontrollers.ClusterRoleTemplateBindingController {
+				return fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
+			},
+			expectedErr: err,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			roleCacheMock := fake.NewMockCacheInterface[*rbacv1.Role](ctrl)
+			roleCacheMock.EXPECT().Get(test.cluster.Namespace, clusterViewName(test.cluster)).Return(&rbacv1.Role{}, errors.NewNotFound(schema.GroupResource{}, ""))
+			roleControllerMock := fake.NewMockControllerInterface[*rbacv1.Role, *rbacv1.RoleList](ctrl)
+			roleControllerMock.EXPECT().Create(gomock.Any())
+			h := handler{
+				clusterRoleTemplateBindings:          test.crtbCacheMock(test.cluster.Name),
+				clusterRoleTemplateBindingController: test.crtbMock(),
+				roleCache:                            roleCacheMock,
+				roleController:                       roleControllerMock,
+			}
+
+			_, err := h.OnCluster("", test.cluster)
+
+			assert.Equal(t, err, test.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45811
 
## Problem
User loses access to a cluster as cluster owner when the cluster `RKE1` is moved to another namespace(workspace) in the Continuous Delivery tab. The problem is that `RoleBindings` are not created.

The issue does not happen while switching `RKE2` clusters, only `RKE1`. The reason is that `Role` and `RoleBindings` are moved to the new namespace of the workspace only in `RKE1`. In `RKE2` `Role` and `RoleBindings` stay in the `fleet-default` namespace, which means they don't need to be recreated.
 
## Solution
Enqueue `CRTBs` for `RKE1` clusters to recreate `RoleBindings`. We do this only when the `Role` is not found and we are going to create it to minimize the impact.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Tested that RoleBindins are created when moving RKE1 clusters to a different workspace.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_