### PR TITLE
[main] add airgap tests for fleet -- approved, waiting for thaw

### DIFF
--- a/tests/v2/validation/fleet/provisioning/airgap/README.md
+++ b/tests/v2/validation/fleet/provisioning/airgap/README.md
@@ -1,0 +1,43 @@
+# Fleet in Airgap
+
+## Getting Started
+You should have a basic understanding of Corral before running this test. In order to run the entire airgap package set the package to `fleet/provisioning/airgap/...` Your GO suite should be set to blank. 
+Running fleet in airgap, in terms of user config, is exactly what you would input for provisioning in airgap; a working corral config that points to your airgapped resources. The only differences are:
+* this test only runs 1 k8s version instead of the entire list
+* this test only uses rke2, as custer type doesn't matter for fleet at this time
+
+
+In your config file, set the following:
+```yaml
+provisioningInput:
+  # For the cni and kubernetes versions please leave blank unless you'd like to specifically test a version. Defaults to latest k8s version and calico. 
+  cni:
+  - calico
+  rke2KubernetesVersion:
+  - v1.xx.xx
+registries:
+  existingNoAuthRegistry: <value> # only set this if the registry was created beforehand just do `corral vars <corral> registry_fqdn` to get the registry hostname 
+corralPackages:
+  corralPackageImages:
+    airgapCustomCluster: .../dist/aws-rancher-custom-cluster-true
+    rancherHA: .../dist/aws-aws-registry-standalone-rke2-rancher-airgap-calico-true-2.15.1-1.11.0 # the name of the corral rancher is configurable with config entry above
+    ...
+  hasDebug: <bool, default=false>
+  hasCleanup: <bool, default=true>
+  hasSetCorralSSHKeys: <bool, default=false> # If you are creating the airgap rancher instance in the same test run, please set this to true so then the air gap cluster can communicate with the rancher instance. If the rancher instance was created beforehand this boolean is ignored.
+corralConfigs:
+  corralConfigUser: <string, default="jenkauto">
+  corralConfigVars:
+    <var1>: <string, "val1"> # for now only aws is supported, so use the appropriate aws vars
+    bastion_ip: <val> # if the air gap rancher instance is created beforehand (not in the same job) set this to the registry public IP, otherwise it is automatically done in the job.
+    corral_private_key: <val> # only set this if you have created the airgap rancher instance beforehand. By doing `corral vars <corral> corral_private_key`
+    corral_public_key: <val> # only set this if you have created the airgap rancher instance beforehand. By doing `corral vars <corral> corral_private_key`
+    registry_cert: <val> # cert for the registry
+    registry_key: <val>  # key for the registry
+    ...
+  corralSSHPath: <string, optional, mostly for local testing>
+```
+
+
+Note: `corralConfigUser` will be the prefix for all resources created in your provider. 
+From there, your `corralConfigVars` should contain the parameters necessary to run the test. You can see what variables need to be set by navigating to your corral package folder and checking the `manifest.yaml` variables.

