### PR TITLE
SAML: return both group and user principals when searching without LDAP

### DIFF
--- a/pkg/auth/providers/common/provider.go
+++ b/pkg/auth/providers/common/provider.go
@@ -8,10 +8,14 @@ import (
 )
 
 const (
+	// UserAttributePrincipalID is a key in the ExtraByProvider field of the UserAttribute that holds principal IDs for a partucular provider.
 	UserAttributePrincipalID = "principalid"
-	UserAttributeUserName    = "username"
-	UserPrincipalType        = "user"
-	GroupPrincipalType       = "group"
+	// UserAttributeUserName is a key in the ExtraByProvider field of the UserAttribute that holds usernames for a partucular provider.
+	UserAttributeUserName = "username"
+	// UserPrincipalType is the user principal type across all providers.
+	UserPrincipalType = "user"
+	// GroupPrincipalType is the group principal type  across all providers.
+	GroupPrincipalType = "group"
 )
 
 type AuthProvider interface {

--- a/pkg/auth/providers/common/provider.go
+++ b/pkg/auth/providers/common/provider.go
@@ -10,6 +10,8 @@ import (
 const (
 	UserAttributePrincipalID = "principalid"
 	UserAttributeUserName    = "username"
+	UserPrincipalType        = "user"
+	GroupPrincipalType       = "group"
 )
 
 type AuthProvider interface {

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -345,7 +345,7 @@ func (s *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]
 }
 
 // SearchPrincipals searches for a principal by name using LDAP if configured.
-// Othwerwise it returns a "fake" principal of a requested type with the name as the searchKey.
+// Otherwise it returns a "fake" principal of a requested type with the name as the searchKey.
 // If the principalType is empty, both user and group principals are returned.
 // This is done because SAML, in the absence of LDAP, doesn't have a user/group lookup mechanism.
 func (s *Provider) SearchPrincipals(searchKey, principalType string, token v3.Token) ([]v3.Principal, error) {

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -322,7 +322,7 @@ func (s *Provider) saveSamlConfig(config *v32.SamlConfig) error {
 
 func (s *Provider) toPrincipal(principalType string, princ v3.Principal, token *v3.Token) v3.Principal {
 	if principalType == s.userType {
-		princ.PrincipalType = "user"
+		princ.PrincipalType = common.UserPrincipalType
 		if token != nil {
 			princ.Me = s.isThisUserMe(token.UserPrincipal, princ)
 			if princ.Me {
@@ -331,7 +331,7 @@ func (s *Provider) toPrincipal(principalType string, princ v3.Principal, token *
 			}
 		}
 	} else {
-		princ.PrincipalType = "group"
+		princ.PrincipalType = common.GroupPrincipalType
 		if token != nil {
 			princ.MemberOf = s.tokenMGR.IsMemberOf(*token, princ)
 		}
@@ -344,6 +344,10 @@ func (s *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]
 	return nil, errors.New("Not implemented")
 }
 
+// SearchPrincipals searches for a principal by name using LDAP if configured.
+// Othwerwise it returns a "fake" principal of a requested type with the name as the searchKey.
+// If the principalType is empty, both user and group principals are returned.
+// This is done because SAML, in the absence of LDAP, doesn't have a user/group lookup mechanism.
 func (s *Provider) SearchPrincipals(searchKey, principalType string, token v3.Token) ([]v3.Principal, error) {
 	if s.hasLdapGroupSearch() {
 		principals, err := s.ldapProvider.SearchPrincipals(searchKey, principalType, token)
@@ -353,22 +357,29 @@ func (s *Provider) SearchPrincipals(searchKey, principalType string, token v3.To
 		}
 	}
 
-	if principalType == "" {
-		principalType = "user"
+	var principals []v3.Principal
+
+	if principalType != common.GroupPrincipalType {
+		principals = append(principals, v3.Principal{
+			ObjectMeta:    metav1.ObjectMeta{Name: s.userType + "://" + searchKey},
+			DisplayName:   searchKey,
+			LoginName:     searchKey,
+			PrincipalType: common.UserPrincipalType,
+			Provider:      s.name,
+		})
 	}
 
-	scheme := s.userType
-	if principalType == "group" {
-		scheme = s.groupType
+	if principalType != common.UserPrincipalType {
+		principals = append(principals, v3.Principal{
+			ObjectMeta:    metav1.ObjectMeta{Name: s.groupType + "://" + searchKey},
+			DisplayName:   searchKey,
+			LoginName:     searchKey,
+			PrincipalType: common.GroupPrincipalType,
+			Provider:      s.name,
+		})
 	}
 
-	return []v3.Principal{{
-		ObjectMeta:    metav1.ObjectMeta{Name: scheme + "://" + searchKey},
-		DisplayName:   searchKey,
-		LoginName:     searchKey,
-		PrincipalType: principalType,
-		Provider:      s.name,
-	}}, nil
+	return principals, nil
 }
 
 func (s *Provider) GetPrincipal(principalID string, token v3.Token) (v3.Principal, error) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/46658
Complementary to #46657
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If LDAP is not configured when searching for principles without specifying the principle type the SAML provider returns only a user, which makes it impossible to choose a group in Add member UI e.g. when adding a cluster/project member.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Return both user and group principles with the same name in such cases.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A