### PR TITLE
[main] Add Auth Providers Init Table Validation Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -434,3 +434,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace github.com/rancher/shepherd => github.com/caliskanugur/shepherd v0.0.0-20240805151837-5a4f296b7e21

--- a/go.sum
+++ b/go.sum
@@ -946,6 +946,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f h1:7+HZb3PwI0cCUETyMDgPCvSta1y3idwBL8PHwSgelJk=
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/caliskanugur/shepherd v0.0.0-20240805151837-5a4f296b7e21 h1:amaZY0Scu3wdU4wWtOuyA4HuQmfRigN6Hq053kLVcxQ=
+github.com/caliskanugur/shepherd v0.0.0-20240805151837-5a4f296b7e21/go.mod h1:7qf+6wlqrQ2Bver/WPCFrT6ZnC0V3KLllOmd1pr8Was=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -1793,8 +1795,6 @@ github.com/rancher/remotedialer v0.4.0 h1:T9yC5bFMsZFVQ6rK0dNrRg6rRb6Zr/4vsig8S0
 github.com/rancher/remotedialer v0.4.0/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
 github.com/rancher/rke v1.6.0 h1:fHdygmtPF1cWXuiYXfwgG4hKvt0n4l57SwCxquRJSfs=
 github.com/rancher/rke v1.6.0/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
-github.com/rancher/shepherd v0.0.0-20240802212035-bdce62c2bc80 h1:/dkxdx/BGZOp7jN0QMUFHrldDOSV3UfxxPdDCjGMZrQ=
-github.com/rancher/shepherd v0.0.0-20240802212035-bdce62c2bc80/go.mod h1:7qf+6wlqrQ2Bver/WPCFrT6ZnC0V3KLllOmd1pr8Was=
 github.com/rancher/steve v0.0.0-20240709130809-47871606146c h1:PIaN0/KUyGcqEcT6GyjUidld2lgGkGxS4dmC3Je3dFs=
 github.com/rancher/steve v0.0.0-20240709130809-47871606146c/go.mod h1:Za4nSt0V6kIHRfUo6jTXKkv6ABMMCHINA8EzhzygCfk=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/tests/v2/validation/auth/provider/openldap/openldap.go
