### PR TITLE
[release-v2.7] GH Actions migration [small-fixes]

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -165,6 +165,8 @@ jobs:
           sudo rm -rf /usr/local/lib/android
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup TAG Variables
+        uses: ./.github/actions/setup-tag-env
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Migrating release/v2.7 to use Github Actions most up-to-date jobs.