### PR TITLE
Backport RBAC-related fixes

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/rancher/wrangler/v2/pkg/apply"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -56,7 +57,9 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 			crbLister:     management.RBAC.ClusterRoleBindings("").Controller().Lister(),
 			crbClient:     management.RBAC.ClusterRoleBindings(""),
 			crLister:      management.RBAC.ClusterRoles("").Controller().Lister(),
+			nsLister:      management.Core.Namespaces("").Controller().Lister(),
 			rLister:       management.RBAC.Roles("").Controller().Lister(),
+			rClient:       management.RBAC.Roles(""),
 			rbLister:      management.RBAC.RoleBindings("").Controller().Lister(),
 			rbClient:      management.RBAC.RoleBindings(""),
 			rtLister:      management.Management.RoleTemplates("").Controller().Lister(),
@@ -77,7 +80,9 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 			crbLister:     management.RBAC.ClusterRoleBindings("").Controller().Lister(),
 			crbClient:     management.RBAC.ClusterRoleBindings(""),
 			crLister:      management.RBAC.ClusterRoles("").Controller().Lister(),
+			nsLister:      management.Core.Namespaces("").Controller().Lister(),
 			rLister:       management.RBAC.Roles("").Controller().Lister(),
+			rClient:       management.RBAC.Roles(""),
 			rbLister:      management.RBAC.RoleBindings("").Controller().Lister(),
 			rbClient:      management.RBAC.RoleBindings(""),
 			rtLister:      management.Management.RoleTemplates("").Controller().Lister(),
@@ -97,6 +102,7 @@ type manager struct {
 	projectLister  v3.ProjectLister
 	crLister       typesrbacv1.ClusterRoleLister
 	rLister        typesrbacv1.RoleLister
+	rClient        typesrbacv1.RoleInterface
 	rbLister       typesrbacv1.RoleBindingLister
 	rbClient       typesrbacv1.RoleBindingInterface
 	crbLister      typesrbacv1.ClusterRoleBindingLister
@@ -458,7 +464,7 @@ func (m *manager) removeAuthV2Permissions(setID string, owner runtime.Object) er
 	return returnErr
 }
 
-// Certain resources (projects, machines, prtbs, crtbs, clusterevents, etc) exist in the mangement plane but are scoped to clusters or
+// Certain resources (projects, machines, prtbs, crtbs, clusterevents, etc) exist in the management plane but are scoped to clusters or
 // projects. They need special RBAC handling because the need to be authorized just inside of the namespace that backs the project
 // or cluster they belong to.
 func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resources map[string]string, subject v1.Subject, binding interface{}) error {
@@ -478,7 +484,6 @@ func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resour
 	}
 
 	desiredRBs := map[string]*v1.RoleBinding{}
-	roleBindings := m.mgmt.RBAC.RoleBindings(namespace)
 	for _, role := range roles {
 		resourceToVerbs := map[string]map[string]string{}
 		for resource, apiGroup := range resources {
@@ -529,7 +534,7 @@ func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resour
 		currentRBs[rb.Name] = rb
 	}
 
-	return m.reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs, roleBindings)
+	return m.reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs, namespace)
 }
 
 // grantManagementClusterScopedPrivilegesInProjectNamespace ensures that rolebindings for roles like cluster-owner (that should be able to fully
@@ -543,7 +548,6 @@ func (m *manager) grantManagementClusterScopedPrivilegesInProjectNamespace(roleT
 	}
 
 	desiredRBs := map[string]*v1.RoleBinding{}
-	roleBindings := m.mgmt.RBAC.RoleBindings(projectNamespace)
 	bindingKey := pkgrbac.GetRTBLabel(binding.ObjectMeta)
 	for _, role := range roles {
 		resourceToVerbs := map[string]map[string]string{}
@@ -597,7 +601,7 @@ func (m *manager) grantManagementClusterScopedPrivilegesInProjectNamespace(roleT
 		currentRBs[rb.Name] = rb
 	}
 
-	return m.reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs, roleBindings)
+	return m.reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs, projectNamespace)
 }
 
 // grantManagementProjectScopedPrivilegesInClusterNamespace ensures that project roles grant permissions to certain cluster-scoped
