### PR TITLE
[v2.9] Bump RKE to `v1.6.2-rc.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.4.0
-	github.com/rancher/rke v1.6.2-rc1
+	github.com/rancher/rke v1.6.2-rc.2
 	github.com/rancher/steve v0.0.0-20240911190153-79304d93b49b
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde
 	github.com/rancher/wrangler v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1516,8 +1516,8 @@ github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVf
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa/go.mod h1:NP3xboG+t2p+XMnrcrJ/L384Ki0Cp3Pww/X+vm5Jcy0=
 github.com/rancher/remotedialer v0.4.0 h1:T9yC5bFMsZFVQ6rK0dNrRg6rRb6Zr/4vsig8S0IJ7ak=
 github.com/rancher/remotedialer v0.4.0/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
-github.com/rancher/rke v1.6.2-rc1 h1:+FnnNNy1Rb48/INMtT5WlxO8uNLLiHoMWdWL9axTh1w=
-github.com/rancher/rke v1.6.2-rc1/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
+github.com/rancher/rke v1.6.2-rc.2 h1:YB+v428/YqtLKiPX8tNgX4QRtTDdN06np+zDVRoEtmU=
+github.com/rancher/rke v1.6.2-rc.2/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
 github.com/rancher/shepherd v0.0.0-20240903171446-6af96d572144 h1:oaBiKdj95Vckp/sethMNdS/KGFhwAvKrs7UDtdgaJeE=
 github.com/rancher/shepherd v0.0.0-20240903171446-6af96d572144/go.mod h1:nVphr8v6qtXd0pth8wMCF9U5eKEPBIaD5+HQCH19uRw=
 github.com/rancher/steve v0.0.0-20240911190153-79304d93b49b h1:2DhkNKDgKPI2PcJRGacpJ9dX9SWgKuhwbz5GlpHS1No=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.10.0
 	github.com/rancher/gke-operator v1.9.2-rc.1
 	github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9
-	github.com/rancher/rke v1.6.2-rc1
+	github.com/rancher/rke v1.6.2-rc.2
 	github.com/rancher/wrangler/v3 v3.0.0
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.30.2

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -96,8 +96,8 @@ github.com/rancher/lasso v0.0.0-20240705194423-b2a060d103c1 h1:vv1jDlYbd4KhGbPNx
 github.com/rancher/lasso v0.0.0-20240705194423-b2a060d103c1/go.mod h1:A/y3BLQkxZXYD60MNDRwAG9WGxXfvd6Z6gWR/a8wPw8=
 github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9 h1:AlRMRs5mHJcdiK83KKJyFVeybPMZ7dOUzC0l3k9aUa8=
 github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9/go.mod h1:dyjfXBsNiroPWOdUZe7diUOUSLf6HQ/r2kEpwH/8zas=
-github.com/rancher/rke v1.6.2-rc1 h1:+FnnNNy1Rb48/INMtT5WlxO8uNLLiHoMWdWL9axTh1w=
-github.com/rancher/rke v1.6.2-rc1/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
+github.com/rancher/rke v1.6.2-rc.2 h1:YB+v428/YqtLKiPX8tNgX4QRtTDdN06np+zDVRoEtmU=
+github.com/rancher/rke v1.6.2-rc.2/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
 github.com/rancher/wrangler/v3 v3.0.0 h1:IHHCA+vrghJDPxjtLk4fmeSCFhNe9fFzLFj3m2B0YpA=
 github.com/rancher/wrangler/v3 v3.0.0/go.mod h1:Dfckuuq7MJk2JWVBDywRlZXMxEyPxHy4XqGrPEzu5Eg=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=

--- a/pkg/client/generated/management/v3/zz_generated_aci_network_provider.go
+++ b/pkg/client/generated/management/v3/zz_generated_aci_network_provider.go
@@ -106,6 +106,7 @@ const (
 	AciNetworkProviderFieldTenant                               = "tenant"
 	AciNetworkProviderFieldToken                                = "token"
 	AciNetworkProviderFieldTolerationSeconds                    = "tolerationSeconds"
+	AciNetworkProviderFieldUnknownMacUnicastAction              = "unknownMacUnicastAction"
 	AciNetworkProviderFieldUseAciAnywhereCRD                    = "useAciAnywhereCrd"
 	AciNetworkProviderFieldUseAciCniPriorityClass               = "useAciCniPriorityClass"
 	AciNetworkProviderFieldUseClusterRole                       = "useClusterRole"
@@ -224,6 +225,7 @@ type AciNetworkProvider struct {
 	Tenant                               string              `json:"tenant,omitempty" yaml:"tenant,omitempty"`
 	Token                                string              `json:"token,omitempty" yaml:"token,omitempty"`
 	TolerationSeconds                    string              `json:"tolerationSeconds,omitempty" yaml:"tolerationSeconds,omitempty"`
+	UnknownMacUnicastAction              string              `json:"unknownMacUnicastAction,omitempty" yaml:"unknownMacUnicastAction,omitempty"`
 	UseAciAnywhereCRD                    string              `json:"useAciAnywhereCrd,omitempty" yaml:"useAciAnywhereCrd,omitempty"`
 	UseAciCniPriorityClass               string              `json:"useAciCniPriorityClass,omitempty" yaml:"useAciCniPriorityClass,omitempty"`
 	UseClusterRole                       string              `json:"useClusterRole,omitempty" yaml:"useClusterRole,omitempty"`


### PR DESCRIPTION
## Update
* Bump RKE to `v1.6.2-rc.2`
* go generate