### PR TITLE
Use defined verbs instead of `*` in "Manage Workloads" RoleTemplate

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -332,16 +332,23 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("").resources("namespaces").verbs("create")
 
 	rb.addRoleTemplate("Manage Workloads", "workloads-manage", "project", false, false, false).
-		addRule().apiGroups("").resources("pods", "pods/attach", "pods/exec", "pods/portforward", "pods/proxy", "replicationcontrollers",
-		"replicationcontrollers/scale").verbs("*").
-		addRule().apiGroups("apps").resources("daemonsets", "deployments", "deployments/rollback", "deployments/scale", "replicasets",
-		"replicasets/scale", "statefulsets", "statefulsets/scale").verbs("*").
-		addRule().apiGroups("autoscaling").resources("horizontalpodautoscalers").verbs("*").
-		addRule().apiGroups("batch").resources("cronjobs", "jobs").verbs("*").
+		addRule().
+		apiGroups("").
+		resources("pods", "pods/attach", "pods/exec", "pods/portforward", "pods/proxy", "replicationcontrollers", "replicationcontrollers/scale").
+		verbs("get", "list", "watch", "create", "delete", "deletecollection", "patch", "update").
+		addRule().
+		apiGroups("apps").
+		resources("daemonsets", "deployments", "deployments/scale", "replicasets", "replicasets/scale", "statefulsets", "statefulsets/scale").
+		verbs("get", "list", "watch", "create", "delete", "deletecollection", "patch", "update").
+		addRule().
+		apiGroups("apps").resources("deployments/rollback").verbs("create", "delete", "deletecollection", "patch", "update").
+		addRule().apiGroups("autoscaling").resources("horizontalpodautoscalers").verbs("get", "list", "watch", "create", "delete", "deletecollection", "patch", "update").
+		addRule().apiGroups("batch").resources("cronjobs", "jobs").verbs("get", "list", "watch", "create", "delete", "deletecollection", "patch", "update").
 		addRule().apiGroups("").resources("limitranges", "pods/log", "pods/status", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status", "bindings").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("*").
-		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("*").
-		rb.addRoleTemplate("View Workloads", "workloads-view", "project", false, false, false).
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("*")
+
+	rb.addRoleTemplate("View Workloads", "workloads-view", "project", false, false, false).
 		addRule().apiGroups("").resources("pods", "replicationcontrollers", "replicationcontrollers/scale").verbs("get", "list", "watch").
 		addRule().apiGroups("apps").resources("daemonsets", "deployments", "deployments/rollback", "deployments/scale", "replicasets",
 		"replicasets/scale", "statefulsets").verbs("get", "list", "watch").
@@ -349,8 +356,9 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("batch").resources("cronjobs", "jobs").verbs("get", "list", "watch").
 		addRule().apiGroups("").resources("limitranges", "pods/log", "pods/status", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status", "bindings").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("get", "list", "watch").
-		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("get", "list", "watch").
-		rb.addRoleTemplate("Manage Ingress", "ingress-manage", "project", false, false, false).
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("get", "list", "watch")
+
+	rb.addRoleTemplate("Manage Ingress", "ingress-manage", "project", false, false, false).
 		addRule().apiGroups("extensions").resources("ingresses").verbs("*").
 		addRule().apiGroups("networking.k8s.io").resources("ingresses").verbs("*")
 


### PR DESCRIPTION
Use defined verbs instead of `*` for some resources in the "Manage Workloads" RoleTemplate.

## Issue: #47000
 
## Problem

A Project Owner should be able to assign the Manage Workloads role template. This was not possible, because some of the permissions defined in the template where broader than the one inherited from the Kubernetes Admin role.

i.e. the Manage Workloads template is allowed to use any verbs (`*`) for the `pods` and others resources, while the Kubernetes Admin is restricted to some of them (`get`, `list`, `watch`, `create`, `delete`, `deletecollection`, `patch`, `update`).

 
## Solution

The implemented solution narrows the verbs to the same defined from the Kubernetes Admin.

| resource | old verbs | new verbs
|--------------|---------------|---------------
| `pods`, `pods/attach`, `pods/exec`, `pods/portforward`, `pods/proxy`, `replicationcontrollers`, `replicationcontrollers/scale` | * | `get`, `list`, `watch`, `create`, `delete`, `deletecollection`, `patch`, `update`
| `daemonsets`, `deployments`,  `deployments/scale`, `replicasets`, `replicasets/scale`, `statefulsets`, `statefulsets/scale` | * | `get`, `list`, `watch`, `create`, `delete`, `deletecollection`, `patch`, `update`
| `deployments/rollback` | * | `create`, `delete`, `deletecollection`, `patch`, `update`
| `horizontalpodautoscalers` | * | `get`, `list`, `watch`, `create`, `delete`, `deletecollection`, `patch`, `update`
| `cronjobs`,  `jobs` | * | `get`, `list`, `watch`, `create`, `delete`, `deletecollection`, `patch`, `update`

 
## Testing
Steps defined in the original issue are valid.

## Engineering Testing
### Manual Testing
Steps defined in the original issue.


## Considerations :warning:

This fix has possible consequences that will need to be reported in the Release Note: any custom Role Template that was inheriting the Manage Workloads template using **custom** verbs will need to be updated, specifying the used verbs, or adding the `*` to the impacted resources.