### PR TITLE
Cleanup of dup PRTB at Rancher startup

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -68,6 +68,7 @@ func main() {
 			err = clean.Cluster()
 		} else if os.Getenv("BINDING_CLEANUP") == "true" {
 			err = errors.Join(
+				clean.DuplicatePRTBs(nil),
 				clean.DuplicateBindings(nil),
 				clean.OrphanBindings(nil),
 				clean.OrphanCatalogBindings(nil),

--- a/pkg/agent/clean/dupe_prtbs.go
+++ b/pkg/agent/clean/dupe_prtbs.go
@@ -1,0 +1,169 @@
+//go:build !windows
+// +build !windows
+
+// Clean duplicated PRTBs found in a management cluster. This will collect all
+// PRTBs and check for duplicates. If they are found delete all but 1.
+
+package clean
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"time"
+
+	rbacv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
+	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac"
+	"github.com/rancher/wrangler/v3/pkg/ratelimit"
+	"github.com/rancher/wrangler/v3/pkg/start"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	dupePRTBsOperation = "clean-dupe-prtbs"
+)
+
+type dupePRTBsCleanup struct {
+	prtbs v3.ProjectRoleTemplateBindingClient
+}
+
+type projectRoleTemplateBindingDuplicate struct {
+	PRTBs []prtbLight
+}
+
+type prtbLight struct {
+	Namespace         string
+	Name              string
+	CreationTimestamp time.Time
+}
+
+func DuplicatePRTBs(clientConfig *restclient.Config) error {
+	logrus.Infof("[%v] starting prtb cleanup", dupePRTBsOperation)
+	if os.Getenv("DRY_RUN") == "true" {
+		logrus.Infof("[%v] DRY_RUN is true, no objects will be deleted/modified", dupePRTBsOperation)
+		dryRun = true
+	}
+
+	var config *restclient.Config
+	var err error
+	if clientConfig != nil {
+		config = clientConfig
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+		if err != nil {
+			logrus.Errorf("[%v] error in building the cluster config %v", dupeBindingsOperation, err)
+			return err
+		}
+	}
+	// No one wants to be slow
+	config.RateLimiter = ratelimit.None
+
+	rancherManagement, err := management.NewFactoryFromConfig(config)
+	if err != nil {
+		return err
+	}
+
+	k8srbac, err := rbac.NewFactoryFromConfig(config)
+	if err != nil {
+		return err
+	}
+
+	starters := []start.Starter{rancherManagement, k8srbac}
+
+	ctx := context.Background()
+	if err := start.All(ctx, 5, starters...); err != nil {
+		return err
+	}
+
+	pc := dupePRTBsCleanup{
+		prtbs: rancherManagement.Management().V3().ProjectRoleTemplateBinding(),
+	}
+
+	return pc.clean()
+}
+
+func (pc *dupePRTBsCleanup) clean() error {
+	prtbs, err := pc.prtbs.List("", metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	dupsMap := analyzeProjectRoleTemplateBindings(prtbs.Items)
+	dupsMap = findAndOrderDuplicates(dupsMap)
+
+	logrus.Infof("[%v] delete duplicates", dupePRTBsOperation)
+
+	for _, prtbSet := range dupsMap {
+		for i, dup := range prtbSet.PRTBs {
+			// skip first to keep the oldest
+			if i == 0 {
+				continue
+			}
+
+			// delete everything else
+			logrus.Infof("[%v] deleting %s.%s", dupePRTBsOperation, dup.Namespace, dup.Name)
+			pc.prtbs.Delete(dup.Namespace, dup.Name, &metav1.DeleteOptions{})
+		}
+	}
+
+	return nil
+}
+
+func analyzeProjectRoleTemplateBindings(prtbs []rbacv3.ProjectRoleTemplateBinding) map[string]projectRoleTemplateBindingDuplicate {
+	logrus.Infof("[%v] analyzing project role template bindings", dupePRTBsOperation)
+
+	hashes := make(map[string]projectRoleTemplateBindingDuplicate)
+
+	for _, prtb := range prtbs {
+		hash := getPRTBHash(prtb)
+
+		entry, found := hashes[hash]
+		// initialize entry on first access
+		if !found {
+			entry.PRTBs = []prtbLight{}
+		}
+
+		entry.PRTBs = append(entry.PRTBs, prtbLight{
+			Namespace:         prtb.ObjectMeta.Namespace,
+			Name:              prtb.ObjectMeta.Name,
+			CreationTimestamp: prtb.ObjectMeta.CreationTimestamp.Time,
+		})
+
+		hashes[hash] = entry
+	}
+
+	return hashes
+}
+
+func findAndOrderDuplicates(all map[string]projectRoleTemplateBindingDuplicate) map[string]projectRoleTemplateBindingDuplicate {
+	logrus.Infof("[%v] find duplicates and order PRTBs", dupePRTBsOperation)
+
+	for k, prtb := range all {
+		if len(prtb.PRTBs) == 1 {
+			delete(all, k)
+			continue
+		}
+
+		slices.SortFunc(prtb.PRTBs, func(a, b prtbLight) int {
+			return int(a.CreationTimestamp.Unix() - b.CreationTimestamp.Unix())
+		})
+	}
+
+	return all
+}
+
+func getPRTBHash(prtb rbacv3.ProjectRoleTemplateBinding) string {
+	return fmt.Sprintf(
+		"%s,%s,%s,%s",
+		prtb.ObjectMeta.Namespace,
+		prtb.ProjectName,
+		prtb.RoleTemplateName,
+		prtb.UserPrincipalName,
+	)
+}

--- a/pkg/agent/clean/dupe_prtbs_windows.go
+++ b/pkg/agent/clean/dupe_prtbs_windows.go
@@ -1,0 +1,9 @@
+package clean
+
+import (
+	restclient "k8s.io/client-go/rest"
+)
+
+func DuplicatePRTBs(clientConfig *restclient.Config) error {
+	return nil
+}

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -221,6 +221,7 @@ func (m *mcm) Start(ctx context.Context) error {
 		providerrefresh.StartRefreshDaemon(ctx, m.ScaledContext, management)
 		managementdata.CleanupOrphanedSystemUsers(ctx, management)
 		clusterupstreamrefresher.MigrateEksRefreshCronSetting(m.wranglerContext)
+		go managementdata.CleanupDuplicatePRTBs(m.ScaledContext, m.wranglerContext)
 		go managementdata.CleanupDuplicateBindings(m.ScaledContext, m.wranglerContext)
 		go managementdata.CleanupOrphanBindings(m.ScaledContext, m.wranglerContext)
 


### PR DESCRIPTION
## Issue: 

SURE-8464
 
## Problem

The exact root cause generating the large set of identical PRTBs seen in the customer's system are not yet known.
 
## Solution

This is a mitigating change, which, depending on the actual root cause, may actually not be needed.
The code looks for duplicate PRTBs at Rancher startup and deletes all but the oldest in each set of copies.
This action is also linked into the code triggered by running the existing `cleanup/binding-clean.sh` script.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_