### PR TITLE
[Main] Update hardening action to include YAML and bash scripts

### DIFF
--- a/tests/v2/actions/hardening/k3s/audit.yaml
+++ b/tests/v2/actions/hardening/k3s/audit.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata

--- a/tests/v2/actions/hardening/rke1/account-update.sh
+++ b/tests/v2/actions/hardening/rke1/account-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+for namespace in $(kubectl get namespaces -A -o=jsonpath="{.items[*]['metadata.name']}"); do
+  echo -n "Patching namespace $namespace - "; 
+  kubectl patch serviceaccount default -n ${namespace} -p "$(cat account_update.yaml)"; 
+done

--- a/tests/v2/actions/hardening/rke1/account-update.yaml
+++ b/tests/v2/actions/hardening/rke1/account-update.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/tests/v2/actions/hardening/rke2/account-update.sh
+++ b/tests/v2/actions/hardening/rke2/account-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+for namespace in $(kubectl get namespaces -A -o=jsonpath="{.items[*]['metadata.name']}"); do
+  echo -n "Patching namespace $namespace - "
+  kubectl patch serviceaccount default -n ${namespace} -p "$(cat /var/lib/rancher/rke2/server/account-update.yaml)"
+done

--- a/tests/v2/actions/hardening/rke2/account-update.yaml
+++ b/tests/v2/actions/hardening/rke2/account-update.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When we first moved to shepherd, the `hardening` package initially maintained the YAML and bash scripts found in the `hardening` package. However, at that time, we did not consistently perform testing with hardened clusters. Hence, there was an issue with Jenkins in running the tests.

The workaround was to remove the YAML and bash scripts and run directly in the go file. This was always meant to be a temporary solution.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Revert back to the YAML and bash scripts now that `hardening` lives once again in rancher/rancher.
 
## Testing
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Jenkins runs will be provided to reviewers offline.