### PR TITLE
[main] Enable provisioning-tests and integration-tests to use cgroupsv2

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,28 +19,19 @@ env:
   REPO: ${{ github.repository_owner }}
 jobs:
   test:
-    runs-on: runs-on,runner=8cpu-linux-x64,image=legacy-cgroups-for-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=16cpu-linux-x64,ram=64,run-id=${{ github.run_id }}
     timeout-minutes: 60
     env:
       K3D_VERSION: v5.7.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Configure Docker for cgroupfs
+        run: |
+          echo '{"exec-opts": ["native.cgroupdriver=cgroupfs"]}'| sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
       - name: Setup Environment Variables
         uses: ./.github/actions/setup-tag-env
-      - name: Clean up Docker
-        run: |
-          docker system prune -af
-          docker volume prune -f
-      # Cleaning the runner is important to free enough space to build rancher, otherwise the build will fail
-      - name: Clean runner
-        run: |
-          # removes dotnet
-          sudo rm -rf /usr/share/dotnet
-          # removes haskell
-          sudo rm -rf /opt/ghc
-          # removes android sdk
-          sudo rm -rf /usr/local/lib/android
       - id: env 
         name: Setup Dependencies Env Variables
         uses: ./.github/actions/setup-build-env
@@ -81,22 +72,14 @@ jobs:
           docker image ls
       - name: Install k3d
         run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
-      - name: Uninstall existing Python versions
-        run: |
-          sudo apt-get remove -y python3
-          sudo apt-get autoremove -y
-          sudo apt-get purge -y python3
-          sudo apt-get clean
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
       - name: Check Python version
         run: |
-          sudo rm -rf /usr/bin/python3
-          sudo cp $(which python3) /usr/bin/python3
-          python3 --version
-          python3 -m ensurepip --upgrade
+          python -V
+          python3 -V
       - name: Install Python and dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -27,7 +27,7 @@ jobs:
         - V2PROV_TEST_DIST: "rke2"
           V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetB_.*$"
     name: Provisioning tests 
