### PR TITLE
[2.8] Add a Quarantine Test Function to Skip the Tests 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -402,3 +402,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace github.com/rancher/shepherd => github.com/caliskanugur/shepherd v0.0.0-20240926141344-82ce0067159b

--- a/go.sum
+++ b/go.sum
@@ -736,6 +736,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f h1:7+HZb3PwI0cCUETyMDgPCvSta1y3idwBL8PHwSgelJk=
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/caliskanugur/shepherd v0.0.0-20240926141344-82ce0067159b h1:d/53kCGn2fRPnf8rlzZrTtvLk2T60gOfMWs9czJ3XQc=
+github.com/caliskanugur/shepherd v0.0.0-20240926141344-82ce0067159b/go.mod h1:1TXkmbjCxMEp8Rzzw+ToyrhJYUGDC0lw6uXLe3Ie+M4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -1547,8 +1549,6 @@ github.com/rancher/remotedialer v0.4.0 h1:T9yC5bFMsZFVQ6rK0dNrRg6rRb6Zr/4vsig8S0
 github.com/rancher/remotedialer v0.4.0/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
 github.com/rancher/rke v1.5.14-rc.1 h1:k+H0K8rSHm7QZFZhBIJHw89xUXjMOE6fY8cU6yQ5zl8=
 github.com/rancher/rke v1.5.14-rc.1/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
-github.com/rancher/shepherd v0.0.0-20240912175831-f5a38e38cf42 h1:zALtoACJZV4pH5/pL9qrNVmw1Aj2k1bZ3AwfPOLC9hM=
-github.com/rancher/shepherd v0.0.0-20240912175831-f5a38e38cf42/go.mod h1:1TXkmbjCxMEp8Rzzw+ToyrhJYUGDC0lw6uXLe3Ie+M4=
 github.com/rancher/steve v0.0.0-20240529152548-9fb3e50aa806 h1:QvB3tddPbwuloBMw/q7zSeYyLvKruQI/era5Y+t56dE=
 github.com/rancher/steve v0.0.0-20240529152548-9fb3e50aa806/go.mod h1:o4vLBzMTKbHHhIiAcbgOiaN3aK1vIjL6ZTgaGxQYpsY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=

--- a/tests/v2/actions/quarantine/quarantine.go
+++ b/tests/v2/actions/quarantine/quarantine.go
@@ -1,0 +1,32 @@
+package quarantine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rancher/shepherd/pkg/environmentflag"
+)
+
+// Quarantine package's Test method skips the given testing T by default when it's used
+// to run quarantine flag, the flag in the configuration needs to be set like:
+//
+// flags:
+//   desiredflags: quarantined
+//
+// or multiple flags with quarantine option:
+//
+// flags:
+//   desiredflags: quarantined|long|otherFlag
+
+func Test(t *testing.T, args ...any) {
+	environmentFlags := environmentflag.NewEnvironmentFlags()
+	environmentflag.LoadEnvironmentFlags(environmentflag.ConfigurationFileKey, environmentFlags)
+
+	quarantined := fmt.Sprintf("Test [%v] is quarantined, skipping:", t.Name())
+
+	reason := append([]any{quarantined}, args...)
+
+	if !environmentFlags.GetValue(environmentflag.Quarantined) {
+		t.Skip(reason)
+	}
+}

--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	rv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/clients/rancher/catalog"
 	client "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -127,7 +128,7 @@ func (w *RancherManagedChartsTest) resetSettings() {
 }
 
 func TestRancherManagedChartsSuite(t *testing.T) {
-	t.Skip()
+	quarantine.Test(t)
 	suite.Run(t, new(RancherManagedChartsTest))
 }
 

