### PR TITLE
[41143] [2.10] Add label to imported cluster nodes that require upgrades

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ replace (
 	k8s.io/component-helpers => k8s.io/component-helpers v0.31.1
 	k8s.io/controller-manager => k8s.io/controller-manager v0.31.1
 	k8s.io/cri-api => k8s.io/cri-api v0.31.1
+	k8s.io/cri-client => k8s.io/cri-client v0.31.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.31.1
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.31.1
 	k8s.io/endpointslice => k8s.io/endpointslice v0.31.1

--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -16,7 +16,7 @@ import (
 	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	mgmtclient "github.com/rancher/rancher/pkg/client/generated/management/v3"
-	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
+	"github.com/rancher/rancher/pkg/controllers/managementuser/nodesyncer"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/kontainer-engine/service"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -200,7 +200,7 @@ func (v *Validator) validateK3sBasedVersionUpgrade(request *types.APIContext, sp
 		return nil
 	}
 
-	isNewer, err := k3sbasedupgrade.IsNewerVersion(prevVersion, updateVersion)
+	isNewer, err := nodesyncer.IsNewerVersion(prevVersion, updateVersion)
 	if err != nil {
 		errMsg := fmt.Sprintf("unable to compare cluster version [%s]", updateVersion)
 		return httperror.NewAPIError(httperror.InvalidBodyContent, errMsg)

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -237,7 +237,7 @@ func (h *handler) onDeployment(_ string, d *k8sappsv1.Deployment) (*k8sappsv1.De
 			appName, ok := d.Labels[legacyAppLabel]
 			if ok {
 				logrus.Debugf("[systemcharts] found deployment %s/%s with label %s=%s", d.Namespace, d.Name, legacyAppLabel, appName)
-				if appName == k3sbasedupgrade.K3sAppNme || appName == k3sbasedupgrade.Rke2AppNme {
+				if appName == k3sbasedupgrade.K3sAppName || appName == k3sbasedupgrade.Rke2AppName {
 					logrus.Debugf("[systemcharts] enqueue %s", repoName)
 					h.clusterRepo.Enqueue(repoName)
 				}

--- a/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
+++ b/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
@@ -20,7 +20,7 @@ const MaxDisplayNodes = 10
 
 // deployPlans creates a master and worker plan in the downstream cluster to instrument
 // the system-upgrade-controller in the downstream cluster
-func (h *handler) deployPlans(cluster *mgmtv3.Cluster, isK3s, isRke2 bool) error {
+func (h *handler) deployPlans(cluster *mgmtv3.Cluster) error {
 	var (
 		upgradeImage   string
 		masterPlanName string
@@ -29,13 +29,13 @@ func (h *handler) deployPlans(cluster *mgmtv3.Cluster, isK3s, isRke2 bool) error
 		strategy       mgmtv3.ClusterUpgradeStrategy
 	)
 	switch {
-	case isRke2:
+	case cluster.Status.Driver == mgmtv3.ClusterDriverRke2:
 		upgradeImage = settings.PrefixPrivateRegistry(rke2upgradeImage)
 		masterPlanName = rke2MasterPlanName
 		workerPlanName = rke2WorkerPlanName
 		Version = cluster.Spec.Rke2Config.Version
 		strategy = cluster.Spec.Rke2Config.ClusterUpgradeStrategy
-	case isK3s:
+	case cluster.Status.Driver == mgmtv3.ClusterDriverK3s:
 		upgradeImage = settings.PrefixPrivateRegistry(k3supgradeImage)
 		masterPlanName = k3sMasterPlanName
 		workerPlanName = k3sWorkerPlanName

--- a/pkg/controllers/management/k3sbasedupgrade/template_test.go
+++ b/pkg/controllers/management/k3sbasedupgrade/template_test.go
@@ -1,9 +1,15 @@
 package k3sbasedupgrade
 
-import "testing"
+import (
+	"testing"
+
+	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func Test_parseVersion(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		version string
@@ -20,6 +26,646 @@ func Test_parseVersion(t *testing.T) {
 			if got := parseVersion(tt.version); got != tt.want {
 				t.Errorf("parseVersion() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestGenerateMasterPlan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		version     string
+		concurrency int
+		drain       bool
+		image       string
+		expected    planv1.Plan
+	}{
+		{
+			name:        "simple plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       false,
+			image:       "test-image",
+			expected: planv1.Plan{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Plan",
+					APIVersion: "upgrade.cattle.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "master-plan",
+					Namespace: "cattle-system",
+					Labels: map[string]string{
+						"rancher-managed": "true",
+					},
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Cordon:             true,
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "drain plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       true,
+			image:       "test-image",
+			expected: planv1.Plan{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Plan",
+					APIVersion: "upgrade.cattle.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "master-plan",
+					Namespace: "cattle-system",
+					Labels: map[string]string{
+						"rancher-managed": "true",
+					},
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Cordon:             true,
+					Drain: &planv1.DrainSpec{
+						Force: true,
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "concurrent plan",
+			version:     "test-version",
+			concurrency: 3,
+			drain:       false,
+			image:       "test-image",
+			expected: planv1.Plan{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Plan",
+					APIVersion: "upgrade.cattle.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "master-plan",
+					Namespace: "cattle-system",
+					Labels: map[string]string{
+						"rancher-managed": "true",
+					},
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        3,
+					ServiceAccountName: "system-upgrade-controller",
+					Cordon:             true,
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, generateMasterPlan(tt.version, tt.concurrency, tt.drain, tt.image, "master-plan"))
+		})
+	}
+}
+
+func TestGenerateWorkerPlan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		version     string
+		concurrency int
+		drain       bool
+		image       string
+		expected    planv1.Plan
+	}{
+		{
+			name:        "simple plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       false,
+			image:       "test-image",
+			expected: planv1.Plan{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Plan",
+					APIVersion: "upgrade.cattle.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker-plan",
+					Namespace: "cattle-system",
+					Labels: map[string]string{
+						"rancher-managed": "true",
+					},
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Cordon:             true,
+					Prepare: &planv1.ContainerSpec{
+						Image: "test-image:test-version",
+						Args:  []string{"prepare", "master-plan"},
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "drain plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       true,
+			image:       "test-image",
+			expected: planv1.Plan{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Plan",
+					APIVersion: "upgrade.cattle.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker-plan",
+					Namespace: "cattle-system",
+					Labels: map[string]string{
+						"rancher-managed": "true",
+					},
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Cordon:             true,
+					Drain: &planv1.DrainSpec{
+						Force: true,
+					},
+					Prepare: &planv1.ContainerSpec{
+						Image: "test-image:test-version",
+						Args:  []string{"prepare", "master-plan"},
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "concurrent plan",
+			version:     "test-version",
+			concurrency: 3,
+			drain:       false,
+			image:       "test-image",
+			expected: planv1.Plan{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Plan",
+					APIVersion: "upgrade.cattle.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker-plan",
+					Namespace: "cattle-system",
+					Labels: map[string]string{
+						"rancher-managed": "true",
+					},
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        3,
+					ServiceAccountName: "system-upgrade-controller",
+					Cordon:             true,
+					Prepare: &planv1.ContainerSpec{
+						Image: "test-image:test-version",
+						Args:  []string{"prepare", "master-plan"},
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, generateWorkerPlan(tt.version, tt.concurrency, tt.drain, tt.image, "worker-plan", "master-plan"))
+		})
+	}
+}
+
+func TestConfigureMasterPlan(t *testing.T) {
+	t.Parallel()
+	masterPlan := planv1.Plan{
+		Spec: planv1.PlanSpec{
+			Upgrade: &planv1.ContainerSpec{
+				Image: "test-image",
+			},
+		},
+	}
+	tests := []struct {
+		name        string
+		version     string
+		concurrency int
+		drain       bool
+		expected    planv1.Plan
+	}{
+		{
+			name:        "simple plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       false,
+			expected: planv1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-plan",
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "drain plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       true,
+			expected: planv1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-plan",
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Drain: &planv1.DrainSpec{
+						Force: true,
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "concurrent plan",
+			version:     "test-version",
+			concurrency: 3,
+			drain:       false,
+			expected: planv1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-plan",
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        3,
+					ServiceAccountName: "system-upgrade-controller",
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			masterPlan := masterPlan
+			assert.Equal(t, tt.expected, configureMasterPlan(masterPlan, tt.version, tt.concurrency, tt.drain, "master-plan"))
+		})
+	}
+}
+
+func TestConfigureWorkerPlan(t *testing.T) {
+	t.Parallel()
+	workerPlan := planv1.Plan{
+		Spec: planv1.PlanSpec{
+			Upgrade: &planv1.ContainerSpec{
+				Image: "test-image",
+			},
+		},
+	}
+	tests := []struct {
+		name        string
+		version     string
+		concurrency int
+		drain       bool
+		expected    planv1.Plan
+	}{
+		{
+			name:        "simple plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       false,
+			expected: planv1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-plan",
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Prepare: &planv1.ContainerSpec{
+						Image: "test-image:test-version",
+						Args:  []string{"prepare", "master-plan"},
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "drain plan",
+			version:     "test-version",
+			concurrency: 1,
+			drain:       true,
+			expected: planv1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-plan",
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        1,
+					ServiceAccountName: "system-upgrade-controller",
+					Drain: &planv1.DrainSpec{
+						Force: true,
+					},
+					Prepare: &planv1.ContainerSpec{
+						Image: "test-image:test-version",
+						Args:  []string{"prepare", "master-plan"},
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+		{
+			name:        "concurrent plan",
+			version:     "test-version",
+			concurrency: 3,
+			drain:       false,
+			expected: planv1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-plan",
+				},
+				Spec: planv1.PlanSpec{
+					Concurrency:        3,
+					ServiceAccountName: "system-upgrade-controller",
+					Prepare: &planv1.ContainerSpec{
+						Image: "test-image:test-version",
+						Args:  []string{"prepare", "master-plan"},
+					},
+					Upgrade: &planv1.ContainerSpec{
+						Image: "test-image",
+					},
+					Version: "test-version",
+					NodeSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+							{
+								Key:      "upgrade.cattle.io/kubernetes-upgrade",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+				Status: planv1.PlanStatus{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			workerPlan := workerPlan
+			assert.Equal(t, tt.expected, configureWorkerPlan(workerPlan, tt.version, tt.concurrency, tt.drain, "test-image", "worker-plan", "master-plan"))
 		})
 	}
 }

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/pkg/errors"
 	cond "github.com/rancher/norman/condition"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -39,6 +40,13 @@ import (
 const (
 	AllNodeKey     = "_machine_all_"
 	annotationName = "management.cattle.io/nodesyncer"
+
+	// UpgradeEnabledLabel is a label which will be set to true on imported RKE2/K3s cluster nodes when the version in the
+	// cluster spec is higher than the version on the nodes. The system-upgrade-controller plan uses a label selector in
+	// the plan specification to determine which nodes must be upgraded. For newly added nodes, this label will not be
+	// applied until the version changes in the cluster spec, preventing unnecessary cordoning until an upgrade is
+	// required.
+	UpgradeEnabledLabel = "upgrade.cattle.io/kubernetes-upgrade"
 )
 
 type nodeSyncer struct {
@@ -135,7 +143,72 @@ func (n *nodeSyncer) sync(key string, node *corev1.Node) (runtime.Object, error)
 		n.machines.Controller().Enqueue(n.clusterNamespace, AllNodeKey)
 	}
 
+	cluster, err := n.nodesSyncer.clusterLister.Get("", n.clusterNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		updateVersion string
+	)
+
+	// only applies to imported k3s/rke2 clusters
+	if cluster.Status.Driver == apimgmtv3.ClusterDriverK3s {
+		if cluster.Spec.K3sConfig == nil {
+			return nil, nil
+		}
+		updateVersion = cluster.Spec.K3sConfig.Version
+	} else if cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 {
+		if cluster.Spec.Rke2Config == nil {
+			return nil, nil
+		}
+		updateVersion = cluster.Spec.Rke2Config.Version
+	} else {
+		return nil, nil
+	}
+
+	// no version set on imported cluster
+	if updateVersion == "" {
+		return nil, nil
+	}
+
+	// if node is running a version lower than what is in the spec
+	if ok, err := IsNewerVersion(node.Status.NodeInfo.KubeletVersion, updateVersion); err != nil {
+		return nil, err
+	} else if ok {
+		node = node.DeepCopy()
+		node.Labels[UpgradeEnabledLabel] = "true"
+		return n.nodesSyncer.nodeClient.Update(node)
+	}
+
 	return nil, nil
+}
+
+// IsNewerVersion returns true if updated versions semver is newer and false if its
+// semver is older. If semver is equal then metadata is alphanumerically compared.
+func IsNewerVersion(prevVersion, updatedVersion string) (bool, error) {
+	parseErrMsg := "failed to parse version: %v"
+	prevVer, err := semver.NewVersion(strings.TrimPrefix(prevVersion, "v"))
+	if err != nil {
+		return false, fmt.Errorf(parseErrMsg, err)
+	}
+
+	updatedVer, err := semver.NewVersion(strings.TrimPrefix(updatedVersion, "v"))
+	if err != nil {
+		return false, fmt.Errorf(parseErrMsg, err)
+	}
+
+	switch updatedVer.Compare(*prevVer) {
+	case -1:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		// using metadata to determine precedence is against semver standards
+		// this is ignored because it because k3s uses it to precedence between
+		// two versions based on same k8s version
+		return updatedVer.Metadata > prevVer.Metadata, nil
+	}
 }
 
 func (n *nodeSyncer) needUpdate(_ string, node *corev1.Node) (bool, error) {

--- a/pkg/image/external/external.go
+++ b/pkg/image/external/external.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
+	"github.com/rancher/rancher/pkg/controllers/managementuser/nodesyncer"
 	"github.com/rancher/rancher/pkg/image"
 	"github.com/sirupsen/logrus"
 )
@@ -61,7 +61,7 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 				continue
 			}
 
-			versionGTMin, err := k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
+			versionGTMin, err := nodesyncer.IsNewerVersion(minVersion, rancherVersion)
 			if err != nil {
 				continue
 			}
@@ -70,7 +70,7 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 				continue
 			}
 
-			versionLTMax, err := k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
+			versionLTMax, err := nodesyncer.IsNewerVersion(rancherVersion, maxVersion)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #41143
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When new nodes are added to an imported cluster, if that cluster has ever been upgraded, nodes are cordoned and the `rke2-upgrade`/`k3s-upgrade` SUC plans are run against them, despite being a no-op.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add a label selector to the SUC plan that only selects nodes that have been determined to be out of date. Update the nodesyncer to apply this label when a cluster has been upgraded.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Tested manually

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

- Test case where new node is added on current version after cluster has already been upgraded
- Test case where new node is added on older version after cluster has already been upgraded
- Test case where new node is added on higher version after cluster has already been upgraded

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
* N/A