--- a/tests/v2/validation/fleet/provisioning/airgap/airgap.go
+++ b/tests/v2/validation/fleet/provisioning/airgap/airgap.go
@@ -1,0 +1,180 @@
+package airgap
+
+import (
+	"crypto/x509"
+	"errors"
+	"os"
+	"strings"
+
+	"encoding/pem"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	"golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	corralBastionIP  = "bastion_ip"
+	corralSSHUser    = "aws_ssh_user"
+	corralPrivateKey = "corral_private_key"
+	systemRegistry   = "system-default-registry"
+
+	fleetExampleFolderName = "fleet-examples.git"
+	rancherGithubURL       = "https://github.com/rancher/"
+	fleetDefaultNS         = "fleet-default"
+
+	sshPort = ":22"
+	rsa     = "RSA"
+	tcp     = "tcp"
+)
+
+func setupAirgapFleetResources(bastionUser, bastionIP, privateKey string) (string, error) {
+	var key ssh.Signer
+	var err error
+
+	if strings.Contains(privateKey, rsa) {
+
+		keyBlock, _ := pem.Decode([]byte(privateKey))
+		if keyBlock == nil {
+			return "", errors.New("unable to use privateKey")
+		}
+
+		rsaKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		if err != nil {
+			return "", err
+		}
+
+		key, err = ssh.NewSignerFromKey(rsaKey)
+	} else {
+		key, err = ssh.ParsePrivateKey([]byte(privateKey))
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return updateLocalFleetRepo(bastionUser, bastionIP, key)
+
+}
+
+// updateLocalFleetRepo clones fleet-examples repo onto the bastion node via ssh
+func updateLocalFleetRepo(bastionUser, bastionIP string, privateKey ssh.Signer) (string, error) {
+	config := &ssh.ClientConfig{
+		User: bastionUser,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(privateKey),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	conn, err := ssh.Dial(tcp, bastionIP+sshPort, config)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	// install git if it isn't on the bastion already
+	err = executeCommand(conn, "git version")
+	if err != nil {
+		gitSession, err := conn.NewSession()
+		if err != nil {
+			return "", err
+		}
+		defer gitSession.Close()
+
+		osOutput, err := gitSession.CombinedOutput("hostnamectl")
+		if err != nil {
+			return "", err
+		}
+		osString := string(osOutput)
+
+		if strings.Contains(osString, "Ubuntu") {
+			err = executeCommand(conn, "sudo apt-get update && sudo apt-get install -y git")
+		} else if strings.Contains(osString, "SUSE") {
+			err = executeCommand(conn, "sudo zypper refresh && sudo zypper install git -y")
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+
+	err = executeCommand(conn, "cd ~/ && git clone --mirror "+rancherGithubURL+fleetExampleFolderName)
+	if err != nil {
+		if !strings.Contains(err.Error(), "128") {
+			return "", err
+		}
+	}
+
+	err = executeCommand(conn, "sudo git config --system --add safe.directory '*'")
+	if err != nil {
+		return "", err
+	}
+
+	session, err := conn.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+
+	internalByteIP, err := session.CombinedOutput("hostname -I | awk '{print $1}'")
+
+	// output ends in a newline, which we don't need
+	return string(internalByteIP)[:len(internalByteIP)-1], err
+}
+
+// executeCommand executes a command via ssh. Each executed command needs its own session. See ssh package for more details.
+func executeCommand(client *ssh.Client, command string) error {
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	session.Stdout = os.Stdout
+	session.Stderr = os.Stderr
+
+	return session.Run(command)
+}
+
+// createSSHSecret is a helper to create a secret using wrangler client for ssh in fleet-default
+func createSSHSecret(client *rancher.Client, data map[string][]byte) (*corev1.Secret, error) {
+	var err error
+
+	ctx := client.WranglerContext
+
+	secretName := namegenerator.AppendRandomString("fleet-ssh")
+	secretTemplate := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: fleetDefaultNS,
+		},
+		Data: data,
+		Type: corev1.SecretTypeSSHAuth,
+	}
+
+	createdSecret, err := ctx.Core.Secret().Create(&secretTemplate)
+
+	return createdSecret, err
+}
+
+// createFleetSSHSecret creates an sshSecret in fleet-default namespace for use with fleet resources
+func createFleetSSHSecret(client *rancher.Client, privateKey string) (string, error) {
+	key, err := ssh.ParsePrivateKey([]byte(privateKey))
+	if err != nil {
+		return "", err
+	}
+
+	keyData := map[string][]byte{
+		"ssh-publickey":  []byte(key.PublicKey().Marshal()),
+		"ssh-privatekey": []byte(privateKey),
+	}
+
+	secretResp, err := createSSHSecret(client, keyData)
+	if err != nil {
+		return "", err
+	}
+
+	return secretResp.Name, nil
+}

--- a/tests/v2/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
+++ b/tests/v2/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
 	"github.com/rancher/rancher/tests/v2/actions/reports"
-	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
-	"github.com/rancher/rancher/tests/v2/validation/provisioning/registries"
 	"github.com/rancher/shepherd/clients/corral"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -56,12 +54,6 @@ func (a *AirGapRKE2CustomClusterTestSuite) SetupSuite() {
 
 	a.clustersConfig = new(provisioninginput.Config)
 	config.LoadConfig(provisioninginput.ConfigurationFileKey, a.clustersConfig)
-
-	corralRancherHA := new(corralha.CorralRancherHA)
-	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
-
-	registriesConfig := new(registries.Registries)
-	config.LoadConfig(registries.RegistriesConfigKey, registriesConfig)
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(a.T(), err)
@@ -199,8 +191,6 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestCustomClusterWithGitRepo() {
 			testClusterConfig.CNI = a.clustersConfig.CNIs[0]
 
 			clusterObject, err := provisioning.CreateProvisioningAirgapCustomCluster(tt.client, testClusterConfig, a.corralPackage)
-			require.NoError(a.T(), err)
-
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(a.T(), err)
 

--- a/tests/v2/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
+++ b/tests/v2/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
@@ -1,0 +1,224 @@
+//go:build validation
+
+package airgap
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/v2/actions/clusters"
+	"github.com/rancher/rancher/tests/v2/actions/fleet"
+	provisioning "github.com/rancher/rancher/tests/v2/actions/provisioning"
+	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
+	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
+	"github.com/rancher/rancher/tests/v2/actions/reports"
+	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/registries"
+	"github.com/rancher/shepherd/clients/corral"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	extensionsfleet "github.com/rancher/shepherd/extensions/fleet"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AirGapRKE2CustomClusterTestSuite struct {
+	suite.Suite
+	client         *rancher.Client
+	standardClient *rancher.Client
+	session        *session.Session
+	corralPackage  *corral.Packages
+	clustersConfig *provisioninginput.Config
+	registryFQDN   string
+	fleetGitRepo   *v1alpha1.GitRepo
+}
+
+func (a *AirGapRKE2CustomClusterTestSuite) TearDownSuite() {
+	a.session.Cleanup()
+}
+
+func (a *AirGapRKE2CustomClusterTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	a.session = testSession
+
+	a.clustersConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, a.clustersConfig)
+
+	corralRancherHA := new(corralha.CorralRancherHA)
+	config.LoadConfig(corralha.CorralRancherHAConfigConfigurationFileKey, corralRancherHA)
+
+	registriesConfig := new(registries.Registries)
+	config.LoadConfig(registries.RegistriesConfigKey, registriesConfig)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(a.T(), err)
+
+	a.client = client
+
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	enabled := true
+
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(a.T(), err)
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(a.T(), err)
+
+	a.standardClient = standardUserClient
+
+	corralConfig := corral.Configurations()
+	err = corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	require.NoError(a.T(), err)
+
+	a.corralPackage = corral.PackagesConfig()
+
+	bastionIP := corralConfig.CorralConfigVars[corralBastionIP]
+	bastionUser := corralConfig.CorralConfigVars[corralSSHUser]
+
+	// format the privateKey string for use with ssh package.
+	privateKey := corralConfig.CorralConfigVars[corralPrivateKey]
+	privateKey = strings.Replace(privateKey, "\\n", "\n", -1)
+	privateKey = strings.Replace(privateKey, "\"", "", -1)
+	privateKey = fmt.Sprintf("%s", privateKey)
+
+	err = corral.UpdateCorralConfig(corralBastionIP, bastionIP)
+	require.NoError(a.T(), err)
+
+	registrySetting, err := client.Management.Setting.ByID(systemRegistry)
+	require.NoError(a.T(), err)
+
+	a.registryFQDN = registrySetting.Value
+
+	internalIP, err := setupAirgapFleetResources(bastionUser, bastionIP, privateKey)
+	require.NoError(a.T(), err, "failed to setup local git repo on bastion")
+
+	fleetSecretName, err := createFleetSSHSecret(client, privateKey)
+	require.NoError(a.T(), err, "failed to create SSH Secrets for fleet")
+
+	a.fleetGitRepo = &v1alpha1.GitRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fleet.FleetMetaName + namegenerator.RandStringLower(5),
+			Namespace: fleet.Namespace,
+		},
+		Spec: v1alpha1.GitRepoSpec{
+			Repo:            fmt.Sprintf("%s@%s:/home/%s/%s", bastionUser, internalIP, bastionUser, fleetExampleFolderName),
+			Branch:          fleet.BranchName,
+			Paths:           []string{fleet.GitRepoPathLinux},
+			CorrectDrift:    &v1alpha1.CorrectDrift{},
+			ImageScanCommit: v1alpha1.CommitSpec{AuthorName: "", AuthorEmail: ""},
+			Targets: []v1alpha1.GitTarget{
+				{
+					ClusterSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      fleet.MatchKey,
+								Operator: fleet.MatchOperator,
+								Values: []string{
+									fleet.HarvesterName,
+								},
+							},
+						},
+					},
+				},
+			},
+			ClientSecretName: fleetSecretName,
+		},
+	}
+
+	a.client, err = a.client.ReLogin()
+	require.NoError(a.T(), err)
+
+	if a.clustersConfig.RKE2KubernetesVersions == nil {
+		rke2Versions, err := kubernetesversions.ListRKE2AllVersions(a.client)
+		require.NoError(a.T(), err)
+
+		a.clustersConfig.RKE2KubernetesVersions = []string{rke2Versions[len(rke2Versions)-1]}
+	}
+
+	if a.clustersConfig.CNIs == nil {
+		a.clustersConfig.CNIs = []string{fleet.CniCalico}
+	}
+}
+
+func (a *AirGapRKE2CustomClusterTestSuite) TestCustomClusterWithGitRepo() {
+	fleetVersion, err := fleet.GetDeploymentVersion(a.client, fleet.FleetControllerName, fleet.LocalName)
+	require.NoError(a.T(), err)
+	singleNodeRoles := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+
+	tests := []struct {
+		name        string
+		client      *rancher.Client
+		machinePool []provisioninginput.MachinePools
+	}{
+		{fleet.FleetName + " " + fleetVersion + "-" + permutations.RKE2AirgapCluster, a.standardClient, singleNodeRoles},
+	}
+	for _, tt := range tests {
+
+		testSession := session.NewSession()
+		defer testSession.Cleanup()
+
+		adminClient, err := a.client.WithSession(testSession)
+		require.NoError(a.T(), err)
+
+		provisioningConfig := *a.clustersConfig
+
+		provisioningConfig.Hardened = true
+		provisioningConfig.MachinePools = tt.machinePool
+
+		a.Run(tt.name, func() {
+
+			logrus.Info("Deploying airgap fleet gitRepo")
+			gitRepoObject, err := extensionsfleet.CreateFleetGitRepo(adminClient, a.fleetGitRepo)
+			require.NoError(a.T(), err)
+
+			logrus.Info("Deploying Custom Airgap Cluster")
+			testClusterConfig := clusters.ConvertConfigToClusterConfig(&provisioningConfig)
+
+			testClusterConfig.KubernetesVersion = a.clustersConfig.RKE2KubernetesVersions[0]
+			testClusterConfig.CNI = a.clustersConfig.CNIs[0]
+
+			clusterObject, err := provisioning.CreateProvisioningAirgapCustomCluster(tt.client, testClusterConfig, a.corralPackage)
+			require.NoError(a.T(), err)
+
+			reports.TimeoutClusterReport(clusterObject, err)
+			require.NoError(a.T(), err)
+
+			provisioning.VerifyCluster(a.T(), tt.client, testClusterConfig, clusterObject)
+
+			status := &apisV1.ClusterStatus{}
+			err = steveV1.ConvertToK8sType(clusterObject.Status, status)
+			require.NoError(a.T(), err)
+
+			err = fleet.VerifyGitRepo(adminClient, gitRepoObject.ID, status.ClusterName, clusterObject.ID)
+			require.NoError(a.T(), err)
+		})
+	}
+
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestFleetInAirGapProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(AirGapRKE2CustomClusterTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/1524 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
we need to test deploying fleet repos in airgap, as well as checking that the resources from the repo are deployed correctly to specified clusters. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
* add ssh helpers to a new file in fleet/ that clone the fleet-examples repo for use in the airgapped cluster(s)
* add helpers to create fleet secrets that can pull the git repo from the bastion node using SSH
* add airgap + fleet provisioning test
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
local and CI (jenkins) passed
