### PR TITLE
[v2.8] Update webhook to v0.4.10-rc3

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 103.0.9+up0.4.10-rc.2
+webhookVersion: 103.0.9+up0.4.10-rc.3
 cspAdapterMinVersion: 103.0.1+up3.0.1
 defaultShellVersion: rancher/shell:v0.1.26
 fleetVersion: 103.1.7+up0.9.8

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,5 +6,5 @@ const (
 	CspAdapterMinVersion = "103.0.1+up3.0.1"
 	DefaultShellVersion  = "rancher/shell:v0.1.26"
 	FleetVersion         = "103.1.7+up0.9.8"
-	WebhookVersion       = "103.0.9+up0.4.10-rc.2"
+	WebhookVersion       = "103.0.9+up0.4.10-rc.3"
 )


### PR DESCRIPTION
This is to facilitate QA testing of the following two PRs:
https://github.com/rancher/webhook/pull/484
https://github.com/rancher/webhook/pull/478

Due to hosted operator updates to pkg/apis, the Go version was bumped to 1.22 for webhook, so we need to re-validate the release candidate. There should be no change in behavior between RC2 and RC3.