### PR TITLE
omit e2e tests from triggering CI, unless CI tests are changed

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - main
       - release/v*
+    paths-ignore:
+      # omit tests from triggering CI except when CI tests are changed
+      - 'tests/v2/validation/**'
+      - 'tests/v2/actions/**'
+      - 'tests/v2/codecoverage/**'
+      - 'tests/validation/**'
 jobs:
   provisioning_tests:
     strategy:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,12 @@
 name: Build Pull Request
 on:
-  - pull_request 
+  pull_request:
+    paths-ignore:
+      # omit tests from triggering CI except when CI tests are changed
+      - 'tests/v2/validation/**'
+      - 'tests/v2/codecoverage/**'
+      - 'tests/validation/**'
+
 env:
   ARCH: amd64
   TAG: v2.10-${{ github.sha }}-head


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
A decent amount of time is wasted running tests against changes to the repo that have nothing to do with the product or the tests that run in CI
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
A decent amount of time is wasted running tests against changes to the repo that have nothing to do with the product or the tests that run in CI
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
add `paths-ignore` to github-actions that will be excluded by default in CI. 

 Starting by omitting tests outside of tests that run on CI from triggering provisioning-tests and building artifacts. 

**note** - .github folder is a proof of concept so you can see what CI will run on 'excluded' PRs. It will be removed upon approval of initial design / idea. 