### PR TITLE
[2.8] Move agent image to bci-micro and add missing FIPS packages

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=final / /chroot/
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
     git-core curl util-linux ca-certificates ca-certificates-mozilla unzip xz gzip sed tar shadow gawk vim-small \
-    netcat-openbsd mkisofs openssh-clients && \
+    netcat-openbsd mkisofs openssh-clients openssl patterns-base-fips && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -24,19 +24,42 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLA
 
 FROM ${RANCHER_IMAGE} AS rancher
 
-FROM registry.suse.com/bci/bci-base:15.5 AS final
+FROM registry.suse.com/bci/bci-micro:15.6 AS final
+
+# Temporary build stage image
+FROM registry.suse.com/bci/bci-base:15.6 AS builder
+
+# Install system packages using builder image that has zypper
+COPY --from=final / /chroot/
+
+# Install some packages with zypper in the chroot of the final micro image
+RUN zypper refresh && \
+    zypper --installroot /chroot -n in --no-recommends \
+    curl util-linux ca-certificates ca-certificates-mozilla jq git-core hostname iproute2 vim-small less \
+    bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat openssl patterns-base-fips && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+# Main stage using bci-micro as the base image
+FROM final
 ARG ARCH=${ARCH}
 ARG VERSION=${VERSION}
 
-ENV KUBECTL_VERSION v1.25.12
-RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
-	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
-    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+# Copy binaries and configuration files from builder to micro
+COPY --from=builder /chroot/ /
+
+# Test that some of the dependency binaries were copied
+# and are working on the target image.
+RUN /usr/bin/unshare --version && \
+    /usr/bin/mount   --version && \
+    /usr/bin/umount  --version && \
+    /usr/bin/nsenter --version
+
+ENV KUBECTL_VERSION v1.27.15
+RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 ENV LOGLEVEL_VERSION v0.1.6
-
 RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
 
 LABEL io.cattle.agent true


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46570
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
This PR does:
1. Migrate the Agent image to BCI-Micro, which is a backport of https://github.com/rancher/rancher/pull/44044 and that was missed in https://github.com/rancher/rancher/pull/46205, where the main Rancher image was migrated to Micro (due to the backport), but not the Agent.
2. Add the missing FIPS packages in the Rancher image, backport of https://github.com/rancher/rancher/pull/46575.
3. Bump kubectl to `v1.27.15`, to fix some CVEs and because the K8s version in v2.8 is already at `1.28.x`.
4. Bump BCI to `15.6` in the Agent image, because the Rancher image is already at `15.6`.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Execute the same tests as in https://github.com/rancher/rancher/issues/46486#issuecomment-2276205364.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_