-    runs-on: runs-on,runner=8cpu-linux-x64,image=legacy-cgroups-for-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=16cpu-linux-x64,ram=64,run-id=${{ github.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,6 +37,10 @@ jobs:
         run: |
           curl -sL https://releases.rancher.com/dapper/latest/dapper-$(uname -s)-$(uname -m) > ./.dapper
           chmod +x ./.dapper
+      - name: Configure Docker for cgroupfs
+        run: |
+          echo '{"exec-opts": ["native.cgroupdriver=cgroupfs"]}'| sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
       - name: Run tests
         run: ./.dapper provisioning-tests
         env:

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -1,9 +1,7 @@
 #!/bin/bash
-set -e
+set -ex
 
-echo Starting rancher server
-
-echo "scripts/run"
+echo Starting rancher server in container
 
 source $(dirname $0)/../version
 source $(dirname $0)/../export-config
@@ -27,13 +25,5 @@ export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}')"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 export CATTLE_FEATURES="harvester=false"
 
-echo "docker run -d --name rancher-server --restart=unless-stopped --privileged -p 6443:6443 -p 8080:8080 -p 443:443 -e CATTLE_SERVER_URL=$CATTLE_SERVER_URL -e CATTLE_BOOTSTRAP_PASSWORD="admin" -e CATTLE_DEV_MODE=yes -e CATTLE_AGENT_IMAGE=$AGENT_IMAGE $IMAGE"
-docker run -d --name rancher-server --restart=unless-stopped --privileged -p 6443:6443 -p 8080:8080 -p 443:443 -e CATTLE_SERVER_URL=$CATTLE_SERVER_URL -e CATTLE_BOOTSTRAP_PASSWORD="admin" -e CATTLE_DEV_MODE=yes -e CATTLE_AGENT_IMAGE=$AGENT_IMAGE $IMAGE
-
-sleep 5
-
-echo "docker container ls"
-docker container ls
-
 mkdir -p /etc/rancher/k3s/
-docker cp rancher-server:/etc/rancher/k3s/k3s.yaml /etc/rancher/k3s/k3s.yaml
+docker run -d --name rancher-server -v /etc/rancher/k3s:/etc/rancher/k3s --restart=unless-stopped --privileged -p 6443:6443 -p 8080:8080 -p 443:443 -e CATTLE_SERVER_URL=$CATTLE_SERVER_URL -e CATTLE_BOOTSTRAP_PASSWORD=$CATTLE_BOOTSTRAP_PASSWORD -e CATTLE_DEV_MODE=yes -e CATTLE_AGENT_IMAGE=$AGENT_IMAGE $IMAGE

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -7,13 +7,8 @@ cleanup()
 {
     EXIT=$?
     set +ex
-    echo Stopping rancher server
-    kill $RANCHER_RUN_PID
-    wait $RANCHER_RUN_PID
-    if [ $PID != -1 ]; then
-      kill $PID
-      wait $PID
-    fi
+    echo Stopping and removing rancher server container
+    docker rm -f rancher-server
     return $EXIT
 }
 
@@ -75,58 +70,40 @@ curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYS
 curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-arm64 -o /usr/share/rancher/ui/assets/rancher-system-agent-arm64
 curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/system-agent-uninstall.sh -o /usr/share/rancher/ui/assets/system-agent-uninstall.sh
 
-run_rancher()
-{
-    RESTART_COUNT=0
-    while sleep 2; do
-        if [ "$PID" != "-1" ] && [ ! -e /proc/$PID ]; then
-            echo Rancher died
-            dump_rancher_logs
-            echo K3s logs were:
-            echo -e "-----K3S-LOG-DUMP-START-----"
-            cat build/testdata/k3s.log
-            echo -e "\n-----K3S-LOG-DUMP-END-----"
-            set +e
-            echo Attempting to kill K3s
-            pkill -e k3s
-            set -e
-            PID=-1
-            if [ "$RESTART_COUNT" = "2" ]; then
-                echo Rancher died 3 times, aborting
-                kill -42 $PWRAPPROC
-            fi
-            RESTART_COUNT=$((RESTART_COUNT + 1))
-            sleep 5
-        fi
-        if [ "$PID" = "-1" ]; then
-          echo Starting rancher server using run
-          ./scripts/gha/run >/tmp/rancher.log 2>&1 &
-          PID=$!
-        fi
-        sleep 2
-    done
-}
-
 dump_rancher_logs()
 {
-  echo Rancher logs were
+  echo Dumping Rancher + K3s Container Logs
   echo -e "-----RANCHER-LOG-DUMP-START-----"
-  cat /tmp/rancher.log
+  docker logs rancher-server &> /tmp/rancher.log
+  if [ -s /tmp/rancher.log ]; then
+    cat /tmp/rancher.log | gzip | base64 -w 0
+  else
+    echo "------EMPTY------"
+  fi
   echo -e "\n-----RANCHER-LOG-DUMP-END-----"
+  docker cp rancher-server:/var/lib/rancher/k3s.log /tmp/k3s.log
+  echo -e "-----K3S-LOG-DUMP-START-----"
+  if [ -s /tmp/k3s.log ]; then
+    cat /tmp/k3s.log | gzip | base64 -w 0
+  else
+    echo "------EMPTY------"
+  fi
+  echo -e "\n-----K3S-LOG-DUMP-END-----"
 }
 
-# uncomment to get startup logs. Don't leave them on because it slows drone down too
-# much
-#tail -F /tmp/rancher.log &
-#TPID=$!
+export -f dump_rancher_logs
 
-trap "exit 1" 42
-PWRAPPROC="$$"
-
-PID=-1
-run_rancher &
-RANCHER_RUN_PID=$!
+./scripts/gha/run 2>&1
 trap cleanup exit
+
+echo "Waiting for K3s kubeconfig to be generated"
+./scripts/retry \
+  --timeout 300 `# Time out after 300 seconds (5 min)` \
+  --sleep 5 `# Sleep for 2 seconds in between attempts` \
+  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
+  --message "/etc/rancher/k3s/k3s.yaml did not exist after {{elapsed}} seconds" `# Print this progress message` \
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why K3s did not start` \
+  "stat /etc/rancher/k3s/k3s.yaml &>/dev/null"
 
 echo "Waiting up to 5 minutes for rancher-webhook deployment"
 ./scripts/retry \
@@ -134,7 +111,8 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
   --sleep 2 `# Sleep for 2 seconds in between attempts` \
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-webhook was not available after {{elapsed}} seconds" `# Print this progress message` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook &"
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why webhook did not start` \
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/rancher-webhook &>/dev/null"
 
 echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
 ./scripts/retry \
@@ -142,7 +120,8 @@ echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
   --sleep 2 `# Sleep for 2 seconds in between attempts` \
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-provisioning-capi was not available after {{elapsed}} seconds" `# Print this progress message` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-provisioning-capi-system deploy/capi-controller-manager &"
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why capi-controller-manager did not start` \
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-provisioning-capi-system deploy/capi-controller-manager  &>/dev/null"
 
 
 echo Running integrationsetup

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -4,6 +4,24 @@ if ./scripts/only-ui-bumps.sh; then
     exit 0
 fi
 
+#########################################################################################################################################
+# DISCLAIMER                                                                                                                            #
+# Copied from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37                              #
+# Permission granted by Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (https://github.com/rancher/k3d/issues/493#issuecomment-827405962) #
+# Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE                           #
+#########################################################################################################################################
+# only run this if rancher is not running in kubernetes cluster and if the init cgroup does not already exist
+# we have to run this early on in provisioning-tests otherwise, the moving of processes is likely to fail due to
+# non-existent PIDs from the retry script below to check for Rancher health
+if [ -f /sys/fs/cgroup/cgroup.controllers ] && [ ! -d /sys/fs/cgroup/init ]; then
+  # move the processes from the root group to the /init group,
+  # otherwise writing subtree_control fails with EBUSY.
+  mkdir -p /sys/fs/cgroup/init
+  xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+  # enable controllers
+  sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+fi
+
 cleanup()
 {
     EXIT=$?
@@ -151,7 +169,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-webhook was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why webhook did not start` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook &>/dev/null"
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/rancher-webhook &>/dev/null"
 
 echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
 ./scripts/retry \
@@ -160,7 +178,7 @@ echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-provisioning-capi was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why webhook did not start` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-provisioning-capi-system deploy/capi-controller-manager &>/dev/null"
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-provisioning-capi-system deploy/capi-controller-manager &>/dev/null"
 
 
 #kill $TPID

--- a/scripts/run
+++ b/scripts/run
@@ -28,8 +28,8 @@ export CATTLE_FEATURES="harvester=false"
 # Permission granted by Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (https://github.com/rancher/k3d/issues/493#issuecomment-827405962) #
 # Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE                           #
 #########################################################################################################################################
-# only run this if rancher is not running in kubernetes cluster
-if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+# only run this if rancher is not running in kubernetes cluster and if the init cgroup does not already exist
+if [ -f /sys/fs/cgroup/cgroup.controllers ] && [ ! -d /sys/fs/cgroup/init ]; then
   # move the processes from the root group to the /init group,
   # otherwise writing subtree_control fails with EBUSY.
   mkdir -p /sys/fs/cgroup/init

--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	PodTestImage           = "rancher/systemd-node:v0.0.5-rc2"
+	PodTestImage           = "rancher/systemd-node:v0.0.5"
 	ObjectStoreServerImage = "rancher/mirrored-minio-minio:RELEASE.2022-12-12T19-27-27Z"
 	ObjectStoreUtilImage   = "rancher/mirrored-minio-mc:RELEASE.2022-12-13T00-23-28Z"
 	SomeK8sVersion         = os.Getenv("SOME_K8S_VERSION")


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/46222

## Summary:
This PR bumps `rancher/systemd-node` to `v0.0.5`, which contains a script that facilitates the usage of cgroupsv2.

It makes corrections to the logic used to run the integration-tests environment, as well as adding cgroups draining logic to the `provisioning-tests` script and corresponding Rancher `run`.