### PR TITLE
[main] Add spot=false to provisioning-tests and integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,12 @@ env:
   REPO: ${{ github.repository_owner }}
 jobs:
   test:
-    runs-on: runs-on,runner=16cpu-linux-x64,ram=64,run-id=${{ github.run_id }}
+    runs-on:
+      - runs-on
+      - spot=capacity-optimized
+      - runner=32cpu-linux-x64
+      - family=c7i-flex+c7i+c7a
+      - run-id=${{ github.run_id }}
     timeout-minutes: 60
     env:
       K3D_VERSION: v5.7.1

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -26,8 +26,13 @@ jobs:
           V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetA_.*$"
         - V2PROV_TEST_DIST: "rke2"
           V2PROV_TEST_RUN_REGEX: "^Test_Operation_SetB_.*$"
-    name: Provisioning tests 
-    runs-on: runs-on,runner=16cpu-linux-x64,ram=64,run-id=${{ github.run_id }}
+    name: Provisioning tests
+    runs-on:
+      - runs-on
+      - spot=capacity-optimized
+      - runner=32cpu-linux-x64
+      - family=c7i-flex+c7i+c7a
+      - run-id=${{ github.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/46456
 
## Problem
GHA Runners keep stating "operation has been cancelled", and this is likely due to the usage of spot instances.

## Solution
Stop using spot instances.