### PR TITLE
[v2.8] Fix go generate in go-get script

### DIFF
--- a/.github/workflows/go-get.yml
+++ b/.github/workflows/go-get.yml
@@ -30,9 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run go get to get Go module
         run: make go-get
+      - name: Run go generate
+        run: |
+          go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.0
+          go generate ./...
       - name: Check for repository changes
         run: |
           if git diff --name-only --exit-code; then
@@ -69,7 +73,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ env.changes_exist == 'true' }}
         id: cpr
-        uses: actions/github-script@v5.0.0
+        uses: actions/github-script@v7
         env:
           SOURCE_BRANCH: ${{ steps.branch.outputs.branch }}
         with:

--- a/scripts/go-get
+++ b/scripts/go-get
@@ -18,4 +18,3 @@ done
 go get -d "${MODULE}@${VERSION}"
 go mod tidy
 go mod verify
-go generate ./...


### PR DESCRIPTION
## Updates
- Move the `go generate ./...` command out of the "go-get" script because the script runs inside a Dapper container, which only copies specific files back to the local system. The generated files in `pkg/client/generated/` are not part of those files, so running `go generate` inside the container won't update them locally. By moving it outside, we ensure the files are correctly generated and available in the local environment.
- Update GitHub Actions workflow to use the latest checkout and script versions.

## Tests
- `go generate` in dapper: https://github.com/rancher/rancher/actions/runs/11334681389/job/31521368140
- `go generate` outside dapper: https://github.com/chiukapoor/rancher/actions/runs/11343938394/job/31547612220

## Issue:
- https://github.com/rancher/rancher/issues/47014