### PR TITLE
[Main] Consolidate release testing into dedicated files

### DIFF
--- a/tests/v2/actions/provisioninginput/config.go
+++ b/tests/v2/actions/provisioninginput/config.go
@@ -84,6 +84,42 @@ var WorkerMachinePool = MachinePools{
 	},
 }
 
+var EtcdMultipleMachines = MachinePools{
+	MachinePoolConfig: machinepools.MachinePoolConfig{
+		NodeRoles: machinepools.NodeRoles{
+			Etcd:     true,
+			Quantity: 3,
+		},
+	},
+}
+
+var ControlPlaneMultipleMachines = MachinePools{
+	MachinePoolConfig: machinepools.MachinePoolConfig{
+		NodeRoles: machinepools.NodeRoles{
+			ControlPlane: true,
+			Quantity:     2,
+		},
+	},
+}
+
+var WorkerMultipleMachines = MachinePools{
+	MachinePoolConfig: machinepools.MachinePoolConfig{
+		NodeRoles: machinepools.NodeRoles{
+			Worker:   true,
+			Quantity: 3,
+		},
+	},
+}
+
+var WindowsMultipleMachines = MachinePools{
+	MachinePoolConfig: machinepools.MachinePoolConfig{
+		NodeRoles: machinepools.NodeRoles{
+			Windows:  true,
+			Quantity: 2,
+		},
+	},
+}
+
 var WindowsMachinePool = MachinePools{
 	MachinePoolConfig: machinepools.MachinePoolConfig{
 		NodeRoles: machinepools.NodeRoles{
@@ -128,6 +164,27 @@ var WorkerNodePool = NodePools{
 	NodeRoles: nodepools.NodeRoles{
 		Worker:   true,
 		Quantity: 1,
+	},
+}
+
+var EtcdMultipleNodes = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 3,
+	},
+}
+
+var ControlPlaneMultipleNodes = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     2,
+	},
+}
+
+var WorkerMultipleNodes = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		Worker:   true,
+		Quantity: 3,
 	},
 }
 

--- a/tests/v2/actions/qaseinput/config.go
+++ b/tests/v2/actions/qaseinput/config.go
@@ -1,0 +1,9 @@
+package qaseinput
+
+const (
+	ConfigurationFileKey = "qaseInput"
+)
+
+type Config struct {
+	LocalQaseReporting bool `yaml:"localQaseReporting" json:"localQaseReporting" default:"false"`
+}

