### PR TITLE
[2.9] Adding oci repositories to the marketplace only works when specifying the full path to the chart

### DIFF
--- a/pkg/catalogv2/oci/client.go
+++ b/pkg/catalogv2/oci/client.go
@@ -319,7 +319,8 @@ func (o *Client) IsOrasRepository() (bool, error) {
 
 		err = repository.Tags(context.Background(), "", tagsFunc)
 		if err != nil {
-			if IsErrorCode(err, errcode.ErrorCodeNameUnknown) {
+			if IsErrorCode(err, errcode.ErrorCodeNameUnknown) ||
+				IsErrorMessage(err, "invalid repository name") {
 				return false, nil
 			}
 			return false, err
@@ -333,4 +334,10 @@ func (o *Client) IsOrasRepository() (bool, error) {
 func IsErrorCode(err error, code string) bool {
 	var ec errcode.Error
 	return errors.As(err, &ec) && ec.Code == code
+}
+
+// IsErrorMessage returns true if err is an Error and its message is found.
+func IsErrorMessage(err error, message string) bool {
+	var ec errcode.Error
+	return errors.As(err, &ec) && strings.Contains(ec.Message, message)
 }


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/47143

Please check the issue for more details 

### Summary 

- Adding additonal check "invalid repository name" to identify non oci repos for harbour registry since harbour works in a different manner. Google Registry and dockerhub work correctly and adding parent repos from these registries work as of now. 