--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/rancher/tests/v2/actions/kubeapi/rbac"
 	"github.com/rancher/rancher/tests/v2/actions/kubeapi/secrets"
 	"github.com/rancher/rancher/tests/v2/actions/namespaces"
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	stevesecrets "github.com/rancher/rancher/tests/v2/actions/secrets"
 	"github.com/rancher/rancher/tests/v2/actions/serviceaccounts"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -2691,6 +2692,6 @@ func TestSteveLocal(t *testing.T) {
 
 func TestSteveDownstream(t *testing.T) {
 	// TODO: Re-enable the test when the bug is fixed
-	t.Skip()
+	quarantine.Test(t, "Re-enable the test when the bug is fixed, r/r#46391")
 	suite.Run(t, new(DownstreamSteveAPITestSuite))
 }

--- a/tests/v2/validation/nodescaling/scaling_node_driver_aks_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_aks_test.go
@@ -5,6 +5,7 @@ package nodescaling
 import (
 	"testing"
 
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	"github.com/rancher/rancher/tests/v2/actions/scalinginput"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters"
@@ -81,6 +82,6 @@ func (s *AKSNodeScalingTestSuite) TestScalingAKSNodePoolsDynamicInput() {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestAKSNodeScalingTestSuite(t *testing.T) {
-	t.Skip("This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
+	quarantine.Test(t, "This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
 	suite.Run(t, new(AKSNodeScalingTestSuite))
 }

--- a/tests/v2/validation/nodescaling/scaling_node_driver_eks_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_eks_test.go
@@ -5,6 +5,7 @@ package nodescaling
 import (
 	"testing"
 
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	"github.com/rancher/rancher/tests/v2/actions/scalinginput"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters"
@@ -81,6 +82,6 @@ func (s *EKSNodeScalingTestSuite) TestScalingEKSNodePoolsDynamicInput() {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestEKSNodeScalingTestSuite(t *testing.T) {
-	t.Skip("This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
+	quarantine.Test(t, "This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
 	suite.Run(t, new(EKSNodeScalingTestSuite))
 }

--- a/tests/v2/validation/nodescaling/scaling_node_driver_gke_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_gke_test.go
@@ -5,6 +5,7 @@ package nodescaling
 import (
 	"testing"
 
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	"github.com/rancher/rancher/tests/v2/actions/scalinginput"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters"
@@ -81,6 +82,6 @@ func (s *GKENodeScalingTestSuite) TestScalingGKENodePoolsDynamicInput() {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestGKENodeScalingTestSuite(t *testing.T) {
-	t.Skip("This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
+	quarantine.Test(t, "This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
 	suite.Run(t, new(GKENodeScalingTestSuite))
 }

--- a/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/aks/hosted_provisioning_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancher/rancher/tests/v2/actions/provisioning"
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	"github.com/rancher/rancher/tests/v2/actions/reports"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -86,6 +87,6 @@ func (h *HostedAKSClusterProvisioningTestSuite) TestProvisioningHostedAKS() {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestHostedAKSClusterProvisioningTestSuite(t *testing.T) {
-	t.Skip("This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
+	quarantine.Test(t, "This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
 	suite.Run(t, new(HostedAKSClusterProvisioningTestSuite))
 }

--- a/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancher/rancher/tests/v2/actions/provisioning"
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	"github.com/rancher/rancher/tests/v2/actions/reports"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -85,6 +86,6 @@ func (h *HostedEKSClusterProvisioningTestSuite) TestProvisioningHostedEKS() {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestHostedEKSClusterProvisioningTestSuite(t *testing.T) {
-	t.Skip("This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
+	quarantine.Test(t, "This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
 	suite.Run(t, new(HostedEKSClusterProvisioningTestSuite))
 }

--- a/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancher/rancher/tests/v2/actions/provisioning"
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/quarantine"
 	"github.com/rancher/rancher/tests/v2/actions/reports"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -84,6 +85,6 @@ func (h *HostedGKEClusterProvisioningTestSuite) TestProvisioningHostedGKE() {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestHostedGKEClusterProvisioningTestSuite(t *testing.T) {
-	t.Skip("This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
+	quarantine.Test(t, "This test has been deprecated; check https://github.com/rancher/hosted-providers-e2e for updated tests")
 	suite.Run(t, new(HostedGKEClusterProvisioningTestSuite))
 }


### PR DESCRIPTION
## Issue:  rancher/qa-tasks/issues/1484 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently to skip a test, `t.Skip `is used. To run a sktest, these skips in the code need to be changed/updated.
 
## Solution
<!-- Describe what you changed or added to fix the issue. Relate your changes back to the original issue and explain why this addresses the issue. -->
Adds a quarantined flag to the environment flags, and function to the rancher/rancher tests. That enables the quarantined tests to be run optionally via the flags.
 
## Testing
<!-- Note: Confirm the changes are not creating any regressions in Shepherd and existing tests -->
Integration tests that are going to be triggered with this PR.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration (Go Framework)
    * Validation (Go Framework)