### PR TITLE
[backport 2.8] Ship ACE Configuration + ChartValues during pre-bootstrap process

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -185,6 +185,17 @@ func addLocalClusterAuthenticationEndpointFile(nodePlan plan.NodePlan, controlPl
 }
 
 func (p *Planner) addManifests(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, entry *planEntry) (plan.NodePlan, error) {
+	bootstrapManifests, err := p.retrievalFunctions.GetBootstrapManifests(controlPlane)
+	if err != nil {
+		return nodePlan, err
+	}
+
+	if len(bootstrapManifests) > 0 {
+		logrus.Debugf("[planner] adding pre-bootstrap manifests")
+		nodePlan.Files = append(nodePlan.Files, bootstrapManifests...)
+		return nodePlan, err
+	}
+
 	files, err := p.getControlPlaneManifests(controlPlane, entry)
 	if err != nil {
 		return nodePlan, err

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -1098,16 +1098,6 @@ func (p *Planner) generatePlanWithConfigFiles(controlPlane *rkev1.RKEControlPlan
 			return nodePlan, config, joinedServer, err
 		}
 
-		bootstrapManifests, err := p.retrievalFunctions.GetBootstrapManifests(controlPlane)
-		if err != nil {
-			return nodePlan, config, joinedServer, err
-		}
-		if len(bootstrapManifests) > 0 {
-			logrus.Debugf("[planner] adding pre-bootstrap manifests")
-			nodePlan.Files = append(nodePlan.Files, bootstrapManifests...)
-			return nodePlan, config, joinedServer, err
-		}
-
 		nodePlan, err = p.addManifests(nodePlan, controlPlane, entry)
 		if err != nil {
 			return nodePlan, config, joinedServer, err


### PR DESCRIPTION
## Issue: #47810    <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When the `provisioningprebootstrap` feature flag is enabled, provisioning a cluster with ACE enabled will have the cluster in a stuck state during the pre-bootstrap flow.

This is due to the fact that the ACE configuration is not present so kubelet refuses to start up.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This is fixed by adding the networking config files (notably ACE configs) during the prebootstrap flow.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Create a cluster on new version with ACE enabled. It will come up just fine vs never coming up.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None


Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

See Testing section.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A - we're realistically building the same file just in a different order.
