### PR TITLE
[2.10] Conditionally update max-failures value for windows plans

### DIFF
--- a/pkg/capr/planner/etcdcreate.go
+++ b/pkg/capr/planner/etcdcreate.go
@@ -67,7 +67,7 @@ func (p *Planner) runEtcdSnapshotManagementServiceStart(controlPlane *rkev1.RKEC
 	// Generate and deliver desired plan for the bootstrap/init node first.
 	if err := p.reconcile(controlPlane, tokensSecret, clusterPlan, true, bootstrapTier, isEtcd, isNotInitNodeOrIsDeleting,
 		"1", "", controlPlane.Spec.UpgradeStrategy.ControlPlaneDrainOptions,
-		-1, 1, false); err != nil {
+		-1, 1, false, true); err != nil {
 		return err
 	}
 

--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -672,7 +672,7 @@ func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane,
 			stopPlan.Instructions = append(stopPlan.Instructions, generateRemoveTLSAndCredDirInstructions(controlPlane)...)
 		}
 		if !equality.Semantic.DeepEqual(server.Plan.Plan, stopPlan) {
-			if err := p.store.UpdatePlan(server, stopPlan, joinedServer, 0, 0); err != nil {
+			if err := p.store.UpdatePlan(server, stopPlan, joinedServer, 0, 0, true); err != nil {
 				return err
 			}
 			updated = true

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -363,7 +363,7 @@ func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEContr
 	// select all etcd and then filter to just initNodes so that unavailable count is correct
 	err = p.reconcile(cp, clusterSecretTokens, plan, true, bootstrapTier, isEtcd, isNotInitNodeOrIsDeleting,
 		"1", "", controlPlaneDrainOptions, -1, 1,
-		false)
+		false, true)
 	capr.Bootstrapped.True(&status)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
@@ -384,7 +384,7 @@ func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEContr
 	// Process all nodes that have the etcd role and are NOT an init node or deleting. Only process 1 node at a time.
 	err = p.reconcile(cp, clusterSecretTokens, plan, true, etcdTier, isEtcd, isInitNodeOrDeleting,
 		"1", joinServer, controlPlaneDrainOptions,
-		-1, 1, false)
+		-1, 1, false, true)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
@@ -393,7 +393,7 @@ func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEContr
 	// Process all nodes that have the controlplane role and are NOT an init node or deleting.
 	err = p.reconcile(cp, clusterSecretTokens, plan, true, controlPlaneTier, isControlPlane, isInitNodeOrDeleting,
 		controlPlaneConcurrency, joinServer, controlPlaneDrainOptions, -1, 1,
-		false)
+		false, true)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
@@ -413,7 +413,7 @@ func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEContr
 	// Process all nodes that are ONLY linux worker nodes.
 	err = p.reconcile(cp, clusterSecretTokens, plan, false, workerTier, isOnlyLinuxWorker, isInitNodeOrDeleting,
 		workerConcurrency, "", workerDrainOptions, -1, 1,
-		false)
+		false, true)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
@@ -438,7 +438,7 @@ func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEContr
 
 	err = p.reconcile(cp, clusterSecretTokens, plan, false, workerTier, isOnlyWindowsWorker, isInitNodeOrDeleting,
 		workerConcurrency, "", workerDrainOptions, windowsMaxFailures,
-		windowsMaxFailureThreshold, resetFailureCountOnRestart)
+		windowsMaxFailureThreshold, resetFailureCountOnRestart, false)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
@@ -857,7 +857,7 @@ type reconcilable struct {
 
 func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, clusterPlan *plan.Plan, required bool, tierName string,
 	include, exclude roleFilter, maxUnavailable, forcedJoinURL string, drainOptions rkev1.DrainOptions,
-	maxFailures, failureThreshold int, resetFailureCountOnSystemAgentRestart bool) error {
+	maxFailures, failureThreshold int, resetFailureCountOnSystemAgentRestart, overwriteFailureValues bool) error {
 	var (
 		ready, outOfSync, nonReady, errMachines, draining, uncordoned []string
 		messages                                                      = map[string][]string{}
@@ -929,14 +929,14 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret pl
 			logrus.Debugf("[planner] rkecluster %s/%s reconcile tier %s - setting initial plan for machine %s/%s", controlPlane.Namespace, controlPlane.Name, tierName, r.entry.Machine.Namespace, r.entry.Machine.Name)
 			logrus.Tracef("[planner] rkecluster %s/%s reconcile tier %s - initial plan for machine %s/%s new: %+v", controlPlane.Namespace, controlPlane.Name, tierName, r.entry.Machine.Namespace, r.entry.Machine.Name, r.desiredPlan)
 			outOfSync = append(outOfSync, r.entry.Machine.Name)
-			if err := p.store.UpdatePlan(r.entry, r.desiredPlan, r.joinedURL, maxFailures, failureThreshold); err != nil {
+			if err := p.store.UpdatePlan(r.entry, r.desiredPlan, r.joinedURL, maxFailures, failureThreshold, overwriteFailureValues); err != nil {
 				return err
 			}
 		} else if r.minorChange {
 			logrus.Debugf("[planner] rkecluster %s/%s reconcile tier %s - minor plan change detected for machine %s/%s, updating plan immediately", controlPlane.Namespace, controlPlane.Name, tierName, r.entry.Machine.Namespace, r.entry.Machine.Name)
 			logrus.Tracef("[planner] rkecluster %s/%s reconcile tier %s - minor plan change for machine %s/%s old: %+v, new: %+v", controlPlane.Namespace, controlPlane.Name, tierName, r.entry.Machine.Namespace, r.entry.Machine.Name, r.entry.Plan.Plan, r.desiredPlan)
 			outOfSync = append(outOfSync, r.entry.Machine.Name)
-			if err := p.store.UpdatePlan(r.entry, r.desiredPlan, r.joinedURL, maxFailures, failureThreshold); err != nil {
+			if err := p.store.UpdatePlan(r.entry, r.desiredPlan, r.joinedURL, maxFailures, failureThreshold, overwriteFailureValues); err != nil {
 				return err
 			}
 		} else if r.change {
@@ -960,7 +960,7 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret pl
 					// Drain is done (or didn't need to be done) and there are no errors, so the plan should be updated to enact the reason the node was drained.
 					logrus.Debugf("[planner] rkecluster %s/%s reconcile tier %s - major plan change for machine %s/%s", controlPlane.Namespace, controlPlane.Name, tierName, r.entry.Machine.Namespace, r.entry.Machine.Name)
 					logrus.Tracef("[planner] rkecluster %s/%s reconcile tier %s - major plan change for machine %s/%s old: %+v, new: %+v", controlPlane.Namespace, controlPlane.Name, tierName, r.entry.Machine.Namespace, r.entry.Machine.Name, r.entry.Plan.Plan, r.desiredPlan)
-					if err = p.store.UpdatePlan(r.entry, r.desiredPlan, r.joinedURL, maxFailures, failureThreshold); err != nil {
+					if err = p.store.UpdatePlan(r.entry, r.desiredPlan, r.joinedURL, maxFailures, failureThreshold, overwriteFailureValues); err != nil {
 						return err
 					} else if r.entry.Metadata.Annotations[capr.DrainDoneAnnotation] != "" {
 						messages[r.entry.Machine.Name] = append(messages[r.entry.Machine.Name], "drain completed")

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -357,7 +357,7 @@ func (p *PlanStore) getPlanSecretFromMachine(machine *capi.Machine) (*corev1.Sec
 
 // UpdatePlan should not be called directly as it will not block further progress if the plan is not in sync
 // maxFailures is the number of attempts the system-agent will make to run the plan (in a failed state). failureThreshold is used to determine when the plan has failed.
-func (p *PlanStore) UpdatePlan(entry *planEntry, newNodePlan plan.NodePlan, joinedTo string, maxFailures, failureThreshold int) error {
+func (p *PlanStore) UpdatePlan(entry *planEntry, newNodePlan plan.NodePlan, joinedTo string, maxFailures, failureThreshold int, overwriteFailureKeys bool) error {
 	if maxFailures < failureThreshold && failureThreshold != -1 && maxFailures != -1 {
 		return fmt.Errorf("failureThreshold (%d) cannot be greater than maxFailures (%d)", failureThreshold, maxFailures)
 	}
@@ -400,15 +400,21 @@ func (p *PlanStore) UpdatePlan(entry *planEntry, newNodePlan plan.NodePlan, join
 	// If the plan is being updated, then delete the probe-statuses so their healthy status will be reported as healthy only when they pass.
 	delete(secret.Data, "probe-statuses")
 
+	_, maxFailuresHasBeenSet := secret.Data["max-failures"]
 	secret.Data["plan"] = data
 	if maxFailures > 0 || maxFailures == -1 {
-		secret.Data["max-failures"] = []byte(strconv.Itoa(maxFailures))
+		if !maxFailuresHasBeenSet || maxFailuresHasBeenSet && overwriteFailureKeys {
+			secret.Data["max-failures"] = []byte(strconv.Itoa(maxFailures))
+		}
 	} else {
 		delete(secret.Data, "max-failures")
 	}
 
+	_, failureThresholdHasBeenSet := secret.Data["failure-threshold"]
 	if failureThreshold > 0 || failureThreshold == -1 {
-		secret.Data["failure-threshold"] = []byte(strconv.Itoa(failureThreshold))
+		if !failureThresholdHasBeenSet || failureThresholdHasBeenSet && overwriteFailureKeys {
+			secret.Data["failure-threshold"] = []byte(strconv.Itoa(failureThreshold))
+		}
 	} else {
 		delete(secret.Data, "failure-threshold")
 	}
@@ -477,7 +483,7 @@ func (p *PlanStore) removePlanSecretLabel(entry *planEntry, key string) error {
 // assignAndCheckPlan assigns the given newPlan to the designated server in the planEntry, and will return nil if the plan is assigned and in sync.
 func assignAndCheckPlan(store *PlanStore, msg string, entry *planEntry, newPlan plan.NodePlan, joinedTo string, failureThreshold, maxRetries int) error {
 	if entry.Plan == nil || !equality.Semantic.DeepEqual(entry.Plan.Plan, newPlan) {
-		if err := store.UpdatePlan(entry, newPlan, joinedTo, failureThreshold, maxRetries); err != nil {
+		if err := store.UpdatePlan(entry, newPlan, joinedTo, failureThreshold, maxRetries, true); err != nil {
 			return err
 		}
 		return errWaiting(fmt.Sprintf("starting %s", msg))


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46620

## Problem

https://github.com/rancher/rancher/pull/47500 updated the `max-failures` value on Windows plans. This ensures that plans  which fail due to transient Windows issues unrelated to Rancher are reattempted. In order to properly reattempt plans, changes to the rancher-system agent were required (https://github.com/rancher/system-agent/pull/201). However, #47500 unconditionally updates the `max-failures` value on all Windows plans, even those delivered to nodes running out dated versions of rancher-wins which do not contain the required system-agent changes. This has an unintended side effect of suppressing plan failure errors in the UI. As older versions of rancher-wins do not reattempt plans which have previously succeeded, but have recently failed, Rancher will never display an error in its UI for that node if an error is encountered.
 
## Solution

Do not update the `max-failures` value on existing Windows plans. Continue to allow `max-failures` to be updated for all Linux plans. This ensures that only new Windows nodes provisioned with the latest version of rancher-wins are configured to run the installation plan multiple times, and behavior on Linux is unchanged. This results in Windows nodes which do not have the correct version of rancher-wins installed properly reporting plan failures. 

The ultimate solution to this issue is to properly upgrade rancher-wins when Rancher is upgraded. **When that functionality is implemented, these changes can be safely reverted.** 

## Testing

+ provision a cluster using a version Rancher server running a commit that does not include #47500 and confirm that the install plan has a `max-failures` value of `-1`. 
+ Upgrade Rancher to a commit containing #47500  and confirm that the existing node plan was not updated. 
+ Provision a new node and confirm that the new node plan has a `max-failures` count of 5. 
+ Attempt to reproduce https://github.com/rancher/rancher/issues/42458 on the first node provisioned. Ensure that the plan failure error is shown in the UI. 

## Engineering Testing
### Manual Testing

I've done the above 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_