### PR TITLE
[45815] [2.9] Add support for CATTLE_AGENT_FALLBACK_PATH

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -125,7 +125,8 @@ const (
 	MinimumHostnameLengthLimit = 10
 	MaximumHostnameLengthLimit = 63
 
-	SystemAgentDataDirEnvVar = "CATTLE_AGENT_VAR_DIR"
+	SystemAgentDataDirEnvVar      = "CATTLE_AGENT_VAR_DIR"
+	SystemAgentFallbackPathEnvVar = "CATTLE_AGENT_FALLBACK_PATH"
 )
 
 var (

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -232,6 +232,18 @@ func (h *handler) getEnvVars(controlPlane *rkev1.RKEControlPlane) ([]corev1.EnvV
 			Value: dir,
 		})
 	}
+	switch capr.GetRuntime(controlPlane.Spec.KubernetesVersion) {
+	case capr.RuntimeRKE2:
+		result = append(result, corev1.EnvVar{
+			Name:  capr.SystemAgentFallbackPathEnvVar,
+			Value: "/opt/rke2/bin",
+		})
+	default:
+		result = append(result, corev1.EnvVar{
+			Name:  capr.SystemAgentFallbackPathEnvVar,
+			Value: "/opt/bin",
+		})
+	}
 
 	return result, nil
 }

--- a/pkg/controllers/capr/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagent.go
@@ -213,6 +213,19 @@ func installer(cluster *rancherv1.Cluster, secretName string) []runtime.Object {
 		})
 	}
 
+	switch capr.GetRuntime(cluster.Spec.KubernetesVersion) {
+	case capr.RuntimeRKE2:
+		env = append(env, corev1.EnvVar{
+			Name:  capr.SystemAgentFallbackPathEnvVar,
+			Value: "/opt/rke2/bin",
+		})
+	default:
+		env = append(env, corev1.EnvVar{
+			Name:  capr.SystemAgentFallbackPathEnvVar,
+			Value: "/opt/bin",
+		})
+	}
+
 	plan := &upgradev1.Plan{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Plan",

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -329,6 +329,19 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 		}
 	}
 
+	switch capr.GetRuntime(cluster.Spec.KubernetesVersion) {
+	case capr.RuntimeRKE2:
+		spec.AgentEnvVars = append(spec.AgentEnvVars, corev1.EnvVar{
+			Name:  capr.SystemAgentFallbackPathEnvVar,
+			Value: "/opt/rke2/bin",
+		})
+	default:
+		spec.AgentEnvVars = append(spec.AgentEnvVars, corev1.EnvVar{
+			Name:  capr.SystemAgentFallbackPathEnvVar,
+			Value: "/opt/bin",
+		})
+	}
+
 	if cluster.Spec.ClusterAgentDeploymentCustomization != nil {
 		clusterAgentCustomizationCopy := cluster.Spec.ClusterAgentDeploymentCustomization.DeepCopy()
 		spec.ClusterAgentDeploymentCustomization = &v3.AgentDeploymentCustomization{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #45815 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Day 2 ops do not work for clusters running SLE Micro 6 since `rke2` is installed into `/opt/rke2/bin`, which is not in the PATH

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Add `/opt/rke2/bin` or `/opt/bin` into the PATH variable in the system-agent systemd env file depending on whether RKE2 or K3s is selected.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manually tested cert rotation, encryption key rotation, etcd snapshot and restore

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: Not feasible to test SLE Micro 6 with current testing framework

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Test all Day 2 ops, I tested 1 node all roles but it would be worth it to verify HA setups as well.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A