### PR TITLE
Fix cached azure client

### DIFF
--- a/pkg/auth/providers/azure/clients/ms_graph_client_test.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client_test.go
@@ -24,8 +24,7 @@ import (
 // TEST_AZURE_APPLICATION_SECRET
 
 func TestMSGraphClient_GetUser(t *testing.T) {
-	secrets := newTestSecretsClient()
-	client := newTestClientWithSecretsClient(t, secrets)
+	client := newTestClient(t)
 
 	user, err := client.GetUser("testuser6@ranchertest.onmicrosoft.com")
 	if err != nil {
@@ -43,7 +42,6 @@ func TestMSGraphClient_GetUser(t *testing.T) {
 	}
 	assert.Equal(t, want, user)
 
-	client = newTestClientWithSecretsClient(t, secrets)
 	_, err = client.GetUser("testuser6@ranchertest.onmicrosoft.com")
 	if err != nil {
 		t.Fatal(err)
@@ -197,8 +195,10 @@ func newTestClientWithSecretsClient(t *testing.T, secrets normancorev1.SecretInt
 }
 
 func newTestSecretsClient() normancorev1.SecretInterface {
-	secrets := map[types.NamespacedName]*corev1.Secret{}
+	return newTestSecretsClientWithMap(map[types.NamespacedName]*corev1.Secret{})
+}
 
+func newTestSecretsClientWithMap(secrets map[types.NamespacedName]*corev1.Secret) normancorev1.SecretInterface {
 	sm := &fakes.SecretInterfaceMock{
 		GetNamespacedFunc: func(namespace, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
 			namespacedName := types.NamespacedName{Namespace: namespace, Name: name}

--- a/pkg/auth/providers/azure/clients/ms_graph_client_test.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client_test.go
@@ -132,8 +132,8 @@ func TestMSGraphClient_ListGroupMemberships(t *testing.T) {
 	}
 
 	assert.Equal(t, []string{
-		"15f6a947-9d67-4e7f-b1d0-f5f52145fed3",
-		"748274fd-3ec7-40d1-b08b-775c1a8ec1af",
+		"15f6a947-9d67-4e7f-b1d0-f5f52145fed3", "5e0d1316-aa15-4c94-83e1-7db91acc7795",
+		"6b2c23ed-626d-4ce4-a889-7c2043ace20e", "748274fd-3ec7-40d1-b08b-775c1a8ec1af",
 		"bf881716-8d6d-456f-b234-2b143dfd5cf0"}, groups)
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The Azure client login was using the access token cache which led to additional tokens being cached.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Changed to create a new client for every token authentication which doesn't use the cache.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Configure Rancher for the Azure provider and login and it should create a secret cattle-global-data/azuread-access-token there should be no `RefreshToken`, `IdToken` or `Account` data, there should only be an access token for the Application client_id/tenant id in the data.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Logged in, checked for reduced data, compared against v2.8.5 storage.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_
This is not automateable, it requires us to login to Azure to test.

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_