### PR TITLE
Userretention settings tests to main

### DIFF
--- a/tests/v2/actions/auth/auth.go
+++ b/tests/v2/actions/auth/auth.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/shepherd/clients/rancher"
+	client "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	LastloginLabel = "cattle.io/last-login"
+)
+
+func GetLastLoginTime(labels map[string]string) (lastLogin time.Time, err error) {
+	value, exists := IsLabelPresent(labels)
+
+	if !exists || value == "" {
+		return
+	}
+	epochTime, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return
+	}
+	lastLogin = ConvertEpochToTime(epochTime)
+	return
+}
+
+func ConvertEpochToTime(epochTime int64) time.Time {
+	return time.Unix(epochTime, 0)
+}
+
+func IsLabelPresent(labels map[string]string) (string, bool) {
+	value, exists := labels[LastloginLabel]
+	return value, exists
+}
+
+func GetUserAfterLogin(rancherClient *rancher.Client, user client.User) (userDetails *v3.User, err error) {
+
+	_, err = rancherClient.AsUser(&user)
+	if err != nil {
+		return
+	}
+	listOpt := v1.ListOptions{
+		FieldSelector: "metadata.name=" + user.ID,
+	}
+	userList, err := rancherClient.WranglerContext.Mgmt.User().List(listOpt)
+
+	if len(userList.Items) == 0 {
+		return nil, fmt.Errorf("User %s not found", user.ID)
+	}
+	userDetails = &userList.Items[0]
+
+	return
+}

--- a/tests/v2/actions/rbac/rbac.go
+++ b/tests/v2/actions/rbac/rbac.go
@@ -4,9 +4,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rancher/norman/types"
+	rbacv2 "github.com/rancher/rancher/tests/v2/actions/kubeapi/rbac"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/users"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Role string
@@ -94,4 +99,62 @@ func VerifyRoleRules(expected, actual map[string][]string) error {
 		}
 	}
 	return nil
+}
+
+// GetRoleBindings is a helper function to fetch rolebindings for a user
+func GetRoleBindings(rancherClient *rancher.Client, clusterID string, userID string) ([]rbacv1.RoleBinding, error) {
+	logrus.Infof("Getting role bindings for user %s in cluster %s", userID, clusterID)
+	listOpt := v1.ListOptions{}
+	roleBindings, err := rbacv2.ListRoleBindings(rancherClient, clusterID, "", listOpt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch RoleBindings: %w", err)
+	}
+
+	var userRoleBindings []rbacv1.RoleBinding
+	for _, rb := range roleBindings.Items {
+		for _, subject := range rb.Subjects {
+			if subject.Name == userID {
+				userRoleBindings = append(userRoleBindings, rb)
+				break
+			}
+		}
+	}
+	logrus.Infof("Found %d role bindings for user %s", len(userRoleBindings), userID)
+	return userRoleBindings, nil
+}
+
+// GetBindings is a helper function to fetch bindings for a user
+func GetBindings(rancherClient *rancher.Client, userID string) (map[string]interface{}, error) {
+	logrus.Infof("Getting all bindings for user %s", userID)
+	bindings := make(map[string]interface{})
+
+	roleBindings, err := GetRoleBindings(rancherClient, rbacv2.LocalCluster, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role bindings: %w", err)
+	}
+	bindings["RoleBindings"] = roleBindings
+
+	logrus.Info("Getting cluster role bindings")
+	clusterRoleBindings, err := rbacv2.ListClusterRoleBindings(rancherClient, rbacv2.LocalCluster, v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster role bindings: %w", err)
+	}
+	bindings["ClusterRoleBindings"] = clusterRoleBindings.Items
+
+	logrus.Info("Getting global role bindings")
+	globalRoleBindings, err := rancherClient.Management.GlobalRoleBinding.ListAll(&types.ListOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list global role bindings: %w", err)
+	}
+	bindings["GlobalRoleBindings"] = globalRoleBindings.Data
+
+	logrus.Info("Getting cluster role template bindings")
+	clusterRoleTemplateBindings, err := rancherClient.Management.ClusterRoleTemplateBinding.List(&types.ListOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster role template bindings: %w", err)
+	}
+	bindings["ClusterRoleTemplateBindings"] = clusterRoleTemplateBindings.Data
+
+	logrus.Info("All bindings retrieved successfully")
+	return bindings, nil
 }

