### PR TITLE
Replace loglevel binary with small shell script

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -58,7 +58,6 @@ ENV CATTLE_MACHINE_VERSION v0.15.0-rancher116
 ENV CATTLE_K3S_VERSION v1.30.2+k3s2
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION v3.5.14
-ENV LOGLEVEL_VERSION v0.1.6
 ENV TINI_VERSION v0.18.0
 ENV TELEMETRY_VERSION v0.6.2
 ENV DOCKER_MACHINE_LINODE_VERSION v0.1.11
@@ -119,7 +118,6 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
-    curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -LO https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-amd64.zip && \
     unzip docker-machine-driver-linode_linux-amd64.zip -d /opt/drivers/management-state/bin && \
     mkdir -p /usr/share/rancher/ui/assets/ && \
@@ -318,6 +316,7 @@ COPY --chown=root:root --chmod=0755 \
      --from=images /src/k3s-airgap-images.tar /var/lib/rancher/k3s/agent/images/
 
 COPY --chown=root:root --chmod=0755 \
+        package/loglevel \
         package/entrypoint.sh \
         package/kustomize.sh \
         package/jailer.sh /usr/bin/

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -63,10 +63,6 @@ ENV KUBECTL_VERSION v1.27.10
 RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
-ENV LOGLEVEL_VERSION v0.1.6
-
-RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
-
 LABEL io.cattle.agent=true
 
 ARG RANCHER_REPO=rancher
@@ -80,7 +76,7 @@ ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
 COPY --from=rancher /usr/bin/tini /usr/bin/
 COPY --from=build /app/agent /usr/bin/
-COPY package/run.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
+COPY package/loglevel package/run.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
 
 LABEL "io.artifacthub.package.logo-url"="https://raw.githubusercontent.com/rancher/ui/master/public/assets/images/logos/welcome-cow.svg" \

--- a/package/loglevel
+++ b/package/loglevel
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+version="v0.2.0+shell0"
+socket_location="${LOG_SOCKET_LOCATION:-/tmp/log.sock}"
+curl_args=""
+
+function print_help {
+  cat <<EOF
+NAME:
+   loglevel - Dynamically change loglevel
+
+USAGE:
+   loglevel [global options] command [command options] [arguments...]
+
+VERSION:
+   $version
+
+COMMANDS:
+   help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --set value              Set loglevel
+   --socket-location value  (default: "/tmp/log.sock") [\$LOG_SOCKET_LOCATION]
+   --help, -h               show help
+   --version, -v            print the version
+EOF
+}
+
+function print_version {
+  echo "loglevel version $version"
+}
+
+while true; do
+  case "$1" in
+    --set )
+      curl_args="--data level=$2"
+      shift 2
+      ;;
+    --socket-location )
+      socket_location="$2"
+      shift 2
+      ;;
+    --help|help|-h|h )
+      print_help
+      exit 0
+      ;;
+    --version|-v)
+      print_version
+      exit 0
+      ;;
+    -* )
+      echo "Incorrect Usage. flag provided but not defined: $1"
+      echo
+      print_help
+      exit 1
+      ;;
+    * )
+      break
+      ;;
+  esac
+done
+
+set -x
+curl --no-progress-meter --fail-with-body --proxy "" --unix-socket "${socket_location}" http://unix/v1/loglevel $curl_args

--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -32,7 +32,6 @@ RUN $URL = 'https://dl.k8s.io/v1.25.12/kubernetes-client-windows-amd64.tar.gz'; 
     tar.exe -xzvf c:\kubernetes.tar.gz; \
     \
     Write-Host 'Complete.'
-# Need to support loglevel & kube-prompt
 # Move for PATH to work
 RUN Copy-Item -Path /wins.exe -Destination /Windows/
 RUN Copy-Item -Path /kubernetes/client/bin/kubectl.exe -Destination /Windows/

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -57,7 +57,6 @@ ENV CATTLE_MACHINE_VERSION v0.15.0-rancher116
 ENV CATTLE_K3S_VERSION v1.30.2+k3s2
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION v3.5.14
-ENV LOGLEVEL_VERSION v0.1.6
 ENV TINI_VERSION v0.18.0
 ENV TELEMETRY_VERSION v0.6.2
 ENV DOCKER_MACHINE_LINODE_VERSION v0.1.11
