### PR TITLE
[v2.10] add mirror-brancz-kube-rbac-proxy to image origins

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -81,6 +81,7 @@ var OriginMap = map[string]string{
 	"longhornio-csi-resizer":                                  "https://github.com/longhorn/longhorn",
 	"machine":                                                 "https://github.com/rancher/machine",
 	"mirrored-amazon-aws-cli":                                 "https://github.com/aws/aws-cli",
+	"mirrored-brancz-kube-rbac-proxy":                         "https://github.com/brancz/kube-rbac-proxy",
 	"mirrored-appscode-kubed":                                 "https://github.com/kubeops/config-syncer",
 	"mirrored-banzaicloud-fluentd":                            "https://github.com/fluent/fluentd",
 	"mirrored-banzaicloud-logging-operator":                   "https://github.com/banzaicloud/logging-operator",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When renaming an image mirror to `rancher/mirrored-brancz-kube-rbac-proxy` we neglected to add the image to `origins.go`.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Add image and its source to `origins.go`