### PR TITLE
[2.8] Update GHA KDM URL

### DIFF
--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -53,7 +53,7 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
 # https://github.com/rancher/rancher/issues/36827 has added appDefaults. We do not use appDefaults
 # here for simplicity's sake, as it requires semver parsing & matching. The last release should
 # be good enough for our needs.
-export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/release-v2.9/data/data.json | jq -r ".$DIST.releases[-1].version")
+export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/release-v2.8/data/data.json | jq -r ".$DIST.releases[-1].version")
 fi
 
 if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then


### PR DESCRIPTION
`scripts/gha/tests` was incorrectly pointing to the `release-v2.9` KDM branch. All other KDM references are correctly pointing to `release-v2.8`.