### PR TITLE
[release/v2.8] Use correct order-of-operations when performing certificate rotation of K3s/RKE2 clusters

### DIFF
--- a/pkg/capr/planner/certificaterotation.go
+++ b/pkg/capr/planner/certificaterotation.go
@@ -27,7 +27,10 @@ func (p *Planner) rotateCertificates(controlPlane *rkev1.RKEControlPlane, status
 		return status, nil
 	}
 
-	for _, node := range collect(clusterPlan, anyRole) {
+	// Assemble our list of nodes in order of etcd-only, etcd with controlplane, controlplane-only, and everything else
+	orderedEntriesToRotate := collectOrderedCertificateRotationEntries(clusterPlan)
+
+	for _, node := range orderedEntriesToRotate {
 		if !shouldRotateEntry(controlPlane.Spec.RotateCertificates, node) {
 			continue
 		}
@@ -53,6 +56,14 @@ func (p *Planner) rotateCertificates(controlPlane *rkev1.RKEControlPlane, status
 
 	status.CertificateRotationGeneration = controlPlane.Spec.RotateCertificates.Generation
 	return status, errWaiting("certificate rotation done")
+}
+
+func collectOrderedCertificateRotationEntries(clusterPlan *plan.Plan) []*planEntry {
+	orderedEntriesToRotate := collect(clusterPlan, IsOnlyEtcd)                                                        // etcd or etcd + worker
+	orderedEntriesToRotate = append(orderedEntriesToRotate, collect(clusterPlan, roleAnd(isControlPlane, isEtcd))...) // etcd + controlplane or etcd + controlplane+worker
+	orderedEntriesToRotate = append(orderedEntriesToRotate, collect(clusterPlan, isOnlyControlPlane)...)              // controlplane or controlplane + worker
+	orderedEntriesToRotate = append(orderedEntriesToRotate, collect(clusterPlan, isOnlyWorker)...)                    // worker
+	return orderedEntriesToRotate
 }
 
 // shouldRotate `true` if the cluster is ready and the generation is stale
@@ -88,6 +99,11 @@ func (p *Planner) rotateCertificatesPlan(controlPlane *rkev1.RKEControlPlane, to
 		rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentRestartInstructions("certificate-rotation/restart", strconv.FormatInt(rotation.Generation, 10), capr.GetRuntimeAgentUnit(controlPlane.Spec.KubernetesVersion))...)
 		return rotatePlan, joinedServer, nil
 	}
+
+	rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentStopInstruction(
+		"certificate-rotation/stop",
+		strconv.FormatInt(rotation.Generation, 10),
+		capr.GetRuntimeServerUnit(controlPlane.Spec.KubernetesVersion)))
 
 	args := []string{
 		"certificate",

--- a/pkg/capr/planner/idempotent.go
+++ b/pkg/capr/planner/idempotent.go
@@ -114,3 +114,18 @@ func idempotentRestartInstructions(identifier, value, runtimeUnit string) []plan
 		),
 	}
 }
+
+// idempotentStopInstruction generates an idempotent stop instruction for the given runtimeUnit. It simply calls systemctl stop <runtime-unit>
+// identifier is expected to be a unique key for tracking, and value should be something like the generation of the attempt (and is what we track to determine whether we should run the instruction or not)
+func idempotentStopInstruction(identifier, value, runtimeUnit string) plan.OneTimeInstruction {
+	return idempotentInstruction(
+		identifier+"-stop",
+		value,
+		"systemctl",
+		[]string{
+			"stop",
+			runtimeUnit,
+		},
+		[]string{},
+	)
+}

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -47,12 +47,13 @@ eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "exp
 eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 
 if [ -z "${SOME_K8S_VERSION}" ]; then
+# Only set SOME_K8S_VERSION if it is empty -- for KDM provisioning tests, this value should already be populated
 # Get the last release for $DIST, which is usually the latest version or an experimental version.
 # Previously this would use channels, but channels no longer reflect the latest version since
 # https://github.com/rancher/rancher/issues/36827 has added appDefaults. We do not use appDefaults
 # here for simplicity's sake, as it requires semver parsing & matching. The last release should
 # be good enough for our needs.
-export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.8/data/data.json | jq -r ".$DIST.releases[-1].version")
+  export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.8/data/data.json | jq -r ".$DIST.releases[-1].version")
 fi
 
 if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/46943

## Original Issue(s): 
https://github.com/rancher/rancher/issues/46034
Also, unpins RKE2 version pinned per https://github.com/rancher/rancher/issues/45577
 
## Problem
The original logic for certificate rotation would rotate certificates unsafely.

## Solution
This PR adds a correct order of operations and properly stops the K3s/RKE2 services on the nodes that are being rotated.

## Testing
## Engineering Testing
### Manual Testing
Perform certificate rotation

### Automated Testing
* Test types added/modified:
    * Unit
    
Summary: Added a new unit test to ensure full coverage of cluster configurations

## QA Testing Considerations

### Regressions Considerations