### PR TITLE
Propagate annotations from management cluster to Fleet cluster

### DIFF
--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -156,6 +156,8 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 		labels["management.cattle.io/cluster-display-name"] = mgmtCluster.Spec.DisplayName
 	}
 
+	annotations := yaml.CleanAnnotationsForExport(mgmtCluster.Annotations)
+
 	agentNamespace := ""
 	clientSecret := status.ClientSecretName
 
@@ -191,9 +193,10 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 
 	return append(objs, &fleet.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name,
-			Namespace: mgmtCluster.Spec.FleetWorkspaceName,
-			Labels:    labels,
+			Name:        cluster.Name,
+			Namespace:   mgmtCluster.Spec.FleetWorkspaceName,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: fleet.ClusterSpec{
 			KubeConfigSecret:          clientSecret,


### PR DESCRIPTION
This replicates behavior which already exists for labels, for the sake of consistency and reducing the risk of confusion for users.

## Issue: https://github.com/rancher/fleet/issues/1584
 
## Problem
Editing a cluster in the UI, through `Cluster Management` then selecting `Edit Config` on a cluster enables a user to create, update or delete labels and annotations, among other fields, for a cluster.
While updates to labels would be visible on the corresponding Fleet cluster, such was not the case for annotations.

## Solution
Update the Fleet cluster provisioning controller to take annotations into account when creating a Fleet cluster, just as labels already are.

## Testing
## Engineering Testing
### Manual Testing
Tested reproduction steps on the UI (for a local cluster), with and without this patch.

### Automated Testing
* Test types added/modified:
    * Unit

## QA Testing Considerations
Test reproduction steps on downstream/imported cluster
 
### Regressions Considerations
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
* Unit tests for the Fleet cluster provisioning controller validate labels and annotations against expectations, based on labels and annotations which exist on the management cluster, taking filtering into account (ie keys starting with `kubectl.kubernetes.io/` or containing `cattle.io/`)