### PR TITLE
[Main] Enhance replace worker nodes to replace all cluster roles

### DIFF
--- a/tests/v2/actions/etcdsnapshot/config.go
+++ b/tests/v2/actions/etcdsnapshot/config.go
@@ -4,13 +4,19 @@ const (
 	ConfigurationFileKey = "snapshotInput"
 )
 
+type ReplaceRoles struct {
+	Etcd         bool `json:"etcd" yaml:"etcd"`
+	ControlPlane bool `json:"controlPlane" yaml:"controlPlane"`
+	Worker       bool `json:"worker" yaml:"worker"`
+}
+
 type Config struct {
-	UpgradeKubernetesVersion     string `json:"upgradeKubernetesVersion" yaml:"upgradeKubernetesVersion"`
-	SnapshotRestore              string `json:"snapshotRestore" yaml:"snapshotRestore"`
-	ControlPlaneConcurrencyValue string `json:"controlPlaneConcurrencyValue" yaml:"controlPlaneConcurrencyValue"`
-	ControlPlaneUnavailableValue string `json:"controlPlaneUnavailableValue" yaml:"controlPlaneUnavailableValue"`
-	WorkerConcurrencyValue       string `json:"workerConcurrencyValue" yaml:"workerConcurrencyValue"`
-	WorkerUnavailableValue       string `json:"workerUnavailableValue" yaml:"workerUnavailableValue"`
-	RecurringRestores            int    `json:"recurringRestores" yaml:"recurringRestores"`
-	ReplaceWorkerNode            bool   `json:"replaceWorkerNode" yaml:"replaceWorkerNode"`
+	UpgradeKubernetesVersion     string        `json:"upgradeKubernetesVersion" yaml:"upgradeKubernetesVersion"`
+	SnapshotRestore              string        `json:"snapshotRestore" yaml:"snapshotRestore"`
+	ControlPlaneConcurrencyValue string        `json:"controlPlaneConcurrencyValue" yaml:"controlPlaneConcurrencyValue"`
+	ControlPlaneUnavailableValue string        `json:"controlPlaneUnavailableValue" yaml:"controlPlaneUnavailableValue"`
+	WorkerConcurrencyValue       string        `json:"workerConcurrencyValue" yaml:"workerConcurrencyValue"`
+	WorkerUnavailableValue       string        `json:"workerUnavailableValue" yaml:"workerUnavailableValue"`
+	RecurringRestores            int           `json:"recurringRestores" yaml:"recurringRestores"`
+	ReplaceRoles                 *ReplaceRoles `json:"replaceRoles" yaml:"replaceRoles"`
 }

--- a/tests/v2/validation/snapshot/README.md
+++ b/tests/v2/validation/snapshot/README.md
@@ -24,6 +24,10 @@ snapshotInput:
   controlPlaneUnavailableValue: "1"
   workerUnavailableValue: "10%"
   recurringRestores: 1                # By default, this is set to 1 if this field is not included in the config.
