### PR TITLE
Bump Go to 1.23.4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ env:
   HOST_ARCH: amd64
   ARCH: amd64
   PYTHON_VERSION: '3.11'
-  GOLANG_VERSION: '1.22'
+  GOLANG_VERSION: '1.23'
   IMAGE: ${{ github.repository_owner }}/rancher
   IMAGE_AGENT: ${{ github.repository_owner }}/rancher-agent
   REPO: ${{ github.repository_owner }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       GOLANG_CI_LINT_VERSION: v1.54.2
       PYTHON_VERSION: '3.11'
-      GOLANG_VERSION: '1.22'
+      GOLANG_VERSION: '1.23'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,4 +1,4 @@
-FROM library/golang:1.22
+FROM library/golang:1.23
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG DAPPER_HOST_ARCH

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher
 
 go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.4
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.27 // for compatibilty with docker 20.10.x

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rancher
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.7
+toolchain go1.23.1
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.27 // for compatibilty with docker 20.10.x

--- a/hack/airgap/go.mod
+++ b/hack/airgap/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/airgap
 
 go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.4
 
 require (
 	github.com/containers/common v0.60.0

--- a/hack/airgap/go.mod
+++ b/hack/airgap/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/airgap
 
-go 1.22.5
+go 1.23.0
+
+toolchain go1.23.1
 
 require (
 	github.com/containers/common v0.60.0

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -233,7 +233,7 @@ ENV ETCD_UNSUPPORTED_ARCH ${ETCD_UNSUPPORTED_ARCH}
 
 
 # Enable exporting of the k3s images as part of the build process.
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS images
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS images
 
 ENV CATTLE_K3S_VERSION v1.31.1+k3s1
 
@@ -247,7 +247,7 @@ RUN go build -tags k3s_export -o export-images ./...
 RUN ./export-images -k3s-version ${CATTLE_K3S_VERSION} -output /src/k3s-airgap-images.tar
 
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS build
 ARG VERSION
 ARG COMMIT
 ARG RKE_VERSION

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -5,7 +5,7 @@ ARG RANCHER_IMAGE=${REGISTRY}/${RANCHER_REPO}/rancher:${RANCHER_TAG}
 ARG ARCH
 ARG VERSION=dev
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS build
 ARG VERSION=${VERSION}
 ARG CGO_ENABLED=0
 ARG TAGS="k8s"

--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -2,7 +2,7 @@ ARG SERVERCORE_VERSION
 ARG ARCH=amd64
 ARG VERSION=dev
 
-FROM library/golang:1.22 as build
+FROM library/golang:1.23 as build
 
 WORKDIR C:/app
 COPY . .

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/pkg/apis
 
 go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.4
 
 replace (
 	k8s.io/api => k8s.io/api v0.31.1

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rancher/pkg/apis
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.7
+toolchain go1.23.1
 
 replace (
 	k8s.io/api => k8s.io/api v0.31.1

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/pkg/client
 
 go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.4
 
 require (
 	github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rancher/pkg/client
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.7
+toolchain go1.23.1
 
 require (
 	github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab

--- a/pkg/codegen/buildconfig/main.go
+++ b/pkg/codegen/buildconfig/main.go
@@ -1,3 +1,6 @@
+// Turn off creation of Alias types, which break code generation.
+// This can be removed after migrating to k8s 1.32 code generators that are aware of the new type.
+// For more details see https://github.com/rancher/rancher/issues/47207
 //go:debug gotypesalias=0
 
 // This program generates a Go file containing a set of exported constants that represent

--- a/pkg/codegen/buildconfig/main.go
+++ b/pkg/codegen/buildconfig/main.go
@@ -1,8 +1,3 @@
-// Turn off creation of Alias types, which break code generation.
-// This can be removed after migrating to k8s 1.32 code generators that are aware of the new type.
-// For more details see https://github.com/rancher/rancher/issues/47207
-//go:debug gotypesalias=0
-
 // This program generates a Go file containing a set of exported constants that represent
 // configuration variables of Rancher at build-time.
 package main

--- a/pkg/codegen/buildconfig/main.go
+++ b/pkg/codegen/buildconfig/main.go
@@ -1,3 +1,5 @@
+//go:debug gotypesalias=0
+
 // This program generates a Go file containing a set of exported constants that represent
 // configuration variables of Rancher at build-time.
 package main

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -1,8 +1,9 @@
 // Turn off creation of Alias types, which break code generation.
 // This can be removed after migrating to k8s 1.32 code generators that are aware of the new type.
 // For more details see https://github.com/rancher/rancher/issues/47207
-//
 //go:debug gotypesalias=0
+
+// This program generates the code for the Rancher types and clients.
 package main
 
 import (

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -1,3 +1,4 @@
+//go:debug gotypesalias=0
 package main
 
 import (

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -1,3 +1,7 @@
+// Turn off creation of Alias types, which break code generation.
+// This can be removed after migrating to k8s 1.32 code generators that are aware of the new type.
+// For more details see https://github.com/rancher/rancher/issues/47207
+//
 //go:debug gotypesalias=0
 package main
 

--- a/tests/v2/codecoverage/Dockerfile.buildcodecoverage
+++ b/tests/v2/codecoverage/Dockerfile.buildcodecoverage
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 # Configure Go
 ENV GOPATH /root/go

--- a/tests/v2/codecoverage/Dockerfile.codecoverage
+++ b/tests/v2/codecoverage/Dockerfile.codecoverage
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 # Configure Go
 ENV GOPATH /root/go

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -227,7 +227,7 @@ ENV ETCD_UNSUPPORTED_ARCH ${ETCD_UNSUPPORTED_ARCH}
 
 
 # Enable exporting of the k3s images as part of the build process.
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS images
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS images
 
 ENV CATTLE_K3S_VERSION v1.31.1+k3s1
 
@@ -242,7 +242,7 @@ RUN go build -tags k3s_export -o export-images ./...
 RUN ./export-images -k3s-version ${CATTLE_K3S_VERSION} -output /src/k3s-airgap-images.tar
 
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS build
 ARG VERSION=dev
 ARG COMMIT
 ARG RKE_VERSION

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -5,7 +5,7 @@ ARG RANCHER_IMAGE=${REGISTRY}/${RANCHER_REPO}/rancher:${RANCHER_TAG}
 ARG ARCH
 ARG VERSION=dev
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS build
 ARG VERSION=${VERSION}
 ARG CGO_ENABLED=0
 ARG TAGS="k8s"

--- a/tests/v2/validation/Dockerfile.e2e
+++ b/tests/v2/validation/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 # Configure Go
 ENV GOFLAGS=-buildvcs=false

--- a/tests/v2/validation/Dockerfile.validation
+++ b/tests/v2/validation/Dockerfile.validation
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # Configure Go
 ENV GOPATH /root/go

--- a/tests/v2/validation/steve/vai/scripts/script.sh
+++ b/tests/v2/validation/steve/vai/scripts/script.sh
@@ -14,9 +14,9 @@ check_go() {
 # Install Go if not already installed
 if ! check_go; then
     echo "Go not found. Installing Go..."
-    curl -L -o go1.22.4.linux-amd64.tar.gz https://go.dev/dl/go1.22.4.linux-amd64.tar.gz --insecure
-    tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz
-    rm go1.22.4.linux-amd64.tar.gz
+    curl -L -o go1.23.1.linux-amd64.tar.gz https://go.dev/dl/go1.23.1.linux-amd64.tar.gz --insecure
+    tar -C /usr/local -xzf go1.23.1.linux-amd64.tar.gz
+    rm go1.23.1.linux-amd64.tar.gz
     echo "Go installed successfully."
 else
     echo "Go is already installed."

--- a/tests/v2/validation/steve/vai/scripts/script.sh
+++ b/tests/v2/validation/steve/vai/scripts/script.sh
@@ -14,9 +14,9 @@ check_go() {
 # Install Go if not already installed
 if ! check_go; then
     echo "Go not found. Installing Go..."
-    curl -L -o go1.23.1.linux-amd64.tar.gz https://go.dev/dl/go1.23.1.linux-amd64.tar.gz --insecure
-    tar -C /usr/local -xzf go1.23.1.linux-amd64.tar.gz
-    rm go1.23.1.linux-amd64.tar.gz
+    curl -L -o go1.23.4.linux-amd64.tar.gz https://go.dev/dl/go1.23.4.linux-amd64.tar.gz --insecure
+    tar -C /usr/local -xzf go1.23.4.linux-amd64.tar.gz
+    rm go1.23.4.linux-amd64.tar.gz
     echo "Go installed successfully."
 else
     echo "Go is already installed."


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Ref: https://github.com/rancher/rancher/issues/48404
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The new stable BCI golang image `registry.suse.com/bci/golang:1.23` is now available.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Start building with Go 1.23 using the latest available toolchain in the BCI image.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A