### PR TITLE
Display error output from dynamiclistener.Server

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -52,7 +52,7 @@ var (
 func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.Handler, bindHost string, httpsPort, httpPort int, acmeDomains []string, noCACerts bool) error {
 	restConfig = rest.CopyConfig(restConfig)
 	restConfig.Timeout = 10 * time.Minute
-	opts := &server.ListenOpts{DisplayServerLogs: true}
+	opts := &server.ListenOpts{}
 	var err error
 
 	core, err := core.NewFactoryFromConfig(restConfig)
@@ -70,6 +70,7 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 			return errors.Wrap(err, "failed to setup TLS listener")
 		}
 	}
+	opts.DisplayServerLogs = true
 
 	opts.BindHost = bindHost
 

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -52,7 +52,7 @@ var (
 func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.Handler, bindHost string, httpsPort, httpPort int, acmeDomains []string, noCACerts bool) error {
 	restConfig = rest.CopyConfig(restConfig)
 	restConfig.Timeout = 10 * time.Minute
-	opts := &server.ListenOpts{}
+	opts := &server.ListenOpts{DisplayServerLogs: true}
 	var err error
 
 	core, err := core.NewFactoryFromConfig(restConfig)

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -110,6 +110,7 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 		CANamespace:   namespace.System,
 		CertNamespace: namespace.System,
 		CertName:      "tls-rancher-internal",
+		DisplayServerLogs: true,
 	}
 	clusterIP, err := getClusterIP(core.Core().V1().Service())
 	if err != nil {


### PR DESCRIPTION
Related to issue https://github.com/rancher/rancher/issues/46956 (v2.10)

This change displays any error messages and panic output from the dynamic listener's http server in rancher's log output