### PR TITLE
[Main] Add RSA key authentication support to Jenkins

### DIFF
--- a/tests/v2/validation/Dockerfile.validation
+++ b/tests/v2/validation/Dockerfile.validation
@@ -22,7 +22,9 @@ ENV CORRAL_VERSION="v1.1.1"
 RUN go install github.com/rancherlabs/corral@${CORRAL_VERSION}
 
 RUN mkdir /root/.ssh && chmod 600 .ssh/jenkins-*
-RUN ssh-keygen -f .ssh/jenkins-* -y > /root/.ssh/public.pub
+RUN for pem_file in .ssh/jenkins-*; do \
+      ssh-keygen -f "$pem_file" -y > "/root/.ssh/$(basename "$pem_file").pub"; \
+    done
 
 RUN CGO_ENABLED=0
 

--- a/tests/v2/validation/Jenkinsfile
+++ b/tests/v2/validation/Jenkinsfile
@@ -39,6 +39,7 @@ node {
                           string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
                           string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
                           string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                          string(credentialsId: 'AWS_SSH_RSA_KEY', variable: 'AWS_SSH_RSA_KEY'),
                           string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
                           string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
                           string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
@@ -81,7 +82,6 @@ node {
                           string(credentialsId: 'QASE_AUTOMATION_TOKEN', variable: 'QASE_AUTOMATION_TOKEN'),
                           string(credentialsId: 'SLACK_WEBHOOK', variable: 'SLACK_WEBHOOK'),
                           string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
-          
         withEnv(paramsMap) {
           stage('Checkout') {
             deleteDir()
@@ -100,6 +100,11 @@ node {
                     def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
                     writeFile file: AWS_SSH_KEY_NAME, text: decoded
                   }
+                }
+
+                dir("./tests/v2/validation/.ssh") {
+                  def decodedRsa = new String(AWS_SSH_RSA_KEY.decodeBase64())
+                  writeFile file: JENKINS_RKE_VALIDATION, text: decodedRsa
                 }
 
                 dir("./tests/v2/validation") {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Add RSA key authentication to Jenkins](https://github.com/rancher/qa-tasks/issues/1596)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Our Jenkins currently only has authentication support for ed25519. This is a problem for Windows-based testing as we need to have RSA authentication as well. Our release testing that uses Windows clusters has not been properly been reported to Qase as a result.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added RSA key authentication support in the Jenkinsfile and Dockerfile.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Jenkins jobs will be given to reviewers offline.