### PR TITLE
Add network policy connectivity tests

### DIFF
--- a/tests/v2/validation/networking/README.md
+++ b/tests/v2/validation/networking/README.md
@@ -1,0 +1,19 @@
+# Networking
+
+## Getting Started
+
+Your GO suite should be set to `-run ^Test<>TestSuite$`. For example to run the network_policy_test.go, set the GO suite
+to `-run ^TestNetworkPolicyTestSuite$` You can find specific tests by checking the test file you plan to run.
+In your config file, set the following:
+
+```json
+"rancher": { 
+  "host": "rancher_server_address",
+  "adminToken": "rancher_admin_token",
+  "clusterName": "cluster_to_run_tests_on",
+  "insecure": true/optional,
+  "cleanup": false/optional,
+}
+```
+
+**NOTE** These tests most run on a server with private networking setup as they rely on being able to SSH into servers

--- a/tests/v2/validation/networking/connectivity/network_policy.go
+++ b/tests/v2/validation/networking/connectivity/network_policy.go
@@ -7,8 +7,6 @@ import (
 )
 
 const (
-	pingCmd = "ping -c 1 -W 1"
-	//pingCmd            = "/bin/sh -c"
 	pingPodProjectName = "ping-project"
 
 	containerName  = "test1"

--- a/tests/v2/validation/networking/connectivity/network_policy.go
+++ b/tests/v2/validation/networking/connectivity/network_policy.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	pingCmd            = "ping -c 1 -W 1"
+	pingCmd = "ping -c 1 -W 1"
+	//pingCmd            = "/bin/sh -c"
 	pingPodProjectName = "ping-project"
 
 	containerName  = "test1"

--- a/tests/v2/validation/networking/connectivity/network_policy.go
+++ b/tests/v2/validation/networking/connectivity/network_policy.go
@@ -1,0 +1,67 @@
+package connectivity
+
+import (
+	"github.com/rancher/shepherd/extensions/workloads"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	pingCmd            = "ping -c 1 -W 1"
+	pingPodProjectName = "ping-project"
+
+	containerName  = "test1"
+	containerImage = "ranchertest/mytestcontainer"
+)
+
+type resourceNames struct {
+	core   map[string]string
+	random map[string]string
+}
+
+// newNames returns a new resourceNames struct
+// it creates a random names with random suffix for each resource by using core and coreWithSuffix names
+func newNames() *resourceNames {
+	const (
+		projectName             = "upgrade-wl-project"
+		namespaceName           = "namespace"
+		deploymentName          = "deployment"
+		daemonsetName           = "daemonset"
+		secretName              = "secret"
+		serviceName             = "service"
+		ingressName             = "ingress"
+		defaultRandStringLength = 3
+	)
+
+	names := &resourceNames{
+		core: map[string]string{
+			"projectName":    projectName,
+			"namespaceName":  namespaceName,
+			"deploymentName": deploymentName,
+			"daemonsetName":  daemonsetName,
+			"secretName":     secretName,
+			"serviceName":    serviceName,
+			"ingressName":    ingressName,
+		},
+	}
+
+	names.random = map[string]string{}
+	for k, v := range names.core {
+		names.random[k] = v + "-" + namegenerator.RandStringLower(defaultRandStringLength)
+	}
+
+	return names
+}
+
+// newPodTemplateWithTestContainer is a private constructor that returns pod template spec for workload creations
+func newPodTemplateWithTestContainer() corev1.PodTemplateSpec {
+	testContainer := newTestContainerMinimal()
+	containers := []corev1.Container{testContainer}
+	return workloads.NewPodTemplate(containers, nil, nil, nil)
+}
+
+// newTestContainerMinimal is a private constructor that returns container for minimal workload creations
+func newTestContainerMinimal() corev1.Container {
+	pullPolicy := corev1.PullAlways
+	return workloads.NewContainer(containerName, containerImage, pullPolicy, nil, nil, nil, nil, nil)
+}

--- a/tests/v2/validation/networking/connectivity/network_policy.go
+++ b/tests/v2/validation/networking/connectivity/network_policy.go
@@ -58,7 +58,7 @@ func newNames() *resourceNames {
 func newPodTemplateWithTestContainer() corev1.PodTemplateSpec {
 	testContainer := newTestContainerMinimal()
 	containers := []corev1.Container{testContainer}
-	return workloads.NewPodTemplate(containers, nil, nil, nil)
+	return workloads.NewPodTemplate(containers, nil, []corev1.LocalObjectReference{}, nil, nil)
 }
 
 // newTestContainerMinimal is a private constructor that returns container for minimal workload creations

--- a/tests/v2/validation/networking/connectivity/network_policy_test.go
+++ b/tests/v2/validation/networking/connectivity/network_policy_test.go
@@ -128,7 +128,7 @@ func (n *NetworkPolicyTestSuite) TestPingPodsFromCPNode() {
 
 	n.T().Logf("Running ping on [%v]", firstMachine.Name)
 
-	for i := 1; i < len(pods.Items); i++ {
+	for i := 0; i < len(pods.Items); i++ {
 		podIP := pods.Items[i].Status.PodIP
 		pingExecCmd := pingCmd + " " + podIP
 		excmdLog, err := sshNode.ExecuteCommand(pingExecCmd)

--- a/tests/v2/validation/networking/connectivity/network_policy_test.go
+++ b/tests/v2/validation/networking/connectivity/network_policy_test.go
@@ -118,18 +118,13 @@ func (n *NetworkPolicyTestSuite) TestPingPods() {
 
 	n.T().Logf("Running ping on [%v]", firstMachine.Name)
 
-	excmd, err := sshNode.ExecuteCommand(pingExecCmd)
+	excmdlog, err := sshNode.ExecuteCommand(pingExecCmd)
 	if err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
 		assert.NoError(n.T(), err)
 	}
-	n.T().Logf("Log of the ping command {%v}", excmd)
+	n.T().Logf("Log of the ping command {%v}", excmdlog)
 
-	//execCmd := []string{"kubectl", "exec", pod1Name, "-n", namespace.Name, " -- ", pingCmd, pod2Ip}
-	//execCmd := []string{namespace.Name, pod1Name, pingCmd, pod2Ip}
-
-	//cmdLog, err := kubectl.Command(n.client, nil, n.project.ClusterID, execCmd, "")
-	//require.NoError(n.T(), err)
-	//n.T().Logf("Log of the kubectl command {%v]", cmdLog)
+	assert.Contains(n.T(), excmdlog, "0% packet loss", "Unable to ping the pod")
 
 }
 

--- a/tests/v2/validation/networking/connectivity/network_policy_test.go
+++ b/tests/v2/validation/networking/connectivity/network_policy_test.go
@@ -4,13 +4,14 @@ package connectivity
 
 import (
 	"errors"
+	"github.com/rancher/rancher/tests/v2/actions/namespaces"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/workloads"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/clusters"
-	"github.com/rancher/shepherd/extensions/namespaces"
-	"github.com/rancher/shepherd/extensions/provisioninginput"
 	"github.com/rancher/shepherd/extensions/sshkeys"
-	"github.com/rancher/shepherd/extensions/workloads"
+	shepworkloads "github.com/rancher/shepherd/extensions/workloads"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ssh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,7 +76,7 @@ func (n *NetworkPolicyTestSuite) TestPingPods() {
 	testContainerPodTemplate := newPodTemplateWithTestContainer()
 
 	n.T().Logf("Creating a daemonset with the test container with name [%v]", names.random["daemonsetName"])
-	daemonsetTemplate := workloads.NewDaemonSetTemplate(names.random["daemonsetName"], namespace.Name, testContainerPodTemplate, true, nil)
+	daemonsetTemplate := shepworkloads.NewDaemonSetTemplate(names.random["daemonsetName"], namespace.Name, testContainerPodTemplate, true, nil)
 	createdDaemonSet, err := steveClient.SteveType(workloads.DaemonsetSteveType).Create(daemonsetTemplate)
 	require.NoError(n.T(), err)
 	assert.Equal(n.T(), createdDaemonSet.Name, names.random["daemonsetName"])
@@ -117,10 +118,11 @@ func (n *NetworkPolicyTestSuite) TestPingPods() {
 
 	n.T().Logf("Running ping on [%v]", firstMachine.Name)
 
-	_, err = sshNode.ExecuteCommand(pingExecCmd)
+	excmd, err := sshNode.ExecuteCommand(pingExecCmd)
 	if err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
 		assert.NoError(n.T(), err)
 	}
+	n.T().Logf("Log of the ping command {%v}", excmd)
 
 	//execCmd := []string{"kubectl", "exec", pod1Name, "-n", namespace.Name, " -- ", pingCmd, pod2Ip}
 	//execCmd := []string{namespace.Name, pod1Name, pingCmd, pod2Ip}

--- a/tests/v2/validation/networking/connectivity/network_policy_test.go
+++ b/tests/v2/validation/networking/connectivity/network_policy_test.go
@@ -38,8 +38,8 @@ type NetworkPolicyTestSuite struct {
 const (
 	nodeRole = "control-plane"
 	// Ping once
-	pingCmd       = "ping -c 1"
-	succesfulPing = "0% packet loss"
+	pingCmd        = "ping -c 1"
+	successfulPing = "0% packet loss"
 )
 
 func (n *NetworkPolicyTestSuite) TearDownSuite() {
@@ -139,7 +139,7 @@ func (n *NetworkPolicyTestSuite) TestPingPods() {
 	}
 	n.T().Logf("Log of the ping command {%v}", excmdLog)
 
-	assert.Contains(n.T(), excmdLog, succesfulPing, "Unable to ping the pod")
+	assert.Contains(n.T(), excmdLog, successfulPing, "Unable to ping the pod")
 
 }
 

--- a/tests/v2/validation/networking/connectivity/network_policy_test.go
+++ b/tests/v2/validation/networking/connectivity/network_policy_test.go
@@ -1,0 +1,98 @@
+package connectivity
+
+import (
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/kubectl"
+	"github.com/rancher/shepherd/extensions/namespaces"
+	"github.com/rancher/shepherd/extensions/workloads"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type NetworkPolicyTestSuite struct {
+	suite.Suite
+	session *session.Session
+	client  *rancher.Client
+	project *management.Project
+}
+
+func (n *NetworkPolicyTestSuite) TearDownSuite() {
+	n.session.Cleanup()
+}
+
+func (n *NetworkPolicyTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	n.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(n.T(), err)
+
+	n.client = client
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmpty(n.T(), clusterName, "Cluster name to install is not set")
+
+	cluster, err := clusters.NewClusterMeta(client, clusterName)
+	require.NoError(n.T(), err)
+
+	projectConfig := &management.Project{
+		ClusterID: cluster.ID,
+		Name:      pingPodProjectName,
+	}
+
+	createdProject, err := client.Management.Project.Create(projectConfig)
+	require.NoError(n.T(), err)
+	require.Equal(n.T(), createdProject.Name, pingPodProjectName)
+	n.project = createdProject
+}
+
+func (n *NetworkPolicyTestSuite) TestPingPods() {
+	names := newNames()
+	n.T().Logf("Creating namespace with name [%v]", names.random["namespaceName"])
+	namespace, err := namespaces.CreateNamespace(n.client, names.random["namespaceName"], "{}", map[string]string{}, map[string]string{}, n.project)
+	require.NoError(n.T(), err)
+	assert.Equal(n.T(), namespace.Name, names.random["namespaceName"])
+
+	steveClient, err := n.client.Steve.ProxyDownstream(n.project.ClusterID)
+	require.NoError(n.T(), err)
+
+	testContainerPodTemplate := newPodTemplateWithTestContainer()
+
+	n.T().Logf("Creating a daemonset with the test container with name [%v]", names.random["daemonsetName"])
+	daemonsetTemplate := workloads.NewDaemonSetTemplate(names.random["daemonsetName"], namespace.Name, testContainerPodTemplate, true, nil)
+	createdDaemonSet, err := steveClient.SteveType(workloads.DaemonsetSteveType).Create(daemonsetTemplate)
+	require.NoError(n.T(), err)
+	assert.Equal(n.T(), createdDaemonSet.Name, names.random["daemonsetName"])
+
+	n.T().Logf("Waiting daemonset [%v] to have expected number of available replicas", names.random["daemonsetName"])
+	err = charts.WatchAndWaitDaemonSets(n.client, n.project.ClusterID, namespace.Name, metav1.ListOptions{})
+	require.NoError(n.T(), err)
+
+	wc, err := n.client.WranglerContext.DownStreamClusterWranglerContext(n.project.ClusterID)
+	require.NoError(n.T(), err)
+
+	pods, err := wc.Core.Pod().List(namespace.Name, metav1.ListOptions{})
+	assert.NoError(n.T(), err)
+	assert.NotEmpty(n.T(), pods)
+
+	pod1Name := pods.Items[0].ObjectMeta.Name
+	pod2Ip := pods.Items[1].Status.PodIP
+	execCmd := []string{"kubectl", "exec", "-n", namespace.Name, pod1Name, pingCmd, pod2Ip}
+
+	cmdLog, err := kubectl.Command(n.client, nil, n.project.ClusterID, execCmd, "")
+	require.NoError(n.T(), err)
+	n.T().Logf("Log of the kubectl command {%v]", cmdLog)
+
+}
+
+func TestNetworkPolicyTestSuite(t *testing.T) {
+	suite.Run(t, new(NetworkPolicyTestSuite))
+}

--- a/tests/validation/tests/v3_api/test_network_policy.py
+++ b/tests/validation/tests/v3_api/test_network_policy.py
@@ -8,6 +8,7 @@ random_password = random_test_name("pass")
 PROJECT_ISOLATION = os.environ.get('RANCHER_PROJECT_ISOLATION', "disabled")
 
 
+# This test is deprecated and is replaced by tests/v2/validation/networking/connectivity/network_policy_test.go
 def test_connectivity_between_pods():
     p_client = namespace["p_client"]
     ns = namespace["ns"]


### PR DESCRIPTION
Introduce new network policy connectivity tests using Rancher client, including setup and teardown processes. Verifies namespace and daemonset creation, as well as basic pod-to-pod connectivity with ping command.

## Issue: [#1427](https://github.com/rancher/qa-tasks/issues/1427)

 
## Problem
To deprecate Python tests, we need to convert existing tests to Go. This test is part of the Network Connectivity suite of Python tests.
 
## Solution
Convert test to Go and use extensions built into the Shepherd test framework.
