### PR TITLE
Fix: SAML logout AuthConfig migration

### DIFF
--- a/pkg/auth/data/authconfig_data.go
+++ b/pkg/auth/data/authconfig_data.go
@@ -97,8 +97,6 @@ func addAuthConfigCore(name, aType string, enabled, sloSupported bool, managemen
 	}
 	annotations[auth.CleanupAnnotation] = auth.CleanupRancherLocked
 
-	// technote: An ObjectClient is used for the creation to ensure that all fields of all the
-	// possible AuthConfig variants make it into the store unharmed.
 	createdOrKnown, err := management.Management.AuthConfigs("").ObjectClient().Create(&v3.AuthConfig{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        name,

--- a/pkg/auth/data/authconfig_data.go
+++ b/pkg/auth/data/authconfig_data.go
@@ -113,19 +113,8 @@ func addAuthConfigCore(name, aType string, enabled, sloSupported bool, managemen
 			return err
 		}
 
-		// The AC already exists. The result of the Create (in `createdOrKnown`) is just the
-		// object given to it as argument. It is NOT the object found in the store. It is
-		// still needed as argument for Patch().
-		//
-		// Given that a Patch operation is (a) quick, and (b) does not throw an error when
-		// given a no-op, pulling the existing object and checking if the flag has the
-		// proper value or not is not really an optimization. Setting the flag is therefore
-		// done unconditionally. This ensures both existence and proper value without fuss.
-		//
-		// Note that the `add` operation works even when the flag field exists. It behaves
-		// like a `replace`. This may just be because the flag is a scalar field, neither
-		// object, nor array.
-
+		// Make sure the logoutAllSupported field is set correctly for the existing authConfig.
+		// Use patch to avoid fetching the object first.
 		patch, err := json.Marshal([]struct {
 			Op    string `json:"op"`
 			Path  string `json:"path"`


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Noticed while working on https://github.com/rancher/rancher/pull/47669
 
## Problem

The code setting up AuthConfig resources on startup of Rancher ignores already existing resources.
This means that when migrating from a older version of Rancher to the version containing SAML logout
the existing AuthConfig resources are not updated to have a `logoutAllSupported` field with a proper value.
While the CRD update makes the field available it will be set to the default, `false`, for all providers, even those
that do support the new feature.
 
## Solution

The code setting up `AuthConfig` resources is extended to not ignore `AlreadyExists` errors.
Instead it uses this as a signal to patch the proper value of `logoutAllSupported` into the existing resource.
This migrates the `AuthConfig` resources of old clusters to have the proper value for the field.
This also fixes any improper changes users may have done by directly editing these resources from outside of Rancher.
As a patch operation this does nothing when the resource already has the field with the proper value.

Limitation: Fixing the flags happens only as part of a restart of the backend binary/pod. This may be a long time after directly editing of AuthConfig resources gave them incorrect values.

An additional guard point may be the disabling of an active auth provider, as that resets the AuthConfig to a base state. Note that this reset currently only removes the undesired fields of the various auth configs, it does not touch the fvalues of the retained fields. This could be extended to also force a proper value on logoutAllSupported.

## Testing

Test scenarios
  1. Migrate a cluster from Rancher without SAML logout to the version having SAML logout. Verify that the `AuthConfig` resources have all the proper values for `logoutAllSupported` after the migration.
  1. Directly edit `AuthConfig` resources to have improper values for `logoutAllSupported`. Restart the Rancher backend. Verify that the `AuthConfig` resources have all the proper values for `logoutAllSupported` after the restart.

The fix should be done within a minute, at most two, from startup.

## Engineering Testing
### Manual Testing

Manual testing with a local cluster and directly edited `AuthConfig` resources (scenario 2) shows Rancher startup fixing the wrong values to the correct settings.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_