### PR TITLE
Respect creator principal when creating project or cluster

### DIFF
--- a/pkg/controllers/management/auth/project_cluster/cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/cluster_handler.go
@@ -105,7 +105,7 @@ func (l *clusterLifecycle) Sync(key string, orig *apisv3.Cluster) (runtime.Objec
 
 	// update if it has changed
 	if obj != nil && !reflect.DeepEqual(orig, obj) {
-		logrus.Infof("[%v] Updating cluster %v", ClusterCreateController, orig.Name)
+		logrus.Infof("[%s] Updating cluster %s", ClusterCreateController, orig.Name)
 		_, err = l.clusterClient.ObjectClient().Update(orig.Name, obj)
 		if err != nil {
 			return nil, err
@@ -119,7 +119,7 @@ func (l *clusterLifecycle) Sync(key string, orig *apisv3.Cluster) (runtime.Objec
 
 	// update if it has changed
 	if obj != nil && !reflect.DeepEqual(orig, obj) {
-		logrus.Infof("[%v] Updating cluster %v", ClusterCreateController, orig.Name)
+		logrus.Infof("[%s] Updating cluster %s", ClusterCreateController, orig.Name)
 		_, err = l.clusterClient.ObjectClient().Update(orig.Name, obj)
 		if err != nil {
 			return nil, err

--- a/pkg/controllers/management/auth/project_cluster/cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/cluster_handler.go
@@ -3,6 +3,7 @@ package project_cluster
 import (
 	"errors"
 	"reflect"
+	"strings"
 
 	"encoding/json"
 	"fmt"
@@ -172,23 +173,30 @@ func (l *clusterLifecycle) createProject(name string, cond condition.Cond, obj r
 		if err != nil {
 			return obj, fmt.Errorf("error accessing project object %v: %w", obj, err)
 		}
+
+		clusterName := metaAccessor.GetName()
+
 		// Attempt to use the cache first
-		projects, err := l.projectLister.List(metaAccessor.GetName(), labels.AsSelector())
+		projects, err := l.projectLister.List(clusterName, labels.AsSelector())
 		if err != nil || len(projects) > 0 {
 			return obj, err
 		}
 
 		// Cache failed, try the API
-		projects2, err := l.projects.List(metaAccessor.GetName(), metav1.ListOptions{LabelSelector: labels.String()})
+		projects2, err := l.projects.List(clusterName, metav1.ListOptions{LabelSelector: labels.String()})
 		if err != nil || len(projects2.Items) > 0 {
 			return obj, err
 		}
 
-		annotation := map[string]string{}
+		clusterAnnotations := metaAccessor.GetAnnotations()
+		annotations := map[string]string{}
 
-		creatorID := metaAccessor.GetAnnotations()[CreatorIDAnnotation]
-		if creatorID != "" {
-			annotation[CreatorIDAnnotation] = creatorID
+		if creatorID := clusterAnnotations[CreatorIDAnnotation]; creatorID != "" {
+			annotations[CreatorIDAnnotation] = creatorID
+		}
+
+		if creatorPrincipleName := clusterAnnotations[creatorPrincipleNameAnnotation]; creatorPrincipleName != "" {
+			annotations[creatorPrincipleNameAnnotation] = creatorPrincipleName
 		}
 
 		if name == project.System {
@@ -196,19 +204,19 @@ func (l *clusterLifecycle) createProject(name string, cond condition.Cond, obj r
 			if err != nil {
 				return obj, err
 			}
-			annotation[project.SystemImageVersionAnnotation] = latestSystemVersion
+			annotations[project.SystemImageVersionAnnotation] = latestSystemVersion
 		}
 
 		project := &apisv3.Project{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "p-",
-				Annotations:  annotation,
+				Annotations:  annotations,
 				Labels:       labels,
 			},
 			Spec: apisv3.ProjectSpec{
 				DisplayName: name,
-				Description: fmt.Sprintf("%s project created for the cluster", name),
-				ClusterName: metaAccessor.GetName(),
+				Description: name + " project created for the cluster",
+				ClusterName: clusterName,
 			},
 		}
 		updated, err := l.addRTAnnotation(project, "project")
@@ -216,8 +224,8 @@ func (l *clusterLifecycle) createProject(name string, cond condition.Cond, obj r
 			return obj, err
 		}
 		project = updated.(*apisv3.Project)
-		logrus.Infof("[%v] Creating %s project for cluster %v", ClusterCreateController, name, metaAccessor.GetName())
-		if _, err = l.mgr.Management.Projects(metaAccessor.GetName()).Create(project); err != nil {
+		logrus.Infof("[%s] Creating %s project for cluster %s", ClusterCreateController, name, clusterName)
+		if _, err = l.mgr.Management.Projects(clusterName).Create(project); err != nil {
 			return obj, err
 		}
 		return obj, nil
@@ -319,35 +327,29 @@ func (l *clusterLifecycle) addRTAnnotation(obj runtime.Object, context string) (
 
 func (l *clusterLifecycle) reconcileClusterCreatorRTB(obj runtime.Object) (runtime.Object, error) {
 	return apisv3.CreatorMadeOwner.DoUntilTrue(obj, func() (runtime.Object, error) {
-		metaAccessor, err := meta.Accessor(obj)
-		if err != nil {
-			return obj, fmt.Errorf("error accessing cluster object %v: %w", obj, err)
+		cluster, ok := obj.(*apisv3.Cluster)
+		if !ok {
+			return obj, fmt.Errorf("expected cluster, got %T", obj)
 		}
 
-		typeAccessor, err := meta.TypeAccessor(obj)
-		if err != nil {
-			return obj, err
-		}
-
-		creatorID, ok := metaAccessor.GetAnnotations()[CreatorIDAnnotation]
-		if !ok || creatorID == "" {
-			logrus.Warnf("[%v] %v %v has no creatorId annotation. Cannot add creator as owner", ClusterCreateController, typeAccessor.GetKind(), metaAccessor.GetName())
+		creatorID := cluster.Annotations[CreatorIDAnnotation]
+		if creatorID == "" {
+			logrus.Warnf("[%s] cluster %s has no creatorId annotation. Cannot add creator as owner", ClusterCreateController, cluster.Name)
 			return obj, nil
 		}
-		cluster := obj.(*apisv3.Cluster)
 
 		if apisv3.ClusterConditionInitialRolesPopulated.IsTrue(cluster) {
 			// The clusterRoleBindings are already completed, no need to check
 			return obj, nil
 		}
 
-		roleJSON := cluster.Annotations[roleTemplatesRequiredAnnotation]
-		if roleJSON == "" {
+		creatorRoleBindings := cluster.Annotations[roleTemplatesRequiredAnnotation]
+		if creatorRoleBindings == "" {
 			return cluster, nil
 		}
 
 		roleMap := make(map[string][]string)
-		err = json.Unmarshal([]byte(roleJSON), &roleMap)
+		err := json.Unmarshal([]byte(creatorRoleBindings), &roleMap)
 		if err != nil {
 			return obj, err
 		}
@@ -357,26 +359,35 @@ func (l *clusterLifecycle) reconcileClusterCreatorRTB(obj runtime.Object) (runti
 		for _, role := range roleMap["required"] {
 			rtbName := "creator-" + role
 
-			if rtb, _ := l.crtbLister.Get(metaAccessor.GetName(), rtbName); rtb != nil {
+			if rtb, _ := l.crtbLister.Get(cluster.Name, rtbName); rtb != nil {
 				createdRoles = append(createdRoles, role)
 				// This clusterRoleBinding exists, need to check all of them so keep going
 				continue
 			}
 
 			// The clusterRoleBinding doesn't exist yet so create it
-			om := metav1.ObjectMeta{
-				Name:      rtbName,
-				Namespace: metaAccessor.GetName(),
-			}
-			om.Annotations = crtbCreatorOwnerAnnotations
-
-			logrus.Infof("[%v] Creating creator clusterRoleTemplateBinding for user %v for cluster %v", ClusterCreateController, creatorID, metaAccessor.GetName())
-			if _, err := l.mgr.Management.ClusterRoleTemplateBindings(metaAccessor.GetName()).Create(&apisv3.ClusterRoleTemplateBinding{
-				ObjectMeta:       om,
-				ClusterName:      metaAccessor.GetName(),
+			crtb := &apisv3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        rtbName,
+					Namespace:   cluster.Name,
+					Annotations: crtbCreatorOwnerAnnotations,
+				},
+				ClusterName:      cluster.Name,
 				RoleTemplateName: role,
 				UserName:         creatorID,
-			}); err != nil && !apierrors.IsAlreadyExists(err) {
+			}
+
+			if principalName := cluster.Annotations[creatorPrincipleNameAnnotation]; principalName != "" {
+				if !strings.HasPrefix(principalName, "local") {
+					// Setting UserPrincipalName only makes sense for non-local users.
+					crtb.UserPrincipalName = principalName
+					crtb.UserName = ""
+				}
+			}
+
+			logrus.Infof("[%s] Creating creator clusterRoleTemplateBinding for user %s for cluster %s", ClusterCreateController, creatorID, cluster.Name)
+			_, err := l.mgr.Management.ClusterRoleTemplateBindings(cluster.Name).Create(crtb)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
 				return obj, err
 			}
 			createdRoles = append(createdRoles, role)
@@ -399,7 +410,7 @@ func (l *clusterLifecycle) reconcileClusterCreatorRTB(obj runtime.Object) (runti
 }
 
 func (l *clusterLifecycle) updateClusterAnnotationandCondition(cluster *apisv3.Cluster, annotation string, updateCondition bool) error {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		c, err := l.clusterClient.Get(cluster.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -416,14 +427,8 @@ func (l *clusterLifecycle) updateClusterAnnotationandCondition(cluster *apisv3.C
 		}
 		// Only log if we successfully updated the cluster
 		if updateCondition {
-			logrus.Infof("[%v] Setting InitialRolesPopulated condition on cluster %v", ClusterCreateController, cluster.Name)
+			logrus.Infof("[%s] Setting InitialRolesPopulated condition on cluster %s", ClusterCreateController, cluster.Name)
 		}
 		return nil
 	})
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pkg/controllers/management/auth/project_cluster/cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/cluster_handler.go
@@ -198,8 +198,8 @@ func (l *clusterLifecycle) createProject(name string, cond condition.Cond, obj r
 			annotations[CreatorIDAnnotation] = creatorID
 		}
 
-		if creatorPrincipleName := clusterAnnotations[creatorPrincipleNameAnnotation]; creatorPrincipleName != "" {
-			annotations[creatorPrincipleNameAnnotation] = creatorPrincipleName
+		if creatorPrincipalName := clusterAnnotations[creatorPrincipalNameAnnotation]; creatorPrincipalName != "" {
+			annotations[creatorPrincipalNameAnnotation] = creatorPrincipalName
 		}
 
 		if name == project.System {
@@ -381,7 +381,7 @@ func (l *clusterLifecycle) reconcileClusterCreatorRTB(obj runtime.Object) (runti
 				UserName:         creatorID,
 			}
 
-			if principalName := cluster.Annotations[creatorPrincipleNameAnnotation]; principalName != "" {
+			if principalName := cluster.Annotations[creatorPrincipalNameAnnotation]; principalName != "" {
 				if !strings.HasPrefix(principalName, "local") {
 					// Setting UserPrincipalName only makes sense for non-local users.
 					crtb.UserPrincipalName = principalName

--- a/pkg/controllers/management/auth/project_cluster/cluster_handler_test.go
+++ b/pkg/controllers/management/auth/project_cluster/cluster_handler_test.go
@@ -48,7 +48,7 @@ func TestClusterLifecycleCreateProjectRespectsUserPrincipalName(t *testing.T) {
 			Name: clusterName,
 			Annotations: map[string]string{
 				CreatorIDAnnotation:            userID,
-				creatorPrincipleNameAnnotation: userPrincipalName,
+				creatorPrincipalNameAnnotation: userPrincipalName,
 			},
 		},
 	}
@@ -61,7 +61,7 @@ func TestClusterLifecycleCreateProjectRespectsUserPrincipalName(t *testing.T) {
 	assert.Equal(t, clusterName, project.Spec.ClusterName)
 	assert.Equal(t, projectName, project.Spec.DisplayName)
 	assert.Equal(t, userID, project.Annotations[CreatorIDAnnotation])
-	assert.Equal(t, userPrincipalName, project.Annotations[creatorPrincipleNameAnnotation])
+	assert.Equal(t, userPrincipalName, project.Annotations[creatorPrincipalNameAnnotation])
 }
 
 func TestReconcileClusterCreatorRTBRespectsUserPrincipalName(t *testing.T) {
@@ -77,7 +77,7 @@ func TestReconcileClusterCreatorRTBRespectsUserPrincipalName(t *testing.T) {
 			Annotations: map[string]string{
 				roleTemplatesRequiredAnnotation: `{"created":["cluster-owner"],"required":["cluster-owner"]}`,
 				CreatorIDAnnotation:             userID,
-				creatorPrincipleNameAnnotation:  userPrincipalName,
+				creatorPrincipalNameAnnotation:  userPrincipalName,
 			},
 		},
 	}

--- a/pkg/controllers/management/auth/project_cluster/cluster_handler_test.go
+++ b/pkg/controllers/management/auth/project_cluster/cluster_handler_test.go
@@ -1,0 +1,117 @@
+package project_cluster
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	mgmtFakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestClusterLifecycleCreateProjectRespectsUserPrincipalName(t *testing.T) {
+	var project *apisv3.Project
+
+	ctrl := gomock.NewController(t)
+	projects := fake.NewMockClientInterface[*apisv3.Project, *apisv3.ProjectList](ctrl)
+	projects.EXPECT().List(gomock.Any(), gomock.Any()).Return(&apisv3.ProjectList{}, nil).Times(1)
+	projects.EXPECT().Create(gomock.Any()).DoAndReturn(func(p *apisv3.Project) (*apisv3.Project, error) {
+		project = p.DeepCopy()
+		return project, nil
+	})
+
+	lifecycle := &clusterLifecycle{
+		projectLister: &mgmtFakes.ProjectListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) (ret []*apisv3.Project, err error) {
+				return nil, nil
+			},
+		},
+		roleTemplateLister: &mgmtFakes.RoleTemplateListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) (ret []*apisv3.RoleTemplate, err error) {
+				return nil, nil
+			},
+		},
+		projects: projects,
+	}
+
+	userID := "u-abcdef"
+	userPrincipalName := "keycloak_user://12345"
+	projectName := "test-project"
+	clusterName := "test-cluster"
+
+	cluster := &apisv3.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: clusterName,
+			Annotations: map[string]string{
+				CreatorIDAnnotation:            userID,
+				creatorPrincipleNameAnnotation: userPrincipalName,
+			},
+		},
+	}
+
+	obj, err := lifecycle.createProject(projectName, apisv3.ClusterConditionSystemProjectCreated, cluster, defaultProjectLabels)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	require.NotNil(t, project)
+	assert.Equal(t, clusterName, project.Spec.ClusterName)
+	assert.Equal(t, projectName, project.Spec.DisplayName)
+	assert.Equal(t, userID, project.Annotations[CreatorIDAnnotation])
+	assert.Equal(t, userPrincipalName, project.Annotations[creatorPrincipleNameAnnotation])
+}
+
+func TestReconcileClusterCreatorRTBRespectsUserPrincipalName(t *testing.T) {
+	var crtbs []*apisv3.ClusterRoleTemplateBinding
+
+	clusterName := "test-cluster"
+	userID := "u-abcdef"
+	userPrincipalName := "keycloak_user://12345"
+
+	cluster := &apisv3.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: clusterName,
+			Annotations: map[string]string{
+				roleTemplatesRequiredAnnotation: `{"created":["cluster-owner"],"required":["cluster-owner"]}`,
+				CreatorIDAnnotation:             userID,
+				creatorPrincipleNameAnnotation:  userPrincipalName,
+			},
+		},
+	}
+
+	lifecycle := &clusterLifecycle{
+		crtbLister: &mgmtFakes.ClusterRoleTemplateBindingListerMock{
+			GetFunc: func(namespace string, name string) (*apisv3.ClusterRoleTemplateBinding, error) {
+				return nil, nil
+			},
+		},
+		crtbClient: &mgmtFakes.ClusterRoleTemplateBindingInterfaceMock{
+			CreateFunc: func(obj *apisv3.ClusterRoleTemplateBinding) (*apisv3.ClusterRoleTemplateBinding, error) {
+				crtbs = append(crtbs, obj)
+				return obj, nil
+			},
+		},
+		clusterClient: &mgmtFakes.ClusterInterfaceMock{
+			GetFunc: func(name string, opts v1.GetOptions) (*apisv3.Cluster, error) {
+				return cluster, nil
+			},
+			UpdateFunc: func(in1 *apisv3.Cluster) (*apisv3.Cluster, error) {
+				return in1, nil
+			},
+		},
+	}
+
+	obj, err := lifecycle.reconcileClusterCreatorRTB(cluster)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	require.Len(t, crtbs, 1)
+	assert.Equal(t, "creator-cluster-owner", crtbs[0].Name)
+	assert.Equal(t, clusterName, crtbs[0].Namespace)
+	assert.Equal(t, clusterName, crtbs[0].ClusterName)
+	assert.Equal(t, "", crtbs[0].UserName)
+	assert.Equal(t, userPrincipalName, crtbs[0].UserPrincipalName)
+}

--- a/pkg/controllers/management/auth/project_cluster/common.go
+++ b/pkg/controllers/management/auth/project_cluster/common.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	CreatorIDAnnotation             = "field.cattle.io/creatorId"
+	creatorPrincipleNameAnnotation  = "field.cattle.io/creator-principle-name"
 	creatorOwnerBindingAnnotation   = "authz.management.cattle.io/creator-owner-binding"
 	roleTemplatesRequiredAnnotation = "authz.management.cattle.io/creator-role-bindings"
 )

--- a/pkg/controllers/management/auth/project_cluster/common.go
+++ b/pkg/controllers/management/auth/project_cluster/common.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	CreatorIDAnnotation             = "field.cattle.io/creatorId"
-	creatorPrincipleNameAnnotation  = "field.cattle.io/creator-principle-name"
+	creatorPrincipalNameAnnotation  = "field.cattle.io/creator-principal-name"
 	creatorOwnerBindingAnnotation   = "authz.management.cattle.io/creator-owner-binding"
 	roleTemplatesRequiredAnnotation = "authz.management.cattle.io/creator-role-bindings"
 )

--- a/pkg/controllers/management/auth/project_cluster/project_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/project_handler.go
@@ -68,7 +68,7 @@ func (l *projectLifecycle) Sync(key string, orig *apisv3.Project) (runtime.Objec
 			projectID = splits[1]
 		}
 		// remove the system account created for this project
-		logrus.Debugf("Deleting system user for project %v", projectID)
+		logrus.Debugf("Deleting system user for project %s", projectID)
 		if err := l.systemAccountManager.RemoveSystemAccount(projectID); err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func (l *projectLifecycle) Sync(key string, orig *apisv3.Project) (runtime.Objec
 
 	// update if it has changed
 	if obj != nil && !reflect.DeepEqual(orig, obj) {
-		logrus.Infof("[%v] Updating project %v", ProjectCreateController, orig.Name)
+		logrus.Infof("[%s] Updating project %s", ProjectCreateController, orig.Name)
 		obj, err = l.projects.ObjectClient().Update(orig.Name, obj)
 		if err != nil {
 			return nil, err
@@ -207,7 +207,7 @@ func (l *projectLifecycle) reconcileProjectCreatorRTB(obj runtime.Object) (runti
 				}
 			}
 
-			logrus.Infof("[%v] Creating creator projectRoleTemplateBinding for user %s for project %s", ProjectCreateController, creatorID, project.Name)
+			logrus.Infof("[%s] Creating creator projectRoleTemplateBinding for user %s for project %s", ProjectCreateController, creatorID, project.Name)
 			_, err := l.prtbClient.Create(prtb)
 			if err != nil && !apierrors.IsAlreadyExists(err) {
 				return obj, err

--- a/pkg/controllers/management/auth/project_cluster/project_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/project_handler.go
@@ -199,7 +199,7 @@ func (l *projectLifecycle) reconcileProjectCreatorRTB(obj runtime.Object) (runti
 				UserName:         creatorID,
 			}
 
-			if principalName := project.Annotations[creatorPrincipleNameAnnotation]; principalName != "" {
+			if principalName := project.Annotations[creatorPrincipalNameAnnotation]; principalName != "" {
 				if !strings.HasPrefix(principalName, "local") {
 					// Setting UserPrincipalName only makes sense for non-local users.
 					prtb.UserPrincipalName = principalName

--- a/pkg/controllers/management/auth/project_cluster/project_handler_test.go
+++ b/pkg/controllers/management/auth/project_cluster/project_handler_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -52,7 +51,7 @@ func TestEnqueueCrtbsOnProjectCreation(t *testing.T) {
 	assert.Equal(t, len(existingCrtbs), len(mockedClusterRoleTemplateBindingController.EnqueueCalls()))
 }
 
-func TestReconcileProjectCreatorRTBRespectsUserPrincipleName(t *testing.T) {
+func TestReconcileProjectCreatorRTBRespectsUserPrincipalName(t *testing.T) {
 	var prtbs []*v3.ProjectRoleTemplateBinding
 
 	lifecycle := &projectLifecycle{
@@ -82,7 +81,7 @@ func TestReconcileProjectCreatorRTBRespectsUserPrincipleName(t *testing.T) {
 			Namespace: clusterID,
 			Annotations: map[string]string{
 				CreatorIDAnnotation:             "u-abcdef",
-				creatorPrincipleNameAnnotation:  userPrincipalName,
+				creatorPrincipalNameAnnotation:  userPrincipalName,
 				roleTemplatesRequiredAnnotation: `{"created":["project-owner"],"required":["project-owner"]}`,
 			},
 		},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/46828

Related webhook changes https://github.com/rancher/webhook/pull/501
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently when a project or a cluster is created by a user who is logged in using an external authentication provider Rancher shows that user's principal ID as the owner in the UI only to be replaced later by it's local user's counterpart.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add `field.cattle.io/creator-principal-name` annotation that can carry the creator's principal ID to complement the existing `field.cattle.io/creatorId` that is set when the corresponding project/cluster object is created.

```
curl https://<rancher-url>/v3/projects \
...
--data-raw '{
    "type":"project",
    "name":"test-project",
    "annotations": {
        "field.cattle.io/creator-principal-name": "keycloak_user://testuser1@example.com"
    },
    ...
}'
```
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

- Create a project via `/v3/projects` endpoint
- Create a project via projects public api
- Create a cluster via `v3/cluster`

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A