### PR TITLE
[v2.9] Backport Windows Environment Variable Formatting Fixes 

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -677,3 +677,42 @@ func PreBootstrap(mgmtCluster *v3.Cluster) bool {
 
 	return !v3.ClusterConditionPreBootstrapped.IsTrue(mgmtCluster)
 }
+
+// FormatWindowsEnvVar accepts a corev1.EnvVar and returns a string to be used in either
+// a Powershell script or the Rancher planner, indicated by the isPlanVariable parameter.
+// This function automatically configures the '$env:' prefix for a given environment variable,
+// automatically prefixes boolean values with '$', and surrounds string variables with double quotes as
+// needed. If the provided variable name incorrectly uses either '$env:' or '$' for the given isPlanVariable
+// value, it will be removed.
+func FormatWindowsEnvVar(envVar corev1.EnvVar, isPlanVariable bool) string {
+	lowerValue := strings.ToLower(envVar.Value)
+	isBool := lowerValue == "$true" || lowerValue == "$false" ||
+		lowerValue == "true" || lowerValue == "false"
+
+	// remove any user provided prefixes and quotations
+	envVar.Name = strings.TrimPrefix(envVar.Name, "$env:")
+	envVar.Value = strings.Trim(envVar.Value, "\"")
+
+	if !isBool {
+		format := ""
+		// Non-boolean variables are always treated as strings,
+		// even numbers
+		format = "$env:%s=\"%s\""
+		if isPlanVariable {
+			format = "%s=%s"
+		}
+
+		return fmt.Sprintf(format, envVar.Name, envVar.Value)
+	}
+
+	if !isPlanVariable {
+		if !strings.HasPrefix(envVar.Value, "$") {
+			envVar.Value = "$" + envVar.Value
+		}
+		return fmt.Sprintf("$env:%s=%s", envVar.Name, envVar.Value)
+	}
+
+	envVar.Value = strings.Trim(envVar.Value, "$")
+
+	return fmt.Sprintf("%s=%s", envVar.Name, envVar.Value)
+}

--- a/pkg/capr/common_test.go
+++ b/pkg/capr/common_test.go
@@ -9,6 +9,7 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -310,6 +311,97 @@ func TestCompressInterface(t *testing.T) {
 			err = DecompressInterface(result, target)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.value, target)
+		})
+	}
+}
+
+func TestFormatWindowsEnvVar(t *testing.T) {
+	tests := []struct {
+		Name           string
+		EnvVar         corev1.EnvVar
+		IsPlanVar      bool
+		ExpectedString string
+	}{
+		{
+			Name: "Basic String",
+			EnvVar: corev1.EnvVar{
+				Name:  "BASIC_STRING",
+				Value: "ABC123",
+			},
+			IsPlanVar:      false,
+			ExpectedString: "$env:BASIC_STRING=\"ABC123\"",
+		},
+		{
+			Name: "Basic Bool",
+			EnvVar: corev1.EnvVar{
+				Name:  "BASIC_BOOL",
+				Value: "true",
+			},
+			IsPlanVar:      false,
+			ExpectedString: "$env:BASIC_BOOL=$true",
+		},
+		{
+			Name: "Basic Plan String",
+			EnvVar: corev1.EnvVar{
+				Name:  "PLAN_STRING",
+				Value: "VALUE",
+			},
+			IsPlanVar:      true,
+			ExpectedString: "PLAN_STRING=VALUE",
+		},
+		{
+			Name: "Basic Plan Bool",
+			EnvVar: corev1.EnvVar{
+				Name:  "PLAN_BOOL",
+				Value: "true",
+			},
+			IsPlanVar:      true,
+			ExpectedString: "PLAN_BOOL=true",
+		},
+		{
+			Name: "Plan Name Mistakenly Includes $env:",
+			EnvVar: corev1.EnvVar{
+				Name:  "$env:PLAN_BOOL",
+				Value: "true",
+			},
+			IsPlanVar:      true,
+			ExpectedString: "PLAN_BOOL=true",
+		},
+		{
+			Name: "Plan Bool Mistakenly Includes $",
+			EnvVar: corev1.EnvVar{
+				Name:  "PLAN_BOOL",
+				Value: "$true",
+			},
+			IsPlanVar:      true,
+			ExpectedString: "PLAN_BOOL=true",
+		},
+		{
+			Name: "Non-Plan String Value Includes $",
+			EnvVar: corev1.EnvVar{
+				Name:  "PLAN_BOOL",
+				Value: "\"$true\"",
+			},
+			IsPlanVar:      false,
+			ExpectedString: "$env:PLAN_BOOL=\"$true\"",
+		},
+		{
+			Name: "Plan String Value Includes $",
+			EnvVar: corev1.EnvVar{
+				Name:  "PLAN_BOOL",
+				Value: "\"$true\"",
+			},
+			IsPlanVar:      true,
+			ExpectedString: "PLAN_BOOL=$true",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			out := FormatWindowsEnvVar(tc.EnvVar, tc.IsPlanVar)
+			if out != tc.ExpectedString {
+				t.Fatalf("Expected %s, got %s", tc.ExpectedString, out)
+			}
 		})
 	}
 }

