### PR TITLE
<main> Convert connection workload tests from Python to Go

### DIFF
--- a/tests/v2/validation/networking/README.md
+++ b/tests/v2/validation/networking/README.md
@@ -16,4 +16,7 @@ In your config file, set the following:
 }
 ```
 
+to `-run ^TestPortTestSuite/TestNodePort$` the Project Network Isolation should be enable on the cluster.
+to `-run ^TestPortTestSuite/TestHostPort$` the Project Network Isolation should be enable on the cluster.
+
 **NOTE** These tests most run on a server with private networking setup as they rely on being able to SSH into servers

--- a/tests/v2/validation/networking/connectivity/network_policy.go
+++ b/tests/v2/validation/networking/connectivity/network_policy.go
@@ -1,16 +1,18 @@
 package connectivity
 
 import (
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/kubectl"
 	"github.com/rancher/shepherd/extensions/workloads"
 	"github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	pingPodProjectName = "ping-project"
-
-	containerName  = "test1"
-	containerImage = "ranchertest/mytestcontainer"
+	containerName      = "test1"
+	containerImage     = "ranchertest/mytestcontainer"
 )
 
 type resourceNames struct {
@@ -63,4 +65,16 @@ func newPodTemplateWithTestContainer() corev1.PodTemplateSpec {
 func newTestContainerMinimal() corev1.Container {
 	pullPolicy := corev1.PullAlways
 	return workloads.NewContainer(containerName, containerImage, pullPolicy, nil, nil, nil, nil, nil)
+}
+
+// curlCommand is a helper to run a curl command on an SSH shell node
+func curlCommand(client *rancher.Client, clusterID string, url string) (string, error) {
+	logrus.Infof("Executing the kubectl command curl %s on the node", url)
+	execCmd := []string{"curl", url}
+	log, err := kubectl.Command(client, nil, clusterID, execCmd, "")
+	if err != nil {
+		return "", err
+	}
+	logrus.Infof("Log of the curl command curl {%v}", log)
+	return log, nil
 }

--- a/tests/v2/validation/networking/connectivity/network_policy_test.go
+++ b/tests/v2/validation/networking/connectivity/network_policy_test.go
@@ -4,6 +4,9 @@ package connectivity
 
 import (
 	"errors"
+	"net/url"
+	"testing"
+
 	"github.com/rancher/rancher/tests/v2/actions/namespaces"
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
 	"github.com/rancher/rancher/tests/v2/actions/workloads"
@@ -16,8 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ssh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/url"
-	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/session"

--- a/tests/v2/validation/networking/connectivity/port_test.go
+++ b/tests/v2/validation/networking/connectivity/port_test.go
@@ -1,0 +1,366 @@
+//go:build (validation || infra.rke2k3s || cluster.any || sanity) && !stress && !extended
+
+package connectivity
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	projectsapi "github.com/rancher/rancher/tests/v2/actions/projects"
+	"github.com/rancher/rancher/tests/v2/actions/services"
+	"github.com/rancher/rancher/tests/v2/actions/workloads"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
+	kubeapinodes "github.com/rancher/shepherd/extensions/kubeapi/nodes"
+	shepworkloads "github.com/rancher/shepherd/extensions/workloads"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	clusterNameAnnotation  = "cluster.x-k8s.io/cluster-name"
+	kubeSystemNamespace    = "kube-system"
+	portLimit              = 65534
+	cloudControllerManager = "aws-cloud-controller-manager"
+)
+
+type PortTestSuite struct {
+	suite.Suite
+	client      *rancher.Client
+	session     *session.Session
+	cluster     *management.Cluster
+	clusterName string
+}
+
+func (p *PortTestSuite) TearDownSuite() {
+	p.session.Cleanup()
+}
+
+func (p *PortTestSuite) SetupSuite() {
+	p.session = session.NewSession()
+
+	client, err := rancher.NewClient("", p.session)
+	require.NoError(p.T(), err)
+
+	p.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in connection")
+	p.clusterName = client.RancherConfig.ClusterName
+	require.NotEmptyf(p.T(), p.clusterName, "Cluster name to install should be set")
+
+	clusterID, err := clusters.GetClusterIDByName(p.client, p.clusterName)
+	require.NoError(p.T(), err, "Error getting cluster ID")
+
+	p.cluster, err = p.client.Management.Cluster.ByID(clusterID)
+	require.NoError(p.T(), err)
+}
+
+func (p *PortTestSuite) TestHostPort() {
+	subSession := p.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating new project and namespace")
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	steveClient, err := p.client.Steve.ProxyDownstream(p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	//This must be a valid port number, 0 < hostPort < 65536
+	//Using a random port to avoid 'port in use' failures and allow the test to be rerun
+	hostPort := rand.IntN(65534) + 1
+
+	testContainerPodTemplate := newPodTemplateWithTestContainer()
+	testContainerPodTemplate.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		corev1.ContainerPort{
+			HostPort:      int32(hostPort),
+			ContainerPort: 80,
+			Protocol:      corev1.ProtocolTCP,
+		},
+	}
+
+	daemonsetName := namegen.AppendRandomString("test-daemonset")
+
+	p.T().Logf("Creating a daemonset with the test container with name [%v]", daemonsetName)
+	daemonsetTemplate := shepworkloads.NewDaemonSetTemplate(daemonsetName, namespace.Name, testContainerPodTemplate, true, nil)
+	createdDaemonSet, err := steveClient.SteveType(workloads.DaemonsetSteveType).Create(daemonsetTemplate)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), createdDaemonSet.Name, daemonsetName)
+
+	p.T().Logf("Waiting for daemonset [%v] to have expected number of available replicas", daemonsetName)
+	err = charts.WatchAndWaitDaemonSets(p.client, p.cluster.ID, namespace.Name, metav1.ListOptions{})
+	require.NoError(p.T(), err)
+
+	p.T().Logf("Getting the node using the cluster name [%v]", p.clusterName)
+	query, err := url.ParseQuery(fmt.Sprintf("%s=%s", clusterNameAnnotation, p.clusterName))
+	assert.NoError(p.T(), err)
+
+	nodeList, err := steveClient.SteveType("node").List(query)
+	assert.NoError(p.T(), err)
+	assert.NotEmpty(p.T(), nodeList, err)
+	assert.NotEmpty(p.T(), nodeList.Data)
+
+	for _, machine := range nodeList.Data {
+		p.T().Log("Getting the node IP")
+		newNode := &corev1.Node{}
+		err = steveV1.ConvertToK8sType(machine.JSONResp, newNode)
+		assert.NoError(p.T(), err)
+		nodeIP := kubeapinodes.GetNodeIP(newNode, corev1.NodeInternalIP)
+
+		p.T().Log("Executing the SSH shell command on the node")
+		log, err := curlCommand(p.client, p.cluster.ID, fmt.Sprintf("%s:%s/name.html", nodeIP, strconv.Itoa(hostPort)))
+		require.NoError(p.T(), err)
+		require.True(p.T(), strings.Contains(log, daemonsetName))
+	}
+}
+
+func (p *PortTestSuite) TestNodePort() {
+	subSession := p.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating new project and namespace")
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	steveClient, err := p.client.Steve.ProxyDownstream(p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	testContainerPodTemplate := newPodTemplateWithTestContainer()
+
+	daemonsetName := namegen.AppendRandomString("test-daemonset")
+
+	p.T().Logf("Creating a daemonset with the test container with name [%v]", daemonsetName)
+	daemonsetTemplate := shepworkloads.NewDaemonSetTemplate(daemonsetName, namespace.Name, testContainerPodTemplate, true, nil)
+	createdDaemonSet, err := steveClient.SteveType(workloads.DaemonsetSteveType).Create(daemonsetTemplate)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), createdDaemonSet.Name, daemonsetName)
+
+	p.T().Logf("Waiting for daemonset [%v] to have expected number of available replicas", daemonsetName)
+	err = charts.WatchAndWaitDaemonSets(p.client, p.cluster.ID, namespace.Name, metav1.ListOptions{})
+	require.NoError(p.T(), err)
+
+	//It will allocate a port from a range 30000-32767
+	//Using a random port to avoid 'port in use' failures and allow the test to be rerun
+	nodePort := rand.IntN(2767) + 30000
+
+	serviceName := namegen.AppendRandomString("test-service")
+	p.T().Logf("Creating service with name [%v]", serviceName)
+	ports := []corev1.ServicePort{
+		{
+			Protocol: corev1.ProtocolTCP,
+			Port:     80,
+			NodePort: int32(nodePort),
+		},
+	}
+	nodePortservice := services.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeNodePort, ports, daemonsetTemplate.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(steveClient, nodePortservice)
+	require.NoError(p.T(), err)
+
+	err = services.VerifyService(steveClient, serviceResp)
+	require.NoError(p.T(), err)
+
+	p.T().Logf("Getting the node using the cluster name [%v]", p.clusterName)
+	query, err := url.ParseQuery(fmt.Sprintf("%s=%s", clusterNameAnnotation, p.clusterName))
+	assert.NoError(p.T(), err)
+
+	nodeList, err := steveClient.SteveType("node").List(query)
+	assert.NoError(p.T(), err)
+	assert.NotEmpty(p.T(), nodeList, err)
+	assert.NotEmpty(p.T(), nodeList.Data)
+
+	for _, machine := range nodeList.Data {
+		p.T().Log("Getting the node IP")
+		newNode := &corev1.Node{}
+		err = steveV1.ConvertToK8sType(machine.JSONResp, newNode)
+		assert.NoError(p.T(), err)
+
+		// Project Network Isolation should be enabled when setting up the cluster for this test
+		nodeIP := kubeapinodes.GetNodeIP(newNode, corev1.NodeExternalIP)
+		if nodeIP == "" {
+			nodeIP = kubeapinodes.GetNodeIP(newNode, corev1.NodeInternalIP)
+		}
+
+		p.T().Log("Executing the SSH shell command on the node")
+		log, err := curlCommand(p.client, p.cluster.ID, fmt.Sprintf("%s:%s/name.html", nodeIP, strconv.Itoa(nodePort)))
+		require.NoError(p.T(), err)
+		require.True(p.T(), strings.Contains(log, daemonsetName))
+	}
+}
+
+func (p *PortTestSuite) TestClusterIP() {
+	subSession := p.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating new project and namespace")
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	steveClient, err := p.client.Steve.ProxyDownstream(p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	testContainerPodTemplate := newPodTemplateWithTestContainer()
+
+	daemonsetName := namegen.AppendRandomString("test-daemonset")
+
+	p.T().Logf("Creating a daemonset with the test container with name [%v]", daemonsetName)
+	daemonsetTemplate := shepworkloads.NewDaemonSetTemplate(daemonsetName, namespace.Name, testContainerPodTemplate, true, nil)
+	createdDaemonSet, err := steveClient.SteveType(workloads.DaemonsetSteveType).Create(daemonsetTemplate)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), createdDaemonSet.Name, daemonsetName)
+
+	p.T().Logf("Waiting for daemonset [%v] to have expected number of available replicas", daemonsetName)
+	err = charts.WatchAndWaitDaemonSets(p.client, p.cluster.ID, namespace.Name, metav1.ListOptions{})
+	require.NoError(p.T(), err)
+
+	//This must be a valid port number, 0 < hostPort < 65536
+	//Using a random port to avoid 'port in use' failures and allow the test to be rerun
+	hostPort := rand.IntN(65534) + 1
+
+	serviceName := namegen.AppendRandomString("test-service")
+	p.T().Logf("Creating service with name [%v]", serviceName)
+	ports := []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(hostPort),
+			TargetPort: intstr.FromInt(80),
+		},
+	}
+	clusterIPService := services.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeClusterIP, ports, daemonsetTemplate.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(steveClient, clusterIPService)
+	require.NoError(p.T(), err)
+
+	err = services.VerifyService(steveClient, serviceResp)
+	require.NoError(p.T(), err)
+
+	serviceResp, err = steveClient.SteveType(services.ServiceSteveType).ByID(serviceResp.ID)
+	assert.NoError(p.T(), err)
+
+	p.T().Log("Getting the cluster IP")
+	newService := &corev1.Service{}
+	err = steveV1.ConvertToK8sType(serviceResp.JSONResp, newService)
+	assert.NoError(p.T(), err)
+	assert.NotEmpty(p.T(), newService.Spec.ClusterIP)
+
+	clusterIP := newService.Spec.ClusterIP
+
+	p.T().Log("Executing the SSH shell command on the node")
+	log, err := curlCommand(p.client, p.cluster.ID, fmt.Sprintf("%s:%s/name.html", clusterIP, strconv.Itoa(hostPort)))
+	require.NoError(p.T(), err)
+	require.True(p.T(), strings.Contains(log, daemonsetName))
+}
+
+func (p *PortTestSuite) TestLoadBalance() {
+	subSession := p.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Checking cluster version and if the cloud-controller-manager is installed")
+	catalogClient, err := p.client.GetClusterCatalogClient(p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	clusterID, err := clusters.GetV1ProvisioningClusterByName(p.client, p.client.RancherConfig.ClusterName)
+	require.NoError(p.T(), err)
+
+	cluster, err := p.client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ByID(clusterID)
+	require.NoError(p.T(), err)
+
+	newCluster := &provv1.Cluster{}
+	err = steveV1.ConvertToK8sType(cluster, newCluster)
+	require.NoError(p.T(), err)
+
+	_, err = catalogClient.Apps(kubeSystemNamespace).Get(context.TODO(), cloudControllerManager, metav1.GetOptions{})
+	if !strings.Contains(newCluster.Spec.KubernetesVersion, "k3s") && err != nil && strings.Contains(err.Error(), "not found") {
+		p.T().Skip("Load Balance test requires access to cloud provider.")
+	}
+
+	log.Info("Creating new project and namespace")
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	steveClient, err := p.client.Steve.ProxyDownstream(p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	testContainerPodTemplate := newPodTemplateWithTestContainer()
+
+	daemonsetName := namegen.AppendRandomString("test-daemonset")
+
+	p.T().Logf("Creating a daemonset with the test container with name [%v]", daemonsetName)
+	daemonsetTemplate := shepworkloads.NewDaemonSetTemplate(daemonsetName, namespace.Name, testContainerPodTemplate, true, nil)
+	createdDaemonSet, err := steveClient.SteveType(workloads.DaemonsetSteveType).Create(daemonsetTemplate)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), createdDaemonSet.Name, daemonsetName)
+
+	p.T().Logf("Waiting for daemonset [%v] to have expected number of available replicas", daemonsetName)
+	err = charts.WatchAndWaitDaemonSets(p.client, p.cluster.ID, namespace.Name, metav1.ListOptions{})
+	require.NoError(p.T(), err)
+
+	//This must be a valid port number, 0 < hostPort < 65536
+	//Using a random port to avoid 'port in use' failures and allow the test to be rerun
+	hostPort := rand.IntN(65534) + 1
+
+	//It will allocate a port from a range 30000-32767
+	//Using a random port to avoid 'port in use' failures and allow the test to be rerun
+	nodePort := rand.IntN(2767) + 30000
+
+	serviceName := namegen.AppendRandomString("test-service")
+	p.T().Logf("Creating service with name [%v]", serviceName)
+	ports := []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(hostPort),
+			TargetPort: intstr.FromInt(80),
+			NodePort:   int32(nodePort),
+		},
+	}
+	lbService := services.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeLoadBalancer, ports, daemonsetTemplate.Spec.Selector.MatchLabels)
+	serviceResp, err := services.CreateService(steveClient, lbService)
+	require.NoError(p.T(), err)
+
+	err = services.VerifyService(steveClient, serviceResp)
+	require.NoError(p.T(), err)
+
+	p.T().Logf("Getting the node using the cluster name [%v]", p.clusterName)
+	query, err := url.ParseQuery(fmt.Sprintf("%s=%s", clusterNameAnnotation, p.clusterName))
+	assert.NoError(p.T(), err)
+
+	nodeList, err := steveClient.SteveType("node").List(query)
+	assert.NoError(p.T(), err)
+	assert.NotEmpty(p.T(), nodeList, err)
+	assert.NotEmpty(p.T(), nodeList.Data)
+
+	for _, machine := range nodeList.Data {
+		p.T().Log("Getting the node IP")
+		newNode := &corev1.Node{}
+		err = steveV1.ConvertToK8sType(machine.JSONResp, newNode)
+		assert.NoError(p.T(), err)
+
+		nodeIP := kubeapinodes.GetNodeIP(newNode, corev1.NodeExternalIP)
+		if nodeIP == "" {
+			nodeIP = kubeapinodes.GetNodeIP(newNode, corev1.NodeInternalIP)
+		}
+
+		p.T().Log("Executing the SSH shell command on the node")
+		log, err := curlCommand(p.client, p.cluster.ID, fmt.Sprintf("%s:%s/name.html", nodeIP, strconv.Itoa(nodePort)))
+		require.NoError(p.T(), err)
+		require.True(p.T(), strings.Contains(log, daemonsetName))
+	}
+}
+
+func TestPortTestSuite(t *testing.T) {
+	suite.Run(t, new(PortTestSuite))
+}

--- a/tests/v2/validation/workloads/workload.go
+++ b/tests/v2/validation/workloads/workload.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rancher/rancher/tests/v2/actions/workloads/pods"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/kubectl"
@@ -32,7 +33,8 @@ const (
 func validateDeploymentUpgrade(t *testing.T, client *rancher.Client, clusterName string, namespaceName string, appv1Deployment *appv1.Deployment, expectedRevision string, image string, expectedReplicas int) {
 	log.Info("Waiting deployment comes up active")
 	err := charts.WatchAndWaitDeployments(client, clusterName, namespaceName, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + appv1Deployment.Name,
+		FieldSelector:  "metadata.name=" + appv1Deployment.Name,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	})
 	require.NoError(t, err)
 

--- a/tests/validation/tests/v3_api/test_workload.py
+++ b/tests/validation/tests/v3_api/test_workload.py
@@ -253,6 +253,7 @@ def test_wl_pause_orchestration():
 
 
 # Windows could not support host port for now.
+#Converted to go test in TestHostPort
 @skip_test_windows_os
 @skip_host_node_port
 def test_wl_with_hostPort():
@@ -276,7 +277,7 @@ def test_wl_with_hostPort():
     workload = wait_for_wl_to_active(p_client, workload)
     validate_hostPort(p_client, workload, source_port, namespace["cluster"])
 
-
+#Converted to go test in TestNodePort
 @skip_host_node_port
 def test_wl_with_nodePort():
     p_client = namespace["p_client"]
@@ -300,7 +301,7 @@ def test_wl_with_nodePort():
     workload = wait_for_wl_to_active(p_client, workload)
     validate_nodePort(p_client, workload, namespace["cluster"], source_port)
 
-
+#Converted to go test in TestClusterIP
 def test_wl_with_clusterIp():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
@@ -339,7 +340,7 @@ def test_wl_with_clusterIp():
     test_pods = wait_for_pods_in_workload(p_client, workload_for_test, 2)
     validate_clusterIp(p_client, workload, cluster_ip, test_pods, source_port)
 
-
+#Converted to go test in TestLoadBalance
 @if_check_lb
 def test_wl_with_lb():
     p_client = namespace["p_client"]


### PR DESCRIPTION
Backports
v2.9: https://github.com/rancher/rancher/pull/47840
v2.8 https://github.com/rancher/rancher/pull/47841
v2.7 https://github.com/rancher/rancher/pull/47842