### PR TITLE
[main/2.11] Add auth config field that allows Rancher to use the service account to search for users

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -421,7 +421,7 @@ type LdapFields struct {
 	GroupMemberMappingAttribute     string   `json:"groupMemberMappingAttribute,omitempty"     norman:"default=member,notnullable,required"`
 	ConnectionTimeout               int64    `json:"connectionTimeout,omitempty"               norman:"default=5000,notnullable,required"`
 	NestedGroupMembershipEnabled    bool     `json:"nestedGroupMembershipEnabled"              norman:"default=false"`
-	SearchUsingServiceAccount       bool     `json:"searchUsingServiceAccount,omitempty"       norman:"default=false"`
+	SearchUsingServiceAccount       bool     `json:"searchUsingServiceAccount"       norman:"default=false"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -421,6 +421,7 @@ type LdapFields struct {
 	GroupMemberMappingAttribute     string   `json:"groupMemberMappingAttribute,omitempty"     norman:"default=member,notnullable,required"`
 	ConnectionTimeout               int64    `json:"connectionTimeout,omitempty"               norman:"default=5000,notnullable,required"`
 	NestedGroupMembershipEnabled    bool     `json:"nestedGroupMembershipEnabled"              norman:"default=false"`
+	SearchUsingServiceAccount       bool     `json:"searchUsingServiceAccount,omitempty"       norman:"default=false"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -70,6 +70,13 @@ func (p *ldapProvider) loginUser(lConn ldapv3.Client, credential *v32.BasicLogin
 		return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.ServerError, "server error while authenticating")
 	}
 
+	if config.SearchUsingServiceAccount {
+		err = ldap.AuthenticateServiceAccountUser(serviceAccountPassword, serviceAccountUserName, "", lConn)
+		if err != nil {
+			return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")
+		}
+	}
+
 	searchOpRequest := ldap.NewWholeSubtreeSearchRequest(
 		userDN,
 		fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass),

--- a/pkg/client/generated/management/v3/zz_generated_free_ipa_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_free_ipa_config.go
@@ -24,6 +24,7 @@ const (
 	FreeIpaConfigFieldOwnerReferences                 = "ownerReferences"
 	FreeIpaConfigFieldPort                            = "port"
 	FreeIpaConfigFieldRemoved                         = "removed"
+	FreeIpaConfigFieldSearchUsingServiceAccount       = "searchUsingServiceAccount"
 	FreeIpaConfigFieldServers                         = "servers"
 	FreeIpaConfigFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	FreeIpaConfigFieldServiceAccountPassword          = "serviceAccountPassword"
@@ -66,6 +67,7 @@ type FreeIpaConfig struct {
 	OwnerReferences                 []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	Port                            int64             `json:"port,omitempty" yaml:"port,omitempty"`
 	Removed                         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	SearchUsingServiceAccount       bool              `json:"searchUsingServiceAccount,omitempty" yaml:"searchUsingServiceAccount,omitempty"`
 	Servers                         []string          `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string            `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string            `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_ldap_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_ldap_config.go
@@ -29,6 +29,7 @@ const (
 	LdapConfigFieldOwnerReferences                 = "ownerReferences"
 	LdapConfigFieldPort                            = "port"
 	LdapConfigFieldRemoved                         = "removed"
+	LdapConfigFieldSearchUsingServiceAccount       = "searchUsingServiceAccount"
 	LdapConfigFieldServers                         = "servers"
 	LdapConfigFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	LdapConfigFieldServiceAccountPassword          = "serviceAccountPassword"
@@ -73,6 +74,7 @@ type LdapConfig struct {
 	OwnerReferences                 []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	Port                            int64             `json:"port,omitempty" yaml:"port,omitempty"`
 	Removed                         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	SearchUsingServiceAccount       bool              `json:"searchUsingServiceAccount,omitempty" yaml:"searchUsingServiceAccount,omitempty"`
 	Servers                         []string          `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string            `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string            `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_ldap_fields.go
+++ b/pkg/client/generated/management/v3/zz_generated_ldap_fields.go
@@ -14,6 +14,7 @@ const (
 	LdapFieldsFieldGroupSearchFilter               = "groupSearchFilter"
 	LdapFieldsFieldNestedGroupMembershipEnabled    = "nestedGroupMembershipEnabled"
 	LdapFieldsFieldPort                            = "port"
+	LdapFieldsFieldSearchUsingServiceAccount       = "searchUsingServiceAccount"
 	LdapFieldsFieldServers                         = "servers"
 	LdapFieldsFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	LdapFieldsFieldServiceAccountPassword          = "serviceAccountPassword"
@@ -43,6 +44,7 @@ type LdapFields struct {
 	GroupSearchFilter               string   `json:"groupSearchFilter,omitempty" yaml:"groupSearchFilter,omitempty"`
 	NestedGroupMembershipEnabled    bool     `json:"nestedGroupMembershipEnabled,omitempty" yaml:"nestedGroupMembershipEnabled,omitempty"`
 	Port                            int64    `json:"port,omitempty" yaml:"port,omitempty"`
+	SearchUsingServiceAccount       bool     `json:"searchUsingServiceAccount,omitempty" yaml:"searchUsingServiceAccount,omitempty"`
 	Servers                         []string `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string   `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string   `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_open_ldap_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_open_ldap_config.go
@@ -25,6 +25,7 @@ const (
 	OpenLdapConfigFieldOwnerReferences                 = "ownerReferences"
 	OpenLdapConfigFieldPort                            = "port"
 	OpenLdapConfigFieldRemoved                         = "removed"
+	OpenLdapConfigFieldSearchUsingServiceAccount       = "searchUsingServiceAccount"
 	OpenLdapConfigFieldServers                         = "servers"
 	OpenLdapConfigFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	OpenLdapConfigFieldServiceAccountPassword          = "serviceAccountPassword"
@@ -68,6 +69,7 @@ type OpenLdapConfig struct {
 	OwnerReferences                 []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	Port                            int64             `json:"port,omitempty" yaml:"port,omitempty"`
 	Removed                         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	SearchUsingServiceAccount       bool              `json:"searchUsingServiceAccount,omitempty" yaml:"searchUsingServiceAccount,omitempty"`
 	Servers                         []string          `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string            `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string            `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`


### PR DESCRIPTION
Originally:  https://github.com/rancher/rancher/pull/46357
## Issue: #43064
 
## Problem
Users on certain LDAP setups do not have the permissions to search as their user. This lead to the error outlined in the issue (Result code 32), since Rancher attempted to bind as their user to perform searches (in order to show the user only the groups/users that they could see as part of their auth configs).
 
## Solution
The solution is to expose a field on the auth config (search_using_service_account, a bool) which will cause Rancher to always use the service account (and never the user) to search for users/groups. This value will default to false, to keep Rancher's current behavior for our existing consumers.

## Engineering Testing
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: Lack of the framework capable of testing this fix/change

Summary: No tests are modified or added.
 
### Regressions Considerations
Existing / newly added automated tests that provide evidence there are no regressions:
* None