### PR TITLE
make quick: remove arch part of tag

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -41,7 +41,7 @@ docker buildx build \
   --build-arg CATTLE_RANCHER_WEBHOOK_VERSION=${CATTLE_RANCHER_WEBHOOK_VERSION} \
   --build-arg CATTLE_CSP_ADAPTER_MIN_VERSION=${CATTLE_CSP_ADAPTER_MIN_VERSION} \
   --build-arg CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION} \
-  --tag rancher/rancher:${TAG}-${ARCH} \
+  --tag rancher/rancher:${TAG} \
   --platform="${OS}/${ARCH}" \
   --file ./package/Dockerfile .
 
@@ -49,10 +49,10 @@ docker buildx build \
   --build-arg VERSION="${TAG}" \
   --build-arg ARCH=${ARCH} \
   --build-arg RANCHER_TAG=${TAG} \
-  --build-arg RANCHER_IMAGE=rancher/rancher:${TAG}-${ARCH} \
+  --build-arg RANCHER_IMAGE=rancher/rancher:${TAG} \
   --build-arg COMMIT="${COMMIT}" \
   --build-arg RKE_VERSION=${RKE_VERSION} \
   --build-arg CATTLE_RANCHER_WEBHOOK_VERSION=${CATTLE_RANCHER_WEBHOOK_VERSION} \
-  --tag rancher/rancher-agent:${TAG}-${ARCH} \
+  --tag rancher/rancher-agent:${TAG} \
   --platform="${OS}/${ARCH}" \
   --file ./package/Dockerfile.agent .


### PR DESCRIPTION
## Issue

https://github.com/rancher/rancher/issues/46352

## Problem

This is a follow up of #46561, aligning it with the behavior in release/v2.9 and main.

It tags the build without the arch, which makes it easier to work with the helm chart.
 
 ## Testing

This is a developer-only script. Tested locally.

