### PR TITLE
[main] P0 tests for GH45811

### DIFF
--- a/tests/v2/actions/kubeapi/rbac/list.go
+++ b/tests/v2/actions/kubeapi/rbac/list.go
@@ -159,3 +159,28 @@ func ListRoleTemplates(client *rancher.Client, listOpt metav1.ListOptions) (*v3.
 
 	return rtList, nil
 }
+
+// ListProjectRoleTemplateBindings is a helper function that uses the dynamic client to list projectroletemplatebindings from local cluster.
+func ListProjectRoleTemplateBindings(client *rancher.Client, listOpt metav1.ListOptions) (*v3.ProjectRoleTemplateBindingList, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(LocalCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredList, err := dynamicClient.Resource(ProjectRoleTemplateBindingGroupVersionResource).Namespace("").List(context.TODO(), listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	prtbList := new(v3.ProjectRoleTemplateBindingList)
+	for _, unstructuredPRTB := range unstructuredList.Items {
+		prtb := &v3.ProjectRoleTemplateBinding{}
+		err := scheme.Scheme.Convert(&unstructuredPRTB, prtb, unstructuredPRTB.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+		prtbList.Items = append(prtbList.Items, *prtb)
+	}
+
+	return prtbList, nil
+}

--- a/tests/v2/validation/rbac/fleetworkspaces/README.md
+++ b/tests/v2/validation/rbac/fleetworkspaces/README.md
@@ -1,0 +1,20 @@
+# Verify rolebindings for users when RKE1 cluster is moved to a new workspace
+
+## Pre-requisites
+
+- Ensure you have an existing RKE1 cluster that the user has access to. If you do not have a downstream RKE1 cluster in Rancher, create one first before running this test.
+
+## Test Setup
+
+Your GO suite should be set to `-run ^TestMoveClusterToFleetWorkspaceTestSuite$`.
+
+In your config file, set the following:
+
+```yaml
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True #optional
+  cleanup: True #optional
+  clusterName: "RKE1_cluster_name"
+```

--- a/tests/v2/validation/rbac/fleetworkspaces/fleetworkspaces.go
+++ b/tests/v2/validation/rbac/fleetworkspaces/fleetworkspaces.go
@@ -1,0 +1,218 @@
+package fleetworkspaces
+
+import (
+	"context"
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/v2/actions/kubeapi/rbac"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultFleetWorkspace       = "fleet-default"
+	localCluster                = "local"
+	userKind                    = "User"
+	clusterNameAnnotationKey    = "cluster.cattle.io/name"
+	ownerNamespaceAnnotationKey = "objectset.rio.cattle.io/owner-namespace"
+)
+
+func createFleetWorkspace(client *rancher.Client) (*management.FleetWorkspace, error) {
+	newWorkspace := namegen.AppendRandomString("testworkspace-")
+	workspacePayload := &management.FleetWorkspace{
+		Annotations:     map[string]string{},
+		Labels:          map[string]string{},
+		Name:            newWorkspace,
+		OwnerReferences: []management.OwnerReference{},
+	}
+
+	workspace, err := client.Management.FleetWorkspace.Create(workspacePayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create FleetWorkspace: %w", err)
+	}
+
+	return workspace, nil
+}
+
+func getClusterFleetWorkspace(client *rancher.Client, clusterID string) (string, error) {
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get cluster by ID %s: %v", clusterID, err)
+	}
+
+	return cluster.FleetWorkspaceName, nil
+}
+
+func verifyClusterRoleTemplateBindingForUser(client *rancher.Client, username string, expectedCount int) error {
+	crtbList, err := rbac.ListClusterRoleTemplateBindings(client, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list ClusterRoleTemplateBindings: %w", err)
+	}
+
+	actualCount := 0
+	for _, crtb := range crtbList.Items {
+		if crtb.UserName == username {
+			actualCount++
+		}
+	}
+
+	if actualCount != expectedCount {
+		return fmt.Errorf("expected %d ClusterRoleTemplateBindings for user %s, but found %d",
+			expectedCount, username, actualCount)
+	}
+
+	return nil
+}
+
+func verifyProjectRoleTemplateBindingForUser(client *rancher.Client, username string, expectedCount int) error {
+	prtbList, err := rbac.ListProjectRoleTemplateBindings(client, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list ProjectRoleTemplateBindings: %w", err)
+	}
+
+	actualCount := 0
+	for _, prtb := range prtbList.Items {
+		if prtb.UserName == username {
+			actualCount++
+		}
+	}
+
+	if actualCount != expectedCount {
+		return fmt.Errorf("expected %d ProjectRoleTemplateBindings for user %s, but found %d",
+			expectedCount, username, actualCount)
+	}
+
+	return nil
+}
+
+func verifyRoleBindingsForUser(adminClient *rancher.Client, user *management.User, clusterID, fleetWorkspaceName string, expectedCount int) error {
+	rblist, err := rbac.ListRoleBindings(adminClient, localCluster, fleetWorkspaceName, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list RoleBindings: %w", err)
+	}
+
+	userID := user.Resource.ID
+	actualCount := 0
+
+	for _, rb := range rblist.Items {
+		for _, subject := range rb.Subjects {
+			if subject.Kind == userKind && subject.Name == userID {
+				if rb.Annotations[clusterNameAnnotationKey] == clusterID {
+					actualCount++
+					break
+				}
+			}
+		}
+	}
+
+	if actualCount != expectedCount {
+		return fmt.Errorf("expected %d role bindings for user %s in workspace %s, but found %d",
+			expectedCount, userID, fleetWorkspaceName, actualCount)
+	}
+
+	return nil
+}
+
+func getAllRoleBindingsForCluster(client *rancher.Client, clusterID, fleetWorkspaceName string) ([]string, error) {
+	rblist, err := rbac.ListRoleBindings(client, localCluster, fleetWorkspaceName, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list RoleBindings: %w", err)
+	}
+
+	roleBindings := []string{}
+
+	for _, rb := range rblist.Items {
+		if rb.Annotations[clusterNameAnnotationKey] == clusterID && rb.Annotations[ownerNamespaceAnnotationKey] == clusterID {
+			roleBindings = append(roleBindings, rb.Name)
+		}
+	}
+
+	return roleBindings, nil
+}
+
+func moveClusterToNewWorkspace(client *rancher.Client, cluster *management.Cluster, targetWorkspace string) (*management.Cluster, error) {
+	updates := &management.Cluster{
+		Name:               cluster.Name,
+		FleetWorkspaceName: targetWorkspace,
+	}
+
+	_, err := client.Management.Cluster.Update(cluster, updates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update cluster with the new workspace: %w", err)
+	}
+
+	updatedCluster, err := waitForClusterUpdate(client, cluster.ID, targetWorkspace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for cluster update: %w", err)
+	}
+
+	_, clusterObject, err := clusters.GetProvisioningClusterByName(client, updatedCluster.ID, targetWorkspace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provisioning cluster by name: %w", err)
+	}
+
+	if clusterObject.Namespace != targetWorkspace {
+		return nil, fmt.Errorf("the namespace in the cluster object does not match the new workspace: expected %s, got %s", targetWorkspace, clusterObject.Namespace)
+	}
+
+	return updatedCluster, nil
+}
+
+func waitForClusterUpdate(client *rancher.Client, clusterID string, expectedFleetWorkspaceName string) (*management.Cluster, error) {
+	var updatedCluster *management.Cluster
+
+	err := kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+		cluster, pollErr := client.Management.Cluster.ByID(clusterID)
+		if pollErr != nil {
+			return false, fmt.Errorf("failed to get cluster by ID: %w", pollErr)
+		}
+
+		if cluster.FleetWorkspaceName == expectedFleetWorkspaceName {
+			updatedCluster = cluster
+			return true, nil
+		}
+		return false, nil
+	},
+	)
+
+	return updatedCluster, err
+}
+
+func createGlobalRoleWithFleetWorkspaceRules(client *rancher.Client) (*v3.GlobalRole, error) {
+	globalRole := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namegen.AppendRandomString("test-fwr"),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"fleet.cattle.io"},
+				Resources: []string{"clusters"},
+			},
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"management.cattle.io"},
+				Resources: []string{"fleetworkspaces"},
+			},
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"fleet.cattle.io"},
+				Resources: []string{"gitrepos"},
+			},
+		},
+	}
+
+	createdGlobalRole, err := rbac.CreateGlobalRole(client, &globalRole)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdGlobalRole, nil
+}

