### PR TITLE
[main] Fix timeout issue in project tests

### DIFF
--- a/tests/v2/actions/projects/projects.go
+++ b/tests/v2/actions/projects/projects.go
@@ -118,20 +118,30 @@ func WaitForProjectFinalizerToUpdate(client *rancher.Client, projectName string,
 	return nil
 }
 
-// WaitForProjectIDAnnotationUpdate is a helper that waits for the project-id annotation to be updated in a specified namespace
-func WaitForProjectIDAnnotationUpdate(client *rancher.Client, clusterID, projectName, namespaceName string) error {
+// WaitForProjectIDUpdate is a helper that waits for the project-id annotation and label to be updated in a specified namespace
+func WaitForProjectIDUpdate(client *rancher.Client, clusterID, projectName, namespaceName string) error {
+	expectedAnnotations := map[string]string{
+		projectsapi.ProjectIDAnnotation: clusterID + ":" + projectName,
+	}
+
+	expectedLabels := map[string]string{
+		projectsapi.ProjectIDAnnotation: projectName,
+	}
+
 	err := kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.OneMinuteTimeout, func() (done bool, pollErr error) {
-		updatedNamespace, pollErr := namespaces.GetNamespaceByName(client, clusterID, namespaceName)
+		namespace, pollErr := namespaces.GetNamespaceByName(client, clusterID, namespaceName)
 		if pollErr != nil {
 			return false, pollErr
 		}
 
-		expectedAnnotations := map[string]string{
-			projectsapi.ProjectIDAnnotation: clusterID + ":" + projectName,
+		for key, expectedValue := range expectedAnnotations {
+			if actualValue, ok := namespace.Annotations[key]; !ok || actualValue != expectedValue {
+				return false, nil
+			}
 		}
 
-		for key, expectedValue := range expectedAnnotations {
-			if actualValue, ok := updatedNamespace.Annotations[key]; !ok || actualValue != expectedValue {
+		for key, expectedValue := range expectedLabels {
+			if actualValue, ok := namespace.Labels[key]; !ok || actualValue != expectedValue {
 				return false, nil
 			}
 		}

--- a/tests/v2/validation/projects/projects.go
+++ b/tests/v2/validation/projects/projects.go
@@ -117,39 +117,6 @@ func checkAnnotationExistsInNamespace(client *rancher.Client, clusterID string, 
 	return nil
 }
 
-func checkNamespaceLabelsAndAnnotations(clusterID string, projectName string, namespace *corev1.Namespace) error {
-	var errorMessages []string
-	expectedLabels := map[string]string{
-		projects.ProjectIDAnnotation: projectName,
-	}
-
-	expectedAnnotations := map[string]string{
-		projects.ProjectIDAnnotation: clusterID + ":" + projectName,
-	}
-
-	for key, value := range expectedLabels {
-		if _, ok := namespace.Labels[key]; !ok {
-			errorMessages = append(errorMessages, fmt.Sprintf("expected label %s not present in namespace labels", key))
-		} else if namespace.Labels[key] != value {
-			errorMessages = append(errorMessages, fmt.Sprintf("label value mismatch for %s: expected %s, got %s", key, value, namespace.Labels[key]))
-		}
-	}
-
-	for key, value := range expectedAnnotations {
-		if _, ok := namespace.Annotations[key]; !ok {
-			errorMessages = append(errorMessages, fmt.Sprintf("expected annotation %s not present in namespace annotations", key))
-		} else if namespace.Annotations[key] != value {
-			errorMessages = append(errorMessages, fmt.Sprintf("annotation value mismatch for %s: expected %s, got %s", key, value, namespace.Annotations[key]))
-		}
-	}
-
-	if len(errorMessages) > 0 {
-		return fmt.Errorf(strings.Join(errorMessages, "\n"))
-	}
-
-	return nil
-}
-
 func getLatestStatusMessageFromDeployment(deployment *appv1.Deployment, messageType string) (string, string, error) {
 	latestTime := time.Time{}
 	latestMessage := ""

--- a/tests/v2/validation/projects/projects_container_default_resource_limit_test.go
+++ b/tests/v2/validation/projects/projects_container_default_resource_limit_test.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/rancher/rancher/tests/v2/actions/kubeapi/namespaces"
 	"github.com/rancher/rancher/tests/v2/actions/kubeapi/projects"
+	project "github.com/rancher/rancher/tests/v2/actions/projects"
 	"github.com/rancher/rancher/tests/v2/actions/rbac"
 	deployment "github.com/rancher/rancher/tests/v2/actions/workloads/deployment"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/shepherd/pkg/wrangler"
@@ -22,6 +24,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 type ProjectsContainerResourceLimitTestSuite struct {
@@ -161,21 +164,19 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestCpuAndMemoryLimitEqualT
 	require.Equal(pcrl.T(), memoryReservation, projectSpec.RequestsMemory, "Memory reservation mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, pcrl.cluster.ID, createdNamespace.Name)
-	require.NoError(pcrl.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(pcrl.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, pcrl.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Verify that the limit range object is created for the namespace and the resource limit in the limit range is accurate.")
-	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Create a deployment in the namespace with one replica and verify that a pod is created.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, 1, "", "", false, false, true)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, 1, "", "", false, false, true)
 	require.NoError(pcrl.T(), err, "Failed to create deployment in the namespace")
 
 	log.Info("Verify that the resource limits and requests for the container in the pod spec is accurate.")
-	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 }
 
@@ -202,21 +203,19 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestCpuAndMemoryLimitGreate
 	require.Equal(pcrl.T(), memoryReservation, projectSpec.RequestsMemory, "Memory reservation mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, pcrl.cluster.ID, createdNamespace.Name)
-	require.NoError(pcrl.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(pcrl.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, pcrl.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Verify that the limit range object is created for the namespace and the resource limit in the limit range is accurate.")
-	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Create a deployment in the namespace with one replica and verify that a pod is created.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, 1, "", "", false, false, true)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, 1, "", "", false, false, true)
 	require.NoError(pcrl.T(), err, "Failed to create deployment in the namespace")
 
 	log.Info("Verify that the resource limits and requests for the container in the pod spec is accurate.")
-	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 }
 
@@ -354,13 +353,11 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestLimitDeletionPropagatio
 	require.Equal(pcrl.T(), memoryReservation, projectSpec.RequestsMemory, "Memory reservation mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, pcrl.cluster.ID, createdNamespace.Name)
-	require.NoError(pcrl.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(pcrl.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, pcrl.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Verify that the limit range object is created for the namespace and the resource limit in the limit range is accurate.")
-	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Remove the container default limits set in the Project.")
@@ -380,16 +377,27 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestLimitDeletionPropagatio
 
 	log.Info("Verify that the limit range in the existing namespace is deleted.")
 	ctx, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(pcrl.cluster.ID)
-	limitRanges, err := ctx.Core.LimitRange().List(updatedNamespace.Name, metav1.ListOptions{})
 	require.NoError(pcrl.T(), err)
-	require.Equal(pcrl.T(), 0, len(limitRanges.Items))
+	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.TenSecondTimeout, func() (done bool, pollErr error) {
+		limitRanges, err := ctx.Core.LimitRange().List(createdNamespace.Name, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(limitRanges.Items) == 0 {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("limit ranges still present in namespace: %d items found", len(limitRanges.Items))
+	})
+	require.NoError(pcrl.T(), err)
 
 	log.Info("Create a deployment in the namespace with one replica and verify that a pod is created.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, 1, "", "", false, false, true)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, 1, "", "", false, false, true)
 	require.NoError(pcrl.T(), err, "Failed to create deployment in the namespace")
 
 	log.Info("Verify that the resource limits and requests for the container in the pod spec is accurate.")
-	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 }
 
@@ -416,21 +424,19 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestOverrideDefaultLimitInN
 	require.Equal(pcrl.T(), memoryReservation, projectSpec.RequestsMemory, "Memory reservation mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, pcrl.cluster.ID, createdNamespace.Name)
-	require.NoError(pcrl.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(pcrl.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, pcrl.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Verify that the limit range object is created for the namespace and the resource limit in the limit range is accurate.")
-	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkLimitRange(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Create a deployment in the namespace with one replica and verify that a pod is created.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, 1, "", "", false, false, true)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, 1, "", "", false, false, true)
 	require.NoError(pcrl.T(), err, "Failed to create deployment in the namespace")
 
 	log.Info("Verify that the resource limits and requests for the container in the pod spec is accurate.")
-	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, updatedNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
+	err = checkContainerResources(standardUserClient, pcrl.cluster.ID, createdNamespace.Name, createdDeployment.Name, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.NoError(pcrl.T(), err)
 
 	log.Info("Override the CPU, memory limit and request in the namespace.")
@@ -438,6 +444,9 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestOverrideDefaultLimitInN
 	cpuReservation = "100m"
 	memoryLimit = "128Mi"
 	memoryReservation = "64Mi"
+
+	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, pcrl.cluster.ID, createdNamespace.Name)
+	require.NoError(pcrl.T(), err)
 	if _, exists := updatedNamespace.Annotations[containerDefaultLimitAnnotation]; !exists {
 		updatedNamespace.Annotations[containerDefaultLimitAnnotation] = fmt.Sprintf(`{"limitsCpu":"%s","limitsMemory":"%s","requestsCpu":"%s","requestsMemory":"%s"}`, cpuLimit, memoryLimit, cpuReservation, memoryReservation)
 	}

--- a/tests/v2/validation/projects/projects_resource_quota_test.go
+++ b/tests/v2/validation/projects/projects_resource_quota_test.go
@@ -83,19 +83,15 @@ func (prq *ProjectsResourceQuotaTestSuite) TestProjectWithoutResourceQuota() {
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace does not have the annotation: field.cattle.io/resourceQuota.")
-	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, updatedNamespace.Name, resourceQuotaAnnotation, false)
+	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, createdNamespace.Name, resourceQuotaAnnotation, false)
 	require.NoError(prq.T(), err, "'field.cattle.io/resourceQuota' annotation should not exist")
 
 	log.Info("Create a deployment in the namespace with ten replicas.")
-	_, err = deployment.CreateDeployment(standardUserClient, prq.cluster.ID, updatedNamespace.Name, 10, "", "", false, false, true)
+	_, err = deployment.CreateDeployment(standardUserClient, prq.cluster.ID, createdNamespace.Name, 10, "", "", false, false, true)
 	require.NoError(prq.T(), err)
 }
 
@@ -116,11 +112,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestProjectWithResourceQuota() {
 	require.Equal(prq.T(), projectPodLimit, createdProject.Spec.ResourceQuota.Limit.Pods, "Project pod limit mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, firstNamespace.Name)
-	require.NoError(prq.T(), err)
-	currentNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, firstNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, currentNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, firstNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the annotation: field.cattle.io/resourceQuota.")
@@ -208,11 +200,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestQuotaPropagationToExistingNamespa
 	require.Equal(prq.T(), projectPodLimit, createdProject.Spec.ResourceQuota.Limit.Pods, "Project pod limit mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the annotation: field.cattle.io/resourceQuota.")
@@ -283,11 +271,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestQuotaDeletionPropagationToExistin
 	require.Equal(prq.T(), projectPodLimit, createdProject.Spec.ResourceQuota.Limit.Pods, "Project pod limit mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the annotation: field.cattle.io/resourceQuota.")
@@ -358,34 +342,30 @@ func (prq *ProjectsResourceQuotaTestSuite) TestOverrideQuotaInNamespace() {
 	require.Equal(prq.T(), projectPodLimit, createdProject.Spec.ResourceQuota.Limit.Pods, "Project pod limit mismatch")
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	currentNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, currentNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the annotation: field.cattle.io/resourceQuota.")
-	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, currentNamespace.Name, resourceQuotaAnnotation, true)
+	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, createdNamespace.Name, resourceQuotaAnnotation, true)
 	require.NoError(prq.T(), err, "'field.cattle.io/resourceQuota' annotation should exist")
 
 	log.Info("Verify that the resource quota validation for the namespace is successful.")
-	err = checkNamespaceResourceQuotaValidationStatus(standardUserClient, prq.cluster.ID, currentNamespace.Name, namespacePodLimit, true, "")
+	err = checkNamespaceResourceQuotaValidationStatus(standardUserClient, prq.cluster.ID, createdNamespace.Name, namespacePodLimit, true, "")
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the resource quota object is created for the namespace and the pod limit in the resource quota is set to 2.")
-	err = checkNamespaceResourceQuota(standardUserClient, prq.cluster.ID, currentNamespace.Name, 2)
+	err = checkNamespaceResourceQuota(standardUserClient, prq.cluster.ID, createdNamespace.Name, 2)
 	require.NoError(prq.T(), err)
 
 	log.Info("Create a deployment in the namespace with two replicas.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, currentNamespace.Name, 2, "", "", false, false, true)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, createdNamespace.Name, 2, "", "", false, false, true)
 	require.NoError(prq.T(), err)
 
 	log.Info("Override the pod limit for the namespace and increase it from 2 to 3.")
 	namespacePodLimit = "3"
 	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
 	require.NoError(prq.T(), err)
-	currentNamespace, err = namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
+	currentNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 	currentNamespace.Annotations[resourceQuotaAnnotation] = fmt.Sprintf(`{"limit": {"pods": "%s"}}`, namespacePodLimit)
 	updatedNamespace, err := downstreamContext.Core.Namespace().Update(currentNamespace)
@@ -435,19 +415,15 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromNoQuotaToQuotaPr
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace does not have the annotation: field.cattle.io/resourceQuota.")
-	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, updatedNamespace.Name, resourceQuotaAnnotation, false)
+	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, createdNamespace.Name, resourceQuotaAnnotation, false)
 	require.NoError(prq.T(), err, "'field.cattle.io/resourceQuota' annotation should not exist")
 
 	log.Info("Create a deployment in the namespace with ten replicas.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, updatedNamespace.Name, 2, "", "", false, false, true)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, createdNamespace.Name, 2, "", "", false, false, true)
 	require.NoError(prq.T(), err)
 
 	log.Info("Create another project in the downstream cluster with resource quota set.")
@@ -468,7 +444,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromNoQuotaToQuotaPr
 	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
-	updatedNamespace, err = namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
+	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 	updatedNamespace.Annotations[projects.ProjectIDAnnotation] = createdProject2.Namespace + ":" + createdProject2.Name
 	movedNamespace, err := downstreamContext.Core.Namespace().Update(updatedNamespace)
@@ -524,23 +500,19 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromQuotaToNoQuotaPr
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the annotation: field.cattle.io/resourceQuota.")
-	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, updatedNamespace.Name, resourceQuotaAnnotation, true)
+	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, createdNamespace.Name, resourceQuotaAnnotation, true)
 	require.NoError(prq.T(), err, "'field.cattle.io/resourceQuota' annotation should exist")
 
 	log.Info("Verify that the resource quota object is created for the namespace and the pod limit in the resource quota is set to 2.")
-	err = checkNamespaceResourceQuota(standardUserClient, prq.cluster.ID, updatedNamespace.Name, 2)
+	err = checkNamespaceResourceQuota(standardUserClient, prq.cluster.ID, createdNamespace.Name, 2)
 	require.NoError(prq.T(), err)
 
 	log.Info("Create a deployment in the namespace with two replicas.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, updatedNamespace.Name, 2, "", "", false, false, true)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, createdNamespace.Name, 2, "", "", false, false, true)
 	require.NoError(prq.T(), err)
 
 	log.Info("Create another project in the downstream cluster without any resource quota set.")
@@ -557,7 +529,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromQuotaToNoQuotaPr
 	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
-	updatedNamespace, err = namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, updatedNamespace.Name)
+	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 	updatedNamespace.Annotations[projects.ProjectIDAnnotation] = createdProject2.Namespace + ":" + createdProject2.Name
 	movedNamespace, err := downstreamContext.Core.Namespace().Update(updatedNamespace)
@@ -599,28 +571,24 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceWithDeploymentTransi
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, updatedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the annotation: field.cattle.io/resourceQuota.")
-	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, updatedNamespace.Name, resourceQuotaAnnotation, true)
+	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, createdNamespace.Name, resourceQuotaAnnotation, true)
 	require.NoError(prq.T(), err, "'field.cattle.io/resourceQuota' annotation should exist")
 
 	log.Info("Verify that the resource quota object is created for the namespace and the pod limit in the resource quota is set to 2.")
-	err = checkNamespaceResourceQuota(standardUserClient, prq.cluster.ID, updatedNamespace.Name, 2)
+	err = checkNamespaceResourceQuota(standardUserClient, prq.cluster.ID, createdNamespace.Name, 2)
 	require.NoError(prq.T(), err)
 
 	log.Info("Create a deployment in the second namespace with ten replicas.")
-	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, updatedNamespace.Name, 10, "", "", false, false, false)
+	createdDeployment, err := deployment.CreateDeployment(standardUserClient, prq.cluster.ID, createdNamespace.Name, 10, "", "", false, false, false)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the deployment fails to create ten replicas.")
 	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.TenSecondTimeout, func() (done bool, pollErr error) {
-		checkErr := checkDeploymentStatus(standardUserClient, prq.cluster.ID, updatedNamespace.Name, createdDeployment.Name, "ReplicaFailure", "FailedCreate", "forbidden: exceeded quota", 0)
+		checkErr := checkDeploymentStatus(standardUserClient, prq.cluster.ID, createdNamespace.Name, createdDeployment.Name, "ReplicaFailure", "FailedCreate", "forbidden: exceeded quota", 0)
 		if checkErr != nil {
 			return false, checkErr
 		}
@@ -643,7 +611,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceWithDeploymentTransi
 	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
-	updatedNamespace, err = namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, updatedNamespace.Name)
+	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 	updatedNamespace.Annotations[projects.ProjectIDAnnotation] = createdProject2.Namespace + ":" + createdProject2.Name
 	movedNamespace, err := downstreamContext.Core.Namespace().Update(updatedNamespace)
@@ -684,19 +652,17 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceBetweenProjectsWithN
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the label and annotation referencing the project.")
-	err = project.WaitForProjectIDAnnotationUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject.Name, createdNamespace.Name)
 	require.NoError(prq.T(), err)
 	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
 	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject.Name, updatedNamespace)
-	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace does not have the annotation: field.cattle.io/resourceQuota.")
-	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, updatedNamespace.Name, resourceQuotaAnnotation, false)
+	err = checkAnnotationExistsInNamespace(standardUserClient, prq.cluster.ID, createdNamespace.Name, resourceQuotaAnnotation, false)
 	require.NoError(prq.T(), err, "'field.cattle.io/resourceQuota' annotation should not exist")
 
 	log.Info("Create a deployment in the namespace with ten replicas.")
-	deployment, err := deployment.CreateDeployment(standardUserClient, createdProject.Namespace, updatedNamespace.Name, 10, "", "", false, false, true)
+	deployment, err := deployment.CreateDeployment(standardUserClient, createdProject.Namespace, createdNamespace.Name, 10, "", "", false, false, true)
 	require.NoError(prq.T(), err)
 
 	log.Info("Create another project in the downstream cluster.")
@@ -718,9 +684,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceBetweenProjectsWithN
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace has the correct label and annotation referencing the second project.")
-	movedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, updatedNamespace.Name)
-	require.NoError(prq.T(), err)
-	err = checkNamespaceLabelsAndAnnotations(prq.cluster.ID, createdProject2.Name, movedNamespace)
+	err = project.WaitForProjectIDUpdate(standardUserClient, prq.cluster.ID, createdProject2.Name, updatedNamespace.Name)
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that the namespace does not have the annotation: field.cattle.io/resourceQuota.")
@@ -728,7 +692,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceBetweenProjectsWithN
 	require.NoError(prq.T(), err, "'field.cattle.io/resourceQuota' annotation should not exist")
 
 	log.Info("Verify that the deployment is in Active state and all pods in the deployment are in Running state.")
-	err = charts.WatchAndWaitDeployments(standardUserClient, prq.cluster.ID, movedNamespace.Name, metav1.ListOptions{
+	err = charts.WatchAndWaitDeployments(standardUserClient, prq.cluster.ID, updatedNamespace.Name, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + deployment.Name,
 	})
 	require.NoError(prq.T(), err)


### PR DESCRIPTION
QA Task: https://github.com/rancher/qa-tasks/issues/1599

The "project container default limit" tests are currently failing intermittently with the following error:
```
/root/go/src/github.com/rancher/rancher/tests/v2/validation/projects/projects_container_default_resource_limit_test.go:208
16:33:20          	Error:      	Received unexpected error:
16:33:20          	            	expected label field.cattle.io/projectId not present in namespace labels
```
Solution:
Fix timeout issue in container default limit tests by adding a wait for the project label/annotation to update 

**Backport PRs:** 
- 2.8: https://github.com/rancher/rancher/pull/47755
- 2.9: https://github.com/rancher/rancher/pull/47741