### PR TITLE
chore: Remove deprecated setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -130,7 +130,6 @@ var (
 	NoDefaultAdmin                      = NewSetting("no-default-admin", "")
 	RestrictedDefaultAdmin              = NewSetting("restricted-default-admin", "false") // When bootstrapping the admin for the first time, give them the global role restricted-admin
 	AKSUpstreamRefresh                  = NewSetting("aks-refresh", "300")
-	EKSUpstreamRefreshCron              = NewSetting("eks-refresh-cron", "*/5 * * * *") // EKSUpstreamRefreshCron is deprecated and will be replaced by EKSUpstreamRefresh
 	EKSUpstreamRefresh                  = NewSetting("eks-refresh", "300")
 	GKEUpstreamRefresh                  = NewSetting("gke-refresh", "300")
 	HideLocalCluster                    = NewSetting("hide-local-cluster", "false")


### PR DESCRIPTION
## Issue: #42047

`EKSUpstreamRefreshCron` setting is not used and can be deprecated. This PR removes this setting.
