### PR TITLE
[BUGFIX] helm-operation pod uses incorrect taint for RKE2 Control Pla…

### DIFF
--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -1030,9 +1030,13 @@ func (s *Operations) createPod(secretData map[string][]byte, kustomize bool, ima
 			Effect:   "NoSchedule",
 		},
 		{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: corev1.TolerationOpEqual,
+			Effect:   "NoSchedule",
+		},
+		{
 			Key:      "node-role.kubernetes.io/etcd",
 			Operator: corev1.TolerationOpEqual,
-			Value:    "true",
 			Effect:   "NoExecute",
 		},
 		{


### PR DESCRIPTION
…ne/etcd nodes, blocking provisioning

## Issue: #46228 #43237
 
## Problem
RKE2 cannot install with dedicated control plane due to different taints from RKE1.
 
## Solution
Update default taints for helm-operation to include both RKE1 and RKE2 node taints.
 
## Testing
Deploy rancher 2.8 or 2.9
Deploy both RKE1 / RKE2 cluster with dedicated control plane (etcd + control-plane but not worker checked).

## Engineering Testing
### Manual Testing
Deployed rancher 2.9.2 with RKE2 cluster on VMWare vSphere

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_