--- a/tests/v2/validation/deleting/README.md
+++ b/tests/v2/validation/deleting/README.md
@@ -6,6 +6,8 @@ Please see below for more details for your config. Please note that the config c
 
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
+2. [Release Testing](#Release-Testing)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -32,3 +34,71 @@ automated check to validate [this issue](https://github.com/rancher/rancher/issu
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/deleting --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestDeleteInitMachineTestSuite/TestDeleteInitMachine"`
 
 If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Release Testing
+The release testing includes all of the tests that are ran during release testing time. Each test will first provision a cluster and then run the specific test. See an example config below:
+
+```yaml
+rancher:
+  host: ""
+  adminToken: ""
+  cleanup: false
+  insecure: true
+provisioningInput:
+  rke1KubernetesVersion: [""]
+  rke2KubernetesVersion: [""]
+  k3sKubernetesVersion: [""]
+  cni: ["calico"]
+  providers: ["linode"]
+linodeCredentials:
+   token: ""
+linodeConfig:
+  authorizedUsers: ""
+  createPrivateIp: true
+  dockerPort: "2376"
+  image: "linode/ubuntu22.04"
+  instanceType: "g6-dedicated-8"
+  label: ""
+  region: "us-west"
+  rootPass: ""
+  sshPort: "22"
+  sshUser: "root"
+  stackscript: ""
+  stackscriptData: ""
+  swapSize: "512"
+  tags: ""
+  token: ""
+  type: "linodeConfig"
+  uaPrefix: "Rancher"
+linodeMachineConfigs:
+  region: "us-west"
+  linodeMachineConfig:
+  - roles: ["etcd", "controlplane", "worker"]
+    authorizedUsers: ""
+    createPrivateIp: true
+    dockerPort: "2376"
+    image: "linode/ubuntu22.04"
+    instanceType: "g6-standard-8"
+    region: "us-west"
+    rootPass: ""
+    sshPort: "22"
+    sshUser: ""
+    stackscript: ""
+    stackscriptData: ""
+    swapSize: "512"
+    tags: ""
+    uaPrefix: "Rancher"
+```
+
+To run, use the following command:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/deleting --junitfile results.xml -- -timeout=300m -tags=validation -v -run "TestDeleteReleaseTestingTestSuite$"`
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `rancher` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/deleting --junitfile results.xml --jsonfile results.json -- -timeout=300m -v -run "TestDeleteReleaseTestingTestSuite$";/path/to/rancher/rancher/reporter`

--- a/tests/v2/validation/deleting/delete_release_testing_test.go
+++ b/tests/v2/validation/deleting/delete_release_testing_test.go
@@ -1,0 +1,206 @@
+//go:build validation
+
+package deleting
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/provisioning"
+	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/qaseinput"
+	qase "github.com/rancher/rancher/tests/v2/validation/pipeline/qase/results"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DeleteReleaseTestingTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	provisioningConfig *provisioninginput.Config
+	qaseConfig         *qaseinput.Config
+}
+
+func (d *DeleteReleaseTestingTestSuite) TearDownSuite() {
+	d.session.Cleanup()
+
+	d.qaseConfig = new(qaseinput.Config)
+	config.LoadConfig(qaseinput.ConfigurationFileKey, d.qaseConfig)
+
+	if d.qaseConfig.LocalQaseReporting {
+		err := qase.ReportTest()
+		require.NoError(d.T(), err)
+	}
+}
+
+func (d *DeleteReleaseTestingTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	d.session = testSession
+
+	d.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, d.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(d.T(), err)
+
+	d.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(d.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(d.T(), err)
+
+	d.standardUserClient = standardUserClient
+}
+
+func (d *DeleteReleaseTestingTestSuite) TestDeleteRKE1Cluster() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdMultipleNodes,
+		provisioninginput.ControlPlaneMultipleNodes,
+		provisioninginput.WorkerMultipleNodes,
+	}
+
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"Deleting RKE1 Cluster", d.standardUserClient},
+	}
+
+	for _, tt := range tests {
+		subSession := d.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(d.T(), err)
+
+		provisioningConfig := *d.provisioningConfig
+		provisioningConfig.NodePools = nodeRolesDedicated
+		_, clusterObject := permutations.RunTestPermutations(&d.Suite, tt.name, client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+
+		adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+		require.NoError(d.T(), err)
+
+		clusterID, err := clusters.GetClusterIDByName(adminClient, clusterObject.Name)
+		require.NoError(d.T(), err)
+
+		clusters.DeleteRKE1Cluster(client, clusterID)
+		provisioning.VerifyDeleteRKE1Cluster(d.T(), client, clusterID)
+	}
+}
+
+func (d *DeleteReleaseTestingTestSuite) TestDeleteCluster() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+	}
+
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"Deleting RKE2 Cluster", d.standardUserClient},
+		{"Deleting K3S Cluster", d.standardUserClient},
+	}
+
+	for _, tt := range tests {
+		subSession := d.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(d.T(), err)
+
+		var clusterObject *v1.SteveAPIObject
+		provisioningConfig := *d.provisioningConfig
+		provisioningConfig.MachinePools = nodeRolesDedicated
+
+		if strings.Contains(tt.name, "RKE2") {
+			clusterObject, _ = permutations.RunTestPermutations(&d.Suite, tt.name, client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+		} else {
+			clusterObject, _ = permutations.RunTestPermutations(&d.Suite, tt.name, client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+		}
+
+		adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+		require.NoError(d.T(), err)
+
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(adminClient, clusterObject.Name)
+		require.NoError(d.T(), err)
+
+		clusters.DeleteK3SRKE2Cluster(adminClient, clusterID)
+		provisioning.VerifyDeleteRKE2K3SCluster(d.T(), adminClient, clusterID)
+	}
+}
+
+func (d *DeleteReleaseTestingTestSuite) TestDeleteInitMachine() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+	}
+
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"RKE2", d.standardUserClient},
+		{"K3S", d.standardUserClient},
+	}
+
+	for _, tt := range tests {
+		subSession := d.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(d.T(), err)
+
+		var clusterObject *v1.SteveAPIObject
+		provisioningConfig := *d.provisioningConfig
+		provisioningConfig.MachinePools = nodeRolesDedicated
+
+		if strings.Contains(tt.name, "RKE2") {
+			clusterObject, _ = permutations.RunTestPermutations(&d.Suite, tt.name, client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+		} else {
+			clusterObject, _ = permutations.RunTestPermutations(&d.Suite, tt.name, client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+		}
+
+		adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+		require.NoError(d.T(), err)
+
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(adminClient, clusterObject.Name)
+		require.NoError(d.T(), err)
+
+		deleteInitMachine(d.T(), adminClient, clusterID)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestDeleteReleaseTestingTestSuite(t *testing.T) {
+	suite.Run(t, new(DeleteReleaseTestingTestSuite))
+}

--- a/tests/v2/validation/nodescaling/scaling_custom_cluster_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scaling_custom_cluster_rke1_test.go
@@ -61,21 +61,15 @@ func (s *RKE1CustomClusterNodeScalingTestSuite) TestScalingRKE1CustomClusterNode
 		Quantity: 1,
 	}
 
-	nodeRolesTwoWorkers := nodepools.NodeRoles{
-		Worker:   true,
-		Quantity: 2,
-	}
-
 	tests := []struct {
 		name      string
 		nodeRoles nodepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling custom control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling custom etcd by 1", nodeRolesEtcd, s.client},
-		{"Scaling custom etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
-		{"Scaling custom worker by 1", nodeRolesWorker, s.client},
-		{"Scaling custom worker by 2", nodeRolesTwoWorkers, s.client},
+		{"Scaling RKE1 custom control plane by 1", nodeRolesControlPlane, s.client},
+		{"Scaling RKE1 custom etcd by 1", nodeRolesEtcd, s.client},
+		{"Scaling RKE1 custom etcd and control plane by 1", nodeRolesEtcdControlPlane, s.client},
+		{"Scaling RKE1 custom worker by 1", nodeRolesWorker, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_node_driver_rke1_test.go
+++ b/tests/v2/validation/nodescaling/scaling_node_driver_rke1_test.go
@@ -55,20 +55,14 @@ func (s *RKE1NodeScalingTestSuite) TestScalingRKE1NodePools() {
 		Quantity: 1,
 	}
 
-	nodeRolesTwoWorkers := nodepools.NodeRoles{
-		Worker:   true,
-		Quantity: 2,
-	}
-
 	tests := []struct {
 		name      string
 		nodeRoles nodepools.NodeRoles
 		client    *rancher.Client
 	}{
-		{"Scaling control plane by 1", nodeRolesControlPlane, s.client},
-		{"Scaling etcd node by 1", nodeRolesEtcd, s.client},
-		{"Scaling worker by 1", nodeRolesWorker, s.client},
-		{"Scaling worker node machine by 2", nodeRolesTwoWorkers, s.client},
+		{"Scaling RKE1 control plane by 1", nodeRolesControlPlane, s.client},
+		{"Scaling RKE1 etcd node by 1", nodeRolesEtcd, s.client},
+		{"Scaling RKE1 worker by 1", nodeRolesWorker, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/nodescaling/scaling_release_testing_test.go
+++ b/tests/v2/validation/nodescaling/scaling_release_testing_test.go
@@ -1,0 +1,492 @@
+//go:build validation
+
+package nodescaling
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/machinepools"
+	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/qaseinput"
+	nodepools "github.com/rancher/rancher/tests/v2/actions/rke1/nodepools"
+	"github.com/rancher/rancher/tests/v2/actions/scalinginput"
+	qase "github.com/rancher/rancher/tests/v2/validation/pipeline/qase/results"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type NodeScalingReleaseTestingTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	scalingConfig      *scalinginput.Config
+	provisioningConfig *provisioninginput.Config
+	qaseConfig         *qaseinput.Config
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) TearDownSuite() {
+	s.session.Cleanup()
+
+	s.qaseConfig = new(qaseinput.Config)
+	config.LoadConfig(qaseinput.ConfigurationFileKey, s.qaseConfig)
+
+	if s.qaseConfig.LocalQaseReporting {
+		err := qase.ReportTest()
+		require.NoError(s.T(), err)
+	}
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	s.session = testSession
+
+	s.scalingConfig = new(scalinginput.Config)
+	config.LoadConfig(scalinginput.ConfigurationFileKey, s.scalingConfig)
+
+	s.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, s.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(s.T(), err)
+
+	s.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(s.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(s.T(), err)
+
+	s.standardUserClient = standardUserClient
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) TestReplacingRKE1Nodes() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdMultipleNodes,
+		provisioninginput.ControlPlaneMultipleNodes,
+		provisioninginput.WorkerMultipleNodes,
+	}
+
+	nodeRolesEtcd := nodepools.NodeRoles{
+		Etcd: true,
+	}
+
+	nodeRolesControlPlane := nodepools.NodeRoles{
+		ControlPlane: true,
+	}
+
+	nodeRolesWorker := nodepools.NodeRoles{
+		Worker: true,
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles nodepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"Replacing RKE1 control plane nodes", nodeRolesControlPlane, s.standardUserClient},
+		{"Replacing RKE1 etcd nodes", nodeRolesEtcd, s.standardUserClient},
+		{"Replacing RKE1 worker nodes", nodeRolesWorker, s.standardUserClient},
+	}
+
+	var clusterObject *management.Cluster
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.NodePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if clusterObject == nil {
+			_, clusterObject = permutations.RunTestPermutations(&s.Suite, "Provision RKE1", client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			err = scalinginput.ReplaceRKE1Nodes(adminClient, clusterObject.Name, tt.nodeRoles.Etcd, tt.nodeRoles.ControlPlane, tt.nodeRoles.Worker)
+			require.NoError(s.T(), err)
+		})
+	}
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) TestReplacingNodes() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+	}
+
+	nodeRolesEtcd := machinepools.NodeRoles{
+		Etcd: true,
+	}
+
+	nodeRolesControlPlane := machinepools.NodeRoles{
+		ControlPlane: true,
+	}
+
+	nodeRolesWorker := machinepools.NodeRoles{
+		Worker: true,
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles machinepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"Replacing RKE2 control plane nodes", nodeRolesControlPlane, s.standardUserClient},
+		{"Replacing RKE2 etcd nodes", nodeRolesEtcd, s.standardUserClient},
+		{"Replacing RKE2 worker nodes", nodeRolesWorker, s.standardUserClient},
+		{"Replacing K3S control plane nodes", nodeRolesControlPlane, s.standardUserClient},
+		{"Replacing K3S etcd nodes", nodeRolesEtcd, s.standardUserClient},
+		{"Replacing K3S worker nodes", nodeRolesWorker, s.standardUserClient},
+	}
+
+	var clusterObject, rke2ClusterObject, k3sClusterObject *v1.SteveAPIObject
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(tt.name, "RKE2") {
+			rke2ClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision RKE2", client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+			clusterObject = rke2ClusterObject
+		} else {
+			k3sClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision K3S", client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+			clusterObject = k3sClusterObject
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			err = scalinginput.ReplaceNodes(adminClient, clusterObject.Name, tt.nodeRoles.Etcd, tt.nodeRoles.ControlPlane, tt.nodeRoles.Worker)
+			require.NoError(s.T(), err)
+		})
+	}
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) TestScalingRKE1NodePools() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdMultipleNodes,
+		provisioninginput.ControlPlaneMultipleNodes,
+		provisioninginput.WorkerMultipleNodes,
+	}
+
+	nodeRolesEtcd := nodepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	}
+
+	nodeRolesControlPlane := nodepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	}
+
+	nodeRolesWorker := nodepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles nodepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"Scaling RKE1 control plane by 1", nodeRolesControlPlane, s.standardUserClient},
+		{"Scaling RKE1 etcd node by 1", nodeRolesEtcd, s.standardUserClient},
+		{"Scaling RKE1 worker by 1", nodeRolesWorker, s.standardUserClient},
+	}
+
+	var clusterObject *management.Cluster
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.NodePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if clusterObject == nil {
+			_, clusterObject = permutations.RunTestPermutations(&s.Suite, "Provision RKE1", client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			clusterID, err := clusters.GetClusterIDByName(adminClient, clusterObject.Name)
+			require.NoError(s.T(), err)
+
+			scalingRKE1NodePools(s.T(), adminClient, clusterID, tt.nodeRoles)
+		})
+	}
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) TestScalingMachinePools() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+	}
+
+	nodeRolesEtcd := machinepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	}
+
+	nodeRolesControlPlane := machinepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	}
+
+	nodeRolesWorker := machinepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	}
+
+	nodeRolesWindows := machinepools.NodeRoles{
+		Windows:  true,
+		Quantity: 1,
+	}
+
+	tests := []struct {
+		name      string
+		client    *rancher.Client
+		isWindows bool
+		nodeRoles machinepools.NodeRoles
+	}{
+		{"Scaling RKE2 control plane by 1", s.standardUserClient, false, nodeRolesControlPlane},
+		{"Scaling RKE2 etcd by 1", s.standardUserClient, false, nodeRolesEtcd},
+		{"Scaling RKE2 worker by 1", s.standardUserClient, false, nodeRolesWorker},
+		{"Scaling RKE2 Windows worker by 1", s.standardUserClient, true, nodeRolesWindows},
+		{"Scaling K3S control plane by 1", s.standardUserClient, false, nodeRolesControlPlane},
+		{"Scaling K3S etcd by 1", s.standardUserClient, false, nodeRolesEtcd},
+		{"Scaling K3S worker by 1", s.standardUserClient, false, nodeRolesWorker},
+	}
+
+	var clusterObject, rke2ClusterObject, k3sClusterObject *v1.SteveAPIObject
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(tt.name, "RKE2") {
+			if !slices.Contains(s.provisioningConfig.Providers, "vsphere") && tt.isWindows {
+				s.T().Skip("Windows test requires access to vSphere")
+			}
+
+			if rke2ClusterObject == nil {
+				rke2ClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision RKE2", client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+			}
+
+			clusterObject = rke2ClusterObject
+		} else {
+			if k3sClusterObject == nil {
+				k3sClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision K3S", client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+			}
+
+			clusterObject = k3sClusterObject
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			clusterID, err := clusters.GetV1ProvisioningClusterByName(adminClient, clusterObject.Name)
+			require.NoError(s.T(), err)
+
+			scalingRKE2K3SNodePools(s.T(), adminClient, clusterID, tt.nodeRoles)
+		})
+	}
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) TestScalingRKE1CustomClusterNodes() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdMultipleNodes,
+		provisioninginput.ControlPlaneMultipleNodes,
+		provisioninginput.WorkerMultipleNodes,
+	}
+
+	nodeRolesEtcd := nodepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	}
+
+	nodeRolesControlPlane := nodepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	}
+
+	nodeRolesEtcdControlPlane := nodepools.NodeRoles{
+		Etcd:         true,
+		ControlPlane: true,
+		Quantity:     1,
+	}
+
+	nodeRolesWorker := nodepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles nodepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"Scaling RKE1 custom control plane by 1", nodeRolesControlPlane, s.standardUserClient},
+		{"Scaling RKE1 custom etcd by 1", nodeRolesEtcd, s.standardUserClient},
+		{"Scaling RKE1 custom etcd and control plane by 1", nodeRolesEtcdControlPlane, s.standardUserClient},
+		{"Scaling RKE1 custom worker by 1", nodeRolesWorker, s.standardUserClient},
+	}
+
+	var clusterObject *management.Cluster
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.NodePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if clusterObject == nil {
+			_, clusterObject = permutations.RunTestPermutations(&s.Suite, tt.name, client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			clusterID, err := clusters.GetClusterIDByName(adminClient, clusterObject.Name)
+			require.NoError(s.T(), err)
+
+			scalingRKE1CustomClusterPools(s.T(), adminClient, clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles)
+		})
+	}
+}
+
+func (s *NodeScalingReleaseTestingTestSuite) TestScalingCustomClusterNodes() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+	}
+
+	nodeRolesEtcd := machinepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	}
+
+	nodeRolesControlPlane := machinepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	}
+
+	nodeRolesWorker := machinepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	}
+
+	nodeRolesWindows := machinepools.NodeRoles{
+		Windows:  true,
+		Quantity: 1,
+	}
+
+	tests := []struct {
+		name      string
+		client    *rancher.Client
+		isWindows bool
+		nodeRoles machinepools.NodeRoles
+	}{
+		{"Scaling custom RKE2 control plane by 1", s.standardUserClient, false, nodeRolesControlPlane},
+		{"Scaling custom RKE2 etcd by 1", s.standardUserClient, false, nodeRolesEtcd},
+		{"Scaling custom RKE2 worker by 1", s.standardUserClient, false, nodeRolesWorker},
+		{"Scaling custom RKE2 Windows worker by 1", s.standardUserClient, true, nodeRolesWindows},
+		{"Scaling custom K3S control plane by 1", s.standardUserClient, false, nodeRolesControlPlane},
+		{"Scaling custom K3S etcd by 1", s.standardUserClient, false, nodeRolesEtcd},
+		{"Scaling custom K3S worker by 1", s.standardUserClient, false, nodeRolesWorker},
+	}
+
+	var clusterObject, rke2ClusterObject, k3sClusterObject *v1.SteveAPIObject
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(tt.name, "RKE2") {
+			if rke2ClusterObject == nil {
+				rke2ClusterObject, _ = permutations.RunTestPermutations(&s.Suite, tt.name, client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+			}
+
+			clusterObject = rke2ClusterObject
+		} else {
+			if k3sClusterObject == nil {
+				k3sClusterObject, _ = permutations.RunTestPermutations(&s.Suite, tt.name, client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+			}
+
+			clusterObject = k3sClusterObject
+		}
+
+		adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+		require.NoError(s.T(), err)
+
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(adminClient, clusterObject.Name)
+		require.NoError(s.T(), err)
+
+		scalingRKE2K3SCustomClusterPools(s.T(), adminClient, clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestNodeScalingReleaseTestingTestSuite(t *testing.T) {
+	suite.Run(t, new(NodeScalingReleaseTestingTestSuite))
+}

--- a/tests/v2/validation/pipeline/qase/results/results.go
+++ b/tests/v2/validation/pipeline/qase/results/results.go
@@ -1,0 +1,37 @@
+package results
+
+import (
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ReportTest is a function that reports the test results.
+func ReportTest() error {
+	runID := os.Getenv("QASE_TEST_RUN_ID")
+	if runID == "" {
+		logrus.Error("QASE_TEST_RUN_ID is not set")
+		return nil
+	}
+
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	reporterPath := filepath.Join(user.HomeDir, "go/src/github.com/rancher/rancher/tests/v2/validation/pipeline/scripts/build_qase_reporter.sh")
+
+	cmd := exec.Command(reporterPath)
+	output, err := cmd.Output()
+	if err != nil {
+		logrus.Error("Error running reporter script: ", err)
+		return err
+	}
+
+	logrus.Info(string(output))
+
+	return nil
+}

--- a/tests/v2/validation/pipeline/scripts/build_qase_reporter.sh
+++ b/tests/v2/validation/pipeline/scripts/build_qase_reporter.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
+
+OS=$(uname | tr '[:upper:]' '[:lower:]')
 cd $(dirname $0)/../../../../../
-if [[ -z "${QASE_TEST_RUN_ID}" ]]; then
+
+if [[ -z ${QASE_TEST_RUN_ID} ]]; then
   echo "no test run ID is provided"
 else
   echo "building qase reporter bin"
-  env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/validation/reporter ./tests/v2/validation/pipeline/qase/reporter
+  env GOOS=${OS} GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/validation/reporter ./tests/v2/validation/pipeline/qase/reporter
 fi

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -88,6 +88,12 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, c.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
+		subSession := c.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(c.T(), err)
+
 		if !tt.runFlag {
 			c.T().Logf("SKIPPED")
 			continue
@@ -95,7 +101,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
-		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.K3SCustomCluster, nil, nil)
+		permutations.RunTestPermutations(&c.Suite, tt.name, client, &provisioningConfig, permutations.K3SCustomCluster, nil, nil)
 	}
 }
 
@@ -123,7 +129,13 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomClusterDyn
 		{provisioninginput.StandardClientName.String(), c.standardUserClient},
 	}
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, c.provisioningConfig, permutations.K3SCustomCluster, nil, nil)
+		subSession := c.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(c.T(), err)
+
+		permutations.RunTestPermutations(&c.Suite, tt.name, client, c.provisioningConfig, permutations.K3SCustomCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/k3s/hardened_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/hardened_cluster_test.go
@@ -94,6 +94,12 @@ func (c *HardenedK3SClusterProvisioningTestSuite) TestProvisioningK3SHardenedClu
 		{"K3S CIS 1.8 Profile Permissive " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, "k3s-cis-1.8-profile-permissive"},
 	}
 	for _, tt := range tests {
+		testSession := session.NewSession()
+		defer testSession.Cleanup()
+
+		client, err := tt.client.WithSession(testSession)
+		require.NoError(c.T(), err)
+
 		c.Run(tt.name, func() {
 			provisioningConfig := *c.provisioningConfig
 			provisioningConfig.MachinePools = tt.machinePools
@@ -105,20 +111,20 @@ func (c *HardenedK3SClusterProvisioningTestSuite) TestProvisioningK3SHardenedClu
 			testConfig := clusters.ConvertConfigToClusterConfig(&provisioningConfig)
 			testConfig.KubernetesVersion = c.provisioningConfig.K3SKubernetesVersions[0]
 
-			clusterObject, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, testConfig)
+			clusterObject, err := provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, testConfig)
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
-			provisioning.VerifyCluster(c.T(), tt.client, testConfig, clusterObject)
+			provisioning.VerifyCluster(c.T(), client, testConfig, clusterObject)
 
-			cluster, err := extensionscluster.NewClusterMeta(tt.client, clusterObject.Name)
+			cluster, err := extensionscluster.NewClusterMeta(client, clusterObject.Name)
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
-			latestCISBenchmarkVersion, err := tt.client.Catalog.GetLatestChartVersion(charts.CISBenchmarkName, catalog.RancherChartRepo)
+			latestCISBenchmarkVersion, err := client.Catalog.GetLatestChartVersion(charts.CISBenchmarkName, catalog.RancherChartRepo)
 			require.NoError(c.T(), err)
 
-			project, err := projects.GetProjectByName(tt.client, cluster.ID, cis.System)
+			project, err := projects.GetProjectByName(client, cluster.ID, cis.System)
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(c.T(), err)
 
@@ -131,8 +137,8 @@ func (c *HardenedK3SClusterProvisioningTestSuite) TestProvisioningK3SHardenedClu
 				ProjectID: c.project.ID,
 			}
 
