### PR TITLE
[SURE-5388]: add owner reference to the secret

### DIFF
--- a/pkg/controllers/management/cluster/clustercontroller.go
+++ b/pkg/controllers/management/cluster/clustercontroller.go
@@ -102,7 +102,7 @@ func (c *controller) capsSync(key string, cluster *v3.Cluster) (runtime.Object, 
 		}
 
 		driver := service.NewEngineService(
-			clusterprovisioner.NewPersistentStore(c.namespaces, c.coreV1),
+			clusterprovisioner.NewPersistentStore(c.namespaces, c.coreV1, c.clusterClient),
 		)
 		k8sCapabilities, err := driver.GetK8sCapabilities(context.Background(), kontainerDriver.Name, kontainerDriver,
 			cluster.Spec)

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -69,7 +69,7 @@ type Provisioner struct {
 
 func Register(ctx context.Context, management *config.ManagementContext) {
 	p := &Provisioner{
-		engineService:         service.NewEngineService(NewPersistentStore(management.Core.Namespaces(""), management.Core)),
+		engineService:         service.NewEngineService(NewPersistentStore(management.Core.Namespaces(""), management.Core, management.Management.Clusters(""))),
 		Clusters:              management.Management.Clusters(""),
 		ConfigMaps:            management.Core.ConfigMaps(""),
 		ClusterController:     management.Management.Clusters("").Controller(),

--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -38,6 +38,7 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 		dynamicSchemasLister: management.Management.DynamicSchemas("").Controller().Lister(),
 		namespaces:           management.Core.Namespaces(""),
 		coreV1:               management.Core,
+		clusterClient:        management.Management.Clusters(""),
 	}
 
 	management.Management.KontainerDrivers("").AddLifecycle(ctx, "mgmt-kontainer-driver-lifecycle", lifecycle)
@@ -48,6 +49,7 @@ type Lifecycle struct {
 	dynamicSchemasLister v3.DynamicSchemaLister
 	namespaces           v1.NamespaceInterface
 	coreV1               corev1.Interface
+	clusterClient        v3.ClusterInterface
 }
 
 func (l *Lifecycle) Create(obj *v3.KontainerDriver) (runtime.Object, error) {
@@ -177,7 +179,7 @@ func (l *Lifecycle) updateDynamicSchema(dynamicSchema *v3.DynamicSchema, obj *v3
 
 func (l *Lifecycle) getResourceFields(obj *v3.KontainerDriver) (map[string]v32.Field, error) {
 	driver := service.NewEngineService(
-		clusterprovisioner.NewPersistentStore(l.namespaces, l.coreV1),
+		clusterprovisioner.NewPersistentStore(l.namespaces, l.coreV1, l.clusterClient),
 	)
 	flags, err := driver.GetDriverCreateOptions(context.Background(), obj.Name, obj, v32.ClusterSpec{
 		GenericEngineConfig: &v32.MapStringInterface{

--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -61,7 +61,7 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 		clusterLister:         management.Management.Clusters("").Controller().Lister(),
 		backupClient:          management.Management.EtcdBackups(""),
 		backupLister:          management.Management.EtcdBackups("").Controller().Lister(),
-		backupDriver:          service.NewEngineService(clusterprovisioner.NewPersistentStore(management.Core.Namespaces(""), management.Core)),
+		backupDriver:          service.NewEngineService(clusterprovisioner.NewPersistentStore(management.Core.Namespaces(""), management.Core, management.Management.Clusters(""))),
 		secretLister:          management.Core.Secrets("").Controller().Lister(),
 		KontainerDriverLister: management.Management.KontainerDrivers("").Controller().Lister(),
 	}

--- a/pkg/controllers/managementuser/certsexpiration/certsexpiration.go
+++ b/pkg/controllers/managementuser/certsexpiration/certsexpiration.go
@@ -59,7 +59,7 @@ func registerDeferred(ctx context.Context, userContext *config.UserContext) {
 		ClusterName:   userContext.ClusterName,
 		ClusterLister: userContext.Management.Management.Clusters("").Controller().Lister(),
 		ClusterClient: userContext.Management.Management.Clusters(""),
-		ClusterStore:  clusterprovisioner.NewPersistentStore(userContext.Management.Core.Namespaces(""), userContext.Management.Core),
+		ClusterStore:  clusterprovisioner.NewPersistentStore(userContext.Management.Core.Namespaces(""), userContext.Management.Core, userContext.Management.Management.Clusters("")),
 		secretLister:  userContext.Core.Secrets(""),
 	}
 

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -149,7 +149,7 @@ func (m *NodeConfig) Save() error {
 
 	m.cm[configKey] = extractedConfig
 
-	if err = m.store.Set(m.id, m.cm); err != nil {
+	if err = m.store.Set(m.id, m.cm, nil); err != nil {
 		m.cm = nil
 		return err
 	}

--- a/pkg/rkenodeconfigserver/lookup.go
+++ b/pkg/rkenodeconfigserver/lookup.go
@@ -18,7 +18,7 @@ type BundleLookup struct {
 
 func NewLookup(namespaces v1.NamespaceInterface, secrets v1.SecretsGetter) *BundleLookup {
 	return &BundleLookup{
-		engineStore: clusterprovisioner.NewPersistentStore(namespaces, secrets),
+		engineStore: clusterprovisioner.NewPersistentStore(namespaces, secrets, nil),
 	}
 }
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40849
 Re-opening PR: https://github.com/rancher/rancher/pull/44560
## Problem
Custom downstream cluster secrets remain in the local cluster after the custom downstream cluster is deleted 
 
## Solution
Add owner reference to the secret so that the secret will be automatically deleted once the cluster is deleted.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
- Create a custom rke1 cluster
- Check secret (kubectl -n cattle-system get secrets -l cattle.io/creator=norman) if it's created or not
- Delete the custom cluster
- Check secret (kubectl -n cattle-system get secrets -l cattle.io/creator=norman) if it's deleted or not

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_
