### PR TITLE
[2.9] omit e2e tests from triggering CI, unless CI tests are changed

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -3,6 +3,12 @@ on:
   pull_request:
     branches:
       - release/v*
+    paths-ignore:
+      # omit tests from triggering CI except when CI tests are changed
+      - 'tests/v2/validation/**'
+      - 'tests/v2/actions/**'
+      - 'tests/v2/codecoverage/**'
+      - 'tests/validation/**'
 jobs:
   provisioning_tests:
     strategy:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,12 @@
 name: Build Pull Request
 on:
-  - pull_request 
+  pull_request:
+    paths-ignore:
+      # omit tests from triggering CI except when CI tests are changed
+      - 'tests/v2/validation/**'
+      - 'tests/v2/codecoverage/**'
+      - 'tests/validation/**'
+
 env:
   ARCH: amd64
   TAG: v2.9-${{ github.sha }}


### PR DESCRIPTION
port of https://github.com/rancher/rancher/pull/47471/commits