+  replaceRoles:                       # If selected, S3 must be properly configured on the cluster. This test is specific to S3 etcd snapshots.
+    etcd: false
+    controlplane: false
+    worker: false
 ```
 
 Additionally, S3 is a supported restore option. If you choose to use S3, then you must have it already enabled on the downstream cluster.

--- a/tests/v2/validation/snapshot/snapshot.go
+++ b/tests/v2/validation/snapshot/snapshot.go
@@ -171,8 +171,8 @@ func snapshotRKE1(t *testing.T, client *rancher.Client, podTemplate corev1.PodTe
 	cluster, err := client.Management.Cluster.ByID(clusterID)
 	require.NoError(t, err)
 
-	if etcdRestore.ReplaceWorkerNode {
-		scaling.ReplaceRKE1Nodes(t, client, clusterName, false, false, true)
+	if etcdRestore.ReplaceRoles != nil && cluster.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig != nil {
+		scaling.ReplaceRKE1Nodes(t, client, clusterName, etcdRestore.ReplaceRoles.Etcd, etcdRestore.ReplaceRoles.ControlPlane, etcdRestore.ReplaceRoles.Worker)
 	}
 
 	podErrors := pods.StatusPods(client, clusterID)
@@ -276,8 +276,8 @@ func snapshotV2Prov(t *testing.T, client *rancher.Client, podTemplate corev1.Pod
 	cluster, _, err := clusters.GetProvisioningClusterByName(client, clusterName, namespace)
 	require.NoError(t, err)
 
-	if etcdRestore.ReplaceWorkerNode {
-		scaling.ReplaceNodes(t, client, clusterName, false, false, true)
+	if etcdRestore.ReplaceRoles != nil && cluster.Spec.RKEConfig.ETCD.S3 != nil {
+		scaling.ReplaceNodes(t, client, clusterName, etcdRestore.ReplaceRoles.Etcd, etcdRestore.ReplaceRoles.ControlPlane, etcdRestore.ReplaceRoles.Worker)
 	}
 
 	podErrors := pods.StatusPods(client, clusterID)

--- a/tests/v2/validation/snapshot/snapshot_additional_test.go
+++ b/tests/v2/validation/snapshot/snapshot_additional_test.go
@@ -43,26 +43,32 @@ func (s *SnapshotAdditionalTestsTestSuite) SetupSuite() {
 	s.client = client
 }
 
-func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceWorkerNode() {
-	snapshotRestoreAll := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion: "",
-		SnapshotRestore:          "all",
-		RecurringRestores:        1,
-		ReplaceWorkerNode:        true,
-	}
-
-	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
-		UpgradeKubernetesVersion: "",
-		SnapshotRestore:          "kubernetesVersion",
-		RecurringRestores:        1,
-		ReplaceWorkerNode:        true,
-	}
-
-	snapshotRestoreNone := &etcdsnapshot.Config{
+func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceNodes() {
+	controlPlaneSnapshotRestore := &etcdsnapshot.Config{
 		UpgradeKubernetesVersion: "",
 		SnapshotRestore:          "none",
 		RecurringRestores:        1,
-		ReplaceWorkerNode:        true,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			ControlPlane: true,
+		},
+	}
+
+	etcdSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			Etcd: true,
+		},
+	}
+
+	workerSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			Worker: true,
+		},
 	}
 
 	tests := []struct {
@@ -70,9 +76,9 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceWorkerNode() {
 		etcdSnapshot *etcdsnapshot.Config
 		client       *rancher.Client
 	}{
-		{"Replace worker nodes and restore cluster config, Kubernetes version and etcd", snapshotRestoreAll, s.client},
-		{"Replace worker nodes and restore Kubernetes version and etcd", snapshotRestoreK8sVersion, s.client},
-		{"Replace worker nodes and restore etcd only", snapshotRestoreNone, s.client},
+		{"Replace control plane nodes", controlPlaneSnapshotRestore, s.client},
+		{"Replace etcd nodes", etcdSnapshotRestore, s.client},
+		{"Replace worker nodes", workerSnapshotRestore, s.client},
 	}
 
 	for _, tt := range tests {
@@ -113,9 +119,13 @@ func (s *SnapshotAdditionalTestsTestSuite) TestSnapshotReplaceWorkerNode() {
 			}
 		}
 
-		s.Run(tt.name, func() {
-			snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot, containerImage)
-		})
+		if strings.Contains(tt.name, "S3") {
+			s.Run(tt.name, func() {
+				snapshotRestore(s.T(), s.client, s.client.RancherConfig.ClusterName, tt.etcdSnapshot, containerImage)
+			})
+		} else {
+			s.T().Skip("Skipping test; only S3 enabled clusters are enabled for this test")
+		}
 	}
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Enhance snapshot_additional_test.go to allow any node role to be replaced, not just worker node role](https://github.com/rancher/qa-tasks/issues/1252)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The `snapshot_additional_test.go` currently has a function that will replace only worker nodes. This should be enhanced so that all roles in a cluster are replaced as that would be good to test. Additionally, since etcd nodes will be replaced, this test needs to be converted to S3 only as we need to save a copy of the snapshot that gets lost once you replace the etcd node.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Enhanced `TestSnapshotReplaceNodes` to replace control plane, etcd and worker nodes, not just worker nodes. Additionally, enhanced this test to be an S3-only test so that we save the snapshot in cloud storage, not just in local storage.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Automated Testing
Jenkins jobs will be provided to reviewers offline.