### PR TITLE
<main> Converted to go the test_wl_pod_scale_down and test_wl_pod_scale_up python tests

### DIFF
--- a/tests/v2/validation/workloads/workload_test.go
+++ b/tests/v2/validation/workloads/workload_test.go
@@ -26,6 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	imageName = "nginx"
+)
+
 type WorkloadTestSuite struct {
 	suite.Suite
 	client  *rancher.Client
@@ -133,7 +137,7 @@ func (w *WorkloadTestSuite) TestWorkloadCronjob() {
 
 	containerTemplate := workloads.NewContainer(
 		containerName,
-		"nginx",
+		imageName,
 		pullPolicy,
 		[]corev1.VolumeMount{},
 		[]corev1.EnvFromSource{},
@@ -168,7 +172,7 @@ func (w *WorkloadTestSuite) TestWorkloadStatefulset() {
 
 	containerTemplate := workloads.NewContainer(
 		containerName,
-		"nginx",
+		imageName,
 		pullPolicy,
 		[]corev1.VolumeMount{},
 		[]corev1.EnvFromSource{},
@@ -203,7 +207,7 @@ func (w *WorkloadTestSuite) TestWorkloadUpgrade() {
 	upgradeDeployment, err := deployment.CreateDeployment(w.client, w.cluster.ID, namespace.Name, 2, "", "", false, false)
 	require.NoError(w.T(), err)
 
-	validateDeploymentUpgrade(w, namespace.Name, upgradeDeployment, "1", "nginx", 2)
+	w.validateDeploymentUpgrade(namespace.Name, upgradeDeployment, "1", imageName, 2)
 
 	containerName := namegen.AppendRandomString("updatetestcontainer")
 	newContainerTemplate := workloads.NewContainer(containerName,
@@ -220,7 +224,7 @@ func (w *WorkloadTestSuite) TestWorkloadUpgrade() {
 	upgradeDeployment, err = deployment.UpdateDeployment(w.client, w.cluster.ID, namespace.Name, upgradeDeployment)
 	require.NoError(w.T(), err)
 
-	validateDeploymentUpgrade(w, namespace.Name, upgradeDeployment, "2", "redis", 2)
+	w.validateDeploymentUpgrade(namespace.Name, upgradeDeployment, "2", "redis", 2)
 
 	containerName = namegen.AppendRandomString("updatetestcontainertwo")
 	newContainerTemplate = workloads.NewContainer(containerName,
@@ -239,28 +243,86 @@ func (w *WorkloadTestSuite) TestWorkloadUpgrade() {
 	_, err = deployment.UpdateDeployment(w.client, w.cluster.ID, namespace.Name, upgradeDeployment)
 	require.NoError(w.T(), err)
 
-	validateDeploymentUpgrade(w, namespace.Name, upgradeDeployment, "3", "ubuntu", 2)
+	w.validateDeploymentUpgrade(namespace.Name, upgradeDeployment, "3", "ubuntu", 2)
 
 	logRollback, err := deployment.RollbackDeployment(w.client, w.cluster.ID, namespace.Name, upgradeDeployment.Name, 1)
 	require.NoError(w.T(), err)
 	require.NotEmpty(w.T(), logRollback)
 
-	validateDeploymentUpgrade(w, namespace.Name, upgradeDeployment, "4", "nginx", 2)
+	w.validateDeploymentUpgrade(namespace.Name, upgradeDeployment, "4", imageName, 2)
 
 	logRollback, err = deployment.RollbackDeployment(w.client, w.cluster.ID, namespace.Name, upgradeDeployment.Name, 2)
 	require.NoError(w.T(), err)
 	require.NotEmpty(w.T(), logRollback)
 
-	validateDeploymentUpgrade(w, namespace.Name, upgradeDeployment, "5", "redis", 2)
+	w.validateDeploymentUpgrade(namespace.Name, upgradeDeployment, "5", "redis", 2)
 
 	logRollback, err = deployment.RollbackDeployment(w.client, w.cluster.ID, namespace.Name, upgradeDeployment.Name, 3)
 	require.NoError(w.T(), err)
 	require.NotEmpty(w.T(), logRollback)
 
-	validateDeploymentUpgrade(w, namespace.Name, upgradeDeployment, "6", "ubuntu", 2)
+	w.validateDeploymentUpgrade(namespace.Name, upgradeDeployment, "6", "ubuntu", 2)
 }
 
-func validateDeploymentUpgrade(w *WorkloadTestSuite, namespaceName string, appv1Deployment *appv1.Deployment, expectedRevision string, image string, expectedContainerCount int) {
+func (w *WorkloadTestSuite) TestWorkloadPodScaleUp() {
+	subSession := w.session.NewSession()
+	defer subSession.Cleanup()
+
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(w.client, w.cluster.ID)
+	require.NoError(w.T(), err)
+
+	scaleUpDeployment, err := deployment.CreateDeployment(w.client, w.cluster.ID, namespace.Name, 1, "", "", false, false)
+	require.NoError(w.T(), err)
+
+	w.validateDeploymentScale(namespace.Name, scaleUpDeployment, imageName, 1)
+
+	replicas := int32(2)
+	scaleUpDeployment.Spec.Replicas = &replicas
+
+	scaleUpDeployment, err = deployment.UpdateDeployment(w.client, w.cluster.ID, namespace.Name, scaleUpDeployment)
+	require.NoError(w.T(), err)
+
+	w.validateDeploymentScale(namespace.Name, scaleUpDeployment, imageName, 2)
+
+	replicas = int32(3)
+	scaleUpDeployment.Spec.Replicas = &replicas
+
+	scaleUpDeployment, err = deployment.UpdateDeployment(w.client, w.cluster.ID, namespace.Name, scaleUpDeployment)
+	require.NoError(w.T(), err)
+
+	w.validateDeploymentScale(namespace.Name, scaleUpDeployment, imageName, 3)
+}
+
+func (w *WorkloadTestSuite) TestWorkloadPodScaleDown() {
+	subSession := w.session.NewSession()
+	defer subSession.Cleanup()
+
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(w.client, w.cluster.ID)
+	require.NoError(w.T(), err)
+
+	scaleDownDeployment, err := deployment.CreateDeployment(w.client, w.cluster.ID, namespace.Name, 3, "", "", false, false)
+	require.NoError(w.T(), err)
+
+	w.validateDeploymentScale(namespace.Name, scaleDownDeployment, imageName, 3)
+
+	replicas := int32(2)
+	scaleDownDeployment.Spec.Replicas = &replicas
+
+	scaleDownDeployment, err = deployment.UpdateDeployment(w.client, w.cluster.ID, namespace.Name, scaleDownDeployment)
+	require.NoError(w.T(), err)
+
+	w.validateDeploymentScale(namespace.Name, scaleDownDeployment, imageName, 2)
+
+	replicas = int32(1)
+	scaleDownDeployment.Spec.Replicas = &replicas
+
+	scaleDownDeployment, err = deployment.UpdateDeployment(w.client, w.cluster.ID, namespace.Name, scaleDownDeployment)
+	require.NoError(w.T(), err)
+
+	w.validateDeploymentScale(namespace.Name, scaleDownDeployment, imageName, 1)
+}
+
+func (w *WorkloadTestSuite) validateDeploymentUpgrade(namespaceName string, appv1Deployment *appv1.Deployment, expectedRevision string, image string, expectedReplicas int) {
 	err := charts.WatchAndWaitDeployments(w.client, w.cluster.ID, namespaceName, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + appv1Deployment.Name,
 	})
@@ -274,7 +336,21 @@ func validateDeploymentUpgrade(w *WorkloadTestSuite, namespaceName string, appv1
 
 	countPods, err := pods.CountPodContainerRunningByImage(w.client, w.cluster.ID, namespaceName, image)
 	require.NoError(w.T(), err)
-	require.Equal(w.T(), expectedContainerCount, countPods)
+	require.Equal(w.T(), expectedReplicas, countPods)
+}
+
+func (w *WorkloadTestSuite) validateDeploymentScale(namespaceName string, scaleDeployment *appv1.Deployment, image string, expectedReplicas int) {
+	err := charts.WatchAndWaitDeployments(w.client, w.cluster.ID, namespaceName, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + scaleDeployment.Name,
+	})
+	require.NoError(w.T(), err)
+
+	err = pods.WatchAndWaitPodContainerRunning(w.client, w.cluster.ID, namespaceName, scaleDeployment)
+	require.NoError(w.T(), err)
+
+	countPods, err := pods.CountPodContainerRunningByImage(w.client, w.cluster.ID, namespaceName, image)
+	require.NoError(w.T(), err)
+	require.Equal(w.T(), expectedReplicas, countPods)
 }
 
 func TestWorkloadTestSuite(t *testing.T) {

--- a/tests/validation/tests/v3_api/test_workload.py
+++ b/tests/validation/tests/v3_api/test_workload.py
@@ -166,7 +166,7 @@ def test_wl_upgrade():
     validate_workload(p_client, workload, "deployment", ns.name, 2)
     validate_workload_image(p_client, workload, TEST_IMAGE_OS_BASE, ns)
 
-
+#Converted to go test in TestWorkloadPodScaleUp
 def test_wl_pod_scale_up():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
@@ -195,7 +195,7 @@ def test_wl_pod_scale_up():
     validate_workload(p_client, workload, "deployment", ns.name, 3)
     validate_pods_are_running_by_id(allpods, workload, ns.name)
 
-
+#Converted to go test in TestWorkloadPodScaleDown
 def test_wl_pod_scale_down():
     p_client = namespace["p_client"]
     ns = namespace["ns"]


### PR DESCRIPTION
Backports

v2.9 https://github.com/rancher/rancher/pull/47225
v2.8 https://github.com/rancher/rancher/pull/47226
v2.7 https://github.com/rancher/rancher/pull/47227