### PR TITLE
[Main] Remove custom cluster PSACT test

### DIFF
--- a/tests/v2/validation/provisioning/k3s/psact_test.go
+++ b/tests/v2/validation/provisioning/k3s/psact_test.go
@@ -111,48 +111,6 @@ func (k *K3SPSACTTestSuite) TestK3SPSACTNodeDriverCluster() {
 	}
 }
 
-func (k *K3SPSACTTestSuite) TestK3SPSACTCustomCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
-
-	tests := []struct {
-		name         string
-		machinePools []provisioninginput.MachinePools
-		psact        provisioninginput.PSACT
-		client       *rancher.Client
-	}{
-		{
-			"Rancher Privileged " + provisioninginput.StandardClientName.String(),
-			nodeRolesDedicated,
-			"rancher-privileged",
-			k.standardUserClient,
-		},
-		{
-			"Rancher Restricted " + provisioninginput.StandardClientName.String(),
-			nodeRolesDedicated,
-			"rancher-restricted",
-			k.standardUserClient,
-		},
-		{
-			"Rancher Baseline " + provisioninginput.AdminClientName.String(),
-			nodeRolesDedicated,
-			"rancher-baseline",
-			k.client,
-		},
-	}
-
-	for _, tt := range tests {
-		provisioningConfig := *k.provisioningConfig
-		provisioningConfig.MachinePools = tt.machinePools
-		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig,
-			permutations.K3SCustomCluster, nil, nil)
-	}
-}
-
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestK3SPSACTTestSuite(t *testing.T) {

--- a/tests/v2/validation/provisioning/rke1/psact_test.go
+++ b/tests/v2/validation/provisioning/rke1/psact_test.go
@@ -111,51 +111,6 @@ func (r *RKE1PSACTTestSuite) TestRKE1PSACTNodeDriverCluster() {
 	}
 }
 
-func (r *RKE1PSACTTestSuite) TestRKE1PSACTCustomCluster() {
-	nodeRolesDedicated := []provisioninginput.NodePools{
-		provisioninginput.EtcdNodePool,
-		provisioninginput.ControlPlaneNodePool,
-		provisioninginput.WorkerNodePool,
-	}
-
-	require.GreaterOrEqual(r.T(), len(r.provisioningConfig.CNIs), 1)
-
-	tests := []struct {
-		name      string
-		nodePools []provisioninginput.NodePools
-		psact     provisioninginput.PSACT
-		client    *rancher.Client
-	}{
-		{
-			name:      "Rancher Privileged " + provisioninginput.StandardClientName.String(),
-			nodePools: nodeRolesDedicated,
-			psact:     "rancher-privileged",
-			client:    r.standardUserClient,
-		},
-		{
-			name:      "Rancher Restricted " + provisioninginput.StandardClientName.String(),
-			nodePools: nodeRolesDedicated,
-			psact:     "rancher-restricted",
-			client:    r.standardUserClient,
-		},
-		{
-			name:      "Rancher Baseline " + provisioninginput.AdminClientName.String(),
-			nodePools: nodeRolesDedicated,
-			psact:     "rancher-baseline",
-			client:    r.client,
-		},
-	}
-
-	for _, tt := range tests {
-		provisioningConfig := *r.provisioningConfig
-		provisioningConfig.NodePools = tt.nodePools
-		provisioningConfig.PSACT = string(tt.psact)
-		provisioningConfig.NodePools[0].SpecifyCustomPublicIP = true
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
-			permutations.RKE1CustomCluster, nil, nil)
-	}
-}
-
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestRKE1PSACTTestSuite(t *testing.T) {

--- a/tests/v2/validation/provisioning/rke2/psact_test.go
+++ b/tests/v2/validation/provisioning/rke2/psact_test.go
@@ -111,48 +111,6 @@ func (r *RKE2PSACTTestSuite) TestRKE2PSACTNodeDriverCluster() {
 	}
 }
 
-func (r *RKE2PSACTTestSuite) TestRKE2PSACTCustomCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
-
-	tests := []struct {
-		name         string
-		machinePools []provisioninginput.MachinePools
-		psact        provisioninginput.PSACT
-		client       *rancher.Client
-	}{
-		{
-			name:         "Rancher Privileged " + provisioninginput.StandardClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-privileged",
-			client:       r.standardUserClient,
-		},
-		{
-			name:         "Rancher Restricted " + provisioninginput.StandardClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-restricted",
-			client:       r.standardUserClient,
-		},
-		{
-			name:         "Rancher Baseline " + provisioninginput.AdminClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-baseline",
-			client:       r.client,
-		},
-	}
-
-	for _, tt := range tests {
-		provisioningConfig := *r.provisioningConfig
-		provisioningConfig.MachinePools = tt.machinePools
-		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
-			permutations.RKE2CustomCluster, nil, nil)
-	}
-}
-
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestRKE2PSACTTestSuite(t *testing.T) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->[Remove custom cluster in the psact_test.go test files]( https://github.com/rancher/qa-tasks/issues/1439)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The `psact_test.go` is testing both node driver and custom cluster. We don't necessarily need to test both for this feature; node driver is enough. Additionally, just is causing release testing to be a bit longer with no real benefit.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Removing custom cluster PSACT test in RKE1/RKE2/K3S.
