### PR TITLE
[v2.9] bump shell RC version to newest

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 104.0.2+up0.5.2
 provisioningCAPIVersion: 104.0.0+up0.3.0
 cspAdapterMinVersion: 104.0.0+up4.0.0
-defaultShellVersion: rancher/shell:v0.2.1
+defaultShellVersion: rancher/shell:v0.2.2-rc.2
 fleetVersion: 104.0.3+up0.10.3-rc.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion    = "104.0.0+up4.0.0"
-	DefaultShellVersion     = "rancher/shell:v0.2.1"
+	DefaultShellVersion     = "rancher/shell:v0.2.2-rc.2"
 	FleetVersion            = "104.0.3+up0.10.3-rc.1"
 	ProvisioningCAPIVersion = "104.0.0+up0.3.0"
 	WebhookVersion          = "104.0.2+up0.5.2"


### PR DESCRIPTION
Per title, this updates shell to newest RC targeting 2.9 rancher.

related to: https://github.com/rancher/rancher/issues/47245