### PR TITLE
<v2.9> Fixed TestProvisioningHostedAKS to use correct TimeoutReport

### DIFF
--- a/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
@@ -76,7 +76,7 @@ func (h *HostedAKSClusterProvisioningTestSuite) TestProvisioningHostedAKS() {
 		config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, &aksClusterConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningAKSHostedCluster(tt.client, aksClusterConfig)
-		reports.TimeoutClusterReport(clusterObject, err)
+		reports.TimeoutRKEReport(clusterObject, err)
 		require.NoError(h.T(), err)
 
 		provisioning.VerifyHostedCluster(h.T(), tt.client, clusterObject)


### PR DESCRIPTION
Changed TestProvisioningHostedAKS to use TimeoutRKEReport