### PR TITLE
[main] Deploy cluster agent from manifest only if it doesn't exist

### DIFF
--- a/pkg/api/steve/additionalapi.go
+++ b/pkg/api/steve/additionalapi.go
@@ -28,6 +28,7 @@ func AdditionalAPIsPreMCM(config *wrangler.Context) func(http.Handler) http.Hand
 		mux.Handle(configserver.ConnectAgent, connectHandler)
 		mux.Handle(configserver.ConnectConfigYamlPath, connectHandler)
 		mux.Handle(configserver.ConnectClusterInfo, connectHandler)
+		mux.Handle(configserver.ConnectClusterAgentYamlPath, connectHandler)
 		mux.Handle(installer.SystemAgentInstallPath, installer.Handler)
 		mux.Handle(installer.WindowsRke2InstallPath, installer.Handler)
 		return func(next http.Handler) http.Handler {

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -696,28 +696,27 @@ func ToOwnerReference(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta) me
 }
 
 // GetTaints returns a slice of taints for the machine in question
-func GetTaints(existingTaints, runtime string, isControlPlane, isEtcd, isWorker bool) (result []corev1.Taint, _ error) {
+func GetTaints(existingTaints, runtime string, isControlPlane, isEtcd, isWorker bool) ([]corev1.Taint, error) {
+	var taints []corev1.Taint
 	if existingTaints != "" {
-		if err := json.Unmarshal([]byte(existingTaints), &result); err != nil {
-			return result, err
+		if err := json.Unmarshal([]byte(existingTaints), &taints); err != nil {
+			return taints, err
 		}
 	}
-
 	if !isWorker {
 		// k3s charts do not have correct tolerations when the master node is both controlplane and etcd
 		if isEtcd && (runtime != RuntimeK3S || !isControlPlane) {
-			result = append(result, corev1.Taint{
+			taints = append(taints, corev1.Taint{
 				Key:    "node-role.kubernetes.io/etcd",
 				Effect: corev1.TaintEffectNoExecute,
 			})
 		}
 		if isControlPlane {
-			result = append(result, corev1.Taint{
+			taints = append(taints, corev1.Taint{
 				Key:    "node-role.kubernetes.io/control-plane",
 				Effect: corev1.TaintEffectNoSchedule,
 			})
 		}
 	}
-
-	return
+	return taints, nil
 }

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -692,4 +692,32 @@ func ToOwnerReference(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta) me
 		Controller:         &[]bool{true}[0],
 		BlockOwnerDeletion: &[]bool{true}[0],
 	}
+
+}
+
+// GetTaints returns a slice of taints for the machine in question
+func GetTaints(existingTaints, runtime string, isControlPlane, isEtcd, isWorker bool) (result []corev1.Taint, _ error) {
+	if existingTaints != "" {
+		if err := json.Unmarshal([]byte(existingTaints), &result); err != nil {
+			return result, err
+		}
+	}
+
+	if !isWorker {
+		// k3s charts do not have correct tolerations when the master node is both controlplane and etcd
+		if isEtcd && (runtime != RuntimeK3S || !isControlPlane) {
+			result = append(result, corev1.Taint{
+				Key:    "node-role.kubernetes.io/etcd",
+				Effect: corev1.TaintEffectNoExecute,
+			})
+		}
+		if isControlPlane {
+			result = append(result, corev1.Taint{
+				Key:    "node-role.kubernetes.io/control-plane",
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+		}
+	}
+
+	return
 }

--- a/pkg/capr/configserver/agent.go
+++ b/pkg/capr/configserver/agent.go
@@ -1,0 +1,115 @@
+package configserver
+
+import (
+	"bytes"
+	"net/http"
+	"sort"
+
+	"github.com/gorilla/mux"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/controllers/dashboard/clusterindex"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/systemtemplate"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// connectClusterAgentYAML renders a cattle-cluster-agent manifest for the given bearer token
+func (r *RKE2ConfigServer) connectClusterAgentYAML(rw http.ResponseWriter, req *http.Request) {
+	token := mux.Vars(req)["token"]
+	if token == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	tokens, err := r.clusterTokenCache.GetByIndex(tokenIndex, token)
+	if err != nil {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		logrus.Errorf("[rke2configserver] error retrieving cluster token by index: %v", err)
+		return
+	}
+
+	if len(tokens) == 0 {
+		logrus.Errorf("[rke2configserver] no tokens found in index")
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	mgmtCluster, err := r.mgmtClusterCache.Get(tokens[0].ObjClusterName())
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error retrieving management cluster for cluster registration token: %v", err)
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+
+	provisioningClusters, err := r.provisioningClusterCache.GetByIndex(clusterindex.ClusterV1ByClusterV3Reference, tokens[0].ObjClusterName())
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error retrieving provisioning cluster: %v", err)
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+	// ensure this is a v2prov cluster
+
+	if len(provisioningClusters) != 1 {
+		logrus.Errorf("[rke2configserver] multiple provisioning clusters found")
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+
+	machines, err := r.machineCache.List(provisioningClusters[0].Namespace, labels.SelectorFromSet(map[string]string{
+		capi.ClusterNameLabel: provisioningClusters[0].Name,
+	}))
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error listing machines: %v", err)
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+
+	var taints []corev1.Taint
+	taintMap := make(map[corev1.Taint]bool)
+
+	for _, m := range machines {
+		machineTaints, err := capr.GetTaints(m.Annotations[capr.TaintsAnnotation], capr.GetRuntime(provisioningClusters[0].Spec.KubernetesVersion), m.Labels[capr.ControlPlaneRoleLabel] == "true", m.Labels[capr.EtcdRoleLabel] == "true", m.Labels[capr.WorkerRoleLabel] == "true")
+		if err != nil {
+			logrus.Errorf("[rke2configserver] error retrieving taints for machine: %v", err)
+			continue
+		}
+		for _, t := range machineTaints {
+			if _, ok := taintMap[t]; !ok {
+				taints = append(taints, t)
+				taintMap[t] = true
+			}
+		}
+	}
+
+	sort.Slice(taints, func(i, j int) bool {
+		return taints[i].ToString() < taints[j].ToString()
+	})
+
+	serverURL := settings.ServerURL.Get()
+	if serverURL == "" {
+		logrus.Errorf("[rke2configserver] server-url not set")
+		http.Error(rw, "server url not set", http.StatusInternalServerError)
+		return
+	}
+
+	clusterAgentTemplate := &bytes.Buffer{}
+	err = systemtemplate.SystemTemplate(clusterAgentTemplate, systemtemplate.GetDesiredAgentImage(mgmtCluster),
+		systemtemplate.GetDesiredAuthImage(mgmtCluster),
+		mgmtCluster.Name, token, serverURL, mgmtCluster.Spec.WindowsPreferedCluster, capr.PreBootstrap(mgmtCluster),
+		mgmtCluster, systemtemplate.GetDesiredFeatures(mgmtCluster), taints, r.secretsCache)
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error encountered rendering cluster-agent manifest: %v", err)
+		http.Error(rw, "unable to render manifest", http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/plain")
+	_, err = rw.Write(clusterAgentTemplate.Bytes())
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error while writing cluster agent YAML manifest: %v", err)
+	}
+	return
+}

--- a/pkg/capr/configserver/server.go
+++ b/pkg/capr/configserver/server.go
@@ -36,15 +36,15 @@ import (
 )
 
 const (
-	ConnectClusterInfo           = "/v3/connect/cluster-info"
-	ConnectConfigYamlPath        = "/v3/connect/config-yaml"
-	ConnectClusterAgentYamlPath  = "/v3/connect/cluster-agent/{token}.yaml"
-	ConnectClusterAgentYamlRegex = `^\/v3\/connect\/cluster-agent\/[bcdfghjklmnpqrstvwxz2456789]{54}\.yaml$` // Per wrangler: pkg/randomtoken
-	ConnectAgent                 = "/v3/connect/agent"
+	ConnectClusterInfo          = "/v3/connect/cluster-info"
+	ConnectConfigYamlPath       = "/v3/connect/config-yaml"
+	ConnectClusterAgentYamlPath = "/v3/connect/cluster-agent/{token}.yaml"
+	ConnectAgent                = "/v3/connect/agent"
 )
 
 var (
-	tokenIndex = "tokenIndex"
+	tokenIndex                   = "tokenIndex"
+	ConnectClusterAgentYamlRegex = regexp.MustCompile(`^\/v3\/connect\/cluster-agent\/[bcdfghjklmnpqrstvwxz2456789]{54}\.yaml$`)
 )
 
 type RKE2ConfigServer struct {
@@ -115,10 +115,10 @@ func (r *RKE2ConfigServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	reg := regexp.MustCompile(ConnectClusterAgentYamlRegex)
 	// Short circuit if the path is the connect cluster agent yaml path
-	if reg.MatchString(req.URL.Path) {
+	if ConnectClusterAgentYamlRegex.MatchString(req.URL.Path) {
 		r.connectClusterAgentYAML(rw, req)
+		return
 	}
 
 	planSecret, secret, err := r.findSA(req)

--- a/pkg/capr/planner/agent.go
+++ b/pkg/capr/planner/agent.go
@@ -1,15 +1,381 @@
 package planner
 
 import (
+	"bytes"
+	"encoding/base64"
 	"fmt"
 	"sort"
+	"text/template"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemtemplate"
 )
 
+const ClusterAgentInitialCreationManifest = `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rancher-cluster-agent-genesis-helper
+  namespace: kube-system
+data:
+  "create-cluster-agent-if-not-exists.sh": {{.ScriptB64}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rancher-cluster-agent-genesis
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rancher-cluster-agent-genesis-binding
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: rancher-cluster-agent-genesis
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: rancher-cluster-agent-genesis-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rancher-cluster-agent-genesis-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-cluster-agent-genesis-deploy-job
+  namespace: kube-system
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+       name: rancher-cluster-agent-genesis-deploy
+    spec:
+        tolerations:
+        - operator: Exists
+        hostNetwork: true
+        serviceAccountName: rancher-cluster-agent-genesis
+        containers:
+          - name: pod
+            image: {{.AgentImage}}
+            env:
+            - name: CATTLE_SERVER
+              value: {{.URL}}
+            - name: CATTLE_CA_CHECKSUM
+              value: {{.CAChecksum}}
+            - name: CATTLE_TOKEN
+              value: {{.Token}}
+            - name: CATTLE_AGENT_STRICT_VERIFY
+              value: "{{.StrictVerify}}"
+            command: ["/bin/sh"]
+            args: ["/helper/create-cluster-agent-if-not-exists.sh"]
+            volumeMounts:
+            - name: secret-volume
+              mountPath: /helper
+        volumes:
+          - name: secret-volume
+            secret:
+              secretName: rancher-cluster-agent-genesis-helper
+        restartPolicy: Never
+`
+
+const ApplyManifestIfNotExistsScript string = `#!/bin/sh
+
+if [ -z "$CATTLE_SERVER" ] || [ -z "$CATTLE_TOKEN" ]; then
+	exit 1
+fi
+
+# info logs the given argument at info log level.
+info() {
+    echo "[INFO] " "$@"
+}
+
+# warn logs the given argument at warn log level.
+warn() {
+    echo "[WARN] " "$@" >&2
+}
+
+# error logs the given argument at error log level.
+error() {
+    echo "[ERROR] " "$@" >&2
+}
+
+# fatal logs the given argument at fatal log level.
+fatal() {
+    echo "[FATAL] " "$@" >&2
+    exit 1
+}
+
+if kubectl get deployments -n cattle-system cattle-cluster-agent > /dev/null; then
+	info "cattle-cluster-agent already exists"
+	exit 0
+fi
+
+check_x509_cert()
+{
+    cert=$1
+    err=$(openssl x509 -in "${cert}" -noout 2>&1)
+    if [ $? -eq 0 ]
+    then
+        echo ""
+    else
+        echo "${err}"
+    fi
+}
+
+ip_to_int() {
+    ip_addr="${1}"
+
+    ip_1=$(echo "${ip_addr}" | cut -d'.' -f1)
+    ip_2=$(echo "${ip_addr}" | cut -d'.' -f2)
+    ip_3=$(echo "${ip_addr}" | cut -d'.' -f3)
+    ip_4=$(echo "${ip_addr}" | cut -d'.' -f4)
+
+    echo $(( $ip_1 * 256*256*256 + $ip_2 * 256*256 + $ip_3 * 256 + $ip_4 ))
+}
+
+valid_ip() {
+    local IP="$1" IFS="." PART
+    set -- $IP
+    [ "$#" != 4 ] && echo 1 && return
+    for PART; do
+        case "$PART" in
+            *[!0-9]*) echo 1 && return
+        esac
+        [ "$PART" -gt 255 ] && echo 1 && return
+    done
+    echo 0
+}
+
+in_no_proxy() {
+    # Get just the host name/IP
+    ip_addr="${1#http://}"
+    ip_addr="${ip_addr#https://}"
+    ip_addr="${ip_addr%%/*}"
+    ip_addr="${ip_addr%%:*}"
+
+    # If this isn't an IP address, then there is nothing to check
+    if [ "$(valid_ip "$ip_addr")" = "1" ]; then
+      echo 1
+      return
+    fi
+
+    i=1
+    proxy_ip=$(echo "$NO_PROXY" | cut -d',' -f$i)
+    while [ -n "$proxy_ip" ]; do
+      subnet_ip=$(echo "${proxy_ip}" | cut -d'/' -f1)
+      cidr_mask=$(echo "${proxy_ip}" | cut -d'/' -f2)
+
+      if [ "$(valid_ip "$subnet_ip")" = "0" ]; then
+        # If these were the same, then proxy_ip is an IP address, not a CIDR. curl handles this correctly.
+        if [ "$cidr_mask" != "$subnet_ip" ]; then
+          cidr_mask=$(( 32 - cidr_mask ))
+          shift_multiply=1
+          while [ "$cidr_mask" -gt 0 ]; do
+            shift_multiply=$(( shift_multiply * 2 ))
+            cidr_mask=$(( cidr_mask - 1 ))
+          done
+
+          # Manual left-shift (<<) by original cidr_mask value
+          netmask=$(( 0xFFFFFFFF * shift_multiply ))
+
+          # Apply netmask to both the subnet IP and the given IP address
+          ip_addr_subnet=$(and "$(ip_to_int "$subnet_ip")" $netmask)
+          subnet=$(and "$(ip_to_int "$ip_addr")" $netmask)
+
+          # Subnet IPs will match if given IP address is in CIDR subnet
+          if [ "${ip_addr_subnet}" -eq "${subnet}" ]; then
+            echo 0
+            return
+          fi
+        fi
+      fi
+
+      i=$(( i + 1 ))
+      proxy_ip=$(echo "$NO_PROXY" | cut -d',' -s -f$i)
+    done
+
+    echo 1
+}
+
+validate_ca_required() {
+    CA_REQUIRED=false
+    if [ -n "${CATTLE_SERVER}" ]; then
+        i=1
+        while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+            VERIFY_RESULT=$(curl $noproxy --connect-timeout 60 --max-time 60 --write-out "%{ssl_verify_result}\n" ${CURL_LOG} -fL "${CATTLE_SERVER}/healthz" -o /dev/null 2>/dev/null)
+            CURL_EXIT="$?"
+            case "${CURL_EXIT}" in
+              0|60)
+                case "${VERIFY_RESULT}" in
+                  0)
+                    info "Determined CA is not necessary to connect to Rancher"
+                    CA_REQUIRED=false
+                    CATTLE_CA_CHECKSUM=""
+                    break
+                    ;;
+                  *)
+                    i=$((i + 1))
+                    if [ "${CURL_EXIT}" -eq "60" ]; then
+                      info "Determined CA is necessary to connect to Rancher"
+                      CA_REQUIRED=true
+                      break
+                    fi
+                    error "Error received while testing necessity of CA. Sleeping for 5 seconds and trying again"
+                    sleep 5
+                    continue
+                    ;;
+                esac
+                ;;
+              *)
+                error "Error while connecting to Rancher to verify CA necessity. Sleeping for 5 seconds and trying again."
+                sleep 5
+                continue
+                ;;
+            esac
+        done
+    fi
+}
+
+RETRYCOUNT=4500
+CACERTS_PATH=cacerts
+
+validate_ca_checksum() {
+    if [ -n "${CATTLE_CA_CHECKSUM}" ]; then
+        CACERT=$(mktemp)
+        i=1
+        while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+            RESPONSE=$(curl $noproxy --connect-timeout 60 --max-time 60 --write-out "%{http_code}\n" --insecure ${CURL_LOG} -fL "${CATTLE_SERVER}/${CACERTS_PATH}" -o ${CACERT})
+            case "${RESPONSE}" in
+            200)
+                info "Successfully downloaded CA certificate"
+                break
+                ;;
+            *)
+                i=$((i + 1))
+                error "$RESPONSE received while downloading the CA certificate. Sleeping for 5 seconds and trying again"
+                sleep 5
+                continue
+                ;;
+            esac
+        done
+        if [ ! -s "${CACERT}" ]; then
+          error "The environment variable CATTLE_CA_CHECKSUM is set but there is no CA certificate configured at ${CATTLE_SERVER}/${CACERTS_PATH}"
+          exit 1
+        fi
+        err=$(check_x509_cert "${CACERT}")
+        if [ -n "${err}" ]; then
+            error "Value from ${CATTLE_SERVER}/${CACERTS_PATH} does not look like an x509 certificate (${err})"
+            error "Retrieved cacerts:"
+            cat "${CACERT}"
+            rm -f "${CACERT}"
+            exit 1
+        else
+            info "Value from ${CATTLE_SERVER}/${CACERTS_PATH} is an x509 certificate"
+        fi
+        CATTLE_SERVER_CHECKSUM=$(sha256sum "${CACERT}" | awk '{print $1}')
+        if [ "${CATTLE_SERVER_CHECKSUM}" != "${CATTLE_CA_CHECKSUM}" ]; then
+            rm -f "${CACERT}"
+            error "Configured cacerts checksum ($CATTLE_SERVER_CHECKSUM) does not match given --ca-checksum ($CATTLE_CA_CHECKSUM)"
+            error "Please check if the correct certificate is configured at${CATTLE_SERVER}/${CACERTS_PATH}"
+            exit 1
+        fi
+        CURL_CAFLAG="--cacert ${CACERT}"
+    fi
+}
+
+validate_rancher_connection() {
+    RANCHER_SUCCESS=false
+    if [ -n "${CATTLE_SERVER}" ]; then
+        i=1
+        while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+            RESPONSE=$(curl $noproxy --connect-timeout 60 --max-time 60 --write-out "%{http_code}\n" ${CURL_CAFLAG} ${CURL_LOG} -fL "${CATTLE_SERVER}/healthz" -o /dev/null)
+            case "${RESPONSE}" in
+            200)
+                info "Successfully tested Rancher connection"
+                RANCHER_SUCCESS=true
+                break
+                ;;
+            *)
+                i=$((i + 1))
+                error "$RESPONSE received while testing Rancher connection. Sleeping for 5 seconds and trying again"
+                sleep 5
+                continue
+                ;;
+            esac
+        done
+        if [ "${RANCHER_SUCCESS}" != "true" ]; then
+          fatal "Error connecting to Rancher. Perhaps --ca-checksum needs to be set?"
+        fi
+    fi
+}
+
+MANIFEST=$(mktemp)
+
+i=1
+noproxy=""
+if [ "$(in_no_proxy "${CATTLE_SERVER}")" = "0" ]; then
+	noproxy="--noproxy '*'"
+fi
+if [ -z "${CATTLE_CA_CHECKSUM}" ] && [ $(echo "${CATTLE_AGENT_STRICT_VERIFY}" | tr '[:upper:]' '[:lower:]') = "true" ]; then
+	fatal "Aborting cluster agent installation due to requested strict CA verification with no CA checksum provided"
+fi
+if [ -n "${CATTLE_CA_CHECKSUM}" ] && [ $(echo "${CATTLE_AGENT_STRICT_VERIFY}" | tr '[:upper:]' '[:lower:]') != "true" ]; then
+	validate_ca_required
+fi
+validate_ca_checksum
+if [ -z "$CATTLE_CA_CHECKSUM" ] && [ -z "$CACERT" ] && [ "$(echo "${CATTLE_AGENT_STRICT_VERIFY}" | tr '[:upper:]' '[:lower:]')" = "false" ]; then
+	info "No CA checksum or cert provided and strict CA verification is disabled"
+	CURL_CAFLAG="-k"
+fi
+validate_rancher_connection
+
+while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+	RESPONSE=$(curl $noproxy --connect-timeout 60 --max-time 300 --write-out "%{http_code}\n" ${CURL_CAFLAG} -fL "${CATTLE_SERVER}/v3/connect/cluster-agent/${CATTLE_TOKEN}.yaml" -o "${MANIFEST}")
+	case "${RESPONSE}" in
+	200)
+		break
+		;;
+	*)
+		i=$((i + 1))
+		sleep 5
+		continue
+		;;
+	esac
+done
+
+if ! kubectl create -f "$MANIFEST"; then
+	info "error applying cattle-cluster-agent"
+	exit 1
+fi
+
+rm $MANIFEST
+`
+
+type tc struct {
+	CAChecksum   string
+	Token        string
+	URL          string
+	ScriptB64    string
+	AgentImage   string
+	StrictVerify string
+}
+
 // generateClusterAgentManifest generates a cluster agent manifest
-func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPlane, entry *planEntry) ([]byte, error) {
+func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPlane) ([]byte, error) {
 	if controlPlane.Spec.ManagementClusterName == "local" {
 		return nil, nil
 	}
@@ -32,10 +398,26 @@ func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPla
 		return nil, err
 	}
 
-	taints, err := getTaints(entry, controlPlane)
-	if err != nil {
-		return nil, err
+	t := template.Must(template.New("cam-apply").Parse(ClusterAgentInitialCreationManifest))
+
+	strictVerify := settings.AgentTLSMode.Get() == settings.AgentTLSModeStrict
+	for _, ev := range controlPlane.Spec.AgentEnvVars {
+		if ev.Name == "STRICT_VERIFY" {
+			strictVerify = true
+		}
 	}
 
-	return systemtemplate.ForCluster(mgmtCluster, tokens[0].Status.Token, taints, p.secretCache)
+	templateContext := tc{
+		URL:          settings.ServerURL.Get(),
+		Token:        tokens[0].Status.Token,
+		CAChecksum:   systemtemplate.CAChecksum(),
+		ScriptB64:    base64.StdEncoding.EncodeToString([]byte(ApplyManifestIfNotExistsScript)),
+		AgentImage:   systemtemplate.GetDesiredAgentImage(mgmtCluster),
+		StrictVerify: fmt.Sprintf("%t", strictVerify),
+	}
+
+	buf := &bytes.Buffer{}
+
+	err = t.Execute(buf, templateContext)
+	return buf.Bytes(), err
 }

--- a/pkg/capr/planner/agent.go
+++ b/pkg/capr/planner/agent.go
@@ -5,12 +5,15 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sort"
+	"strings"
 	"text/template"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemtemplate"
 )
+
+var t = template.Must(template.New("cam-apply").Parse(ClusterAgentInitialCreationManifest))
 
 const ClusterAgentInitialCreationManifest = `
 apiVersion: v1
@@ -93,11 +96,6 @@ spec:
 `
 
 const ApplyManifestIfNotExistsScript string = `#!/bin/sh
-
-if [ -z "$CATTLE_SERVER" ] || [ -z "$CATTLE_TOKEN" ]; then
-	exit 1
-fi
-
 # info logs the given argument at info log level.
 info() {
     echo "[INFO] " "$@"
@@ -118,6 +116,10 @@ fatal() {
     echo "[FATAL] " "$@" >&2
     exit 1
 }
+
+if [ -z "$CATTLE_SERVER" ] || [ -z "$CATTLE_TOKEN" ]; then
+	fatal "CATTLE_SERVER and CATTLE_TOKEN must not be empty"
+fi
 
 if kubectl get deployments -n cattle-system cattle-cluster-agent > /dev/null; then
 	info "cattle-cluster-agent already exists"
@@ -398,11 +400,12 @@ func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPla
 		return nil, err
 	}
 
-	t := template.Must(template.New("cam-apply").Parse(ClusterAgentInitialCreationManifest))
-
 	strictVerify := settings.AgentTLSMode.Get() == settings.AgentTLSModeStrict
 	for _, ev := range controlPlane.Spec.AgentEnvVars {
-		if ev.Name == "STRICT_VERIFY" {
+		if strictVerify == true {
+			break
+		}
+		if ev.Name == "STRICT_VERIFY" && strings.ToLower(ev.Value) == "true" {
 			strictVerify = true
 		}
 	}

--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -406,7 +406,7 @@ func addTaints(config map[string]interface{}, entry *planEntry, cp *rkev1.RKECon
 		taintString []string
 	)
 
-	taints, err := getTaints(entry, cp)
+	taints, err := capr.GetTaints(entry.Metadata.Annotations[capr.TaintsAnnotation], capr.GetRuntime(cp.Spec.KubernetesVersion), isControlPlane(entry), isEtcd(entry), isWorker(entry))
 	if err != nil {
 		return err
 	}

--- a/pkg/capr/planner/manifests.go
+++ b/pkg/capr/planner/manifests.go
@@ -30,14 +30,16 @@ func (p *Planner) getControlPlaneManifests(controlPlane *rkev1.RKEControlPlane, 
 		return nil, nil
 	}
 
-	clusterAgent, err := p.getClusterAgentManifestFile(controlPlane, entry)
+	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
+
+	clusterAgent, err := p.getClusterAgentManifestFile(controlPlane, runtime, entry)
 	if err != nil {
 		return nil, err
 	}
 	result = append(result, clusterAgent)
 
 	// if we have a nil snapshotMetadata object, it's probably because the annotation didn't exist on the controlplane object. this is not breaking though so don't block.
-	snapshotMetadata := getEtcdSnapshotExtraMetadata(controlPlane, capr.GetRuntime(controlPlane.Spec.KubernetesVersion))
+	snapshotMetadata := getEtcdSnapshotExtraMetadata(controlPlane, runtime)
 	if snapshotMetadata == nil {
 		logrus.Errorf("Error while generating etcd snapshot extra metadata manifest for cluster %s", controlPlane.Spec.ClusterName)
 	} else {
@@ -68,8 +70,8 @@ func getEtcdSnapshotExtraMetadata(controlPlane *rkev1.RKEControlPlane, runtime s
 }
 
 // getClusterAgentManifestFile returns a plan.File that contains the cluster agent manifest.
-func (p *Planner) getClusterAgentManifestFile(controlPlane *rkev1.RKEControlPlane, entry *planEntry) (plan.File, error) {
-	data, err := p.generateClusterAgentManifest(controlPlane, entry)
+func (p *Planner) getClusterAgentManifestFile(controlPlane *rkev1.RKEControlPlane, runtime string, entry *planEntry) (plan.File, error) {
+	data, err := p.generateClusterAgentManifest(controlPlane)
 	if err != nil {
 		return plan.File{}, err
 	}

--- a/pkg/capr/planner/manifests.go
+++ b/pkg/capr/planner/manifests.go
@@ -32,7 +32,7 @@ func (p *Planner) getControlPlaneManifests(controlPlane *rkev1.RKEControlPlane, 
 
 	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
 
-	clusterAgent, err := p.getClusterAgentManifestFile(controlPlane, runtime, entry)
+	clusterAgent, err := p.getClusterAgentManifestFile(controlPlane)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func getEtcdSnapshotExtraMetadata(controlPlane *rkev1.RKEControlPlane, runtime s
 }
 
 // getClusterAgentManifestFile returns a plan.File that contains the cluster agent manifest.
-func (p *Planner) getClusterAgentManifestFile(controlPlane *rkev1.RKEControlPlane, runtime string, entry *planEntry) (plan.File, error) {
+func (p *Planner) getClusterAgentManifestFile(controlPlane *rkev1.RKEControlPlane) (plan.File, error) {
 	data, err := p.generateClusterAgentManifest(controlPlane)
 	if err != nil {
 		return plan.File{}, err


### PR DESCRIPTION
## Issue
https://github.com/rancher/rancher/issues/41132

## Problem
There are two controllers possibly conflicting deploying the cluster agent: the cluster deploy controller and the manifest delivered by planner.

## Solution
The planner will now deploy the cluster agent only if it doesn't exist. This ensures that the planner initiates the first cluster agent necessary for establishing a connection to the Rancher server but is no-op once the cluster deploy controller takes over.

Note: This code is from @Oats87's pull request (https://github.com/rancher/rancher/pull/41573), with minor changes in the installation script for provisioning tests, calculate unique taints and manage the agent TLS mode.

## Testing
### Manual Testing
Tested cluster provisioning and upgrades manually to ensure the changes work as expected.
### Automated Testing
Existing provisioning tests already cover this use case.