### PR TITLE
Address bug when bootstrap secret is created outside of Rancher helm-chart

### DIFF
--- a/pkg/data/management/bootstrap_password.go
+++ b/pkg/data/management/bootstrap_password.go
@@ -36,7 +36,7 @@ func GetBootstrapPassword(ctx context.Context, secrets corev1.SecretInterface) (
 		if hasPasswordKey {
 			return string(bootstrapPasswordBytes), generated, nil
 		}
-		logrus.Debug("A bootstrap password secret was found, but did not match the expected structure.")
+		logrus.Warn("A bootstrap password secret was found, but did not match the expected structure.")
 	}
 
 	// if the password secret is not set check the env for user-input, or fall back to generating one
@@ -45,13 +45,11 @@ func GetBootstrapPassword(ctx context.Context, secrets corev1.SecretInterface) (
 	if userPasswordValue == "" {
 		generated = true
 		userPasswordValue, _ = randomtoken.Generate()
-		s.StringData[bootstrapPasswordSecretKey] = userPasswordValue
-	} else {
-		s.StringData[bootstrapPasswordSecretKey] = userPasswordValue
 	}
+	s.StringData[bootstrapPasswordSecretKey] = userPasswordValue
 
 	// persist the password
-	if s.GetResourceVersion() != "" {
+	if s != nil && s.GetResourceVersion() != "" {
 		_, err = secrets.Update(ctx, s, metav1.UpdateOptions{})
 	} else {
 		s.Name = bootstrapPasswordSecretName

--- a/pkg/data/management/bootstrap_password.go
+++ b/pkg/data/management/bootstrap_password.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"github.com/sirupsen/logrus"
 	"os"
 
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
@@ -16,7 +17,7 @@ const (
 	bootstrapPasswordSecretKey  = "bootstrapPassword"
 )
 
-// GetBootstrapPassword reads the bootstrap password from it's secret.  If the secret is not found
+// GetBootstrapPassword reads the bootstrap password from its secret.  If the secret is not found
 // it will be set from `CATTLE_BOOTSTRAP_PASSWORD` or generated if this is empty as well.
 func GetBootstrapPassword(ctx context.Context, secrets corev1.SecretInterface) (string, bool, error) {
 	var s *v1.Secret
@@ -29,17 +30,24 @@ func GetBootstrapPassword(ctx context.Context, secrets corev1.SecretInterface) (
 		return "", false, err
 	}
 
-	// if the bootstrap password is set return it
-	if s.StringData[bootstrapPasswordSecretKey] != "" {
-		return s.StringData[bootstrapPasswordSecretKey], generated, nil
+	if s != nil {
+		// if the bootstrap password is set return it
+		bootstrapPasswordBytes, hasPasswordKey := s.Data[bootstrapPasswordSecretKey]
+		if hasPasswordKey {
+			return string(bootstrapPasswordBytes), generated, nil
+		}
+		logrus.Debug("A bootstrap password secret was found, but did not match the expected structure.")
 	}
 
-	// if the password is not set check the env and fall back to generating one
+	// if the password secret is not set check the env for user-input, or fall back to generating one
+	userPasswordValue := os.Getenv("CATTLE_BOOTSTRAP_PASSWORD")
 	s.StringData = make(map[string]string)
-	s.StringData[bootstrapPasswordSecretKey] = os.Getenv("CATTLE_BOOTSTRAP_PASSWORD")
-	if s.StringData[bootstrapPasswordSecretKey] == "" {
+	if userPasswordValue == "" {
 		generated = true
-		s.StringData[bootstrapPasswordSecretKey], _ = randomtoken.Generate()
+		userPasswordValue, _ = randomtoken.Generate()
+		s.StringData[bootstrapPasswordSecretKey] = userPasswordValue
+	} else {
+		s.StringData[bootstrapPasswordSecretKey] = userPasswordValue
 	}
 
 	// persist the password
@@ -53,5 +61,5 @@ func GetBootstrapPassword(ctx context.Context, secrets corev1.SecretInterface) (
 		return "", false, err
 	}
 
-	return s.StringData[bootstrapPasswordSecretKey], generated, nil
+	return userPasswordValue, generated, nil
 }


### PR DESCRIPTION
## Issue: SURE-9210
 
https://github.com/rancher/rancher/issues/47964
 
## Solution
Add proper checks to verify secret exists and has valid PW data, then read the data by base64 decoding it.

## Testing

I've verified this works by following the reproduction steps from the issue. First to verify the bug, then again using my local built image with this change verifying the issue is gone.

The debug image I used is:
```
        rancherImage: mallardduck/rancher
        rancherImageTag: v2.10.0-dev.35
```