### PR TITLE
[2.8] Populate clusterId field on ResourceSyncController on regular cluster controller startup

### DIFF
--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -109,6 +109,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 		upstreamSecrets:   mgmt.Core.Secrets(clusterRec.Spec.FleetWorkspaceName),
 		downstreamSecrets: cluster.Core.Secrets(""),
 		clusterName:       clusterRec.Spec.DisplayName,
+		clusterId:         clusterRec.Name,
 	}
 
 	resourceSyncController.upstreamSecrets.AddHandler(ctx, "secret-resource-synced", resourceSyncController.sync)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/47470 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Minor bug found during testing - during initial sync the planner will substitute out a magic string `{{clusterId}}` with the management cluster ID. This process works fine during bootstrap copy of secrets, but then due to a copy/paste error the clusterId field on the controller struct wasn't set when the "full-time" resource-sync controller started up. 

This resulted in if the controller fired due to an update that changed the secret data upstream it would override the downstream secret with a clusterId value of `""` since the field was not populated.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Inject the clusterId during controller creation.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit -> there are unit tests that cover this behavior but the struct field not being populated was not caught.


Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Re-test synchronizing a CSI secret downstream and updating it -> it should still contain the clusterId instead of just an empty string. 
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_