@@ -610,7 +614,6 @@ func (m *manager) grantManagementProjectScopedPrivilegesInClusterNamespace(roleT
 	}
 
 	desiredRBs := map[string]*v1.RoleBinding{}
-	roleBindings := m.mgmt.RBAC.RoleBindings(clusterNamespace)
 	bindingKey := pkgrbac.GetRTBLabel(binding.ObjectMeta)
 	for _, role := range roles {
 		resourceToVerbs := map[string]map[string]string{}
@@ -659,7 +662,7 @@ func (m *manager) grantManagementProjectScopedPrivilegesInClusterNamespace(roleT
 		currentRBs[rb.Name] = rb
 	}
 
-	return m.reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs, roleBindings)
+	return m.reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs, clusterNamespace)
 }
 
 func (m *manager) gatherAndDedupeRoles(roleTemplateName string) (map[string]*v3.RoleTemplate, error) {
@@ -683,7 +686,9 @@ func (m *manager) gatherAndDedupeRoles(roleTemplateName string) (map[string]*v3.
 	return roles, nil
 }
 
-func (m *manager) reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs map[string]*v1.RoleBinding, roleBindings typesrbacv1.RoleBindingInterface) error {
+// reconcileDesiredMGMTPlaneRoleBindings ensures that the desired management plane role bindings
+// exist and delete any that should not exist
+func (m *manager) reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs map[string]*v1.RoleBinding, namespace string) error {
 	rbsToDelete := map[string]bool{}
 	processed := map[string]bool{}
 	for _, rb := range currentRBs {
@@ -700,17 +705,27 @@ func (m *manager) reconcileDesiredMGMTPlaneRoleBindings(currentRBs, desiredRBs m
 		}
 	}
 
-	for _, rb := range desiredRBs {
-		logrus.Infof("[%v] Creating roleBinding for subject %v with role %v in namespace %v", m.controller, rb.Subjects[0].Name, rb.RoleRef.Name, rb.Namespace)
-		_, err := roleBindings.Create(rb)
-		if err != nil && !apierrors.IsAlreadyExists(err) {
+	for name := range rbsToDelete {
+		logrus.Infof("[%v] Deleting roleBinding %v", m.controller, name)
+		if err := m.rbClient.DeleteNamespaced(namespace, name, &metav1.DeleteOptions{}); err != nil {
 			return err
 		}
 	}
 
-	for name := range rbsToDelete {
-		logrus.Infof("[%v] Deleting roleBinding %v", m.controller, name)
-		if err := roleBindings.Delete(name, &metav1.DeleteOptions{}); err != nil {
+	// If the namespace is terminating don't create RoleBindings
+	ns, err := m.nsLister.Get("", namespace)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't get namespace %v", namespace)
+	}
+	if ns.Status.Phase == corev1.NamespaceTerminating {
+		logrus.Warnf("[%v] Namespace %v is terminating, not creating roleBindings", m.controller, namespace)
+		return nil
+	}
+
+	for _, rb := range desiredRBs {
+		logrus.Infof("[%v] Creating roleBinding for subject %v with role %v in namespace %v", m.controller, rb.Subjects[0].Name, rb.RoleRef.Name, rb.Namespace)
+		_, err := m.rbClient.Create(rb)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 	}
@@ -761,11 +776,14 @@ func checkGroup(apiGroup string, rule v1.PolicyRule) bool {
 	return false
 }
 
+// reconcileManagementPlaneRole ensures that the management plane role exists and has the right rules.
+// If not, update or create it as needed.
 func (m *manager) reconcileManagementPlaneRole(namespace string, resourceToVerbs map[string]map[string]string, rt *v3.RoleTemplate) error {
-	roleCli := m.mgmt.RBAC.Roles(namespace)
 	update := false
 	if role, err := m.rLister.Get(namespace, rt.Name); err == nil && role != nil {
 		newRole := role.DeepCopy()
+		// If the permissions specified by resourceToVerbs is a subset of the existing
+		// rules of the Role, don't update
 		for resource, newVerbs := range resourceToVerbs {
 			currentVerbs := map[string]string{}
 			for _, rule := range role.Rules {
@@ -793,7 +811,6 @@ func (m *manager) reconcileManagementPlaneRole(namespace string, resourceToVerbs
 				if !added {
 					newRole.Rules = append(newRole.Rules, buildRule(resource, newVerbs))
 				}
-
 			}
 		}
 
@@ -812,9 +829,19 @@ func (m *manager) reconcileManagementPlaneRole(namespace string, resourceToVerbs
 
 		if update {
 			logrus.Infof("[%v] Updating role %v in namespace %v", m.controller, newRole.Name, namespace)
-			_, err := roleCli.Update(newRole)
+			_, err := m.rClient.Update(newRole)
 			return err
 		}
+		return nil
+	}
+
+	// If the namespace is terminating, don't create a Role in it
+	ns, err := m.nsLister.Get("", namespace)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't get namespace %v", namespace)
+	}
+	if ns.Status.Phase == corev1.NamespaceTerminating {
+		logrus.Warnf("[%v] Namespace %v is terminating, not creating role", m.controller, namespace)
 		return nil
 	}
 
@@ -823,9 +850,10 @@ func (m *manager) reconcileManagementPlaneRole(namespace string, resourceToVerbs
 		rules = append(rules, buildRule(resource, newVerbs))
 	}
 	logrus.Infof("[%v] Creating role %v in namespace %v", m.controller, rt.Name, namespace)
-	_, err := roleCli.Create(&v1.Role{
+	_, err = m.rClient.Create(&v1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: rt.Name,
+			Name:      rt.Name,
+			Namespace: namespace,
 		},
 		Rules: rules,
 	})

--- a/pkg/controllers/management/auth/manager_test.go
+++ b/pkg/controllers/management/auth/manager_test.go
@@ -4,10 +4,16 @@ import (
 	"fmt"
 	"testing"
 
+	normanFakes "github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	fakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	rbacFakes "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -90,4 +96,593 @@ func roleListerGetFunc(ns, name string) (*v3.RoleTemplate, error) {
 		}, name)
 	}
 	return role, nil
+}
+
+func Test_reconcileDesiredMGMTPlaneRoleBindings(t *testing.T) {
+	t.Parallel()
+
+	type StateChanges struct {
+		t          *testing.T
+		createdRBs map[string]*rbacv1.RoleBinding
+		deletedRBs map[string]bool
+	}
+
+	type State struct {
+		nsListerMock *normanFakes.NamespaceListerMock
+		rbClientMock *rbacFakes.RoleBindingInterfaceMock
+		stateChanges *StateChanges
+	}
+
+	rb1 := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rb1",
+			Namespace: "ns1",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "roleRef1",
+		},
+		Subjects: []rbacv1.Subject{{Name: "subject1"}},
+	}
+	rb2 := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rb2",
+			Namespace: "ns2",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "roleRef2",
+		},
+		Subjects: []rbacv1.Subject{{Name: "subject2"}},
+	}
+	rb3 := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rb3",
+			Namespace: "ns3",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "roleRef3",
+		},
+		Subjects: []rbacv1.Subject{{Name: "subject3"}},
+	}
+
+	tests := []struct {
+		name            string
+		currentRBs      map[string]*rbacv1.RoleBinding
+		desiredRBs      map[string]*rbacv1.RoleBinding
+		stateSetup      func(State)
+		stateAssertions func(StateChanges)
+		wantError       bool
+	}{
+		{
+			name: "get namespace fails",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return nil, fmt.Errorf("error")
+				}
+			},
+			wantError: true,
+		},
+		{
+			name: "namespace is terminating",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceTerminating,
+						},
+					}, nil
+				}
+			},
+			wantError: false,
+		},
+		{
+			name: "create rb fails",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceActive,
+						},
+					}, nil
+				}
+				state.rbClientMock.CreateFunc = func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					return nil, fmt.Errorf("error")
+				}
+				state.rbClientMock.DeleteNamespacedFunc = func(_, name string, _ *v1.DeleteOptions) error {
+					return nil
+				}
+			},
+			currentRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1},
+			desiredRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1, "rb2": rb2},
+			wantError:  true,
+		},
+		{
+			name: "delete rb fails",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceActive,
+						},
+					}, nil
+				}
+				state.rbClientMock.CreateFunc = func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					return nil, nil
+				}
+				state.rbClientMock.DeleteNamespacedFunc = func(_, name string, _ *v1.DeleteOptions) error {
+					return fmt.Errorf("error")
+				}
+			},
+			currentRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1, "rb2": rb2},
+			desiredRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1},
+			wantError:  true,
+		},
+		{
+			name: "add new rb",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceActive,
+						},
+					}, nil
+				}
+				state.rbClientMock.CreateFunc = func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					state.stateChanges.createdRBs[rb.Name] = rb
+					return nil, nil
+				}
+				state.rbClientMock.DeleteNamespacedFunc = func(_, name string, _ *v1.DeleteOptions) error {
+					state.stateChanges.deletedRBs[name] = true
+					return nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdRBs, 1)
+				require.Contains(stateChanges.t, stateChanges.createdRBs, "rb2")
+				require.Len(stateChanges.t, stateChanges.deletedRBs, 0)
+			},
+			currentRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1},
+			desiredRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1, "rb2": rb2},
+			wantError:  false,
+		},
+		{
+			name: "delete unwanted rb",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceActive,
+						},
+					}, nil
+				}
+				state.rbClientMock.CreateFunc = func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					state.stateChanges.createdRBs[rb.Name] = rb
+					return nil, nil
+				}
+				state.rbClientMock.DeleteNamespacedFunc = func(_, name string, _ *v1.DeleteOptions) error {
+					state.stateChanges.deletedRBs[name] = true
+					return nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdRBs, 0)
+				require.Len(stateChanges.t, stateChanges.deletedRBs, 1)
+				require.Contains(stateChanges.t, stateChanges.deletedRBs, "rb2")
+			},
+			currentRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1, "rb2": rb2},
+			desiredRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1},
+			wantError:  false,
+		},
+		{
+			name: "delete unwanted rb and add new rb",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceActive,
+						},
+					}, nil
+				}
+				state.rbClientMock.CreateFunc = func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					state.stateChanges.createdRBs[rb.Name] = rb
+					return nil, nil
+				}
+				state.rbClientMock.DeleteNamespacedFunc = func(_, name string, _ *v1.DeleteOptions) error {
+					state.stateChanges.deletedRBs[name] = true
+					return nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdRBs, 1)
+				require.Contains(stateChanges.t, stateChanges.createdRBs, "rb3")
+				require.Len(stateChanges.t, stateChanges.deletedRBs, 1)
+				require.Contains(stateChanges.t, stateChanges.deletedRBs, "rb2")
+			},
+			currentRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1, "rb2": rb2},
+			desiredRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1, "rb3": rb3},
+			wantError:  false,
+		},
+		{
+			name: "ignore duplicate current rbs",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(namespace string, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceActive,
+						},
+					}, nil
+				}
+				state.rbClientMock.CreateFunc = func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					state.stateChanges.createdRBs[rb.Name] = rb
+					return nil, nil
+				}
+				state.rbClientMock.DeleteNamespacedFunc = func(_, name string, _ *v1.DeleteOptions) error {
+					state.stateChanges.deletedRBs[name] = true
+					return nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdRBs, 0)
+				require.Len(stateChanges.t, stateChanges.deletedRBs, 0)
+			},
+			currentRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1, "rb2": rb1},
+			desiredRBs: map[string]*rbacv1.RoleBinding{"rb1": rb1},
+			wantError:  false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			manager := manager{}
+			nsLister := normanFakes.NamespaceListerMock{}
+			rbClient := rbacFakes.RoleBindingInterfaceMock{}
+
+			stateChanges := StateChanges{
+				t:          t,
+				createdRBs: map[string]*rbacv1.RoleBinding{},
+				deletedRBs: map[string]bool{},
+			}
+			state := State{
+				nsListerMock: &nsLister,
+				rbClientMock: &rbClient,
+				stateChanges: &stateChanges,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			manager.nsLister = &nsLister
+			manager.rbClient = &rbClient
+
+			err := manager.reconcileDesiredMGMTPlaneRoleBindings(test.currentRBs, test.desiredRBs, "")
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.stateAssertions != nil {
+				test.stateAssertions(*state.stateChanges)
+			}
+		})
+	}
+}
+
+func Test_reconcileManagementPlaneRole(t *testing.T) {
+	t.Parallel()
+
+	type StateChanges struct {
+		t       *testing.T
+		newRole *rbacv1.Role
+	}
+
+	type State struct {
+		nsListerMock *normanFakes.NamespaceListerMock
+		rListerMock  *rbacFakes.RoleListerMock
+		rClientMock  *rbacFakes.RoleInterfaceMock
+		stateChanges *StateChanges
+	}
+
+	rules := map[string]map[string]string{
+		"resource1": {
+			"verb1": "group1",
+			"verb2": "group1",
+		},
+		"resource2": {
+			"verb3": "group2",
+			"verb4": "group2",
+		},
+	}
+	rule1 := rbacv1.PolicyRule{
+		Resources: []string{"resource1"},
+		Verbs:     []string{"verb1", "verb2"},
+		APIGroups: []string{"group1"},
+	}
+	rule2 := rbacv1.PolicyRule{
+		Resources: []string{"resource2"},
+		Verbs:     []string{"verb3", "verb4"},
+		APIGroups: []string{"group2"},
+	}
+	roleTemplate := &v3.RoleTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "roleTemplate",
+		},
+	}
+	activeNamespace := &corev1.Namespace{
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
+
+	tests := []struct {
+		name            string
+		namespace       string
+		resourceToVerbs map[string]map[string]string
+		roleTemplate    *v3.RoleTemplate
+		stateSetup      func(State)
+		stateAssertions func(StateChanges)
+		wantError       bool
+	}{
+		{
+			name: "get namespace fails",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(_, _ string) (*corev1.Namespace, error) {
+					return nil, fmt.Errorf("error")
+				}
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, nil
+				}
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       true,
+		},
+		{
+			name: "namespace is terminating",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(_, _ string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{
+						Status: corev1.NamespaceStatus{
+							Phase: corev1.NamespaceTerminating,
+						},
+					}, nil
+				}
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, nil
+				}
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       false,
+		},
+		{
+			name: "create role fails",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(_, _ string) (*corev1.Namespace, error) {
+					return activeNamespace, nil
+				}
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					return nil, fmt.Errorf("error")
+				}
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       true,
+		},
+		{
+			name: "role already has the right verbs",
+			stateSetup: func(state State) {
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{
+						Rules: []rbacv1.PolicyRule{rule1, rule2},
+					}
+					return role, nil
+				}
+				// it should not create a role
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.newRole = role
+					return nil, nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.NotNil(stateChanges.t, stateChanges.newRole)
+				require.Len(stateChanges.t, stateChanges.newRole.Rules, 0)
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       false,
+		},
+		{
+			name: "role does not exist",
+			stateSetup: func(state State) {
+				state.nsListerMock.GetFunc = func(_, _ string) (*corev1.Namespace, error) {
+					return activeNamespace, nil
+				}
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.newRole = role
+					return nil, nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.NotNil(stateChanges.t, stateChanges.newRole)
+				require.Len(stateChanges.t, stateChanges.newRole.Rules, 2)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule1)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule2)
+				require.Equal(stateChanges.t, "roleTemplate", stateChanges.newRole.Name)
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       false,
+		},
+		{
+			name: "role is missing a rule",
+			stateSetup: func(state State) {
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "role",
+						},
+						Rules: []rbacv1.PolicyRule{rule1},
+					}
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.newRole = role
+					return nil, nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.NotNil(stateChanges.t, stateChanges.newRole)
+				require.Len(stateChanges.t, stateChanges.newRole.Rules, 2)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule1)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule2)
+				require.Equal(stateChanges.t, "role", stateChanges.newRole.Name)
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       false,
+		},
+		{
+			name: "role has no rules",
+			stateSetup: func(state State) {
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "role",
+						},
+						Rules: []rbacv1.PolicyRule{},
+					}
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.newRole = role
+					return nil, nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.NotNil(stateChanges.t, stateChanges.newRole)
+				require.Len(stateChanges.t, stateChanges.newRole.Rules, 2)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule1)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule2)
+				require.Equal(stateChanges.t, "role", stateChanges.newRole.Name)
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       false,
+		},
+		{
+			name: "role has rule that is missing verb",
+			stateSetup: func(state State) {
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "role",
+						},
+						Rules: []rbacv1.PolicyRule{
+							rule1,
+							{
+								Resources: []string{"resource2"},
+								Verbs:     []string{"verb3"},
+								APIGroups: []string{"group2"},
+							},
+						},
+					}
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.newRole = role
+					return nil, nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.NotNil(stateChanges.t, stateChanges.newRole)
+				require.Len(stateChanges.t, stateChanges.newRole.Rules, 2)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule1)
+				require.Contains(stateChanges.t, stateChanges.newRole.Rules, rule2)
+				require.Equal(stateChanges.t, "role", stateChanges.newRole.Name)
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       false,
+		},
+		{
+			name: "existing role rules are a superset of resourceToVerbs",
+			stateSetup: func(state State) {
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "role",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Resources: []string{"*"},
+								Verbs:     []string{"verb1", "verb2"},
+								APIGroups: []string{"group1"},
+							},
+							{
+								Resources: []string{"resource2"},
+								Verbs:     []string{"verb3", "verb4"},
+								APIGroups: []string{"*"},
+							},
+						},
+					}
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.newRole = role
+					return nil, nil
+				}
+			},
+			stateAssertions: func(stateChanges StateChanges) {
+				require.NotNil(stateChanges.t, stateChanges.newRole)
+				require.Len(stateChanges.t, stateChanges.newRole.Rules, 0)
+			},
+			roleTemplate:    roleTemplate,
+			resourceToVerbs: rules,
+			wantError:       false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			manager := manager{}
+			nsLister := normanFakes.NamespaceListerMock{}
+			rLister := rbacFakes.RoleListerMock{}
+			rClient := rbacFakes.RoleInterfaceMock{}
+
+			stateChanges := StateChanges{
+				t:       t,
+				newRole: &rbacv1.Role{},
+			}
+			state := State{
+				nsListerMock: &nsLister,
+				rListerMock:  &rLister,
+				rClientMock:  &rClient,
+				stateChanges: &stateChanges,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			manager.nsLister = &nsLister
+			manager.rLister = &rLister
+			manager.rClient = &rClient
+
+			err := manager.reconcileManagementPlaneRole(test.namespace, test.resourceToVerbs, test.roleTemplate)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.stateAssertions != nil {
+				test.stateAssertions(*state.stateChanges)
+			}
+		})
+	}
 }

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -3,7 +3,6 @@ package rbac
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -20,6 +19,7 @@ import (
 	"github.com/rancher/wrangler/v2/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,7 +192,7 @@ func (m *manager) ensureClusterRoles(rt *v3.RoleTemplate) error {
 }
 
 func (m *manager) compareAndUpdateClusterRole(clusterRole *rbacv1.ClusterRole, rt *v3.RoleTemplate) error {
-	if reflect.DeepEqual(clusterRole.Rules, rt.Rules) {
+	if equality.Semantic.DeepEqual(clusterRole.Rules, rt.Rules) {
 		return nil
 	}
 	clusterRole = clusterRole.DeepCopy()


### PR DESCRIPTION
Issues: #46735 #46736
Backports: #42924 #44519 

These changes are part of 2.9.0, in addition to #45518 which was already backported (although the order now is not preserved vs. 2.9)
I have tested those 3 patches on top of 2.8.5 and confirmed they are effective.