-			cis.SetupCISBenchmarkChart(tt.client, c.project.ClusterID, c.chartInstallOptions, charts.CISBenchmarkNamespace)
-			cis.RunCISScan(tt.client, c.project.ClusterID, tt.scanProfileName)
+			cis.SetupCISBenchmarkChart(client, c.project.ClusterID, c.chartInstallOptions, charts.CISBenchmarkNamespace)
+			cis.RunCISScan(client, c.project.ClusterID, tt.scanProfileName)
 		})
 	}
 }

--- a/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
@@ -60,8 +60,14 @@ func (k *KdmChecksTestSuite) TestK3SK8sVersions() {
 }
 
 func (k *KdmChecksTestSuite) TestProvisioningSingleNodeK3SClusters() {
+	testSession := session.NewSession()
+	defer testSession.Cleanup()
+
+	client, err := k.client.WithSession(testSession)
+	require.NoError(k.T(), err)
+
 	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.Providers), 1)
-	permutations.RunTestPermutations(&k.Suite, "oobRelease-", k.client, k.provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+	permutations.RunTestPermutations(&k.Suite, "oobRelease-", client, k.provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 }
 
 func TestPostKdmOutOfBandReleaseChecks(t *testing.T) {

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -89,13 +89,19 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 	}
 
 	for _, tt := range tests {
+		testSession := session.NewSession()
+		defer testSession.Cleanup()
+
+		client, err := tt.client.WithSession(testSession)
+		require.NoError(k.T(), err)
+
 		if !tt.runFlag {
 			k.T().Logf("SKIPPED")
 			continue
 		}
 		provisioningConfig := *k.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
-		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+		permutations.RunTestPermutations(&k.Suite, tt.name, client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 	}
 }
 
@@ -113,7 +119,13 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SClusterDynamicIn
 	}
 
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, k.provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+		testSession := session.NewSession()
+		defer testSession.Cleanup()
+
+		client, err := tt.client.WithSession(testSession)
+		require.NoError(k.T(), err)
+
+		permutations.RunTestPermutations(&k.Suite, tt.name, client, k.provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/k3s/psact_test.go
+++ b/tests/v2/validation/provisioning/k3s/psact_test.go
@@ -105,10 +105,16 @@ func (k *K3SPSACTTestSuite) TestK3SPSACTNodeDriverCluster() {
 	}
 
 	for _, tt := range tests {
+		testSession := session.NewSession()
+		defer testSession.Cleanup()
+
+		client, err := tt.client.WithSession(testSession)
+		require.NoError(k.T(), err)
+
 		provisioningConfig := *k.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
 		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig,
+		permutations.RunTestPermutations(&k.Suite, tt.name, client, &provisioningConfig,
 			permutations.K3SProvisionCluster, nil, nil)
 	}
 }

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -90,6 +90,12 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRolesDedicated, c.standardUserClient, c.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
+		subSession := c.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(c.T(), err)
+
 		if !tt.runFlag {
 			c.T().Logf("SKIPPED")
 			continue
@@ -98,7 +104,8 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
 		provisioningConfig.NodePools[0].SpecifyCustomPublicIP = true
-		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
+
+		permutations.RunTestPermutations(&c.Suite, tt.name, client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
 	}
 }
 
