### PR TITLE
[2.10] replace the usage of Wrangler's onRemove() function with onChange(), combined with a custom finalizer

### DIFF
--- a/pkg/controllers/dashboard/scaleavailable/scale.go
+++ b/pkg/controllers/dashboard/scaleavailable/scale.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	AvailableAnnotation = "management.cattle.io/scale-available"
+	availableAnnotation = "management.cattle.io/scale-available"
 )
 
 type handler struct {
@@ -30,14 +30,14 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 	}
 	deploymentCache := wrangler.Apps.Deployment().Cache()
 	wrangler.Apps.Deployment().OnChange(ctx, "scale-available", h.OnChange)
-	deploymentCache.AddIndexer(AvailableAnnotation, func(obj *appsv1.Deployment) ([]string, error) {
-		if val := obj.Annotations[AvailableAnnotation]; val != "" {
-			return []string{AvailableAnnotation}, nil
+	deploymentCache.AddIndexer(availableAnnotation, func(obj *appsv1.Deployment) ([]string, error) {
+		if val := obj.Annotations[availableAnnotation]; val != "" {
+			return []string{availableAnnotation}, nil
 		}
 		return nil, nil
 	})
 	relatedresource.Watch(ctx, "scale-available-trigger", func(namespace, name string, obj runtime.Object) (result []relatedresource.Key, _ error) {
-		deps, err := deploymentCache.GetByIndex(AvailableAnnotation, AvailableAnnotation)
+		deps, err := deploymentCache.GetByIndex(availableAnnotation, availableAnnotation)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func (h *handler) OnChange(key string, deployment *appsv1.Deployment) (*appsv1.D
 	if deployment == nil {
 		return nil, nil
 	}
-	numStr := deployment.Annotations[AvailableAnnotation]
+	numStr := deployment.Annotations[availableAnnotation]
 	if numStr == "" {
 		return deployment, nil
 	}

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -3,6 +3,9 @@ package systemcharts
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"time"
 
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -22,12 +25,14 @@ import (
 	k8sappsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
-	repoName          = "rancher-charts"
-	sucDeploymentName = "system-upgrade-controller"
-	legacyAppLabel    = "io.cattle.field/appId"
+	repoName           = "rancher-charts"
+	sucDeploymentName  = "system-upgrade-controller"
+	legacyAppLabel     = "io.cattle.field/appId"
+	legacyAppFinalizer = "systemcharts.cattle.io/legacy-k3s-based-upgrader-deprecation"
 )
 
 var (
@@ -50,7 +55,8 @@ func Register(ctx context.Context, wContext *wrangler.Context, registryOverride 
 	h := &handler{
 		manager:          wContext.SystemChartsManager,
 		namespaces:       wContext.Core.Namespace(),
-		deployment:       wContext.Apps.Deployment().Cache(),
+		deployment:       wContext.Apps.Deployment(),
+		deploymentCache:  wContext.Apps.Deployment().Cache(),
 		clusterRepo:      wContext.Catalog.ClusterRepo(),
 		chartsConfig:     chart.RancherConfigGetter{ConfigCache: wContext.Core.ConfigMap().Cache()},
 		registryOverride: registryOverride,
@@ -64,14 +70,15 @@ func Register(ctx context.Context, wContext *wrangler.Context, registryOverride 
 	// ensure the system charts are installed with the correct values when there are changes to the rancher config map
 	relatedresource.WatchClusterScoped(ctx, "bootstrap-configmap-charts", relatedConfigMaps, wContext.Catalog.ClusterRepo(), wContext.Core.ConfigMap())
 
-	wContext.Apps.Deployment().OnRemove(ctx, "legacy-k3sBasedUpgrader-deprecation", h.onDeployment)
+	wContext.Apps.Deployment().OnChange(ctx, "legacy-k3sBasedUpgrader-deprecation", h.onDeployment)
 	return nil
 }
 
 type handler struct {
 	manager          chart.Manager
 	namespaces       corecontrollers.NamespaceController
-	deployment       deploymentControllers.DeploymentCache
+	deployment       deploymentControllers.DeploymentController
+	deploymentCache  deploymentControllers.DeploymentCache
 	clusterRepo      catalogcontrollers.ClusterRepoController
 	chartsConfig     chart.RancherConfigGetter
 	registryOverride string
@@ -204,14 +211,15 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 			},
 			Enabled: func() bool {
 				toEnable := false
-				suc, err := h.deployment.Get(namespace.System, sucDeploymentName)
+				suc, err := h.deploymentCache.Get(namespace.System, sucDeploymentName)
 
 				// the absence of the deployment or the absence of the legacy label on the existing deployment indicate
 				// that the old rancher-k3s/rke2-upgrader Project App has been removed
 				if err != nil {
-					logrus.Debugf("[systemcharts] failed to get the deployment %s/%s: %s", namespace.System, sucDeploymentName, err.Error())
 					if errors.IsNotFound(err) {
 						toEnable = true
+					} else {
+						logrus.Warnf("[systemcharts] failed to get the deployment %s/%s: %s", namespace.System, sucDeploymentName, err.Error())
 					}
 				}
 				if suc != nil {
@@ -219,7 +227,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 						toEnable = true
 					}
 				}
-				logrus.Debugf("[systemcharts] feature ManagedSystemUpgradeController = %t, toEnable = %t",
+				logrus.Infof("[systemcharts] feature ManagedSystemUpgradeController = %t, toEnable = %t",
 					features.ManagedSystemUpgradeController.Enabled(), toEnable)
 
 				return features.ManagedSystemUpgradeController.Enabled() && toEnable
@@ -232,14 +240,47 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 // when a specific event occurs on the target deployment. It is currently used to manage
 // the migration from the legacy k3s-based-upgrader app to the system-upgrade-controller app.
 func (h *handler) onDeployment(_ string, d *k8sappsv1.Deployment) (*k8sappsv1.Deployment, error) {
+	var found bool
 	if d != nil && d.Namespace == namespace.System && d.Name == sucDeploymentName {
+		appName, ok := d.Labels[legacyAppLabel]
+		if ok {
+			if appName == k3sbasedupgrade.K3sAppName || appName == k3sbasedupgrade.Rke2AppName {
+				found = true
+			}
+		}
+	}
+	if found {
+		index := slices.Index(d.Finalizers, legacyAppFinalizer)
+		logrus.Infof("[systemcharts] found deployment %s/%s with label %s=%s, index of target finalzier = %d",
+			d.Namespace, d.Name, legacyAppLabel, d.Labels[legacyAppLabel], index)
+		d = d.DeepCopy()
+		// When the deployment is being deleted, remove the finalizer if it exists, and enqueue the rancher-charts clusterRepo
 		if d.DeletionTimestamp != nil {
-			appName, ok := d.Labels[legacyAppLabel]
-			if ok {
-				logrus.Debugf("[systemcharts] found deployment %s/%s with label %s=%s", d.Namespace, d.Name, legacyAppLabel, appName)
-				if appName == k3sbasedupgrade.K3sAppName || appName == k3sbasedupgrade.Rke2AppName {
-					logrus.Debugf("[systemcharts] enqueue %s", repoName)
-					h.clusterRepo.Enqueue(repoName)
+			if index >= 0 {
+				var finalizers []string
+				finalizers = append(finalizers, d.Finalizers[:index]...)
+				finalizers = append(finalizers, d.Finalizers[index+1:]...)
+				d.Finalizers = finalizers
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					_, err := h.deployment.Update(d)
+					return err
+				})
+				if err != nil {
+					return nil, fmt.Errorf("[systemcharts] failed to update deployment %s/%s: %w", d.Namespace, d.Name, err)
+				}
+			}
+			logrus.Infof("[systemcharts] enqueue %s", repoName)
+			h.clusterRepo.EnqueueAfter(repoName, 2*time.Second)
+		} else {
+			// Add the finalizer if it is absent, ensuring Wrangler can detect the deletion event
+			if index == -1 {
+				d.Finalizers = append(d.Finalizers, legacyAppFinalizer)
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					_, err := h.deployment.Update(d)
+					return err
+				})
+				if err != nil {
+					return nil, fmt.Errorf("[systemcharts] failed to update deployment %s/%s: %w", d.Namespace, d.Name, err)
 				}
 			}
 		}

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -63,15 +63,17 @@ type testMocks struct {
 	manager         *chartfake.MockManager
 	namespaceCtrl   *fake.MockNonNamespacedControllerInterface[*v1.Namespace, *v1.NamespaceList]
 	configCache     *fake.MockCacheInterface[*v1.ConfigMap]
+	deployment      *fake.MockControllerInterface[*appsv1.Deployment, *appsv1.DeploymentList]
 	deploymentCache *fake.MockCacheInterface[*appsv1.Deployment]
 }
 
 func (t *testMocks) Handler() *handler {
 	return &handler{
-		manager:      t.manager,
-		namespaces:   t.namespaceCtrl,
-		chartsConfig: chart.RancherConfigGetter{ConfigCache: t.configCache},
-		deployment:   t.deploymentCache,
+		manager:         t.manager,
+		namespaces:      t.namespaceCtrl,
+		chartsConfig:    chart.RancherConfigGetter{ConfigCache: t.configCache},
+		deployment:      t.deployment,
+		deploymentCache: t.deploymentCache,
 	}
 }
 

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -242,17 +242,6 @@ func (c *ClusterLifecycleCleanup) createCleanupClusterRole(userContext *config.U
 			Resources:     []string{"validatingwebhookconfigurations", "mutatingwebhookconfigurations"},
 			ResourceNames: []string{WebhookConfigurationName},
 		},
-		// This is needed for removing finalizers from deployments
-		{
-			Verbs:     []string{"list", "get", "update"},
-			APIGroups: []string{"apps"},
-			Resources: []string{"deployments"},
-		},
-		{
-			Verbs:     []string{"list"},
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-		},
 	}
 	clusterRole := rbacV1.ClusterRole{
 		ObjectMeta: meta,


### PR DESCRIPTION
# Notes to Reviewers

~The provisioning tests are failing to wait for the `rancher-webhook` deployment to become active, as the image `registry.rancher.com/rancher/rancher-webhook:v0.6.1-rc.9` is missing.~
~Once the image-missing issue is resolved by other teams, I'll run the failed CI tests again.~

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/47863

 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 

The usage of  Wrangler's `onRemove()` function results in adding the `wrangler.cattle.io/legacy-k3sBasedUpgrader-deprecation` finalizer to all Deployments across namespaces. This leads to resource cleanup failures in downstream imported clusters when removed from Rancher. While [the cleanup logic was enhanced](https://github.com/rancher/rancher/pull/47882) to address this, it does not resolve the broader issue of the finalizer being applied to all Deployments in all namespaces. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This PR resolves the problem by replacing Wrangler's `onRemove()` function with `onChange()`, along with using a custom finalizer. 
This PR also reverts the cleanup logic modifications made in the [previous PR](https://github.com/rancher/rancher/pull/47882).
 

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


The problem described in the issue does not happen anymore on the Rancher setup that is built from the PR. Standalone k3s and rke2 clusters are used for testing.

Additionally, the upgrade scenario for Rancher with existing imported k3s/rke2 clusters was also successfully tested.
 
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
- The same scenario described in the issue—removing and then re-adding an imported cluster—should be tested.
- Additionally, since these changes affect the logic for deprecating the legacy k3s-based-upgrader, it’s important to perform the tests mentioned in [this comment](https://github.com/rancher/rancher/issues/42448#issuecomment-2429888031) to ensure full coverage.


### Regressions Considerations
 
- The same scenario described in the issue—removing and then re-adding an imported cluster.
- The general functionality of the migration from k3sBased-upgrade-controller to system-chart