### PR TITLE
Adding 0 ttl on harvester migration

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -3,7 +3,9 @@ package rancher
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mcuadros/go-version"
 	"github.com/rancher/norman/condition"
@@ -663,7 +665,9 @@ func migrateHarvesterCloudCredentialExpiration(w *wrangler.Context) error {
 			})
 			if apierrors.IsNotFound(err) {
 				logrus.Debugf("Cloud credential [%s] using nonexistent token", secret.Name)
-				continue
+				// if the secret is not found, we use the unix 0 timestamp. This is done a bit odd since
+				// time.Unix returns an int64 and we don't want to produce overflow
+				expiration = strconv.FormatInt(time.Unix(0, 0).UnixMilli(), 10)
 			} else if err != nil {
 				return fmt.Errorf("failed to get harvester cloud credential expiration from kubeconfig: %w", err)
 			}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/47608 (follow-up enhancement for this issue)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
https://github.com/rancher/rancher/pull/47594 prevented crashloop but creds with expired token did not get new annotation added to them which does not allow UI to rotate them.
 
## Solution
When harvester credentials are migrated, this now adds a 0 ttl for tokens which were not found, rather than simply skipping those tokens.
 
## Testing
To be handled by Harvester team