### PR TITLE
[v2.8] Bump rancher-webhook to v0.4.13

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 103.0.12+up0.4.13-rc.1
+webhookVersion: 103.0.12+up0.4.13
 cspAdapterMinVersion: 103.0.1+up3.0.1
 defaultShellVersion: rancher/shell:v0.1.26
 fleetVersion: 103.1.10+up0.9.11

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,5 +6,5 @@ const (
 	CspAdapterMinVersion = "103.0.1+up3.0.1"
 	DefaultShellVersion  = "rancher/shell:v0.1.26"
 	FleetVersion         = "103.1.10+up0.9.11"
-	WebhookVersion       = "103.0.12+up0.4.13-rc.1"
+	WebhookVersion       = "103.0.12+up0.4.13"
 )


### PR DESCRIPTION
# Release note for [v0.4.13](https://github.com/rancher/webhook/releases/tag/v0.4.13)

## What's Changed
* [v0.4] Sync dependencies with Rancher by @tomleb in https://github.com/rancher/webhook/pull/542


**Full Changelog**: https://github.com/rancher/webhook/compare/v0.4.12...v0.4.13

# Useful links

- Commit comparison: https://github.com/rancher/webhook/compare/v0.4.13-rc.1...v0.4.13
- Release v0.4.13-rc.1: https://github.com/rancher/webhook/releases/tag/v0.4.13-rc.1