### PR TITLE
[2.10] Deprecate rancher-k3s-upgrader

### DIFF
--- a/pkg/controllers/dashboard/chart/chart.go
+++ b/pkg/controllers/dashboard/chart/chart.go
@@ -24,6 +24,9 @@ const (
 
 	// ProvisioningCAPIChartName name of the chart for rancher-provisioning-capi.
 	ProvisioningCAPIChartName = "rancher-provisioning-capi"
+
+	// SystemUpgradeControllerChartName name of the chart system-upgrade-controller
+	SystemUpgradeControllerChartName = "system-upgrade-controller"
 )
 
 var errKeyNotFound = errors.New("key not found")
@@ -59,7 +62,7 @@ type RancherConfigGetter struct {
 	ConfigCache corev1.ConfigMapCache
 }
 
-// GetPriorityClassName attempts to retrieve the priority class for rancher pods and feature charts as set via helm values.
+// GetGlobalValue attempts to retrieve value of the specified key from the configmap that stores rancher configuration information.
 func (r *RancherConfigGetter) GetGlobalValue(key string) (string, error) {
 	return r.getKey(key, settings.ConfigMapName.Get())
 }

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -7,34 +7,41 @@ import (
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
+	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
 	"github.com/rancher/rancher/pkg/features"
+	catalogcontrollers "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/data"
+	deploymentControllers "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps/v1"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
+	k8sappsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
-	repoName         = "rancher-charts"
-	priorityClassKey = "priorityClassName"
+	repoName          = "rancher-charts"
+	sucDeploymentName = "system-upgrade-controller"
+	legacyAppLabel    = "io.cattle.field/appId"
 )
 
 var (
 	primaryImages = map[string]string{
-		chart.WebhookChartName:          "rancher/rancher-webhook",
-		chart.ProvisioningCAPIChartName: "rancher/mirrored-cluster-api-controller",
+		chart.WebhookChartName:                 "rancher/rancher-webhook",
+		chart.ProvisioningCAPIChartName:        "rancher/mirrored-cluster-api-controller",
+		chart.SystemUpgradeControllerChartName: "rancher/system-upgrade-controller",
 	}
 	watchedSettings = map[string]struct{}{
-		settings.RancherWebhookVersion.Name:          {},
-		settings.RancherProvisioningCAPIVersion.Name: {},
-		settings.SystemDefaultRegistry.Name:          {},
-		settings.ShellImage.Name:                     {},
+		settings.RancherWebhookVersion.Name:               {},
+		settings.RancherProvisioningCAPIVersion.Name:      {},
+		settings.SystemDefaultRegistry.Name:               {},
+		settings.ShellImage.Name:                          {},
+		settings.SystemUpgradeControllerChartVersion.Name: {},
 	}
 )
 
@@ -43,6 +50,8 @@ func Register(ctx context.Context, wContext *wrangler.Context, registryOverride 
 	h := &handler{
 		manager:          wContext.SystemChartsManager,
 		namespaces:       wContext.Core.Namespace(),
+		deployment:       wContext.Apps.Deployment().Cache(),
+		clusterRepo:      wContext.Catalog.ClusterRepo(),
 		chartsConfig:     chart.RancherConfigGetter{ConfigCache: wContext.Core.ConfigMap().Cache()},
 		registryOverride: registryOverride,
 	}
@@ -54,12 +63,16 @@ func Register(ctx context.Context, wContext *wrangler.Context, registryOverride 
 
 	// ensure the system charts are installed with the correct values when there are changes to the rancher config map
 	relatedresource.WatchClusterScoped(ctx, "bootstrap-configmap-charts", relatedConfigMaps, wContext.Catalog.ClusterRepo(), wContext.Core.ConfigMap())
+
+	wContext.Apps.Deployment().OnRemove(ctx, "legacy-k3sBasedUpgrader-deprecation", h.onDeployment)
 	return nil
 }
 
 type handler struct {
 	manager          chart.Manager
 	namespaces       corecontrollers.NamespaceController
+	deployment       deploymentControllers.DeploymentCache
+	clusterRepo      catalogcontrollers.ClusterRepoController
 	chartsConfig     chart.RancherConfigGetter
 	registryOverride string
 }
@@ -148,20 +161,9 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 					},
 				}
 				// add priority class value
