### PR TITLE
[2.8] Tag agent for tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -45,8 +45,8 @@ export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 # copied to the in-cluster registry during test setup below.
 source ./scripts/version
 # export CATTLE_AGENT_IMAGE="rancher/rancher-agent:${AGENT_TAG}"
-# using :head for now while figuring out why loading from the docker cache isn't working
-export CATTLE_AGENT_IMAGE="rancher/rancher-agent:v2.8-head"
+# using v2.8-4ac9c55885285bd8ce3c7b7e31fc2deb056e1a25-head for now while figuring out why loading from the docker cache isn't working
+export CATTLE_AGENT_IMAGE="rancher/rancher-agent:v2.8-4ac9c55885285bd8ce3c7b7e31fc2deb056e1a25-head"
 echo "Using Rancher agent image $CATTLE_AGENT_IMAGE"
 
 eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"


### PR DESCRIPTION
## Issue: n/a<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

After introducing [some agent changes](#47356) the provisioning tests were continually failing since the `scripts/provisioning-tests` script did not use the built agent image it instead was pulling from dockerhub.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Mirror necessary rancher-agent image to dockerhub and then update the script to use that in the interim of fixing the CI
 
## Testing
If the provisioning tests pass -> we're good. 