### PR TITLE
cis benchmark chart p0 test automation

### DIFF
--- a/tests/v2/validation/charts/cisbenchmark_test.go
+++ b/tests/v2/validation/charts/cisbenchmark_test.go
@@ -1,0 +1,224 @@
+package charts
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/charts"
+	"github.com/rancher/rancher/tests/v2/validation/charts/resources"
+	cis "github.com/rancher/rancher/tests/v2/validation/provisioning/resources/cisbenchmark"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	extencharts "github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type CisBenchmarkTestSuite struct {
+	suite.Suite
+	cisProfileName      string
+	client              *rancher.Client
+	session             *session.Session
+	project             *management.Project
+	chartInstallOptions *charts.InstallOptions
+}
+
+func (c *CisBenchmarkTestSuite) TearDownSuite() {
+	c.session.Cleanup()
+}
+
+func (c *CisBenchmarkTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	c.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(c.T(), err)
+
+	c.client = client
+
+	cisConfig := new(resources.CisConfig)
+	config.LoadConfig(resources.CisConfigFileKey, cisConfig)
+	c.cisProfileName = cisConfig.ProfileName
+	require.NotEmptyf(c.T(), c.cisProfileName, "CIS profile name required")
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(c.T(), clusterName, "Cluster name to install is not set")
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(c.T(), err)
+
+	if cisConfig.ChartVersion == "" {
+		cisConfig.ChartVersion, err = client.Catalog.GetLatestChartVersion(charts.CISBenchmarkName, catalog.RancherChartRepo)
+		require.NoError(c.T(), err)
+	}
+
+	projectConfig := &management.Project{
+		ClusterID: clusterID,
+		Name:      resources.CISBenchmarkProjectName,
+	}
+	createdProject, err := client.Management.Project.Create(projectConfig)
+	require.NoError(c.T(), err)
+	require.Equal(c.T(), createdProject.Name, resources.CISBenchmarkProjectName)
+	c.project = createdProject
+
+	c.chartInstallOptions = &charts.InstallOptions{
+		Cluster: &clusters.ClusterMeta{
+			ID:   clusterID,
+			Name: clusterName,
+		},
+		Version:   cisConfig.ChartVersion,
+		ProjectID: createdProject.ID,
+	}
+
+}
+
+func (c *CisBenchmarkTestSuite) TestFreshInstallCisBenchmarkChart() {
+	subSession := c.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := c.client.WithSession(subSession)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Checking if the cis-benchmark chart is already installed")
+	initialCisbenchmarkChart, err := extencharts.GetChartStatus(client, c.project.ClusterID, charts.CISBenchmarkNamespace, charts.CISBenchmarkName)
+	require.NoError(c.T(), err)
+
+	if initialCisbenchmarkChart.IsAlreadyInstalled {
+		c.T().Skip("Skipping fresh installtion. cis-benchmark chart is already installed.")
+	}
+
+	c.T().Log("Installing latest version of cis benchmark chart")
+	err = charts.InstallCISBenchmarkChart(client, c.chartInstallOptions)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Waiting for cisbenchmark chart deployments to have expected number of available replicas")
+	err = extencharts.WatchAndWaitDeployments(client, c.project.ClusterID, charts.CISBenchmarkNamespace, metav1.ListOptions{})
+	require.NoError(c.T(), err)
+
+	c.T().Log("Running a scan")
+
+	// Run the scan
+	err = cis.RunCISScan(client, c.project.ClusterID, c.cisProfileName, true)
+	require.NoError(c.T(), err)
+
+}
+
+func (c *CisBenchmarkTestSuite) TestDynamicUpgradeCisbenchmarkChart() {
+	subSession := c.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := c.client.WithSession(subSession)
+	require.NoError(c.T(), err)
+
+	// Change cisbenchmark install option version to previous version of the latest version
+	versionsList, err := client.Catalog.GetListChartVersions(charts.CISBenchmarkName, catalog.RancherChartRepo)
+	require.NoError(c.T(), err)
+
+	if len(versionsList) < 2 {
+		c.T().Skip("Skipping the upgrade case, only one version of cis-benchmark is available")
+	}
+
+	c.T().Log("Checking if the cis-benchmark chart is installed with one of the previous versions")
+	initialCisbenchmarkChart, err := extencharts.GetChartStatus(client, c.project.ClusterID, charts.CISBenchmarkNamespace, charts.CISBenchmarkName)
+	require.NoError(c.T(), err)
+
+	if !initialCisbenchmarkChart.IsAlreadyInstalled {
+		c.T().Skip("cis-benchmark chart is not installed, skipping the upgrade case")
+	}
+
+	versionLatest := versionsList[0]
+	c.T().Log(versionLatest)
+
+	versionBeforeLatest := versionsList[1]
+	c.T().Log(versionBeforeLatest)
+	c.chartInstallOptions.Version = versionBeforeLatest
+
+	if initialCisbenchmarkChart.ChartDetails.Spec.Chart.Metadata.Version == versionLatest {
+		c.T().Skip("Skipping the upgrade case, latest version of cis-benchmark chart is already installed")
+	}
+
+	c.T().Log("Running a scan")
+
+	// Run the scan
+	err = cis.RunCISScan(client, c.project.ClusterID, c.cisProfileName, true)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Upgrading cis-benchmark chart to the latest version")
+	c.chartInstallOptions.Version = versionLatest
+	err = charts.UpgradeCISBenchmarkChart(client, c.chartInstallOptions)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Verifying cis-benchmark chart installation")
+
+	err = resources.VerifyCISChartInstallation(client, c.project.ClusterID, versionLatest, c.cisProfileName)
+	require.NoError(c.T(), err)
+}
+
+func (c *CisBenchmarkTestSuite) TestUpgradeCisbenchmarkChart() {
+	subSession := c.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := c.client.WithSession(subSession)
+	require.NoError(c.T(), err)
+
+	// Change cisbenchmark install option version to previous version of the latest version
+	versionsList, err := client.Catalog.GetListChartVersions(charts.CISBenchmarkName, catalog.RancherChartRepo)
+	require.NoError(c.T(), err)
+
+	if len(versionsList) < 2 {
+		c.T().Skip("Skipping the upgrade case, only one version of cis-benchmark is available")
+	}
+
+	versionLatest := versionsList[0]
+	c.T().Log(versionLatest)
+
+	versionBeforeLatest := versionsList[1]
+	c.T().Log(versionBeforeLatest)
+	c.chartInstallOptions.Version = versionBeforeLatest
+
+	c.T().Log("Checking if the cis-benchmark chart is installed with one of the previous versions")
+	initialCisbenchmarkChart, err := extencharts.GetChartStatus(client, c.project.ClusterID, charts.CISBenchmarkNamespace, charts.CISBenchmarkName)
+	require.NoError(c.T(), err)
+
+	if initialCisbenchmarkChart.IsAlreadyInstalled && initialCisbenchmarkChart.ChartDetails.Spec.Chart.Metadata.Version == versionLatest {
+		c.T().Skip("Skipping the upgrade case, cis-benchmark chart is already installed with the latest version")
+	}
+
+	if !initialCisbenchmarkChart.IsAlreadyInstalled {
+		c.T().Log("Installing cis-benchmark chart with the version before the latest version")
+		err = charts.InstallCISBenchmarkChart(client, c.chartInstallOptions)
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting cis-benchmark chart deployments to have expected number of available replicas")
+		err = extencharts.WatchAndWaitDeployments(client, c.project.ClusterID, charts.CISBenchmarkNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting cisbenchmark chart DaemonSets to have expected number of available nodes")
+		err = extencharts.WatchAndWaitDaemonSets(client, c.project.ClusterID, charts.CISBenchmarkNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+	}
+
+	c.T().Log("Running a scan")
+
+	// Run the scan
+	err = cis.RunCISScan(client, c.project.ClusterID, c.cisProfileName, true)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Upgrading cis-benchmark chart to the latest version")
+	c.chartInstallOptions.Version = versionLatest
+	err = charts.UpgradeCISBenchmarkChart(client, c.chartInstallOptions)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Verifying cis-benchmark chart installation")
+
+	err = resources.VerifyCISChartInstallation(client, c.project.ClusterID, versionLatest, c.cisProfileName)
+	require.NoError(c.T(), err)
+}
+
+func TestCisBenchmarkTestSuite(t *testing.T) {
+	suite.Run(t, new(CisBenchmarkTestSuite))
+}

--- a/tests/v2/validation/charts/resources/cisbenchmark.go
+++ b/tests/v2/validation/charts/resources/cisbenchmark.go
@@ -1,0 +1,52 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/v2/actions/charts"
+	cis "github.com/rancher/rancher/tests/v2/validation/provisioning/resources/cisbenchmark"
+	"github.com/rancher/shepherd/clients/rancher"
+	extencharts "github.com/rancher/shepherd/extensions/charts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	CisConfigFileKey        = "cisConfig"
+	CISBenchmarkProjectName = "cis-operator-system"
+)
+
+type CisConfig struct {
+	ProfileName  string `json:"profileName" yaml:"profileName"`
+	ChartVersion string `json:"chartVersion" yaml:"chartVersion"`
+}
+
+func VerifyCISChartInstallation(client *rancher.Client, clusterID string, chartVersion string, cisProfileName string) error {
+	// Upgrade the CIS benchmark chart
+
+	err := extencharts.WatchAndWaitDeployments(client, clusterID, charts.CISBenchmarkNamespace, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	err = extencharts.WatchAndWaitDaemonSets(client, clusterID, charts.CISBenchmarkNamespace, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	cisbenchmarkChartPostUpgrade, err := extencharts.GetChartStatus(client, clusterID, charts.CISBenchmarkNamespace, charts.CISBenchmarkName)
+	if err != nil {
+		return err
+	}
+
+	chartVersionPostUpgrade := cisbenchmarkChartPostUpgrade.ChartDetails.Spec.Chart.Metadata.Version
+	if chartVersion != chartVersionPostUpgrade {
+		return fmt.Errorf("Expected chart version %s, got %s", chartVersion, chartVersionPostUpgrade)
+	}
+
+	// Run the scan
+	err = cis.RunCISScan(client, clusterID, cisProfileName, true)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tests/v2/validation/provisioning/resources/cisbenchmark/cisbenchmark.go
+++ b/tests/v2/validation/provisioning/resources/cisbenchmark/cisbenchmark.go
@@ -1,11 +1,15 @@
 package charts
 
 import (
+	"encoding/json"
+	"errors"
+	"strings"
 	"time"
 
 	cis "github.com/rancher/cis-operator/pkg/apis/cis.cattle.io/v1"
 	"github.com/rancher/rancher/tests/v2/actions/charts"
 	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	extensionscharts "github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/defaults"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
@@ -19,9 +23,36 @@ const (
 	System = "System"
 	pass   = "pass"
 	scan   = "scan"
+	fail   = "fail"
 
 	cisBenchmarkSteveType = "cis.cattle.io.clusterscan"
+	clusterScanReportType = "cis.cattle.io.clusterscanreport"
 )
+
+// CisReport is the report structure stored as report json in cluster scan report spec.
+type CisReport struct {
+	Total         int
+	Pass          int
+	Fail          int
+	Skip          int
+	Warn          int
+	NotApplicable int
+	Results       []*Group `json:"results"`
+}
+
+// Group is the result structure stored as report json in Results of CisReport
+type Group struct {
+	ID     string      `yaml:"id" json:"id"`
+	Text   string      `json:"description"`
+	Checks []*CisCheck `json:"checks"`
+}
+
+// CisCheck is the ID, Description and State structure of individual test in cluster scan.
+type CisCheck struct {
+	Id          string
+	Description string
+	State       string
+}
 
 // SetupCISBenchmarkChart installs the CIS Benchmark chart and waits for all resources to be ready.
 func SetupCISBenchmarkChart(client *rancher.Client, projectClusterID string, chartInstallOptions *charts.InstallOptions, benchmarkNamespace string) error {
@@ -55,7 +86,7 @@ func SetupCISBenchmarkChart(client *rancher.Client, projectClusterID string, cha
 }
 
 // RunCISScan runs the CIS Benchmark scan with the specified profile name.
-func RunCISScan(client *rancher.Client, projectClusterID, scanProfileName string) error {
+func RunCISScan(client *rancher.Client, projectClusterID, scanProfileName string, printFailedChecks bool) error {
 	logrus.Infof("Running CIS Benchmark scan: %s", scanProfileName)
 
 	cisScan := cis.ClusterScan{
@@ -96,5 +127,59 @@ func RunCISScan(client *rancher.Client, projectClusterID, scanProfileName string
 
 	logrus.Infof("CIS Benchmark scan passed!")
 
+	if printFailedChecks {
+		logrus.Infof("Checking cluster scan report for failed checks")
+		err = checkScanReport(steveclient, scan.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkScanReport(steveClient *v1.Client, scanName string) error {
+	scanReportList, err := steveClient.SteveType(clusterScanReportType).List(nil)
+	if err != nil {
+		return err
+	}
+
+	scanReportIdx := -1
+
+	for idx, scanReport := range scanReportList.Data {
+		if strings.Contains(scanReport.Name, scanName) {
+			scanReportIdx = idx
+			break
+		}
+	}
+
+	if scanReportIdx < 0 {
+		return errors.New("scan report not found")
+	}
+
+	scanReport := &cis.ClusterScanReport{}
+	scanReportSpec := scanReportList.Data[scanReportIdx]
+	err = v1.ConvertToK8sType(scanReportSpec, scanReport)
+	if err != nil {
+		return err
+	}
+
+	reportData := &CisReport{}
+	err = json.Unmarshal([]byte(scanReport.Spec.ReportJSON), &reportData)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Out of total number of %d scans, %d scans passed, %d scans were skipped and %d scans failed", reportData.Total, reportData.Pass, reportData.Skip, reportData.Fail)
+	for _, group := range reportData.Results {
+		for _, check := range group.Checks {
+			if check.State == fail {
+				logrus.Infof("check failed: id: %s state: %s description: %s ", check.Id, check.State, check.Description)
+			}
+		}
+	}
+	if reportData.Fail != 0 {
+		return errors.New("cluster scan failed")
+	}
 	return nil
 }

--- a/tests/v2/validation/provisioning/rke1/hardened_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/hardened_cluster_test.go
@@ -132,7 +132,7 @@ func (c *HardenedRKE1ClusterProvisioningTestSuite) TestProvisioningRKE1HardenedC
 			}
 
 			cis.SetupCISBenchmarkChart(tt.client, c.project.ClusterID, c.chartInstallOptions, charts.CISBenchmarkNamespace)
-			cis.RunCISScan(tt.client, c.project.ClusterID, tt.scanProfileName)
+			cis.RunCISScan(tt.client, c.project.ClusterID, tt.scanProfileName, false)
 		})
 	}
 }

--- a/tests/v2/validation/provisioning/rke2/hardened_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/hardened_cluster_test.go
@@ -132,7 +132,7 @@ func (c *HardenedRKE2ClusterProvisioningTestSuite) TestProvisioningRKE2HardenedC
 			}
 
 			cis.SetupCISBenchmarkChart(tt.client, c.project.ClusterID, c.chartInstallOptions, charts.CISBenchmarkNamespace)
-			cis.RunCISScan(tt.client, c.project.ClusterID, tt.scanProfileName)
+			cis.RunCISScan(tt.client, c.project.ClusterID, tt.scanProfileName, false)
 		})
 	}
 }


### PR DESCRIPTION
This PR serves the purpose of automating the CIS Scan P0 checks on any cluster.

Following are the requirements before running the test.

1. Should have a cluster ready on rancher server.
2. Following config file should be set as CATTLE_TEST_CONFIG.
```
rancher:
 host: "<rancher server IP address>"
 adminToken: "<admin/user token>"
 cleanup: true 
 clusterName: "<Name of cluster>"
cis:
 profileName: "<CIS Profile Name>"
```
Update everything in the angle brackets < > with actual value.

run the test with following command.
go test csibenchmark_test.go -timeout 0m -v

If all the checks pass, the test will pass successfully. If there are any failures, the test will fail and list all the failures in terminal/console.