### PR TITLE
[46429] [2.10] Add system-agent data-dir env var to suc plan

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -251,15 +251,15 @@ func GetDistroDataDir(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("/var/lib/rancher/%s", GetRuntime(controlPlane.Spec.KubernetesVersion))
 }
 
-func GetProvisioningDataDir(controlPlane *rkev1.RKEControlPlane) string {
-	if dir := controlPlane.Spec.DataDirectories.Provisioning; dir != "" {
+func GetProvisioningDataDir(spec *rkev1.RKEClusterSpecCommon) string {
+	if dir := spec.DataDirectories.Provisioning; dir != "" {
 		return dir
 	}
 	return "/var/lib/rancher/capr"
 }
 
-func GetSystemAgent(controlPlane *rkev1.RKEControlPlane) string {
-	if dir := controlPlane.Spec.DataDirectories.SystemAgent; dir != "" {
+func GetSystemAgentDataDir(spec *rkev1.RKEClusterSpecCommon) string {
+	if dir := spec.DataDirectories.SystemAgent; dir != "" {
 		return dir
 	}
 	return "/var/lib/rancher/agent"

--- a/pkg/capr/planner/idempotent.go
+++ b/pkg/capr/planner/idempotent.go
@@ -36,7 +36,7 @@ fi
 `
 
 func idempotentActionScriptPath(controlPlane *rkev1.RKEControlPlane) string {
-	return path.Join(capr.GetProvisioningDataDir(controlPlane), "idempotence/idempotent.sh")
+	return path.Join(capr.GetProvisioningDataDir(&controlPlane.Spec.RKEClusterSpecCommon), "idempotence/idempotent.sh")
 }
 
 // generateIdempotencyCleanupInstruction generates a one-time instruction that performs a cleanup of the given key.
@@ -49,7 +49,7 @@ func generateIdempotencyCleanupInstruction(controlPlane *rkev1.RKEControlPlane, 
 		Command: "/bin/sh",
 		Args: []string{
 			"-c",
-			fmt.Sprintf("rm -rf %s/idempotence/%s", capr.GetProvisioningDataDir(controlPlane), key),
+			fmt.Sprintf("rm -rf %s/idempotence/%s", capr.GetProvisioningDataDir(&controlPlane.Spec.RKEClusterSpecCommon), key),
 		},
 	}
 }
@@ -70,7 +70,7 @@ func idempotentInstruction(controlPlane *rkev1.RKEControlPlane, identifier, valu
 			hashedValue,
 			hashedCommand,
 			command,
-			capr.GetProvisioningDataDir(controlPlane)},
+			capr.GetProvisioningDataDir(&controlPlane.Spec.RKEClusterSpecCommon)},
 			args...),
 		Env: env,
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/46429
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
Forwardport of https://github.com/rancher/rancher/pull/46363

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The `system-agent-upgrader` SUC plan does not contain the environment variables for the `system-agent` data directory (`CATTLE_AGENT_VAR_DIR`), so when the system upgrade controller applies the plan, the previous configuration is lost and the default of `/var/lib/rancher/agent` is used.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add the `CATTLE_AGENT_VAR_DIR` env var to the `system-agent-upgrader` SUC plan if the data directory is configured for the `system-agent`.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manually tested that after the `system-agent-upgrader` plan was run successfully, that the `/var/lib/rancher/agent` directory does not exist.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: Not currently feasibly to create tests for this usecase.
* If "None" - GH Issue/PR: https://github.com/rancher/rancher/issues/46413

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Should be tested both with and without a `system-agent` data directory configured for both RKE2 and K3s.
Would be nice to see what happens on Windows.