--- a/pkg/capr/planner/instructions_test.go
+++ b/pkg/capr/planner/instructions_test.go
@@ -50,7 +50,7 @@ func TestPlanner_generateInstallInstruction(t *testing.T) {
 				command:         "powershell.exe",
 				scriptName:      "run.ps1",
 				envs:            []string{},
-				expectedEnvsLen: 2,
+				expectedEnvsLen: 3,
 				image:           "my/custom-image-",
 				expectedImage:   "my/custom-image-rke2:v1.21.5-rke2r2",
 			},
@@ -77,8 +77,8 @@ func TestPlanner_generateInstallInstruction(t *testing.T) {
 				os:              "windows",
 				command:         "powershell.exe",
 				scriptName:      "run.ps1",
-				envs:            []string{"$env:HTTP_PROXY", "$env:HTTPS_PROXY", "$env:INSTALL_RKE2_EXEC"},
-				expectedEnvsLen: 4,
+				envs:            []string{"HTTP_PROXY", "HTTPS_PROXY", "INSTALL_RKE2_EXEC"},
+				expectedEnvsLen: 5,
 				image:           "my/custom-image-",
 				expectedImage:   "my/custom-image-rke2:v1.21.5-rke2r2",
 			},
@@ -106,7 +106,7 @@ func TestPlanner_generateInstallInstruction(t *testing.T) {
 			a.Equal(p.Image, tt.args.expectedImage)
 			a.Equal(tt.args.expectedEnvsLen, len(p.Env))
 			for _, e := range tt.args.envs {
-				a.True(findEnv(p.Env, e), "couldn't find %s in environment", e)
+				a.True(findEnvName(p.Env, e), "couldn't find %s in environment", e)
 			}
 		})
 	}
@@ -149,7 +149,7 @@ func TestPlanner_addInstallInstructionWithRestartStamp(t *testing.T) {
 				os:              "windows",
 				command:         "powershell.exe",
 				scriptName:      "run.ps1",
-				envs:            []string{"$env:RESTART_STAMP"},
+				envs:            []string{"WINS_RESTART_STAMP"},
 				image:           "my/custom-image-",
 				expectedImage:   "my/custom-image-rke2:v1.21.5-rke2r2",
 			},
@@ -181,7 +181,7 @@ func TestPlanner_addInstallInstructionWithRestartStamp(t *testing.T) {
 			a.Contains(instruction.Args, tt.args.scriptName)
 			a.GreaterOrEqual(len(instruction.Env), 1)
 			for _, e := range tt.args.envs {
-				a.True(findEnv(instruction.Env, e), "couldn't find %s in environment", e)
+				a.True(findEnvName(instruction.Env, e), "couldn't find %s in environment", e)
 			}
 		})
 	}
