### PR TITLE
Bump `CATTLE_DASHBOARD_UI_VERSION` & `CATTLE_UI_VERSION` to v2.8.7-rc3

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -221,8 +221,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
 
-ENV CATTLE_UI_VERSION 2.8.7-rc2
-ENV CATTLE_DASHBOARD_UI_VERSION v2.8.7-rc2
+ENV CATTLE_UI_VERSION 2.8.7-rc3
+ENV CATTLE_DASHBOARD_UI_VERSION v2.8.7-rc3
 ENV CATTLE_CLI_VERSION v2.8.6
 
 


### PR DESCRIPTION
Bump `CATTLE_DASHBOARD_UI_VERSION` & `CATTLE_UI_VERSION` to v2.8.7-rc3

### Dashboard/UI Builds

- https://github.com/rancher/ui/actions/runs/10406585937
- https://github.com/rancher/dashboard/actions/runs/10406586796