### PR TITLE
[main ] improve the quick script

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -10,6 +10,7 @@ COMMIT=$(git rev-parse --short HEAD)
 TAG="${TAG:-$(yq '.env.TAG | sub("-.*", "")' < .github/workflows/pull-request.yml)-${COMMIT}}"
 OS="${OS:-linux}"
 ARCH="${ARCH:-amd64}"
+REPO="${REPO:-rancher}"
 CATTLE_K3S_VERSION=$(grep -m1 'ENV CATTLE_K3S_VERSION' package/Dockerfile | awk '{print $3}')
 CATTLE_KDM_BRANCH=$(grep -m1 'ARG CATTLE_KDM_BRANCH=' package/Dockerfile | cut -d '=' -f2)
 RKE_VERSION=$(grep -m1 'github.com/rancher/rke' go.mod | awk '{print $2}')
@@ -18,38 +19,41 @@ if [[ -z "$RKE_VERSION" ]]; then
 fi
 CATTLE_RANCHER_WEBHOOK_VERSION=$(yq '.webhookVersion' < build.yaml)
 CATTLE_CSP_ADAPTER_MIN_VERSION=$(yq '.cspAdapterMinVersion' < build.yaml)
+CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=$(yq '.provisioningCAPIVersion' < build.yaml)
 CATTLE_FLEET_VERSION=$(yq '.fleetVersion' < build.yaml)
 
 # download airgap images and export it to a tarball
-curl -Lf https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-images.txt -o ./k3s-images.txt
+curl -Lf https://github.com/rancher/k3s/releases/download/"${CATTLE_K3S_VERSION}"/k3s-images.txt -o ./k3s-images.txt
 AIRGAP_IMAGES=$(grep -e 'docker.io/rancher/mirrored-pause' -e 'docker.io/rancher/mirrored-coredns-coredns' ./k3s-images.txt)
 xargs -n1 docker pull <<< "${AIRGAP_IMAGES}"
 xargs -n2 docker save -o ./k3s-airgap-images.tar <<< "${AIRGAP_IMAGES}"
 
 # download kontainer driver metadata
-curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json > ./data.json
+curl -sLf https://releases.rancher.com/kontainer-driver-metadata/"${CATTLE_KDM_BRANCH}"/data.json > ./data.json
 
 # start the builds
 docker buildx build \
   --build-arg VERSION="${TAG}" \
-  --build-arg ARCH=${ARCH} \
+  --build-arg ARCH="${ARCH}" \
+  --build-arg IMAGE_REPO="${REPO}" \
   --build-arg COMMIT="${COMMIT}" \
-  --build-arg RKE_VERSION=${RKE_VERSION} \
-  --build-arg CATTLE_RANCHER_WEBHOOK_VERSION=${CATTLE_RANCHER_WEBHOOK_VERSION} \
-  --build-arg CATTLE_CSP_ADAPTER_MIN_VERSION=${CATTLE_CSP_ADAPTER_MIN_VERSION} \
-  --build-arg CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION} \
-  --tag rancher/rancher:${TAG} \
+  --build-arg RKE_VERSION="${RKE_VERSION}" \
+  --build-arg CATTLE_RANCHER_WEBHOOK_VERSION="${CATTLE_RANCHER_WEBHOOK_VERSION}" \
+  --build-arg CATTLE_CSP_ADAPTER_MIN_VERSION="${CATTLE_CSP_ADAPTER_MIN_VERSION}" \
+  --build-arg CATTLE_FLEET_VERSION="${CATTLE_FLEET_VERSION}" \
+  --tag "${REPO}"/rancher:"${TAG}" \
   --platform="${OS}/${ARCH}" \
   --file ./package/Dockerfile .
 
 docker buildx build \
   --build-arg VERSION="${TAG}" \
-  --build-arg ARCH=${ARCH} \
-  --build-arg RANCHER_TAG=${TAG} \
-  --build-arg RANCHER_IMAGE=rancher/rancher:${TAG} \
+  --build-arg ARCH="${ARCH}" \
+  --build-arg RANCHER_TAG="${TAG}" \
+  --build-arg RANCHER_REPO="${REPO}" \
   --build-arg COMMIT="${COMMIT}" \
-  --build-arg RKE_VERSION=${RKE_VERSION} \
-  --build-arg CATTLE_RANCHER_WEBHOOK_VERSION=${CATTLE_RANCHER_WEBHOOK_VERSION} \
-  --tag rancher/rancher-agent:${TAG} \
+  --build-arg RKE_VERSION="${RKE_VERSION}" \
+  --build-arg CATTLE_RANCHER_WEBHOOK_VERSION="${CATTLE_RANCHER_WEBHOOK_VERSION}" \
+  --build-arg CATTLE_RANCHER_PROVISIONING_CAPI_VERSION="${CATTLE_RANCHER_PROVISIONING_CAPI_VERSION}" \
+  --tag "${REPO}"/rancher-agent:"${TAG}" \
   --platform="${OS}/${ARCH}" \
   --file ./package/Dockerfile.agent .

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -67,8 +67,10 @@ ENV LOGLEVEL_VERSION v0.1.6
 
 RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
 
-LABEL io.cattle.agent true
-ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
+LABEL io.cattle.agent=true
+
+ARG RANCHER_REPO=rancher
+ENV AGENT_IMAGE ${RANCHER_REPO}/rancher-agent:${VERSION}
 # For now, this value needs to be manually synced with the one in the main Dockerfile. This pins downstream webhook's version.
 ARG CATTLE_RANCHER_WEBHOOK_VERSION
 ENV CATTLE_RANCHER_WEBHOOK_VERSION=$CATTLE_RANCHER_WEBHOOK_VERSION


### PR DESCRIPTION
this PR enhances the quick script to allow setting the image repository during the build process, enabling Rancher to deploy the cluster agent with the correct image into the downstream cluster.  

Example usage: `REPO=my-repo make quick` 

The changes was validated in my local environment during development. 

