### PR TITLE
Support Azure AD for China region

### DIFF
--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -19,6 +19,7 @@ import (
 	msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	msgraphgroups "github.com/microsoftgraph/msgraph-sdk-go/groups"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	msgraphusers "github.com/microsoftgraph/msgraph-sdk-go/users"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
@@ -89,6 +90,13 @@ func NewMSGraphClient(config *v32.AzureADConfig, secrets normancorev1.SecretInte
 		return nil, fmt.Errorf("creating graph service client: %w", err)
 	}
 
+	graphBaseURL, err := url.JoinPath(config.GraphEndpoint, "v1.0")
+	if err != nil {
+		return nil, fmt.Errorf("making graph base url for %s: %w", config.GraphEndpoint, err)
+	}
+	logrus.Debugf("[%s] graph base url: %s", providerLogPrefix, graphBaseURL)
+	graphClient.GetAdapter().SetBaseUrl(graphBaseURL)
+
 	return &AzureMSGraphClient{
 		Credential:         cred,
 		GraphEndpointURL:   graphEndpoint,
@@ -113,7 +121,7 @@ func (c AzureMSGraphClient) GetUser(userID string) (v3.Principal, error) {
 	logrus.Debugf("[%s] GetUser %s", providerLogPrefix, userID)
 	result, err := c.GraphClient.Users().ByUserId(userID).Get(context.Background(), nil)
 	if err != nil {
-		return v3.Principal{}, fmt.Errorf("getting user by ID: %w", err)
+		return v3.Principal{}, fmt.Errorf("getting user by ID: %w", getMSGraphErrorData(err))
 	}
 
 	return userToPrincipal(result), nil
@@ -127,13 +135,13 @@ func (c AzureMSGraphClient) ListUsers(filter string) ([]v3.Principal, error) {
 			Filter: &filter,
 		}})
 	if err != nil {
-		return nil, fmt.Errorf("listing users: %w", err)
+		return nil, fmt.Errorf("listing users: %w", getMSGraphErrorData(err))
 	}
 
 	pageIterator, err := msgraphcore.NewPageIterator[models.Userable](
 		result, c.GraphClient.GetAdapter(), models.CreateUserCollectionResponseFromDiscriminatorValue)
 	if err != nil {
-		return nil, fmt.Errorf("iterating over user list: %w", err)
+		return nil, fmt.Errorf("iterating over user list: %w", getMSGraphErrorData(err))
 	}
 
 	var users []v3.Principal
@@ -150,7 +158,7 @@ func (c AzureMSGraphClient) GetGroup(groupID string) (v3.Principal, error) {
 	logrus.Debugf("[%s] GetGroup %s", providerLogPrefix, groupID)
 	result, err := c.GraphClient.Groups().ByGroupId(groupID).Get(context.Background(), nil)
 	if err != nil {
-		return v3.Principal{}, fmt.Errorf("getting group by ID: %w", err)
+		return v3.Principal{}, fmt.Errorf("getting group by ID: %w", getMSGraphErrorData(err))
 	}
 
 	return groupToPrincipal(result), nil
@@ -164,13 +172,13 @@ func (c AzureMSGraphClient) ListGroups(filter string) ([]v3.Principal, error) {
 			Filter: &filter,
 		}})
 	if err != nil {
-		return nil, fmt.Errorf("listing groups: %w", err)
+		return nil, fmt.Errorf("listing groups: %w", getMSGraphErrorData(err))
 	}
 
 	pageIterator, err := msgraphcore.NewPageIterator[models.Groupable](
 		result, c.GraphClient.GetAdapter(), models.CreateGroupCollectionResponseFromDiscriminatorValue)
 	if err != nil {
-		return nil, fmt.Errorf("iterating over group list: %w", err)
+		return nil, fmt.Errorf("iterating over group list: %w", getMSGraphErrorData(err))
 	}
 
 	var groups []v3.Principal
