### PR TITLE
[Main] Add build tags to the proxy tests

### DIFF
--- a/tests/v2/validation/provisioning/proxy/k3s_proxy_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/proxy/k3s_proxy_custom_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build validation
+
 package proxy
 
 import (

--- a/tests/v2/validation/provisioning/proxy/k3s_proxy_node_driver_test.go
+++ b/tests/v2/validation/provisioning/proxy/k3s_proxy_node_driver_test.go
@@ -1,3 +1,5 @@
+//go:build validation
+
 package proxy
 
 import (

--- a/tests/v2/validation/provisioning/proxy/proxy.go
+++ b/tests/v2/validation/provisioning/proxy/proxy.go
@@ -1,7 +1,6 @@
 package proxy
 
 const (
-	//corralPackageProxyCustomClusterName = "proxyCustomCluster"
 	corralPackageAirgapCustomClusterName = "airgapCustomCluster"
 	corralBastionIP                      = "bastion_ip"
 	corralRegistryIP                     = "registry_ip"

--- a/tests/v2/validation/provisioning/proxy/rke1_proxy_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/proxy/rke1_proxy_custom_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build validation
+
 package proxy
 
 import (

--- a/tests/v2/validation/provisioning/proxy/rke1_proxy_node_driver_test.go
+++ b/tests/v2/validation/provisioning/proxy/rke1_proxy_node_driver_test.go
@@ -1,3 +1,5 @@
+//go:build validation
+
 package proxy
 
 import (

--- a/tests/v2/validation/provisioning/proxy/rke2_proxy_node_driver_test.go
+++ b/tests/v2/validation/provisioning/proxy/rke2_proxy_node_driver_test.go
@@ -1,3 +1,5 @@
+//go:build validation
+
 package proxy
 
 import (


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Add Missing Proxy Test Build Flags](https://github.com/rancher/qa-tasks/issues/1603)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The proxy tests do not have a build tag on them, causing the recurring runs to fail. This needs to be addressed.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added build tags to the proxy tests.