### PR TITLE
Csp-adapter v5.0.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 105.0.0+up0.6.1-rc.5
 provisioningCAPIVersion: 105.0.0+up0.4.0
-cspAdapterMinVersion: 105.0.0+up5.0.0-rc1
+cspAdapterMinVersion: 105.0.0+up5.0.0
 defaultShellVersion: rancher/shell:v0.3.0-rc.2
 fleetVersion: 105.0.0+up0.11.0-beta.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion    = "105.0.0+up5.0.0-rc1"
+	CspAdapterMinVersion    = "105.0.0+up5.0.0"
 	DefaultShellVersion     = "rancher/shell:v0.3.0-rc.2"
 	FleetVersion            = "105.0.0+up0.11.0-beta.1"
 	ProvisioningCAPIVersion = "105.0.0+up0.4.0"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/46833
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 Support k8s 1.31
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
scenario 1 (fresh install):

On an EKS cluster, install locally built rancher with cspAdapterMinVersion: 105.0.0+up5.0.0
Validated the support config and license entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.