-				if priorityClassName, err := h.chartsConfig.GetGlobalValue(chart.PriorityClassKey); err != nil {
-					if !chart.IsNotFoundError(err) {
-						logrus.Warnf("Failed to get rancher %s for 'rancher-webhook': %s", chart.PriorityClassKey, err.Error())
-					}
-				} else {
-					values[priorityClassKey] = priorityClassName
-				}
-
+				h.setPriorityClass(values, chart.WebhookChartName)
 				// get custom values for the rancher-webhook
-				configMapValues, err := h.chartsConfig.GetChartValues(chart.WebhookChartName)
-				if err != nil && !chart.IsNotFoundError(err) {
-					logrus.Warnf("Failed to get rancher rancherWebhookValues %s", err.Error())
-				}
-
+				configMapValues := h.getChartValues(chart.WebhookChartName)
 				return data.MergeMaps(values, configMapValues)
 			},
 			Enabled: func() bool { return true },
@@ -179,27 +181,89 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 			Values: func() map[string]interface{} {
 				values := map[string]interface{}{}
 				// add priority class value
-				if priorityClassName, err := h.chartsConfig.GetGlobalValue(chart.PriorityClassKey); err != nil {
-					if !chart.IsNotFoundError(err) {
-						logrus.Warnf("Failed to get rancher %s for 'rancher-provisioning-capi': %s", chart.PriorityClassKey, err.Error())
-					}
-				} else {
-					values[priorityClassKey] = priorityClassName
-				}
-
+				h.setPriorityClass(values, chart.ProvisioningCAPIChartName)
 				// get custom values for the rancher-provisioning-capi
-				configMapValues, err := h.chartsConfig.GetChartValues(chart.ProvisioningCAPIChartName)
-				if err != nil && !chart.IsNotFoundError(err) {
-					logrus.Warnf("Failed to get rancher-provisioning-capi %s", err.Error())
-				}
-
+				configMapValues := h.getChartValues(chart.ProvisioningCAPIChartName)
 				return data.MergeMaps(values, configMapValues)
 			},
 			Enabled:         func() bool { return true },
 			Uninstall:       !features.EmbeddedClusterAPI.Enabled(),
 			RemoveNamespace: !features.EmbeddedClusterAPI.Enabled(),
 		},
+		{
+			ReleaseNamespace:    namespace.System,
+			ChartName:           chart.SystemUpgradeControllerChartName,
+			ExactVersionSetting: settings.SystemUpgradeControllerChartVersion,
+			Values: func() map[string]interface{} {
+				values := map[string]interface{}{}
+				// add priority class value
+				h.setPriorityClass(values, chart.SystemUpgradeControllerChartName)
+				// get custom values for system-upgrade-controller
+				configMapValues := h.getChartValues(chart.SystemUpgradeControllerChartName)
+				return data.MergeMaps(values, configMapValues)
+			},
+			Enabled: func() bool {
+				toEnable := false
+				suc, err := h.deployment.Get(namespace.System, sucDeploymentName)
+
+				// the absence of the deployment or the absence of the legacy label on the existing deployment indicate
+				// that the old rancher-k3s/rke2-upgrader Project App has been removed
+				if err != nil {
+					logrus.Debugf("[systemcharts] failed to get the deployment %s/%s: %s", namespace.System, sucDeploymentName, err.Error())
+					if errors.IsNotFound(err) {
+						toEnable = true
+					}
+				}
+				if suc != nil {
+					if _, ok := suc.Labels[legacyAppLabel]; !ok {
+						toEnable = true
+					}
+				}
+				logrus.Debugf("[systemcharts] feature ManagedSystemUpgradeController = %t, toEnable = %t",
+					features.ManagedSystemUpgradeController.Enabled(), toEnable)
+
+				return features.ManagedSystemUpgradeController.Enabled() && toEnable
+			},
+		},
 	}