--- a/tests/v2/validation/auth/userretention/userretention.go
+++ b/tests/v2/validation/auth/userretention/userretention.go
@@ -1,0 +1,107 @@
+package userretention
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rancher/rancher/tests/v2/actions/auth"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	disableInactiveUserAfter  = "disable-inactive-user-after"
+	deleteInactiveUserAfter   = "delete-inactive-user-after"
+	userRetentionCron         = "user-retention-cron"
+	authUserSessionTTLMinutes = "auth-user-session-ttl-minutes"
+	testTTLValue              = "1"
+	userRetentionDryRun       = "user-retention-dry-run"
+	lastloginLabel            = "cattle.io/last-login"
+	defaultWaitDuration       = 70 * time.Second
+	isActive                  = true
+	isInActive                = false
+	webhookErrorMessage       = "admission webhook \"rancher.cattle.io.settings.management.cattle.io\" denied the request: value: Invalid value:"
+	forbiddenError            = "403 Forbidden"
+	unauthorizedError         = "401 Unauthorized"
+)
+
+func setupUserRetentionSettings(client *rancher.Client, disableAfterValue string, deleteAfterValue string, userRetentionCronValue string, dryRunValue string) error {
+	logrus.Info("Setting up user retention settings TO : ")
+	logrus.Infof("DisableAfterValue as %s, DeleteAfterValue as %s, UserRetentionCronValue as %s, DryRunValue as %s", disableAfterValue, deleteAfterValue, userRetentionCronValue, dryRunValue)
+	err := updateUserRetentionSettings(client, disableInactiveUserAfter, disableAfterValue)
+	if err != nil {
+		return fmt.Errorf("failed to update disable-inactive-user-after setting: %w", err)
+	}
+	err = updateUserRetentionSettings(client, deleteInactiveUserAfter, deleteAfterValue)
+	if err != nil {
+		return fmt.Errorf("failed to update delete-inactive-user-after setting: %w", err)
+	}
+
+	err = updateUserRetentionSettings(client, userRetentionCron, userRetentionCronValue)
+	if err != nil {
+		return fmt.Errorf("failed to update user-retention-cron setting: %w", err)
+	}
+	err = updateUserRetentionSettings(client, userRetentionDryRun, dryRunValue)
+	if err != nil {
+		return fmt.Errorf("failed to update user-retention-dry-run setting: %w", err)
+	}
+	logrus.Info("User retention settings setup completed")
+	return nil
+}
+
+func updateUserRetentionSettings(client *rancher.Client, settingName string, settingValue string) error {
+	logrus.Infof("Updating setting: %s, value: %s", settingName, settingValue)
+	setting, err := client.WranglerContext.Mgmt.Setting().Get(settingName, v1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get setting %s: %w", settingName, err)
+	}
+
+	setting.Value = settingValue
+	_, err = client.WranglerContext.Mgmt.Setting().Update(setting)
+	if err != nil {
+		return fmt.Errorf("failed to update setting %s: %w", settingName, err)
+	}
+	return nil
+}
+
+func pollUserStatus(rancherClient *rancher.Client, userID string, expectedStatus bool) error {
+	logrus.Infof("Polling user status for user %s, expected status: %v", userID, expectedStatus)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultWaitDuration)
+	defer cancel()
+
+	adminID, err := users.GetUserIDByName(rancherClient, "admin")
+	if err != nil {
+		return fmt.Errorf("failed to get admin user ID: %v", err)
+	}
+	adminUser, err := rancherClient.Management.User.ByID(adminID)
+	if err != nil {
+		return fmt.Errorf("failed to get admin user: %v", err)
+	}
+	adminUser.Password = rancherClient.RancherConfig.AdminPassword
+
+	return wait.PollUntilContextTimeout(ctx, defaults.FiveSecondTimeout, defaultWaitDuration, true, func(ctx context.Context) (bool, error) {
+		logrus.Info("Logging in with default admin user")
+		_, err := auth.GetUserAfterLogin(rancherClient, *adminUser)
+		if err != nil {
+			return false, fmt.Errorf("failed to login with admin user: %v", err)
+		}
+
+		logrus.Info("Searching for the user status using the admin client")
+		user, err := rancherClient.Management.User.ByID(userID)
+		if err != nil {
+			return false, fmt.Errorf("failed to get user by ID: %v", err)
+		}
+		if user.Enabled == nil {
+			return false, fmt.Errorf("user.Enabled is nil")
+		}
+
+		currentStatus := *user.Enabled
+		logrus.Infof("Current user status: %v, Expected status: %v", currentStatus, expectedStatus)
+		return currentStatus == expectedStatus, nil
+	})
+}

