### PR TITLE
[46512] [2.10] Dump rancher logs when webhook fails to deploy

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -121,6 +121,7 @@ dump_rancher_logs()
   cat /tmp/rancher.log | gzip | base64 -w 0
   echo -e "\n-----RANCHER-LOG-DUMP-END-----"
 }
+export -f dump_rancher_logs
 
 # Compile Rancher
 # This needs to happen before build_and_run_rancher is executed in the background.
@@ -150,6 +151,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
   --sleep 2 `# Sleep for 2 seconds in between attempts` \
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-webhook was not available after {{elapsed}} seconds" `# Print this progress message` \
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why webhook did not start` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook &>/dev/null"
 
 echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
@@ -158,6 +160,7 @@ echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
   --sleep 2 `# Sleep for 2 seconds in between attempts` \
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-provisioning-capi was not available after {{elapsed}} seconds" `# Print this progress message` \
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why webhook did not start` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-provisioning-capi-system deploy/capi-controller-manager &>/dev/null"
 
 

--- a/scripts/retry
+++ b/scripts/retry
@@ -22,6 +22,7 @@ print_usage() {
     echo "                          elapsed time (in seconds) and total attempts respectively."
     echo "  -i, --message-interval  The number of command attempts to make before each printing of the progress message"
     echo "                          (default: 5)."
+    echo " -e, --exit-command       Optional command to run before exiting (default: '')"
     echo
 }
 
@@ -49,6 +50,10 @@ while [[ $# -gt 0 ]]; do
         -i | --message-interval)
             shift
             messageInterval="$1"
+            ;;
+        -e | --exit-command)
+            shift
+            exitCommand="$1"
             ;;
         *)
             cmd="$@"
@@ -82,5 +87,8 @@ done
 # If we timed out, print the final progress message and exit with code 1.
 if [ "$elapsedSeconds" -gt "$timeoutSeconds" ]; then
   print_progress
+  if [ -n "$exitCommand" ]; then
+    eval "$exitCommand"
+  fi
   exit 1
 fi


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/46512
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Forwardport of https://github.com/rancher/rancher/pull/45602
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Occasionally, the webhook may fail to deploy during `provisioning-tests`. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Dump Rancher logs if webhook fails to deploy.
