### PR TITLE
<main> Fixed TestProvisioningHostedAKS to use correct TimeoutReport

### DIFF
--- a/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
@@ -76,7 +76,7 @@ func (h *HostedAKSClusterProvisioningTestSuite) TestProvisioningHostedAKS() {
 		config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, &aksClusterConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningAKSHostedCluster(tt.client, aksClusterConfig)
-		reports.TimeoutClusterReport(clusterObject, err)
+		reports.TimeoutRKEReport(clusterObject, err)
 		require.NoError(h.T(), err)
 
 		provisioning.VerifyHostedCluster(h.T(), tt.client, clusterObject)


### PR DESCRIPTION
Changed TestProvisioningHostedAKS to use TimeoutRKEReport

Issue
https://github.com/rancher/qa-tasks/issues/1486

Backport
v2.9 https://github.com/rancher/rancher/pull/46651
v2.8 https://github.com/rancher/rancher/pull/46653
v2.7 https://github.com/rancher/rancher/pull/46655