### PR TITLE
Enqueue PRTBs for RKE clusters to recreate RoleBindings

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -42,6 +42,7 @@ type handler struct {
 	clusterRoleTemplateBindings          mgmtcontrollers.ClusterRoleTemplateBindingCache
 	clusterRoleTemplateBindingController mgmtcontrollers.ClusterRoleTemplateBindingController
 	projectRoleTemplateBindingController mgmtcontrollers.ProjectRoleTemplateBindingController
+	projectRoleTemplateBindings          mgmtcontrollers.ProjectRoleTemplateBindingCache
 	roleTemplatesCache                   mgmtcontrollers.RoleTemplateCache
 	clusters                             provisioningcontrollers.ClusterCache
 	mgmtClusters                         mgmtcontrollers.ClusterCache
@@ -74,6 +75,7 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 		clusterRoleTemplateBindings:          clients.Mgmt.ClusterRoleTemplateBinding().Cache(),
 		clusterRoleTemplateBindingController: clients.Mgmt.ClusterRoleTemplateBinding(),
 		projectRoleTemplateBindingController: clients.Mgmt.ProjectRoleTemplateBinding(),
+		projectRoleTemplateBindings:          clients.Mgmt.ProjectRoleTemplateBinding().Cache(),
 		roleTemplatesCache:                   clients.Mgmt.RoleTemplate().Cache(),
 		clusters:                             clients.Provisioning.Cluster().Cache(),
 		mgmtClusters:                         clients.Mgmt.Cluster().Cache(),

--- a/pkg/controllers/management/authprovisioningv2/cluster.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster.go
@@ -68,7 +68,7 @@ func (h *handler) createClusterViewRole(cluster *v1.Cluster) error {
 
 		// This is needed for creating RoleBindings when moving rke clusters to a different workspace.
 		// This is only needed for rke because Role and RoleBindings are moved to the new workspace. In other k8s distros they stay in the fleet-default ns.
-		if err = h.enqueueCRTBsForRKEClusters(cluster); err != nil {
+		if err = h.enqueueRoleTemplateBindingsForRKEClusters(cluster); err != nil {
 			return err
 		}
 		return nil
@@ -113,7 +113,7 @@ func (h *handler) cleanClusterAdminRoleBindings(cluster *v1.Cluster) error {
 	return nil
 }
 
-func (h *handler) enqueueCRTBsForRKEClusters(cluster *v1.Cluster) error {
+func (h *handler) enqueueRoleTemplateBindingsForRKEClusters(cluster *v1.Cluster) error {
 	if cluster.Labels[kubernetesprovider.ProviderKey] == providers.RKE {
 		crtbs, err := h.clusterRoleTemplateBindings.List(cluster.Name, labels.Everything())
 		if err != nil {

--- a/pkg/controllers/management/authprovisioningv2/cluster.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster.go
@@ -3,15 +3,17 @@ package authprovisioningv2
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/rancher/kubernetes-provider-detector/providers"
-	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/kubernetesprovider"
+	"k8s.io/apimachinery/pkg/labels"
+
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/rbac"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 // OnCluster creates the roles required for users to be able to see/manage the
@@ -119,6 +121,16 @@ func (h *handler) enqueueCRTBsForRKEClusters(cluster *v1.Cluster) error {
 		}
 		for _, crtb := range crtbs {
 			h.clusterRoleTemplateBindingController.Enqueue(crtb.Namespace, crtb.Name)
+		}
+		prtbs, err := h.projectRoleTemplateBindings.List("", labels.Everything())
+		if err != nil {
+			return err
+		}
+		for _, prtb := range prtbs {
+			clusterName := strings.Split(prtb.ProjectName, ":")[0]
+			if clusterName == cluster.Name {
+				h.projectRoleTemplateBindingController.Enqueue(prtb.Namespace, prtb.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Issue:  https://github.com/rancher/rancher/issues/47441
 
## Problem
Same as https://github.com/rancher/rancher/pull/46498 but for `RoleBindings` created for `Projects` instead of `Clusters`
 
## Solution
Enqueue `PRTBs` for RKE1 clusters to recreate `RoleBindings`. We do this only when the Role is not found and we are going to create it to minimize the impact.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Tested that RoleBindings are created when moving RKE1 clusters to a different workspace.

### Automated Testing
Unit Tests 