### PR TITLE
[v2.8] go get steve to include refactored partitioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.4.0
 	github.com/rancher/rke v1.5.15-rc.2
-	github.com/rancher/steve v0.0.0-20241028205544-b0e3b528a82f
+	github.com/rancher/steve v0.0.0-20241029132722-c744f0b17b88
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde
 	github.com/rancher/wrangler/v2 v2.1.4
 	github.com/robfig/cron v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1549,8 +1549,8 @@ github.com/rancher/rke v1.5.15-rc.2 h1:ASq7oQY7JEUu5CnTtsE2f+Ml9Ur07D+BguAB+zVE8
 github.com/rancher/rke v1.5.15-rc.2/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
 github.com/rancher/shepherd v0.0.0-20241025145825-ac788a5e1033 h1:K+kOyR3WiGuyWbP5sdGdM9iNStWa/xWS6fL4K/R/Q7g=
 github.com/rancher/shepherd v0.0.0-20241025145825-ac788a5e1033/go.mod h1:1TXkmbjCxMEp8Rzzw+ToyrhJYUGDC0lw6uXLe3Ie+M4=
-github.com/rancher/steve v0.0.0-20241028205544-b0e3b528a82f h1:zNbK7riwKUpwq+7myx10RsKvXF4uPBAVXtPn32v+cz0=
-github.com/rancher/steve v0.0.0-20241028205544-b0e3b528a82f/go.mod h1:v0hTRvX7jcB9Gsq614KS2FpYKz4BydmGne2i3lhRbYI=
+github.com/rancher/steve v0.0.0-20241029132722-c744f0b17b88 h1:ok5PBtEMAQfE1x9yrdqx344VyqYeIkAWoC1O8dcQUZE=
+github.com/rancher/steve v0.0.0-20241029132722-c744f0b17b88/go.mod h1:v0hTRvX7jcB9Gsq614KS2FpYKz4BydmGne2i3lhRbYI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=


### PR DESCRIPTION
Updated to include https://github.com/rancher/steve/pull/311 to facilitate QA testing

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Steve now reliably honors a namespace filter (during watch/list operations) that it was previously ignoring in some cases, depending on how the API request was formatted. This is strictly a bugfix, so well behaved consumers shouldn't be affected, but anything accidentally relying on the missing filter behavior may need to be adjusted.