### PR TITLE
Add values for path and pathType in ingress to make them controllable

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -54,7 +54,7 @@ spec:
           servicePort: {{ .Values.ingress.servicePort }}
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
-        pathType: {{ .Values.ingress.pathType | default ImplementationSpecific }}
+        pathType: {{ .Values.ingress.pathType | default "ImplementationSpecific" }}
         path: {{ .Values.ingress.path | default "/" }}
         {{- end }}
 {{- if eq .Values.tls "ingress" }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -54,8 +54,8 @@ spec:
           servicePort: {{ .Values.ingress.servicePort }}
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
-        pathType: ImplementationSpecific
-        path: "/"
+        pathType: {{ .Values.ingress.pathType | default ImplementationSpecific }}
+        path: {{ .Values.ingress.path | default "/" }}
         {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:


### PR DESCRIPTION
## Issue: (https://github.com/rancher/rancher/issues/44160) and (https://github.com/rancher/rancher/issues/43366)

## Problem
Hardcoded values for path breaks Rancher Deployments in EKS when using AWS ALBs. 
 
## Solution
Simple solution is to make path and pathType controllable with helm values.
 
## Testing
Manually tested

## QA Testing Considerations