+}
+
+// onDeployment enqueues the rancher-charts ClusterRepo to the controller's processing queue
+// when a specific event occurs on the target deployment. It is currently used to manage
+// the migration from the legacy k3s-based-upgrader app to the system-upgrade-controller app.
+func (h *handler) onDeployment(_ string, d *k8sappsv1.Deployment) (*k8sappsv1.Deployment, error) {
+	if d != nil && d.Namespace == namespace.System && d.Name == sucDeploymentName {
+		if d.DeletionTimestamp != nil {
+			appName, ok := d.Labels[legacyAppLabel]
+			if ok {
+				logrus.Debugf("[systemcharts] found deployment %s/%s with label %s=%s", d.Namespace, d.Name, legacyAppLabel, appName)
+				if appName == k3sbasedupgrade.K3sAppNme || appName == k3sbasedupgrade.Rke2AppNme {
+					logrus.Debugf("[systemcharts] enqueue %s", repoName)
+					h.clusterRepo.Enqueue(repoName)
+				}
+			}
+		}
+	}
+	return d, nil
+}
+
+// setPriorityClass attempts to retrieve the priority class for rancher pods and set it in the specified map
+func (h *handler) setPriorityClass(values map[string]interface{}, chartName string) {
+	priorityClassName, err := h.chartsConfig.GetGlobalValue(chart.PriorityClassKey)
+	if err == nil {
+		values[chart.PriorityClassKey] = priorityClassName
+	} else if !chart.IsNotFoundError(err) {
+		logrus.Warnf("[systemcharts] Failed to get rancher %s for %s: %s", chart.PriorityClassKey, chartName, err.Error())
+	}
+}
+
+// getChartValues attempts to retrieve chart values for the specified chart
+func (h *handler) getChartValues(chartName string) map[string]interface{} {
+	configMapValues, err := h.chartsConfig.GetChartValues(chartName)
+	if err != nil && !chart.IsNotFoundError(err) {
+		logrus.Warnf("[systemcharts] Failed to get chart values for %s: %s", chartName, err.Error())
+	}
+	return configMapValues
 }
 
 func relatedFeatures(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {

--- a/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
+++ b/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 	"time"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/clusterdeploy"
 	planClientset "github.com/rancher/rancher/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/sirupsen/logrus"
@@ -21,13 +20,13 @@ const MaxDisplayNodes = 10
 
 // deployPlans creates a master and worker plan in the downstream cluster to instrument
 // the system-upgrade-controller in the downstream cluster
-func (h *handler) deployPlans(cluster *v3.Cluster, isK3s, isRke2 bool) error {
+func (h *handler) deployPlans(cluster *mgmtv3.Cluster, isK3s, isRke2 bool) error {
 	var (
 		upgradeImage   string
 		masterPlanName string
 		workerPlanName string
 		Version        string
-		strategy       v32.ClusterUpgradeStrategy
+		strategy       mgmtv3.ClusterUpgradeStrategy
 	)
 	switch {
 	case isRke2:
@@ -145,7 +144,7 @@ func (h *handler) deployPlans(cluster *v3.Cluster, isK3s, isRke2 bool) error {
 		if err != nil {
 			return err
 		}
-		logrus.Infof("[k3s-based-upgrader] plans successfully deployed into cluster [%s]", cluster.Name)
+		logrus.Infof("[k3s-based-upgrader] plans are successfully deployed into cluster [%s]", cluster.Name)
 	}
 
 	cluster, err = h.modifyClusterCondition(cluster, *masterPlan, *workerPlan, strategy)
@@ -182,26 +181,27 @@ func cmp(a, b planv1.Plan) bool {
 }
 
 // cluster state management during the upgrade, plans may be ""
-func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, workerPlan planv1.Plan, strategy v32.ClusterUpgradeStrategy) (*v3.Cluster, error) {
+func (h *handler) modifyClusterCondition(cluster *mgmtv3.Cluster, masterPlan, workerPlan planv1.Plan, strategy mgmtv3.ClusterUpgradeStrategy) (*mgmtv3.Cluster, error) {
 
 	// implement a simple state machine
 	// UpgradedTrue => GenericUpgrading =>  MasterPlanUpgrading || WorkerPlanUpgrading =>  UpgradedTrue
 
+	cluster = cluster.DeepCopy()
 	if masterPlan.Name == "" && workerPlan.Name == "" {
 		// enter upgrading state
-		if v32.ClusterConditionUpgraded.IsTrue(cluster) {
-			v32.ClusterConditionUpgraded.Unknown(cluster)
-			v32.ClusterConditionUpgraded.Message(cluster, "cluster is being upgraded")
+		if mgmtv3.ClusterConditionUpgraded.IsTrue(cluster) {
+			mgmtv3.ClusterConditionUpgraded.Unknown(cluster)
+			mgmtv3.ClusterConditionUpgraded.Message(cluster, "cluster is being upgraded")
 			return h.clusterClient.Update(cluster)
 		}
-		if v32.ClusterConditionUpgraded.IsUnknown(cluster) {
+		if mgmtv3.ClusterConditionUpgraded.IsUnknown(cluster) {
 			// remain in upgrading state if we are passed empty plans
 			return cluster, nil
 		}
 	}
 
 	if masterPlan.Name != "" && len(masterPlan.Status.Applying) > 0 {
-		v32.ClusterConditionUpgraded.Unknown(cluster)
+		mgmtv3.ClusterConditionUpgraded.Unknown(cluster)
 		c := strategy.ServerConcurrency
 		masterPlanMessage := fmt.Sprintf("controlplane node [%s] being upgraded",
 			upgradingMessage(c, masterPlan.Status.Applying))
@@ -210,7 +210,7 @@ func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, worker
 	}
 
 	if workerPlan.Name != "" && len(workerPlan.Status.Applying) > 0 {
-		v32.ClusterConditionUpgraded.Unknown(cluster)
+		mgmtv3.ClusterConditionUpgraded.Unknown(cluster)
 		c := strategy.WorkerConcurrency
 		workerPlanMessage := fmt.Sprintf("worker node [%s] being upgraded",
 			upgradingMessage(c, workerPlan.Status.Applying))
@@ -219,9 +219,10 @@ func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, worker
 
 	// if we made it this far nothing is applying
 	// see k3supgrade_handler also
-	v32.ClusterConditionUpgraded.True(cluster)
+	mgmtv3.ClusterConditionUpgraded.True(cluster)
+	mgmtv3.ClusterConditionUpgraded.Message(cluster, "")
 	if cluster.Spec.LocalClusterAuthEndpoint.Enabled {
-		// If ACE is enabled, the force a re-deploy of the cluster-agent and kube-api-auth
+		// If ACE is enabled, then force a re-deployment of the cluster-agent and kube-api-auth
 		cluster.Annotations[clusterdeploy.AgentForceDeployAnn] = "true"
 	}
 	return h.clusterClient.Update(cluster)
@@ -240,14 +241,14 @@ func upgradingMessage(concurrency int, nodes []string) string {
 	return strings.Join(nodes[:concurrency], ", ")
 }
 
-func (h *handler) enqueueOrUpdate(cluster *v3.Cluster, upgradeMessage string) (*v3.Cluster, error) {
-	if v32.ClusterConditionUpgraded.GetMessage(cluster) == upgradeMessage {
+func (h *handler) enqueueOrUpdate(cluster *mgmtv3.Cluster, upgradeMessage string) (*mgmtv3.Cluster, error) {
+	if mgmtv3.ClusterConditionUpgraded.GetMessage(cluster) == upgradeMessage {
 		// update would be no op
 		h.clusterEnqueueAfter(cluster.Name, time.Second*5) // prevent controller from remaining in this state
 		return cluster, nil
 	}
 
-	v32.ClusterConditionUpgraded.Message(cluster, upgradeMessage)
+	mgmtv3.ClusterConditionUpgraded.Message(cluster, upgradeMessage)
 	return h.clusterClient.Update(cluster)
 
 }

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -3,15 +3,12 @@ package k3sbasedupgrade
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/coreos/go-semver/semver"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	v33 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
-	app2 "github.com/rancher/rancher/pkg/app"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/namespace"
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/project"
-	"github.com/rancher/rancher/pkg/ref"
+	"github.com/rancher/rancher/pkg/settings"
 	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -19,13 +16,22 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, error) {
+const (
+	K3sAppNme  = "rancher-k3s-upgrader"
+	Rke2AppNme = "rancher-rke2-upgrader"
+)
+
+// globalCounter keeps track of the number of clusters for which the handler is concurrently uninstalling the legacy K3s-based upgrade app.
+// An atomic integer is used for efficiency, as it is lighter than a traditional lock.
+var globalCounter atomic.Int32
+
+func (h *handler) onClusterChange(_ string, cluster *mgmtv3.Cluster) (*mgmtv3.Cluster, error) {
 	if cluster == nil || cluster.DeletionTimestamp != nil {
 		return nil, nil
 	}
-	isK3s := cluster.Status.Driver == v32.ClusterDriverK3s
-	isRke2 := cluster.Status.Driver == v32.ClusterDriverRke2
-	// only applies to k3s/rke2 clusters
+	isK3s := cluster.Status.Driver == mgmtv3.ClusterDriverK3s
+	isRke2 := cluster.Status.Driver == mgmtv3.ClusterDriverRke2
+	// only applies to imported k3s/rke2 clusters
 	if !isK3s && !isRke2 {
 		return cluster, nil
 	}
@@ -34,9 +40,20 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 		return cluster, nil
 	}
 
+	if mgmtv3.ClusterConditionUpgraded.IsTrue(cluster) {
+		if globalCounter.Load() < int32(settings.K3sBasedUpgraderUninstallConcurrency.GetInt()) {
+			globalCounter.Add(1)
+			err := h.uninstallK3sBasedUpgradeController(cluster)
+			globalCounter.Add(-1)
+			if err != nil {
+				return nil, fmt.Errorf("[k3s-based-upgrader] failed to uninstall k3s based upgrade app: %w", err)
+			}
+		}
+	}
+
 	var (
 		updateVersion string
-		strategy      v32.ClusterUpgradeStrategy
+		strategy      mgmtv3.ClusterUpgradeStrategy
 	)
 	switch {
 	case isK3s:
@@ -63,19 +80,22 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 			return cluster, err
 		}
 		if !needsUpgrade {
-			// if upgrade was in progress, make sure to set the state back
-			if v32.ClusterConditionUpgraded.IsUnknown(cluster) {
+			// if upgrade was in progress, make sure to set the state back to true
+			if mgmtv3.ClusterConditionUpgraded.IsUnknown(cluster) {
+				logrus.Debug("[k3s-based-upgrader] updating the Upgraded condition to true")
+				cluster = cluster.DeepCopy()
+				mgmtv3.ClusterConditionUpgraded.True(cluster)
+				mgmtv3.ClusterConditionUpgraded.Message(cluster, "")
+				if cluster, err = h.clusterClient.Update(cluster); err != nil {
+					return nil, err
+				}
 				logrus.Infof("[k3s-based-upgrader] finished upgrading cluster [%s]", cluster.Name)
-				v32.ClusterConditionUpgraded.True(cluster)
-				v32.ClusterConditionUpgraded.Message(cluster, "")
-				return h.clusterClient.Update(cluster)
 			}
 			return cluster, nil
 		}
-
 	}
 
-	if v32.ClusterConditionUpgraded.IsTrue(cluster) {
+	if mgmtv3.ClusterConditionUpgraded.IsTrue(cluster) {
 		logrus.Infof("[k3s-based-upgrader] upgrading cluster [%s] version from [%s] to [%s]",
 			cluster.Name, cluster.Status.Version.GitVersion, updateVersion)
 		if isNewer {
@@ -93,11 +113,6 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 		return cluster, err
 	}
 
-	// create or update k3supgradecontroller if necessary
-	if err = h.deployK3sBasedUpgradeController(cluster.Name, isK3s, isRke2); err != nil {
-		return cluster, err
-	}
-
 	// deploy plans into downstream cluster
 	if err = h.deployPlans(cluster, isK3s, isRke2); err != nil {
 		return cluster, err
@@ -106,40 +121,15 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 	return cluster, nil
 }
 
-// deployK3sBaseUpgradeController creates a rancher k3s/rke2 upgrader controller if one does not exist.
-// Updates k3s upgrader controller if one exists and is not the newest available version.
-func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isRke2 bool) error {
-	userCtx, err := h.manager.UserContextNoControllers(clusterName)
+// uninstallK3sBasedUpgradeController uninstalls the k3s-based-upgrader app from the cluster if it exists.
+func (h *handler) uninstallK3sBasedUpgradeController(cluster *mgmtv3.Cluster) error {
+	userCtx, err := h.manager.UserContextNoControllers(cluster.Name)
 	if err != nil {
 		return err
 	}
 
 	projectLister := userCtx.Management.Management.Projects("").Controller().Lister()
-	systemProject, err := project.GetSystemProject(clusterName, projectLister)
-	if err != nil {
-		return err
-	}
-
-	templateID := k3sUpgraderCatalogName
-	template, err := h.templateLister.Get(namespace.GlobalNamespace, templateID)
-	if err != nil {
-		return err
-	}
-
-	latestTemplateVersion, err := h.catalogManager.LatestAvailableTemplateVersion(template, clusterName)
-	if err != nil {
-		return err
-	}
-
-	creator, err := h.systemAccountManager.GetSystemUser(clusterName)
-	if err != nil {
-		return err
-	}
-	systemProjectID := ref.Ref(systemProject)
-	_, systemProjectName := ref.Parse(systemProjectID)
-
-	nsClient := userCtx.Core.Namespaces("")
-	appProjectName, err := app2.EnsureAppProjectName(nsClient, systemProjectName, clusterName, systemUpgradeNS, creator.Name)
+	systemProject, err := project.GetSystemProject(cluster.Name, projectLister)
 	if err != nil {
 		return err
 	}
@@ -147,61 +137,23 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isR
 	appLister := userCtx.Management.Project.Apps("").Controller().Lister()
 	appClient := userCtx.Management.Project.Apps("")
 
-	latestVersionID := latestTemplateVersion.ExternalID
-	var appname string
+	var appName string
 	switch {
-	case isK3s:
-		appname = "rancher-k3s-upgrader"
-	case isRke2:
-		appname = "rancher-rke2-upgrader"
+	case cluster.Status.Driver == mgmtv3.ClusterDriverK3s:
+		appName = K3sAppNme
+	case cluster.Status.Driver == mgmtv3.ClusterDriverRke2:
+		appName = Rke2AppNme
 	}
-	app, err := appLister.Get(systemProjectName, appname)
+	app, err := appLister.Get(systemProject.Name, appName)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		logrus.Infof("[k3s-based-upgrader] installing app [%s] in cluster [%s]", appname, clusterName)
-		desiredApp := &v33.App{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      appname,
-				Namespace: systemProjectName,
-				Annotations: map[string]string{
-					"field.cattle.io/creatorId": creator.Name,
-				},
-			},
-			Spec: v33.AppSpec{
-				Description:     "Upgrade controller for k3s based clusters",
-				ExternalID:      latestVersionID,
-				ProjectName:     appProjectName,
-				TargetNamespace: systemUpgradeNS,
-			},
-		}
-
-		// k3s upgrader doesn't exist yet, so it will need to be created
-		if _, err = appClient.Create(desiredApp); err != nil {
-			return err
-		}
-	} else {
-		if !checkDeployed(app) {
-			if !v33.AppConditionForceUpgrade.IsUnknown(app) {
-				v33.AppConditionForceUpgrade.Unknown(app)
-			}
-			logrus.Warnln("force redeploying system-upgrade-controller")
-			if _, err = appClient.Update(app); err != nil {
-				return err
-			}
-		}
-
-		// everything is up-to-date and are set up properly, no need to update.
-		if app.Spec.ExternalID == latestVersionID {
+		if errors.IsNotFound(err) {
 			return nil
 		}
-
-		desiredApp := app.DeepCopy()
-		desiredApp.Spec.ExternalID = latestVersionID
-		logrus.Infof("[k3s-based-upgrader] updating app [%s] in cluster [%s]", appname, clusterName)
-		// new version of k3s upgrade available, or the valuesYaml have changed, update app
-		if _, err = appClient.Update(desiredApp); err != nil {
+		return err
+	}
+	if app != nil && app.DeletionTimestamp == nil {
+		logrus.Infof("[k3s-based-upgrader] uninstalling the app [%s] from the cluster [%s]", app.Name, cluster.Name)
+		if err := appClient.DeleteNamespaced(app.Namespace, app.Name, &metav1.DeleteOptions{}); !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -237,7 +189,7 @@ func IsNewerVersion(prevVersion, updatedVersion string) (bool, error) {
 }
 
 // nodeNeedsUpgrade checks all nodes in cluster, returns true if they still need to be upgraded
-func (h *handler) nodesNeedUpgrade(cluster *v3.Cluster, version string) (bool, error) {
+func (h *handler) nodesNeedUpgrade(cluster *mgmtv3.Cluster, version string) (bool, error) {
 	v3NodeList, err := h.nodeLister.List(cluster.Name, labels.Everything())
 	if err != nil {
 		return false, err
@@ -254,8 +206,4 @@ func (h *handler) nodesNeedUpgrade(cluster *v3.Cluster, version string) (bool, e
 		}
 	}
 	return false, nil
-}
-
-func checkDeployed(app *v33.App) bool {
-	return v33.AppConditionDeployed.IsTrue(app) || v33.AppConditionInstalled.IsTrue(app)
 }

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -65,6 +65,12 @@ var (
 		true,
 		false,
 		false)
+	ManagedSystemUpgradeController = newFeature(
+		"managed-system-upgrade-controller",
+		"Enable the installation of the system-upgrade-controller app as a managed system chart",
+		true,
+		false,
+		false)
 	RKE2 = newFeature(
 		"rke2",
 		"Enable provisioning of RKE2",

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -231,9 +231,13 @@ var (
 	// debug purposes.
 	RKE2ChartDefaultURL = NewSetting("rke2-chart-default-url", "https://git.rancher.io/")
 
-	// SystemDefaultRegistry is the default contrainer registry used for images.
+	// SystemDefaultRegistry is the default container registry used for images.
 	// The environmental variable "CATTLE_BASE_REGISTRY" controls the default value of this setting.
 	SystemDefaultRegistry = NewSetting("system-default-registry", os.Getenv("CATTLE_BASE_REGISTRY"))
+
+	// K3sBasedUpgraderUninstallConcurrency defines the maximum number of clusters
+	// for which the K3s-based-upgrade handler can simultaneously uninstall the legacy K3s-based upgrade app.
+	K3sBasedUpgraderUninstallConcurrency = NewSetting("k3s-based-upgrader-uninstall-concurrency", "5")
 
 	// UIBanners holds configuration to display a custom fixed banner in the header, footer, or both
 	UIBanners = NewSetting("ui-banners", "{}")

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -171,15 +171,22 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 }
 
 func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
+	enableMSUC := false
+	if cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 || cluster.Status.Driver == apimgmtv3.ClusterDriverK3s {
+		// the case of imported rke2/k3s cluster
+		enableMSUC = true
+	}
+
 	return map[string]bool{
-		features.MCM.Name():                      false,
-		features.MCMAgent.Name():                 true,
-		features.Fleet.Name():                    false,
-		features.RKE2.Name():                     false,
-		features.ProvisioningV2.Name():           false,
-		features.EmbeddedClusterAPI.Name():       false,
-		features.UISQLCache.Name():               features.UISQLCache.Enabled(),
-		features.ProvisioningPreBootstrap.Name(): capr.PreBootstrap(cluster),
+		features.MCM.Name():                            false,
+		features.MCMAgent.Name():                       true,
+		features.Fleet.Name():                          false,
+		features.RKE2.Name():                           false,
+		features.ProvisioningV2.Name():                 false,
+		features.EmbeddedClusterAPI.Name():             false,
+		features.UISQLCache.Name():                     features.UISQLCache.Enabled(),
+		features.ProvisioningPreBootstrap.Name():       capr.PreBootstrap(cluster),
+		features.ManagedSystemUpgradeController.Name(): features.ManagedSystemUpgradeController.Enabled() && enableMSUC,
 	}
 }
 


### PR DESCRIPTION
Notes

The `Provisioning tests` are failing because the CI is not using the agent image built from the CI itself, causing it to exit due to an unrecognized feature flag. To move this PR forward, we will temporarily ignore those CI failures and rerun the tests once the CI issue is resolved.


## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/42448

unblocks https://github.com/rancher/dashboard/issues/11942

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
We need a new approach for installing the system-upgrade-controller app in downstream RKE2/K3s imported clusters, aiming to completely phase out support for the legacy [Catalog and Catalog App feature](https://ranchermanager.docs.rancher.com/v2.0-v2.4/how-to-guides/new-user-guides/helm-charts-in-rancher) in Rancher.  


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

We will leverage the established SystemCharts mechanism to install the system-upgrade-controller chart from the rancher-charts ClusterRepo, which has demonstrated reliable performance.

We will repurpose the K3sbasedupgrade handler to uninstall the rancher-k3s-upgrader chart (if it exists) while continuing to deploy the upgrade plan and manage the cluster’s condition during the upgrade process.

For more information, please refer to the RFC-016 

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

A Rancher image is built from the PR to validate the following scenarios: 

Scenarios 1:  Run this new version of Rancher,  create a new imported RKE2/K3s cluster, then upgrade the cluster's k8s version, confirm the new app is installed and the cluster upgrade succeeds  

Scenarios 2: Run Rancher v2.9.2, create a few imported  RKE2/K3s clusters, upgrade the cluster's k8s version, then upgrade Rancher to the new version, confirm that the old app is removed and the new app is installed and the cluster upgrade succeeds  

Scenario 3:  Continue on the setup used in scenario 2, roll back Rancher to v2.9.2, upgrade the cluster's k8s version of some clusters, confirm that the old app is installed and the cluster upgrade succeeds  
 

### Automated Testing
N/A 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
The same scenarios that are mentioned above 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

The same scenarios that are mentioned above 

Existing / newly added automated tests that provide evidence there are no regressions:

N/A 

