### PR TITLE
Run provisioning tests on `main`

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -2,6 +2,7 @@ name: Provisioning tests
 on:
   pull_request:
     branches:
+      - main
       - release/v*
 jobs:
   provisioning_tests:


### PR DESCRIPTION
Fixed branch filter to make v2prov tests run on PRs in `main` branch