### PR TITLE
Bump rancher-webhook to v0.6.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 105.0.0+up0.6.1-rc.12
+webhookVersion: 105.0.0+up0.6.1
 provisioningCAPIVersion: 105.0.0+up0.4.0
 cspAdapterMinVersion: 105.0.0+up5.0.1-rc1
 defaultShellVersion: rancher/shell:v0.3.0-rc.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,5 +7,5 @@ const (
 	DefaultShellVersion     = "rancher/shell:v0.3.0-rc.2"
 	FleetVersion            = "105.0.0+up0.11.0"
 	ProvisioningCAPIVersion = "105.0.0+up0.4.0"
-	WebhookVersion          = "105.0.0+up0.6.1-rc.12"
+	WebhookVersion          = "105.0.0+up0.6.1"
 )


### PR DESCRIPTION
# Release note for [v0.6.1](https://github.com/rancher/webhook/releases/tag/v0.6.1)

## What's Changed
* Add validation for ClusterRepo by @rohitsakala in https://github.com/rancher/webhook/pull/470
* Remove a race condition from a flakey integration test by @ericpromislow in https://github.com/rancher/webhook/pull/469
* [46381] [2.10] Add validation to data directories on creation by @jakefhyde in https://github.com/rancher/webhook/pull/474
* Change the base branch from "release/v0.5" to "main" in renovate config by @maxsokolovsky in https://github.com/rancher/webhook/pull/486
* Current dev work is now for rancher 2.10 by @ericpromislow in https://github.com/rancher/webhook/pull/468
* Update actions/upload-artifact digest to 834a144 by @renovate-rancher in https://github.com/rancher/webhook/pull/487
* Update module github.com/rancher/dynamiclistener to v0.6.0 by @renovate-rancher in https://github.com/rancher/webhook/pull/490
* [Forwardport] Bump rke to v1.6.0 and dynamiclistener to v0.6.0 by @nflynt in https://github.com/rancher/webhook/pull/483
* Update actions/checkout action to v4.1.7 by @renovate-rancher in https://github.com/rancher/webhook/pull/423
* Update actions/upload-artifact digest to b18b1d3 by @renovate-rancher in https://github.com/rancher/webhook/pull/492
* Update actions/upload-artifact action to v4.4.0 by @renovate-rancher in https://github.com/rancher/webhook/pull/489
* Drop the direct dependency on rke/types. by @ericpromislow in https://github.com/rancher/webhook/pull/491
* Update dependency go to v1.22.7 by @renovate-rancher in https://github.com/rancher/webhook/pull/463
* Check that {disable|delete}-inactive-user-after setting is not less than auth-user-session-ttl-minutes by @pmatseykanets in https://github.com/rancher/webhook/pull/471
* Display error output from dynamiclistener.Server by @ericpromislow in https://github.com/rancher/webhook/pull/494
* Update Rancher in CI by @tomleb in https://github.com/rancher/webhook/pull/502
* Fix webhook not deployed in CI by @tomleb in https://github.com/rancher/webhook/pull/503
* added catalog.cattle.io/managed:true to chart by @gehrkefc in https://github.com/rancher/webhook/pull/498
* Validate creatorId and creator-principal-name annotations for cluster/project by @pmatseykanets in https://github.com/rancher/webhook/pull/501
* Prevent dropping unknown cluster fields  by @kinarashah in https://github.com/rancher/webhook/pull/515
* Add checks for annotation to opt out of cluster owner RBAC by @JonCrowther in https://github.com/rancher/webhook/pull/511
* Validate LastUsedAt for Token and ClusterAuthToken by @pmatseykanets in https://github.com/rancher/webhook/pull/520
* Use Namespaced scope for ClusterAuthToken validator by @pmatseykanets in https://github.com/rancher/webhook/pull/522
* [main][forwardport] Add validation to Toleration and Affinitys Keys by @thatmidwesterncoder in https://github.com/rancher/webhook/pull/459
* Bump to k8s 1.31 by @ericpromislow in https://github.com/rancher/webhook/pull/528
* [0.6] Make sure to update the name in the mutator by @JonCrowther in https://github.com/rancher/webhook/pull/535
* [0.6] Revert backing namespace changes by @JonCrowther in https://github.com/rancher/webhook/pull/539
* Sync dependencies with Rancher by @tomleb in https://github.com/rancher/webhook/pull/540
* UnRC *-operator by @tomleb in https://github.com/rancher/webhook/pull/543

## New Contributors
* @gehrkefc made their first contribution in https://github.com/rancher/webhook/pull/498

**Full Changelog**: https://github.com/rancher/webhook/compare/v0.6.0...v0.6.1

# Useful links

- Commit comparison: https://github.com/rancher/webhook/compare/v0.6.1-rc.12...v0.6.1
- Release v0.6.1-rc.12: https://github.com/rancher/webhook/releases/tag/v0.6.1-rc.12