### PR TITLE
[head/2.10] Bump shell for k8s 1.31

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 105.0.0+up0.6.1-rc.4
 provisioningCAPIVersion: 104.0.0+up0.3.0
 cspAdapterMinVersion: 104.0.0+up4.0.0
-defaultShellVersion: rancher/shell:v0.2.1
+defaultShellVersion: rancher/shell:v0.3.0-rc.2
 fleetVersion: 105.0.0+up0.10.4-rc.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion    = "104.0.0+up4.0.0"
-	DefaultShellVersion     = "rancher/shell:v0.2.1"
+	DefaultShellVersion     = "rancher/shell:v0.3.0-rc.2"
 	FleetVersion            = "105.0.0+up0.10.4-rc.1"
 	ProvisioningCAPIVersion = "104.0.0+up0.3.0"
 	WebhookVersion          = "105.0.0+up0.6.1-rc.4"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/47246

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Bump shell to the RC that includes helm with 1.31 support