### PR TITLE
Fix spelling error in two error messages

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -505,7 +505,7 @@ func (p *Planner) renderFiles(controlPlane *rkev1.RKEControlPlane, entry *planEn
 						}
 						hash := sha256.Sum256(secret.Data[v.Key])
 						if v.Hash != "" && v.Hash != base64.StdEncoding.EncodeToString(hash[:]) {
-							return files, fmt.Errorf("secret %s does not cotain the expected content", secret.Name)
+							return files, fmt.Errorf("secret %s does not contain the expected content", secret.Name)
 						}
 						if v.Permissions != "" {
 							file.Permissions = v.Permissions
@@ -533,7 +533,7 @@ func (p *Planner) renderFiles(controlPlane *rkev1.RKEControlPlane, entry *planEn
 						}
 						hash := sha256.Sum256([]byte(configmap.Data[v.Key]))
 						if v.Hash != "" && v.Hash != base64.StdEncoding.EncodeToString(hash[:]) {
-							return files, fmt.Errorf("configmap %s does not cotain the expected content", configmap.Name)
+							return files, fmt.Errorf("configmap %s does not contain the expected content", configmap.Name)
 						}
 						if v.Permissions != "" {
 							file.Permissions = v.Permissions


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Two minor spelling errors inside error messages (cotain -> contain).
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Fixed the spelling.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
I do not believe any extra testing is needed.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
I do not believe any extra testing is needed as there are only very minor changes in text strings.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change

* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: Two minor spelling erros are fixed.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_