### PR TITLE
Allow to disable fleet cluster provisioning via provisioning.cattle.io/externally-managed annotation

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller_test.go
+++ b/pkg/controllers/provisioningv2/cluster/controller_test.go
@@ -26,8 +26,9 @@ func TestRegexp(t *testing.T) {
 
 func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 	tests := []struct {
-		name    string
-		cluster *v3.Cluster
+		name     string
+		cluster  *v3.Cluster
+		expected bool
 	}{
 		{
 			name: "test-default",
@@ -40,6 +41,7 @@ func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 					FleetWorkspaceName: "test-fleet-workspace-name",
 				},
 			},
+			expected: true,
 		},
 		{
 			name: "test-cluster-agent-customization",
@@ -55,6 +57,37 @@ func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 					FleetWorkspaceName: "test-fleet-workspace-name",
 				},
 			},
+			expected: true,
+		},
+		{
+			name: "test-turtles-owned-cluster-creation",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-33333",
+					Labels: map[string]string{
+						turtlesOwnedLab: "",
+					},
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{},
+					// Empty fleet workspace, typically prevents provisioningv1 cluster creation
+					FleetWorkspaceName: "",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no-cluster-for-no-fleet",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-44444",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase:    v3.ClusterSpecBase{},
+					FleetWorkspaceName: "",
+				},
+			},
+			expected: false,
 		},
 	}
 
@@ -65,6 +98,12 @@ func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 			obj, _, err := h.generateProvisioningClusterFromLegacyCluster(tt.cluster, tt.cluster.Status)
 
 			assert.Nil(t, err)
+
+			if !tt.expected {
+				assert.Nil(t, obj, "Expected no prov cluster objects")
+				return
+			}
+
 			assert.NotNil(t, obj, "Expected non-nil prov cluster obj")
 			provCluster := obj[0].(*v1.Cluster)
 

--- a/pkg/controllers/provisioningv2/cluster/controller_test.go
+++ b/pkg/controllers/provisioningv2/cluster/controller_test.go
@@ -64,8 +64,8 @@ func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 			cluster: &v3.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "c-33333",
-					Labels: map[string]string{
-						turtlesOwnedLab: "",
+					Annotations: map[string]string{
+						externallyManagedAnn: "true",
 					},
 				},
 				Spec: v3.ClusterSpec{

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -106,7 +106,7 @@ func (h *handler) assignWorkspace(key string, cluster *apimgmtv3.Cluster) (*apim
 		return cluster, nil
 	}
 
-	if cluster.Spec.FleetWorkspaceName == "" {
+	if cluster.Spec.FleetWorkspaceName == "" && settings.FleetManagementByDefault.Get() == "true" {
 		def := settings.FleetDefaultWorkspaceName.Get()
 		if def == "" {
 			return cluster, nil

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -28,6 +28,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	turtlesOwnedLab = "cluster-api.cattle.io/owned"
+)
+
 // ClusterHostGetter provides cluster API server URL retrieval.
 type ClusterHostGetter interface {
 	GetClusterHost(clientcmd.ClientConfig) (string, []byte, error)
@@ -106,7 +110,10 @@ func (h *handler) assignWorkspace(key string, cluster *apimgmtv3.Cluster) (*apim
 		return cluster, nil
 	}
 
-	if cluster.Spec.FleetWorkspaceName == "" && settings.FleetManagementByDefault.Get() == "true" {
+	// Clusters labeled with turtlesOwned label will manage fleet deployment externally
+	_, turtlesOwned := cluster.Labels[turtlesOwnedLab]
+
+	if cluster.Spec.FleetWorkspaceName == "" && !turtlesOwned {
 		def := settings.FleetDefaultWorkspaceName.Get()
 		if def == "" {
 			return cluster, nil

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
@@ -213,8 +213,8 @@ func TestAssignWorkspace(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
 					Namespace: "fleet-default",
-					Labels: map[string]string{
-						turtlesOwnedLab: "",
+					Annotations: map[string]string{
+						externallyManagedAnn: "true",
 					},
 				},
 				Spec: apimgmtv3.ClusterSpec{},
@@ -226,8 +226,8 @@ func TestAssignWorkspace(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "local-cluster",
 					Namespace: "fleet-local",
-					Labels: map[string]string{
-						turtlesOwnedLab: "",
+					Annotations: map[string]string{
+						externallyManagedAnn: "true",
 					},
 				},
 				Spec: apimgmtv3.ClusterSpec{

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
@@ -10,7 +10,6 @@ import (
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/settings"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/require"
@@ -204,11 +203,6 @@ func TestAssignWorkspace(t *testing.T) {
 
 	h := &handler{}
 
-	settings.FleetManagementByDefault.Set("false")
-	defer func() {
-		settings.FleetManagementByDefault.Set("true")
-	}()
-
 	tests := []struct {
 		name    string
 		cluster *apimgmtv3.Cluster
@@ -219,6 +213,9 @@ func TestAssignWorkspace(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
 					Namespace: "fleet-default",
+					Labels: map[string]string{
+						turtlesOwnedLab: "",
+					},
 				},
 				Spec: apimgmtv3.ClusterSpec{},
 			},
@@ -229,6 +226,9 @@ func TestAssignWorkspace(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "local-cluster",
 					Namespace: "fleet-local",
+					Labels: map[string]string{
+						turtlesOwnedLab: "",
+					},
 				},
 				Spec: apimgmtv3.ClusterSpec{
 					FleetWorkspaceName: "specific-name",

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -124,7 +124,6 @@ var (
 	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.10")
 	SystemManagedChartsOperationTimeout = NewSetting("system-managed-charts-operation-timeout", "300s")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none
-	FleetManagementByDefault            = NewSetting("fleet-management-by-default", "true")                               // instructs defaulting behavior for management clusters with empty FleetWorkspaceName
 	ShellImage                          = NewSetting("shell-image", buildconfig.DefaultShellVersion)
 	IgnoreNodeName                      = NewSetting("ignore-node-name", "") // nodes to ignore when syncing v1.node to v3.node
 	NoDefaultAdmin                      = NewSetting("no-default-admin", "")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -124,6 +124,7 @@ var (
 	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.10")
 	SystemManagedChartsOperationTimeout = NewSetting("system-managed-charts-operation-timeout", "300s")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none
+	FleetManagementByDefault            = NewSetting("fleet-management-by-default", "true")                               // instructs defaulting behavior for management clusters with empty FleetWorkspaceName
 	ShellImage                          = NewSetting("shell-image", buildconfig.DefaultShellVersion)
 	IgnoreNodeName                      = NewSetting("ignore-node-name", "") // nodes to ignore when syncing v1.node to v3.node
 	NoDefaultAdmin                      = NewSetting("no-default-admin", "")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/turtles/issues/622
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Management v3 cluster creation always creates a fleet agent for the cluster import. This prevents having more granular settings regarding fleet agent configuration.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Prevent setting default fleet workspace name for the clusters annotated with “provisioning.cattle.io/externally-managed”. Users can always explicitly specify the `fleetWorkspaceName` on the cluster, in order to provision fleet agent.

As the `fleetWorkspaceName` is a discriminating value between legacy and non-legacy clusters, treat clusters which are annotated with `provisioning.cattle.io/externally-managed` as requiring provisioning cluster creation, due to https://github.com/rancher/dashboard/issues/11664 (imported clusters are not visible).

Original solution using `setting` was replaced with a label due to considerations on `provisioningv2` behavior, as these clusters might be hit with https://github.com/rancher/dashboard/issues/11664. 

## Testing
Unit + manual in the cluster, using `make quick`.

## Engineering Testing
### Manual Testing
Provision a cluster, run `make quick`, upgrade rancher image as per [README steps](https://github.com/rancher/rancher/blob/0d525c88e9f3a3a2bce0ad43c27fc24a6b1440a3/docs/development.md#deploy-your-custom-image-via-helm)

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_