### PR TITLE
Impersonate ServiceAccount on downstream clusters

### DIFF
--- a/pkg/auth/context/context.go
+++ b/pkg/auth/context/context.go
@@ -5,7 +5,11 @@ import "context"
 // saAuthenticatedContextKey is the context key for the SAAuthenticated flag.
 type saAuthenticatedContextKey struct{}
 
+// saImpersonationContextKey is the context key for the SA impersonation.
+type saImpersonationContextKey struct{}
+
 var saContextKey = saAuthenticatedContextKey{}
+var saImpersonationKey = saImpersonationContextKey{}
 
 // IsSAAuthenticated returns true if the SAAuthenticated flag is set in the context.
 func IsSAAuthenticated(ctx context.Context) bool {
@@ -16,4 +20,15 @@ func IsSAAuthenticated(ctx context.Context) bool {
 // SetSAAuthenticated sets the SAAuthenticated flag in the context.
 func SetSAAuthenticated(ctx context.Context) context.Context {
 	return context.WithValue(ctx, saContextKey, true)
+}
+
+// SetSAImpersonation sets the impersonated SA in the context.
+func SetSAImpersonation(ctx context.Context, impSA string) context.Context {
+	return context.WithValue(ctx, saImpersonationKey, impSA)
+}
+
+// GetSAImpersonation returns the impersonated SA from the context.
+func GetSAImpersonation(ctx context.Context) string {
+	impSA, _ := ctx.Value(saImpersonationKey).(string)
+	return impSA
 }

--- a/pkg/auth/requests/impersonate.go
+++ b/pkg/auth/requests/impersonate.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 
 	"github.com/rancher/rancher/pkg/auth/audit"
+	authcontext "github.com/rancher/rancher/pkg/auth/context"
 	"github.com/rancher/rancher/pkg/auth/requests/sar"
 	"github.com/rancher/steve/pkg/auth"
 	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	k8sUser "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
@@ -55,36 +57,47 @@ func (h *impersonatingAuth) Authenticate(req *http.Request) (k8sUser.Info, bool,
 	// impersonate a different user, verify the token user is authz to impersonate
 	if h.sar != nil {
 		if reqUser != "" && reqUser != user {
-			canDo, err := h.sar.UserCanImpersonateUser(req, user, reqUser)
-			if err != nil {
-				return nil, false, err
-			} else if !canDo {
-				return nil, false, errors.New("not allowed to impersonate user")
-			}
-			impersonateUser = true
-
-			for _, g := range reqGroup {
-				if slices.Contains(groups, g) {
-					//user belongs to the group they are trying to impersonate
-					continue
-				}
-				canDo, err := h.sar.UserCanImpersonateGroup(req, user, g)
+			if strings.HasPrefix(reqUser, serviceaccount.ServiceAccountUsernamePrefix) {
+				canDo, err := h.sar.UserCanImpersonateServiceAccount(req, user, reqUser)
 				if err != nil {
-					return nil, false, fmt.Errorf("error checking if user can impersonate group: %w", err)
+					return nil, false, err
 				} else if !canDo {
-					return nil, false, errors.New("not allowed to impersonate group")
+					return nil, false, errors.New("not allowed to impersonate service account")
 				}
-				impersonateGroup = true
-			}
-
-			if len(reqExtras) > 0 {
-				canDo, err := h.sar.UserCanImpersonateExtras(req, user, reqExtras)
+				// add impersonated SA to context
+				*req = *req.WithContext(authcontext.SetSAImpersonation(req.Context(), reqUser))
+			} else {
+				canDo, err := h.sar.UserCanImpersonateUser(req, user, reqUser)
 				if err != nil {
-					return nil, false, fmt.Errorf("error checking if user can impersonate extras: %w", err)
+					return nil, false, err
 				} else if !canDo {
-					return nil, false, errors.New("not allowed to impersonate extras")
+					return nil, false, errors.New("not allowed to impersonate user")
 				}
-				impersonateExtras = true
+				impersonateUser = true
+
+				for _, g := range reqGroup {
+					if slices.Contains(groups, g) {
+						//user belongs to the group they are trying to impersonate
+						continue
+					}
+					canDo, err := h.sar.UserCanImpersonateGroup(req, user, g)
+					if err != nil {
+						return nil, false, fmt.Errorf("error checking if user can impersonate group: %w", err)
+					} else if !canDo {
+						return nil, false, errors.New("not allowed to impersonate group")
+					}
+					impersonateGroup = true
+				}
+
+				if len(reqExtras) > 0 {
+					canDo, err := h.sar.UserCanImpersonateExtras(req, user, reqExtras)
+					if err != nil {
+						return nil, false, fmt.Errorf("error checking if user can impersonate extras: %w", err)
+					} else if !canDo {
+						return nil, false, errors.New("not allowed to impersonate extras")
+					}
+					impersonateExtras = true
+				}
 			}
 		}
 	}

--- a/pkg/auth/requests/impersonate.go
+++ b/pkg/auth/requests/impersonate.go
@@ -60,7 +60,7 @@ func (h *impersonatingAuth) Authenticate(req *http.Request) (k8sUser.Info, bool,
 			if strings.HasPrefix(reqUser, serviceaccount.ServiceAccountUsernamePrefix) {
 				canDo, err := h.sar.UserCanImpersonateServiceAccount(req, user, reqUser)
 				if err != nil {
-					return nil, false, err
+					return nil, false, fmt.Errorf("error checking if user can impersonate service account: %w", err)
 				} else if !canDo {
 					return nil, false, errors.New("not allowed to impersonate service account")
 				}
@@ -69,7 +69,7 @@ func (h *impersonatingAuth) Authenticate(req *http.Request) (k8sUser.Info, bool,
 			} else {
 				canDo, err := h.sar.UserCanImpersonateUser(req, user, reqUser)
 				if err != nil {
-					return nil, false, err
+					return nil, false, fmt.Errorf("error checking if user can impersonate another user: %w", err)
 				} else if !canDo {
 					return nil, false, errors.New("not allowed to impersonate user")
 				}

--- a/pkg/auth/requests/mocks/sar.go
+++ b/pkg/auth/requests/mocks/sar.go
@@ -48,7 +48,7 @@ func (mr *MockSubjectAccessReviewMockRecorder) UserCanImpersonateExtras(req, use
 }
 
 // UserCanImpersonateGroup mocks base method.
-func (m *MockSubjectAccessReview) UserCanImpersonateGroup(req *http.Request, user string, group string) (bool, error) {
+func (m *MockSubjectAccessReview) UserCanImpersonateGroup(req *http.Request, user, group string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserCanImpersonateGroup", req, user, group)
 	ret0, _ := ret[0].(bool)
@@ -60,6 +60,21 @@ func (m *MockSubjectAccessReview) UserCanImpersonateGroup(req *http.Request, use
 func (mr *MockSubjectAccessReviewMockRecorder) UserCanImpersonateGroup(req, user, group interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserCanImpersonateGroup", reflect.TypeOf((*MockSubjectAccessReview)(nil).UserCanImpersonateGroup), req, user, group)
+}
+
+// UserCanImpersonateServiceAccount mocks base method.
+func (m *MockSubjectAccessReview) UserCanImpersonateServiceAccount(req *http.Request, user, sa string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserCanImpersonateServiceAccount", req, user, sa)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UserCanImpersonateServiceAccount indicates an expected call of UserCanImpersonateServiceAccount.
+func (mr *MockSubjectAccessReviewMockRecorder) UserCanImpersonateServiceAccount(req, user, sa interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserCanImpersonateServiceAccount", reflect.TypeOf((*MockSubjectAccessReview)(nil).UserCanImpersonateServiceAccount), req, user, sa)
 }
 
 // UserCanImpersonateUser mocks base method.

--- a/pkg/auth/requests/sar/sar.go
+++ b/pkg/auth/requests/sar/sar.go
@@ -36,6 +36,7 @@ func NewSubjectAccessReview(getter SubjectAccessReviewClientGetter) SubjectAcces
 	}
 }
 
+// UserCanImpersonateUser checks if user can impersonate as impUser
 func (sar subjectAccessReview) UserCanImpersonateUser(req *http.Request, user, impUser string) (bool, error) {
 	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
 	if err != nil {
@@ -44,6 +45,7 @@ func (sar subjectAccessReview) UserCanImpersonateUser(req *http.Request, user, i
 	return sar.checkUserCanImpersonateUser(req.Context(), userContext, user, impUser)
 }
 
+// UserCanImpersonateGroup checks if user can impersonate as the group
 func (sar subjectAccessReview) UserCanImpersonateGroup(req *http.Request, user string, group string) (bool, error) {
 	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
 	if err != nil {
@@ -52,6 +54,7 @@ func (sar subjectAccessReview) UserCanImpersonateGroup(req *http.Request, user s
 	return sar.checkUserCanImpersonateGroup(req.Context(), userContext, user, group)
 }
 
+// UserCanImpersonateExtras checks if user can impersonate extras
 func (sar subjectAccessReview) UserCanImpersonateExtras(req *http.Request, user string, impExtras map[string][]string) (bool, error) {
 	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
 	if err != nil {
@@ -60,6 +63,7 @@ func (sar subjectAccessReview) UserCanImpersonateExtras(req *http.Request, user 
 	return sar.checkUserCanImpersonateExtras(req.Context(), userContext, user, impExtras)
 }
 
+// UserCanImpersonateServiceAccount checks if user can impersonate as the service account
 func (sar subjectAccessReview) UserCanImpersonateServiceAccount(req *http.Request, user string, sa string) (bool, error) {
 	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
 	if err != nil {

--- a/pkg/auth/util/common_util.go
+++ b/pkg/auth/util/common_util.go
@@ -10,6 +10,12 @@ var (
 	RequestKey = struct{}{}
 )
 
+// WriteError write the error message and the http status code in the ResponseWriter
+func WriteError(w http.ResponseWriter, httpStatus int, err error) {
+	w.WriteHeader(httpStatus)
+	w.Write([]byte(err.Error()))
+}
+
 // ReturnHTTPError handles sending out Error response
 // TODO Use the Norman API error framework instead
 func ReturnHTTPError(w http.ResponseWriter, r *http.Request, httpStatus int, errorMessage string) {

--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -59,18 +59,14 @@ var (
 	er = &errorResponder{}
 )
 
-type urlGetter func() (url.URL, error)
-
-type authGetter func() (string, error)
-
-type transportGetter func() (http.RoundTripper, error)
-
-type tokenCreator func(context.Context, ClusterContextGetter, string, string) (string, error)
-
-type impersonatorAccountTokenGetter func(user.Info, ClusterContextGetter, string) (string, error)
-
-type errorResponder struct {
-}
+type (
+	urlGetter                      func() (url.URL, error)
+	transportGetter                func() (http.RoundTripper, error)
+	tokenCreator                   func(context.Context, ClusterContextGetter, string, string) (string, error)
+	impersonatorAccountTokenGetter func(user.Info, ClusterContextGetter, string) (string, error)
+	errorResponder                 struct {
+	}
+)
 
 func (e *errorResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
 	w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/clusterrouter/proxy/proxy_server_test.go
+++ b/pkg/clusterrouter/proxy/proxy_server_test.go
@@ -2,18 +2,19 @@ package proxy
 
 import (
 	"context"
-	"github.com/pkg/errors"
-	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	auth "github.com/rancher/rancher/pkg/auth/context"
-	"github.com/stretchr/testify/assert"
 	"io"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/apiserver/pkg/endpoints/request"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/pkg/errors"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	auth "github.com/rancher/rancher/pkg/auth/context"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 func TestServeHTTP(t *testing.T) {

--- a/pkg/clusterrouter/proxy/proxy_server_test.go
+++ b/pkg/clusterrouter/proxy/proxy_server_test.go
@@ -1,0 +1,165 @@
+package proxy
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	auth "github.com/rancher/rancher/pkg/auth/context"
+	"github.com/stretchr/testify/assert"
+	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestServeHTTP(t *testing.T) {
+	tests := map[string]struct {
+		tokenCreator                   tokenCreator
+		impersonatorAccountTokenGetter impersonatorAccountTokenGetter
+		header                         http.Header
+		ctx                            func() context.Context
+		wantHeader                     http.Header
+		wantErr                        string
+	}{
+		"get impersonation token": {
+			header: map[string][]string{},
+			ctx: func() context.Context {
+				ctx := context.TODO()
+				return request.WithUser(ctx, &user.DefaultInfo{
+					Name: "user",
+					UID:  "user",
+				})
+			},
+			impersonatorAccountTokenGetter: func(_ user.Info, _ ClusterContextGetter, _ string) (string, error) {
+				return "fake-token", nil
+			},
+			wantHeader: map[string][]string{
+				"Authorization": {
+					"Bearer fake-token",
+				},
+			},
+			wantErr: "",
+		},
+		"impersonate sa": {
+			tokenCreator: func(_ context.Context, _ ClusterContextGetter, _ string, _ string) (string, error) {
+				return "fake-token", nil
+			},
+			header: map[string][]string{
+				"Impersonate-User":  {"user"},
+				"Impersonate-Group": {"group"},
+			},
+			ctx: func() context.Context {
+				ctx := context.TODO()
+				ctx = request.WithUser(ctx, &user.DefaultInfo{
+					Name: "user",
+					UID:  "user",
+				})
+
+				return auth.SetSAImpersonation(ctx, "system:serviceaccount:ns-test:sa")
+			},
+			wantHeader: map[string][]string{
+				"Authorization": {
+					"Bearer fake-token",
+				},
+			},
+			wantErr: "",
+		},
+		"get impersonation token - error": {
+			header: map[string][]string{},
+			ctx: func() context.Context {
+				ctx := context.TODO()
+				return request.WithUser(ctx, &user.DefaultInfo{
+					Name: "user",
+					UID:  "user",
+				})
+			},
+			impersonatorAccountTokenGetter: func(_ user.Info, _ ClusterContextGetter, _ string) (string, error) {
+				return "", errors.New("can't create token")
+			},
+			wantHeader: map[string][]string{},
+			wantErr:    "can't create token",
+		},
+		"impersonate sa - create token error": {
+			tokenCreator: func(ctx context.Context, getter ClusterContextGetter, s string, s2 string) (string, error) {
+				return "", errors.New("can't create token")
+			},
+			header: map[string][]string{},
+			ctx: func() context.Context {
+				ctx := context.TODO()
+				ctx = request.WithUser(ctx, &user.DefaultInfo{
+					Name: "user",
+					UID:  "user",
+				})
+
+				return auth.SetSAImpersonation(ctx, "system:serviceaccount:ns-test:sa")
+			},
+			wantHeader: map[string][]string{},
+			wantErr:    "can't create token",
+		},
+		"already authenticated with a serviceaccount token": {
+			header: map[string][]string{},
+			ctx: func() context.Context {
+				ctx := context.TODO()
+				ctx = request.WithUser(ctx, &user.DefaultInfo{
+					Name: "user",
+					UID:  "user",
+				})
+
+				return auth.SetSAAuthenticated(ctx)
+			},
+			wantHeader: map[string][]string{},
+			wantErr:    "",
+		},
+		"user not authenticated": {
+			header: map[string][]string{},
+			ctx: func() context.Context {
+				return context.TODO()
+			},
+			wantHeader: map[string][]string{},
+			wantErr:    "Unauthorized 401",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			r := RemoteService{
+				transport: func() (http.RoundTripper, error) {
+					return http.DefaultTransport, nil
+				},
+				url: func() (url.URL, error) {
+					return url.URL{}, nil
+				},
+				cluster: &v3.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+				tokenCreator:                   test.tokenCreator,
+				impersonatorAccountTokenGetter: test.impersonatorAccountTokenGetter,
+			}
+			req := &http.Request{
+				URL: &url.URL{
+					Path: "http://localhost",
+				},
+				Header: test.header,
+			}
+			req = req.WithContext(test.ctx())
+			rw := httptest.NewRecorder()
+
+			r.ServeHTTP(rw, req)
+
+			assert.Equal(t, test.wantHeader, req.Header)
+			if test.wantErr != "" {
+				bodyBytes, err := io.ReadAll(rw.Body)
+				assert.NoError(t, err)
+				assert.Contains(t, string(bodyBytes), test.wantErr)
+			}
+		})
+	}
+
+}

--- a/pkg/clusterrouter/proxy/proxy_server_test.go
+++ b/pkg/clusterrouter/proxy/proxy_server_test.go
@@ -28,8 +28,7 @@ func TestServeHTTP(t *testing.T) {
 		"get impersonation token": {
 			header: map[string][]string{},
 			ctx: func() context.Context {
-				ctx := context.TODO()
-				return request.WithUser(ctx, &user.DefaultInfo{
+				return request.WithUser(context.TODO(), &user.DefaultInfo{
 					Name: "user",
 					UID:  "user",
 				})


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41988
 
## Problem
Users can't impersonate `ServiceAccounts` on downstream clusters.
Impersonating users was done in https://github.com/rancher/rancher/pull/46968
 
## Solution
Allow users to impersonate `ServiceAccounts` on downstream clusters:
- Verify the user making the request have enough permissions to impersonate SA in the downstream cluster. Reject the request if the user doesn't have enough permissions.
- Get a token for the impersonated SA using the `TokenRequest` api.
- Use this token in the `Authorization` header.

## Testing

Unit tests added. Minor refactor in `proxy_server.go` in order to make it testable.

## Additional Info 

We were setting a `userInfo` with `system:cattle:error` or `system:unauthenticated` in the context of the request in the [ToMiddleware](https://github.com/rancher/steve/blob/main/pkg/auth/filter.go#L145) if the [Authenticate](https://github.com/rancher/rancher/blob/v2.9.1/pkg/auth/requests/impersonate.go#L56) method in `impersonateAuth` returned an error. Then we were always returning a generic 401 in the [authHeaderHandler](https://github.com/rancher/rancher/blob/v2.9.1/pkg/auth/requests/filter.go#L29) if the userInfo is `system:cattle:error` .

This PR uses new impersonate middleware (Handler) that directly returns the error, without setting the userInfo to `system:cattle:error`. This allow us to display error messages to the user.


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_