### PR TITLE
refactor(pkg/managementuser/certsexpiration): remove cached client

### DIFF
--- a/pkg/controllers/managementuser/certsexpiration/certsexpiration.go
+++ b/pkg/controllers/managementuser/certsexpiration/certsexpiration.go
@@ -149,7 +149,7 @@ func (c Controller) getCertsFromUserCluster() (map[string]pki.CertificatePKI, er
 		FieldSelector: fmt.Sprintf("type=%s", corev1.SecretTypeOpaque),
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting certificate secrets for cluster [%s]: %w", c.ClusterName, err)
 	}
 	for _, secret := range secrets.Items {
 		if strings.HasPrefix(secret.GetName(), "kube-") {


### PR DESCRIPTION
## Issue: #46827
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem

This component list all secrets in the downstream cluster, to later filter by namespace ("kube-system") and secret type (opaque).
Also, this controller is exclusive for RKE1-based clusters, which is being deprecated.
 
## Solution

These changes replace the cache with a simple `ListNamespaced` operation, using the a `FieldSelector` with a specific secret type, which will apply the filter server-side.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_