### PR TITLE
[Main] Report Jenkins results to Slack

### DIFF
--- a/tests/v2/validation/Jenkinsfile.rc
+++ b/tests/v2/validation/Jenkinsfile.rc
@@ -328,8 +328,6 @@ node {
                       sh "./yq e 'del(.flags.desiredflags)' -i ${mainRancherConfigPath}"
                       sh "./yq e '.flags.desiredflags = \"Short|Long\"' -i ${mainRancherConfigPath}"
                       sh "./yq e 'del(.corralRancherHA)' -i ${mainRancherConfigPath}"
-
-                      def config3Yaml = readFile(file: "${mainRancherConfigPath}")
                     }
                     parallel jobs
                   } catch(err) {
@@ -371,6 +369,7 @@ node {
               }
               sh "docker rmi -f ${imageName}"
               sh "docker volume rm -f ${validationVolume}"
+              slackSend(channel: "${SLACK_CHANNEL}", message: "${env.JOB_NAME} Build #${env.BUILD_NUMBER} finished. More details: ${env.BUILD_URL}")
             }
           } // dir 
         } // withEnv


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Upon further enhancing of Hostbusters daily sanity runs, we want to be able to report the results via Slack so that we can simply click the build URL that it outputs.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Utilizes `slackSend` function to report results to channel.