### PR TITLE
[v2.9] Bump `rancher/cli` to v2.9.2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -231,7 +231,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.9.2-alpha3
 ENV CATTLE_DASHBOARD_UI_VERSION v2.9.2-alpha3
-ENV CATTLE_CLI_VERSION v2.9.0
+ENV CATTLE_CLI_VERSION v2.9.2
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -212,7 +212,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.9.0-alpha2
 ENV CATTLE_DASHBOARD_UI_VERSION v2.9.0-alpha6
-ENV CATTLE_CLI_VERSION v2.9.0
+ENV CATTLE_CLI_VERSION v2.9.2
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=


### PR DESCRIPTION
Bump `rancher/cli` to v2.9.2