### PR TITLE
Update rancher-csp-adapter version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 105.0.0+up0.6.1-rc.5
 provisioningCAPIVersion: 105.0.0+up0.4.0
-cspAdapterMinVersion: 104.0.0+up4.0.0
+cspAdapterMinVersion: 105.0.0+up5.0.0-rc1
 defaultShellVersion: rancher/shell:v0.3.0-rc.2
 fleetVersion: 105.0.0+up0.10.4-rc.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion    = "104.0.0+up4.0.0"
+	CspAdapterMinVersion    = "105.0.0+up5.0.0-rc1"
 	DefaultShellVersion     = "rancher/shell:v0.3.0-rc.2"
 	FleetVersion            = "105.0.0+up0.10.4-rc.1"
 	ProvisioningCAPIVersion = "105.0.0+up0.4.0"


### PR DESCRIPTION
##Issue:
rancher/rancher#46833

##Problem:
Support k8s 1.31

##Testing:

On an EKS cluster, install locally built rancher with cspAdapterMinVersion: 105.0.0+up5.0.0-rc1
Validated the support config and license entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up