### PR TITLE
[2.10] fix RKE1 cluster provisioning failures

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -403,6 +403,12 @@ func aliasToPath(driver string, config map[string]interface{}, ns string) error 
 				if err != nil {
 					return err
 				}
+				if !devMode && settings.UnprivilegedJailUser.Get() == "true" {
+					err = jailer.SetJailOwnership(fullPath)
+					if err != nil {
+						return err
+					}
+				}
 				// Add the field and path
 				if devMode {
 					config[driverField] = fullPath


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/47938

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When provisioning RKE1 node driver clusters, if cloud-init user data is set in the node template (currently available only for vSphere node templates in the Rancher UI, though it can be added to other node template types via the API), node creation will fail due to permission issues.


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This PR adjusts the cluster provisioning logic to set the appropriate ownership of the affected files. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


The issue was reproduced by creating a node-driver RKE1 cluster with a Digital Ocean node template, where user data was added via the API. 

The fix has been validated on a Rancher build from the PR. Using the same Digital Ocean node template, the cluster is created successfully, confirming the fix works as expected.

<img width="1542" alt="Screenshot 2024-11-07 at 4 42 29 PM" src="https://github.com/user-attachments/assets/3ac9a8d2-93c1-43ec-ba5b-f215a43ce28c">

Please reach out to me for more details if needed. 
 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
We'd like to confirm that provisioning an RKE1 node-driver cluster with a node template that includes user data works. 
A vSphere cluster is preferred, as this is where the issue was originally reported.

We should also cover the case of upgrading Rancher and adding new nodes to existing clusters. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->


The same scenarios as the above section describes. 
 