### PR TITLE
[backport v2.9] Support synchronizing resources directly to downstream clusters

### DIFF
--- a/pkg/agent/rancher/rancher.go
+++ b/pkg/agent/rancher/rancher.go
@@ -70,6 +70,11 @@ type handler struct {
 }
 
 func (h *handler) startRancher() {
+	if features.ProvisioningPreBootstrap.Enabled() {
+		logrus.Debugf("not starting embedded rancher due to pre-bootstrap...")
+		return
+	}
+
 	clientConfig := kubeconfig.GetNonInteractiveClientConfig("")
 	server, err := rancher.New(h.ctx, clientConfig, &rancher.Options{
 		HTTPListenPort:  80,

--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -47,7 +47,7 @@ func (ch *ClusterImport) ClusterImportHandler(resp http.ResponseWriter, req *htt
 	}
 
 	if err = systemtemplate.SystemTemplate(resp, image.Resolve(settings.AgentImage.Get()), authImage, "", token, url,
-		false, cluster, nil, nil, nil); err != nil {
+		false, false, cluster, nil, nil, nil); err != nil {
 		resp.WriteHeader(500)
 		resp.Write([]byte(err.Error()))
 	}

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -36,15 +36,16 @@ const (
 	ClusterActionSaveAsTemplate        = "saveAsTemplate"
 
 	// ClusterConditionReady Cluster ready to serve API (healthy when true, unhealthy when false)
-	ClusterConditionReady          condition.Cond = "Ready"
-	ClusterConditionPending        condition.Cond = "Pending"
-	ClusterConditionCertsGenerated condition.Cond = "CertsGenerated"
-	ClusterConditionEtcd           condition.Cond = "etcd"
-	ClusterConditionProvisioned    condition.Cond = "Provisioned"
-	ClusterConditionUpdated        condition.Cond = "Updated"
-	ClusterConditionUpgraded       condition.Cond = "Upgraded"
-	ClusterConditionWaiting        condition.Cond = "Waiting"
-	ClusterConditionRemoved        condition.Cond = "Removed"
+	ClusterConditionReady           condition.Cond = "Ready"
+	ClusterConditionPending         condition.Cond = "Pending"
+	ClusterConditionCertsGenerated  condition.Cond = "CertsGenerated"
+	ClusterConditionEtcd            condition.Cond = "etcd"
+	ClusterConditionPreBootstrapped condition.Cond = "PreBootstrapped"
+	ClusterConditionProvisioned     condition.Cond = "Provisioned"
+	ClusterConditionUpdated         condition.Cond = "Updated"
+	ClusterConditionUpgraded        condition.Cond = "Upgraded"
+	ClusterConditionWaiting         condition.Cond = "Waiting"
+	ClusterConditionRemoved         condition.Cond = "Removed"
 	// ClusterConditionNoDiskPressure true when all cluster nodes have sufficient disk
 	ClusterConditionNoDiskPressure condition.Cond = "NoDiskPressure"
 	// ClusterConditionNoMemoryPressure true when all cluster nodes have sufficient memory

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -18,10 +18,12 @@ import (
 	"time"
 
 	"github.com/rancher/channelserver/pkg/model"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/channelserver"
+	"github.com/rancher/rancher/pkg/features"
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
@@ -31,6 +33,7 @@ import (
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/name"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -663,4 +666,14 @@ func ParseSnapshotClusterSpecOrError(snapshot *rkev1.ETCDSnapshot) (*provv1.Clus
 		}
 	}
 	return nil, fmt.Errorf("unable to find and decode snapshot ClusterSpec for snapshot")
+}
+
+func PreBootstrap(mgmtCluster *v3.Cluster) bool {
+	// if the upstream rancher _does not_ have pre-bootstrapping enabled just always return false.
+	if !features.ProvisioningPreBootstrap.Enabled() {
+		logrus.Debug("[pre-bootstrap] feature-flag disabled, skipping pre-bootstrap flow")
+		return false
+	}
+
+	return !v3.ClusterConditionPreBootstrapped.IsTrue(mgmtCluster)
 }

--- a/pkg/capr/planner/agent.go
+++ b/pkg/capr/planner/agent.go
@@ -14,7 +14,7 @@ func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPla
 		return nil, nil
 	}
 
-	tokens, err := p.clusterRegistrationTokenCache.GetByIndex(clusterRegToken, controlPlane.Spec.ManagementClusterName)
+	tokens, err := p.clusterRegistrationTokenCache.GetByIndex(ClusterRegToken, controlPlane.Spec.ManagementClusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/capr/planner/certificaterotation_test.go
+++ b/pkg/capr/planner/certificaterotation_test.go
@@ -247,7 +247,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 	}
 
 	genericSetup := func(mp *mockPlanner) {
-		mp.clusterRegistrationTokenCache.EXPECT().GetByIndex(clusterRegToken, "somecluster").Return([]*v3.ClusterRegistrationToken{{Status: v3.ClusterRegistrationTokenStatus{Token: "lol"}}}, nil)
+		mp.clusterRegistrationTokenCache.EXPECT().GetByIndex(ClusterRegToken, "somecluster").Return([]*v3.ClusterRegistrationToken{{Status: v3.ClusterRegistrationTokenStatus{Token: "lol"}}}, nil)
 		mp.managementClusters.EXPECT().Get("somecluster").Return(&v3.Cluster{}, nil)
 	}
 
@@ -423,8 +423,9 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			mockPlanner := newMockPlanner(t, InfoFunctions{
-				SystemAgentImage: func() string { return "system-agent" },
-				ImageResolver:    image.ResolveWithControlPlane,
+				SystemAgentImage:      func() string { return "system-agent" },
+				ImageResolver:         image.ResolveWithControlPlane,
+				GetBootstrapManifests: func(plane *rkev1.RKEControlPlane) ([]plan.File, error) { return nil, nil },
 			})
 			if tt.setup != nil {
 				tt.setup(mockPlanner)

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	clusterRegToken = "clusterRegToken"
+	ClusterRegToken = "clusterRegToken"
 
 	EtcdSnapshotConfigMapKey = "provisioning-cluster-spec"
 
@@ -135,10 +135,11 @@ type InfoFunctions struct {
 	ReleaseData             func(context.Context, *rkev1.RKEControlPlane) *model.Release
 	SystemAgentImage        func() string
 	SystemPodLabelSelectors func(plane *rkev1.RKEControlPlane) []string
+	GetBootstrapManifests   func(plane *rkev1.RKEControlPlane) ([]plan.File, error)
 }
 
 func New(ctx context.Context, clients *wrangler.Context, functions InfoFunctions) *Planner {
-	clients.Mgmt.ClusterRegistrationToken().Cache().AddIndexer(clusterRegToken, func(obj *v3.ClusterRegistrationToken) ([]string, error) {
+	clients.Mgmt.ClusterRegistrationToken().Cache().AddIndexer(ClusterRegToken, func(obj *v3.ClusterRegistrationToken) ([]string, error) {
 		return []string{obj.Spec.ClusterName}, nil
 	})
 	store := NewStore(clients.Core.Secret(),
@@ -868,6 +869,11 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret pl
 		return err
 	}
 
+	preBootstrapManifests, err := p.retrievalFunctions.GetBootstrapManifests(controlPlane)
+	if err != nil {
+		return err
+	}
+
 	for _, r := range reconcilables {
 		logrus.Tracef("[planner] rkecluster %s/%s reconcile tier %s - processing machine entry: %s/%s", controlPlane.Namespace, controlPlane.Name, tierName, r.entry.Machine.Namespace, r.entry.Machine.Name)
 		// we exclude here and not in collect to ensure that include matched at least one node
@@ -961,6 +967,9 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret pl
 		} else if !kubeletVersionUpToDate(controlPlane, r.entry.Machine) {
 			outOfSync = append(outOfSync, r.entry.Machine.Name)
 			messages[r.entry.Machine.Name] = append(messages[r.entry.Machine.Name], "waiting for kubelet to update")
+		} else if isControlPlane(r.entry) && len(preBootstrapManifests) > 0 {
+			outOfSync = append(outOfSync, r.entry.Machine.Name)
+			messages[r.entry.Machine.Name] = append(messages[r.entry.Machine.Name], "waiting for cluster pre-bootstrap to complete")
 		} else if isControlPlane(r.entry) && !controlPlane.Status.AgentConnected {
 			// If the control plane nodes are currently being provisioned/updated, then it should be ensured that cluster-agent is connected.
 			// Without the agent connected, the controllers running in Rancher, including CAPI, can't communicate with the downstream cluster.
@@ -1021,6 +1030,7 @@ func (p *Planner) generatePlanWithConfigFiles(controlPlane *rkev1.RKEControlPlan
 		nodePlan plan.NodePlan
 		err      error
 	)
+
 	if !controlPlane.Spec.UnmanagedConfig {
 		nodePlan, reg, err = p.commonNodePlan(controlPlane, plan.NodePlan{})
 		if err != nil {
@@ -1030,8 +1040,19 @@ func (p *Planner) generatePlanWithConfigFiles(controlPlane *rkev1.RKEControlPlan
 			joinedServer string
 			config       map[string]interface{}
 		)
+
 		nodePlan, config, joinedServer, err = p.addConfigFile(nodePlan, controlPlane, entry, tokensSecret, joinServer, reg, renderS3)
 		if err != nil {
+			return nodePlan, config, joinedServer, err
+		}
+
+		bootstrapManifests, err := p.retrievalFunctions.GetBootstrapManifests(controlPlane)
+		if err != nil {
+			return nodePlan, config, joinedServer, err
+		}
+		if len(bootstrapManifests) > 0 {
+			logrus.Debugf("[planner] adding pre-bootstrap manifests")
+			nodePlan.Files = append(nodePlan.Files, bootstrapManifests...)
 			return nodePlan, config, joinedServer, err
 		}
 
@@ -1058,6 +1079,7 @@ func (p *Planner) generatePlanWithConfigFiles(controlPlane *rkev1.RKEControlPlan
 
 		return nodePlan, config, joinedServer, err
 	}
+
 	return plan.NodePlan{}, map[string]interface{}{}, "", nil
 }
 

--- a/pkg/capr/planner/planner_test.go
+++ b/pkg/capr/planner/planner_test.go
@@ -148,6 +148,7 @@ func TestPlanner_addInstruction(t *testing.T) {
 			entry := createTestPlanEntry(tt.args.os)
 			planner.retrievalFunctions.SystemAgentImage = func() string { return "system-agent" }
 			planner.retrievalFunctions.ImageResolver = image.ResolveWithControlPlane
+			planner.retrievalFunctions.GetBootstrapManifests = func(cp *rkev1.RKEControlPlane) ([]plan.File, error) { return nil, nil }
 			// act
 			p, err := planner.addInstallInstructionWithRestartStamp(plan.NodePlan{}, controlPlane, entry)
 
@@ -518,6 +519,7 @@ func Test_getInstallerImage(t *testing.T) {
 			var planner Planner
 			planner.retrievalFunctions.ImageResolver = image.ResolveWithControlPlane
 			planner.retrievalFunctions.SystemAgentImage = func() string { return "rancher/system-agent-installer-" }
+			planner.retrievalFunctions.GetBootstrapManifests = func(cp *rkev1.RKEControlPlane) ([]plan.File, error) { return nil, nil }
 
 			assert.Equal(t, tt.expected, planner.getInstallerImage(tt.controlPlane))
 		})

--- a/pkg/controllers/capr/controllers.go
+++ b/pkg/controllers/capr/controllers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
+	"github.com/rancher/rancher/pkg/provisioningv2/prebootstrap"
 	"github.com/rancher/rancher/pkg/provisioningv2/systeminfo"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
@@ -30,6 +31,7 @@ func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager 
 		ReleaseData:             capr.GetKDMReleaseData,
 		SystemAgentImage:        settings.SystemAgentInstallerImage.Get,
 		SystemPodLabelSelectors: systeminfo.NewRetriever(clients).GetSystemPodLabelSelectors,
+		GetBootstrapManifests:   prebootstrap.NewRetriever(clients).GeneratePreBootstrapClusterAgentManifest,
 	})
 	if features.MCM.Enabled() {
 		dynamicschema.Register(ctx, clients)

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rancher/rancher/pkg/capr"
+
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -445,7 +447,8 @@ func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authIma
 	}
 
 	buf := &bytes.Buffer{}
-	err = systemtemplate.SystemTemplate(buf, agentImage, authImage, cluster.Name, token, url, cluster.Spec.WindowsPreferedCluster,
+	err = systemtemplate.SystemTemplate(buf, agentImage, authImage, cluster.Name, token, url,
+		cluster.Spec.WindowsPreferedCluster, capr.PreBootstrap(cluster),
 		cluster, features, taints, cd.secretLister)
 
 	return buf.Bytes(), err

--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -1,14 +1,19 @@
 package secret
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/rancher/norman/controller"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/capr"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -32,6 +37,18 @@ const (
 	update                     = "update"
 	projectNamespaceAnnotation = "management.cattle.io/system-namespace"
 	userSecretAnnotation       = "secret.user.cattle.io/secret"
+
+	syncAnnotation             = "provisioning.cattle.io/sync"
+	syncPreBootstrapAnnotation = "provisioning.cattle.io/sync-bootstrap"
+	syncNamespaceAnnotation    = "provisioning.cattle.io/sync-target-namespace"
+	syncNameAnnotation         = "provisioning.cattle.io/sync-target-name"
+	syncedAtAnnotation         = "provisioning.cattle.io/synced-at"
+)
+
+var (
+	// as of right now kube-system is the only appropriate target for this functionality.
+	// also included is "" to support copying into the same ns the secret is in
+	approvedPreBootstrapTargetNamespaces = []string{"kube-system", ""}
 )
 
 type Controller struct {
@@ -43,7 +60,25 @@ type Controller struct {
 	clusterName               string
 }
 
-func Register(ctx context.Context, cluster *config.UserContext) {
+type ResourceSyncController struct {
+	upstreamSecrets   v1.SecretInterface
+	downstreamSecrets v1.SecretInterface
+	clusterName       string
+	clusterId         string
+}
+
+func Bootstrap(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *apimgmtv3.Cluster) error {
+	c := &ResourceSyncController{
+		upstreamSecrets:   mgmt.Core.Secrets(clusterRec.Spec.FleetWorkspaceName),
+		downstreamSecrets: cluster.Core.Secrets(""),
+		clusterName:       clusterRec.Spec.DisplayName,
+		clusterId:         clusterRec.Name,
+	}
+
+	return c.bootstrap(mgmt.Management.Clusters(""), clusterRec)
+}
+
+func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *apimgmtv3.Cluster) {
 	starter := cluster.DeferredStart(ctx, func(ctx context.Context) error {
 		registerDeferred(ctx, cluster)
 		return nil
@@ -69,6 +104,153 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 
 		return obj, nil
 	})
+
+	resourceSyncController := &ResourceSyncController{
+		upstreamSecrets:   mgmt.Core.Secrets(clusterRec.Spec.FleetWorkspaceName),
+		downstreamSecrets: cluster.Core.Secrets(""),
+		clusterName:       clusterRec.Spec.DisplayName,
+	}
+
+	resourceSyncController.upstreamSecrets.AddHandler(ctx, "secret-resource-synced", resourceSyncController.sync)
+}
+
+func (c *ResourceSyncController) bootstrap(mgmtClusterClient v3.ClusterInterface, mgmtCluster *apimgmtv3.Cluster) error {
+	secrets, err := c.upstreamSecrets.List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list secrets in %v namespace: %w", mgmtCluster.Spec.FleetWorkspaceName, err)
+	}
+
+	logrus.Debugf("[pre-bootstrap][secrets] looking for secrets-to synchronize to cluster %v", c.clusterName)
+
+	for _, sec := range secrets.Items {
+		s := &sec
+
+		if !c.bootstrapSyncable(s) {
+			continue
+		}
+
+		logrus.Debugf("[pre-bootstrap-sync][secrets] syncing secret %v/%v to cluster %v", s.Namespace, s.Name, c.clusterName)
+
+		_, err = c.sync("", s)
+		if err != nil {
+			return fmt.Errorf("failed to synchronize secret %v/%v to cluster %v: %w", s.Namespace, s.Name, c.clusterName, err)
+		}
+
+		logrus.Debugf("[pre-boostrap-sync][secret] successfully synced secret %v/%v to downstream cluster %v", s.Namespace, s.Name, c.clusterName)
+	}
+
+	apimgmtv3.ClusterConditionPreBootstrapped.True(mgmtCluster)
+	_, err = mgmtClusterClient.Update(mgmtCluster)
+	if err != nil {
+		return fmt.Errorf("failed to update cluster bootstrap condition for %v: %w", c.clusterName, err)
+	}
+
+	return nil
+}
+
+func (c *ResourceSyncController) syncable(obj *corev1.Secret) bool {
+	// no sync annotations, we don't care about this secret
+	if obj.Annotations[syncAnnotation] == "" && obj.Annotations[syncPreBootstrapAnnotation] == "" {
+		return false
+	}
+
+	// if secret is authorized to be synchronized to the cluster
+	if !slices.Contains(strings.Split(obj.Annotations[capr.AuthorizedObjectAnnotation], ","), c.clusterName) {
+		return false
+	}
+
+	// if the secret is not in a namespace that we are allowed to sync to
+	if !slices.Contains(approvedPreBootstrapTargetNamespaces, obj.Annotations[syncNamespaceAnnotation]) {
+		return false
+	}
+
+	return true
+}
+
+func (c *ResourceSyncController) bootstrapSyncable(obj *corev1.Secret) bool {
+	// only difference between sync and bootstrapSync is requiring the boostrap sync annotation to be set to "true"
+	return c.syncable(obj) && obj.Annotations[syncPreBootstrapAnnotation] == "true"
+}
+
+func (c *ResourceSyncController) injectClusterIdIntoSecretData(sec *corev1.Secret) *corev1.Secret {
+	for key, value := range sec.Data {
+		if bytes.Contains(value, []byte("{{clusterId}}")) {
+			sec.Data[key] = bytes.ReplaceAll(value, []byte("{{clusterId}}"), []byte(c.clusterId))
+		}
+	}
+
+	return sec
+}
+
+func (c *ResourceSyncController) removeClusterIdFromSecretData(sec *corev1.Secret) *corev1.Secret {
+	for key, value := range sec.Data {
+		if bytes.Contains(value, []byte(c.clusterId)) {
+			sec.Data[key] = bytes.ReplaceAll(value, []byte(c.clusterId), []byte("{{clusterId}}"))
+		}
+	}
+
+	return sec
+}
+
+func (c *ResourceSyncController) sync(key string, obj *corev1.Secret) (runtime.Object, error) {
+	if obj == nil {
+		return nil, nil
+	}
+
+	if !c.syncable(obj) {
+		return obj, nil
+	}
+
+	name := obj.Annotations[syncNameAnnotation]
+	if name == "" {
+		name = obj.Name
+	}
+	ns := obj.Annotations[syncNamespaceAnnotation]
+	if ns == "" {
+		ns = obj.Namespace
+	}
+
+	logrus.Debugf("[resource-sync][secret] synchronizing %v/%v to %v/%v for cluster %v", obj.Namespace, obj.Name, ns, name, c.clusterName)
+
+	var targetSecret *corev1.Secret
+	var err error
+	if targetSecret, err = c.downstreamSecrets.GetNamespaced(ns, name, metav1.GetOptions{}); err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get downstream secret %v/%v in cluster %v: %w", ns, name, c.clusterName, err)
+	}
+
+	if targetSecret == nil || errors.IsNotFound(err) {
+		logrus.Debugf("[resource-sync][secret] creating secret %v/%v in cluster %v", ns, name, c.clusterName)
+
+		newSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Data:       obj.Data,
+		}
+
+		newSecret = c.injectClusterIdIntoSecretData(newSecret)
+
+		_, err = c.downstreamSecrets.Create(newSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create secret %v/%v in cluster %v: %w", ns, name, c.clusterName, err)
+		}
+	} else if !reflect.DeepEqual(c.removeClusterIdFromSecretData(targetSecret).Data, obj.Data) {
+		logrus.Debugf("[resource-sync][secret] updating secret %v/%v in cluster %v", ns, name, c.clusterName)
+
+		targetSecret.Data = obj.Data
+		targetSecret = c.injectClusterIdIntoSecretData(targetSecret)
+
+		_, err = c.downstreamSecrets.Update(targetSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update secret %v/%v in cluster %v: %w", ns, name, c.clusterName, err)
+		}
+	} else {
+		logrus.Debugf("[resource-sync][secret] skipping downstream update - contents are the same")
+		return obj, nil
+	}
+
+	logrus.Debugf("[resource-sync][secret] successfully synchronized secret %v/%v to %v/%v for cluster %v", obj.Namespace, obj.Name, ns, name, c.clusterName)
+
+	obj.Annotations[syncedAtAnnotation] = time.Now().Format(time.RFC3339)
+	return obj, nil
 }
 
 func registerDeferred(ctx context.Context, cluster *config.UserContext) {

--- a/pkg/controllers/managementuser/secret/secret_test.go
+++ b/pkg/controllers/managementuser/secret/secret_test.go
@@ -1,0 +1,28 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestInjectClusterIdIntoSecretData(t *testing.T) {
+	sec := &corev1.Secret{Data: map[string][]byte{
+		"bazqux": []byte("{{clusterId}}"),
+	}}
+
+	c := ResourceSyncController{clusterId: "foobar"}
+
+	assert.Equal(t, c.injectClusterIdIntoSecretData(sec).Data["bazqux"], []byte("foobar"))
+}
+
+func TestRemoveClusterIdFromSecretData(t *testing.T) {
+	sec := &corev1.Secret{Data: map[string][]byte{
+		"bazqux": []byte("foobar"),
+	}}
+
+	c := ResourceSyncController{clusterId: "foobar"}
+
+	assert.Equal(t, c.removeClusterIdFromSecretData(sec).Data["bazqux"], []byte("{{clusterId}}"))
+}

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -132,6 +132,12 @@ var (
 		true,
 		true,
 		true)
+	ProvisioningPreBootstrap = newFeature(
+		"provisioningprebootstrap",
+		"Support running pre-bootstrap workloads on downstream clusters",
+		false,
+		true,
+		true)
 )
 
 type Feature struct {

--- a/pkg/provisioningv2/prebootstrap/resolve.go
+++ b/pkg/provisioningv2/prebootstrap/resolve.go
@@ -1,0 +1,81 @@
+package prebootstrap
+
+import (
+	"encoding/base64"
+	"fmt"
+	"path"
+	"sort"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/capr/planner"
+	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/systemtemplate"
+	"github.com/rancher/rancher/pkg/wrangler"
+	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+)
+
+func NewRetriever(clients *wrangler.Context) *Retriever {
+	return &Retriever{
+		mgmtClusterCache:              clients.Mgmt.Cluster().Cache(),
+		clusterRegistrationTokenCache: clients.Mgmt.ClusterRegistrationToken().Cache(),
+		secretCache:                   clients.Core.Secret().Cache(),
+	}
+
+}
+
+type Retriever struct {
+	mgmtClusterCache              mgmtcontrollers.ClusterCache
+	clusterRegistrationTokenCache mgmtcontrollers.ClusterRegistrationTokenCache
+	secretCache                   corecontrollers.SecretCache
+}
+
+func (r *Retriever) GeneratePreBootstrapClusterAgentManifest(controlPlane *rkev1.RKEControlPlane) ([]plan.File, error) {
+	shouldDo, err := r.preBootstrapCluster(controlPlane)
+	if !shouldDo {
+		return nil, nil
+	}
+
+	tokens, err := r.clusterRegistrationTokenCache.GetByIndex(planner.ClusterRegToken, controlPlane.Spec.ManagementClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no cluster registration token found")
+	}
+
+	sort.Slice(tokens, func(i, j int) bool {
+		return tokens[i].Name < tokens[j].Name
+	})
+
+	mgmtCluster, err := r.mgmtClusterCache.Get(controlPlane.Spec.ManagementClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get mgmt Cluster %v: %w", controlPlane.Spec.ManagementClusterName, err)
+	}
+
+	// passing in nil for taints since prebootstrapping involves specific taints to uninitialized nodes
+	data, err := systemtemplate.ForCluster(mgmtCluster, tokens[0].Status.Token, nil, r.secretCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate pre-bootstrap cluster-agent manifest: %w", err)
+	}
+
+	return []plan.File{{
+		Content: base64.StdEncoding.EncodeToString(data),
+		Path:    path.Join(capr.GetDistroDataDir(controlPlane), "server/manifests/rancher/cluster-agent.yaml"),
+		Dynamic: true,
+		Minor:   true,
+	}}, nil
+}
+
+func (r *Retriever) preBootstrapCluster(cp *rkev1.RKEControlPlane) (bool, error) {
+	mgmtCluster, err := r.mgmtClusterCache.Get(cp.Spec.ManagementClusterName)
+	if err != nil {
+		logrus.Warnf("[pre-bootstrap] failed to get management cluster [%v] for rke control plane [%v]: %v", cp.Spec.ManagementClusterName, cp.Name, err)
+		return false, fmt.Errorf("failed to get mgmt Cluster %v: %w", cp.Spec.ManagementClusterName, err)
+	}
+
+	return capr.PreBootstrap(mgmtCluster), nil
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -56,7 +56,7 @@ var (
 		"cattle-elemental-system",
 	}
 
-	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:v2.9-head")
+	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:head")
 	AgentRolloutTimeout = NewSetting("agent-rollout-timeout", "300s")
 	AgentRolloutWait    = NewSetting("agent-rollout-wait", "true")
 	// AgentTLSMode is translated to the environment variable STRICT_VERIFY when rendering the cluster/node agent manifests and should not be specified as a default agent setting as it has no direct effect on the agent itself.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -56,7 +56,7 @@ var (
 		"cattle-elemental-system",
 	}
 
-	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:head")
+	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:v2.9-head")
 	AgentRolloutTimeout = NewSetting("agent-rollout-timeout", "300s")
 	AgentRolloutWait    = NewSetting("agent-rollout-wait", "true")
 	// AgentTLSMode is translated to the environment variable STRICT_VERIFY when rendering the cluster/node agent manifests and should not be specified as a default agent setting as it has no direct effect on the agent itself.

--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -53,6 +53,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 		token                            string
 		url                              string
 		isWindowsCluster                 bool
+		isPreBootstrap                   bool
 		features                         map[string]bool
 		taints                           []corev1.Taint
 		secrets                          map[string]*corev1.Secret
@@ -183,7 +184,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 
 			mockSecrets = tt.secrets
 			var b bytes.Buffer
-			err := SystemTemplate(&b, tt.agentImage, tt.authImage, tt.namespace, tt.token, tt.url, tt.isWindowsCluster, tt.cluster, tt.features, tt.taints, secretLister)
+			err := SystemTemplate(&b, tt.agentImage, tt.authImage, tt.namespace, tt.token, tt.url, tt.isWindowsCluster, tt.isPreBootstrap, tt.cluster, tt.features, tt.taints, secretLister)
 
 			assert.Nil(t, err)
 			decoder := scheme.Codecs.UniversalDeserializer()

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -111,7 +111,11 @@ rules:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- if .IsPreBootstrap }}
+  name: cattle-cluster-agent-bootstrap
+  {{- else }}
   name: cattle-cluster-agent
+  {{- end }}
   namespace: cattle-system
   annotations:
     management.cattle.io/scale-available: "2"
@@ -130,7 +134,24 @@ spec:
       {{- end }}
       serviceAccountName: cattle
       tolerations:
-      {{- if .Tolerations }}
+      {{- if .IsPreBootstrap }}
+      # tolerations wrt running on the pre-bootstrapped node
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/controlplane
+        value: "true"
+      - effect: NoSchedule
+        key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+      - effect: NoSchedule
+        key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+      - effect: NoExecute
+        key: "node-role.kubernetes.io/etcd"
+        operator: "Exists"
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: "Exists"
+      {{- else if .Tolerations }}
       # Tolerations added based on found taints on controlplane nodes
 {{ .Tolerations | indent 6 }}
       {{- else }}
@@ -172,6 +193,9 @@ spec:
             value: "true"
           - name: CATTLE_CLUSTER_REGISTRY
             value: "{{.ClusterRegistry}}"
+          {{- if .IsPreBootstrap }}
+          # since we're on the host network, talk to the apiserver over localhost
+          {{- end }}
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}
       {{- end }}
@@ -183,6 +207,10 @@ spec:
       {{- if .PrivateRegistryConfig}}
       imagePullSecrets:
       - name: cattle-private-registry
+      {{- end }}
+      {{- if .IsPreBootstrap }}
+      # use hostNetwork since the CNI (and coreDNS) is not up yet
+      hostNetwork: true
       {{- end }}
       volumes:
       - name: cattle-credentials

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -41,6 +41,14 @@ export SOME_K8S_VERSION=${SOME_K8S_VERSION}
 export TB_ORG=${TB_ORG}
 export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 
+# Tell Rancher to use the recently-built Rancher cluster agent image. This image is built as part of CI and will be
+# copied to the in-cluster registry during test setup below.
+source ./scripts/version
+# export CATTLE_AGENT_IMAGE="rancher/rancher-agent:${AGENT_TAG}"
+# using :head for now while figuring out why loading from the docker cache isn't working
+export CATTLE_AGENT_IMAGE="rancher/rancher-agent:head"
+echo "Using Rancher agent image $CATTLE_AGENT_IMAGE"
+
 eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -46,7 +46,7 @@ export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 source ./scripts/version
 # export CATTLE_AGENT_IMAGE="rancher/rancher-agent:${AGENT_TAG}"
 # using :head for now while figuring out why loading from the docker cache isn't working
-export CATTLE_AGENT_IMAGE="rancher/rancher-agent:head"
+export CATTLE_AGENT_IMAGE="rancher/rancher-agent:v2.9-head"
 echo "Using Rancher agent image $CATTLE_AGENT_IMAGE"
 
 eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/47469

Support synchronizing resources directly to downstream clusters (https://github.com/rancher/rancher/pull/47437)

* conditionally bootstrap controllers based on condition

* finish pre-bootstrap templating

* change to feature-flag for feature and implement controllers

* update tests to expect second call to planner#mgmtClusters.Get(...)

* code review comments



* refactor boostrapManifests into an InfoFunction

---------

## Issue:  <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

This is a backport of https://github.com/rancher/rancher/pull/47437