### PR TITLE
Bump UI to v2.9.2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -229,8 +229,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.9.2-rc1
-ENV CATTLE_DASHBOARD_UI_VERSION v2.9.2-rc1
+ENV CATTLE_UI_VERSION 2.9.2
+ENV CATTLE_DASHBOARD_UI_VERSION v2.9.2
 ENV CATTLE_CLI_VERSION v2.9.2
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install


### PR DESCRIPTION
Bump UI to v2.9.2
Releases:
https://github.com/rancher/dashboard/releases/tag/v2.9.2
https://github.com/rancher/ui/releases/tag/v2.9.2

Workflow runs:
https://github.com/rancher/dashboard/actions/runs/10946583875
https://github.com/rancher/ui/actions/runs/10946661299
