### PR TITLE
[v2.7] Fix auth provider cleanup service

### DIFF
--- a/pkg/auth/cleanup/service.go
+++ b/pkg/auth/cleanup/service.go
@@ -160,6 +160,7 @@ func (s *Service) deleteUsers(config *v3.AuthConfig) error {
 	}
 
 	for _, u := range users.Items {
+		u := u
 		providerName := getProviderNameFromPrincipalNames(u.PrincipalIDs...)
 		if providerName == config.Name {
 			// A fully external user (who was never local) has no password.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

A reference to a loop variable is used leading to unexpected results.
This causes unit tests [to fail](https://github.com/rancher/rancher/actions/runs/11145755402/job/30982471888?pr=47354)

```
--- FAIL: TestRunCleanup (0.00s)
    service_test.go:140: 
        	Error Trace:	/home/runner/work/rancher/rancher/pkg/auth/cleanup/service_test.go:140
        	Error:      	"[local://boss azuread_user://authprincipal]" should have 1 item(s), but has 2
        	Test:       	TestRunCleanup
        	Messages:   	every user after cleanup must have only one principal ID, got 2
FAIL
```

The behavior of for loops was fixed in Go 1.22 but v2.7 still uses 1.20.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Make a copy of the loop variable.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A