### PR TITLE
Sort ResourceNames in Role rules created from RoleTemplates

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/role.go
+++ b/pkg/controllers/management/authprovisioningv2/role.go
@@ -335,6 +335,7 @@ func (h *handler) getResourceNames(resourceMatch resourceMatch, cluster *v1.Clus
 		}
 		result = append(result, objMeta.GetName())
 	}
+	sort.Strings(result)
 	return result, nil
 }
 

--- a/pkg/controllers/management/authprovisioningv2/role_test.go
+++ b/pkg/controllers/management/authprovisioningv2/role_test.go
@@ -10,11 +10,13 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/api/rbac/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -297,6 +299,29 @@ func Test_OnRemoveClusterRoleBinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockIndexGetter []runtime.Object
+
+func (m mockIndexGetter) GetByIndex(schema.GroupVersionKind, string, string) ([]runtime.Object, error) {
+	return m, nil
+}
+
+func Test_getResourceNames_sorted(t *testing.T) {
+	objs := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "b3"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "c5"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "b4"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "a2"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "a1"}},
+	}
+	want := []string{"a1", "a2", "b3", "b4", "c5"}
+
+	got, err := getResourceNames(mockIndexGetter(objs), resourceMatch{}, &provisioningv1.Cluster{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, want, got)
 }
 
 func createNameAndNamespaceAnnotation(n string) map[string]string {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
I've observed some `role` objects being updated quite often. Using `kubectl get -w` I observed the only change was the order of the `resourceNames` inside the rules.
Since `wrangler`'s `apply` is being used, the update produced by previous applies trigger new reconciliation, possibly causing an endless update loop due to successive lists of resourceNames not being equal.
 
## Solution
Sort the names obtained from the result of `GetByIndex`, ensuring the result is stable.
 
## Testing
A small refactor was needed in order to add a unit tests (`dynamic.Controller` is not an interface so it can't be mocked).