### PR TITLE
[main] Block provisioning if release data is not found for a CAPR cluster

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -205,6 +205,9 @@ func GetKDMReleaseData(ctx context.Context, controlPlane *rkev1.RKEControlPlane)
 		return nil
 	}
 	release := channelserver.GetReleaseConfigByRuntimeAndVersion(ctx, GetRuntime(controlPlane.Spec.KubernetesVersion), controlPlane.Spec.KubernetesVersion)
+	if len(release.ServerArgs) == 0 || len(release.AgentArgs) == 0 {
+		return nil
+	}
 	return &release
 }
 

--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -91,7 +91,9 @@ func addUserConfig(config map[string]interface{}, controlPlane *rkev1.RKEControl
 		}
 	}
 
-	filterConfigData(config, controlPlane, entry)
+	if err := filterConfigData(config, controlPlane, entry); err != nil {
+		return err
+	}
 
 	// "data-dir" is explicitly not added to KDM for filtering because it is mapped to a field in the provisioning cluster
 	// CRD. While technically possible to add feature gates and update KDM, there is nothing to be gained from such an

--- a/pkg/capr/planner/filter.go
+++ b/pkg/capr/planner/filter.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/rancher/channelserver/pkg/model"
 	"github.com/rancher/norman/types/convert"
@@ -9,14 +10,14 @@ import (
 	"github.com/rancher/rancher/pkg/capr"
 )
 
-func filterConfigData(config map[string]interface{}, controlPlane *rkev1.RKEControlPlane, entry *planEntry) {
+func filterConfigData(config map[string]interface{}, controlPlane *rkev1.RKEControlPlane, entry *planEntry) error {
 	var (
 		isServer = isControlPlane(entry) || isEtcd(entry)
 		release  = capr.GetKDMReleaseData(context.TODO(), controlPlane)
 	)
 
 	if release == nil {
-		return
+		return fmt.Errorf("could not find release data")
 	}
 
 	for k, v := range config {
@@ -26,6 +27,7 @@ func filterConfigData(config map[string]interface{}, controlPlane *rkev1.RKECont
 			delete(config, k)
 		}
 	}
+	return nil
 }
 
 func filterField(isServer bool, k string, v interface{}, release model.Release) (interface{}, bool) {

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -226,7 +226,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 
 	releaseData := p.retrievalFunctions.ReleaseData(p.ctx, cp)
 	if releaseData == nil {
-		return status, errWaitingf("%s/%s: releaseData nil for version %s", cp.Namespace, cp.Name, cp.Spec.KubernetesVersion)
+		return status, errWaitingf("%s/%s: KDM release data is empty for %s", cp.Namespace, cp.Name, cp.Spec.KubernetesVersion)
 	}
 
 	capiCluster, err := capr.GetOwnerCAPICluster(cp, p.capiClusters)


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/47086

## Original Issue:
https://github.com/rancher/rancher/issues/46855
 
## Problem
There was no effective mechanism for determining release data validity for CAPR clusters. 

## Solution
This blocks provisioning from delivering bad configurations if release data is not available for a given version.
 
## Testing

## Engineering Testing
### Manual Testing
1. Provision a RKE2 (custom) cluster w/ Rancher v2.8.7
1. Upgrade Rancher to this version
1. Ensure that Rancher errors saying release data was invalid

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: Difficult to test across Rancher versions

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations

Existing / newly added automated tests that provide evidence there are no regressions:
