### PR TITLE
fix: restore previous logic on providers/azure and providerrefresh pkgs

### DIFF
--- a/pkg/auth/providerrefresh/daemon.go
+++ b/pkg/auth/providerrefresh/daemon.go
@@ -36,14 +36,14 @@ func StartRefreshDaemon(ctx context.Context, scaledContext *config.ScaledContext
 
 }
 
-func UpdateRefreshCronTime(refreshCronTime string) error {
+func UpdateRefreshCronTime(refreshCronTime string) {
 	if ref == nil || refreshCronTime == "" {
-		return fmt.Errorf("refresh cron time must be provided")
+		return
 	}
 
 	parsed, err := ParseCron(refreshCronTime)
 	if err != nil {
-		return fmt.Errorf("parsing error: %v", err)
+		logrus.Errorf("%v", err)
 	}
 
 	c.Stop()
@@ -54,16 +54,14 @@ func UpdateRefreshCronTime(refreshCronTime string) error {
 		c.Schedule(parsed, job)
 		c.Start()
 	}
-	return nil
 }
 
-func UpdateRefreshMaxAge(maxAge string) error {
+func UpdateRefreshMaxAge(maxAge string) {
 	if ref == nil {
-		return fmt.Errorf("refresh max age must be provided")
+		return
 	}
 
 	ref.ensureMaxAgeUpToDate(maxAge)
-	return nil
 }
 
 func RefreshAllForCron() {

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -520,20 +520,19 @@ func samePrincipal(me v3.Principal, other v3.Principal) bool {
 }
 
 // UpdateGroupCacheSize attempts to update the size of the group cache defined at the package level.
-func UpdateGroupCacheSize(size string) error {
+func UpdateGroupCacheSize(size string) {
 	if size == "" {
-		return fmt.Errorf("azure-group-cache-size must be provided")
+		return
 	}
 
 	i, err := strconv.Atoi(size)
 	if err != nil {
-		return fmt.Errorf("error parsing azure-group-cache-size, skipping update %v", err)
+		return
 	}
 	if i < 0 {
-		return fmt.Errorf("azure-group-cache-size must be >= 0, skipping update")
+		return
 	}
 	clients.GroupCache.Resize(i)
-	return nil
 }
 
 func (ap *Provider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {

--- a/pkg/controllers/management/auth/setting.go
+++ b/pkg/controllers/management/auth/setting.go
@@ -53,7 +53,7 @@ func (c *SettingController) sync(key string, obj *v3.Setting) (runtime.Object, e
 		settings.DeleteInactiveUserAfter.Name,
 		settings.UserLastLoginDefault.Name:
 		if err := c.ensureUserRetentionLabels(); err != nil {
-			logrus.Errorf("error updating retention labels for users: %w", err)
+			logrus.Errorf("error updating retention labels for users: %v", err)
 		}
 	}
 	return nil, nil

--- a/pkg/controllers/management/auth/setting.go
+++ b/pkg/controllers/management/auth/setting.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	"github.com/rancher/rancher/pkg/auth/providers/azure"
@@ -11,15 +10,13 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const authSettingController = "mgmt-auth-settings-controller"
 
 type SettingController struct {
-	providerRefreshCronTime   func(string) error
-	providerRefreshMaxAge     func(string) error
-	azureUpdateGroupCacheSize func(string) error
 	ensureUserRetentionLabels func() error
 	scheduleUserRetention     func(string) error
 }
@@ -30,9 +27,6 @@ func newAuthSettingController(ctx context.Context, mgmt *config.ManagementContex
 	userRetentionLabeler := userretention.NewUserLabeler(ctx, mgmt.Wrangler)
 
 	return &SettingController{
-		providerRefreshCronTime:   providerrefresh.UpdateRefreshCronTime,
-		providerRefreshMaxAge:     providerrefresh.UpdateRefreshMaxAge,
-		azureUpdateGroupCacheSize: azure.UpdateGroupCacheSize,
 		ensureUserRetentionLabels: userRetentionLabeler.EnsureForAll,
 		scheduleUserRetention:     userRetentionDaemon.Schedule,
 	}
@@ -46,26 +40,20 @@ func (c *SettingController) sync(key string, obj *v3.Setting) (runtime.Object, e
 
 	switch obj.Name {
 	case settings.AuthUserInfoResyncCron.Name:
-		if err := c.providerRefreshCronTime(obj.Value); err != nil {
-			return nil, fmt.Errorf("error refreshing cron time: %v", err)
-		}
+		providerrefresh.UpdateRefreshCronTime(obj.Value)
 	case settings.AuthUserInfoMaxAgeSeconds.Name:
-		if err := c.providerRefreshMaxAge(obj.Value); err != nil {
-			return nil, fmt.Errorf("error refreshing max age: %v", err)
-		}
+		providerrefresh.UpdateRefreshMaxAge(obj.Value)
 	case settings.AzureGroupCacheSize.Name:
-		if err := c.azureUpdateGroupCacheSize(obj.Value); err != nil {
-			return nil, fmt.Errorf("error updating group cache size with azure: %v", err)
-		}
+		azure.UpdateGroupCacheSize(obj.Value)
 	case settings.UserRetentionCron.Name:
 		if err := c.scheduleUserRetention(obj.Value); err != nil {
-			return nil, fmt.Errorf("error scheduling user retention daemon: %v", err)
+			logrus.Errorf("error scheduling user retention daemon: %v", err)
 		}
 	case settings.DisableInactiveUserAfter.Name,
 		settings.DeleteInactiveUserAfter.Name,
 		settings.UserLastLoginDefault.Name:
 		if err := c.ensureUserRetentionLabels(); err != nil {
-			return nil, fmt.Errorf("error updating retention labels for users: %w", err)
+			logrus.Errorf("error updating retention labels for users: %w", err)
 		}
 	}
 	return nil, nil

--- a/pkg/controllers/management/auth/setting_test.go
+++ b/pkg/controllers/management/auth/setting_test.go
@@ -8,29 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestSettingsSyncWithEmptyAzureGroupCacheSize(t *testing.T) {
-	var azureGroupCacheSizeCalledTimes int
-	controller := &SettingController{
-		azureUpdateGroupCacheSize: func(_ string) error {
-			azureGroupCacheSizeCalledTimes++
-			return nil
-		},
-	}
-	name := settings.AzureGroupCacheSize.Name
-	t.Run(name, func(t *testing.T) {
-		_, err := controller.sync(name, &v3.Setting{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Value:      "",
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if want, got := 1, azureGroupCacheSizeCalledTimes; want != got {
-			t.Fatalf("Expected azureGroupCacheSizeCalledTimes: %d got %d", want, got)
-		}
-	})
-}
-
 func TestSettingsSyncEnsureUserRetentionLabels(t *testing.T) {
 	for _, name := range []string{
 		settings.DisableInactiveUserAfter.Name,
@@ -81,43 +58,5 @@ func TestSettingsSyncScheduleUserRetention(t *testing.T) {
 
 	if want, got := 1, scheduleRetentionCalledTimes; want != got {
 		t.Fatalf("Expected scheduleRetentionCalledTimes: %d got %d", want, got)
-	}
-}
-
-func TestSettingsSyncWithProviderRefresh(t *testing.T) {
-	// counter to ensure the providerrefresh are called during execution
-	var providerRefreshCalledTimes int
-	controller := &SettingController{
-		providerRefreshCronTime: func(_ string) error {
-			providerRefreshCalledTimes++
-			return nil
-		},
-		providerRefreshMaxAge: func(_ string) error {
-			providerRefreshCalledTimes++
-			return nil
-		},
-	}
-
-	for _, name := range []string{
-		settings.AuthUserInfoResyncCron.Name,
-		settings.AuthUserInfoMaxAgeSeconds.Name,
-	} {
-		t.Run(name, func(t *testing.T) {
-			// reset the value after each test run
-			defer func() {
-				providerRefreshCalledTimes = 0
-			}()
-
-			_, err := controller.sync(name, &v3.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: name},
-				Value:      "* * * * *",
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if want, got := 1, providerRefreshCalledTimes; want != got {
-				t.Fatalf("Expected providerRefreshCalledTimes: %d got %d", want, got)
-			}
-		})
 	}
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46970

## Problem
The recent changes in packages `pkg/auth/providers/azure` and `pkg/auth/providerrefresh/`  introduced the bug linked above.

## Solution
Revert the changes to restore the previous behavior.