+++ b/tests/v2/validation/auth/provider/openldap/openldap.go
@@ -1,4 +1,4 @@
-package auth
+package openldap
 
 import (
 	"context"

--- a/tests/v2/validation/auth/provider/provider.go
+++ b/tests/v2/validation/auth/provider/provider.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/auth"
+	v3 "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/stretchr/testify/require"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const ConfigurationFileKey = "authInput"
+
+type User struct {
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+}
+
+type AuthConfig struct {
+	Group             string `json:"group,omitempty" yaml:"group,omitempty"`
+	Users             []User `json:"users,omitempty" yaml:"users,omitempty"`
+	NestedGroup       string `json:"nestedGroup,omitempty" yaml:"nestedGroup,omitempty"`
+	NestedUsers       []User `json:"nestedUsers,omitempty" yaml:"nestedUsers,omitempty"`
+	DoubleNestedGroup string `json:"doubleNestedGroup,omitempty" yaml:"doubleNestedGroup,omitempty"`
+	DoubleNestedUsers []User `json:"doubleNestedUsers,omitempty" yaml:"doubleNestedUsers,omitempty"`
+}
+
+const (
+	passwordSecretID                     = "cattle-global-data/openldapconfig-serviceaccountpassword"
+	authProvCleanupAnnotationKey         = "management.cattle.io/auth-provider-cleanup"
+	authProvCleanupAnnotationValLocked   = "rancher-locked"
+	authProvCleanupAnnotationValUnlocked = "unlocked"
+)
+
+func waitUntilAnnotationIsUpdated(client *rancher.Client) (*v3.AuthConfig, error) {
+	ldapConfig, err := client.Management.AuthConfig.ByID("openldap")
+	if err != nil {
+		return nil, err
+	}
+
+	err = kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, 2*time.Minute, true, func(context.Context) (bool, error) {
+		newLDAPConfig, err := client.Management.AuthConfig.ByID("openldap")
+		if err != nil {
+			return false, nil
+		}
+
+		if ldapConfig.Annotations[authProvCleanupAnnotationKey] != newLDAPConfig.Annotations[authProvCleanupAnnotationKey] {
+			ldapConfig = newLDAPConfig
+			return true, nil
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ldapConfig, err
+}
+
+var userEnabled = true
+
+func login(client *rancher.Client, authProvider auth.Provider, user *v3.User) (*rancher.Client, error) {
+	user.Enabled = &userEnabled
+	return client.AsAuthUser(user, authProvider)
+}
+
+func newPrincipalID(authConfigID, principalType, name, searchBase string) string {
+	return fmt.Sprintf("%v_%v://cn=%v,ou=%vs,%v", authConfigID, principalType, name, principalType, searchBase)
+}
+
+func newWithAccessMode(t *testing.T, client *rancher.Client, authConfigID, accessMode string, allowedPrincipalIDs []string) (existing, updates *v3.AuthConfig) {
+	t.Helper()
+
+	existing, err := client.Management.AuthConfig.ByID(authConfigID)
+	require.NoError(t, err)
+
+	updates = existing
+	updates.AccessMode = accessMode
+
+	if allowedPrincipalIDs != nil {
+		updates.AllowedPrincipalIDs = allowedPrincipalIDs
+	}
+
+	return
+}

--- a/tests/v2/validation/auth/provider/provider_test.go
+++ b/tests/v2/validation/auth/provider/provider_test.go
@@ -1,0 +1,484 @@
+package provider
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/auth"
+	v3 "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/namespaces"
+	"github.com/rancher/shepherd/extensions/projects"
+	"github.com/rancher/shepherd/extensions/rbac"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type AuthProviderTestSuite struct {
+	suite.Suite
+	session    *session.Session
+	client     *rancher.Client
+	cluster    *clusters.ClusterMeta
+	authConfig *AuthConfig
+}
+
+func (a *AuthProviderTestSuite) SetupSuite() {
+	a.authConfig = new(AuthConfig)
+	config.LoadConfig(ConfigurationFileKey, a.authConfig)
+
+	if a.authConfig == nil {
+		a.T().Skipf("Auth configuration is not provided, skipping the tests")
+	}
+
+	session := session.NewSession()
+	a.session = session
+
+	client, err := rancher.NewClient("", session)
+	require.NoError(a.T(), err)
+
+	a.client = client
+
+	cluster, err := clusters.NewClusterMeta(a.client, a.client.RancherConfig.ClusterName)
+	require.NoError(a.T(), err)
+
+	a.cluster = cluster
+}
+
+func (a *AuthProviderTestSuite) TearDownSuite() {
+	a.session.Cleanup()
+}
+
+func (a *AuthProviderTestSuite) TestAuth() {
+	client := a.client
+
+	tests := []struct {
+		name         string
+		authConfigID string
+		enable       func(client *rancher.Client)
+		update       func(existing, updates *v3.AuthConfig) (*v3.AuthConfig, error)
+		admin        *v3.User
+		authProvider auth.Provider
+		searchBase   string
+	}{
+		{
+			name:         "Open LDAP",
+			authConfigID: "openldap",
+			enable:       a.enableOLDAP,
+			admin: &v3.User{
+				Username: client.Auth.OLDAP.Config.Users.Admin.Username,
+				Password: client.Auth.OLDAP.Config.Users.Admin.Password,
+			},
+			update:       client.Auth.OLDAP.Update,
+			authProvider: auth.OpenLDAPAuth,
+			searchBase:   client.Auth.OLDAP.Config.Users.SearchBase,
+		},
+	}
+
+	for _, tt := range tests {
+		session := session.NewSession()
+		a.session = session
+
+		client, err := client.WithSession(session)
+		require.NoError(a.T(), err)
+
+		defer session.Cleanup()
+
+		logrus.Infof("Validating %v: Enabling", tt.name)
+		tt.enable(client)
+
+		authAdmin, err := login(a.client, tt.authProvider, tt.admin)
+		require.NoError(a.T(), err, "Login as Admin failed")
+
+		logrus.Infof("Validating %v: Access modes | Allow any valid user", tt.name)
+		a.anyAccessMode(authAdmin, tt.authProvider)
+
+		logrus.Infof("Validating %v: Refresh Group Memberships from the Users & Authentication", tt.name)
+		a.refreshGroup(authAdmin, tt.authConfigID, a.authConfig.Group, a.authConfig.NestedGroup, tt.searchBase)
+
+		logrus.Infof("Checking if the cluster name is given in the configuration for [%v] tests", tt.name)
+		if a.client.RancherConfig.ClusterName == "" {
+			a.T().Skipf("Cluster name is not provided, skipping the cluster for the %v test next steps", tt.name)
+		}
+
+		logrus.Infof("Validating %v: Group Membership", tt.name)
+		a.groupMembership(authAdmin, tt.authProvider, tt.searchBase, tt.authConfigID)
+
+		logrus.Infof("Validating %v: Access modes | Allow members of clusters and projects, plus authorized users & groups", tt.name)
+		a.clusterAndProjectMembersAccessMode(authAdmin, tt.authProvider, tt.update, tt.searchBase, tt.authConfigID)
+
+		logrus.Infof("Validating %v: Access modes | Restrict access to only the authorized users & groups", tt.name)
+		a.restrictedAccessMode(authAdmin, tt.authProvider, tt.update, tt.searchBase, tt.authConfigID)
+	}
+}
+
+func (a *AuthProviderTestSuite) anyAccessMode(authAdmin *rancher.Client, authProvider auth.Provider) {
+	session := session.NewSession()
+	defer session.Cleanup()
+
+	authAdmin, err := authAdmin.WithSession(session)
+	require.NoError(a.T(), err, "Instantiating as Admin with the new session failed")
+
+	for _, v := range slices.Concat(a.authConfig.Users, a.authConfig.NestedUsers, a.authConfig.DoubleNestedUsers) {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+
+		logrus.Infof("Verifying logging as user [%v], should be able to login", v.Username)
+
+		_, err := login(authAdmin, authProvider, user)
+		require.NoError(a.T(), err)
+	}
+}
+
+func (a *AuthProviderTestSuite) refreshGroup(authAdmin *rancher.Client, authConfigID, groupName, nestedGroupName, searchBase string) {
+	session := session.NewSession()
+	defer session.Cleanup()
+
+	authAdmin, err := authAdmin.WithSession(session)
+	require.NoError(a.T(), err, "Instantiating as Admin with the new session failed")
+
+	adminGroupPrincipalID := newPrincipalID(authConfigID, "group", groupName, searchBase)
+	newAdminGlobalRole := &v3.GlobalRoleBinding{
+		GlobalRoleID:     rbac.Admin.String(),
+		GroupPrincipalID: adminGroupPrincipalID,
+	}
+
+	logrus.Infof("Creating a global role binding for group [%v] with [%v] role", newAdminGlobalRole.GroupPrincipalID, newAdminGlobalRole.GlobalRoleID)
+
+	_, err = authAdmin.Management.GlobalRoleBinding.Create(newAdminGlobalRole)
+	require.NoError(a.T(), err, "Error occured while creating a role [%v]", newAdminGlobalRole)
+
+	logrus.Infof("Verifying refreshing the group membership for group [%v]", groupName)
+
+	err = users.RefreshGroupMembership(authAdmin)
+	require.NoError(a.T(), err, "Error occured refreshing the group membership for group %v", groupName)
+
+	standardGroupPrincipalID := newPrincipalID(authConfigID, "group", nestedGroupName, searchBase)
+	newStandardGlobalRole := &v3.GlobalRoleBinding{
+		GlobalRoleID:     rbac.StandardUser.String(),
+		GroupPrincipalID: standardGroupPrincipalID,
+	}
+
+	logrus.Infof("Creating a global role binding for group [%v] with [%v] role", newStandardGlobalRole.GroupPrincipalID, newStandardGlobalRole.GlobalRoleID)
+
+	_, err = authAdmin.Management.GlobalRoleBinding.Create(newStandardGlobalRole)
+	require.NoError(a.T(), err, "Error occured while creating a role %v", newStandardGlobalRole)
+
+	logrus.Infof("Verifying refreshing the group membership for group [%v]", nestedGroupName)
+
+	err = users.RefreshGroupMembership(authAdmin)
+	require.NoError(a.T(), err, "Error occured refreshing the group membership for group [%v]", nestedGroupName)
+}
+
+func (a *AuthProviderTestSuite) groupMembership(authAdmin *rancher.Client, authProvider auth.Provider, searchBase, authConfigID string) {
+	session := session.NewSession()
+	defer session.Cleanup()
+
+	authAdmin, err := authAdmin.WithSession(session)
+	require.NoError(a.T(), err, "Instantiating as Admin with the new session failed")
+
+	doubleNestedGroupPrincipalID := newPrincipalID(authConfigID, "group", a.authConfig.DoubleNestedGroup, searchBase)
+	groupCRTB := &v3.ClusterRoleTemplateBinding{
+		ClusterID:        a.cluster.ID,
+		GroupPrincipalID: doubleNestedGroupPrincipalID,
+		RoleTemplateID:   rbac.ClusterOwner.String(),
+	}
+	logrus.Infof("Creating cluster role template binding for group [%v] with role [%v]", groupCRTB.GroupPrincipalID, groupCRTB.RoleTemplateID)
+	_, err = authAdmin.Management.ClusterRoleTemplateBinding.Create(groupCRTB)
+	require.NoError(a.T(), err, "Error occured while creating cluster role template binding")
+
+	for _, v := range a.authConfig.DoubleNestedUsers {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+		userClient, err := login(authAdmin, authProvider, user)
+		require.NoError(a.T(), err)
+
+		newUserClient, err := userClient.ReLogin()
+		require.NoError(a.T(), err)
+
+		clusterList, err := newUserClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).List(nil)
+		require.NoError(a.T(), err)
+
+		logrus.Infof("Verifying user [%v] lists [%v] clusters while expecting [%v] clusters to be listed", v.Username, len(clusterList.Data), 1)
+		assert.Equalf(a.T(), 1, len(clusterList.Data), "Error occured while: user [%v] lists [%v] clusters while expecting [%v] clusters to be listed", v.Username, len(clusterList.Data), 1)
+	}
+
+	for _, v := range slices.Concat(a.authConfig.Users, a.authConfig.NestedUsers) {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+		userClient, err := login(authAdmin, authProvider, user)
+		require.NoError(a.T(), err)
+
+		logrus.Infof("Verifying user [%v] should NOT lists clusters", v.Username)
+
+		_, err = userClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).List(nil)
+
+		assert.NotNilf(a.T(), err, "Error should contain error message", "Error occured while: user [%v] should NOT lists clusters", v.Username)
+		assert.Containsf(a.T(), err.Error(), "Resource type [provisioning.cattle.io.cluster] has no method GET", "Error occured while: user [%v] should NOT lists clusters", v.Username)
+	}
+
+	var createdCRTB *rbacv1.ClusterRoleBinding
+
+	listCRTB, err := authAdmin.Steve.SteveType("rbac.authorization.k8s.io.clusterrolebinding").List(nil)
+	require.NoError(a.T(), err)
+
+	for _, v := range listCRTB.Data {
+		crtb := &rbacv1.ClusterRoleBinding{}
+
+		err = v1.ConvertToK8sType(v.JSONResp, crtb)
+		require.NoError(a.T(), err)
+
+		for _, v := range crtb.Subjects {
+			if v.Name == doubleNestedGroupPrincipalID {
+				createdCRTB = crtb
+			}
+		}
+	}
+	assert.NotNilf(a.T(), createdCRTB, "Error occured while: creating the CRTB")
+
+	logrus.Infof("Creating a project with the admin")
+
+	projectTemplate := projects.NewProjectConfig(a.cluster.ID)
+	projectResp, err := authAdmin.Management.Project.Create(projectTemplate)
+
+	require.NoError(a.T(), err)
+	assert.NotNilf(a.T(), projectResp, "Error occured while: project is created with the admin")
+
+	nestedGroupPrincipalID := newPrincipalID(authConfigID, "group", a.authConfig.NestedGroup, searchBase)
+	groupPRTB := &v3.ProjectRoleTemplateBinding{
+		ProjectID:        projectResp.ID,
+		GroupPrincipalID: nestedGroupPrincipalID,
+		RoleTemplateID:   rbac.ProjectOwner.String(),
+	}
+
+	logrus.Infof("Creating a PRTB for group [%v]", a.authConfig.NestedGroup)
+
+	groupPRTBResp, err := authAdmin.Management.ProjectRoleTemplateBinding.Create(groupPRTB)
+	require.NoError(a.T(), err)
+	assert.NotNilf(a.T(), groupPRTBResp, "Error occured while: creating a  PRTB for group [%v]", a.authConfig.NestedGroup)
+
+	for _, v := range a.authConfig.NestedUsers {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+		userClient, err := login(authAdmin, authProvider, user)
+		require.NoError(a.T(), err)
+
+		namespaceName := namegen.AppendRandomString("testns-")
+		namespace, err := namespaces.CreateNamespace(userClient, namespaceName, "{}", nil, nil, projectResp)
+		require.NoError(a.T(), err)
+
+		logrus.Infof("Verifying user [%v] has created namespace [%v]", v.Username, namespaceName)
+		assert.Equal(a.T(), namespaceName, namespace.Name, "Error occured while: user [%v] has created namespace [%v]", v.Username, namespaceName)
+	}
+}
+
+func (a *AuthProviderTestSuite) restrictedAccessMode(
+	authAdmin *rancher.Client, authProvider auth.Provider, update func(existing, updates *v3.AuthConfig) (*v3.AuthConfig, error), searchBase string, authConfigID string,
+) {
+	session := session.NewSession()
+	defer session.Cleanup()
+
+	authAdmin, err := authAdmin.WithSession(session)
+	require.NoError(a.T(), err, "Instantiating as Admin with the new session failed")
+
+	groupPrincipalID := newPrincipalID(authConfigID, "group", a.authConfig.Group, searchBase)
+	groupCRTB := &v3.ClusterRoleTemplateBinding{
+		ClusterID:        a.cluster.ID,
+		GroupPrincipalID: groupPrincipalID,
+		RoleTemplateID:   rbac.ClusterMember.String(),
+	}
+
+	logrus.Infof("Creating cluster role template binding for group [%v] with role [%v]", groupCRTB.GroupPrincipalID, groupCRTB.RoleTemplateID)
+
+	_, err = authAdmin.Management.ClusterRoleTemplateBinding.Create(groupCRTB)
+	require.NoError(a.T(), err, "Error occured while creating cluster role template binding")
+
+	defaultProject, err := projects.GetProjectByName(authAdmin, a.cluster.ID, "Default")
+	require.NoError(a.T(), err)
+
+	for _, v := range a.authConfig.NestedUsers {
+		nestedUserPrincipalID := newPrincipalID(authConfigID, "user", v.Username, searchBase)
+
+		userPRTB := &v3.ProjectRoleTemplateBinding{
+			ProjectID:        defaultProject.ID,
+			GroupPrincipalID: nestedUserPrincipalID,
+			RoleTemplateID:   rbac.ProjectOwner.String(),
+		}
+
+		logrus.Infof("Creating project role template binding for user [%v] with role [%v]", userPRTB.GroupPrincipalID, userPRTB.RoleTemplateID)
+		userPRTBResp, err := authAdmin.Management.ProjectRoleTemplateBinding.Create(userPRTB)
+		require.NoError(a.T(), err)
+
+		logrus.Infof("Verifying project role template binding has created for user [%v]", v.Username)
+		assert.NotNilf(a.T(), userPRTBResp, "Error occured while: project role template binding is created for user [%v]", v.Username)
+	}
+
+	var principalIDs []string
+
+	principalIDs = append(principalIDs, newPrincipalID(authConfigID, "group", a.authConfig.DoubleNestedGroup, searchBase))
+	for _, v := range a.authConfig.DoubleNestedUsers {
+		principalIDs = append(principalIDs, newPrincipalID(authConfigID, "user", v.Username, searchBase))
+	}
+
+	logrus.Infof("Verifying access mode updated to restrict access to only the authorized users & groups")
+
+	existing, updates := newWithAccessMode(a.T(), authAdmin, authConfigID, "required", principalIDs)
+	newAuthConfig, err := update(existing, updates)
+
+	require.NoError(a.T(), err)
+	assert.Equal(a.T(), existing.AccessMode, newAuthConfig.AccessMode, "Error occured while: access mode updated to restrict access to only the authorized users & groups")
+
+	for _, v := range a.authConfig.DoubleNestedUsers {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+		_, err := login(authAdmin, authProvider, user)
+
+		logrus.Infof("Verifying logging as user [%v], should be able to login", v.Username)
+		assert.NoErrorf(a.T(), err, "Error occured while: logging as user [%v], should be able to login", v.Username)
+
+	}
+
+	for _, v := range slices.Concat(a.authConfig.Users, a.authConfig.NestedUsers) {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+		_, err := login(authAdmin, authProvider, user)
+
+		logrus.Infof("Verifying logging as user [%v], should be able to login", v.Username)
+		assert.Errorf(a.T(), err, "Error occured while: logging as user [%v], should be able to login", v.Username)
+	}
+
+	logrus.Infof("Rolling back the access mode to unrestricted from restrict access to only the authorized users & groups")
+
+	// Rollback only happens with the local client change a.client to authAdmin to reproduce the issue
+	authExisting, authWithUnrestricted := newWithAccessMode(a.T(), a.client, authConfigID, "unrestricted", nil)
+	newAuthConfig, err = update(authExisting, authWithUnrestricted)
+
+	require.NoError(a.T(), err)
+	assert.Equal(a.T(), authExisting.AccessMode, newAuthConfig.AccessMode, "Rolling back the access mode to unrestricted from restrict access to only the authorized users & groups")
+}
+
+func (a *AuthProviderTestSuite) clusterAndProjectMembersAccessMode(
+	authAdmin *rancher.Client,
+	authProvider auth.Provider,
+	update func(existing, updates *v3.AuthConfig) (*v3.AuthConfig, error),
+	searchBase string, authConfigID string,
+) {
+	session := session.NewSession()
+	defer session.Cleanup()
+
+	authAdmin, err := authAdmin.WithSession(session)
+	require.NoError(a.T(), err, "Instantiating as Admin with the new session failed")
+
+	doubleNestedGroupPrincipalID := newPrincipalID(authConfigID, "group", a.authConfig.DoubleNestedGroup, searchBase)
+	groupCRTB := &v3.ClusterRoleTemplateBinding{
+		ClusterID:        a.cluster.ID,
+		GroupPrincipalID: doubleNestedGroupPrincipalID,
+		RoleTemplateID:   rbac.ClusterMember.String(),
+	}
+
+	logrus.Infof("Creating cluster role template binding for group [%v] with role [%v]", groupCRTB.GroupPrincipalID, groupCRTB.RoleTemplateID)
+	_, err = authAdmin.Management.ClusterRoleTemplateBinding.Create(groupCRTB)
+	require.NoError(a.T(), err, "Error occured while creating cluster role template binding")
+
+	defaultProject, err := projects.GetProjectByName(authAdmin, a.cluster.ID, "Default")
+	require.NoError(a.T(), err)
+
+	for _, v := range a.authConfig.NestedUsers {
+		nestedGroupPrincipalID := newPrincipalID(authConfigID, "user", v.Username, searchBase)
+
+		userPRTB := &v3.ProjectRoleTemplateBinding{
+			ProjectID:        defaultProject.ID,
+			GroupPrincipalID: nestedGroupPrincipalID,
+			RoleTemplateID:   rbac.ProjectOwner.String(),
+		}
+		userPRTBResp, err := authAdmin.Management.ProjectRoleTemplateBinding.Create(userPRTB)
+		require.NoError(a.T(), err)
+
+		logrus.Infof("Verifying project role binding has created for user [%v]", v.Username)
+		assert.NotNilf(a.T(), userPRTBResp, "Error occured while: creating a project role binding for user [%v]", v.Username)
+	}
+
+	logrus.Infof("Verifying access mode updated to allow members of clusters and projects, plus authorized users & groups")
+
+	authExisting, authWithRestricted := newWithAccessMode(a.T(), authAdmin, authConfigID, "restricted", nil)
+	newAuthConfig, err := update(authExisting, authWithRestricted)
+
+	require.NoError(a.T(), err)
+	assert.Equal(a.T(), authExisting.AccessMode, newAuthConfig.AccessMode, "Error occured while: access mode updated to allow members of clusters and projects, plus authorized users & groups")
+
+	for _, v := range slices.Concat(a.authConfig.DoubleNestedUsers, a.authConfig.NestedUsers) {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+		_, err := login(authAdmin, authProvider, user)
+
+		logrus.Infof("Verifying logging as user [%v], should be able to login", v.Username)
+		assert.NoErrorf(a.T(), err, "Error occured while: logging as user [%v], should be able to login", v.Username)
+	}
+
+	for _, v := range a.authConfig.Users {
+		user := &v3.User{
+			Username: v.Username,
+			Password: v.Password,
+		}
+		_, err := login(authAdmin, authProvider, user)
+
+		logrus.Infof("Verifying logging as user [%v], should NOT be able to login", v.Username)
+		assert.Errorf(a.T(), err, "Verifying logging as user [%v], should NOT be able to login", v.Username)
+	}
+
+	logrus.Infof("Rolling back the access mode to unrestricted from allow members of clusters and projects, plus authorized users & groups")
+
+	authExisting, authWithUnrestricted := newWithAccessMode(a.T(), authAdmin, authConfigID, "unrestricted", nil)
+	newAuthConfig, err = update(authExisting, authWithUnrestricted)
+
+	require.NoError(a.T(), err)
+	assert.Equal(a.T(), authExisting.AccessMode, newAuthConfig.AccessMode, "Rolling back the access mode to unrestricted from allow members of clusters and projects, plus authorized users & groups")
+}
+
+func (a *AuthProviderTestSuite) enableOLDAP(client *rancher.Client) {
+	err := client.Auth.OLDAP.Enable()
+	require.NoError(a.T(), err)
+
+	ldapConfig, err := client.Management.AuthConfig.ByID("openldap")
+	require.NoError(a.T(), err)
+
+	assert.Truef(a.T(), ldapConfig.Enabled, "Checking if Open LDAP has enabled")
+
+	assert.Equalf(a.T(), authProvCleanupAnnotationValUnlocked, ldapConfig.Annotations[authProvCleanupAnnotationKey], "Checking if annotation set to unlocked for LDAP Auth Config")
+
+	passwordSecretResp, err := client.Steve.SteveType("secret").ByID(passwordSecretID)
+	assert.NoErrorf(a.T(), err, "Checking open LDAP config secret for service account password exists")
+
+	passwordSecret := &corev1.Secret{}
+	err = v1.ConvertToK8sType(passwordSecretResp.JSONResp, passwordSecret)
+	require.NoError(a.T(), err)
+
+	assert.Equal(a.T(), client.Auth.OLDAP.Config.ServiceAccount.Password, string(passwordSecret.Data["serviceaccountpassword"]), "Checking if serviceaccountpassword value is equal to the given")
+}
+
+func TestAuthProviderSuite(t *testing.T) {
+	suite.Run(t, new(AuthProviderTestSuite))
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/1315 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Currently, auth provider automation tests are limited to manual testing.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Create a generic table test (as much as possible) in the validations that can be used for the other auth providers, starting with Open LDAP automation.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)
 
### Regressions Considerations

Runs will be provided offline