### PR TITLE
Overwrite BCI labels

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ version: %VERSION%
 appVersion: %APP_VERSION%
 kubeVersion: < 1.31.0-0
 home: https://rancher.com
-icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg
+icon: https://raw.githubusercontent.com/rancher/ui/master/public/assets/images/logos/welcome-cow.svg
 keywords:
   - rancher
 sources:

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -329,8 +329,8 @@ VOLUME /var/lib/kubelet
 VOLUME /var/lib/cni
 VOLUME /var/log
 
-LABEL "io.artifacthub.package.logo-url"="https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg" \
-      "io.artifacthub.package.readme-url"="https://github.com/rancher/rancher/blob/${VERSION}/README.md" \
+LABEL "io.artifacthub.package.logo-url"="https://raw.githubusercontent.com/rancher/ui/master/public/assets/images/logos/welcome-cow.svg" \
+      "io.artifacthub.package.readme-url"="https://raw.githubusercontent.com/rancher/rancher/${VERSION}/README.md" \
       "org.opencontainers.image.description"="Rancher Manager: complete container management platform." \
       "org.opencontainers.image.title"="Rancher Manager: complete container management platform." \
       "org.opencontainers.image.source"="https://github.com/rancher/rancher" \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -329,4 +329,12 @@ VOLUME /var/lib/kubelet
 VOLUME /var/lib/cni
 VOLUME /var/log
 
+LABEL "io.artifacthub.package.logo-url"="https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg" \
+      "io.artifacthub.package.readme-url"="https://github.com/rancher/rancher/blob/${VERSION}/README.md" \
+      "org.opencontainers.image.description"="Rancher Manager: complete container management platform." \
+      "org.opencontainers.image.title"="Rancher Manager: complete container management platform." \
+      "org.opencontainers.image.source"="https://github.com/rancher/rancher" \
+      "org.opencontainers.image.version"=${VERSION} \
+      "org.opensuse.reference"=rancher/rancher:${VERSION}
+
 ENTRYPOINT ["entrypoint.sh"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -81,8 +81,8 @@ COPY --from=build /app/agent /usr/bin/
 COPY package/run.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
 
-LABEL "io.artifacthub.package.logo-url"="https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg" \
-      "io.artifacthub.package.readme-url"="https://github.com/rancher/rancher/blob/${VERSION}/README.md" \
+LABEL "io.artifacthub.package.logo-url"="https://raw.githubusercontent.com/rancher/ui/master/public/assets/images/logos/welcome-cow.svg" \
+      "io.artifacthub.package.readme-url"="https://raw.githubusercontent.com/rancher/rancher/${VERSION}/README.md" \
       "org.opencontainers.image.description"="Rancher Manager Agent: complete container management platform." \
       "org.opencontainers.image.title"="Rancher Manager Agent: complete container management platform." \
       "org.opencontainers.image.source"="https://github.com/rancher/rancher" \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -80,4 +80,13 @@ COPY --from=rancher /usr/bin/tini /usr/bin/
 COPY --from=build /app/agent /usr/bin/
 COPY package/run.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
+
+LABEL "io.artifacthub.package.logo-url"="https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg" \
+      "io.artifacthub.package.readme-url"="https://github.com/rancher/rancher/blob/${VERSION}/README.md" \
+      "org.opencontainers.image.description"="Rancher Manager Agent: complete container management platform." \
+      "org.opencontainers.image.title"="Rancher Manager Agent: complete container management platform." \
+      "org.opencontainers.image.source"="https://github.com/rancher/rancher" \
+      "org.opencontainers.image.version"=${VERSION} \
+      "org.opensuse.reference"=rancher/rancher-agent:${VERSION}
+
 ENTRYPOINT ["run.sh"]


### PR DESCRIPTION
The transition to BCI-based images meant that we started releasing Rancher Manager with BCI labels. These changes ensure that the metadata baked into the released images are now Rancher Manager specific, whilst retaining all base image related labels for both SLE and BCI.

Here's the diff on labels between a local version and `rancher/rancher:v2.8.2`:
```diff
    "com.suse.bci.micro.authors": "SUSE LLC (https://www.suse.com/)",
    "com.suse.bci.micro.created": "2024-08-09T15:24:32.303161690Z",
    "com.suse.bci.micro.description": "A micro environment for containers based on the SLE Base Container Image.",
    "com.suse.bci.micro.disturl": "obs://build.suse.de/SUSE:SLE-15-SP6:Update:CR/images/c4136c6519a0f7f58d2c0ca542aee82a-micro-image",
    "com.suse.bci.micro.eula": "sle-bci",
    "com.suse.bci.micro.lifecycle-url": "https://www.suse.com/lifecycle#suse-linux-enterprise-server-15",
    "com.suse.bci.micro.name": "15.6.24.2",
    "com.suse.bci.micro.reference": "registry.suse.com/bci/bci-micro:15.6.24.2",
    "com.suse.bci.micro.release-stage": "released",
    "com.suse.bci.micro.source": "https://sources.suse.com/SUSE:SLE-15-SP6:Update:CR/micro-image/c4136c6519a0f7f58d2c0ca542aee82a/",
    "com.suse.bci.micro.supportlevel": "l3",
    "com.suse.bci.micro.title": "SLE BCI 15 SP6 Micro",
    "com.suse.bci.micro.url": "https://www.suse.com/products/base-container-images/",
    "com.suse.bci.micro.vendor": "SUSE LLC",
    "com.suse.bci.micro.version": "15.6.24.2",
    "com.suse.eula": "sle-bci",
    "com.suse.lifecycle-url": "https://www.suse.com/lifecycle#suse-linux-enterprise-server-15",
    "com.suse.release-stage": "released",
    "com.suse.supportlevel": "l3",
-   "io.artifacthub.package.logo-url": "https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
+   "io.artifacthub.package.logo-url": "https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg",
-   "io.artifacthub.package.readme-url": "https://sources.suse.com/SUSE:SLE-15-SP5:Update:CR/sles15-image/603ef2195b0f6b8b5b3c9e012728aac2//README.md",
+   "io.artifacthub.package.readme-url": "https://github.com/rancher/rancher/blob/v2.10-f7ce3508b/README.md",
    "org.openbuildservice.disturl": "obs://build.suse.de/SUSE:SLE-15-SP6:Update:CR/images/c4136c6519a0f7f58d2c0ca542aee82a-micro-image",
    "org.opencontainers.image.authors": "SUSE LLC (https://www.suse.com/)",
    "org.opencontainers.image.created": "2024-08-09T15:24:32.303161690Z",
-   "org.opencontainers.image.description": "Image for containers based on SUSE Linux Enterprise Server 15 SP5.",
+   "org.opencontainers.image.description": "Rancher Manager: complete container management platform.",
+   "org.opencontainers.image.ref.name": "v2.10-f7ce3508b",
    "org.opencontainers.image.source": "https://github.com/rancher/rancher",
-   "org.opencontainers.image.title": "SLE BCI 15 SP5 Base Container Image",
+   "org.opencontainers.image.title": "Rancher Manager: complete container management platform.",
    "org.opencontainers.image.url": "https://github.com/rancher/rancher",
    "org.opencontainers.image.vendor": "SUSE LLC",
-   "org.opencontainers.image.version": "15.5.36.11.2",
+   "org.opencontainers.image.version": "v2.10-f7ce3508b",
-   "org.opensuse.reference": "registry.suse.com/suse/sle15:15.5.36.11.2"
+   "org.opensuse.reference": "rancher/rancher:v2.10-f7ce3508b"
```