### PR TITLE
Don't override desired agent and auth image of management cluster

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -17,7 +17,6 @@ import (
 	rkecontrollers "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
-	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	"github.com/rancher/wrangler/v3/pkg/condition"
@@ -306,9 +305,8 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.DefaultPodSecurityAdmissionConfigurationTemplateName = cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
 	spec.DefaultClusterRoleForProjectMembers = cluster.Spec.DefaultClusterRoleForProjectMembers
 	spec.EnableNetworkPolicy = cluster.Spec.EnableNetworkPolicy
-	spec.DesiredAgentImage = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
-	spec.DesiredAuthImage = image.ResolveWithCluster(settings.AuthImage.Get(), cluster)
-
+	spec.DesiredAgentImage = image.GetDesiredAgentImage(cluster, &spec)
+	spec.DesiredAuthImage = image.GetDesiredAuthImage(cluster, &spec)
 	spec.ClusterSecrets.PrivateRegistrySecret = image.GetPrivateRepoSecretFromCluster(cluster)
 	spec.ClusterSecrets.PrivateRegistryURL = image.GetPrivateRepoURLFromCluster(cluster)
 

--- a/pkg/provisioningv2/image/resolve.go
+++ b/pkg/provisioningv2/image/resolve.go
@@ -78,23 +78,23 @@ func getPrivateRepoURL(machineGlobalConfig rkev1.GenericMap, machineSelectorConf
 	return settings.SystemDefaultRegistry.Get()
 }
 
-func GetDesiredAgentImage(cp *rkev1.RKEControlPlane, mgmtCluster *v3.Cluster) string {
-	desiredAgent := mgmtCluster.Spec.DesiredAgentImage
-	if mgmtCluster.Spec.AgentImageOverride != "" {
-		desiredAgent = mgmtCluster.Spec.AgentImageOverride
+func GetDesiredAgentImage(cluster *v1.Cluster, mgmtClusterSpec *v3.ClusterSpec) string {
+	desiredAgent := mgmtClusterSpec.DesiredAgentImage
+	if mgmtClusterSpec.AgentImageOverride != "" {
+		desiredAgent = mgmtClusterSpec.AgentImageOverride
 	}
 	if desiredAgent == "" || desiredAgent == "fixed" {
-		desiredAgent = ResolveWithControlPlane(settings.AgentImage.Get(), cp)
+		desiredAgent = ResolveWithCluster(settings.AgentImage.Get(), cluster)
 	}
 	return desiredAgent
 }
 
-func GetDesiredAuthImage(cp *rkev1.RKEControlPlane, mgmtCluster *v3.Cluster) string {
+func GetDesiredAuthImage(cluster *v1.Cluster, mgmtClusterSpec *v3.ClusterSpec) string {
 	var desiredAuth string
-	if mgmtCluster.Spec.LocalClusterAuthEndpoint.Enabled {
-		desiredAuth = mgmtCluster.Spec.DesiredAuthImage
+	if mgmtClusterSpec.LocalClusterAuthEndpoint.Enabled {
+		desiredAuth = mgmtClusterSpec.DesiredAuthImage
 		if desiredAuth == "" || desiredAuth == "fixed" {
-			desiredAuth = ResolveWithControlPlane(settings.AuthImage.Get(), cp)
+			desiredAuth = ResolveWithCluster(settings.AuthImage.Get(), cluster)
 		}
 	}
 	return desiredAuth


### PR DESCRIPTION
## Issue
https://github.com/rancher/rancher/issues/47593 

## Problem
`DesiredAgentImage` value set on the management cluster gets lost and rancher uses the default agent image for deploying cluster agent.

## Solution
Utilize the existing GetDesired*() function to get the correct agent image value when syncing with the provisioning cluster. This PR only intends to the fix the existing bug in codebase, but for later we should also consider exposing`DesiredAgentImage` on the provisioning cluster similar to `AgentDeploymentCustomization`. 