### PR TITLE
2.8 changing clusterrepo interval to 1h

### DIFF
--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	interval = 6 * time.Hour
+	interval = 1 * time.Hour
 )
 
 type repoHandler struct {


### PR DESCRIPTION
Changing the refresh interval to 1h to match with other Rancher releases