### PR TITLE
saml logoutall - retain `logoutAllSupported` flag when resetting an auth config back to unused when it is disabled.

### DIFF
--- a/pkg/controllers/management/auth/auth_config.go
+++ b/pkg/controllers/management/auth/auth_config.go
@@ -194,7 +194,13 @@ func (ac *authConfigController) refreshUsers(obj *v3.AuthConfig) error {
 
 // resetAuthConfig takes an Auth Config as a map and deletes all entries except those with basic metadata fields.
 func resetAuthConfig(cfg map[string]any) {
-	retainFields := map[string]bool{"apiVersion": true, "kind": true, "metadata": true, "type": true}
+	retainFields := map[string]bool{
+		"apiVersion":         true,
+		"kind":               true,
+		"metadata":           true,
+		"type":               true,
+		"logoutAllSupported": true,
+	}
 	for field := range cfg {
 		if !retainFields[field] {
 			delete(cfg, field)

--- a/pkg/controllers/management/auth/auth_config_test.go
+++ b/pkg/controllers/management/auth/auth_config_test.go
@@ -124,8 +124,8 @@ func TestCleanupRuns(t *testing.T) {
 func TestAuthConfigReset(t *testing.T) {
 	t.Parallel()
 
-	allFields := []string{"accessMode", "allowedPrincipalIds", "apiVersion", "kind", "metadata", "type", "status"}
-	postResetFields := []string{"apiVersion", "kind", "metadata", "type", "status"}
+	allFields := []string{"accessMode", "allowedPrincipalIds", "apiVersion", "kind", "metadata", "type", "status", "logoutAllSupported"}
+	postResetFields := []string{"apiVersion", "kind", "metadata", "type", "status", "logoutAllSupported"}
 
 	tests := []struct {
 		annotationValue string
@@ -153,6 +153,7 @@ func TestAuthConfigReset(t *testing.T) {
 				Enabled:             false,
 				AccessMode:          "unrestricted",
 				AllowedPrincipalIDs: []string{"user1", "user2"},
+				LogoutAllSupported:  true,
 			}
 
 			mockUsers := newMockUserLister()


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
 
#47489 

## Problem

When disabling an auth provider supporting logout-all as per its auth config resource the flag reporting this is reset, and the auth provider will from then report that it does not support logout-all.
 
## Solution

The function which strips all the irrelevant keys out of auth configs on reset is modified to retain the `logoutAllSupported` field.

## Testing
## Engineering Testing
### Manual Testing
### Automated Testing
* Test types added/modified:
    * Unit tests of the auth config controller

## QA Testing Considerations

Scenario:
- Enable a external auth provider supporting logout-all (any of the SAML providers).
- Disable the provider again
- Re-enable the same provider and verify that logout-all is still supported.
 
### Regressions Considerations