@@ -211,7 +211,7 @@ func TestPlanner_generateInstallInstructionWithSkipStart(t *testing.T) {
 				os:              "linux",
 				command:         "sh",
 				scriptName:      "run.sh",
-				envs:            []string{"INSTALL_RKE2_SKIP_START=true"},
+				envs:            []string{"INSTALL_RKE2_SKIP_START"},
 				image:           "my/custom-image-",
 				expectedImage:   "my/custom-image-rke2:v1.21.5-rke2r2",
 			},
@@ -224,7 +224,7 @@ func TestPlanner_generateInstallInstructionWithSkipStart(t *testing.T) {
 				os:              "windows",
 				command:         "powershell.exe",
 				scriptName:      "run.ps1",
-				envs:            []string{"$env:INSTALL_RKE2_SKIP_START=\"true\""},
+				envs:            []string{"INSTALL_RKE2_SKIP_START"},
 				image:           "my/custom-image-",
 				expectedImage:   "my/custom-image-rke2:v1.21.5-rke2r2",
 			},
@@ -253,7 +253,7 @@ func TestPlanner_generateInstallInstructionWithSkipStart(t *testing.T) {
 			a.Contains(p.Args, tt.args.scriptName)
 			a.GreaterOrEqual(len(p.Env), 1)
 			for _, e := range tt.args.envs {
-				a.True(findEnv(p.Env, e), "couldn't find %s in environment", e)
+				a.True(findEnvName(p.Env, e), "couldn't find %s in environment", e)
 			}
 		})
 	}

--- a/pkg/capr/planner/planner_test.go
+++ b/pkg/capr/planner/planner_test.go
@@ -124,7 +124,7 @@ func TestPlanner_addInstruction(t *testing.T) {
 				os:              "windows",
 				command:         "powershell.exe",
 				scriptName:      "run.ps1",
-				envs:            []string{"$env:RESTART_STAMP", "$env:INSTALL_RKE2_EXEC"},
+				envs:            []string{"WINS_RESTART_STAMP", "INSTALL_RKE2_EXEC"},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestPlanner_addInstruction(t *testing.T) {
 			a.Contains(instruction.Image, tt.args.expectedVersion)
 			a.Contains(instruction.Args, tt.args.scriptName)
 			for _, e := range tt.args.envs {
-				a.True(findEnv(instruction.Env, e), "couldn't find %s in environment", e)
+				a.True(findEnvName(instruction.Env, e), "couldn't find %s in environment", e)
 			}
 		})
 	}
@@ -213,9 +213,13 @@ func createTestPlanEntryWithoutRoles(os string) *planEntry {
 	return entry
 }
 
-func findEnv(s []string, v string) bool {
+func findEnvName(s []string, v string) bool {
 	for _, item := range s {
-		if strings.Contains(item, v) {
+		split := strings.Split(item, "=")
+		if len(split) != 2 {
+			return false
+		}
+		if split[0] == v {
 			return true
 		}
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/47718, https://github.com/rancher/rancher/issues/47719, https://github.com/rancher/rancher/issues/47720
 
This is a _partial_ backport of https://github.com/rancher/rancher/pull/47500. Only the changes which fix how Windows environment variables are formatted have been included. This is needed so that the changes in the `system-agent-installer-rke2` will be leveraged on 2.9. 

## Testing
+ Provision a Windows cluster using any version of rke2 
+ Look at the machine-plan secret in the local cluster for the Windows node
+ Verify that the environment variables set in the plan key are not prefixed with `$env:`, do not include quotes around strings and numbers, and does not prefix boolean values with `$`. 
  + Note the `$env:RKE2_DATA_DIR` variable was intentionally not fixed, and will still have the `$env:` prefix and value quotes 
   + Ensure that `WINS_RESTART_STAMP`, `INSTALL_RKE2_VERSION` and `INSTALL_RKE2_EXEC` are all present 
+ Add two agent environment variables: `abc=123` and `def=true`
+ Ensure that the machine-plan secret  in the local cluster  for the Windows node contains those variables, and that it meets the formatting requirements described in step 3

## Engineering Testing
### Manual Testing
I've done the above 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_