### PR TITLE
[v2.9] Propagate annotations from management cluster to Fleet cluster

### DIFF
--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -156,6 +156,8 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 		labels["management.cattle.io/cluster-display-name"] = mgmtCluster.Spec.DisplayName
 	}
 
+	annotations := yaml.CleanAnnotationsForExport(mgmtCluster.Annotations)
+
 	agentNamespace := ""
 	clientSecret := status.ClientSecretName
 
@@ -191,9 +193,10 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 
 	return append(objs, &fleet.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name,
-			Namespace: mgmtCluster.Spec.FleetWorkspaceName,
-			Labels:    labels,
+			Name:        cluster.Name,
+			Namespace:   mgmtCluster.Spec.FleetWorkspaceName,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: fleet.ClusterSpec{
 			KubeConfigSecret:          clientSecret,


### PR DESCRIPTION
This replicates behavior which already exists for labels, for the sake of consistency and reducing the risk of confusion for users.

Issue: https://github.com/rancher/fleet/issues/2937

Backport of https://github.com/rancher/rancher/pull/47125 to v2.9. 