### PR TITLE
fix(authprovisioningv2): only add finalizers to necessary RBAC resources

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -16,7 +16,9 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	apiextcontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	rbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/gvk"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -94,10 +96,10 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 	clients.Mgmt.RoleTemplate().OnChange(ctx, "auth-prov-v2-roletemplate", h.OnChange)
 	clients.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-crtb", h.OnCRTB)
 	clients.Mgmt.ProjectRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-prtb", h.OnPRTB)
-	clients.RBAC.Role().OnRemove(ctx, "auth-prov-v2-role", h.OnRemoveRole)
-	clients.RBAC.RoleBinding().OnRemove(ctx, "auth-prov-v2-rb", h.OnRemoveRoleBinding)
-	clients.RBAC.ClusterRole().OnRemove(ctx, "auth-prov-v2-crole", h.OnRemoveClusterRole)
-	clients.RBAC.ClusterRoleBinding().OnRemove(ctx, "auth-prov-v2-crb", h.OnRemoveClusterRoleBinding)
+	scopedOnRemove(ctx, "auth-prov-v2-role", clients.RBAC.Role(), h.OnRemoveRole)
+	scopedOnRemove(ctx, "auth-prov-v2-rb", clients.RBAC.RoleBinding(), h.OnRemoveRoleBinding)
+	scopedOnRemove(ctx, "auth-prov-v2-crole", clients.RBAC.ClusterRole(), h.OnRemoveClusterRole)
+	scopedOnRemove(ctx, "auth-prov-v2-crb", clients.RBAC.ClusterRoleBinding(), h.OnRemoveClusterRoleBinding)
 	clients.Provisioning.Cluster().OnChange(ctx, "auth-prov-v2-cluster", h.OnCluster)
 	clients.CRD.CustomResourceDefinition().OnChange(ctx, "auth-prov-v2-crd", h.OnCRD)
 	if features.RKE2.Enabled() {
@@ -110,4 +112,16 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 		return []string{obj.RoleTemplateName}, nil
 	})
 	return nil
+}
+
+func scopedOnRemove[T generic.RuntimeMetaObject](ctx context.Context, name string, c generic.ControllerMeta, sync generic.ObjectHandler[T]) {
+	condition := isProtectedRBACResource
+	onRemoveHandler := generic.NewRemoveHandler(name, c.Updater(), generic.FromObjectHandlerToHandler(sync))
+	c.AddGenericHandler(ctx, name, func(key string, obj runtime.Object) (runtime.Object, error) {
+		if !condition(obj) {
+			// ignore
+			return obj, nil
+		}
+		return onRemoveHandler(key, obj)
+	})
 }

--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -115,13 +115,11 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 }
 
 func scopedOnRemove[T generic.RuntimeMetaObject](ctx context.Context, name string, c generic.ControllerMeta, sync generic.ObjectHandler[T]) {
-	condition := isProtectedRBACResource
 	onRemoveHandler := generic.NewRemoveHandler(name, c.Updater(), generic.FromObjectHandlerToHandler(sync))
 	c.AddGenericHandler(ctx, name, func(key string, obj runtime.Object) (runtime.Object, error) {
-		if !condition(obj) {
-			// ignore
-			return obj, nil
+		if isProtectedRBACResource(obj) {
+			return onRemoveHandler(key, obj)
 		}
-		return onRemoveHandler(key, obj)
+		return obj, nil
 	})
 }

--- a/pkg/controllers/management/authprovisioningv2/role.go
+++ b/pkg/controllers/management/authprovisioningv2/role.go
@@ -167,6 +167,30 @@ func (h *handler) OnChange(key string, rt *v3.RoleTemplate) (*v3.RoleTemplate, e
 	return rt, nil
 }
 
+func isProtectedRBACResource(obj runtime.Object) bool {
+	var isClusterRole bool
+	switch obj.(type) {
+	case *rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding:
+		isClusterRole = true
+	}
+
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return false
+	}
+	annotations := m.GetAnnotations()
+
+	if _, ok := annotations[clusterNameLabel]; !ok {
+		return false
+	}
+
+	if _, ok := annotations[clusterNamespaceLabel]; !ok && !isClusterRole {
+		return false
+	}
+
+	return true
+}
+
 func (h *handler) hasAnnotationsForDeletingCluster(annotations map[string]string, isClusterRole bool) (bool, error) {
 	clusterName, cOK := annotations[clusterNameLabel]
 	clusterNamespace, cnOK := annotations[clusterNamespaceLabel]


### PR DESCRIPTION
## Issue: #47045
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Using `OnRemove`  adds a finalizer to all the resources for the specific kind. Currently, this Rancher component does that for `Role`, `RoleBinding`, `ClusterRole` and `ClusterRoleBinding` kinds, but later it will skip some of them depending on certain annotations being present.
This creates unnecessary activity, or even a conflict if resources owned by another controller try to fight for the same resource (see https://github.com/tigera/operator/issues/3480).

## Solution
At the moment, `wrangler` does not allow for specifying a smaller granularity, so I've added a pre-condition to the `NewRemoveHandler` and used `AddGenericHandler` directly.

The condition func was extracted from the existing validation being performed (see `hasAnnotationsForDeletingCluster`).
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

I've confirmed that after removing finalizers from an existing resource:
```
kubectl patch clusterrolebinding/system:node --type=json -p '[{"op": "remove", "path": "/metadata/finalizers"}]'
```
Rancher does not to add it back.

However, adding the annotation used for the validation:
```
kubectl annotate clusterrolebinding/system:node cluster.cattle.io/name=local
```
triggers the addition of the finalizer:
```
  finalizers:
  - wrangler.cattle.io/auth-prov-v2-crb
```

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