@@ -117,7 +124,13 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomClusterDy
 		{provisioninginput.StandardClientName.String(), c.standardUserClient},
 	}
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, c.provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
+		subSession := c.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(c.T(), err)
+
+		permutations.RunTestPermutations(&c.Suite, tt.name, client, c.provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
@@ -69,6 +69,7 @@ func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE1Clusters() {
 
 	client, err := k.client.WithSession(subSession)
 	require.NoError(k.T(), err)
+
 	permutations.RunTestPermutations(&k.Suite, "oobRelease-", client, k.provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
 
 }

--- a/tests/v2/validation/provisioning/rke1/provisioning_cloud_provider_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_cloud_provider_test.go
@@ -126,14 +126,22 @@ func (r *RKE1CloudProviderTestSuite) TestVsphereCloudProviderRKE1Cluster() {
 	}
 
 	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
 		if !tt.runFlag {
 			r.T().Logf("SKIPPED")
 			continue
 		}
+
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.CloudProvider = "rancher-vsphere"
 		provisioningConfig.NodePools = tt.nodePools
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -88,13 +88,21 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1Cluster() {
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRolesDedicated, r.standardUserClient, r.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := r.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
 		if !tt.runFlag {
 			r.T().Logf("SKIPPED")
 			continue
 		}
+
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
 	}
 }
 
@@ -112,7 +120,13 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1ClusterDynamic
 		{provisioninginput.StandardClientName.String(), r.standardUserClient},
 	}
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, r.provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := r.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, r.provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/rke1/psact_test.go
+++ b/tests/v2/validation/provisioning/rke1/psact_test.go
@@ -105,10 +105,16 @@ func (r *RKE1PSACTTestSuite) TestRKE1PSACTNodeDriverCluster() {
 	}
 
 	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
 		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, &provisioningConfig,
 			permutations.RKE1ProvisionCluster, nil, nil)
 	}
 }

