### PR TITLE
Removed forward slashes from the tests

### DIFF
--- a/tests/v2/validation/auth/userretention/userretention_disable_user_test.go
+++ b/tests/v2/validation/auth/userretention/userretention_disable_user_test.go
@@ -1,3 +1,5 @@
+//go:build (validation || infra.any || cluster.any || sanity) && !stress && !extended
+
 package userretention
 
 import (

--- a/tests/v2/validation/auth/userretention/userretention_settings_test.go
+++ b/tests/v2/validation/auth/userretention/userretention_settings_test.go
@@ -34,12 +34,13 @@ func (ur *UserRetentionSettingsTestSuite) TearDownSuite() {
 }
 
 func (ur *UserRetentionSettingsTestSuite) testPositiveInputValues(settingName string, tests []struct {
+	name        string
 	value       string
 	description string
 }) {
 	logrus.Infof("Updating %s settings with positive values:", settingName)
 	for _, inputValue := range tests {
-		ur.T().Run(inputValue.value, func(*testing.T) {
+		ur.T().Run(inputValue.name, func(*testing.T) {
 			err := updateUserRetentionSettings(ur.client, settingName, inputValue.value)
 			assert.NoError(ur.T(), err, "Unexpected error for input '%s'", inputValue.value)
 
@@ -56,12 +57,13 @@ func (ur *UserRetentionSettingsTestSuite) testPositiveInputValues(settingName st
 }
 
 func (ur *UserRetentionSettingsTestSuite) testNegativeInputValues(settingName string, tests []struct {
+	name        string
 	value       string
 	description string
 }) {
 	logrus.Infof("Updating %s settings with negative values:", settingName)
 	for _, inputValue := range tests {
-		ur.T().Run(inputValue.value, func(*testing.T) {
+		ur.T().Run(inputValue.name, func(*testing.T) {
 			err := updateUserRetentionSettings(ur.client, settingName, inputValue.value)
 			assert.Error(ur.T(), err, "Expected an error for input '%s', but got nil", inputValue.value)
 
@@ -110,108 +112,114 @@ func (ur *UserRetentionSettingsTestSuite) validateSettingsNotUpdated(settingName
 
 func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDisableInactiveUserAfterWithPositiveInputValues() {
 	tests := []struct {
+		name        string
 		value       string
 		description string
 	}{
-		{"", "No action - users will not be deactivated"},
-		{"0s", "Users will be deactivated after 0s"},
-		{"0m", "Users will be deactivated after 0m"},
-		{"0h", "Users will be deactivated after 0h"},
-		{"10s", "Users will be deactivated after 10s"},
-		{"10m", "Users will be deactivated after 10m"},
-		{"20h", "Users will be deactivated after 20h"},
-		{"10000s", "Users will be deactivated after 10000s"},
-		{"10000m", "Users will be deactivated after 10000m"},
-		{"10000h", "Users will be deactivated after 10000h"},
+		{"DisableAfterUpdatedNoAction", "", "No action - users will not be deactivated"},
+		{"DisableAfterUpdatedZeroSeconds", "0s", "Users will be deactivated after 0s"},
+		{"DisableAfterUpdatedZeroMinutes", "0m", "Users will be deactivated after 0m"},
+		{"DisableAfterUpdatedZeroHours", "0h", "Users will be deactivated after 0h"},
+		{"DisableAfterUpdatedTenSeconds", "10s", "Users will be deactivated after 10s"},
+		{"DisableAfterUpdatedTenMinutes", "10m", "Users will be deactivated after 10m"},
+		{"DisableAfterUpdatedTwentyHours", "20h", "Users will be deactivated after 20h"},
+		{"DisableAfterUpdatedTenThousandSeconds", "10000s", "Users will be deactivated after 10000s"},
+		{"DisableAfterUpdatedTenThousandMinutes", "10000m", "Users will be deactivated after 10000m"},
+		{"DisableAfterUpdatedTenThousandHours", "10000h", "Users will be deactivated after 10000h"},
 	}
 	ur.testPositiveInputValues(disableInactiveUserAfter, tests)
 }
 
 func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDisableInactiveUserAfterWithNegativeInputValues() {
 	tests := []struct {
+		name        string
 		value       string
 		description string
 	}{
-		{"10", "Invalid value: \"10\": time: missing unit in duration \"10\""},
-		{"10S", "Invalid value: \"10S\": time: unknown unit \"S\" in duration \"10S\""},
-		{"10M", "Invalid value: \"10M\": time: unknown unit \"M\" in duration \"10M\""},
-		{"10H", "Invalid value: \"10H\": time: unknown unit \"H\" in duration \"10H\""},
-		{"10sec", "Invalid value: \"10sec\": time: unknown unit \"sec\" in duration \"10sec\""},
-		{"10min", "Invalid value: \"10min\": time: unknown unit \"min\" in duration \"10min\""},
-		{"20hour", "Invalid value: \"20hour\": time: unknown unit \"hour\" in duration \"20hour\""},
-		{"1d", "Invalid value: \"1d\": time: unknown unit \"d\" in duration \"1d\""},
-		{"-20m", "Invalid value: \"-20m\": negative duration"},
-		{"tens", "Invalid value: \"tens\": time: invalid duration \"tens\""},
+		{"DisableAfterUpdateErrorMissingUnit", "10", "Invalid value: \"10\": time: missing unit in duration \"10\""},
+		{"DisableAfterUpdateErrorInvalidUnitS", "10S", "Invalid value: \"10S\": time: unknown unit \"S\" in duration \"10S\""},
+		{"DisableAfterUpdateErrorInvalidUnitM", "10M", "Invalid value: \"10M\": time: unknown unit \"M\" in duration \"10M\""},
+		{"DisableAfterUpdateErrorInvalidUnitH", "10H", "Invalid value: \"10H\": time: unknown unit \"H\" in duration \"10H\""},
+		{"DisableAfterUpdateErrorInvalidUnitSec", "10sec", "Invalid value: \"10sec\": time: unknown unit \"sec\" in duration \"10sec\""},
+		{"DisableAfterUpdateErrorInvalidUnitMin", "10min", "Invalid value: \"10min\": time: unknown unit \"min\" in duration \"10min\""},
+		{"DisableAfterUpdateErrorInvalidUnitHour", "20hour", "Invalid value: \"20hour\": time: unknown unit \"hour\" in duration \"20hour\""},
+		{"DisableAfterUpdateErrorInvalidUnitDay", "1d", "Invalid value: \"1d\": time: unknown unit \"d\" in duration \"1d\""},
+		{"DisableAfterUpdateErrorNegativeDuration", "-20m", "Invalid value: \"-20m\": negative duration"},
+		{"DisableAfterUpdateErrorInvalidDuration", "tens", "Invalid value: \"tens\": time: invalid duration \"tens\""},
 	}
 	ur.testNegativeInputValues(disableInactiveUserAfter, tests)
 }
 
 func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDeleteInactiveUserAfterWithPositiveInputValues() {
 	tests := []struct {
+		name        string
 		value       string
 		description string
 	}{
-		{"", "No action - users will not be deleted"},
-		{"100000000s", "Users will delete after 100000000s"},
-		{"200000m", "Users will delete after 200000m"},
-		{"10000h", "Users will delete after 10000h"},
+		{"DeleteAfterNoAction", "", "No action - users will not be deleted"},
+		{"DeleteAfterHundredMillionSeconds", "100000000s", "Users will delete after 100000000s"},
+		{"DeleteAfterTwoHundredThousandMinutes", "200000m", "Users will delete after 200000m"},
+		{"DeleteAfterTenThousandHours", "10000h", "Users will delete after 10000h"},
 	}
 	ur.testPositiveInputValues(deleteInactiveUserAfter, tests)
 }
 
 func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDeleteInactiveUserAfterWithNegativeInputValues() {
 	tests := []struct {
+		name        string
 		value       string
 		description string
 	}{
-		{"10", "Invalid value: \"10\": time: missing unit in duration \"10\""},
-		{"10s", "Invalid value: \"10s\": must be at least 336h0m0s"},
-		{"10m", "Invalid value: \"10m\": must be at least 336h0m0s"},
-		{"10h", "Invalid value: \"10h\": must be at least 336h0m0s"},
-		{"10S", "Invalid value: \"10S\": time: unknown unit \"S\" in duration \"10S\""},
-		{"10M", "Invalid value: \"10M\": time: unknown unit \"M\" in duration \"10M\""},
-		{"10H", "Invalid value: \"10H\": time: unknown unit \"H\" in duration \"10H\""},
-		{"10sec", "Invalid value: \"10sec\": time: unknown unit \"sec\" in duration \"10sec\""},
-		{"10min", "Invalid value: \"10min\": time: unknown unit \"min\" in duration \"10min\""},
-		{"20hour", "Invalid value: \"20hour\": time: unknown unit \"hour\" in duration \"20hour\""},
-		{"1d", "Invalid value: \"1d\": time: unknown unit \"d\" in duration \"1d\""},
-		{"-20m", "Invalid value: \"-20m\": negative duration"},
+		{"DeleteErrorMissingUnit", "10", "Invalid value: \"10\": time: missing unit in duration \"10\""},
+		{"DeleteErrorTooShortSeconds", "10s", "Invalid value: \"10s\": must be at least 336h0m0s"},
+		{"DeleteErrorTooShortMinutes", "10m", "Invalid value: \"10m\": must be at least 336h0m0s"},
+		{"DeleteErrorTooShortHours", "10h", "Invalid value: \"10h\": must be at least 336h0m0s"},
+		{"DeleteErrorInvalidUnitS", "10S", "Invalid value: \"10S\": time: unknown unit \"S\" in duration \"10S\""},
+		{"DeleteErrorInvalidUnitM", "10M", "Invalid value: \"10M\": time: unknown unit \"M\" in duration \"10M\""},
+		{"DeleteErrorInvalidUnitH", "10H", "Invalid value: \"10H\": time: unknown unit \"H\" in duration \"10H\""},
+		{"DeleteErrorInvalidUnitSec", "10sec", "Invalid value: \"10sec\": time: unknown unit \"sec\" in duration \"10sec\""},
+		{"DeleteErrorInvalidUnitMin", "10min", "Invalid value: \"10min\": time: unknown unit \"min\" in duration \"10min\""},
+		{"DeleteErrorInvalidUnitHour", "20hour", "Invalid value: \"20hour\": time: unknown unit \"hour\" in duration \"20hour\""},
+		{"DeleteErrorInvalidUnitDay", "1d", "Invalid value: \"1d\": time: unknown unit \"d\" in duration \"1d\""},
+		{"DeleteErrorNegativeDuration", "-20m", "Invalid value: \"-20m\": negative duration"},
 	}
 	ur.testNegativeInputValues(deleteInactiveUserAfter, tests)
 }
 
 func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForUserRetentionCronWithPositiveInputValues() {
 	tests := []struct {
+		name        string
 		value       string
 		description string
 	}{
-		{"0 * * * *", "every 1 hour"},
-		{"0 0 * * *", "every 1 day"},
-		{"*/5 * * * *", "every 5 mins"},
-		{"*/1 * * * *", "every min"},
-		{"* * * * *", "every min"},
-		{"30/1 * * * *", "every 30 sec"},
-		{"0-5 14 * * *", "every minute starting at 2:00 PM and ending at 2:05 PM, every day"},
-		{"0 0 1,2 * *", "at midnight of 1st, 2nd day of each month"},
-		{"0 0 1,2 * 3", "at midnight of 1st, 2nd day of each month, and each Wednesday"},
+		{"CronRunsEvery1Hour", "0 * * * *", "every 1 hour"},
+		{"CronRunsEvery1Day", "0 0 * * *", "every 1 day"},
+		{"CronRunsEvery5Minutes", "*/5 * * * *", "every 5 mins"},
+		{"CronRunsEvery1Minute", "*/1 * * * *", "every min"},
+		{"CronRunsEveryMinute", "* * * * *", "every min"},
+		{"CronRunsEvery30Seconds", "30/1 * * * *", "every 30 sec"},
+		{"CronRunsEvery2PMTo205PM", "0-5 14 * * *", "every minute starting at 2:00 PM and ending at 2:05 PM, every day"},
+		{"CronRunsFirstSecondDayMidnight", "0 0 1,2 * *", "at midnight of 1st, 2nd day of each month"},
+		{"CronRunsFirstSecondDayWednesdayMidnight", "0 0 1,2 * 3", "at midnight of 1st, 2nd day of each month, and each Wednesday"},
 	}
 	ur.testPositiveInputValues(userRetentionCron, tests)
 }
 
 func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForUserRetentionCronWithNegativeInputValues() {
 	tests := []struct {
+		name        string
 		value       string
 		description string
 	}{
-		{"* * * * * *", "Invalid value: \"* * * * * *\": Expected exactly 5 fields, found 6: * * * * * *"},
-		{"*/-1 * * * *", "Invalid value: \"*/-1 * * * *\": Negative number (-1) not allowed: -1"},
-		{"60/1 * * * *", "Invalid value: \"60/1 * * * *\": Beginning of range (60) beyond end of range (59): 60/1"},
-		{"-30/1 * * * *", "Invalid value: \"-30/1 * * * *\": Failed to parse int from : strconv.Atoi: parsing \"\": invalid syntax"},
-		{"(*/1) * * * *", "Invalid value: \"(*/1) * * * *\": Failed to parse int from (*: strconv.Atoi: parsing \"(*\": invalid syntax"},
-		{"10min", "Invalid value: \"10min\": Expected exactly 5 fields, found 1: 10min"},
-		{"* * * * * */2", "Invalid value: \"* * * * * */2\": Expected exactly 5 fields, found 6: * * * * * */2"},
-		{"1d", "Invalid value: \"1d\": Expected exactly 5 fields, found 1: 1d"},
-		{"-20m", "Invalid value: \"-20m\": Expected exactly 5 fields, found 1: -20m"},
+		{"CronUpdateErrorTooManyFields", "* * * * * *", "Invalid value: \"* * * * * *\": Expected exactly 5 fields, found 6: * * * * * *"},
+		{"CronUpdateErrorNegativeNumber", "*/-1 * * * *", "Invalid value: \"*/-1 * * * *\": Negative number (-1) not allowed: -1"},
+		{"CronUpdateErrorOutOfRange", "60/1 * * * *", "Invalid value: \"60/1 * * * *\": Beginning of range (60) beyond end of range (59): 60/1"},
+		{"CronUpdateErrorNegativeStart", "-30/1 * * * *", "Invalid value: \"-30/1 * * * *\": Failed to parse int from : strconv.Atoi: parsing \"\": invalid syntax"},
+		{"CronUpdateErrorInvalidSyntax", "(*/1) * * * *", "Invalid value: \"(*/1) * * * *\": Failed to parse int from (*: strconv.Atoi: parsing \"(*\": invalid syntax"},
+		{"CronUpdateErrorTooManyFields", "* * * * * */2", "Invalid value: \"* * * * * */2\": Expected exactly 5 fields, found 6: * * * * * */2"},
+		{"CronUpdateErrorLessFields1", "10min", "Invalid value: \"10min\": Expected exactly 5 fields, found 1: 10min"},
+		{"CronUpdateErrorLessFields2", "1d", "Invalid value: \"1d\": Expected exactly 5 fields, found 1: 1d"},
+		{"CronUpdateErrorInvalidNegative", "-20m", "Invalid value: \"-20m\": Expected exactly 5 fields, found 1: -20m"},
 	}
 	ur.testNegativeInputValues(userRetentionCron, tests)
 }


### PR DESCRIPTION
https://github.com/rancher/qa-tasks/issues/1578

Currently, slack reporter for recurring run fails with:

05:15:58.491  [31mERRO[0m[0114] error reporting: error with slack message post: 400 Bad Request 400: **** 

The potential problem is: that it uses string manipulation to check the [forward slashes](https://github.com/rancher/rancher/blob/release/v2.9/tests/v2/validation/pipeline/slack/slack.go#L46). It sends the wrong parsed string to the slack API.

Example names (there are more, make sure to check names) that need updates: https://github.com/rancher/rancher/blob/release/v2.9/tests/v2/validation/auth/userretention/userretention_settings_test.go#L191-L193

Extra information about forward slashes in the test names: https://github.com/rancher/rancher/tree/main/tests#how-to-write-tests