### PR TITLE
Add new endpoint networks-extended

### DIFF
--- a/pkg/api/norman/customization/vsphere/listers.go
+++ b/pkg/api/norman/customization/vsphere/listers.go
@@ -51,6 +51,35 @@ func processSoapFinder(ctx context.Context, fieldName string, cc *v1.Secret, dc 
 	return data, err
 }
 
+func processSoapFinderExtended(ctx context.Context, fieldName string, cc *v1.Secret, dc string) ([]map[string]interface{}, error) {
+	finder, err := getSoapFinder(ctx, cc, dc)
+	if err != nil {
+		return nil, fmt.Errorf("error getting soap finder: %v", err)
+	}
+	var data []map[string]interface{}
+	switch fieldName {
+	case "networks-extended":
+		data, err = listNetworksExtended(ctx, finder)
+	}
+	return data, err
+}
+
+func listNetworksExtended(ctx context.Context, finder *find.Finder) ([]map[string]interface{}, error) {
+	networks, err := finder.NetworkList(ctx, "*")
+	if err != nil {
+		return nil, fmt.Errorf("error listing networks: %v", err)
+	}
+
+	data := make([]map[string]interface{}, len(networks))
+	for i, net := range networks {
+		data[i] = map[string]interface{}{
+			"name": net.GetInventoryPath(),
+			"moid": net.Reference().String(),
+		}
+	}
+	return data, nil
+}
+
 func processTagsManager(ctx context.Context, fieldName string, cc *v1.Secret, cat string) ([]map[string]string, error) {
 	tagsManager, err := getTagsManager(ctx, cc)
 	if err != nil {
@@ -295,7 +324,7 @@ func listHosts(ctx context.Context, finder *find.Finder) ([]string, error) {
 		return nil, err
 	}
 
-	data := []string{""} //blank default
+	data := []string{""} // blank default
 
 	for _, h := range hosts {
 		data = append(data, h.InventoryPath)

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -114,7 +114,7 @@ func router(ctx context.Context, localClusterEnabled bool, tunnelAuthorizer *mcm
 	authed.Path("/meta/{resource:aks.+}").Handler(aks.NewAKSHandler(scaledContext))
 	authed.Path("/meta/{resource:gke.+}").Handler(gke.NewGKEHandler(scaledContext))
 	authed.Path("/meta/oci/{resource}").Handler(oci.NewOCIHandler(scaledContext))
-	authed.Path("/meta/vsphere/{field}").Handler(vsphere.NewVsphereHandler(scaledContext))
+	authed.Path("/meta/vsphere/{field}").Methods(http.MethodGet).Handler(vsphere.NewVsphereHandler(scaledContext))
 	authed.Path("/v3/tokenreview").Methods(http.MethodPost).Handler(&webhook.TokenReviewer{})
 	authed.Path("/metrics/{clusterID}").Handler(metricsHandler)
 	authed.Path(supportconfigs.Endpoint).Handler(&supportConfigGenerator)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/44779 

Will unblock UI: https://github.com/rancher/dashboard/issues/9817
 
## Problem

When creating a node-driver vSphere cluster, if duplicate network names exist in the same data center, Rancher UI stalls when provisioning at the networks tab and the provisioning process fails.

 
## Solution

On the backend, a new HTTP endpoint, `/meta/vsphere/networks-extended`, will be introduced to provide additional details about network resources within the data center. The data returned will include both the network name and the managed object identifier (MOID), with each network having a unique MOID.

On the frontend, the UI will use this new endpoint to display the network name and MOID on the NodeTemplate (for RKE1) and VmwarevsphereConfig (for RKE2/K3s) configuration pages, setting the network flag with the selected network's MOID.


Additional changes include:
- Adding the `X-API-Deprecated: true` header to the existing `/meta/vsphere/networks` endpoint.
- Restricting the `/meta/vsphere/` endpoint to only allow GET requests.

For further details, please refer to the RFC.


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


The following results have been confirmed in the development environment:
- The new endpoint returns the expected data in the correct format.
- The `X-API-Deprecated: true` header appears in the response from the `/meta/vsphere/networks` endpoint.
- The `/meta/vsphere/` endpoint returns a `405 Method Not Allowed` response code when a request method other than GET is used.



### Automated Testing

N/A 

## QA Testing Considerations

Tests should focus on areas related to managing NodeTemplates (for RKE1) and VmwarevsphereConfig (for RKE2/K3s), as well as clusters that utilize these configurations.


### Regressions Considerations
 

- Creation, updating, and deletion of new or old NodeTemplates (for RKE1) and VmwarevsphereConfig (for RKE2/K3s).
- Creation, updating, and deletion of new or old clusters that utilize these configurations.