@@ -118,7 +117,6 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
-    curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -LO https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-amd64.zip && \
     unzip docker-machine-driver-linode_linux-amd64.zip -d /opt/drivers/management-state/bin && \
     mkdir -p /usr/share/rancher/ui/assets/ && \
@@ -318,6 +316,7 @@ COPY --chown=root:root --chmod=0755 \
      --from=images /src/k3s-airgap-images.tar /var/lib/rancher/k3s/agent/images/
 
 COPY --chown=root:root --chmod=0755 \
+        package/loglevel \
         package/entrypoint.sh \
         package/kustomize.sh \
         package/jailer.sh /usr/bin/

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -63,10 +63,6 @@ ENV KUBECTL_VERSION v1.27.10
 RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
-ENV LOGLEVEL_VERSION v0.1.6
-
-RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
-
 LABEL io.cattle.agent true
 ENV AGENT_IMAGE ${RANCHER_REPO}/rancher-agent:${VERSION}
 # For now, this value needs to be manually synced with the one in the main Dockerfile. This pins downstream webhook's version.
@@ -78,6 +74,6 @@ ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
 COPY --from=rancher /usr/bin/tini /usr/bin/
 COPY --from=build /app/agent /usr/bin/
-COPY package/run_agent.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
+COPY package/loglevel package/run_agent.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
 ENTRYPOINT ["run.sh"]

--- a/tests/v2/codecoverage/package/loglevel
+++ b/tests/v2/codecoverage/package/loglevel
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+version="v0.2.0+shell0"
+socket_location="${LOG_SOCKET_LOCATION:-/tmp/log.sock}"
+curl_args=""
+
+function print_help {
+  cat <<EOF
+NAME:
+   loglevel - Dynamically change loglevel
+
+USAGE:
+   loglevel [global options] command [command options] [arguments...]
+
+VERSION:
+   $version
+
+COMMANDS:
+   help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --set value              Set loglevel
+   --socket-location value  (default: "/tmp/log.sock") [\$LOG_SOCKET_LOCATION]
+   --help, -h               show help
+   --version, -v            print the version
+EOF
+}
+
+function print_version {
+  echo "loglevel version $version"
+}
+
+while true; do
+  case "$1" in
+    --set )
+      curl_args="--data level=$2"
+      shift 2
+      ;;
+    --socket-location )
+      socket_location="$2"
+      shift 2
+      ;;
+    --help|help|-h|h )
+      print_help
+      exit 0
+      ;;
+    --version|-v)
+      print_version
+      exit 0
+      ;;
+    -* )
+      echo "Incorrect Usage. flag provided but not defined: $1"
+      echo
+      print_help
+      exit 1
+      ;;
+    * )
+      break
+      ;;
+  esac
+done
+
+set -x
+curl --no-progress-meter --fail-with-body --proxy "" --unix-socket "${socket_location}" http://unix/v1/loglevel $curl_args


### PR DESCRIPTION
## Issue: SURE-8512
 
## Problem
The loglevel binary is built from a separate project that is essentially unmaintained: https://github.com/rancher/loglevel/blob/master/main.go

It serves very little purpose and is just a thin wrapper around a HTTP API presented via unix socket within the rancher container.
 
## Solution
Replace project and binary with shell script. Shell script should support the same CLI flags and env vars as the binary.
 
## Testing

Covered by tests

## Engineering Testing

### Manual Testing

Ran the script myself, seems to work

### Automated Testing
* Test types added/modified:
    * Integration (Go Framework)

## QA Testing Considerations
 
### Regressions Considerations

Existing / newly added automated tests that provide evidence there are no regressions:
