### PR TITLE
Temporarily comment out `AWS_RSA_KEY_NAME` and `AWS_SSH_RSA_KEY`

### DIFF
--- a/tests/v2/validation/Jenkinsfile.rc
+++ b/tests/v2/validation/Jenkinsfile.rc
@@ -76,8 +76,8 @@ node {
                           string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
                           string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
                           
-                          string(credentialsId: 'AWS_RSA_KEY_NAME', variable: 'AWS_RSA_KEY_NAME'),
-                          string(credentialsId: 'AWS_SSH_RSA_KEY', variable: 'AWS_SSH_RSA_KEY'),
+                          //string(credentialsId: 'AWS_RSA_KEY_NAME', variable: 'AWS_RSA_KEY_NAME'),
+                          //string(credentialsId: 'AWS_SSH_RSA_KEY', variable: 'AWS_SSH_RSA_KEY'),
 
                           string(credentialsId: 'RANCHER_VALID_TLS_CERT', variable: 'RANCHER_VALID_TLS_CERT'),
                           string(credentialsId: 'RANCHER_VALID_TLS_KEY', variable: 'RANCHER_VALID_TLS_KEY'),
@@ -125,7 +125,7 @@ node {
               config = config.replace('${AZURE_SUBSCRIPTION_ID}', env.AZURE_SUBSCRIPTION_ID)
 
               config = config.replace('${AWS_SSH_PEM_KEY}', env.AWS_SSH_KEY_NAME)
-              config = config.replace('${AWS_SSH_RSA_KEY}', env.AWS_SSH_RSA_KEY)
+              //config = config.replace('${AWS_SSH_RSA_KEY}', env.AWS_SSH_RSA_KEY)
               config = config.replace('${RANCHER_LINODE_ACCESSKEY}', env.RANCHER_LINODE_ACCESSKEY)
 
               if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The Jenkins POC environment is seeing an issue with `AWS_RSA_KEY_NAME` and `AWS_SSH_RSA_KEY` in the `Jenkinsfile.rc` file. From the Jenkins console output, it appears that that variable is the issue. Upon further investigation, Jenkins does not even store that variable.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. --> 
Temporarily commenting out the variables to see if this resolves the issue.