### PR TITLE
[v2.9] adding dynamic test for fleet + config entry for gitRepo in config

### DIFF
--- a/tests/v2/actions/fleet/fleet.go
+++ b/tests/v2/actions/fleet/fleet.go
@@ -11,11 +11,24 @@ import (
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	extensionsfleet "github.com/rancher/shepherd/extensions/fleet"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
+	"github.com/rancher/shepherd/pkg/config"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
+
+// The json/yaml config key for the corral package to be build ..
+const (
+	gitRepoConfigConfigurationFileKey = "gitRepo"
+)
+
+// GitRepoConfig is a function that reads in the gitRepo object from the config file
+func GitRepoConfig() *v1alpha1.GitRepo {
+	var gitRepo v1alpha1.GitRepo
+	config.LoadConfig(gitRepoConfigConfigurationFileKey, &gitRepo)
+	return &gitRepo
+}
 
 const (
 	DeploymentResourceSteveType = "apps.deployment"

--- a/tests/v2/validation/fleet/README.md
+++ b/tests/v2/validation/fleet/README.md
@@ -1,0 +1,46 @@
+# Fleet Integrations
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+2. [Public Repo Tests](#Public-Repo)
+
+## Getting Started
+Your GO suite should be set to `-run ^TestFleet<enter_test_name_here>TestSuite$`. You can find the correct suite name in the below README links, or by checking the test file you plan to run.
+In your config file, set the following:
+```yaml
+rancher:
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  cleanup: false
+  insecure: true/optional
+  cleanup: false/optional
+  clusterName: "your-cluster-name"
+```
+
+## Public Repo
+
+TestFleetPublicRepo/TestGitRepoDeployment
+
+There is no additional config for the static test. Simply input the clusterName you'd like the fleet GitRepo + resources deployed to. 
+The test will report the fleetVersion being used, and fail if gitRepo deployment fails or if resources via Steve don't come up properly. 
+
+## Dynamic Test
+
+TestFleetPublicRepo/TestDynamicGitRepoDeployment
+
+Add the following to the root level of the go config with your own parameters to run a test using your own GitRepo:
+```yaml
+gitRepo:
+  metadata:
+    name: "dynamic-test-1"
+    namespace: "fleet-default"
+  spec:
+    repo: https://github.com/rancher/fleet-examples
+    branch: master
+    paths:
+    - simple
+    imageScanCommit:
+      authorName: ""
+      authorEmail: ""
+    ForceSyncGeneration: 1
+```

--- a/tests/v2/validation/fleet/public_repo_test.go
+++ b/tests/v2/validation/fleet/public_repo_test.go
@@ -3,6 +3,8 @@
 package fleet
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -28,6 +30,7 @@ type FleetPublicRepoTestSuite struct {
 	suite.Suite
 	client             *rancher.Client
 	session            *session.Session
+	clusterID          string
 	provisioningConfig *provisioninginput.Config
 }
 
@@ -47,44 +50,56 @@ func (f *FleetPublicRepoTestSuite) SetupSuite() {
 	config.LoadConfig(provisioninginput.ConfigurationFileKey, userConfig)
 
 	f.provisioningConfig = userConfig
-}
 
-func (f *FleetPublicRepoTestSuite) TestGitRepoDeployment() {
-	defer f.session.Cleanup()
-
-	var clusterID string
-	var err error
 	clusterObject, _, _ := extensionscluster.GetProvisioningClusterByName(f.client, f.client.RancherConfig.ClusterName, "fleet-default")
 	if clusterObject != nil {
 		status := &provv1.ClusterStatus{}
 		err := steveV1.ConvertToK8sType(clusterObject.Status, status)
 		require.NoError(f.T(), err)
 
-		clusterID = status.ClusterName
-		logrus.Info(clusterID)
+		f.clusterID = status.ClusterName
 	} else {
-		clusterID, err = extensionscluster.GetClusterIDByName(f.client, f.client.RancherConfig.ClusterName)
+		f.clusterID, err = extensionscluster.GetClusterIDByName(f.client, f.client.RancherConfig.ClusterName)
 		require.NoError(f.T(), err)
 	}
 
-	podErrors := pods.StatusPods(f.client, clusterID)
+	podErrors := pods.StatusPods(f.client, f.clusterID)
 	require.Empty(f.T(), podErrors)
+}
+
+func (f *FleetPublicRepoTestSuite) TestGitRepoDeployment() {
+	defer f.session.Cleanup()
 
 	fleetVersion, err := fleet.GetDeploymentVersion(f.client, fleet.FleetControllerName, "local")
 	require.NoError(f.T(), err)
 
 	chartVersion, err := f.client.Catalog.GetLatestChartVersion("fleet", catalog.RancherChartRepo)
 	require.NoError(f.T(), err)
+
+	// fleet chart version may contain chart version info that is a superset of the version reported by the fleet deployment.
 	require.Contains(f.T(), chartVersion, fleetVersion[1:])
 
-	f.Run("/fleet "+fleetVersion, func() {
+	urlQuery, err := url.ParseQuery(fmt.Sprintf("labelSelector=%s=%s", "cattle.io/os", "windows"))
+	require.NoError(f.T(), err)
+
+	steveClient, err := f.client.Steve.ProxyDownstream(f.clusterID)
+	require.NoError(f.T(), err)
+
+	winsNodeList, err := steveClient.SteveType("node").List(urlQuery)
+	require.NoError(f.T(), err)
+
+	if len(winsNodeList.Data) > 0 {
+		fleetVersion += " windows"
+	}
+
+	f.Run("fleet "+fleetVersion, func() {
 		fleetGitRepo := v1alpha1.GitRepo{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "automatedrepo-" + namegenerator.RandStringLower(5),
 				Namespace: "fleet-default",
 			},
 			Spec: v1alpha1.GitRepoSpec{
-				Repo:                "https://github.com/rancher/fleet-examples", // "https://github.com/rancher/fleet-examplestypo",
+				Repo:                "https://github.com/rancher/fleet-examples",
 				Branch:              "master",
 				Paths:               []string{"simple"},
 				CorrectDrift:        &v1alpha1.CorrectDrift{},
@@ -94,6 +109,10 @@ func (f *FleetPublicRepoTestSuite) TestGitRepoDeployment() {
 			},
 		}
 
+		if len(winsNodeList.Data) > 0 {
+			fleetGitRepo.Spec.Paths = []string{"multi-cluster/windows-helm"}
+		}
+
 		f.client, err = f.client.ReLogin()
 		require.NoError(f.T(), err)
 
@@ -101,9 +120,44 @@ func (f *FleetPublicRepoTestSuite) TestGitRepoDeployment() {
 		gitRepoObject, err := extensionsfleet.CreateFleetGitRepo(f.client, &fleetGitRepo)
 		require.NoError(f.T(), err)
 
-		fleet.VerifyGitRepo(f.T(), f.client, gitRepoObject.ID, clusterID, "fleet-default/"+f.client.RancherConfig.ClusterName)
+		fleet.VerifyGitRepo(f.T(), f.client, gitRepoObject.ID, f.clusterID, "fleet-default/"+f.client.RancherConfig.ClusterName)
 
 	})
+}
+
+func (f *FleetPublicRepoTestSuite) TestDynamicGitRepoDeployment() {
+	defer f.session.Cleanup()
+
+	dynamicGitRepo := fleet.GitRepoConfig()
+	require.NotNil(f.T(), dynamicGitRepo)
+
+	if len(dynamicGitRepo.Spec.Targets) < 1 {
+		dynamicGitRepo.Spec.Targets = []v1alpha1.GitTarget{
+			{
+				ClusterName: f.client.RancherConfig.ClusterName,
+			},
+		}
+	}
+
+	fleetVersion, err := fleet.GetDeploymentVersion(f.client, fleet.FleetControllerName, "local")
+	require.NoError(f.T(), err)
+
+	chartVersion, err := f.client.Catalog.GetLatestChartVersion("fleet", catalog.RancherChartRepo)
+	require.NoError(f.T(), err)
+	require.Contains(f.T(), chartVersion, fleetVersion[1:])
+
+	f.client, err = f.client.ReLogin()
+	require.NoError(f.T(), err)
+
+	logrus.Info("Deploying dynamic gitRepo: ", dynamicGitRepo.ObjectMeta)
+	logrus.Info("Deploying dynamic gitRepo: ", dynamicGitRepo.Spec)
+
+	gitRepoObject, err := extensionsfleet.CreateFleetGitRepo(f.client, dynamicGitRepo)
+	require.NoError(f.T(), err)
+
+	// expects dynamicGitRepo.GitRepoSpec.Targets to include RancherConfig.ClusterName
+	fleet.VerifyGitRepo(f.T(), f.client, gitRepoObject.ID, f.clusterID, "fleet-default/"+f.client.RancherConfig.ClusterName)
+
 }
 
 // In order for 'go test' to run this suite, we need to create


### PR DESCRIPTION
port of https://github.com/rancher/rancher/pull/47008