### PR TITLE
[41179] Add version tombstone to migrations

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mcuadros/go-version"
+	"github.com/pkg/errors"
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/rancher/pkg/api/norman/customization/cred"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -58,6 +59,8 @@ const (
 	systemAgentVarDirMigratedKey                    = "systemAgentVarDirMigrated"
 	harvesterCloudCredentialExpirationMigratedKey   = "harvesterCloudCredentialExpirationMigrated"
 )
+
+var ErrTombstoneValidation = errors.New("version tombstone validation failed")
 
 func runMigrations(wranglerContext *wrangler.Context) error {
 	if err := forceUpgradeLogout(wranglerContext.Core.ConfigMap(), wranglerContext.Mgmt.Token(), "v2.6.0"); err != nil {
@@ -150,20 +153,30 @@ func versionTombstone(configMapController controllerv1.ConfigMapController) erro
 		return err
 	}
 
-	if !semver.IsValid(rancherversion.Version) {
-		logrus.Errorf("rancher version %s is not semver compliant, skipping tombstone validation", rancherversion.Version)
-		return nil
+	validate := false
+
+	if rancherversion.Version == "dev" {
+		logrus.Debugf("Development environment detected, skipping tombstone validation.")
+	} else if !semver.IsValid(rancherversion.Version) {
+		logrus.Errorf("Rancher version %s is not semver compliant, skipping tombstone validation.", rancherversion.Version)
+	} else if semver.Prerelease(rancherversion.Version) != "" {
+		logrus.Infof("Rancher version %s detected as prerelease, skipping tombstone validation.", rancherversion.Version)
+	} else {
+		validate = true
 	}
 
 	lastVersion := cm.Data[rancherVersionKey]
-	if lastVersion != "" {
+	if lastVersion != "" && validate {
 		if !semver.IsValid(lastVersion) {
-			logrus.Errorf("Previous Rancher version %s is not semver compliant, skipping tombstone validation", lastVersion)
-			lastVersion = ""
-		}
-		if semver.Compare(lastVersion, rancherversion.Version) == 1 {
-			logrus.Fatalf("Detected Rancher downgrade from %s to %s. In order to perform a rollback of Rancher, use the Rancher Backup Restore Operator. If a suitable backup is unavailable, version tombstone validation can be temporarily disabled by deleting the rancherVersionTombstone config map in the cattle-system namespace.",
-				lastVersion, rancherversion.Version)
+			logrus.Errorf("Previous Rancher version %s is not semver compliant, skipping tombstone validation.", lastVersion)
+			// Hotfixes count as previous versions, and alpha/rc versions are assumed to be at your own risk.
+			// If users want to downgrade to consume a hotfix, they should not be prevented.
+		} else if semver.Prerelease(lastVersion) != "" {
+			logrus.Errorf("Previous Rancher version %s is not semver compliant, skipping tombstone validation.", rancherversion.Version)
+		} else if semver.Compare(lastVersion, rancherversion.Version) == 1 {
+			logrus.Errorf("Detected Rancher downgrade from %s to %s. In order to perform a rollback of Rancher, use the Rancher Backup Restore Operator. If a suitable backup is unavailable, version tombstone validation can be temporarily disabled by deleting the %s config map in the cattle-system namespace.",
+				lastVersion, rancherversion.Version, rancherVersionTombstoneConfig)
+			return ErrTombstoneValidation
 		}
 	}
 

--- a/pkg/rancher/migrations_test.go
+++ b/pkg/rancher/migrations_test.go
@@ -1,0 +1,199 @@
+package rancher
+
+import (
+	"errors"
+	rancherversion "github.com/rancher/rancher/pkg/version"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+func TestVersionTombstone(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectError bool
+		expected    map[string]string
+		setup       func(*v1.ConfigMap, *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], *fake.MockCacheInterface[*v1.ConfigMap])
+	}{
+		{
+			name:        "error config map",
+			expectError: true,
+			setup: func(_ *v1.ConfigMap, _ *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(nil, errors.New("error getting config map"))
+			},
+		},
+		{
+			name:        "dev version",
+			expectError: false,
+			setup: func(_ *v1.ConfigMap, _ *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				rancherversion.Version = "dev"
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: cattleNamespace,
+						Name:      rancherVersionTombstoneConfig,
+					},
+					Data: map[string]string{},
+				}, nil)
+			},
+		},
+		{
+			name:        "no last version",
+			expectError: false,
+			expected: map[string]string{
+				rancherVersionKey: "v2.11.0",
+			},
+			setup: func(cm *v1.ConfigMap, controller *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				rancherversion.Version = "v2.11.0"
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: cattleNamespace,
+						Name:      rancherVersionTombstoneConfig,
+					},
+					Data: map[string]string{},
+				}, nil)
+				controller.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+					*cm = *obj
+					return obj, nil
+				}).AnyTimes()
+			},
+		},
+		{
+			name:        "invalid version",
+			expectError: false,
+			expected: map[string]string{
+				rancherVersionKey: "not-a-version",
+			},
+			setup: func(cm *v1.ConfigMap, controller *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				rancherversion.Version = "not-a-version"
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: cattleNamespace,
+						Name:      rancherVersionTombstoneConfig,
+					},
+					Data: map[string]string{},
+				}, nil)
+				controller.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+					*cm = *obj
+					return obj, nil
+				}).AnyTimes()
+			},
+		},
+		{
+			name:        "prerelease version",
+			expectError: false,
+			expected: map[string]string{
+				rancherVersionKey: "v2.11.0-alpha1",
+			},
+			setup: func(cm *v1.ConfigMap, controller *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				rancherversion.Version = "v2.11.0-alpha1"
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: cattleNamespace,
+						Name:      rancherVersionTombstoneConfig,
+					},
+					Data: map[string]string{},
+				}, nil)
+				controller.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+					*cm = *obj
+					return obj, nil
+				}).AnyTimes()
+			},
+		},
+		{
+			name:        "last version invalid",
+			expectError: false,
+			expected: map[string]string{
+				rancherVersionKey: "v2.11.0",
+			},
+			setup: func(cm *v1.ConfigMap, controller *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				rancherversion.Version = "v2.11.0"
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       cattleNamespace,
+						Name:            rancherVersionTombstoneConfig,
+						ResourceVersion: "1",
+					},
+					Data: map[string]string{
+						rancherVersionKey: "not-a-version",
+					},
+				}, nil)
+				controller.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+					*cm = *obj
+					return obj, nil
+				}).AnyTimes()
+			},
+		},
+		{
+			name:        "last version pre-release",
+			expectError: false,
+			expected: map[string]string{
+				rancherVersionKey: "v2.11.0",
+			},
+			setup: func(cm *v1.ConfigMap, controller *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				rancherversion.Version = "v2.11.0"
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       cattleNamespace,
+						Name:            rancherVersionTombstoneConfig,
+						ResourceVersion: "1",
+					},
+					Data: map[string]string{
+						rancherVersionKey: "v2.11.1-alpha1",
+					},
+				}, nil)
+				controller.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+					*cm = *obj
+					return obj, nil
+				}).AnyTimes()
+			},
+		},
+		{
+			name:        "last version lesser",
+			expectError: true,
+			setup: func(cm *v1.ConfigMap, controller *fake.MockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList], cache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				rancherversion.Version = "v2.10.0"
+				cache.EXPECT().Get(cattleNamespace, rancherVersionTombstoneConfig).Return(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       cattleNamespace,
+						Name:            rancherVersionTombstoneConfig,
+						ResourceVersion: "1",
+					},
+					Data: map[string]string{
+						rancherVersionKey: "v2.11.0",
+					},
+				}, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			configMapController := fake.NewMockControllerInterface[*v1.ConfigMap, *v1.ConfigMapList](ctrl)
+			configMapCache := fake.NewMockCacheInterface[*v1.ConfigMap](ctrl)
+			configMapController.EXPECT().Cache().Return(configMapCache)
+			cm := &v1.ConfigMap{}
+			configMapController.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *v1.ConfigMap) (*v1.ConfigMap, error) {
+				cm = obj
+				return obj, nil
+			}).AnyTimes()
+
+			tt.setup(cm, configMapController, configMapCache)
+			err := versionTombstone(configMapController)
+			if err == nil && tt.expectError {
+				t.Errorf("versionTombstone should return error")
+			} else if err != nil && !tt.expectError {
+				t.Errorf("versionTombstone should not return error: %v", err)
+			} else if tt.expected != nil {
+				assert.True(t, reflect.DeepEqual(cm.Data, tt.expected))
+			} else {
+				assert.Equal(t, cm.Data[rancherVersionKey], tt.expected[rancherVersionKey])
+			}
+		})
+	}
+}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -300,6 +300,9 @@ func (r *Rancher) Start(ctx context.Context) error {
 		if err := dashboarddata.Add(ctx, r.Wrangler, localClusterEnabled(r.opts), r.opts.AddLocal == "false", r.opts.Embedded); err != nil {
 			return err
 		}
+		if err := runPreflightMigrations(r.Wrangler); err != nil {
+			return err
+		}
 		if err := r.Wrangler.StartWithTransaction(ctx, func(ctx context.Context) error {
 			return dashboard.Register(ctx, r.Wrangler, r.opts.Embedded, r.opts.ClusterRegistry)
 		}); err != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/41179
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> 
Performing a Rancher downgrade can currently cause issues due to migrations running at startup being version specific. Currently, when a downgrade of Rancher is performed, the backup restore operator must be used.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add the Rancher version as a tombstone, preventing Rancher from starting if a downgrade is detected.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Build an image of Rancher including this change with a semver compliant tag and run it
- Confirm value is written to `rancherVersionTombstone` config map
- Build another image of Rancher with a higher tag and upgrade
- Confirm upgrade success new value is written to `rancherVersionTombstone` config map
- Downgrade to original version
- Confirm Rancher exits with clear error message
- Remove `rancherVersionTombstone` config map and confirm Rancher starts

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit - Todo

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Both the case where the `rancherVersionTombstone` is deleted to override safeguarding behavior, and upgrading back to the version present in the `rancherVersionTombstone` config map should be tested.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A