### PR TITLE
Bump rancher-webhook to v0.5.4-rc.2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 104.0.3+up0.5.3
+webhookVersion: 104.0.4+up0.5.4-rc.2
 provisioningCAPIVersion: 104.0.0+up0.3.0
 cspAdapterMinVersion: 104.0.0+up4.0.0
 defaultShellVersion: rancher/shell:v0.2.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,5 +7,5 @@ const (
 	DefaultShellVersion     = "rancher/shell:v0.2.2"
 	FleetVersion            = "104.1.1+up0.10.5"
 	ProvisioningCAPIVersion = "104.0.0+up0.3.0"
-	WebhookVersion          = "104.0.3+up0.5.3"
+	WebhookVersion          = "104.0.4+up0.5.4-rc.2"
 )


### PR DESCRIPTION
# Release note for [v0.5.4-rc.2](https://github.com/rancher/webhook/releases/tag/v0.5.4-rc.2)

## What's Changed
* Revert "[v0.5] Populate backing namespace field for projects" by @JonCrowther in https://github.com/rancher/webhook/pull/538
* [v0.5] Sync dependencies with Rancher by @tomleb in https://github.com/rancher/webhook/pull/541


**Full Changelog**: https://github.com/rancher/webhook/compare/v0.5.4-rc.1...v0.5.4-rc.2

# Useful links

- Commit comparison: https://github.com/rancher/webhook/compare/v0.5.3...v0.5.4-rc.2
- Release v0.5.3: https://github.com/rancher/webhook/releases/tag/v0.5.3