### PR TITLE
[main] remove deprecated monitoring v1 webhook receiver

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -253,7 +253,6 @@ var OriginMap = map[string]string{
 	"ui-plugin-catalog":                                       "https://github.com/rancher/ui-plugin-charts",
 	"weave-kube":                                              "https://github.com/weaveworks-experiments/weave-kube",
 	"weave-npc":                                               "https://github.com/weaveworks/weave",
-	"webhook-receiver":                                        "https://github.com/rancher/webhook-receiver",
 	"windows_exporter-package":                                "https://github.com/rancher/windows_exporter-package",
 	"wins":                                                    "https://github.com/rancher/wins",
 	"wmi_exporter-package":                                    "https://github.com/rancher/wmi_exporter-package",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

A the `rancher/webhook-receiver` image is no longer used and is left over from monitoring v1 and is tripping several CVE flags.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Remove image to alleviate CVE concerns.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Existing / newly added automated tests that provide evidence there are no regressions: