### PR TITLE
[2.10] fix the cluster-cleanup logic

### DIFF
--- a/pkg/agent/clean/cluster.go
+++ b/pkg/agent/clean/cluster.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rancher/rancher/pkg/controllers/dashboard/scaleavailable"
 	"github.com/rancher/rancher/pkg/controllers/management/usercontrollers"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
 	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy/helm"
@@ -32,6 +33,8 @@ import (
 	"github.com/sirupsen/logrus"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -72,6 +75,11 @@ var (
 	}
 )
 
+const (
+	// The finalizer is added by Wrangler to deployments, please check the `systemcharts` package for more details
+	legacyK3sBasedUpgraderDeprecationFinalizer = "wrangler.cattle.io/legacy-k3sBasedUpgrader-deprecation"
+)
+
 type getNSFunc func(*kubernetes.Clientset) ([]string, error)
 
 func Cluster() error {
@@ -105,6 +113,19 @@ func Cluster() error {
 	}
 
 	var errors []error
+
+	// First, scale the cattle-cluster-agent down to 0 to stop it from running controllers,
+	// particularly the `systemcharts` handler that adds finalizers to deployments
+	if err := scaleDownClusterAgent(client); err != nil {
+		errors = append(errors, err)
+	}
+
+	// Deployments should be cleaned up before removing namespaces, specifically by removing the finalizer.
+	deploymentErr := cleanupDeployments(client)
+	if len(deploymentErr) > 0 {
+		errors = append(errors, deploymentErr...)
+	}
+
 	var toRemove = make([]string, len(nsToRemove))
 	copy(toRemove, nsToRemove)
 
@@ -270,6 +291,117 @@ func cleanupNamespaces(client *kubernetes.Clientset) []error {
 
 	return errs
 
+}
+
+// scaleDownClusterAgent ensures to scale down the cattle-cluster-agent deployment to zero
+func scaleDownClusterAgent(client *kubernetes.Clientset) error {
+	logrus.Info("Attempting to scale down the cattle-cluster-agent deployment")
+	err := tryUpdate(func() error {
+		agent, err := client.AppsV1().Deployments(namespace.System).Get(context.TODO(), "cattle-cluster-agent", metav1.GetOptions{})
+		if err != nil {
+			if apierror.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		var updated bool
+		if agent.Spec.Replicas != nil && *agent.Spec.Replicas != 0 {
+			var zero int32 = 0
+			agent.Spec.Replicas = &zero
+			updated = true
+		}
+		// for the usage of the annotation, please check the package `scaleavailable`
+		val := agent.Annotations[scaleavailable.AvailableAnnotation]
+		if val != "invalid" {
+			agent.Annotations[scaleavailable.AvailableAnnotation] = "invalid"
+			updated = true
+		}
+
+		if updated {
+			logrus.Info("Scaling down cattle-cluster-agent")
+			if !dryRun {
+				_, err = client.AppsV1().Deployments(namespace.System).Update(context.TODO(), agent, metav1.UpdateOptions{})
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Waiting for cattle-cluster-agent's pods to be removed")
+	var backoff = wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   1.5,
+		Jitter:   0,
+		Steps:    5,
+	}
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		set := labels.Set(map[string]string{"app": "cattle-cluster-agent"})
+		podList, err := client.CoreV1().Pods(namespace.System).List(context.TODO(), metav1.ListOptions{LabelSelector: set.String()})
+		if err != nil {
+			if apierror.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		if podList != nil && len(podList.Items) > 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func cleanupDeployments(client *kubernetes.Clientset) []error {
+	logrus.Info("Starting cleanup of deployments")
+	deployments, err := client.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return []error{err}
+	}
+	var errs []error
+	for _, item := range deployments.Items {
+		err = tryUpdate(func() error {
+			deployment, err := client.AppsV1().Deployments(item.Namespace).Get(context.TODO(), item.Name, metav1.GetOptions{})
+			if err != nil {
+				if apierror.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+			var updated bool
+			// Cleanup finalizers
+			if len(deployment.Finalizers) > 0 {
+				var finalizers []string
+				for _, finalizer := range deployment.Finalizers {
+					if finalizer != legacyK3sBasedUpgraderDeprecationFinalizer {
+						finalizers = append(finalizers, finalizer)
+					}
+				}
+				if len(deployment.Finalizers) != len(finalizers) {
+					updated = true
+					deployment.Finalizers = finalizers
+				}
+			}
+			if updated {
+				logrus.Infof("Updating deployment: %s", deployment.Name)
+				if !dryRun {
+					_, err = client.AppsV1().Deployments(deployment.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
 }
 
 func cleanupClusterRoleBindings(client *kubernetes.Clientset) []error {

--- a/pkg/controllers/dashboard/scaleavailable/scale.go
+++ b/pkg/controllers/dashboard/scaleavailable/scale.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	availableAnnotation = "management.cattle.io/scale-available"
+	AvailableAnnotation = "management.cattle.io/scale-available"
 )
 
 type handler struct {
@@ -30,14 +30,14 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 	}
 	deploymentCache := wrangler.Apps.Deployment().Cache()
 	wrangler.Apps.Deployment().OnChange(ctx, "scale-available", h.OnChange)
-	deploymentCache.AddIndexer(availableAnnotation, func(obj *appsv1.Deployment) ([]string, error) {
-		if val := obj.Annotations[availableAnnotation]; val != "" {
-			return []string{availableAnnotation}, nil
+	deploymentCache.AddIndexer(AvailableAnnotation, func(obj *appsv1.Deployment) ([]string, error) {
+		if val := obj.Annotations[AvailableAnnotation]; val != "" {
+			return []string{AvailableAnnotation}, nil
 		}
 		return nil, nil
 	})
 	relatedresource.Watch(ctx, "scale-available-trigger", func(namespace, name string, obj runtime.Object) (result []relatedresource.Key, _ error) {
-		deps, err := deploymentCache.GetByIndex(availableAnnotation, availableAnnotation)
+		deps, err := deploymentCache.GetByIndex(AvailableAnnotation, AvailableAnnotation)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func (h *handler) OnChange(key string, deployment *appsv1.Deployment) (*appsv1.D
 	if deployment == nil {
 		return nil, nil
 	}
-	numStr := deployment.Annotations[availableAnnotation]
+	numStr := deployment.Annotations[AvailableAnnotation]
 	if numStr == "" {
 		return deployment, nil
 	}

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -242,6 +242,17 @@ func (c *ClusterLifecycleCleanup) createCleanupClusterRole(userContext *config.U
 			Resources:     []string{"validatingwebhookconfigurations", "mutatingwebhookconfigurations"},
 			ResourceNames: []string{WebhookConfigurationName},
 		},
+		// This is needed for removing finalizers from deployments
+		{
+			Verbs:     []string{"list", "get", "update"},
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments"},
+		},
+		{
+			Verbs:     []string{"list"},
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+		},
 	}
 	clusterRole := rbacV1.ClusterRole{
 		ObjectMeta: meta,


### PR DESCRIPTION
fix the cluster-cleanup logic where finalizers on the deployments are not properly removed

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/47863

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
In the downstream cluster, the `systemChart` handler runs within the cattle-cluster-agent, adding the `wrangler.cattle.io/legacy-k3sBasedUpgrader-deprecation` finalizer to all Deployments in all namespaces. When an imported cluster is removed from Rancher, Rancher triggers a cleanup job on the downstream cluster to delete all Rancher-related resources. However, due to this finalizer, Deployments in the `cattle-system` namespace, as well as the namespace itself, become stuck in the removal process. This occurs even though the cleanup job reports success because it successfully initiates the namespace deletion.

Note that this issue is generic and can be reproduced in any imported cluster.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
The cluster cleanup logic has been updated to first scale down the `cattle-cluster-agent` deployment, preventing it from running controllers—especially the `systemcharts` handler that adds finalizers to deployments. Then, it removes the `wrangler.cattle.io/legacy-k3sBasedUpgrader-deprecation` finalizer from all deployments before proceeding with namespace removal.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The problem described in the issue does not happen anymore on the Rancher setup that is built from the PR. A standalone k3s cluster is used for testing as this issue is generic and can be reproduced in any imported cluster.

For reference, here are the logs of the pod that performs the cleanup:

<details>
<summary>k logs -f cattle-cleanup-8lsg4-hsx9l</summary>

```
time="2024-11-05T02:13:03Z" level=warning msg="failed to reconcile kubelet, error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
time="2024-11-05T02:13:03Z" level=info msg="Starting sleep for 1 min to allow server time to disconnect...."
time="2024-11-05T02:13:03Z" level=info msg="Listening on /tmp/log.sock"
time="2024-11-05T02:14:03Z" level=info msg="Starting cluster cleanup"
time="2024-11-05T02:14:03Z" level=info msg="Attempting to scale down the cattle-cluster-agent deployment"
time="2024-11-05T02:14:03Z" level=info msg="Scaling down cattle-cluster-agent"
W1105 02:14:03.979388       1 warnings.go:70] spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key: beta.kubernetes.io/os is deprecated since v1.14; use "kubernetes.io/os" instead
time="2024-11-05T02:14:03Z" level=info msg="Waiting for cattle-cluster-agent's pods to be removed"
time="2024-11-05T02:14:06Z" level=info msg="Starting cleanup of deployments"
time="2024-11-05T02:14:06Z" level=info msg="Updating deployment: cattle-cluster-agent"
time="2024-11-05T02:14:06Z" level=info msg="Updating deployment: rancher-webhook"
time="2024-11-05T02:14:06Z" level=info msg="Updating deployment: system-upgrade-controller"
time="2024-11-05T02:14:06Z" level=info msg="Updating deployment: coredns"
time="2024-11-05T02:14:06Z" level=info msg="Updating deployment: local-path-provisioner"
time="2024-11-05T02:14:06Z" level=info msg="Updating deployment: metrics-server"
time="2024-11-05T02:14:07Z" level=info msg="Updating deployment: traefik"
time="2024-11-05T02:14:07Z" level=info msg="Attempting to remove cattle-system namespace"
time="2024-11-05T02:14:07Z" level=info msg="Updating namespace: cattle-system"
time="2024-11-05T02:14:07Z" level=info msg="Deleting namespace: cattle-system"
time="2024-11-05T02:14:07Z" level=info msg="Attempting to remove cattle-prometheus namespace"
time="2024-11-05T02:14:07Z" level=info msg="Attempting to remove cattle-logging namespace"
time="2024-11-05T02:14:07Z" level=info msg="Attempting to remove cattle-fleet-system namespace"
time="2024-11-05T02:14:07Z" level=info msg="Updating namespace: cattle-fleet-system"
time="2024-11-05T02:14:07Z" level=info msg="Deleting namespace: cattle-fleet-system"
time="2024-11-05T02:14:07Z" level=info msg="Attempting to remove cattle-provisioning-capi-system namespace"
time="2024-11-05T02:14:07Z" level=info msg="Attempting to remove cattle-impersonation-system namespace"
time="2024-11-05T02:14:07Z" level=info msg="Updating namespace: cattle-impersonation-system"
time="2024-11-05T02:14:07Z" level=info msg="Deleting namespace: cattle-impersonation-system"
time="2024-11-05T02:14:08Z" level=info msg="Starting cleanup of webhook-specific resources"
time="2024-11-05T02:14:08Z" level=info msg="Deleting clusterrolebinding rancher-webhook"
time="2024-11-05T02:14:08Z" level=info msg="Deleting mutatingwebhookconfiguration rancher.cattle.io"
time="2024-11-05T02:14:08Z" level=info msg="Deleting validatingwebhookconfigurations rancher.cattle.io"
time="2024-11-05T02:14:08Z" level=info msg="Starting cleanup of namespaces"
time="2024-11-05T02:14:08Z" level=info msg="Updating namespace: cattle-fleet-system"
time="2024-11-05T02:14:08Z" level=info msg="Updating namespace: cattle-impersonation-system"
time="2024-11-05T02:14:09Z" level=info msg="Updating namespace: cattle-system"
time="2024-11-05T02:14:09Z" level=info msg="Updating namespace: cattle-ui-plugin-system"
time="2024-11-05T02:14:10Z" level=info msg="Updating namespace: default"
time="2024-11-05T02:14:10Z" level=info msg="Updating namespace: kube-node-lease"
time="2024-11-05T02:14:10Z" level=info msg="Updating namespace: kube-public"
time="2024-11-05T02:14:11Z" level=info msg="Updating namespace: kube-system"
time="2024-11-05T02:14:11Z" level=info msg="Updating namespace: local"
time="2024-11-05T02:14:11Z" level=info msg="Starting cleanup of clusterRoleBindings"
time="2024-11-05T02:14:11Z" level=info msg="Deleting clusterRoleBinding: cattle-admin-binding"
time="2024-11-05T02:14:11Z" level=info msg="Deleting clusterRoleBinding: cattle-impersonation-u-czzglyp7x3"
time="2024-11-05T02:14:11Z" level=info msg="Deleting clusterRoleBinding: cattle-impersonation-u-nqfgy5nls3"
time="2024-11-05T02:14:11Z" level=info msg="Deleting clusterRoleBinding: crb-6pxwstcijv"
time="2024-11-05T02:14:11Z" level=info msg="Deleting clusterRoleBinding: crb-goi2bpvrno"
time="2024-11-05T02:14:11Z" level=info msg="Deleting clusterRoleBinding: globaladmin-user-vc289"
time="2024-11-05T02:14:11Z" level=info msg="Starting cleanup of roleBindings"
time="2024-11-05T02:14:11Z" level=info msg="Starting cleanup of clusterRoles"
time="2024-11-05T02:14:11Z" level=info msg="Deleting clusterRole: cattle-admin"
time="2024-11-05T02:14:12Z" level=info msg="Deleting clusterRole: cattle-impersonation-u-czzglyp7x3"
time="2024-11-05T02:14:12Z" level=info msg="Deleting clusterRole: cattle-impersonation-u-nqfgy5nls3"
time="2024-11-05T02:14:12Z" level=info msg="Deleting clusterRole: cluster-owner"
time="2024-11-05T02:14:12Z" level=info msg="Deleting clusterRole: p-bwpzx-namespaces-edit"
time="2024-11-05T02:14:12Z" level=info msg="Deleting clusterRole: p-bwpzx-namespaces-readonly"
time="2024-11-05T02:14:12Z" level=info msg="Deleting clusterRole: p-vtvn8-namespaces-edit"
time="2024-11-05T02:14:13Z" level=info msg="Deleting clusterRole: p-vtvn8-namespaces-readonly"
time="2024-11-05T02:14:13Z" level=info msg="Starting cleanup of roles"
time="2024-11-05T02:14:13Z" level=info msg="Starting cleanup of jobs"
time="2024-11-05T02:14:13Z" level=info msg="Deleting job: cattle-cleanup-8lsg4"
```

</details>


### Automated Testing

n/a 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

The same scenario as the issue describes.  
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 
The cleanup Job fails to execute or the pod keeps returning errors. 


### Existing / newly added automated tests that provide evidence there are no regressions:
 n/a 