### PR TITLE
Update certificate issuer in test_certificate

### DIFF
--- a/tests/validation/tests/v3_api/test_certificate.py
+++ b/tests/validation/tests/v3_api/test_certificate.py
@@ -393,7 +393,7 @@ class TestCertificate:
                 name=cert_name, key=rancher_private_key,
                 certs=rancher_cert
             )
-            assert certificate_allns_valid.issuer == 'R3'
+            assert certificate_allns_valid.issuer == 'E6'
             # Delete the certificate
             p_client.delete(certificate_allns_valid)
 
@@ -424,7 +424,7 @@ class TestCertificate:
                 name=cert_name, key=rancher_private_key, certs=rancher_cert,
                 namespaceId=ns['name']
             )
-            assert certificate_valid.issuer == 'R3'
+            assert certificate_valid.issuer == 'E6'
             # Delete the certificate
             p_client.delete(certificate_valid)
 
@@ -728,7 +728,7 @@ def create_project_client(request):
         name="cert-valid", key=rancher_private_key, certs=rancher_cert,
         namespaceId=ns['name']
     )
-    assert certificate_valid.issuer == 'R3'
+    assert certificate_valid.issuer == 'E6'
 
     certificate_allns_valid = p_client.create_certificate(
         name="cert-all-ns-valid", key=rancher_private_key,


### PR DESCRIPTION
QA task: https://github.com/rancher/qa-tasks/issues/1545

test_certificate is currently failing due to an issuer mismatch error:
```
	failed on setup with "AssertionError: assert 'E6' == 'R3'
  - R3
  + E6"
	Stacktrace
	request = <SubRequest 'create_project_client' for <Function test_certificate_create_validcert_for_single_ns>>
	@pytest.fixture(scope='module', autouse="True")
    def create_project_client(request):
        client, cluster = get_user_client_and_cluster()
        create_kubeconfig(cluster)
        project, ns = create_project_and_ns(USER_TOKEN, cluster,
                                            project_name="test-certificate",
                                            ns_name="ns-certificate")
        p_client = get_project_client_for_token(project, USER_TOKEN)
        c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
        certificate_valid = p_client.create_namespaced_certificate(
            name="cert-valid", key=rancher_private_key, certs=rancher_cert,
            namespaceId=ns['name']
        )
>       assert certificate_valid.issuer == 'R3'
E       AssertionError: assert 'E6' == 'R3'
E         - R3
E         + E6
tests/v3_api/test_certificate.py:731: AssertionError
```
It appears that the issuer has changed from 'R3' to 'E6'- this change is causing the test to fail. Initially, certificates were issued by 'R3', but they are now being issued by 'E6'. This is part of how Let's Encrypt manages their certificates, rotating between different intermediates (like R3 and E6). Recently, it seems they began using 'E6' instead of 'R3'. Since it's normal for Let's Encrypt to rotate between different certificate authorities, the test should be updated to reflect this issuer change.
More details: https://letsencrypt.org/certificates/

Note: Back port and forward port PRs will be created once this gets approved
