### PR TITLE
refactor(pkg/metrics): only use downstream caches if available

### DIFF
--- a/pkg/metrics/object_count.go
+++ b/pkg/metrics/object_count.go
@@ -1,0 +1,112 @@
+package metrics
+
+import (
+	"context"
+
+	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	projectv3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
+	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+type clusterObjectCounter interface {
+	ConfigMaps(context.Context) (int64, error)
+	Namespaces(context.Context) (int64, error)
+	Nodes(context.Context) (int64, error)
+	Secrets(context.Context) (int64, error)
+	ClusterRoleBindings(context.Context) (int64, error)
+	RoleBindings(context.Context) (int64, error)
+	AppRevisions(context.Context) (int64, error)
+	CatalogTemplateVersions(context.Context) (int64, error)
+	Projects(context.Context) (int64, error)
+}
+
+type clusterCountClient struct {
+	// There are *complete* caches only for some kinds, use that when available (see pkg/controllers/managementuser/controllers.go).
+
+	core interface {
+		corev1.NamespacesGetter
+	}
+	rbac interface {
+		rbacv1.ClusterRoleBindingsGetter
+		rbacv1.RoleBindingsGetter
+	}
+
+	// Otherwise, use a client directly.
+
+	dynamic dynamic.Interface
+}
+
+func (h *metricsHandler) getClusterClient(clusterID string) (clusterObjectCounter, error) {
+	cluster, err := h.clusterManager.UserContext(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return &clusterCountClient{
+		dynamic: dynamic.New(cluster.UnversionedClient),
+		core:    cluster.Core,
+		rbac:    cluster.RBAC,
+	}, nil
+}
+
+func (c clusterCountClient) countAllObjects(ctx context.Context, gvr schema.GroupVersionResource) (int64, error) {
+	// Starting on Kubernetes 1.16, ListMeta includes a RemainingItemCount field, with an estimation of the number of items that couldn't fit in the request
+	// Use that to obtain the number of objects without having to perform all the calls.
+	list, err := c.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	n := int64(len(list.Items))
+	if remaining := list.GetRemainingItemCount(); remaining != nil {
+		n += *remaining
+	}
+	return n, nil
+}
+
+func (c clusterCountClient) Namespaces(_ context.Context) (int64, error) {
+	list, err := c.core.Namespaces(metav1.NamespaceAll).Controller().Lister().List(metav1.NamespaceAll, labels.Everything())
+	return int64(len(list)), err
+}
+
+func (c clusterCountClient) ClusterRoleBindings(_ context.Context) (int64, error) {
+	list, err := c.rbac.ClusterRoleBindings(metav1.NamespaceAll).Controller().Lister().List(metav1.NamespaceAll, labels.Everything())
+	return int64(len(list)), err
+}
+
+func (c clusterCountClient) RoleBindings(_ context.Context) (int64, error) {
+	list, err := c.rbac.RoleBindings(metav1.NamespaceAll).Controller().Lister().List(metav1.NamespaceAll, labels.Everything())
+	return int64(len(list)), err
+}
+
+func (c clusterCountClient) ConfigMaps(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, corev1.ConfigMapGroupVersionResource)
+}
+
+func (c clusterCountClient) Nodes(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, corev1.NodeGroupVersionResource)
+}
+
+func (c clusterCountClient) Secrets(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, corev1.SecretGroupVersionResource)
+}
+
+func (c clusterCountClient) AppRevisions(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, projectv3.AppRevisionGroupVersionResource)
+}
+
+func (c clusterCountClient) CatalogTemplateVersions(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, managementv3.CatalogTemplateVersionGroupVersionResource)
+}
+
+func (c clusterCountClient) Projects(ctx context.Context) (int64, error) {
+	return c.countAllObjects(ctx, managementv3.ProjectGroupVersionResource)
+}


### PR DESCRIPTION
## Issue: #46827
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem

This component is only used for getting a count of certain kinds in the downstream (or local) cluster. However, since it uses `Controller().Lister()` constructs, those caches are not always populated with the right contents (e.g. [could be filtered](https://github.com/rancher/rancher/blob/82e36ddee661314fcda74b3b8bd27bd83ab85c79/pkg/controllers/managementuser/controllers.go#L70-L77)), leading to inconsistent results.
 
## Solution

These changes limit the use of those caches to a limited set of kinds, falling back to a dynamic client for the rest.
In order to avoid listing all resources, this client will calculate the objects count by using a LIST operation limited to 1 item and read the remaining object count from the [response metadata](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/list-meta/).

`ServiceAccounts` and `Secrets` were intentionally moved to use the dynamic client, since there are cases when their caches are limited to a single namespace.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Running these changes manually and using the `/metrics/{clusterID}` endpoints, the results shown now are more accurate.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations

Requests for downstream clusters may be slower, due to the latency introduced by the API calls, but the results will be more accurate instead.

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_