--- a/tests/v2/validation/auth/userretention/userretention_delete_user_test.go
+++ b/tests/v2/validation/auth/userretention/userretention_delete_user_test.go
@@ -1,0 +1,258 @@
+//go:build (validation || infra.any || cluster.any || sanity) && !stress && !extended
+
+package userretention
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/v2/actions/auth"
+	"github.com/rancher/rancher/tests/v2/actions/rbac"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type URDeleteTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (ur *URDeleteTestSuite) SetupSuite() {
+	logrus.Info("Setting up URDeleteTestSuite")
+	ur.session = session.NewSession()
+
+	logrus.Info("Creating new Rancher client")
+	client, err := rancher.NewClient("", ur.session)
+	require.NoError(ur.T(), err)
+	ur.client = client
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "0")
+	require.NoError(ur.T(), err)
+}
+
+func (ur *URDeleteTestSuite) TearDownSuite() {
+	logrus.Info("Tearing down URDeleteTestSuite")
+	ur.session.Cleanup()
+}
+
+func (ur *URDeleteTestSuite) TestDefaultAdminUserIsNotDeleted() {
+	logrus.Info("Setting up user retention settings")
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+	setupUserRetentionSettings(ur.client, "", "400h", "*/1 * * * *", "false")
+
+	logrus.Info("Getting admin user details")
+	adminID, err := users.GetUserIDByName(ur.client, "admin")
+	require.NoError(ur.T(), err)
+	adminUser, err := ur.client.Management.User.ByID(adminID)
+	require.NoError(ur.T(), err)
+	adminUser.Password = ur.client.RancherConfig.AdminPassword
+
+	logrus.Info("Updating user attributes")
+	userAttributes, err := ur.client.WranglerContext.Mgmt.UserAttribute().Get(adminUser.ID, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	userAttributes.DeleteAfter = &v1.Duration{Duration: time.Second * 10}
+	_, err = ur.client.WranglerContext.Mgmt.UserAttribute().Update(userAttributes)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Attempting initial login")
+	_, err = auth.GetUserAfterLogin(ur.client, *adminUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Waiting for default duration")
+	time.Sleep(defaultWaitDuration)
+
+	logrus.Info("Attempting login after wait period")
+	_, err = auth.GetUserAfterLogin(ur.client, *adminUser)
+	require.NoError(ur.T(), err)
+}
+
+func (ur *URDeleteTestSuite) TestAdminUserGetDeleted() {
+	logrus.Info("Setting up user retention settings")
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+	setupUserRetentionSettings(ur.client, "", "400h", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new admin user")
+	newAdminUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "admin")
+	require.NoError(ur.T(), err)
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newAdminUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Updating user attributes")
+	userAttributes, err := ur.client.WranglerContext.Mgmt.UserAttribute().Get(newAdminUser.ID, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	userAttributes.DeleteAfter = &v1.Duration{Duration: time.Second * 10}
+	_, err = ur.client.WranglerContext.Mgmt.UserAttribute().Update(userAttributes)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Verifying user status")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled, "User's active state does not match expected state")
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Waiting for default duration")
+	pollUserStatus(ur.client, newAdminUser.ID, isInActive)
+
+	logrus.Info("Attempting login after wait period")
+	_, err = auth.GetUserAfterLogin(ur.client, *newAdminUser)
+	require.ErrorContains(ur.T(), err, unauthorizedError)
+
+	logrus.Info("Checking bindings after user deletion")
+	bindingsAfter, err := rbac.GetBindings(ur.client, newAdminUser.ID)
+	require.NoError(ur.T(), err)
+	require.Empty(ur.T(), bindingsAfter["RoleBindings"], "Expected no RoleBindings after user deletion")
+
+	logrus.Info("Checking global role bindings after user deletion")
+	globalRoleBindingsAfter, err := ur.client.Management.GlobalRoleBinding.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"userId": newAdminUser.ID,
+		},
+	})
+	require.NoError(ur.T(), err)
+	require.Empty(ur.T(), globalRoleBindingsAfter.Data, "Expected no GlobalRoleBindings after user deletion")
+}
+
+func (ur *URDeleteTestSuite) TestStandardUserGetDeleted() {
+	logrus.Info("Setting up user retention settings")
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+	setupUserRetentionSettings(ur.client, "", "400h", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new standard user")
+	newStdUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Logging in with new standard user")
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Updating user attributes")
+	userAttributes, err := ur.client.WranglerContext.Mgmt.UserAttribute().Get(newStdUser.ID, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	userAttributes.DeleteAfter = &v1.Duration{Duration: time.Second * 10}
+	_, err = ur.client.WranglerContext.Mgmt.UserAttribute().Update(userAttributes)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Verifying user status")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Polling user status to disable")
+	pollUserStatus(ur.client, newStdUser.ID, isInActive)
+
+	logrus.Info("Attempting login after wait period")
+	_, err = auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.ErrorContains(ur.T(), err, unauthorizedError)
+
+	logrus.Info("Checking bindings after user deletion")
+	bindingsAfter, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err)
+	require.Empty(ur.T(), bindingsAfter["RoleBindings"], "Expected no RoleBindings after user deletion")
+
+	logrus.Info("Checking global role bindings after user deletion")
+	globalRoleBindingsAfter, err := ur.client.Management.GlobalRoleBinding.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"userId": newStdUser.ID,
+		},
+	})
+	require.NoError(ur.T(), err)
+	require.Empty(ur.T(), globalRoleBindingsAfter.Data, "Expected no GlobalRoleBindings after user deletion")
+}
+
+func (ur *URDeleteTestSuite) TestUserIsNotDeletedWithBlankSettings() {
+	logrus.Info("Setting up user retention settings with blank values")
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+	setupUserRetentionSettings(ur.client, "", "400h", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new standard user")
+	newUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Logging in with new user")
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Updating user attributes")
+	userAttributes, err := ur.client.WranglerContext.Mgmt.UserAttribute().Get(newUser.ID, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	userAttributes.DeleteAfter = nil
+	_, err = ur.client.WranglerContext.Mgmt.UserAttribute().Update(userAttributes)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Verifying user status")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Waiting for default duration")
+	time.Sleep(defaultWaitDuration)
+
+	logrus.Info("Verifying user status after wait period")
+	userReLogin1, err := ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin1).Enabled)
+}
+
+func (ur *URDeleteTestSuite) TestUserIsNotGetDeletedWithDryRun() {
+	logrus.Info("Setting up user retention settings with dry run")
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+	setupUserRetentionSettings(ur.client, "", "400h", "*/1 * * * *", "true")
+
+	logrus.Info("Creating new standard user")
+	newUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Logging in with new user")
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Updating user attributes")
+	userAttributes, err := ur.client.WranglerContext.Mgmt.UserAttribute().Get(newUser.ID, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	userAttributes.DeleteAfter = &v1.Duration{Duration: time.Second * 10}
+	_, err = ur.client.WranglerContext.Mgmt.UserAttribute().Update(userAttributes)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Verifying user status")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Getting initial bindings")
+	bindingsBefore, _ := rbac.GetBindings(ur.client, newUser.ID)
+
+	logrus.Info("Waiting for default duration")
+	time.Sleep(2 * defaultWaitDuration)
+
+	logrus.Info("Verifying user status after wait period")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+
+	logrus.Info("Checking bindings after wait period")
+	bindingsAfter, _ := rbac.GetBindings(ur.client, newUser.ID)
+	require.Equal(ur.T(), bindingsBefore, bindingsAfter, "RoleBindings")
+	require.Equal(ur.T(), bindingsBefore, bindingsAfter, "ClusterRoleBindings")
+	require.Equal(ur.T(), bindingsBefore, bindingsAfter, "GlobalRoleBindings")
+	require.Equal(ur.T(), bindingsBefore, bindingsAfter, "ClusterRoleTemplateBindings")
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Resetting user retention dry run setting")
+	err = updateUserRetentionSettings(ur.client, userRetentionDryRun, "false")
+	require.NoError(ur.T(), err)
+}
+
+func TestURDeleteUserSuite(t *testing.T) {
+	suite.Run(t, new(URDeleteTestSuite))
+}

