### PR TITLE
feat: bump harvester driver to v0.7.1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -86,7 +86,7 @@ ENV TELEMETRY_VERSION v0.6.2
 ENV DOCKER_MACHINE_LINODE_VERSION v0.1.12
 ENV LINODE_UI_DRIVER_VERSION v0.7.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
-ENV DOCKER_MACHINE_HARVESTER_VERSION v0.6.7
+ENV DOCKER_MACHINE_HARVESTER_VERSION v0.7.1
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
 ENV HELM_VERSION v3.13.3
 ENV KUSTOMIZE_VERSION v5.0.1
@@ -141,10 +141,10 @@ RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACH
     cp /opt/drivers/management-state/bin/docker-machine-driver-linode /usr/share/rancher/ui/assets/ && \
     rm docker-machine-driver-linode_linux-amd64.zip
 
-RUN curl -LO https://releases.rancher.com/harvester-node-driver/${DOCKER_MACHINE_HARVESTER_VERSION}/docker-machine-driver-harvester-amd64.tar.gz && \
-    tar -xf docker-machine-driver-harvester-amd64.tar.gz -C /opt/drivers/management-state/bin && \
+RUN curl -LO https://github.com/harvester/docker-machine-driver-harvester/releases/download/${DOCKER_MACHINE_HARVESTER_VERSION}/docker-machine-driver-harvester-${ARCH}.tar.gz && \
+    tar -xf docker-machine-driver-harvester-${ARCH}.tar.gz -C /opt/drivers/management-state/bin && \
     cp /opt/drivers/management-state/bin/docker-machine-driver-harvester /usr/share/rancher/ui/assets/ && \
-    rm docker-machine-driver-harvester-amd64.tar.gz
+    rm docker-machine-driver-harvester-${ARCH}.tar.gz
 
 ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
     TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \

--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"runtime"
 	"strings"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -103,7 +104,13 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	}
 	harvesterEnabled := features.GetFeatureByName(HarvesterDriver).Enabled()
 	// make sure the version number is consistent with the one at Line 40 of package/Dockerfile
-	if err := addMachineDriver(HarvesterDriver, "https://releases.rancher.com/harvester-node-driver/v0.6.7/docker-machine-driver-harvester-amd64.tar.gz", "", "a913f22a7cad5d0df18e0dfa8a8ae19703c36eb8ed4f6a34ae471a06af0890c3", []string{"releases.rancher.com"}, harvesterEnabled, harvesterEnabled, false, management); err != nil {
+	harvesterDriverVersion := "v0.7.1"
+	harvesterDriverURL := fmt.Sprintf("https://github.com/harvester/docker-machine-driver-harvester/releases/download/%s/docker-machine-driver-harvester-%s.tar.gz", harvesterDriverVersion, runtime.GOARCH)
+	harvesterDriverCheckSum := "e423f4bdd08398689b55183b72f5a6f7f177a3c636224bba52aef328be96834b"
+	if runtime.GOARCH == "arm64" {
+		harvesterDriverCheckSum = "31e9690a9a72247f293e14284e0d68492dacdba6919cf172bd3d9bcf4b166573"
+	}
+	if err := addMachineDriver(HarvesterDriver, harvesterDriverURL, "", harvesterDriverCheckSum, []string{"github.com"}, harvesterEnabled, harvesterEnabled, false, management); err != nil {
 		return err
 	}
 	linodeBuiltin := true


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Bump Harvester machine driver to version v0.7.1.

https://github.com/harvester/harvester/issues/6829
https://github.com/rancher/rancher/issues/47631
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Bump kubernetes package version in `go.mod`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

1. Confirm that the Harvester node driver shows up in Version v0.7.1
2. Install a Harvester cluster and import into Rancher for virtualization management
3. Create new cloud credentials
4. Create a downstream cluster using the Harvester node driver
5. Rotate cloud credentials as explained in https://harvesterhci.io/kb/renew_harvester_cloud_credentials/
6. Scale down / delete the downstream cluster. This should complete without errors.


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_