### PR TITLE
Set annotation to guest cluster VM when deleting the cluster

### DIFF
--- a/pkg/controllers/capr/machineprovision/controller.go
+++ b/pkg/controllers/capr/machineprovision/controller.go
@@ -9,17 +9,6 @@ import (
 	"time"
 
 	"github.com/rancher/lasso/pkg/dynamic"
-	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
-	"github.com/rancher/rancher/pkg/capr"
-	"github.com/rancher/rancher/pkg/controllers/management/drivers/nodedriver"
-	"github.com/rancher/rancher/pkg/controllers/management/node"
-	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
-	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
-	ranchercontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
-	"github.com/rancher/rancher/pkg/namespace"
-	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
-	"github.com/rancher/rancher/pkg/settings"
-	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/data"
@@ -40,16 +29,33 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
+
+	k8dynamic "k8s.io/client-go/dynamic"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/controllers/management/drivers/nodedriver"
+	"github.com/rancher/rancher/pkg/controllers/management/node"
+	"github.com/rancher/rancher/pkg/features"
+	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
+	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	ranchercontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/wrangler"
 )
 
 const (
 	createJobConditionType = "CreateJob"
 	deleteJobConditionType = "DeleteJob"
 
-	forceRemoveMachineAnn = "provisioning.cattle.io/force-machine-remove"
+	forceRemoveMachineAnn       = "provisioning.cattle.io/force-machine-remove"
+	removedAllPVCsAnnotationKey = "harvesterhci.io/removeAllPersistentVolumeClaims"
 )
 
 type infraObject struct {
@@ -307,6 +313,12 @@ func (h *handler) namespaceIsRemoved(obj runtime.Object) (bool, error) {
 func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, error) {
 	if removed, err := h.namespaceIsRemoved(obj); err != nil || removed {
 		return obj, err
+	}
+
+	if features.Harvester.Enabled() {
+		if _, err := h.onRemoveHarvester(key, obj); err != nil {
+			return obj, err
+		}
 	}
 
 	infra, err := newInfraObject(obj)
@@ -919,4 +931,102 @@ func ExecutingMachineMessage(podLabels map[string]string, namespace string) stri
 		podLabels[InfraMachineKind],
 		podLabels[CapiMachineName],
 	)
+}
+
+// onRemoveHarvester adds an annotation to the `VirtualMachine` resource
+// of the downstream cluster that informs the Harvester node driver to
+// remove all PVCs when the VM is deleted from it.
+// There is no other way to do this because the node driver does not know
+// whether the node is only deleted because it is to be redeployed or
+// whether it is to be permanently deleted because the parent cluster is
+// deleted.
+func (h *handler) onRemoveHarvester(key string, obj runtime.Object) (runtime.Object, error) {
+	if obj.GetObjectKind().GroupVersionKind().Kind != "HarvesterMachine" {
+		return obj, nil
+	}
+
+	infra, err := newInfraObject(obj)
+	if err != nil {
+		return obj, err
+	}
+
+	capiCluster, err := capr.GetCAPIClusterFromLabel(obj, h.capiClusterCache)
+	if err != nil && !apierrors.IsNotFound(err) {
+		logrus.Errorf("[machineprovision] %s: error getting cluster (apiversion=cluster.x-k8s.io): %v", key, err)
+		return obj, err
+	}
+	if err != nil && apierrors.IsNotFound(err) {
+		logrus.Debugf("[machineprovision] %s: there is no cluster (apiversion=cluster.x-k8s.io). Continue ...", key)
+		return obj, nil
+	}
+
+	// Skip if the cluster (cluster.x-k8s.io) is not being deleted.
+	if capiCluster.DeletionTimestamp.IsZero() {
+		return obj, nil
+	}
+
+	rancherCluster, err := h.rancherClusterCache.Get(infra.meta.GetNamespace(), capiCluster.Name)
+	if err != nil {
+		logrus.Errorf("[machineprovision] %s: error getting cluster (apiversion=provisioning.cattle.io): %v", key, err)
+		return obj, err
+	}
+
+	secret, err := GetCloudCredentialSecret(h.secrets, "", rancherCluster.Spec.CloudCredentialSecretName)
+	if err != nil {
+		logrus.Errorf("[machineprovision] %s: error getting cloud credential secret: %v", key, err)
+		return obj, err
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(secret.Data["harvestercredentialConfig-kubeconfigContent"])
+	if err != nil {
+		logrus.Errorf("[machineprovision] %s: error getting REST config from cloud credential secret: %v", key, err)
+		return obj, err
+	}
+
+	// We need to use the dynamic client here because we do not want to import
+	// the kubevirt API into Rancher.
+	dynamicClient, err := k8dynamic.NewForConfig(restConfig)
+	if err != nil {
+		logrus.Errorf("[machineprovision] %s: error getting dynamic client: %v", key, err)
+		return obj, err
+	}
+
+	resourceGVR := schema.GroupVersionResource{
+		Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines",
+	}
+	resourceName := infra.meta.GetName()
+	resourceNamespace := infra.data.String("spec", "vmNamespace")
+
+	resource, err := dynamicClient.Resource(resourceGVR).Namespace(resourceNamespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logrus.Errorf("[machineprovision] %s: error getting VM (gvr=%s, namespace=%s, name=%s): %v",
+			key, resourceGVR.String(), resourceNamespace, resourceName, err)
+		return obj, err
+	}
+	if err != nil && apierrors.IsNotFound(err) {
+		logrus.Debugf("[machineprovision] %s: there is no VM (gvr=%s, namespace=%s, name=%s). Continue ...",
+			key, resourceGVR.String(), resourceNamespace, resourceName)
+		return obj, nil
+	}
+
+	annotations := resource.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if _, ok := annotations[removedAllPVCsAnnotationKey]; !ok {
+		annotations[removedAllPVCsAnnotationKey] = "true"
+		resource.SetAnnotations(annotations)
+
+		_, err = dynamicClient.Resource(resourceGVR).Namespace(resourceNamespace).Update(context.TODO(), resource, metav1.UpdateOptions{})
+		if err != nil {
+			logrus.Errorf("[machineprovision] %s: error updating VM (gvr=%s, namespace=%s, name=%s): %v",
+				key, resourceGVR.String(), resourceNamespace, resourceName, err)
+			return obj, err
+		}
+
+		logrus.Infof("[machineprovision] %s: VM successfully marked for removal (gvr=%s, namespace=%s, name=%s)",
+			key, resourceGVR.String(), resourceNamespace, resourceName)
+	}
+
+	return obj, nil
 }

--- a/pkg/controllers/provisioningv2/controllers.go
+++ b/pkg/controllers/provisioningv2/controllers.go
@@ -2,9 +2,11 @@ package provisioningv2
 
 import (
 	"context"
+
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/fleetcluster"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/fleetworkspace"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/harvestercleanup"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/machineconfigcleanup"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/managedchart"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/provisioningcluster"
@@ -28,5 +30,9 @@ func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager 
 		managedchart.Register(ctx, clients)
 		fleetcluster.Register(ctx, clients)
 		fleetworkspace.Register(ctx, clients)
+	}
+
+	if features.Harvester.Enabled() {
+		harvestercleanup.Register(ctx, clients)
 	}
 }

