### PR TITLE
Change the way how configmap is fetched in integration test

### DIFF
--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -798,6 +798,9 @@ func (c *ClusterRepoTestSuite) testClusterRepoRetries(params ClusterRepoParams) 
 	require.NoError(c.T(), err)
 
 	downloadTime := cr.Status.DownloadTime
+
+	cr, err = c.catalogClient.ClusterRepos().Get(context.TODO(), cr.Name, metav1.GetOptions{})
+	require.NoError(c.T(), err)
 	cr.Spec.GitBranch = "main"
 	cr, err = c.catalogClient.ClusterRepos().Update(context.TODO(), cr, metav1.UpdateOptions{})
 	require.NoError(c.T(), err)


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/47088 

Please check the issue for more details 

### Summary 

Changing the way how we fetch configmap resouce. I couldn't reproduce the flaky test. So this PR is kind of a hunch removing uncertainities in the flaky part of the codebase.