--- a/tests/v2/validation/provisioning/rke2/ace_test.go
+++ b/tests/v2/validation/provisioning/rke2/ace_test.go
@@ -120,6 +120,7 @@ func (r *RKE2ACETestSuite) TestProvisioningRKE2ClusterACE() {
 
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(r.T(), err)
+
 		r.provisioningConfig.MachinePools = tt.machinePools
 		permutations.RunTestPermutations(&r.Suite, tt.name, client, r.provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}

--- a/tests/v2/validation/provisioning/rke2/agent_customization_test.go
+++ b/tests/v2/validation/provisioning/rke2/agent_customization_test.go
@@ -128,6 +128,7 @@ func (r *RKE2AgentCustomizationTestSuite) TestProvisioningRKE2ClusterAgentCustom
 
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(r.T(), err)
+
 		r.provisioningConfig.MachinePools = tt.machinePools
 
 		if tt.agent == "fleet-agent" {
@@ -178,6 +179,7 @@ func (r *RKE2AgentCustomizationTestSuite) TestFailureProvisioningRKE2ClusterAgen
 
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(r.T(), err)
+
 		r.provisioningConfig.MachinePools = tt.machinePools
 
 		if tt.agent == "fleet-agent" {

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -126,17 +126,22 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster()
 		{"5 nodes - 1 role per node + 2 Windows workers " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicatedTwoWindows, true, c.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
+		subSession := c.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := c.client.WithSession(subSession)
+		require.NoError(c.T(), err)
+
 		if !tt.runFlag {
 			c.T().Logf("SKIPPED")
 			continue
 		}
 
-		testSession := session.NewSession()
-		defer testSession.Cleanup()
 		if (c.isWindows == tt.isWindows) || (c.isWindows && !tt.isWindows) {
 			provisioningConfig := *c.provisioningConfig
 			provisioningConfig.MachinePools = tt.machinePools
-			permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE2CustomCluster, nil, nil)
+
+			permutations.RunTestPermutations(&c.Suite, tt.name, client, &provisioningConfig, permutations.RKE2CustomCluster, nil, nil)
 		} else {
 			c.T().Skip("Skipping Windows tests")
 		}
@@ -156,12 +161,13 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomClusterDy
 		{provisioninginput.StandardClientName.String(), c.standardUserClient},
 	}
 	for _, tt := range tests {
-		testSession := session.NewSession()
-		defer testSession.Cleanup()
-		_, err := tt.client.WithSession(testSession)
+		subSession := c.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := c.client.WithSession(subSession)
 		require.NoError(c.T(), err)
 
-		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, c.provisioningConfig, permutations.RKE2CustomCluster, nil, nil)
+		permutations.RunTestPermutations(&c.Suite, tt.name, client, c.provisioningConfig, permutations.RKE2CustomCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
@@ -64,6 +64,7 @@ func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE2Clusters() {
 
 	client, err := k.client.WithSession(subSession)
 	require.NoError(k.T(), err)
+
 	permutations.RunTestPermutations(&k.Suite, "oobRelease-", client, k.provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 }
 

--- a/tests/v2/validation/provisioning/rke2/provisioning_cloud_provider_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_cloud_provider_test.go
@@ -91,6 +91,12 @@ func (r *RKE2CloudProviderTestSuite) TestAWSCloudProviderCluster() {
 	}
 
 	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := r.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
 		if !tt.runFlag {
 			r.T().Logf("SKIPPED")
 			continue
@@ -99,7 +105,8 @@ func (r *RKE2CloudProviderTestSuite) TestAWSCloudProviderCluster() {
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.CloudProvider = "aws"
 		provisioningConfig.MachinePools = tt.machinePools
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }
 
@@ -123,6 +130,12 @@ func (r *RKE2CloudProviderTestSuite) TestVsphereCloudProviderCluster() {
 	}
 
 	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := r.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
 		if !tt.runFlag {
 			r.T().Logf("SKIPPED")
 			continue
@@ -131,7 +144,8 @@ func (r *RKE2CloudProviderTestSuite) TestVsphereCloudProviderCluster() {
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.CloudProvider = "rancher-vsphere"
 		provisioningConfig.MachinePools = tt.machinePools
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -91,6 +91,12 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 	}
 
 	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := r.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
 		if !tt.runFlag {
 			r.T().Logf("SKIPPED")
 			continue
@@ -103,7 +109,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 			r.T().Skip("Windows test requires access to vsphere")
 		}
 
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }
 
@@ -121,7 +127,13 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2ClusterDynamic
 	}
 
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, r.provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := r.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, r.provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/rke2/psact_test.go
+++ b/tests/v2/validation/provisioning/rke2/psact_test.go
@@ -105,10 +105,17 @@ func (r *RKE2PSACTTestSuite) TestRKE2PSACTNodeDriverCluster() {
 	}
 
 	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := r.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
 		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, client, &provisioningConfig,
 			permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }

--- a/tests/v2/validation/snapshot/README.md
+++ b/tests/v2/validation/snapshot/README.md
@@ -6,6 +6,8 @@ Please see below for more details for your config. Please note that the config c
 
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
+2. [Release Testing](#Release-Testing)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -54,3 +56,71 @@ Note: This test will only work with Windows nodes existing in the cluster. Run t
 
 ### Sanpshot additional tests
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestSnapshotAdditionalTestsTestSuite$"`
+
+## Release Testing
+The release testing includes all of the tests that are ran during release testing time. Each test will first provision a cluster and then run the specific test. See an example config below:
+
+```yaml
+rancher:
+  host: ""
+  adminToken: ""
+  cleanup: false
+  clusterName: ""
+  insecure: true
+provisioningInput:
+  rke1KubernetesVersion: [""]
+  rke2KubernetesVersion: [""]
+  k3sKubernetesVersion: [""]
+  cni: ["calico"]
+  providers: ["linode"]
+linodeCredentials:
+   token: ""
+linodeConfig:
+  authorizedUsers: ""
+  createPrivateIp: true
+  dockerPort: "2376"
+  image: "linode/ubuntu22.04"
+  instanceType: "g6-dedicated-8"
+  label: ""
+  region: "us-west"
+  rootPass: ""
+  sshPort: "22"
+  sshUser: "root"
+  stackscript: ""
+  stackscriptData: ""
+  swapSize: "512"
+  tags: ""
+  token: ""
+  type: "linodeConfig"
+  uaPrefix: "Rancher"
+linodeMachineConfigs:
+  linodeMachineConfig:
+  - roles: ["etcd", "controlplane", "worker"]
+    authorizedUsers: ""
+    createPrivateIp: true
+    dockerPort: "2376"
+    image: "linode/ubuntu22.04"
+    instanceType: "g6-standard-8"
+    region: "us-west"
+    rootPass: ""
+    sshPort: "22"
+    sshUser: ""
+    stackscript: ""
+    stackscriptData: ""
+    swapSize: "512"
+    tags: ""
+    uaPrefix: "Rancher"
+```
+
+To run, use the following command:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=240m -tags=validation -v -run "TestSnapshotRestoreReleaseTestingTestSuite$"`
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `rancher` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml --jsonfile results.json -- -timeout=300m -v -run "TestSnapshotRestoreReleaseTestingTestSuite$";/path/to/rancher/rancher/reporter`

--- a/tests/v2/validation/snapshot/snapshot_release_testing_test.go
+++ b/tests/v2/validation/snapshot/snapshot_release_testing_test.go
@@ -1,0 +1,537 @@
+//go:build validation
+
+package snapshot
+
+import (
+	"strings"
+	"testing"
+
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/v2/actions/etcdsnapshot"
+	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/qaseinput"
+	qase "github.com/rancher/rancher/tests/v2/validation/pipeline/qase/results"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	linuxImage         = "nginx"
+	winsContainerImage = "mcr.microsoft.com/windows/servercore/iis"
+)
+
+type SnapshotRestoreReleaseTestingTestSuite struct {
+	suite.Suite
+	session            *session.Session
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	provisioningConfig *provisioninginput.Config
+	clustersConfig     *etcdsnapshot.Config
+	qaseConfig         *qaseinput.Config
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TearDownSuite() {
+	s.session.Cleanup()
+
+	s.qaseConfig = new(qaseinput.Config)
+	config.LoadConfig(qaseinput.ConfigurationFileKey, s.qaseConfig)
+
+	if s.qaseConfig.LocalQaseReporting {
+		err := qase.ReportTest()
+		require.NoError(s.T(), err)
+	}
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	s.session = testSession
+
+	s.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, s.provisioningConfig)
+
+	s.clustersConfig = new(etcdsnapshot.Config)
+	config.LoadConfig(etcdsnapshot.ConfigurationFileKey, s.clustersConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(s.T(), err)
+
+	s.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(s.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(s.T(), err)
+
+	s.standardUserClient = standardUserClient
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TestRKE1SnapshotRestore() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdNodePool,
+		provisioninginput.ControlPlaneNodePool,
+		provisioninginput.WorkerNodePool,
+	}
+
+	snapshotRestoreNone := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+	}
+
+	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "kubernetesVersion",
+		RecurringRestores:        1,
+	}
+
+	snapshotRestoreAll := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion:     "",
+		SnapshotRestore:              "all",
+		ControlPlaneUnavailableValue: "3",
+		WorkerUnavailableValue:       "15%",
+		RecurringRestores:            1,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"RKE1 Local Restore etcd only", snapshotRestoreNone, s.standardUserClient},
+		{"RKE1 Local Restore K8s version and etcd", snapshotRestoreK8sVersion, s.standardUserClient},
+		{"RKE1 Local Restore cluster config, K8s version and etcd", snapshotRestoreAll, s.standardUserClient},
+	}
+
+	var clusterObject *management.Cluster
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.NodePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if clusterObject == nil {
+			_, clusterObject = permutations.RunTestPermutations(&s.Suite, "Provision RKE1", client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			err = etcdsnapshot.CreateAndValidateSnapshotRestore(adminClient, clusterObject.Name, tt.etcdSnapshot, linuxImage)
+			require.NoError(s.T(), err)
+		})
+	}
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TestSnapshotRestore() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	snapshotRestoreNone := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+	}
+
+	snapshotRestoreK8sVersion := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "kubernetesVersion",
+		RecurringRestores:        1,
+	}
+
+	snapshotRestoreAll := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion:     "",
+		SnapshotRestore:              "all",
+		ControlPlaneConcurrencyValue: "15%",
+		WorkerConcurrencyValue:       "20%",
+		RecurringRestores:            1,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"RKE2 Local Restore etcd only", snapshotRestoreNone, s.standardUserClient},
+		{"RKE2 Local Restore K8s version and etcd", snapshotRestoreK8sVersion, s.standardUserClient},
+		{"RKE2 Local Restore cluster config, K8s version and etcd", snapshotRestoreAll, s.standardUserClient},
+		{"K3S Local Restore etcd only", snapshotRestoreNone, s.standardUserClient},
+		{"K3S Local Restore K8s version and etcd", snapshotRestoreK8sVersion, s.standardUserClient},
+		{"K3S Local Restore cluster config, K8s version and etcd", snapshotRestoreAll, s.standardUserClient},
+	}
+
+	var clusterObject, rke2ClusterObject, k3sClusterObject *v1.SteveAPIObject
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(tt.name, "RKE2") {
+			if rke2ClusterObject == nil {
+				rke2ClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision RKE2", client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+			}
+
+			clusterObject = rke2ClusterObject
+		} else {
+			if k3sClusterObject == nil {
+				k3sClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision K3S", client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+			}
+
+			clusterObject = k3sClusterObject
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, tt.client.Session)
+			require.NoError(s.T(), err)
+
+			err = etcdsnapshot.CreateAndValidateSnapshotRestore(adminClient, clusterObject.Name, tt.etcdSnapshot, linuxImage)
+			require.NoError(s.T(), err)
+		})
+	}
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TestRKE1SnapshotReplaceNodes() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdMultipleNodes,
+		provisioninginput.ControlPlaneMultipleNodes,
+		provisioninginput.WorkerMultipleNodes,
+	}
+
+	controlPlaneSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			ControlPlane: true,
+		},
+	}
+
+	etcdSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			Etcd: true,
+		},
+	}
+	workerSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			Worker: true,
+		},
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"RKE1 Replace control plane nodes", controlPlaneSnapshotRestore, s.standardUserClient},
+		{"RKE1 Replace etcd nodes", etcdSnapshotRestore, s.standardUserClient},
+		{"RKE1 Replace worker nodes", workerSnapshotRestore, s.standardUserClient},
+	}
+
+	var clusterObject *management.Cluster
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.NodePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if clusterObject == nil {
+			_, clusterObject = permutations.RunTestPermutations(&s.Suite, "Provision RKE1", client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+		}
+
+		adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+		require.NoError(s.T(), err)
+
+		if clusterObject.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig != nil {
+			s.Run(tt.name, func() {
+				err := etcdsnapshot.CreateAndValidateSnapshotRestore(adminClient, clusterObject.Name, tt.etcdSnapshot, linuxImage)
+				require.NoError(s.T(), err)
+			})
+		} else {
+			s.T().Skip("Skipping test; only S3 enabled clusters are enabled for this test")
+		}
+	}
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TestSnapshotReplaceNodes() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+	}
+
+	controlPlaneSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			ControlPlane: true,
+		},
+	}
+
+	etcdSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			Etcd: true,
+		},
+	}
+
+	workerSnapshotRestore := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+		ReplaceRoles: &etcdsnapshot.ReplaceRoles{
+			Worker: true,
+		},
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"RKE2 Replace control plane nodes", controlPlaneSnapshotRestore, s.standardUserClient},
+		{"RKE2 Replace etcd nodes", etcdSnapshotRestore, s.standardUserClient},
+		{"RKE2 Replace worker nodes", workerSnapshotRestore, s.standardUserClient},
+		{"K3S Replace control plane nodes", controlPlaneSnapshotRestore, s.standardUserClient},
+		{"K3S Replace etcd nodes", etcdSnapshotRestore, s.standardUserClient},
+		{"K3S Replace worker nodes", workerSnapshotRestore, s.standardUserClient},
+	}
+
+	var clusterObject, rke2ClusterObject, k3sClusterObject *v1.SteveAPIObject
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(tt.name, "RKE2") {
+			rke2ClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision RKE2", client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+			clusterObject = rke2ClusterObject
+		} else {
+			k3sClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision K3S", client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+			clusterObject = k3sClusterObject
+		}
+
+		adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+		require.NoError(s.T(), err)
+
+		clusterID, err := clusters.GetV1ProvisioningClusterByName(adminClient, clusterObject.Name)
+		require.NoError(s.T(), err)
+
+		cluster, err := adminClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+		require.NoError(s.T(), err)
+
+		updatedCluster := new(apisV1.Cluster)
+		err = v1.ConvertToK8sType(cluster, &updatedCluster)
+		require.NoError(s.T(), err)
+
+		if updatedCluster.Spec.RKEConfig.ETCD.S3 != nil {
+			s.Run(tt.name, func() {
+				err := etcdsnapshot.CreateAndValidateSnapshotRestore(adminClient, clusterObject.Name, tt.etcdSnapshot, linuxImage)
+				require.NoError(s.T(), err)
+			})
+		} else {
+			s.T().Skip("Skipping test; only S3 enabled clusters are enabled for this test")
+		}
+	}
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TestRKE1SnapshotRecurringRestores() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdNodePool,
+		provisioninginput.ControlPlaneNodePool,
+		provisioninginput.WorkerNodePool,
+	}
+
+	snapshotRestoreNone := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        5,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"RKE1 Restore snapshot 5 times", snapshotRestoreNone, s.standardUserClient},
+	}
+
+	var clusterObject *management.Cluster
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.NodePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if clusterObject == nil {
+			_, clusterObject = permutations.RunTestPermutations(&s.Suite, "Provision RKE1", client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			err = etcdsnapshot.CreateAndValidateSnapshotRestore(adminClient, clusterObject.Name, tt.etcdSnapshot, linuxImage)
+			require.NoError(s.T(), err)
+		})
+	}
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TestSnapshotRecurringRestores() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	snapshotRestoreNone := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        5,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"RKE2 Restore snapshot 5 times", snapshotRestoreNone, s.standardUserClient},
+		{"K3S Restore snapshot 5 times", snapshotRestoreNone, s.standardUserClient},
+	}
+
+	var clusterObject, rke2ClusterObject, k3sClusterObject *v1.SteveAPIObject
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		if strings.Contains(tt.name, "RKE2") {
+			rke2ClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision RKE2", client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+			clusterObject = rke2ClusterObject
+		} else {
+			k3sClusterObject, _ = permutations.RunTestPermutations(&s.Suite, "Provision K3S", client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+			clusterObject = k3sClusterObject
+		}
+
+		s.Run(tt.name, func() {
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(s.T(), err)
+
+			err = etcdsnapshot.CreateAndValidateSnapshotRestore(adminClient, clusterObject.Name, tt.etcdSnapshot, linuxImage)
+			require.NoError(s.T(), err)
+		})
+	}
+}
+
+func (s *SnapshotRestoreReleaseTestingTestSuite) TestSnapshotRestoreWindows() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+		provisioninginput.WindowsMachinePool,
+	}
+
+	snapshotRestoreAll := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion:     "",
+		SnapshotRestore:              "all",
+		ControlPlaneConcurrencyValue: "15%",
+		ControlPlaneUnavailableValue: "3",
+		WorkerConcurrencyValue:       "20%",
+		WorkerUnavailableValue:       "15%",
+		RecurringRestores:            1,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		client       *rancher.Client
+	}{
+		{"Restore Windows cluster config, Kubernetes version and etcd", snapshotRestoreAll, s.standardUserClient},
+	}
+
+	provisioningConfig := *s.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := s.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(s.T(), err)
+
+		clusterObject, _ := permutations.RunTestPermutations(&s.Suite, tt.name, client, &provisioningConfig, permutations.RKE2CustomCluster, nil, nil)
+
+		adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+		require.NoError(s.T(), err)
+
+		err = etcdsnapshot.CreateAndValidateSnapshotRestore(adminClient, clusterObject.Name, tt.etcdSnapshot, winsContainerImage)
+		require.NoError(s.T(), err)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestSnapshotRestoreReleaseTestingTestSuite(t *testing.T) {
+	suite.Run(t, new(SnapshotRestoreReleaseTestingTestSuite))
+}