--- a/tests/v2/validation/auth/userretention/userretention_disable_user_test.go
+++ b/tests/v2/validation/auth/userretention/userretention_disable_user_test.go
@@ -1,0 +1,302 @@
+//go:build (validation || infra.any || cluster.any || sanity) && !stress && !extended
+
+package userretention
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/tests/v2/actions/auth"
+	"github.com/rancher/rancher/tests/v2/actions/rbac"
+	"github.com/rancher/shepherd/clients/rancher"
+	managementv3 "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type URDisableTestSuite struct {
+	suite.Suite
+	client    *rancher.Client
+	session   *session.Session
+	adminUser *managementv3.User
+}
+
+func (ur *URDisableTestSuite) SetupSuite() {
+	logrus.Info("Setting up URDisableTestSuite")
+	ur.session = session.NewSession()
+
+	logrus.Info("Creating new Rancher client")
+	client, err := rancher.NewClient("", ur.session)
+	require.NoError(ur.T(), err)
+	ur.client = client
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "0")
+	require.NoError(ur.T(), err)
+}
+
+func (ur *URDisableTestSuite) TearDownSuite() {
+	logrus.Info("Tearing down URDisableTestSuite")
+	if ur.adminUser != nil {
+		logrus.Info("Deleting admin user")
+		err := ur.client.Management.User.Delete(ur.adminUser)
+		if err != nil {
+			logrus.Errorf("Failed to delete admin user: %v", err)
+		}
+	}
+	logrus.Info("Cleaning up session")
+	ur.session.Cleanup()
+}
+
+func (ur *URDisableTestSuite) assertBindingsEqual(before, after map[string]interface{}) {
+	require.Equal(ur.T(), before["RoleBindings"], after["RoleBindings"], "RoleBindings mismatch")
+	require.Equal(ur.T(), before["ClusterRoleBindings"], after["ClusterRoleBindings"], "ClusterRoleBindings mismatch")
+	require.Equal(ur.T(), before["GlobalRoleBindings"], after["GlobalRoleBindings"], "GlobalRoleBindings mismatch")
+	require.Equal(ur.T(), before["ClusterRoleTemplateBindings"], after["ClusterRoleTemplateBindings"], "ClusterRoleTemplateBindings mismatch")
+}
+
+func (ur *URDisableTestSuite) TestDefaultAdminUserIsNotDisabled() {
+	logrus.Info("Setting up user retention settings")
+	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
+	logrus.Info("Retrieving admin user details")
+	adminID, err := users.GetUserIDByName(ur.client, "admin")
+	require.NoError(ur.T(), err)
+	adminUser, err := ur.client.Management.User.ByID(adminID)
+	require.NoError(ur.T(), err)
+	adminUser.Password = ur.client.RancherConfig.AdminPassword
+
+	logrus.Info("Attempting initial login for admin user")
+	_, err = auth.GetUserAfterLogin(ur.client, *adminUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Waiting for default duration")
+	time.Sleep(defaultWaitDuration)
+
+	logrus.Info("Attempting login after wait period")
+	_, err = auth.GetUserAfterLogin(ur.client, *adminUser)
+	require.NoError(ur.T(), err)
+}
+
+func (ur *URDisableTestSuite) TestAdminUserGetDisabled() {
+	logrus.Info("Setting up user retention settings")
+	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new admin user")
+	newAdminUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "admin")
+	require.NoError(ur.T(), err)
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newAdminUser)
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+
+	bindingsBefore, err := rbac.GetBindings(ur.client, newAdminUser.ID)
+	require.NoError(ur.T(), err, "Failed to get initial bindings")
+
+	logrus.Info("Polling user status")
+	pollUserStatus(ur.client, newAdminUser.ID, isInActive)
+
+	logrus.Info("Verifying user status after polling")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isInActive, *(userReLogin).Enabled)
+
+	logrus.Info("Attempting login with disabled user")
+	_, err = auth.GetUserAfterLogin(ur.client, *newAdminUser)
+	require.ErrorContains(ur.T(), err, forbiddenError)
+	bindingsAfter, err := rbac.GetBindings(ur.client, newAdminUser.ID)
+	require.NoError(ur.T(), err, "Failed to get final bindings")
+	ur.assertBindingsEqual(bindingsBefore, bindingsAfter)
+
+}
+
+func (ur *URDisableTestSuite) TestStandardUserGetDisabled() {
+	logrus.Info("Setting up user retention settings")
+	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new standard user")
+	newStdUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+
+	logrus.Info("Getting initial bindings")
+	bindingsBefore, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get initial bindings")
+
+	logrus.Info("Polling user status")
+	pollUserStatus(ur.client, newStdUser.ID, isInActive)
+
+	logrus.Info("Verifying user status after polling")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isInActive, *(userReLogin).Enabled)
+
+	logrus.Info("Attempting login with disabled user")
+	_, err = auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.ErrorContains(ur.T(), err, forbiddenError)
+
+	logrus.Info("Getting final bindings")
+	bindingsAfter, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get final bindings")
+	ur.assertBindingsEqual(bindingsBefore, bindingsAfter)
+}
+
+func (ur *URDisableTestSuite) TestDisabledUserGetEnabled() {
+	logrus.Info("Setting up user retention settings")
+	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new standard user")
+	newStdUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+
+	logrus.Info("Getting initial bindings")
+	bindingsBefore, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get initial bindings")
+
+	logrus.Info("Polling user status to disable")
+	pollUserStatus(ur.client, newStdUser.ID, isInActive)
+
+	logrus.Info("Verifying user status after polling")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isInActive, *(userReLogin).Enabled)
+
+	logrus.Info("Attempting login with disabled user")
+	_, err = auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.ErrorContains(ur.T(), err, forbiddenError)
+
+	logrus.Info("Enabling the disabled user")
+	enabled := true
+	userReLogin.Enabled = &enabled
+	activateUser, err := ur.client.WranglerContext.Mgmt.User().Update(userReLogin)
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(activateUser).Enabled)
+
+	logrus.Info("Verifying user status after enabling")
+	activeUserReLogin, err := ur.client.WranglerContext.Mgmt.User().Get(activateUser.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(activeUserReLogin).Enabled)
+
+	logrus.Info("Getting final bindings")
+	bindingsAfterEnabled, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get final bindings")
+	ur.assertBindingsEqual(bindingsBefore, bindingsAfterEnabled)
+}
+
+func (ur *URDisableTestSuite) TestStandardUserDidNotGetDisabledWithBlankSettings() {
+	logrus.Info("Setting up user retention settings with blank values")
+	setupUserRetentionSettings(ur.client, "", "", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new standard user")
+	newUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newUser)
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+
+	logrus.Info("Waiting for default duration")
+	time.Sleep(defaultWaitDuration)
+
+	logrus.Info("Attempting login after wait period")
+	userReLogin, err = auth.GetUserAfterLogin(ur.client, *newUser)
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+}
+
+func (ur *URDisableTestSuite) TestUserDisableByUpdatingUserattributes() {
+	logrus.Info("Setting up user retention settings")
+	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
+
+	logrus.Info("Creating new standard user")
+	newStdUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Getting initial bindings")
+	bindingsBefore, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get initial bindings")
+
+	logrus.Info("Updating user attributes")
+	userAttributes, err := ur.client.WranglerContext.Mgmt.UserAttribute().Get(newStdUser.ID, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	userAttributes.DisableAfter = &v1.Duration{Duration: time.Second * 10}
+	_, err = ur.client.WranglerContext.Mgmt.UserAttribute().Update(userAttributes)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Verifying user status after updating attributes")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Polling user status")
+	pollUserStatus(ur.client, newStdUser.ID, isInActive)
+
+	logrus.Info("Verifying user status after polling")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isInActive, *(userReLogin).Enabled)
+
+	logrus.Info("Attempting login with disabled user")
+	_, err = auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.ErrorContains(ur.T(), err, forbiddenError)
+
+	logrus.Info("Getting final bindings")
+	bindingsAfter, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get final bindings")
+	ur.assertBindingsEqual(bindingsBefore, bindingsAfter)
+}
+
+func (ur *URDisableTestSuite) TestUserIsNotDisabledWithDryRun() {
+	logrus.Info("Setting up user retention settings with dry run")
+	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "true")
+
+	logrus.Info("Creating new standard user")
+	newStdUser, err := users.CreateUserWithRole(ur.client, users.UserConfig(), "user")
+	require.NoError(ur.T(), err)
+	userReLogin, err := auth.GetUserAfterLogin(ur.client, *newStdUser)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Getting initial bindings")
+	bindingsBefore, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get initial bindings")
+
+	logrus.Info("Updating user attributes")
+	userAttributes, err := ur.client.WranglerContext.Mgmt.UserAttribute().Get(newStdUser.ID, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	userAttributes.DisableAfter = &v1.Duration{Duration: time.Second * 10}
+	_, err = ur.client.WranglerContext.Mgmt.UserAttribute().Update(userAttributes)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Verifying user status after updating attributes")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+	require.NoError(ur.T(), err)
+
+	logrus.Info("Waiting for default duration")
+	time.Sleep(2 * defaultWaitDuration)
+
+	logrus.Info("Attempting login after wait period")
+	userReLogin, err = ur.client.WranglerContext.Mgmt.User().Get(userReLogin.Name, v1.GetOptions{})
+	require.NoError(ur.T(), err)
+	require.Equal(ur.T(), isActive, *(userReLogin).Enabled)
+
+	logrus.Info("Getting final bindings")
+	bindingsAfter, err := rbac.GetBindings(ur.client, newStdUser.ID)
+	require.NoError(ur.T(), err, "Failed to get final bindings")
+	ur.assertBindingsEqual(bindingsBefore, bindingsAfter)
+
+	logrus.Info("User retention settings:dry run settings back to default value")
+	err = updateUserRetentionSettings(ur.client, userRetentionDryRun, "false")
+	require.NoError(ur.T(), err)
+}
+
+func TestURDisableUserSuite(t *testing.T) {
+	suite.Run(t, new(URDisableTestSuite))
+}

