### PR TITLE
[main] Bump Audit Log Image versions

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -76,3 +76,14 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+    Select correct auditLog image
+*/}}
+{{- define "auditLog_image" -}}
+  {{- if .Values.busyboxImage }}
+    {{- .Values.busyboxImage}}
+  {{- else }}
+    {{- .Values.auditLog.image.repository -}}:{{- .Values.auditLog.image.tag -}}
+  {{- end }}
+{{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -27,7 +27,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- printf "%s-%s" .Chart.Name .Chart.Version | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-# Render Values in configurationSnippet
+{{/*
+Render Values in configurationSnippet
+*/}}
 {{- define "configurationSnippet" -}}
   {{- tpl (.Values.ingress.configurationSnippet) . | nindent 6 -}}
 {{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -210,16 +210,8 @@ spec:
 {{- if eq .Values.auditLog.destination "sidecar" }}
   {{- if gt (int .Values.auditLog.level) 0 }}
       # Make audit logs available for Rancher log collector tools.
-      {{- if .Values.busyboxImage }}
-      - image: {{ .Values.busyboxImage}}
-      {{- else }}
-      - image: {{ .Values.auditLog.image.repository }}:{{.Values.auditLog.image.tag}}
-      {{- end }}
-      {{- if .Values.busyboxImagePullPolicy }}
-        imagePullPolicy: {{ .Values.busyboxImagePullPolicy }}
-      {{- else }}
-        imagePullPolicy: {{ .Values.auditLog.image.pullPolicy }}
-      {{- end }}
+      - image: {{ include "auditLog_image" . }}
+        imagePullPolicy: {{ default .Values.auditLog.image.pullPolicy .Values.busyboxImagePullPolicy }}
         name: {{ template "rancher.name" . }}-audit-log
         command: ["tail"]
         args: ["-F", "/var/log/auditlog/rancher-api-audit.log"]

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -70,7 +70,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[1].image
-      value: rancher/mirrored-bci-micro:15.4.14.3
+      value: rancher/mirrored-bci-micro:15.6.24.2
 - it: should override auditLog.image.repository value when auditLog.destination is sidecar and auditLog.level > 0 and both auditLog.image.repository and auditLog.image.tag are set
   set:
     auditLog:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -20,6 +20,16 @@
           "description": "auditLog.level must be a number 0-3; 0 to disable, 3 for most verbose"
         }
       }
+    },
+    "busyboxImage": {
+      "type": "string",
+      "description": "[DEPRECATED] This value is deprecated, use `auditLog.image.repository` & `auditLog.image.tag` instead.",
+      "deprecated": true
+    },
+    "busyboxImagePullPolicy": {
+      "type": "string",
+      "description": "[DEPRECATED] This value is deprecated, use `auditLog.image.pullPolicy` instead.",
+      "deprecated": true
     }
   },
   "required": [],

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5,6 +5,21 @@
       "type": ["string", "null"],
       "enum": ["strict", "system-store", "", null],
       "description": "agentTLSMode must be 'strict' or 'system-store' or null (defaults to system-store)"
+    },
+    "auditLog": {
+      "type": "object",
+      "properties": {
+        "destination": {
+          "type": "string",
+          "enum": ["sidecar", "hostPath"],
+          "description": "auditLog.destination must be either 'sidecar' or 'hostPath'"
+        },
+        "level": {
+          "type": "integer",
+          "enum": [0, 1, 2, 3],
+          "description": "auditLog.level must be a number 0-3; 0 to disable, 3 for most verbose"
+        }
+      }
     }
   },
   "required": [],

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,7 +23,7 @@ auditLog:
   # Important: update pkg/image/export/resolve.go when this default image is changed, so that it's reflected accordingly in rancher-images.txt generated for air-gapped setups.
   image:
     repository: "rancher/mirrored-bci-micro"
-    tag: 15.4.14.3
+    tag: 15.6.24.2
     # Override imagePullPolicy image
     # options: Always, Never, IfNotPresent
     pullPolicy: "IfNotPresent"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,11 +6,11 @@ additionalTrustedCAs: false
 antiAffinity: preferred
 topologyKey: kubernetes.io/hostname
 
-# Audit Logs https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
+# Audit Logs
+# Source: https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-api-audit-log
 # The audit log is piped to the console of the rancher-audit-log container in the rancher pod.
-# https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
-# destination stream to sidecar container console or hostPath volume
-# level: Verbosity of logs, 0 to 3. 0 is off 3 is a lot.
+# level: Verbosity of logs, 0 to 3. 0 is off, 3 most verbose.
+# Docs: https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-api-audit-log#audit-log-levels
 auditLog:
   destination: sidecar
   hostPath: /var/log/rancher/audit/

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -147,8 +147,8 @@ func setRequirementImages(osType OSType, imagesSet map[string]map[string]struct{
 	case Linux:
 		addSourceToImage(imagesSet, settings.ShellImage.Get(), coreLabel)
 		addSourceToImage(imagesSet, settings.MachineProvisionImage.Get(), coreLabel)
-		addSourceToImage(imagesSet, "rancher/mirrored-bci-busybox:15.4.11.2", coreLabel)
-		addSourceToImage(imagesSet, "rancher/mirrored-bci-micro:15.4.14.3", coreLabel)
+		addSourceToImage(imagesSet, "rancher/mirrored-bci-busybox:15.6.24.2", coreLabel)
+		addSourceToImage(imagesSet, "rancher/mirrored-bci-micro:15.6.24.2", coreLabel)
 	}
 }
 


### PR DESCRIPTION
## Issue: Security related bumps
 
## Problem
See title; using old BCI images for audit log
 
## Solution
Bump audit logs
 
## Testing
Install rancher and check the audit log image tag in use.

## Engineering Testing
### Manual Testing
Manually rendered via template command.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit - Helm unit tests updated as needed

## QA Testing Considerations
The primary concern here is just bumping the BCI image we're using.
I also added Scheme for values I touched - these improve user experience while editing values files.
 
### Regressions Considerations
Highly unlikely - auditLog sidecar simply `tail`'s the log. As long as the image still has tag it should work fine.