### PR TITLE
Bump to webhook v0.5.2-rc.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 104.0.1+up0.5.1
+webhookVersion: 104.0.2+up0.5.2-rc.1
 provisioningCAPIVersion: 104.0.0+up0.3.0
 cspAdapterMinVersion: 104.0.0+up4.0.0
 defaultShellVersion: rancher/shell:v0.2.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,5 +7,5 @@ const (
 	DefaultShellVersion     = "rancher/shell:v0.2.1"
 	FleetVersion            = "104.0.2+up0.10.2-rc.1"
 	ProvisioningCAPIVersion = "104.0.0+up0.3.0"
-	WebhookVersion          = "104.0.1+up0.5.1"
+	WebhookVersion          = "104.0.2+up0.5.2-rc.1"
 )


### PR DESCRIPTION
Related to 2.9 backport issue #46452 (for underlying issue #46381)