### PR TITLE
Bumping steve version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.4.0
 	github.com/rancher/rke v1.7.0-rc.1
-	github.com/rancher/steve v0.0.0-20241015140027-8fc2dd4f7460
+	github.com/rancher/steve v0.0.0-20241018171542-f6c6ca839c22
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde
 	github.com/rancher/wrangler v1.1.2
 	github.com/rancher/wrangler/v3 v3.0.1-rc.3

--- a/go.sum
+++ b/go.sum
@@ -834,8 +834,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20241011174838-687a861827fb h1:snHofVgYVBLpKRozzc5LcyuduVcXLO88zwXM1hvTyaA=
 github.com/rancher/shepherd v0.0.0-20241011174838-687a861827fb/go.mod h1:zekxs8n6YwnsX1i58abObrkWDfdA9O3hV8wQATuS+8o=
-github.com/rancher/steve v0.0.0-20241015140027-8fc2dd4f7460 h1:nGMBH+Myybh4hxQMGoPbzcZSqL5FncxH+tGXQJTMa/E=
-github.com/rancher/steve v0.0.0-20241015140027-8fc2dd4f7460/go.mod h1:LWe5a9aeVks56JqTVr0SIwGRMS9TY+rIdwN59WDiEY0=
+github.com/rancher/steve v0.0.0-20241018171542-f6c6ca839c22 h1:qF72bmpo2Y5qFmVs7v2K2A+4yiykDv91WAbAnGgtuKU=
+github.com/rancher/steve v0.0.0-20241018171542-f6c6ca839c22/go.mod h1:LWe5a9aeVks56JqTVr0SIwGRMS9TY+rIdwN59WDiEY0=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#47601
 
## Problem
See rancher/steve#300. Steve previously did not add metadata.state through the formatter when the cache was enabled.
 
## Solution
The formatter will always add metadata.state, even if the cache is enabled.
 
## Testing
Manual, based on rancher/dashboard#12262