### PR TITLE
Add retryonconflict to fetch the clusterrepo

### DIFF
--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/memory"
 )
@@ -817,9 +818,23 @@ func (c *ClusterRepoTestSuite) testClusterRepoRetries(params ClusterRepoParams) 
 	require.NoError(c.T(), err)
 
 	downloadTime := cr.Status.DownloadTime
-	cr.Spec.GitBranch = "main"
-	cr, err = c.catalogClient.ClusterRepos().Update(context.TODO(), cr, metav1.UpdateOptions{})
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cr, err = c.catalogClient.ClusterRepos().Get(context.TODO(), cr.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		cr.Spec.GitBranch = "main"
+		cr, err = c.catalogClient.ClusterRepos().Update(context.TODO(), cr, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 	require.NoError(c.T(), err)
+
 	// Validate the ClusterRepo was created and resources were downloaded
 	clusterRepo, err := c.pollUntilDownloaded(params.Name, metav1.Time{})
 	require.NoError(c.T(), err)


### PR DESCRIPTION
Please check the issue for more details 

### Summary 

- Adding retry mechanism to fetch the clusterrepo since one fetch is not sufficient.