--- a/tests/v2/validation/rbac/fleetworkspaces/fleetworkspaces_test.go
+++ b/tests/v2/validation/rbac/fleetworkspaces/fleetworkspaces_test.go
@@ -1,0 +1,234 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+
+package fleetworkspaces
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/projects"
+	"github.com/rancher/rancher/tests/v2/actions/rbac"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type MoveClusterToFleetWorkspaceTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (fw *MoveClusterToFleetWorkspaceTestSuite) TearDownSuite() {
+	currentWorkspace, err := getClusterFleetWorkspace(fw.client, fw.cluster.ID)
+	require.NoError(fw.T(), err)
+
+	if currentWorkspace != fw.cluster.FleetWorkspaceName {
+		_, err := moveClusterToNewWorkspace(fw.client, fw.cluster, fw.cluster.FleetWorkspaceName)
+		if err != nil {
+			log.Warn("Failed to move cluster back to the original workspace:", err)
+		}
+	}
+
+	fw.session.Cleanup()
+}
+
+func (fw *MoveClusterToFleetWorkspaceTestSuite) SetupSuite() {
+	fw.session = session.NewSession()
+
+	client, err := rancher.NewClient("", fw.session)
+	require.NoError(fw.T(), err)
+	fw.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in fw")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(fw.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(fw.client, clusterName)
+	require.NoError(fw.T(), err, "Error getting cluster ID")
+	fw.cluster, err = fw.client.Management.Cluster.ByID(clusterID)
+	require.NoError(fw.T(), err)
+}
+
+func (fw *MoveClusterToFleetWorkspaceTestSuite) testMoveClusterAndVerifyBindings(client *rancher.Client, user *management.User, role rbac.Role, newFleetWorkspace string, oldFleetWorkspace string) {
+	log.Info("Retrieve the role bindings created for the cluster in the old fleet workspace .")
+	allRbList, err := getAllRoleBindingsForCluster(fw.client, fw.cluster.ID, oldFleetWorkspace)
+	require.NoError(fw.T(), err)
+	allRbCount := len(allRbList)
+
+	log.Info("Move the downstream RKE1 cluster to the newly created fleet workspace.")
+	updatedCluster, err := moveClusterToNewWorkspace(client, fw.cluster, newFleetWorkspace)
+	require.NoError(fw.T(), err, "Failed to update cluster with the new workspace")
+
+	log.Info("Verify that the user can still list the downstream cluster.")
+	newUserClient, err := fw.client.AsUser(user)
+	require.NoError(fw.T(), err)
+	rbac.VerifyUserCanListCluster(fw.T(), client, newUserClient, fw.cluster.ID, role)
+
+	log.Info("Verify that the cluster is no longer available in the old fleet workspace.")
+	_, _, err = clusters.GetProvisioningClusterByName(fw.client, updatedCluster.ID, oldFleetWorkspace)
+	require.Error(fw.T(), err)
+
+	if role != rbac.ClusterMember {
+		log.Info("Verify that the old role bindings for the user are deleted from the old fleet workspace.")
+		err = verifyRoleBindingsForUser(fw.client, user, updatedCluster.ID, oldFleetWorkspace, 0)
+		require.NoError(fw.T(), err)
+	}
+
+	log.Info("Verify that the new role binding is created for the user in the new fleet workspace.")
+	err = verifyRoleBindingsForUser(fw.client, user, updatedCluster.ID, newFleetWorkspace, 1)
+	require.NoError(fw.T(), err)
+
+	if role == rbac.ProjectOwner || role == rbac.ProjectMember {
+		log.Info("Verify that the project role template binding exists for the user.")
+		err = verifyProjectRoleTemplateBindingForUser(fw.client, user.ID, 1)
+		require.NoError(fw.T(), err)
+	} else {
+		log.Info("Verify that the cluster role template binding exists for the user.")
+		err = verifyClusterRoleTemplateBindingForUser(fw.client, user.ID, 1)
+		require.NoError(fw.T(), err)
+	}
+
+	log.Info("Verify that the new role bindings are created for the cluster in the new fleet workspace .")
+	allRbList, err = getAllRoleBindingsForCluster(fw.client, fw.cluster.ID, newFleetWorkspace)
+	require.NoError(fw.T(), err)
+	require.Equal(fw.T(), allRbCount, len(allRbList))
+}
+
+func (fw *MoveClusterToFleetWorkspaceTestSuite) TestMoveClusterToNewFleetWorkspace() {
+	subSession := fw.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role rbac.Role
+	}{
+		{rbac.ClusterOwner},
+		{rbac.ClusterMember},
+		{rbac.ProjectOwner},
+		{rbac.ProjectMember},
+	}
+
+	for _, tt := range tests {
+		fw.Run("Validate moving cluster to a new fleet workspace and verifying the rolebindings for user with role "+tt.role.String(), func() {
+			defer func() {
+				_, err := moveClusterToNewWorkspace(fw.client, fw.cluster, fw.cluster.FleetWorkspaceName)
+				if err != nil {
+					log.Warn("Failed to move cluster back to the original workspace:", err)
+				}
+			}()
+
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, _, err := projects.CreateProjectAndNamespace(fw.client, fw.cluster.ID)
+			assert.NoError(fw.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project as role %s", tt.role)
+			createdUser, _, err := rbac.AddUserWithRoleToCluster(fw.client, rbac.StandardUser.String(), tt.role.String(), fw.cluster, adminProject)
+			assert.NoError(fw.T(), err)
+
+			log.Info("Verify that the user can list the downstream cluster.")
+			newUserClient, err := fw.client.AsUser(createdUser)
+			assert.NoError(fw.T(), err)
+			rbac.VerifyUserCanListCluster(fw.T(), fw.client, newUserClient, fw.cluster.ID, tt.role)
+
+			if strings.Contains(tt.role.String(), "project") {
+				log.Info("Verify that the project role template binding is created for the user.")
+				err = verifyProjectRoleTemplateBindingForUser(fw.client, createdUser.ID, 1)
+				require.NoError(fw.T(), err)
+				userProject, err := projects.ListProjectNames(newUserClient, fw.cluster.ID)
+				assert.NoError(fw.T(), err)
+				assert.Equal(fw.T(), 1, len(userProject))
+				assert.Equal(fw.T(), adminProject.Name, userProject[0])
+			} else {
+				log.Info("Verify that the cluster role template binding is created for the user.")
+				err = verifyClusterRoleTemplateBindingForUser(fw.client, createdUser.ID, 1)
+				assert.NoError(fw.T(), err)
+			}
+
+			log.Info("Verify the role bindings created for the user in the fleet-default workspace.")
+			err = verifyRoleBindingsForUser(fw.client, createdUser, fw.cluster.ID, defaultFleetWorkspace, 1)
+			assert.NoError(fw.T(), err)
+
+			log.Info("Create a new fleet workspace.")
+			createdFleetWorkspace, err := createFleetWorkspace(fw.client)
+			assert.NoError(fw.T(), err, "Failed to create workspace")
+
+			fw.testMoveClusterAndVerifyBindings(fw.client, createdUser, tt.role, createdFleetWorkspace.Name, defaultFleetWorkspace)
+		})
+	}
+}
+
+func (fw *MoveClusterToFleetWorkspaceTestSuite) TestMoveClusterToNewFleetWorkspaceWithCustomRole() {
+	subSession := fw.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create a custom global role with the following rules: fleetworkspaces with all verbs, gitrepos with all verbs, clusters with all verbs.")
+	createdGlobalRole, err := createGlobalRoleWithFleetWorkspaceRules(fw.client)
+	require.NoError(fw.T(), err)
+
+	log.Info("Create a user with global role standard user and custom global role.")
+	createdUser, err := users.CreateUserWithRole(fw.client, users.UserConfig(), rbac.StandardUser.String(), createdGlobalRole.Name)
+	require.NoError(fw.T(), err)
+
+	log.Info("Add the user as cluster owner to the downstream cluster.")
+	err = users.AddClusterRoleToUser(fw.client, fw.cluster, createdUser, rbac.ClusterOwner.String(), nil)
+	require.NoError(fw.T(), err)
+
+	log.Info("Verify that the cluster role template binding is created for the user.")
+	err = verifyClusterRoleTemplateBindingForUser(fw.client, createdUser.ID, 1)
+	require.NoError(fw.T(), err)
+
+	log.Info("Verify that the role binding is created for the cluster in the fleet workspace.")
+	err = verifyRoleBindingsForUser(fw.client, createdUser, fw.cluster.ID, defaultFleetWorkspace, 1)
+	require.NoError(fw.T(), err)
+
+	log.Info("Verify that the user can list the downstream cluster.")
+	newUserClient, err := fw.client.AsUser(createdUser)
+	require.NoError(fw.T(), err)
+	rbac.VerifyUserCanListCluster(fw.T(), fw.client, newUserClient, fw.cluster.ID, rbac.ClusterOwner)
+
+	log.Info("Create a new fleet workspace.")
+	createdFleetWorkspace, err := createFleetWorkspace(newUserClient)
+	require.NoError(fw.T(), err, "Failed to create workspace")
+
+	fw.testMoveClusterAndVerifyBindings(newUserClient, createdUser, rbac.ClusterOwner, createdFleetWorkspace.Name, defaultFleetWorkspace)
+}
+
+func (fw *MoveClusterToFleetWorkspaceTestSuite) TestMoveClusterBackToOriginalWorkspace() {
+	subSession := fw.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Infof("Create a standard user and add the user to a cluster/project as role %s", rbac.ClusterOwner.String())
+	createdUser, _, err := rbac.AddUserWithRoleToCluster(fw.client, rbac.StandardUser.String(), rbac.ClusterOwner.String(), fw.cluster, nil)
+	require.NoError(fw.T(), err)
+
+	log.Info("Verify that the cluster role template binding is created for the user.")
+	err = verifyClusterRoleTemplateBindingForUser(fw.client, createdUser.ID, 1)
+	require.NoError(fw.T(), err)
+
+	log.Info("Verify that the role binding is created for the user in the fleet workspace.")
+	err = verifyRoleBindingsForUser(fw.client, createdUser, fw.cluster.ID, defaultFleetWorkspace, 1)
+	require.NoError(fw.T(), err)
+
+	log.Info("Verify that the user can list the downstream cluster.")
+	newUserClient, err := fw.client.AsUser(createdUser)
+	require.NoError(fw.T(), err)
+	rbac.VerifyUserCanListCluster(fw.T(), fw.client, newUserClient, fw.cluster.ID, rbac.ClusterOwner)
+
+	log.Info("Create a new fleet workspace.")
+	createdFleetWorkspace, err := createFleetWorkspace(fw.client)
+	require.NoError(fw.T(), err, "Failed to create workspace")
+
+	fw.testMoveClusterAndVerifyBindings(fw.client, createdUser, rbac.ClusterOwner, createdFleetWorkspace.Name, defaultFleetWorkspace)
+
+	fw.testMoveClusterAndVerifyBindings(fw.client, createdUser, rbac.ClusterOwner, defaultFleetWorkspace, createdFleetWorkspace.Name)
+}
+
+func TestMoveClusterToFleetWorkspaceTestSuite(t *testing.T) {
+	suite.Run(t, new(MoveClusterToFleetWorkspaceTestSuite))
+}


### PR DESCRIPTION
QA task: https://github.com/rancher/qa-tasks/issues/1577

Automate the following P0 tests for GH45811

- [x] Verify roleBindings for cluster owner when RKE1 cluster is moved to a new workspace
- [x] Verify roleBindings for cluster member when RKE1 cluster is moved to a new workspace
- [x] Verify roleBindings for project owner when RKE1 cluster is moved to a new workspace
- [x] Verify roleBindings for project member when RKE1 cluster is moved to a new workspace
- [x] Verify roleBindings after user with custom role moves RKE1 cluster to a new workspace
- [x] Verify cluster access after moving the cluster back to original workspace

Note: No backports will be created for this PR 