@@ -216,14 +224,14 @@ func (c AzureMSGraphClient) listGroupMemberships(ctx context.Context, userID str
 					Count:  &requestCount,
 				}})
 	if err != nil {
-		return fmt.Errorf("listing group memberships: %w", err)
+		return fmt.Errorf("listing group memberships: %w", getMSGraphErrorData(err))
 	}
 
 	pageIterator, err := msgraphcore.NewPageIterator[models.DirectoryObjectable](
 		result, c.GraphClient.GetAdapter(),
 		models.CreateDirectoryObjectCollectionResponseFromDiscriminatorValue)
 	if err != nil {
-		return fmt.Errorf("iterating over group membership list: %w", err)
+		return fmt.Errorf("iterating over group membership list: %w", getMSGraphErrorData(err))
 	}
 
 	err = pageIterator.Iterate(ctx, func(do models.DirectoryObjectable) bool {
@@ -404,6 +412,16 @@ func oidFromAuthCode(token string, config *v32.AzureADConfig, endpointURL string
 	}
 
 	return authResult.IDToken.Oid, nil
+}
+
+func getMSGraphErrorData(err error) error {
+	if odataErr, ok := err.(*odataerrors.ODataError); ok {
+		if oErr := odataErr.GetErrorEscaped(); oErr != nil {
+			return fmt.Errorf("%v: code: %s, msg: %s", odataErr, *oErr.GetCode(), *oErr.GetMessage())
+		}
+		return odataErr
+	}
+	return err
 }
 
 // accessTokenCache is responsible for reading (replacing) the access token from some storage (a secret in the database,

--- a/pkg/auth/providers/azure/clients/ms_graph_client_test.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client_test.go
@@ -25,8 +25,15 @@ import (
 // TEST_AZURE_TENANT_ID
 // TEST_AZURE_APPLICATION_ID
 // TEST_AZURE_APPLICATION_SECRET
+// TEST_AZURE_CHINA
+
+var isTestAzureChina = os.Getenv("TEST_AZURE_CHINA") != ""
 
 func TestMSGraphClient_GetUser(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping GetUser test for China region")
+	}
+
 	client := newTestClient(t)
 
 	user, err := client.GetUser("testuser6@ranchertest.onmicrosoft.com")
@@ -52,6 +59,9 @@ func TestMSGraphClient_GetUser(t *testing.T) {
 }
 
 func TestMSGraphClient_ListUsers(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping ListUsers test for China region")
+	}
 	client := newTestClient(t)
 
 	users, err := client.ListUsers("")
@@ -68,6 +78,9 @@ func TestMSGraphClient_ListUsers(t *testing.T) {
 }
 
 func TestMSGraphClient_ListUsers_with_filter(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping ListUsers with filter test for China region")
+	}
 	client := newTestClient(t)
 
 	users, err := client.ListUsers("startswith(userPrincipalName,'fresh')")
@@ -78,6 +91,9 @@ func TestMSGraphClient_ListUsers_with_filter(t *testing.T) {
 }
 
 func TestMSGraphClient_GetGroup(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping GetGroup test for China region")
+	}
 	client := newTestClient(t)
 
 	group, err := client.GetGroup("00d7a0e6-e0b1-44be-8577-0fb76b13e853")
@@ -97,6 +113,9 @@ func TestMSGraphClient_GetGroup(t *testing.T) {
 }
 
 func TestMSGraphClient_ListGroups(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping ListGroups test for China region")
+	}
 	client := newTestClient(t)
 
 	groups, err := client.ListGroups("")
@@ -108,6 +127,9 @@ func TestMSGraphClient_ListGroups(t *testing.T) {
 }
 
 func TestMSGraphClient_ListGroups_with_filter(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping ListGroups with filter test for China region")
+	}
 	client := newTestClient(t)
 
 	groups, err := client.ListGroups("")
@@ -125,6 +147,9 @@ func TestMSGraphClient_ListGroups_with_filter(t *testing.T) {
 }
 
 func TestMSGraphClient_ListGroupMemberships(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping ListGroupMemberships test for China region")
+	}
 	client := newTestClient(t)
 
 	groups, err := client.ListGroupMemberships("testuser1@ranchertest.onmicrosoft.com", "")
@@ -139,6 +164,9 @@ func TestMSGraphClient_ListGroupMemberships(t *testing.T) {
 }
 
 func TestMSGraphClient_ListGroupMemberships_nested_groups(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping ListGroupMemberships with nested groups test for China region")
+	}
 	client := newTestClient(t)
 
 	groups, err := client.ListGroupMemberships("anunesteduser1@ranchertest.onmicrosoft.com", "")
@@ -153,6 +181,9 @@ func TestMSGraphClient_ListGroupMemberships_nested_groups(t *testing.T) {
 }
 
 func TestMSGraphClient_ListGroupMemberships_with_filter(t *testing.T) {
+	if isTestAzureChina {
+		t.Skip("Skipping ListGroupMemberships with filter test for China region")
+	}
 	client := newTestClient(t)
 
 	groups, err := client.ListGroupMemberships("testuser1@ranchertest.onmicrosoft.com", "")
@@ -162,6 +193,176 @@ func TestMSGraphClient_ListGroupMemberships_with_filter(t *testing.T) {
 	unfilteredCount := len(groups)
 
 	groups, err = client.ListGroupMemberships("testuser1@ranchertest.onmicrosoft.com", "startswith(displayName,'test')")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Less(t, len(groups), unfilteredCount)
+}
+
+func TestMSGraphClient_GetUser_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China GetUser test")
+	}
+
+	secrets := newTestSecretsClient()
+	client := newTestClientWithSecretsClient(t, secrets)
+
+	user, err := client.GetUser("testuser2@rancherchina.partner.onmschina.cn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := mgmtv3.Principal{
+		PrincipalType: "user",
+		Provider:      Name,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "azuread_user://7372dca1-19b9-42a5-8ee5-8e936f014638",
+		},
+		DisplayName: "testuser2",
+		LoginName:   "testuser2@rancherchina.partner.onmschina.cn",
+	}
+	assert.Equal(t, want, user)
+
+	client = newTestClientWithSecretsClient(t, secrets)
+	_, err = client.GetUser("testuser2@rancherchina.partner.onmschina.cn")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMSGraphClient_ListUsers_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China ListUsers test")
+	}
+	client := newTestClient(t)
+
+	users, err := client.ListUsers("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var displayNames []string
+	for _, v := range users {
+		displayNames = append(displayNames, v.DisplayName)
+	}
+	assert.Len(t, users, 12)
+}
+
+func TestMSGraphClient_ListUsers_with_filter_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China ListUsers with filter test")
+	}
+	client := newTestClient(t)
+
+	users, err := client.ListUsers("startswith(userPrincipalName,'test')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, users, 2)
+}
+
+func TestMSGraphClient_GetGroup_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China GetGroup test")
+	}
+	client := newTestClient(t)
+
+	group, err := client.GetGroup("3298ffd2-fc04-484d-bbd9-71c21d23dbe4")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := mgmtv3.Principal{
+		PrincipalType: "group",
+		Provider:      Name,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "azuread_group://3298ffd2-fc04-484d-bbd9-71c21d23dbe4",
+		},
+		DisplayName: "rancher-user",
+	}
+	assert.Equal(t, want, group)
+}
+
+func TestMSGraphClient_ListGroups_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China ListGroups test")
+	}
+	client := newTestClient(t)
+
+	groups, err := client.ListGroups("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Greater(t, len(groups), 1)
+}
+
+func TestMSGraphClient_ListGroups_with_filter_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China ListGroups with filter test")
+	}
+	client := newTestClient(t)
+
+	groups, err := client.ListGroups("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unfilteredCount := len(groups)
+
+	groups, err = client.ListGroups("startswith(displayName,'rancher')")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Less(t, len(groups), unfilteredCount)
+}
+
+func TestMSGraphClient_ListGroupMemberships_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China ListGroupMemberships test")
+	}
+	client := newTestClient(t)
+
+	groups, err := client.ListGroupMemberships("testuser1@rancherchina.partner.onmschina.cn", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, []string{
+		"3298ffd2-fc04-484d-bbd9-71c21d23dbe4",
+	}, groups)
+}
+
+func TestMSGraphClient_ListGroupMemberships_nested_groups_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China ListGroupMemberships with nested groups test")
+	}
+	client := newTestClient(t)
+
+	groups, err := client.ListGroupMemberships("testuser2@rancherchina.partner.onmschina.cn", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, []string{
+		"0636b6f7-9940-412c-b4d4-bbcf3a165f85",
+		"3298ffd2-fc04-484d-bbd9-71c21d23dbe4",
+		"83ad5bc7-2148-43ba-8f51-c5018c5f8a8c",
+	}, groups)
+}
+
+func TestMSGraphClient_ListGroupMemberships_with_filter_China(t *testing.T) {
+	if !isTestAzureChina {
+		t.Skip("Skipping China ListGroupMemberships with filter test")
+	}
+	client := newTestClient(t)
+
+	groups, err := client.ListGroupMemberships("testuser2@rancherchina.partner.onmschina.cn", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unfilteredCount := len(groups)
+
+	groups, err = client.ListGroupMemberships("testuser2@rancherchina.partner.onmschina.cn", "startswith(displayName,'rancher')")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,10 +382,17 @@ func newTestClientWithSecretsClient(t *testing.T, secrets normancorev1.SecretInt
 	if tenantID == "" || applicationID == "" || applicationSecret == "" {
 		t.Skip("Skipping MSGraph Client Tests for Azure because missing environment variables, TEST_AZURE_TENANT_ID, TEST_AZURE_APPLICATION_ID and TEST_AZURE_APPLICATION_SECRET must be set")
 	}
+	endpoint := "https://login.microsoftonline.com/"
+	graphEndpoint := "https://graph.microsoft.com"
+
+	if isTestAzureChina {
+		endpoint = "https://login.partner.microsoftonline.cn/"
+		graphEndpoint = "https://microsoftgraph.chinacloudapi.cn"
+	}
 
 	client, err := NewMSGraphClient(&apismgmtv3.AzureADConfig{
-		Endpoint:          "https://login.microsoftonline.com/",
-		GraphEndpoint:     "https://graph.microsoft.com",
+		Endpoint:          endpoint,
+		GraphEndpoint:     graphEndpoint,
 		TenantID:          tenantID,
 		ApplicationID:     applicationID,
 		ApplicationSecret: applicationSecret,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/47251
 
## Problem
The way we generate graph client uses an empty baseUrl for request adapter, which will be set as Global Azure Graph API as default. This will cause failure when getting resource information from Azure China.
 
## Solution
The graph client uses the global graph API as the base url. To support custom graph API such as China region, we need to customize the base url when generating the client.

I checked issues from Microsoft Graph client SDK and found [this issue](https://github.com/microsoftgraph/msgraph-sdk-go/issues/26). We need to set the correct base URL for different graph API.

We also need to [improve the error message described here](https://github.com/microsoftgraph/msgraph-sdk-go/discussions/218) instead of just showing the error message like `error status code received from the API` which can’t give us more information such as response status code and the real error message.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

1. Register Rancher with Azure China and set the Redirect URI to `<MY_RANCHER_URL>/verify-auth-azure`.
2. Create a new client secret and save it.
3. Set required API permissions for Rancher.
4. Allow Public Client Flows.
5. Copy Azure China application data to the forms in Rancher AzureAD authentication provider. The endpoints should be selected for China.
6. Click Save and login to Azure account from the popup window.
7. The Azure AD auth provider becomes active.

### Automated Testing

* Test types added/modified:
    * Unit(Add `TEST_AZURE_CHINA` environment)

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations

 We need regression testing for both Global and China Azure AD auth.