--- a/pkg/controllers/provisioningv2/harvestercleanup/controller.go
+++ b/pkg/controllers/provisioningv2/harvestercleanup/controller.go
@@ -1,0 +1,183 @@
+package harvestercleanup
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/rancher/wrangler/v3/pkg/data"
+	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8dynamic "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/controllers/capr/machineprovision"
+	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
+	provcontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/wrangler"
+)
+
+const (
+	harvMachineProvCleanupHandlerName       = "harvester-machine-provision-cleanup"
+	skipHarvMachineProvCleanupAnnotationKey = "harvesterhci.io/skipHarvesterMachineProvisionCleanup"
+	removedAllPVCsAnnotationKey             = "harvesterhci.io/removeAllPersistentVolumeClaims"
+)
+
+type handler struct {
+	capiClusters capicontrollers.ClusterCache
+	clusterCache provcontrollers.ClusterCache
+	secretCache  corecontrollers.SecretCache
+}
+
+func Register(ctx context.Context, clients *wrangler.Context) {
+	h := handler{
+		capiClusters: clients.CAPI.Cluster().Cache(),
+		clusterCache: clients.Provisioning.Cluster().Cache(),
+		secretCache:  clients.Core.Secret().Cache(),
+	}
+
+	clients.Dynamic.OnChange(ctx, harvMachineProvCleanupHandlerName, validGVK, h.onChange)
+}
+
+func validGVK(gvk schema.GroupVersionKind) bool {
+	// It is not necessary to check the version here.
+	return gvk.Group == "rke-machine.cattle.io" && gvk.Kind == "HarvesterMachine"
+}
+
+// onChange adds an annotation to the `VirtualMachine` resource of the
+// downstream cluster that informs the Harvester node driver to remove all
+// PVCs when the VM is deleted from it.
+// There is no other way to do this because the node driver does not know
+// whether the node is only deleted because it is to be redeployed or
+// whether it is to be permanently deleted because the parent cluster is
+// deleted.
+func (h *handler) onChange(obj runtime.Object) (runtime.Object, error) {
+	if obj == nil {
+		return obj, nil
+	}
+
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Exit immediately if the object is not being deleted.
+	if objMeta.GetDeletionTimestamp().IsZero() {
+		return obj, nil
+	}
+
+	objData, err := data.Convert(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	key := objMeta.GetNamespace() + "/" + objMeta.GetName()
+
+	capiCluster, err := capr.GetCAPIClusterFromLabel(obj, h.capiClusters)
+	if apierrors.IsNotFound(err) {
+		logrus.Warnf("[%s] %s: there is no cluster (apiversion=cluster.x-k8s.io). Skipping ...", harvMachineProvCleanupHandlerName, key)
+		return obj, nil
+	}
+	if err != nil {
+		logrus.Errorf("[%s] %s: error getting cluster (apiversion=cluster.x-k8s.io): %v", harvMachineProvCleanupHandlerName, key, err)
+		return obj, err
+	}
+
+	// Skip if the CAPI cluster (cluster.x-k8s.io) is not being deleted.
+	if capiCluster.DeletionTimestamp.IsZero() {
+		return obj, nil
+	}
+
+	// Skip if forced via annotation that contains a boolean value.
+	if value, ok := capiCluster.Annotations[skipHarvMachineProvCleanupAnnotationKey]; ok {
+		boolValue, err := strconv.ParseBool(value)
+		if boolValue && err == nil {
+			return obj, nil
+		}
+	}
+
+	cluster, err := h.clusterCache.Get(objMeta.GetNamespace(), capiCluster.Name)
+	if err != nil {
+		logrus.Errorf("[%s] %s: error getting cluster (apiversion=provisioning.cattle.io): %v", harvMachineProvCleanupHandlerName, key, err)
+		return obj, err
+	}
+
+	// Skip if forced via annotation that contains a boolean value.
+	if value, ok := cluster.Annotations[skipHarvMachineProvCleanupAnnotationKey]; ok {
+		boolValue, err := strconv.ParseBool(value)
+		if boolValue && err == nil {
+			return obj, nil
+		}
+	}
+
+	secret, err := machineprovision.GetCloudCredentialSecret(h.secretCache, "", cluster.Spec.CloudCredentialSecretName)
+	if err != nil {
+		logrus.Errorf("[%s] %s: error getting cloud credential secret: %v", harvMachineProvCleanupHandlerName, key, err)
+		return obj, err
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(secret.Data["harvestercredentialConfig-kubeconfigContent"])
+	if err != nil {
+		logrus.Errorf("[%s] %s: error getting REST config from cloud credential secret: %v", harvMachineProvCleanupHandlerName, key, err)
+		return obj, err
+	}
+
+	// We need to use the dynamic client here because we do not want to import
+	// the kubevirt API into Rancher.
+	dynamicClient, err := k8dynamic.NewForConfig(restConfig)
+	if err != nil {
+		logrus.Errorf("[%s] %s: error getting dynamic client: %v", harvMachineProvCleanupHandlerName, key, err)
+		return obj, err
+	}
+
+	resourceGVR := schema.GroupVersionResource{
+		Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines",
+	}
+	resourceName := objMeta.GetName()
+	resourceNamespace := objData.String("spec", "vmNamespace")
+
+	resource, err := dynamicClient.Resource(resourceGVR).Namespace(resourceNamespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		logrus.Warnf("[%s] %s: there is no VM (gvr=%s, namespace=%s, name=%s). Skipping ...",
+			harvMachineProvCleanupHandlerName, key, resourceGVR.String(), resourceNamespace, resourceName)
+		return obj, nil
+	}
+	if err != nil {
+		logrus.Errorf("[%s] %s: error getting VM (gvr=%s, namespace=%s, name=%s): %v",
+			harvMachineProvCleanupHandlerName, key, resourceGVR.String(), resourceNamespace, resourceName, err)
+		return obj, err
+	}
+
+	annotations := resource.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if _, ok := annotations[removedAllPVCsAnnotationKey]; !ok {
+		annotations[removedAllPVCsAnnotationKey] = "true"
+		resource.SetAnnotations(annotations)
+
+		_, err = dynamicClient.Resource(resourceGVR).Namespace(resourceNamespace).Update(context.TODO(), resource, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Warnf("[%s] %s: there is no VM to update (gvr=%s, namespace=%s, name=%s). Skipping ...",
+					harvMachineProvCleanupHandlerName, key, resourceGVR.String(), resourceNamespace, resourceName)
+				return obj, nil
+			} else {
+				err = fmt.Errorf("failed to update VM (gvr=%s, namespace=%s, name=%s): %w", resourceGVR.String(), resourceNamespace, resourceName, err)
+				logrus.Errorf("[%s] %s: %v", harvMachineProvCleanupHandlerName, key, err)
+				return obj, err
+			}
+		}
+
+		logrus.Infof("[%s] %s: VM successfully marked for removal (gvr=%s, namespace=%s, name=%s)",
+			harvMachineProvCleanupHandlerName, key, resourceGVR.String(), resourceNamespace, resourceName)
+	}
+
+	return obj, nil
+}


### PR DESCRIPTION
Signed-off-by: Volker Theile <vtheile@suse.com>

## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/harvester/harvester/issues/2825

## Problem
If a guest cluster is deleted, the [PVCs of the workloads are not deleted](https://github.com/harvester/docker-machine-driver-harvester/blob/03e510a33007aeb9ab9fbd63b85f7a4d6acc4488/harvester/harvester.go#L183) in Harvester. This is because the Harvester node driver does not know why the associated VM has to be deleted, e.g. because its parameters have changed or because the guest cluster is deleted.
 
## Solution
To solve the problem, a `OnChange` handler on `harvestermachines.rke-machine.cattle.io` will be implemented that checks whether the deletion timestamp is set for the associated cluster when the machine resource is deleted. If this is the case, an annotation is set on the VM in the downstream cluster which is then processed by the Harvester node driver.

See https://github.com/harvester/docker-machine-driver-harvester/pull/64 for the node driver part.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
- Link a Harvester cluster with Rancher in the `Virtualization` page.
- Go to the `Cluster Management` page to create a new cluster.
- Click `Create` and choose Harvester.
- File the cloud credential page if necessary. Press `Create`.
- Make sure to download an ISO image in the Harvester UI, e.g. [Ubuntu 22.04](https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img).
- Make sure to create a virtual network in Harvester, e.g. `vlan1`.
- Go to `Cluster Management` and press the `Create` button.
- Select `Harvester`.
- Use the following settings to create the cluster and then press the `Create` button.
```
Name: harvclst01
Image volume: ubuntu-22.04-minimal-cloudimg-amd64.img
Disk: 20 GiB
Network: default/vlan1
```
- Create a deployment in the new created cluster.
- Check in the Harvester UI that there is a new volume created that is used by the deployment.
- In the Rancher UI, delete the Harvester guest cluster.
- Use k9s to monitor the pods in the Rancher cluster. Soon after the deletion has been started, there should be a pod called `fleet-default/xxx-poolX-xxxxxxxx-xxxxx-machine-provision-xxxxx`. Check the logs of this pod and look out for the log message `(xxx-poolX-xxxxxxxx-xxxxx) Force the removal of all persistent volume claims`.
- Finally after the cluster has been deleted, go to the Harvester UI and make sure the volume that was used by the guest cluster and the volume created by the deployment have been removed.

