### PR TITLE
[v2.9] Sort ResourceNames in Role rules created from RoleTemplates

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/role.go
+++ b/pkg/controllers/management/authprovisioningv2/role.go
@@ -322,8 +322,12 @@ func (h *handler) objects(rt *v3.RoleTemplate, enqueue bool, cluster *v1.Cluster
 	return nil
 }
 
-func (h *handler) getResourceNames(resourceMatch resourceMatch, cluster *v1.Cluster) ([]string, error) {
-	objs, err := h.dynamic.GetByIndex(resourceMatch.GVK, clusterIndexed, fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name))
+type indexGetter interface {
+	GetByIndex(gvk schema.GroupVersionKind, indexName, key string) ([]runtime.Object, error)
+}
+
+func getResourceNames(indexer indexGetter, resourceMatch resourceMatch, cluster *v1.Cluster) ([]string, error) {
+	objs, err := indexer.GetByIndex(resourceMatch.GVK, clusterIndexed, fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name))
 	if err != nil {
 		return nil, err
 	}
@@ -335,6 +339,7 @@ func (h *handler) getResourceNames(resourceMatch resourceMatch, cluster *v1.Clus
 		}
 		result = append(result, objMeta.GetName())
 	}
+	sort.Strings(result)
 	return result, nil
 }
 
@@ -364,7 +369,7 @@ func (h *handler) createRoleForCluster(rt *v3.RoleTemplate, matches []match, clu
 	}
 
 	for _, match := range matches {
-		names, err := h.getResourceNames(match.Match, cluster)
+		names, err := getResourceNames(h.dynamic, match.Match, cluster)
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/management/authprovisioningv2/role_test.go
+++ b/pkg/controllers/management/authprovisioningv2/role_test.go
@@ -11,10 +11,12 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/api/rbac/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -297,6 +299,29 @@ func Test_OnRemoveClusterRoleBinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockIndexGetter []runtime.Object
+
+func (m mockIndexGetter) GetByIndex(schema.GroupVersionKind, string, string) ([]runtime.Object, error) {
+	return m, nil
+}
+
+func Test_getResourceNames_sorted(t *testing.T) {
+	objs := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "b3"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "c5"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "b4"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "a2"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "a1"}},
+	}
+	want := []string{"a1", "a2", "b3", "b4", "c5"}
+
+	got, err := getResourceNames(mockIndexGetter(objs), resourceMatch{}, &provisioningv1.Cluster{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, want, got)
 }
 
 func createNameAndNamespaceAnnotation(n string) map[string]string {


### PR DESCRIPTION
## Issue: #47410

Backport #47192 (almost clean cherry-pick, only a small conflict in the imports)