--- a/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/v2/validation/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -59,7 +59,7 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 		etcdSnapshot *etcdsnapshot.Config
 		client       *rancher.Client
 	}{
-		{"Restore cluster config, Kubernetes version and etcd", snapshotRestoreAll, s.client},
+		{"Restore upgrade strategy - cluster config, Kubernetes version and etcd", snapshotRestoreAll, s.client},
 	}
 
 	for _, tt := range tests {

--- a/tests/v2/validation/upgrade/README.md
+++ b/tests/v2/validation/upgrade/README.md
@@ -3,6 +3,8 @@
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
 2. [Cloud Provider Migration](#cloud-provider-migration)
+3. [Release Testing](#Release-Testing)
+4. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 Kubernetes and pre/post upgrade workload tests use the same single shared configuration as shown below. You can find the correct suite name below by checking the test file you plan to run.
@@ -85,3 +87,115 @@ vmwarevsphereConfig:
 See below how to run each of the tests:
 
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/upgrade --junitfile results.xml -- -timeout=60m -tags=validation -v -run ^TestCloudProviderVersionUpgradeSuite$"`
+
+## Release Testing
+The release testing includes all of the tests that are ran during release testing time. Each test will first provision a cluster and then run the specific test. See an example config below:
+
+```yaml
+rancher:
+  host: ""
+  adminToken: ""
+  cleanup: false
+  clusterName: ""
+  insecure: true
+provisioningInput:
+  rke1KubernetesVersion: [""]           # Put version you want to upgrade from
+  rke2KubernetesVersion: [""]           # Put version you want to upgrade from
+  k3sKubernetesVersion: [""]            # Put version you want to upgrade from
+  cni: ["calico"]
+  providers: ["aws"]
+  nodeProviders: ["ec2"]
+upgradeInput:
+  clusters:
+     - provisioningInput:
+        rke1KubernetesVersion: [""]     # Put version to upgrade to
+        rke2KubernetesVersion: [""]     # Put version to upgrade to
+        k3sKubernetesVersion: [""]      # Put version to upgrade to
+awsEC2Configs:
+  region: "us-east-2"
+  awsSecretAccessKey: ""
+  awsAccessKeyID: ""
+  awsEC2Config:
+    - instanceType: "t3a.xlarge"
+      awsRegionAZ: "us-east-2a"
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: ""
+      awsIAMProfile: ""
+      awsCICDInstanceTag: ""
+      awsUser: "ubuntu"
+      volumeSize: 100
+      roles: ["etcd", "controlplane", "worker"]
+    - instanceType: "t3a.2xlarge"
+      awsRegionAZ: "us-east-2a"
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: ""
+      awsUser: "Administrator"
+      volumeSize: 100
+      roles: ["windows"]
+sshPath: 
+  sshPath: "/root/go/src/github.com/rancher/rancher/tests/v2/validation/.ssh"
+awsCredentials:
+  secretKey: ""
+  accessKey: ""
+  defaultRegion: "us-east-2"
+awsMachineConfigs:
+  region: "us-east-2"
+  awsMachineConfig:
+  - roles: ["etcd", "controlplane", "worker"]
+    ami: ""
+    instanceType: "t3a.xlarge"
+    sshUser: "ubuntu"
+    vpcId: ""
+    volumeType: "gp2"
+    zone: "a"
+    retries: "5"
+    rootSize: "100"
+    securityGroup: [""]
+amazonec2Config:
+  accessKey: ""
+  ami: ""
+  blockDurationMinutes: "0"
+  encryptEbsVolume: false
+  httpEndpoint: "enabled"
+  httpTokens: "optional"
+  iamInstanceProfile: ""
+  insecureTransport: false
+  instanceType: "t2.2xlarge"
+  monitoring: false
+  privateAddressOnly: false
+  region: "us-east-2"
+  requestSpotInstance: true
+  retries: "5"
+  rootSize: "100"
+  secretKey: ""
+  securityGroup: [""]
+  securityGroupReadonly: false
+  spotPrice: "0.50"
+  sshKeyContents: ""
+  sshUser: ""
+  subnetId: ""
+  tags: ""
+  type: "amazonec2Config"
+  useEbsOptimizedInstance: false
+  usePrivateAddress: false
+  volumeType: "gp2"
+  vpcId: ""
+  zone: "a"
+```
+
+To run, use the following command:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/upgrade --junitfile results.xml -- -timeout=300m -tags=validation -v -run "TestUpgradeKubernetesReleaseTestingTestSuite$"`
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `rancher` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/upgrade --junitfile results.xml --jsonfile results.json -- -timeout=300m -v -run "TestUpgradeKubernetesReleaseTestingTestSuite$";/path/to/rancher/rancher/reporter`

--- a/tests/v2/validation/upgrade/kubernetes_release_testing_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_release_testing_test.go
@@ -1,0 +1,229 @@
+//go:build validation
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/clusters"
+	"github.com/rancher/rancher/tests/v2/actions/provisioning"
+	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/qaseinput"
+	"github.com/rancher/rancher/tests/v2/actions/upgradeinput"
+	qase "github.com/rancher/rancher/tests/v2/validation/pipeline/qase/results"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type UpgradeKubernetesReleaseTestingTestSuite struct {
+	suite.Suite
+	session            *session.Session
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	clusters           []upgradeinput.Cluster
+	provisioningConfig *provisioninginput.Config
+	qaseConfig         *qaseinput.Config
+}
+
+func (u *UpgradeKubernetesReleaseTestingTestSuite) TearDownSuite() {
+	u.session.Cleanup()
+
+	u.qaseConfig = new(qaseinput.Config)
+	config.LoadConfig(qaseinput.ConfigurationFileKey, u.qaseConfig)
+
+	if u.qaseConfig.LocalQaseReporting {
+		err := qase.ReportTest()
+		require.NoError(u.T(), err)
+	}
+}
+
+func (u *UpgradeKubernetesReleaseTestingTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	u.session = testSession
+
+	u.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, u.provisioningConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(u.T(), err)
+
+	u.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(u.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(u.T(), err)
+
+	u.standardUserClient = standardUserClient
+
+	clusters, err := upgradeinput.LoadUpgradeKubernetesConfig(client)
+	require.NoError(u.T(), err)
+
+	u.clusters = clusters
+}
+
+func (u *UpgradeKubernetesReleaseTestingTestSuite) TestUpgradeRKE1Kubernetes() {
+	nodeRolesDedicated := []provisioninginput.NodePools{
+		provisioninginput.EtcdMultipleNodes,
+		provisioninginput.ControlPlaneMultipleNodes,
+		provisioninginput.WorkerMultipleNodes,
+	}
+
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"Upgrading ", u.standardUserClient},
+	}
+
+	var clusterObject *management.Cluster
+	provisioningConfig := *u.provisioningConfig
+	provisioningConfig.NodePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := u.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(u.T(), err)
+
+		for _, cluster := range u.clusters {
+			if clusterObject == nil {
+				_, clusterObject = permutations.RunTestPermutations(&u.Suite, tt.name, client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
+			}
+
+			testConfig := clusters.ConvertConfigToClusterConfig(&cluster.ProvisioningInput)
+
+			testConfig.KubernetesVersion = cluster.ProvisioningInput.RKE1KubernetesVersions[0]
+			tt.name += "RKE1 cluster from " + provisioningConfig.RKE1KubernetesVersions[0] + " to " + testConfig.KubernetesVersion
+
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(u.T(), err)
+
+			createPreUpgradeWorkloads(u.T(), adminClient, clusterObject.Name, cluster.FeaturesToTest, nil, containerImage)
+
+			upgradedCluster, err := upgradeRKE1Cluster(u.T(), adminClient, clusterObject.Name, testConfig)
+			require.NoError(u.T(), err)
+
+			clusterResp, err := extensionscluster.GetClusterIDByName(adminClient, upgradedCluster.Name)
+			require.NoError(u.T(), err)
+
+			upgradedRKE1Cluster, err := adminClient.Management.Cluster.ByID(clusterResp)
+			require.NoError(u.T(), err)
+
+			provisioning.VerifyRKE1Cluster(u.T(), adminClient, testConfig, upgradedRKE1Cluster)
+			createPostUpgradeWorkloads(u.T(), adminClient, clusterObject.Name, cluster.FeaturesToTest)
+		}
+	}
+}
+
+func (u *UpgradeKubernetesReleaseTestingTestSuite) TestUpgradeKubernetes() {
+	nodeRolesDedicated := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+	}
+
+	nodeRolesWindows := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMultipleMachines,
+		provisioninginput.ControlPlaneMultipleMachines,
+		provisioninginput.WorkerMultipleMachines,
+		provisioninginput.WindowsMultipleMachines,
+	}
+
+	tests := []struct {
+		name         string
+		client       *rancher.Client
+		isRKE2       bool
+		nodeSelector map[string]string
+	}{
+		{"Upgrading ", u.standardUserClient, true, nil},
+		{"Upgrading ", u.standardUserClient, false, nil},
+		{"Upgrading ", u.standardUserClient, true, map[string]string{"kubernetes.io/os": "windows"}},
+	}
+
+	var clusterObject, rke2ClusterObject, k3sClusterObject *v1.SteveAPIObject
+	var testConfig *clusters.ClusterConfig
+	var image string
+
+	provisioningConfig := *u.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesDedicated
+
+	for _, tt := range tests {
+		subSession := u.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(u.T(), err)
+
+		for _, cluster := range u.clusters {
+			if tt.isRKE2 && tt.nodeSelector == nil {
+				rke2ClusterObject, _ = permutations.RunTestPermutations(&u.Suite, tt.name, client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
+				clusterObject = rke2ClusterObject
+			} else if tt.isRKE2 && tt.nodeSelector != nil {
+				provisioningConfig.MachinePools = nodeRolesWindows
+				rke2ClusterObject, _ = permutations.RunTestPermutations(&u.Suite, tt.name, client, &provisioningConfig, permutations.RKE2CustomCluster, nil, nil)
+				clusterObject = rke2ClusterObject
+			} else if !tt.isRKE2 && tt.nodeSelector == nil {
+				k3sClusterObject, _ = permutations.RunTestPermutations(&u.Suite, tt.name, client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
+				clusterObject = k3sClusterObject
+			}
+
+			testConfig = clusters.ConvertConfigToClusterConfig(&cluster.ProvisioningInput)
+
+			if tt.isRKE2 && tt.nodeSelector == nil {
+				testConfig.KubernetesVersion = cluster.ProvisioningInput.RKE2KubernetesVersions[0]
+				tt.name += "RKE2 cluster from " + provisioningConfig.RKE2KubernetesVersions[0] + " to " + testConfig.KubernetesVersion
+			} else if tt.isRKE2 && tt.nodeSelector != nil {
+				testConfig.KubernetesVersion = cluster.ProvisioningInput.RKE2KubernetesVersions[0]
+				tt.name += "RKE2 Windows cluster from " + provisioningConfig.RKE2KubernetesVersions[0] + " to " + testConfig.KubernetesVersion
+			} else if !tt.isRKE2 && tt.nodeSelector == nil {
+				testConfig.KubernetesVersion = cluster.ProvisioningInput.K3SKubernetesVersions[0]
+				tt.name += "K3S cluster from " + provisioningConfig.K3SKubernetesVersions[0] + " to " + testConfig.KubernetesVersion
+			}
+
+			if tt.nodeSelector == nil {
+				image = containerImage
+			} else {
+				image = windowsContainerImage
+			}
+
+			adminClient, err := rancher.NewClient(tt.client.RancherConfig.AdminToken, client.Session)
+			require.NoError(u.T(), err)
+
+			createPreUpgradeWorkloads(u.T(), adminClient, clusterObject.Name, cluster.FeaturesToTest, tt.nodeSelector, image)
+			upgradedCluster, err := upgradeRKE2K3SCluster(u.T(), adminClient, clusterObject.Name, testConfig)
+			require.NoError(u.T(), err)
+
+			provisioning.VerifyCluster(u.T(), adminClient, testConfig, upgradedCluster)
+			createPostUpgradeWorkloads(u.T(), adminClient, clusterObject.Name, cluster.FeaturesToTest)
+		}
+	}
+}
+
+func TestUpgradeKubernetesReleaseTestingTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeKubernetesReleaseTestingTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Consolidate release testing into package-specific files for easability](https://github.com/rancher/qa-tasks/issues/1586)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
During release testing, there are too many manual factors that contribute to how long it takes. Few examples include having to setup manually clusters for packages excluding `provisioning`, getting unique configs for each test and ensuring you know how to actually run the test.

There needs to be a way to have all of the tests ran during release testing in a centralized location with a uniform config that can be used for various tests. Additionally, we need to have the option to report Qase results locally as we're completely at the mercy of Jenkins. There needs to be an option to report test results locally and with Jenkins.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Consolidated relevant provisioning release tests into one test file. The general workflow of the tests is the following:
- Provision cluster first
- Run specific test (i.e. after cluster is provisioned, proceed to run node driver scaling test cases)
- If you wish to, report results to Qase locally after the test is finished running
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
I have run each of the added release test files locally.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Jenkins jobs will be ran and provided to reviewers offline.