### PR TITLE
[release/v2.8] [v2prov] Set machine join URL annotation on plan secret if not already set when loading plan

### DIFF
--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -242,26 +242,6 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 
 	if joinedTo, ok := secret.Annotations[capr.JoinedToAnnotation]; ok {
 		result.JoinedTo = joinedTo
-	} else {
-		if configFirstHalf, configSecondHalf, found := strings.Cut(ConfigYamlFileName, "%s"); found {
-			for _, v := range result.Plan.Files {
-				if strings.Contains(v.Path, configFirstHalf) && strings.Contains(v.Path, configSecondHalf) {
-					// We found our config file, process it to look for the joined node and then break
-					cfr, err := base64.StdEncoding.DecodeString(v.Content)
-					if err != nil {
-						return nil, err
-					}
-					var cf = map[string]interface{}{}
-					if err := json.Unmarshal(cfr, &cf); err != nil {
-						return nil, err
-					}
-					if server, ok := cf["server"]; ok {
-						result.JoinedTo = server.(string)
-					}
-					break
-				}
-			}
-		}
 	}
 
 	if len(output) > 0 {
@@ -514,6 +494,7 @@ func assignAndCheckPlan(store *PlanStore, msg string, entry *planEntry, newPlan 
 	return nil
 }
 
+// setMachineJoinURL determines and updates a machine plan secret with the join URL/joined URL for the provided node.
 func (p *PlanStore) setMachineJoinURL(entry *planEntry, capiCluster *capi.Cluster, controlPlane *rkev1.RKEControlPlane) error {
 	var (
 		err     error
@@ -546,22 +527,54 @@ func (p *PlanStore) setMachineJoinURL(entry *planEntry, capiCluster *capi.Cluste
 				}
 			}
 		}
-
-		joinURL = joinURLFromAddress(address, capr.GetRuntimeSupervisorPort(controlPlane.Spec.KubernetesVersion))
+		if address != "" {
+			joinURL = joinURLFromAddress(address, capr.GetRuntimeSupervisorPort(controlPlane.Spec.KubernetesVersion))
+		}
 	}
+
+	updateRequired := false
 
 	if joinURL != "" && entry.Metadata.Annotations[capr.JoinURLAnnotation] != joinURL {
 		entry.Metadata.Annotations[capr.JoinURLAnnotation] = joinURL
+		updateRequired = true
+	}
+
+	// In certain cases, it is possible that the joined-to annotation is not set. Attempt to determine the joined to
+	// annotation based on the delivered plan.
+	if !isInitNode(entry) && entry.Metadata.Annotations[capr.JoinedToAnnotation] == "" {
+		if configFirstHalf, configSecondHalf, found := strings.Cut(ConfigYamlFileName, "%s"); found {
+			for _, v := range entry.Plan.Plan.Files {
+				if strings.Contains(v.Path, configFirstHalf) && strings.Contains(v.Path, configSecondHalf) {
+					// We found our config file, process it to look for the joined node and then break
+					cfr, err := base64.StdEncoding.DecodeString(v.Content)
+					if err != nil {
+						return err
+					}
+					var cf = map[string]interface{}{}
+					if err := json.Unmarshal(cfr, &cf); err != nil {
+						return err
+					}
+					if server, ok := cf["server"]; ok {
+						entry.Metadata.Annotations[capr.JoinedToAnnotation] = server.(string)
+						updateRequired = true
+					}
+					break
+				}
+			}
+		}
+	}
+
+	if updateRequired {
 		if err := p.updatePlanSecretLabelsAndAnnotations(entry); err != nil {
 			return err
 		}
-
 		return generic.ErrSkip
 	}
 
 	return nil
 }
 
