### PR TITLE
[backport 2.9] Make provisioningprebootstrap feature flag force a restart of rancher when toggled

### DIFF
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -136,7 +136,7 @@ var (
 		"provisioningprebootstrap",
 		"Support running pre-bootstrap workloads on downstream clusters",
 		false,
-		true,
+		false,
 		true)
 )
 


### PR DESCRIPTION
…re restart)

## Issue: #47815   <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When enabling the `provisioningprebootstrap` feature flag - any clusters that already exist will be changed to the `Updating` state and then from there stuck in `waiting for cluster pre-bootstrap to copmlete`. This is due to the fact that the controllers that actually pre-bootstrap the cluster objects only starts on initial cluster-agent connect (during initial provision). 

This can be fixed by restarting rancher and thus restarting the controllers, but there is a feature on feature flags to handle this for us. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

By changing the `dynamic` field on the feature flag it will force a restart when toggled. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Create clusters in older rancher version, update to current version, toggle feature flag. Rancher should restart and the cluster(s) will reconcile

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
1. Toggled flag
2. Rancher restarted 
3. ???
4. Profit!

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
I would just validate that the pods restart when toggling this flag. 
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A this just makes sure rancher restarts when toggling this flag. 

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_