### PR TITLE
Updates the name of cloud credential expiry time

### DIFF
--- a/pkg/api/norman/customization/cred/store.go
+++ b/pkg/api/norman/customization/cred/store.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const CloudCredentialExpirationAnnotation = "cattle.io/expiration-timestamp"
+const CloudCredentialExpirationAnnotation = "rancher.io/expiration-timestamp"
 
 func Wrap(store types.Store, ns v1.NamespaceInterface, nodeTemplateLister v3.NodeTemplateLister, provClusterCache provv1.ClusterCache, tokenLister v3.TokenLister) types.Store {
 	transformStore := &transform.Store{


### PR DESCRIPTION
Previously, the cloud credential expiry annotation used a "cattle.io" prefix. This lead to norman preventing updates to the value. Since the value needs to be updated on rotation, this was changed to rancher.io, which is not protected.

## Issue: <!-- link the issue or issues this PR resolves here -->
#47492
 
## Problem
Currently, Harvester's cloud credentials have an expiry time in the "cattle.io/expiration-timestamp" annotation. Norman (as linked in the issue) views this annotation as protected, and does not allow updating this value through Norman, even when the change originates from internal Rancher code rather than the end user.
 
## Solution
The annotation now is named "rancher.io/expiration-timestamp". Because this has a different prefix, it's no longer protected, and now be updated. 
 
## Testing
Small manual testing was done to validate that the original issue was resolved.