### PR TITLE
Bump UI to v2.8.8-alpha2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -221,8 +221,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
 
-ENV CATTLE_UI_VERSION 2.8.7
-ENV CATTLE_DASHBOARD_UI_VERSION v2.8.7
+ENV CATTLE_UI_VERSION 2.8.8-alpha1
+ENV CATTLE_DASHBOARD_UI_VERSION v2.8.8-alpha1
 ENV CATTLE_CLI_VERSION v2.8.6
 
 


### PR DESCRIPTION
Bump UI to v2.8.8-alpha1
Releases:
https://github.com/rancher/dashboard/releases/tag/v2.8.8-alpha1
https://github.com/rancher/ui/releases/tag/v2.8.8-alpha1
Workflow runs:
https://github.com/rancher/dashboard/actions/runs/10854317939
https://github.com/rancher/ui/actions/runs/10854332967