### PR TITLE
Wait for namespace to be fully deleted before removing entry in associated namespaced cluster role

### DIFF
--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -588,7 +588,7 @@ func (n *nsLifecycle) asyncCleanupRBAC(namespaceName string) {
 					err := n.reconcileNamespaceProjectClusterRole(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}})
 					if err != nil {
 						logrus.Errorf("error cleaning up RBAC for namespace %s: %v", namespaceName, err)
-						return false, err
+						return true, err
 					}
 					logrus.Debugf("successfully cleaned up RBAC for namespace %s", namespaceName)
 					return true, nil

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -7,11 +7,11 @@ import (
 
 	coreFakes "github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
 
-	"github.com/golang/mock/gomock"
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/api/rbac/v1"

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -3,7 +3,11 @@ package rbac
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	coreFakes "github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
+
+	"github.com/golang/mock/gomock"
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
@@ -13,6 +17,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
@@ -489,4 +494,104 @@ func (d *DummyIndexer) GetIndexers() cache.Indexers {
 
 func (d *DummyIndexer) AddIndexers(newIndexers cache.Indexers) error {
 	return nil
+}
+
+func TestAsyncCleanupRBAC_NamespaceDeleted(t *testing.T) {
+	tests := []struct {
+		name                  string
+		indexedRoles          []*rbacv1.ClusterRole
+		nsGetCalls            int
+		nsGetTerminatingCalls int
+	}{
+		{
+			name:                  "namespace already deleted",
+			nsGetCalls:            1,
+			nsGetTerminatingCalls: 0,
+		},
+		{
+			name:                  "namespace still terminating need to wait",
+			nsGetCalls:            2,
+			nsGetTerminatingCalls: 1,
+		},
+	}
+
+	namespaceName := "test-namespace"
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			timesCalled := 0
+			nsTerminatingCount := 0
+
+			namespaceListerMock := &coreFakes.NamespaceListerMock{
+				GetFunc: func(namespace string, name string) (*corev1.Namespace, error) {
+					timesCalled++
+					if nsTerminatingCount < test.nsGetTerminatingCalls {
+						nsTerminatingCount++
+						return &corev1.Namespace{
+							TypeMeta: metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-namespace",
+							},
+							Status: corev1.NamespaceStatus{
+								Phase: corev1.NamespaceTerminating,
+							},
+						}, nil
+					}
+					// indicate deleted namespace
+					return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+				},
+			}
+
+			indexedRoles := []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
+			}
+			indexer := DummyIndexer{
+				clusterRoles: map[string][]*rbacv1.ClusterRole{
+					namespaceName: indexedRoles,
+				},
+				err: nil,
+			}
+
+			fakeClusterRoles := &fakes.ClusterRoleInterfaceMock{
+				UpdateFunc: func(in *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+					return in, nil
+				},
+				DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+					return nil
+				},
+			}
+			fakeLister := &fakes.ClusterRoleListerMock{
+				GetFunc: func(namespace string, name string) (*rbacv1.ClusterRole, error) {
+					return &rbacv1.ClusterRole{}, nil
+				},
+			}
+			nsLifecycle := &nsLifecycle{
+				m: &manager{
+					nsLister:     namespaceListerMock,
+					crLister:     fakeLister,
+					crIndexer:    &indexer,
+					clusterRoles: fakeClusterRoles,
+				},
+			}
+
+			nsLifecycle.asyncCleanupRBAC(namespaceName)
+
+			waitForCondition(t, func() bool {
+				return timesCalled == test.nsGetCalls
+			}, 15*time.Second, time.Second)
+		})
+	}
+}
+
+func waitForCondition(t *testing.T, condition func() bool, timeout time.Duration, interval time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("condition not met within %v", timeout)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/43799
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The UI fails to remove a deleted namespace because as part of the finalizer for the namespace, we remove the RBAC required for the UI to see that the namespace has been removed.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
We now hold on to the RBAC until the namespace is fully deleted.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Manual and unit tests

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
As a cluster member (remember admins will always have the required RBAC and will not show the problem).  Create a namespace in a project.  Then delete that namespace.  Prior to this fix, the namespace would linger as "Terminating" in the UI until the page was refreshed.  After this fix, the namespace will be removed after a few seconds.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Unit tests added

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Nothing comes to mind, but it's worth making sure that this works for other user levels (admin, other cluster permissions where namespace deletion is allowed)

_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_