--- a/tests/v2/validation/auth/userretention/userretention_settings_test.go
+++ b/tests/v2/validation/auth/userretention/userretention_settings_test.go
@@ -1,0 +1,344 @@
+//go:build (validation || infra.any || cluster.any || sanity) && !stress && !extended
+
+package userretention
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type UserRetentionSettingsTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (ur *UserRetentionSettingsTestSuite) SetupSuite() {
+	ur.session = session.NewSession()
+	client, err := rancher.NewClient("", ur.session)
+	require.NoError(ur.T(), err)
+	ur.client = client
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "0")
+	require.NoError(ur.T(), err)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TearDownSuite() {
+	ur.session.Cleanup()
+}
+
+func (ur *UserRetentionSettingsTestSuite) testPositiveInputValues(settingName string, tests []struct {
+	name        string
+	value       string
+	description string
+}) {
+	logrus.Infof("Updating %s settings with positive values:", settingName)
+	for _, inputValue := range tests {
+		ur.T().Run(inputValue.name, func(*testing.T) {
+			err := updateUserRetentionSettings(ur.client, settingName, inputValue.value)
+			assert.NoError(ur.T(), err, "Unexpected error for input '%s'", inputValue.value)
+
+			if err == nil {
+				settings, err1 := ur.client.Management.Setting.ByID(settingName)
+				if assert.NoError(ur.T(), err1, "Failed to retrieve settings") {
+					assert.Equal(ur.T(), settingName, settings.Name)
+					assert.Equal(ur.T(), inputValue.value, settings.Value)
+				}
+			}
+			logrus.Infof("%s setting is updated to %s ; %s", settingName, inputValue.value, inputValue.description)
+		})
+	}
+}
+
+func (ur *UserRetentionSettingsTestSuite) testNegativeInputValues(settingName string, tests []struct {
+	name        string
+	value       string
+	description string
+}) {
+	logrus.Infof("Updating %s settings with negative values:", settingName)
+	for _, inputValue := range tests {
+		ur.T().Run(inputValue.name, func(*testing.T) {
+			err := updateUserRetentionSettings(ur.client, settingName, inputValue.value)
+			assert.Error(ur.T(), err, "Expected an error for input '%s', but got nil", inputValue.value)
+
+			if err != nil {
+				ur.validateError(err, inputValue.description)
+				ur.validateSettingsNotUpdated(settingName, inputValue.value)
+			}
+			logrus.Infof("Failed to update %s settings to %s; %s", settingName, inputValue.value, inputValue.description)
+		})
+	}
+}
+
+func (ur *UserRetentionSettingsTestSuite) validateError(err error, expectedDescription string) {
+	var statusErr *apierrors.StatusError
+	var found bool
+
+	switch e := err.(type) {
+	case interface{ Unwrap() error }:
+		if innerErr := e.Unwrap(); innerErr != nil {
+			if innerWrapper, ok := innerErr.(interface{ Unwrap() error }); ok {
+				if deepestErr := innerWrapper.Unwrap(); deepestErr != nil {
+					statusErr, found = deepestErr.(*apierrors.StatusError)
+				}
+			}
+		}
+	}
+
+	if found && statusErr != nil {
+		assert.Equal(ur.T(), int32(400), statusErr.ErrStatus.Code, "Status code should be 400")
+		assert.Equal(ur.T(), metav1.StatusReasonBadRequest, statusErr.ErrStatus.Reason, "Reason should be BadRequest")
+		assert.Contains(ur.T(), statusErr.ErrStatus.Message, expectedDescription, "Error should contain the expected description")
+	} else {
+		errMsg := err.Error()
+		assert.Contains(ur.T(), errMsg, "denied the request", "Error should mention denied request")
+		assert.Contains(ur.T(), errMsg, expectedDescription, "Error should contain the expected description")
+	}
+}
+
+func (ur *UserRetentionSettingsTestSuite) validateSettingsNotUpdated(settingName, inputValue string) {
+	settings, err := ur.client.Management.Setting.ByID(settingName)
+	if assert.NoError(ur.T(), err, "Failed to retrieve settings") {
+		assert.Equal(ur.T(), settingName, settings.Name)
+		assert.NotEqual(ur.T(), inputValue, settings.Value)
+	}
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDisableInactiveUserAfterWithPositiveInputValues() {
+
+	err := updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "1")
+	require.NoError(ur.T(), err)
+
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"DisableAfterUpdatedNoAction", "", "No action - users will not be deactivated"},
+		{"DisableAfterUpdatedZeroSeconds", "0s", "Users will be deactivated after 0s"},
+		{"DisableAfterUpdatedZeroMinutes", "0m", "Users will be deactivated after 0m"},
+		{"DisableAfterUpdatedZeroHours", "0h", "Users will be deactivated after 0h"},
+		{"DisableAfterUpdatedTenSeconds", "60s", "Users will be deactivated after 60s"},
+		{"DisableAfterUpdatedTenMinutes", "10m", "Users will be deactivated after 10m"},
+		{"DisableAfterUpdatedTwentyHours", "20h", "Users will be deactivated after 20h"},
+		{"DisableAfterUpdatedTenThousandSeconds", "10000s", "Users will be deactivated after 10000s"},
+		{"DisableAfterUpdatedTenThousandMinutes", "10000m", "Users will be deactivated after 10000m"},
+		{"DisableAfterUpdatedTenThousandHours", "10000h", "Users will be deactivated after 10000h"},
+	}
+	ur.testPositiveInputValues(disableInactiveUserAfter, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDisableInactiveUserAfterWithNegativeInputValues() {
+	err := updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "1")
+	require.NoError(ur.T(), err)
+
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"DisableAfterUpdateErrorMissingUnit", "10", "Invalid value: \"10\": time: missing unit in duration \"10\""},
+		{"DisableAfterUpdateErrorInvalidUnitS", "10S", "Invalid value: \"10S\": time: unknown unit \"S\" in duration \"10S\""},
+		{"DisableAfterUpdateErrorInvalidUnitM", "10M", "Invalid value: \"10M\": time: unknown unit \"M\" in duration \"10M\""},
+		{"DisableAfterUpdateErrorInvalidUnitH", "10H", "Invalid value: \"10H\": time: unknown unit \"H\" in duration \"10H\""},
+		{"DisableAfterUpdateErrorInvalidUnitSec", "10sec", "Invalid value: \"10sec\": time: unknown unit \"sec\" in duration \"10sec\""},
+		{"DisableAfterUpdateErrorInvalidUnitMin", "10min", "Invalid value: \"10min\": time: unknown unit \"min\" in duration \"10min\""},
+		{"DisableAfterUpdateErrorInvalidUnitHour", "20hour", "Invalid value: \"20hour\": time: unknown unit \"hour\" in duration \"20hour\""},
+		{"DisableAfterUpdateErrorInvalidUnitDay", "1d", "Invalid value: \"1d\": time: unknown unit \"d\" in duration \"1d\""},
+		{"DisableAfterUpdateErrorNegativeDuration", "-20m", "Invalid value: \"-20m\": negative value"},
+		{"DisableAfterUpdateErrorInvalidDuration", "tens", "Invalid value: \"tens\": time: invalid duration \"tens\""},
+	}
+	ur.testNegativeInputValues(disableInactiveUserAfter, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDeleteInactiveUserAfterWithPositiveInputValues() {
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"DeleteAfterNoAction", "", "No action - users will not be deleted"},
+		{"DeleteAfterHundredMillionSeconds", "100000000s", "Users will delete after 100000000s"},
+		{"DeleteAfterTwoHundredThousandMinutes", "200000m", "Users will delete after 200000m"},
+		{"DeleteAfterTenThousandHours", "10000h", "Users will delete after 10000h"},
+	}
+	ur.testPositiveInputValues(deleteInactiveUserAfter, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForDeleteInactiveUserAfterWithNegativeInputValues() {
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"DeleteErrorMissingUnit", "10", "Invalid value: \"10\": time: missing unit in duration \"10\""},
+		{"DeleteErrorTooShortSeconds", "10s", "Forbidden: must be at least 336h0m0s"},
+		{"DeleteErrorTooShortMinutes", "10m", "Forbidden: must be at least 336h0m0s"},
+		{"DeleteErrorTooShortHours", "10h", "Forbidden: must be at least 336h0m0s"},
+		{"DeleteErrorInvalidUnitS", "10S", "time: unknown unit"},
+		{"DeleteErrorInvalidUnitM", "10M", "time: unknown unit"},
+		{"DeleteErrorInvalidUnitH", "10H", "time: unknown unit"},
+		{"DeleteErrorInvalidUnitSec", "10sec", "time: unknown unit"},
+		{"DeleteErrorInvalidUnitMin", "10min", "time: unknown unit"},
+		{"DeleteErrorInvalidUnitHour", "20hour", "time: unknown unit"},
+		{"DeleteErrorInvalidUnitDay", "1d", "time: unknown unit"},
+		{"DeleteErrorNegativeDuration", "-20m", "negative value"},
+	}
+	ur.testNegativeInputValues(deleteInactiveUserAfter, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForUserRetentionCronWithPositiveInputValues() {
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"CronRunsEvery1Hour", "0 * * * *", "every 1 hour"},
+		{"CronRunsEvery1Day", "0 0 * * *", "every 1 day"},
+		{"CronRunsEvery5Minutes", "*/5 * * * *", "every 5 mins"},
+		{"CronRunsEvery1Minute", "*/1 * * * *", "every min"},
+		{"CronRunsEveryMinute", "* * * * *", "every min"},
+		{"CronRunsEvery30Seconds", "30/1 * * * *", "every 30 sec"},
+		{"CronRunsEvery2PMTo205PM", "0-5 14 * * *", "every minute starting at 2:00 PM and ending at 2:05 PM, every day"},
+		{"CronRunsFirstSecondDayMidnight", "0 0 1,2 * *", "at midnight of 1st, 2nd day of each month"},
+		{"CronRunsFirstSecondDayWednesdayMidnight", "0 0 1,2 * 3", "at midnight of 1st, 2nd day of each month, and each Wednesday"},
+	}
+	ur.testPositiveInputValues(userRetentionCron, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForUserRetentionCronWithNegativeInputValues() {
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"CronUpdateErrorTooManyFields", "* * * * * *", "Invalid value: \"* * * * * *\": Expected exactly 5 fields, found 6: * * * * * *"},
+		{"CronUpdateErrorNegativeNumber", "*/-1 * * * *", "Invalid value: \"*/-1 * * * *\": Negative number (-1) not allowed: -1"},
+		{"CronUpdateErrorOutOfRange", "60/1 * * * *", "Invalid value: \"60/1 * * * *\": Beginning of range (60) beyond end of range (59): 60/1"},
+		{"CronUpdateErrorNegativeStart", "-30/1 * * * *", "Invalid value: \"-30/1 * * * *\": Failed to parse int from : strconv.Atoi: parsing \"\": invalid syntax"},
+		{"CronUpdateErrorInvalidSyntax", "(*/1) * * * *", "Invalid value: \"(*/1) * * * *\": Failed to parse int from (*: strconv.Atoi: parsing \"(*\": invalid syntax"},
+		{"CronUpdateErrorTooManyFields", "* * * * * */2", "Invalid value: \"* * * * * */2\": Expected exactly 5 fields, found 6: * * * * * */2"},
+		{"CronUpdateErrorLessFields1", "10min", "Invalid value: \"10min\": Expected exactly 5 fields, found 1: 10min"},
+		{"CronUpdateErrorLessFields2", "1d", "Invalid value: \"1d\": Expected exactly 5 fields, found 1: 1d"},
+		{"CronUpdateErrorInvalidNegative", "-20m", "Invalid value: \"-20m\": Expected exactly 5 fields, found 1: -20m"},
+	}
+	ur.testNegativeInputValues(userRetentionCron, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForAuthUserSessionTTLWithPositiveInputValues() {
+
+	err := setupUserRetentionSettings(ur.client, "1600h", "1600h", "*/1 * * * *", "false")
+	require.NoError(ur.T(), err)
+
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"TTLUpdatedMin", "1", "Minimum 1 minute session"},
+		{"TTLUpdatedHour", "60", "One hour session"},
+		{"TTLUpdatedDay", "1440", "24 hour session"},
+		{"TTLUpdatedWeek", "10080", "One week session"},
+	}
+	ur.testPositiveInputValues(authUserSessionTTLMinutes, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestUpdateSettingsForAuthUserSessionTTLWithNegativeInputValues() {
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"TTLErrorNegative", "-10", "negative value"},
+		{"TTLErrorNonNumeric", "abc", "strconv.ParseInt: parsing \"abc\": invalid syntax"},
+		{"TTLErrorDecimal", "10.5", "strconv.ParseInt: parsing \"10.5\": invalid syntax"},
+		{"TTLErrorSpecialChars", "10@20", "strconv.ParseInt: parsing \"10@20\": invalid syntax"},
+	}
+	ur.testNegativeInputValues(authUserSessionTTLMinutes, tests)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestDisableInactiveUserLessThanTTL() {
+	err := setupUserRetentionSettings(ur.client, "1600m", "1600h", "*/1 * * * *", "false")
+	require.NoError(ur.T(), err)
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "1600")
+	require.NoError(ur.T(), err)
+
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"DisableLessThanTTL30m", "30m", "Forbidden: can't be less than auth-user-session-ttl-minutes"},
+		{"DisableLessThanTTL599m", "599m", "Forbidden: can't be less than auth-user-session-ttl-minutes"},
+		{"DisableLessThanTTL1h", "1h", "Forbidden: can't be less than auth-user-session-ttl-minutes"},
+	}
+	ur.testNegativeInputValues(disableInactiveUserAfter, tests)
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, testTTLValue)
+	require.NoError(ur.T(), err)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestDeleteInactiveUserLessThanTTL() {
+	err := setupUserRetentionSettings(ur.client, "21600m", "1600h", "*/1 * * * *", "false")
+	require.NoError(ur.T(), err)
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "21600")
+	require.NoError(ur.T(), err)
+
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"DeleteLessThanTTL4h", "338h", "Forbidden: can't be less than auth-user-session-ttl-minutes"},
+		{"DeleteLessThanTTL359m", "359h", "Forbidden: can't be less than auth-user-session-ttl-minutes"},
+		{"DeleteLessThanTTL5h", "5h", "Forbidden: must be at least 336h0m0s"},
+	}
+	ur.testNegativeInputValues(deleteInactiveUserAfter, tests)
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, testTTLValue)
+	require.NoError(ur.T(), err)
+}
+
+func (ur *UserRetentionSettingsTestSuite) TestInactiveUserSettingsGreaterThanTTL() {
+	err := updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "60")
+	require.NoError(ur.T(), err)
+
+	tests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"ValidDisableAfter2h", "2h", "Valid value greater than TTL"},
+		{"ValidDisableAfter61m", "61m", "Valid value greater than TTL"},
+		{"ValidDisableAfter3600s", "3600s", "Valid value greater than TTL"},
+	}
+	ur.testPositiveInputValues(disableInactiveUserAfter, tests)
+
+	deleteTests := []struct {
+		name        string
+		value       string
+		description string
+	}{
+		{"ValidDeleteAfter337h", "337h", "Valid value greater than minimum and TTL"},
+		{"ValidDeleteAfter20160m", "20160m", "Valid value greater than minimum and TTL"},
+	}
+	ur.testPositiveInputValues(deleteInactiveUserAfter, deleteTests)
+
+	err = updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, testTTLValue)
+	require.NoError(ur.T(), err)
+}
+
+func TestUserRetentionSettingsSuite(t *testing.T) {
+	suite.Run(t, new(UserRetentionSettingsTestSuite))
+}


### PR DESCRIPTION
**This PR has two changes:**

1. Userretention settings updates to main branch (These changes were approved on v2.9 already and merged)
2. Added new tests related to Auth TTL https://github.com/rancher/rancher/issues/46648

**Note:**
The recent changes related to Auth TTL were in the file tests/v2/validation/auth/userretention/userretention_settings_test.go