### PR TITLE
[v2.10] Change the backing namespace of projects

### DIFF
--- a/pkg/api/norman/customization/globalnamespaceaccess/access_common.go
+++ b/pkg/api/norman/customization/globalnamespaceaccess/access_common.go
@@ -37,6 +37,7 @@ type MemberAccess struct {
 	Prtbs              v3.ProjectRoleTemplateBindingInterface
 	Crtbs              v3.ClusterRoleTemplateBindingInterface
 	ProjectLister      v3.ProjectLister
+	ProjectClient      v3.ProjectInterface
 	ClusterLister      v3.ClusterLister
 }
 
@@ -63,7 +64,7 @@ func (ma *MemberAccess) IsAdmin(callerID string) (bool, error) {
 		return false, err
 	}
 	if u == nil {
-		return false, fmt.Errorf("No user found with ID %v", callerID)
+		return false, fmt.Errorf("no user found with ID %v", callerID)
 	}
 	// Get globalRoleBinding for this user
 	grbs, err := ma.GrbLister.List("", labels.NewSelector())
@@ -180,9 +181,19 @@ func (ma *MemberAccess) EnsureRoleInTargets(targetProjects, roleTemplates []stri
 		callerIsProjectOwner := false
 		callerIsProjectMember := false
 		callerIsClusterOwner := false
-		prtbs, err := ma.PrtbLister.List(pname, labels.NewSelector())
+
+		backingNamespace := pname
+		p, err := ma.ProjectClient.GetNamespaced(cname, pname, v1.GetOptions{})
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to get project %s in namespace %s: %w", pname, cname, err)
+		}
+		if p.Status.BackingNamespace != "" {
+			backingNamespace = p.Status.BackingNamespace
+		}
+
+		prtbs, err := ma.PrtbLister.List(backingNamespace, labels.NewSelector())
+		if err != nil {
+			return fmt.Errorf("unable to get PRTBs in namespace %s: %w", backingNamespace, err)
 		}
 		for _, prtb := range prtbs {
 			if prtb.UserName == callerID {
@@ -524,21 +535,29 @@ func (ma *MemberAccess) RemoveRolesFromTargets(targetProjects, rolesToRemove []s
 			return httperror.NewAPIError(httperror.InvalidBodyContent, errMsg)
 		}
 		clusterName, projectName := split[0], split[1]
-		clustersCovered := make(map[string]bool)
-		prtbs, err := ma.PrtbLister.List(projectName, labels.NewSelector())
+		backingNamespace := projectName
+		p, err := ma.ProjectClient.GetNamespaced(clusterName, projectName, v1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to get project %s in namespace %s: %w", projectName, clusterName, err)
+		}
+		if p.Status.BackingNamespace != "" {
+			backingNamespace = p.Status.BackingNamespace
+		}
+		prtbs, err := ma.PrtbLister.List(backingNamespace, labels.NewSelector())
 		if err != nil {
 			return err
 		}
 		for _, prtb := range prtbs {
 			if prtb.UserPrincipalName == systemUserPrincipalID {
 				if removeAllRoles || rolesToRemoveMap[prtb.RoleTemplateName] {
-					if err = ma.Prtbs.DeleteNamespaced(projectName, prtb.Name, &v1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+					if err = ma.Prtbs.DeleteNamespaced(backingNamespace, prtb.Name, &v1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
 						return err
 					}
 				}
 			}
 		}
 
+		clustersCovered := make(map[string]bool)
 		if !clustersCovered[clusterName] {
 			crtbs, err := ma.CrtbLister.List(clusterName, labels.NewSelector())
 			if err != nil {

--- a/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
+++ b/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
@@ -230,6 +230,7 @@ func (w Wrapper) modifyProjects(request *types.APIContext, actionName string) ([
 		Prtbs:              w.Prtbs,
 		Crtbs:              w.Crtbs,
 		ProjectLister:      w.ProjectLister,
+		ProjectClient:      w.ProjectClient,
 		ClusterLister:      w.ClusterLister,
 	}
 	accessType, err := ma.GetAccessTypeOfCaller(callerID, creatorID, mcapp.Name, mcapp.Spec.Members)

--- a/pkg/api/norman/customization/multiclusterapp/validator_multiclusterapp.go
+++ b/pkg/api/norman/customization/multiclusterapp/validator_multiclusterapp.go
@@ -42,6 +42,7 @@ type Wrapper struct {
 	Prtbs                         v3.ProjectRoleTemplateBindingInterface
 	Crtbs                         v3.ClusterRoleTemplateBindingInterface
 	ProjectLister                 v3.ProjectLister
+	ProjectClient                 v3.ProjectInterface
 	ClusterLister                 v3.ClusterLister
 	Apps                          pv3.AppInterface
 	TemplateVersionLister         v3.CatalogTemplateVersionLister
@@ -102,6 +103,7 @@ func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data
 		Prtbs:              w.Prtbs,
 		Crtbs:              w.Crtbs,
 		ProjectLister:      w.ProjectLister,
+		ProjectClient:      w.ProjectClient,
 		ClusterLister:      w.ClusterLister,
 	}
 	var targetProjects []string

--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -171,7 +171,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	authn.SetRTBStore(ctx, schemas.Schema(&managementschema.Version, client.ProjectRoleTemplateBindingType), apiContext)
 	nodeStore.SetupStore(schemas.Schema(&managementschema.Version, client.NodeType))
 	projectaction.SetProjectStore(schemas.Schema(&managementschema.Version, client.ProjectType), apiContext)
-	setupScopedTypes(schemas)
+	setupScopedTypes(schemas, apiContext)
 	setupPasswordTypes(ctx, schemas, apiContext)
 
 	multiclusterapp.SetMemberStore(ctx, schemas.Schema(&managementschema.Version, client.MultiClusterAppType), apiContext)
@@ -185,7 +185,8 @@ func setupPasswordTypes(ctx context.Context, schemas *types.Schemas, management 
 	passwordStore.SetPasswordStore(schemas, secretStore, nsStore)
 }
 
-func setupScopedTypes(schemas *types.Schemas) {
+func setupScopedTypes(schemas *types.Schemas, management *config.ScaledContext) {
+	projectClient := management.Management.Projects("")
 	for _, schema := range schemas.Schemas() {
 		if schema.Scope != types.NamespaceScope || schema.Store == nil || schema.Store.Context() != config.ManagementStorageContext {
 			continue
@@ -201,7 +202,7 @@ func setupScopedTypes(schemas *types.Schemas) {
 				continue
 			}
 
-			schema.Store = scoped.NewScopedStore(key, schema.Store)
+			schema.Store = scoped.NewScopedStore(key, schema.Store, projectClient)
 			ns.Required = false
 			schema.ResourceFields["namespaceId"] = ns
 			break
@@ -627,6 +628,7 @@ func MultiClusterApps(schemas *types.Schemas, management *config.ScaledContext) 
 		Prtbs:                         management.Management.ProjectRoleTemplateBindings(""),
 		Crtbs:                         management.Management.ClusterRoleTemplateBindings(""),
 		ProjectLister:                 management.Management.Projects("").Controller().Lister(),
+		ProjectClient:                 management.Management.Projects(""),
 		ClusterLister:                 management.Management.Clusters("").Controller().Lister(),
 		Apps:                          management.Project.Apps(""),
 		TemplateVersionLister:         management.Management.CatalogTemplateVersions("").Controller().Lister(),

--- a/pkg/api/norman/store/scoped/store.go
+++ b/pkg/api/norman/store/scoped/store.go
@@ -25,7 +25,9 @@ func NewScopedStore(key string, store types.Store, pClient v3.ProjectInterface) 
 				if data == nil {
 					return data, nil
 				}
-				if key == "clusterId" {
+
+				v := convert.ToString(data[key])
+				if !strings.HasSuffix(v, ":"+convert.ToString(data[client.ProjectFieldNamespaceId])) && !strings.HasSuffix(v, "-"+convert.ToString(data[client.ProjectFieldNamespaceId])) {
 					data[key] = data[client.ProjectFieldNamespaceId]
 				}
 

--- a/pkg/api/norman/store/scoped/store_test.go
+++ b/pkg/api/norman/store/scoped/store_test.go
@@ -1,0 +1,142 @@
+package scoped
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/rancher/norman/types"
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakeStore struct {
+}
+
+func (f fakeStore) Context() types.StorageContext {
+	return ""
+}
+func (f fakeStore) ByID(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (f fakeStore) List(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+func (f fakeStore) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	return data, nil
+}
+func (f fakeStore) Update(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, id string) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (f fakeStore) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (f fakeStore) Watch(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) (chan map[string]interface{}, error) {
+	return nil, nil
+}
+
+func TestStoreCreate(t *testing.T) {
+	store := fakeStore{}
+
+	p := fakes.ProjectInterfaceMock{}
+
+	tests := []struct {
+		name              string
+		key               string
+		getNamespacedFunc func(string, string, v1.GetOptions) (*v3.Project, error)
+		data              map[string]interface{}
+		want              map[string]interface{}
+		wantErr           bool
+	}{
+		{
+			name: "nil data returns nil",
+			data: nil,
+			want: nil,
+		},
+		{
+			name: "project: set namespace no backing namespace",
+			key:  "projectId",
+			getNamespacedFunc: func(s1, s2 string, g v1.GetOptions) (*v3.Project, error) {
+				p := v3.Project{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "project-XYZ",
+						Namespace: "cluster-ABC",
+					},
+				}
+				return &p, nil
+			},
+			data: map[string]interface{}{
+				"projectId": "cluster-ABC:project-XYZ",
+			},
+			want: map[string]interface{}{
+				"projectId":   "cluster-ABC:project-XYZ",
+				"namespaceId": "project-XYZ",
+			},
+		},
+		{
+			name: "project: set namespace to backing namespace",
+			key:  "projectId",
+			getNamespacedFunc: func(s1, s2 string, g v1.GetOptions) (*v3.Project, error) {
+				p := v3.Project{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "project-XYZ",
+						Namespace: "cluster-ABC",
+					},
+					Status: apisv3.ProjectStatus{
+						BackingNamespace: "c-ABC-p-XYZ",
+					},
+				}
+				return &p, nil
+			},
+			data: map[string]interface{}{
+				"projectId": "cluster-ABC:project-XYZ",
+			},
+			want: map[string]interface{}{
+				"projectId":   "cluster-ABC:project-XYZ",
+				"namespaceId": "c-ABC-p-XYZ",
+			},
+		},
+		{
+			name: "error getting project",
+			key:  "projectId",
+			getNamespacedFunc: func(s1, s2 string, g v1.GetOptions) (*v3.Project, error) {
+				return nil, fmt.Errorf("error")
+			},
+			data: map[string]interface{}{
+				"projectId": "cluster-ABC:project-XYZ",
+			},
+			wantErr: true,
+		},
+		{
+			name: "cluster: set namespaceId",
+			key:  "clusterId",
+			data: map[string]interface{}{
+				"clusterId": "cluster-ABC",
+			},
+			want: map[string]interface{}{
+				"clusterId":   "cluster-ABC",
+				"namespaceId": "cluster-ABC",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p.GetNamespacedFunc = tt.getNamespacedFunc
+			s := &Store{
+				Store:         store,
+				key:           tt.key,
+				projectClient: &p,
+			}
+			got, err := s.Create(nil, nil, tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Store.Create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Store.Create() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"strings"
+
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
 	v1 "k8s.io/api/core/v1"
@@ -352,6 +354,13 @@ type ProjectRoleTemplateBinding struct {
 	// Deprecated.
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty" norman:"nocreate,noupdate"`
+}
+
+func (p *ProjectRoleTemplateBinding) ObjClusterName() string {
+	if parts := strings.SplitN(p.ProjectName, ":", 2); len(parts) == 2 {
+		return parts[0]
+	}
+	return ""
 }
 
 // +genclient

--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -1,8 +1,6 @@
 package v3
 
 import (
-	"strings"
-
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
 	v1 "k8s.io/api/core/v1"
@@ -21,6 +19,8 @@ var (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="BACKINGNAMESPACE",type="string",JSONPath=".status.backingNamespace"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Project is a group of namespaces.
 // Projects are used to create a multi-tenant environment within a Kubernetes cluster by managing namespace operations,
@@ -51,6 +51,10 @@ type ProjectStatus struct {
 	// Conditions are a set of indicators about aspects of the project.
 	// +optional
 	Conditions []ProjectCondition `json:"conditions,omitempty"`
+
+	// BackingNamespace is the name of the namespace that contains resources associated with the project.
+	// +optional
+	BackingNamespace string `json:"backingNamespace,omitempty"`
 }
 
 // ProjectCondition is the status of an aspect of the project.
@@ -348,13 +352,6 @@ type ProjectRoleTemplateBinding struct {
 	// Deprecated.
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty" norman:"nocreate,noupdate"`
-}
-
-func (p *ProjectRoleTemplateBinding) ObjClusterName() string {
-	if parts := strings.SplitN(p.ProjectName, ":", 2); len(parts) == 2 {
-		return parts[0]
-	}
-	return ""
 }
 
 // +genclient

--- a/pkg/client/generated/management/v3/zz_generated_project.go
+++ b/pkg/client/generated/management/v3/zz_generated_project.go
@@ -7,6 +7,7 @@ import (
 const (
 	ProjectType                               = "project"
 	ProjectFieldAnnotations                   = "annotations"
+	ProjectFieldBackingNamespace              = "backingNamespace"
 	ProjectFieldClusterID                     = "clusterId"
 	ProjectFieldConditions                    = "conditions"
 	ProjectFieldContainerDefaultResourceLimit = "containerDefaultResourceLimit"
@@ -29,6 +30,7 @@ const (
 type Project struct {
 	types.Resource
 	Annotations                   map[string]string       `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	BackingNamespace              string                  `json:"backingNamespace,omitempty" yaml:"backingNamespace,omitempty"`
 	ClusterID                     string                  `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
 	Conditions                    []ProjectCondition      `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	ContainerDefaultResourceLimit *ContainerResourceLimit `json:"containerDefaultResourceLimit,omitempty" yaml:"containerDefaultResourceLimit,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_project_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_project_status.go
@@ -1,10 +1,12 @@
 package client
 
 const (
-	ProjectStatusType            = "projectStatus"
-	ProjectStatusFieldConditions = "conditions"
+	ProjectStatusType                  = "projectStatus"
+	ProjectStatusFieldBackingNamespace = "backingNamespace"
+	ProjectStatusFieldConditions       = "conditions"
 )
 
 type ProjectStatus struct {
-	Conditions []ProjectCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	BackingNamespace string             `json:"backingNamespace,omitempty" yaml:"backingNamespace,omitempty"`
+	Conditions       []ProjectCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 }

--- a/pkg/controllers/management/auth/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/crtb_handler_test.go
@@ -5,8 +5,12 @@ import (
 	"testing"
 	"time"
 
+	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
+	corefakes "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +18,7 @@ import (
 )
 
 var (
-	e           = fmt.Errorf("error")
+	errDefault  = fmt.Errorf("error")
 	defaultCRTB = v3.ClusterRoleTemplateBinding{
 		UserName:           "test",
 		GroupName:          "",
@@ -37,10 +41,23 @@ var (
 			Name: "test-project",
 		},
 	}
+	backingNamespaceProject = v3.Project{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-project",
+		},
+		Status: apisv3.ProjectStatus{
+			BackingNamespace: "c-ABC-p-XYZ",
+		},
+	}
 	deletingProject = v3.Project{
 		ObjectMeta: v1.ObjectMeta{
 			Name:              "deleting-project",
 			DeletionTimestamp: &v1.Time{Time: time.Now()},
+		},
+	}
+	defaultBinding = rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-binding",
 		},
 	}
 )
@@ -66,7 +83,7 @@ func TestReconcileBindings(t *testing.T) {
 			name: "error getting cluster",
 			stateSetup: func(cts crtbTestState) {
 				cts.clusterListerMock.GetFunc = func(namespace, name string) (*v3.Cluster, error) {
-					return nil, e
+					return nil, errDefault
 				}
 			},
 			wantError: true,
@@ -91,7 +108,7 @@ func TestReconcileBindings(t *testing.T) {
 				}
 				cts.managerMock.EXPECT().
 					checkReferencedRoles("roleTemplate", "cluster", gomock.Any()).
-					Return(true, e)
+					Return(true, errDefault)
 			},
 			wantError: true,
 			crtb:      defaultCRTB.DeepCopy(),
@@ -108,7 +125,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(true, nil)
 				cts.managerMock.EXPECT().
 					ensureClusterMembershipBinding("clustername-clusterowner", gomock.Any(), gomock.Any(), true, gomock.Any()).
-					Return(e)
+					Return(errDefault)
 
 			},
 			wantError: true,
@@ -129,7 +146,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(nil)
 				cts.managerMock.EXPECT().
 					grantManagementPlanePrivileges("roleTemplate", gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(e)
+					Return(errDefault)
 			},
 			wantError: true,
 			crtb:      defaultCRTB.DeepCopy(),
@@ -151,7 +168,7 @@ func TestReconcileBindings(t *testing.T) {
 					grantManagementPlanePrivileges("roleTemplate", gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 				cts.projectListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Project, error) {
-					return nil, e
+					return nil, errDefault
 				}
 			},
 			wantError: true,
@@ -179,7 +196,7 @@ func TestReconcileBindings(t *testing.T) {
 				}
 				cts.managerMock.EXPECT().
 					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "test-project", gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(e)
+					Return(errDefault)
 
 			},
 			wantError: true,
@@ -238,6 +255,32 @@ func TestReconcileBindings(t *testing.T) {
 			crtb: defaultCRTB.DeepCopy(),
 		},
 		{
+			name: "successfully reconcile clustermember with backingNamespace",
+			stateSetup: func(cts crtbTestState) {
+				cts.managerMock.EXPECT().
+					checkReferencedRoles("roleTemplate", "cluster", gomock.Any()).
+					Return(false, nil)
+				cts.managerMock.EXPECT().
+					ensureClusterMembershipBinding("clustername-clustermember", gomock.Any(), gomock.Any(), false, gomock.Any()).
+					Return(nil)
+				cts.managerMock.EXPECT().
+					grantManagementPlanePrivileges("roleTemplate", gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+				cts.managerMock.EXPECT().
+					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "c-ABC-p-XYZ", gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+				cts.clusterListerMock.GetFunc = func(namespace, name string) (*v3.Cluster, error) {
+					c := defaultCluster.DeepCopy()
+					return c, nil
+				}
+				cts.projectListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Project, error) {
+					p := backingNamespaceProject.DeepCopy()
+					return []*v3.Project{p}, nil
+				}
+			},
+			crtb: defaultCRTB.DeepCopy(),
+		},
+		{
 			name: "skip projects that are deleting",
 			stateSetup: func(cts crtbTestState) {
 				cts.managerMock.EXPECT().
@@ -252,7 +295,7 @@ func TestReconcileBindings(t *testing.T) {
 				// This should not be called
 				cts.managerMock.EXPECT().
 					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "deleting-project", gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(e).AnyTimes()
+					Return(errDefault).AnyTimes()
 				cts.clusterListerMock.GetFunc = func(namespace, name string) (*v3.Cluster, error) {
 					c := defaultCluster.DeepCopy()
 					return c, nil
@@ -301,4 +344,112 @@ func setupTest(t *testing.T) crtbTestState {
 		projectListerMock: &projectListerMock,
 	}
 	return state
+}
+
+func Test_removeMGMTClusterScopedPrivilegesInProjectNamespace(t *testing.T) {
+	tests := []struct {
+		name                  string
+		projectListFunc       func(string, labels.Selector) ([]*apisv3.Project, error)
+		roleBindingListFunc   func(string, labels.Selector) ([]*rbacv1.RoleBinding, error)
+		roleBindingDeleteFunc func(string, string, *v1.DeleteOptions) error
+		binding               *v3.ClusterRoleTemplateBinding
+		wantErr               bool
+	}{
+		{
+			name: "error listing projects",
+			projectListFunc: func(s1 string, s2 labels.Selector) ([]*apisv3.Project, error) {
+				return nil, errDefault
+			},
+			binding: defaultCRTB.DeepCopy(),
+			wantErr: true,
+		},
+		{
+			name: "error listing rolebindings",
+			projectListFunc: func(s1 string, s2 labels.Selector) ([]*apisv3.Project, error) {
+				return []*apisv3.Project{
+					defaultProject.DeepCopy(),
+				}, nil
+			},
+			roleBindingListFunc: func(s1 string, s2 labels.Selector) ([]*rbacv1.RoleBinding, error) {
+				return nil, errDefault
+			},
+			binding: defaultCRTB.DeepCopy(),
+			wantErr: true,
+		},
+		{
+			name: "error deleting rolebindings",
+			projectListFunc: func(s1 string, s2 labels.Selector) ([]*apisv3.Project, error) {
+				return []*apisv3.Project{
+					defaultProject.DeepCopy(),
+				}, nil
+			},
+			roleBindingListFunc: func(s1 string, s2 labels.Selector) ([]*rbacv1.RoleBinding, error) {
+				return []*rbacv1.RoleBinding{
+					defaultBinding.DeepCopy(),
+				}, nil
+			},
+			roleBindingDeleteFunc: func(s1, s2 string, do *v1.DeleteOptions) error {
+				return errDefault
+			},
+			binding: defaultCRTB.DeepCopy(),
+			wantErr: true,
+		},
+		{
+			name: "successfully delete rolebindings no backing namespace",
+			projectListFunc: func(s1 string, s2 labels.Selector) ([]*apisv3.Project, error) {
+				return []*apisv3.Project{
+					defaultProject.DeepCopy(),
+				}, nil
+			},
+			roleBindingListFunc: func(s1 string, s2 labels.Selector) ([]*rbacv1.RoleBinding, error) {
+				assert.Equal(t, defaultProject.Name, s1)
+				return []*rbacv1.RoleBinding{
+					defaultBinding.DeepCopy(),
+				}, nil
+			},
+			roleBindingDeleteFunc: func(s1, s2 string, do *v1.DeleteOptions) error {
+				assert.Equal(t, defaultProject.Name, s1)
+				return nil
+			},
+			binding: defaultCRTB.DeepCopy(),
+		},
+		{
+			name: "successfully delete rolebindings with backing namespace",
+			projectListFunc: func(s1 string, s2 labels.Selector) ([]*apisv3.Project, error) {
+				return []*apisv3.Project{
+					backingNamespaceProject.DeepCopy(),
+				}, nil
+			},
+			roleBindingListFunc: func(s1 string, s2 labels.Selector) ([]*rbacv1.RoleBinding, error) {
+				assert.Equal(t, backingNamespaceProject.Status.BackingNamespace, s1)
+				return []*rbacv1.RoleBinding{
+					defaultBinding.DeepCopy(),
+				}, nil
+			},
+			roleBindingDeleteFunc: func(s1, s2 string, do *v1.DeleteOptions) error {
+				assert.Equal(t, backingNamespaceProject.Status.BackingNamespace, s1)
+				return nil
+			},
+			binding: defaultCRTB.DeepCopy(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := fakes.ProjectListerMock{}
+			p.ListFunc = tt.projectListFunc
+			rbl := corefakes.RoleBindingListerMock{}
+			rbl.ListFunc = tt.roleBindingListFunc
+			rbi := corefakes.RoleBindingInterfaceMock{}
+			rbi.DeleteNamespacedFunc = tt.roleBindingDeleteFunc
+
+			c := &crtbLifecycle{
+				projectLister: &p,
+				rbLister:      &rbl,
+				rbClient:      &rbi,
+			}
+			if err := c.removeMGMTClusterScopedPrivilegesInProjectNamespace(tt.binding); (err != nil) != tt.wantErr {
+				t.Errorf("crtbLifecycle.removeMGMTClusterScopedPrivilegesInProjectNamespace() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/pkg/controllers/management/auth/project_cluster/cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/cluster_handler.go
@@ -84,7 +84,7 @@ func (l *clusterLifecycle) Sync(key string, orig *apisv3.Cluster) (runtime.Objec
 	}
 
 	obj := orig.DeepCopyObject()
-	obj, err := reconcileResourceToNamespace(obj, ClusterCreateController, l.nsLister, l.nsClient)
+	obj, err := reconcileResourceToNamespace(obj, ClusterCreateController, orig.Name, l.nsLister, l.nsClient)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (l *clusterLifecycle) Remove(obj *apisv3.Cluster) (runtime.Object, error) {
 	}
 	returnErr = errors.Join(
 		l.deleteSystemProject(obj, ClusterRemoveController),
-		deleteNamespace(obj, ClusterRemoveController, l.nsClient),
+		deleteNamespace(ClusterRemoveController, obj.Name, l.nsClient),
 	)
 	return obj, returnErr
 }

--- a/pkg/controllers/management/auth/project_cluster/common_test.go
+++ b/pkg/controllers/management/auth/project_cluster/common_test.go
@@ -1,0 +1,150 @@
+package project_cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+var (
+	errDefault    = fmt.Errorf("error")
+	errNsNotFound = apierrors.NewNotFound(v1.Resource("namespace"), "")
+
+	defaultNamespace = v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default-namespace",
+		},
+	}
+	terminatingNamespace = v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "terminating-namespace",
+		},
+		Status: v1.NamespaceStatus{
+			Phase: v1.NamespaceTerminating,
+		},
+	}
+)
+
+func Test_deleteNamespace(t *testing.T) {
+	tests := []struct {
+		name         string
+		nsGetFunc    func(context.Context, string, metav1.GetOptions) (*v1.Namespace, error)
+		nsDeleteFunc func(context.Context, string, metav1.DeleteOptions) error
+		wantErr      bool
+	}{
+		{
+			name: "error getting namespace",
+			nsGetFunc: func(ctx context.Context, s string, g metav1.GetOptions) (*v1.Namespace, error) {
+				return nil, errDefault
+			},
+			wantErr: true,
+		},
+		{
+			name: "namespace not found",
+			nsGetFunc: func(ctx context.Context, s string, g metav1.GetOptions) (*v1.Namespace, error) {
+				return nil, errNsNotFound
+			},
+		},
+		{
+			name: "namespace is terminating",
+			nsGetFunc: func(ctx context.Context, s string, g metav1.GetOptions) (*v1.Namespace, error) {
+				return terminatingNamespace.DeepCopy(), nil
+			},
+		},
+		{
+			name: "successfully delete namespace",
+			nsGetFunc: func(ctx context.Context, s string, g metav1.GetOptions) (*v1.Namespace, error) {
+				return defaultNamespace.DeepCopy(), nil
+			},
+			nsDeleteFunc: func(ctx context.Context, s string, do metav1.DeleteOptions) error {
+				return nil
+			},
+		},
+		{
+			name: "deleting namespace not found",
+			nsGetFunc: func(ctx context.Context, s string, g metav1.GetOptions) (*v1.Namespace, error) {
+				return defaultNamespace.DeepCopy(), nil
+			},
+			nsDeleteFunc: func(ctx context.Context, s string, do metav1.DeleteOptions) error {
+				return errNsNotFound
+			},
+		},
+		{
+			name: "error deleting namespace",
+			nsGetFunc: func(ctx context.Context, s string, g metav1.GetOptions) (*v1.Namespace, error) {
+				return defaultNamespace.DeepCopy(), nil
+			},
+			nsDeleteFunc: func(ctx context.Context, s string, do metav1.DeleteOptions) error {
+				return errDefault
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nsClientFake := mockNamespaces{
+				getter:  tt.nsGetFunc,
+				deleter: tt.nsDeleteFunc,
+			}
+			if err := deleteNamespace("", "", nsClientFake); (err != nil) != tt.wantErr {
+				t.Errorf("deleteNamespace() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+type mockNamespaces struct {
+	getter  func(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Namespace, error)
+	deleter func(ctx context.Context, name string, opts metav1.DeleteOptions) error
+}
+
+func (m mockNamespaces) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Namespace, error) {
+	return m.getter(ctx, name, opts)
+}
+
+func (m mockNamespaces) Create(ctx context.Context, namespace *v1.Namespace, opts metav1.CreateOptions) (*v1.Namespace, error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) Update(ctx context.Context, namespace *v1.Namespace, opts metav1.UpdateOptions) (*v1.Namespace, error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) UpdateStatus(ctx context.Context, namespace *v1.Namespace, opts metav1.UpdateOptions) (*v1.Namespace, error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return m.deleter(ctx, name, opts)
+}
+
+func (m mockNamespaces) List(ctx context.Context, opts metav1.ListOptions) (*v1.NamespaceList, error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Namespace, err error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) Apply(ctx context.Context, namespace *applycorev1.NamespaceApplyConfiguration, opts metav1.ApplyOptions) (result *v1.Namespace, err error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) ApplyStatus(ctx context.Context, namespace *applycorev1.NamespaceApplyConfiguration, opts metav1.ApplyOptions) (result *v1.Namespace, err error) {
+	panic("implement me")
+}
+
+func (m mockNamespaces) Finalize(ctx context.Context, item *v1.Namespace, opts metav1.UpdateOptions) (*v1.Namespace, error) {
+	panic("implement me")
+}

--- a/pkg/controllers/management/auth/project_cluster/project_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/project_handler.go
@@ -3,6 +3,7 @@ package project_cluster
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -74,18 +75,19 @@ func (l *projectLifecycle) Sync(key string, orig *apisv3.Project) (runtime.Objec
 		return nil, nil
 	}
 
+	var err error
 	obj := orig.DeepCopyObject()
 
 	backingNamespace := orig.Name
 	if orig.Status.BackingNamespace != "" {
 		backingNamespace = orig.Status.BackingNamespace
 	}
-	_, err := reconcileResourceToNamespace(obj, ProjectCreateController, backingNamespace, l.nsLister, l.nsClient)
+	obj, err = reconcileResourceToNamespace(obj, ProjectCreateController, backingNamespace, l.nsLister, l.nsClient)
 	if err != nil {
 		return nil, err
 	}
 
-	obj, err = l.reconcileProjectCreatorRTB(orig, backingNamespace)
+	obj, err = l.reconcileProjectCreatorRTB(obj, backingNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +158,12 @@ func (l *projectLifecycle) Remove(obj *apisv3.Project) (runtime.Object, error) {
 	return obj, returnErr
 }
 
-func (l *projectLifecycle) reconcileProjectCreatorRTB(project *apisv3.Project, nsName string) (runtime.Object, error) {
+func (l *projectLifecycle) reconcileProjectCreatorRTB(obj runtime.Object, nsName string) (runtime.Object, error) {
+	project, ok := obj.(*apisv3.Project)
+	if !ok {
+		return obj, fmt.Errorf("expected project, got %T", obj)
+	}
+
 	// If we specify no creator owner RBAC, exit
 	if _, ok := project.Annotations[NoCreatorRBACAnnotation]; ok {
 		logrus.Infof("[%s] annotation %s found. Skipping adding creator as owner", ProjectCreateController, NoCreatorRBACAnnotation)

--- a/pkg/controllers/management/auth/project_cluster/project_handler_test.go
+++ b/pkg/controllers/management/auth/project_cluster/project_handler_test.go
@@ -87,13 +87,13 @@ func TestReconcileProjectCreatorRTBRespectsUserPrincipalName(t *testing.T) {
 		},
 	}
 
-	obj, err := lifecycle.reconcileProjectCreatorRTB(project)
+	obj, err := lifecycle.reconcileProjectCreatorRTB(project, clusterID)
 	require.NoError(t, err)
 	require.NotNil(t, obj)
 
 	require.Len(t, prtbs, 1)
 	assert.Equal(t, "creator-project-owner", prtbs[0].Name)
-	assert.Equal(t, "p-abcdef", prtbs[0].Namespace)
+	assert.Equal(t, clusterID, prtbs[0].Namespace)
 	assert.Equal(t, clusterID+":p-abcdef", prtbs[0].ProjectName)
 	assert.Equal(t, "", prtbs[0].UserName)
 	assert.Equal(t, userPrincipalName, prtbs[0].UserPrincipalName)
@@ -109,7 +109,7 @@ func TestReconcileProjectCreatorRTBNoCreatorRBAC(t *testing.T) {
 			},
 		},
 	}
-	obj, err := lifecycle.reconcileProjectCreatorRTB(project)
+	obj, err := lifecycle.reconcileProjectCreatorRTB(project, clusterID)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -138,7 +138,7 @@ func (p *prtbLifecycle) reconcileSubject(binding *v3.ProjectRoleTemplateBinding)
 		return binding, nil
 	}
 
-	return nil, fmt.Errorf("Binding %v has no subject", binding.Name)
+	return nil, fmt.Errorf("binding %s has no subject", binding.Name)
 }
 
 // When a PRTB is created or updated, translate it into several k8s roles and bindings to actually enforce the RBAC.

--- a/pkg/controllers/managementlegacy/multiclusterapp/handler_multiclusterapp.go
+++ b/pkg/controllers/managementlegacy/multiclusterapp/handler_multiclusterapp.go
@@ -32,6 +32,7 @@ type MCAppController struct {
 	prtbLister                    v3.ProjectRoleTemplateBindingLister
 	crtbs                         v3.ClusterRoleTemplateBindingInterface
 	crtbLister                    v3.ClusterRoleTemplateBindingLister
+	projectClient                 v3.ProjectInterface
 	rtLister                      v3.RoleTemplateLister
 	users                         v3.UserInterface
 	userManager                   user.Manager
@@ -65,6 +66,7 @@ func Register(ctx context.Context, management *config.ManagementContext, cluster
 		prtbLister:                    management.Management.ProjectRoleTemplateBindings("").Controller().Lister(),
 		crtbs:                         management.Management.ClusterRoleTemplateBindings(""),
 		crtbLister:                    management.Management.ClusterRoleTemplateBindings("").Controller().Lister(),
+		projectClient:                 management.Management.Projects(""),
 		rtLister:                      management.Management.RoleTemplates("").Controller().Lister(),
 		userManager:                   management.UserManager,
 		users:                         management.Management.Users(""),
@@ -150,9 +152,17 @@ func (mc *MCAppController) sync(key string, mcapp *v3.MultiClusterApp) (runtime.
 			projectName := split[1]
 
 			if rt.Context == "project" {
+				backingNamespace := projectName
+				project, err := mc.projectClient.GetNamespaced(clusterName, projectName, v1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				if project.Status.BackingNamespace != "" {
+					backingNamespace = project.Status.BackingNamespace
+				}
 				prtbName = mcapp.Name + "-" + r
 				// check if these prtbs already exist
-				if err = mc.createPrtb(projectName, p.ProjectName, prtbName, r, systemUser.Name, systemUserPrincipalID); err != nil {
+				if err = mc.createPrtb(backingNamespace, p.ProjectName, prtbName, r, systemUser.Name, systemUserPrincipalID); err != nil {
 					return nil, err
 				}
 			} else if rt.Context == "cluster" {
@@ -352,14 +362,14 @@ func (c *ClusterController) updateAnswersForCluster(clusterName string, mcapp *v
 	}
 }
 
-func (mc *MCAppController) createPrtb(projectName, projectID, prtbName, roleTemplateName, systemUserName, systemUserPrincipalID string) error {
-	_, err := mc.prtbLister.Get(projectName, prtbName)
+func (mc *MCAppController) createPrtb(projectNamespace, projectID, prtbName, roleTemplateName, systemUserName, systemUserPrincipalID string) error {
+	_, err := mc.prtbLister.Get(projectNamespace, prtbName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			_, err := mc.prtbs.Create(&v3.ProjectRoleTemplateBinding{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      prtbName,
-					Namespace: projectName,
+					Namespace: projectNamespace,
 				},
 				UserName:          systemUserName,
 				UserPrincipalName: systemUserPrincipalID,

--- a/pkg/crds/yaml/generated/management.cattle.io_projects.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_projects.yaml
@@ -14,7 +14,14 @@ spec:
     singular: project
   scope: Namespaced
   versions:
-  - name: v3
+  - additionalPrinterColumns:
+    - jsonPath: .status.backingNamespace
+      name: BACKINGNAMESPACE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v3
     schema:
       openAPIV3Schema:
         description: |-
@@ -270,6 +277,10 @@ spec:
           status:
             description: Status is the most recently observed status of the project.
             properties:
+              backingNamespace:
+                description: BackingNamespace is the name of the namespace that contains
+                  resources associated with the project.
+                type: string
               conditions:
                 description: Conditions are a set of indicators about aspects of the
                   project.
@@ -306,3 +317,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}


### PR DESCRIPTION
The project namespace used to get created based on the name of the project. Now it gets created based on the cluster ID and project ID.