+// joinURLFromAddress accepts both an address (IPv4, IPv6, hostname) and returns a fully rendered join URL including `https://` and the supervisor port
 func joinURLFromAddress(address string, port int) string {
 	// ipv6 addresses need to be enclosed in brackets in URLs, and hostnames will fail to be parsed as IPs
 	if net.ParseIP(address) != nil && strings.Count(address, ":") >= 2 {
@@ -572,6 +585,7 @@ func joinURLFromAddress(address string, port int) string {
 	return fmt.Sprintf("https://%s:%d", address, port)
 }
 
+// getJoinURLFromOutput parses the periodic output from a given entry and determines the full join URL including `https://` and the supervisor port
 func getJoinURLFromOutput(entry *planEntry, capiCluster *capi.Cluster, rkeControlPlane *rkev1.RKEControlPlane) (string, error) {
 	if entry.Plan == nil || !IsEtcdOnlyInitNode(entry) || capiCluster.Spec.ControlPlaneRef == nil || rkeControlPlane == nil {
 		return "", nil

--- a/pkg/capr/planner/store_test.go
+++ b/pkg/capr/planner/store_test.go
@@ -1,6 +1,16 @@
 package planner
 
 import (
+	"encoding/base64"
+	"github.com/golang/mock/gomock"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/provisioningv2/image"
+	"github.com/rancher/wrangler/v2/pkg/generic"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +46,939 @@ func TestJoinURLFromAddress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, joinURLFromAddress(tt.address, tt.port))
+		})
+	}
+}
+
+// TestJoinURLReconcilation is a unit test to specifically ensure the join URL annotation is properly reconciled on a plan secret.
+func TestSetMachineJoinURL(t *testing.T) {
+	t.Parallel()
+
+	const rkeBootstrapName = "bogus-rkebootstrap"
+	// IPv4 expected IP is 10.20.30.45
+	periodicOutputIPv4, err := base64.StdEncoding.DecodeString("H4sIAAAAAAAAA8WQXWvCMBSG/0rJtUJSP8CCF1LnltBW1NqP3HVJhNTOSptYW/G/L07QwXaxu10cOOe8nI/3uQCWHZWuRD/jvBJ1DZwLOGQfAjg/lB6oFS+1MpJoiaIxkjQhHc6P76YmaxePcT47+7kPgzAdLOf7YdClKJj7rR/OpOcSncaowHkpmT1RdIMgTQLoxaMTfd3e9IbGURtFxGctHsctKfnbumFdefK6l8bLsQnfxAotc9wt5zOZbBqZ2ucjjUfwr3NBt5dJgvhuNZ3ePYmqMp5MLs5SuSU35mEPFFmtNpoxY32ni7U+hPILy6KSFtEHa2Ih27GHzgha29C1bGgPzIpdJgsDrX6sWJiG4M9xcDV3FOP9O+UH7WfvG+dfOP3Pz9dPl9MWAykCAAA=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// IPv6 expected IP is [::ffff:7f00:1]
+	periodicOutputIPv6, err := base64.StdEncoding.DecodeString("H4sIAAAAAAAAA8WQXYuCQBSG/4p4XTBaCQp7EUqrg6OgpumdzdgyrmY4M5lG/31nC2ph9345N+e8L+fruaq4PHHRV/OSkL5iTLWu6rFsK9X65cxUxkknuLSqEfIi02ixg5NXn/ayhpHtGV69vqAagSDJF6HzuQymXAscNKJkTX0bijzTGq/uKNZNXsQaKHYB8LPVuXjffvtDkaVjmkKER8/IRtgRNxrw1J19jRlhW8jIjUDPB+R0l13SjWj6GLwGMK8NWJmlgmzSOHERDRtGSzcC2EWGP5r7sD7du8OatMhZGygFhrxzEcaQHFLNfPxW9b38TebVhXK7IxICmKlNyXgsMJYIDqKJxDGhdzybnipQHBVT0XRLX1oroGwTW9GBvpAjDiVtJDz2HLGRQkVe7epN7uGYzB+0n9Rf2g/ef/B6+5ebb1+QQBuRMQIAAA==")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		entry         *planEntry
+		controlPlane  *rkev1.RKEControlPlane
+		capiCluster   *capi.Cluster
+		inputSecret   *corev1.Secret
+		updatedSecret *corev1.Secret
+	}{
+		{
+			name: "ipv4 rke2 control+etcd no change",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: &corev1.NodeSystemInfo{},
+						Addresses: capi.MachineAddresses{
+							capi.MachineAddress{
+								Type:    capi.MachineInternalIP,
+								Address: "128.0.0.1",
+							},
+							capi.MachineAddress{
+								Type:    capi.MachineExternalIP,
+								Address: "127.0.0.1",
+							},
+						},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://128.0.0.1:9345",
+					},
+				},
+			},
+			updatedSecret: nil,
+		},
+		{
+			name: "ipv4 rke2 control+etcd external IP-only set url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: &corev1.NodeSystemInfo{},
+						Addresses: capi.MachineAddresses{
+							capi.MachineAddress{
+								Type:    capi.MachineExternalIP,
+								Address: "127.0.0.1",
+							},
+						},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{},
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://127.0.0.1:9345",
+					},
+				},
+			},
+		},
+		{
+			name: "ipv4 rke2 control+etcd set url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: &corev1.NodeSystemInfo{},
+						Addresses: capi.MachineAddresses{
+							capi.MachineAddress{
+								Type:    capi.MachineExternalIP,
+								Address: "127.0.0.1",
+							},
+							capi.MachineAddress{
+								Type:    capi.MachineInternalIP,
+								Address: "128.0.0.1",
+							},
+						},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{},
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://128.0.0.1:9345",
+					},
+				},
+			},
+		},
+		{
+			name: "ipv4 rke2 control+etcd nil NodeInfo",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: nil,
+						Addresses: capi.MachineAddresses{
+							capi.MachineAddress{
+								Type:    capi.MachineInternalIP,
+								Address: "128.0.0.1",
+							},
+							capi.MachineAddress{
+								Type:    capi.MachineExternalIP,
+								Address: "127.0.0.1",
+							},
+						},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAutosetDisabled: "true",
+						capr.JoinURLAnnotation:      "https://127.0.0.1:9345",
+					},
+				},
+			},
+			updatedSecret: nil,
+		},
+		{
+			name: "ipv4 rke2 control+etcd autoset disabled",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: nil,
+						Addresses: capi.MachineAddresses{
+							capi.MachineAddress{
+								Type:    capi.MachineInternalIP,
+								Address: "222.0.0.1",
+							},
+							capi.MachineAddress{
+								Type:    capi.MachineExternalIP,
+								Address: "223.0.0.1",
+							},
+						},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{},
+				},
+			},
+			updatedSecret: nil,
+		},
+		{
+			name: "ipv4 rke2 control+etcd no change",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: &corev1.NodeSystemInfo{},
+						Addresses: capi.MachineAddresses{
+							capi.MachineAddress{
+								Type:    capi.MachineInternalIP,
+								Address: "128.0.0.1",
+							},
+						},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://128.0.0.1:9345",
+					},
+				},
+			},
+			updatedSecret: nil,
+		},
+		{
+			name: "ipv4 k3s control+etcd set url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: &corev1.NodeSystemInfo{},
+						Addresses: capi.MachineAddresses{
+							capi.MachineAddress{
+								Type:    capi.MachineInternalIP,
+								Address: "128.0.0.1",
+							},
+						},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+k3s1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{},
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.ControlPlaneRoleLabel: "true",
+						capr.EtcdRoleLabel:         "true",
+						capr.WorkerRoleLabel:       "true",
+						capr.InitNodeLabel:         "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://128.0.0.1:6443",
+					},
+				},
+			},
+		},
+
+		{
+			name:  "ipv4 k3s etcd-only no change",
+			entry: &planEntry{},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+k3s1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://10.20.30.45:6443",
+					},
+				},
+				Data: map[string][]byte{
+					"applied-periodic-output": periodicOutputIPv4,
+				},
+			},
+			updatedSecret: nil,
+		},
+		{
+			name:  "ipv6 k3s etcd-only no change",
+			entry: &planEntry{},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+k3s1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://[::ffff:7f00:1]:6443",
+					},
+				},
+				Data: map[string][]byte{
+					"applied-periodic-output": periodicOutputIPv6,
+				},
+			},
+			updatedSecret: nil,
+		},
+		{
+			name:  "ipv4 rke2 etcd-only no change",
+			entry: &planEntry{},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://10.20.30.45:9345",
+					},
+				},
+				Data: map[string][]byte{
+					"applied-periodic-output": periodicOutputIPv4,
+				},
+			},
+			updatedSecret: nil,
+		},
+		{
+			name:  "ipv6 rke2 etcd-only no change",
+			entry: &planEntry{},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://[::ffff:7f00:1]:9345",
+					},
+				},
+				Data: map[string][]byte{
+					"applied-periodic-output": periodicOutputIPv6,
+				},
+			},
+			updatedSecret: nil,
+		},
+
+		{
+			name: "ipv4 k3s etcd-only set url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+k3s1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv4,
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://10.20.30.45:6443",
+					},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv4,
+				},
+			},
+		},
+		{
+			name: "ipv6 k3s etcd-only set url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+k3s1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv6,
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://[::ffff:7f00:1]:6443",
+					},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv6,
+				},
+			},
+		},
+		{
+			name: "ipv4 rke2 etcd-only set url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv4,
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://10.20.30.45:9345",
+					},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv4,
+				},
+			},
+		},
+		{
+			name: "ipv6 rke2 etcd-only set url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv6,
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.EtcdRoleLabel: "true",
+						capr.InitNodeLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinURLAnnotation: "https://[::ffff:7f00:1]:9345",
+					},
+				},
+				Data: map[string][]byte{
+					"plan":                    []byte("{}"),
+					"applied-periodic-output": periodicOutputIPv6,
+				},
+			},
+		},
+
+		{
+			name: "ipv4 rke2 worker-only set joined-to url from empty",
+			entry: &planEntry{
+				Machine: &capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Status: capi.MachineStatus{
+						NodeInfo: &corev1.NodeSystemInfo{},
+					},
+					Spec: capi.MachineSpec{
+						Bootstrap: capi.Bootstrap{ConfigRef: &corev1.ObjectReference{Kind: "RKEBootstrap", Name: rkeBootstrapName}},
+					},
+				},
+			},
+			controlPlane: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					KubernetesVersion: "v1.25.5+rke2r1",
+				},
+			},
+			capiCluster: &capi.Cluster{
+				Spec: capi.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "something",
+					},
+				},
+			},
+			inputSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.WorkerRoleLabel: "true",
+					},
+					Annotations: map[string]string{},
+				},
+				Data: map[string][]byte{
+					"plan": []byte("{\"files\":[{\"content\":\"ewogICJzZXJ2ZXIiOiAiaHR0cHM6Ly8yOC44OS45My4yOjkzNDUiCn0=\",\"path\":\"/etc/rancher/k3s/config.yaml.d/50-rancher.yaml\"}]}"),
+				},
+			},
+			updatedSecret: &corev1.Secret{
+				Type: capr.SecretTypeMachinePlan,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      capr.PlanSecretFromBootstrapName(rkeBootstrapName),
+					Namespace: "test",
+					Labels: map[string]string{
+						capr.WorkerRoleLabel: "true",
+					},
+					Annotations: map[string]string{
+						capr.JoinedToAnnotation: "https://28.89.93.2:9345",
+					},
+				},
+				Data: map[string][]byte{
+					"plan": []byte("{\"files\":[{\"content\":\"ewogICJzZXJ2ZXIiOiAiaHR0cHM6Ly8yOC44OS45My4yOjkzNDUiCn0=\",\"path\":\"/etc/rancher/k3s/config.yaml.d/50-rancher.yaml\"}]}"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mp := newMockPlanner(t, InfoFunctions{
+				SystemAgentImage: func() string { return "system-agent" },
+				ImageResolver:    image.ResolveWithControlPlane,
+			})
+
+			n, e := SecretToNode(tt.inputSecret)
+			assert.NoError(t, e)
+			tt.entry.Plan = n
+			isc := tt.inputSecret.DeepCopy()
+			tt.entry.Metadata = &plan.Metadata{
+				Labels:      isc.Labels,
+				Annotations: isc.Annotations,
+			}
+
+			// if `tt.updatedSecret` is not nil, we expect that `setMachineJoinURL` is going to perform an update of the secret to set the join URL
+			if tt.updatedSecret != nil {
+				mp.secretClient.EXPECT().Get(tt.inputSecret.Namespace, tt.inputSecret.Name, metav1.GetOptions{}).Return(tt.inputSecret, nil)
+				mp.secretClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(secret *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, tt.updatedSecret, secret)
+					return secret, nil
+				}).AnyTimes()
+			}
+
+			err := mp.planner.store.setMachineJoinURL(tt.entry, tt.capiCluster, tt.controlPlane)
+			if tt.updatedSecret == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, generic.ErrSkip, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/46441

## Original Issue: 
https://github.com/rancher/rancher/issues/42856
 
## Problem
In certain cases, it is possible to encounter errors as the join URL annotation was added to a later version of Rancher. If the join URL was not already set on the plan secret, the planner may error out.

## Solution
Set the join URL on loading the plan.
 
## Testing

## Engineering Testing
### Manual Testing
Ran through the test case

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
I attempted to cover regression potential with the unit test cases I added.