### PR TITLE
[46431] [2.10] Add data-dir support to killall in etcd restore

### DIFF
--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -345,7 +345,7 @@ func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControl
 		controlPlane,
 		"etcd-restore/restore-kill-all",
 		fmt.Sprintf("%v", controlPlane.Status.ETCDSnapshotRestore),
-		generateKillAllInstruction(runtime)))
+		generateKillAllInstruction(controlPlane)))
 
 	if runtime == capr.RuntimeRKE2 {
 		if generated, instruction := generateManifestRemovalInstruction(controlPlane, entry); generated {
@@ -387,22 +387,29 @@ func (p *Planner) generateStopServiceAndKillAllPlan(controlPlane *rkev1.RKEContr
 	if err != nil {
 		return nodePlan, joinedServer, err
 	}
+
 	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
-	nodePlan.Instructions = append(nodePlan.Instructions,
-		generateKillAllInstruction(runtime))
+	nodePlan.Instructions = append(nodePlan.Instructions, generateKillAllInstruction(controlPlane))
+
 	if runtime == capr.RuntimeRKE2 {
 		if generated, instruction := generateManifestRemovalInstruction(controlPlane, server); generated {
 			nodePlan.Instructions = append(nodePlan.Instructions, instruction)
 		}
 	}
+
 	return nodePlan, joinedServer, nil
 }
 
-func generateKillAllInstruction(runtime string) plan.OneTimeInstruction {
+func generateKillAllInstruction(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
+	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
 	killAllScript := runtime + "-killall.sh"
+
 	return plan.OneTimeInstruction{
 		Name:    "shutdown",
 		Command: "/bin/sh",
+		Env: []string{
+			fmt.Sprintf("%s_DATA_DIR=%s", strings.ToUpper(runtime), capr.GetDistroDataDir(controlPlane)),
+		},
 		Args: []string{
 			"-c",
 			fmt.Sprintf("if [ -z $(command -v %s) ] && [ -z $(command -v %s) ]; then echo %s does not appear to be installed; exit 0; else %s; fi", runtime, killAllScript, runtime, killAllScript),


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/46431
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Forwardport of https://github.com/rancher/rancher/pull/46103

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When doing a etcd snapshot restore after upgrading the rke2 cluster k8s version the cluster hangs and all pods on the control plane remain in a pending state.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add `RKE2_DATA_DIR` and `K3S_DATA_DIR` to killall calls within the planner, which will cause the manifests to be successfully removed.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Confirm etcd restore happens successfully for both RKE2 and K3s provisioned clusters.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manually confirmed RKE2 & K3s clusters perform a restore

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: Existing tests will validate this once this is merged and KDM bumps RKE2/K3s versions to a version which includes the fixes required on the distro side:
* https://github.com/rancher/rke2/issues/6292
* https://github.com/k3s-io/k3s/issues/10471

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

N/A (no considerations besides regular test cases).

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Would be worthwhile to confirm clusters without a data directory configuration restore correctly.