### PR TITLE
[2.9] Remove helm3-charts library

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -122,7 +122,6 @@ ENV CATTLE_CSP_ADAPTER_MIN_VERSION=$CATTLE_CSP_ADAPTER_MIN_VERSION
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \
-    mkdir -p /var/lib/rancher-data/local-catalogs/helm3-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
     git clone -b $CATTLE_SYSTEM_CHART_DEFAULT_BRANCH --depth 1 https://github.com/rancher/system-charts /var/lib/rancher-data/local-catalogs/system-library && \
     # Temporarily clone from our GitHub's main repo, to avoid unnecessary load
@@ -134,8 +133,7 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     git clone -b $CATTLE_RKE2_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 && \
     # Revert the previous change in git.rancher.io from .gitconfig
     rm "${HOME}/.gitconfig" && \
-    git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library && \
-    git clone -b master --depth 1 https://github.com/rancher/helm3-charts /var/lib/rancher-data/local-catalogs/helm3-library
+    git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \

--- a/pkg/catalog/manager/catalog_sync.go
+++ b/pkg/catalog/manager/catalog_sync.go
@@ -33,7 +33,7 @@ func (m *Manager) Sync(key string, obj *v3.Catalog) (runtime.Object, error) {
 
 	// When setting SystemCatalog is set to bundled, always force our catalogs to keep running that way
 	if m.bundledMode {
-		if (catalog.Name == "helm3-library" || catalog.Name == "library" || catalog.Name == "system-library") && catalog.Spec.CatalogKind != helmlib.KindHelmInternal {
+		if (catalog.Name == "library" || catalog.Name == "system-library") && catalog.Spec.CatalogKind != helmlib.KindHelmInternal {
 			catalog.Spec.CatalogKind = helmlib.KindHelmInternal
 			catalog, err = m.catalogClient.Update(catalog)
 			if err != nil {

--- a/pkg/catalog/utils/utils.go
+++ b/pkg/catalog/utils/utils.go
@@ -87,7 +87,7 @@ func GetCatalogImageCacheName(catalogName string) string {
 func GetCatalogChartPath(catalog *v3.Catalog, bundledMode bool) (string, error) {
 	if bundledMode {
 		switch catalog.Name {
-		case "helm3-library", "library", "system-library":
+		case "library", "system-library":
 			return filepath.Join(helmlib.InternalCatalog, catalog.Name), nil
 		case "rancher-charts", "rancher-partner-charts", "rancher-rke2-charts":
 			return filepath.Join(helmlib.InternalCatalog, "v2", catalog.Name), nil

--- a/pkg/data/management/catalog_data.go
+++ b/pkg/data/management/catalog_data.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/catalog/utils"
 
-	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy/helm/common"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/helm"
 	"github.com/rancher/rancher/pkg/settings"
@@ -32,11 +31,6 @@ const (
 	systemLibraryBranch = "master"
 	systemLibraryName   = "system-library"
 	defSystemChartVer   = "management.cattle.io/default-system-chart-version"
-
-	helm3LibraryURL    = "https://git.rancher.io/helm3-charts"
-	helm3LibraryBranch = "master"
-	helm3LibraryName   = "helm3-library"
-	helm3HelmVersion   = common.HelmV3
 )
 
 // updateCatalogURL updates annotations if they are outdated and system catalog url/branch if it matches outdated defaults
@@ -134,14 +128,6 @@ func syncCatalogs(management *config.ManagementContext) error {
 				return nil
 			}
 			return doAddCatalogs(management, libraryName, libraryURL, libraryBranch, "", bundledMode)
-		},
-		// add helm3 charts
-		func() error {
-			// If running in bundled mode don't turn on the normal library by default
-			if bundledMode {
-				return nil
-			}
-			return doAddCatalogs(management, helm3LibraryName, helm3LibraryURL, helm3LibraryBranch, helm3HelmVersion, bundledMode)
 		},
 		// add system-charts
 		func() error {

--- a/tests/v2/actions/cli/cli.go
+++ b/tests/v2/actions/cli/cli.go
@@ -109,31 +109,3 @@ func DeleteNamespaces(client *ranchercli.Client, namespaceName, projectName stri
 
 	return nil
 }
-
-// CreateCatalogs will create and delete catalogs in the specified cluster.
-func CreateCatalogs(client *ranchercli.Client, catalogName string) error {
-	logrus.Infof("Creating a catalog...")
-	err := client.ExecuteCommand(rancher, catalog, "add", catalogName, "https://git.rancher.io/helm3-charts")
-	if err != nil {
-		return err
-	}
-
-	logrus.Infof("Validating the catalog exists...")
-	err = client.Exists(rancher, catalog, catalogName)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteCatalogs will delete catalogs in the specified cluster.
-func DeleteCatalogs(client *ranchercli.Client, catalogName string) error {
-	logrus.Infof("Deleting the catalog...")
-	err := client.Delete(catalog, catalogName)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -103,7 +103,6 @@ ENV CATTLE_CSP_ADAPTER_MIN_VERSION=$CATTLE_CSP_ADAPTER_MIN_VERSION
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \
-    mkdir -p /var/lib/rancher-data/local-catalogs/helm3-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
     git clone -b $CATTLE_SYSTEM_CHART_DEFAULT_BRANCH --depth 1 https://github.com/rancher/system-charts /var/lib/rancher-data/local-catalogs/system-library && \
     # Temporarily clone from our GitHub's main repo, to avoid unnecessary load
@@ -115,8 +114,7 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     git clone -b $CATTLE_RKE2_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 && \
     # Revert the previous change in git.rancher.io from .gitconfig
     rm "${HOME}/.gitconfig" && \
-    git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library && \
-    git clone -b master --depth 1 https://github.com/rancher/helm3-charts /var/lib/rancher-data/local-catalogs/helm3-library
+    git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \

--- a/tests/v2/validation/cli/cli_test.go
+++ b/tests/v2/validation/cli/cli_test.go
@@ -63,16 +63,6 @@ func (c *CLITestSuite) TestNamespaces() {
 	require.NoError(c.T(), err)
 }
 
-func (c *CLITestSuite) TestCatalog() {
-	var catalogName = namegen.AppendRandomString("catalog")
-
-	err := cli.CreateCatalogs(c.client.CLI, catalogName)
-	require.NoError(c.T(), err)
-
-	err = cli.DeleteCatalogs(c.client.CLI, catalogName)
-	require.NoError(c.T(), err)
-}
-
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestCLITestSuite(t *testing.T) {


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/47122

Please look into the issue for more details 

### Summary 

- Removing helm3-charts library since it is deprecated.