### PR TITLE
Adding node metrics view capability to nodes view role

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -209,7 +209,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("cluster.x-k8s.io").resources("machines").verbs("get", "watch").
 		addRule().apiGroups("cluster.x-k8s.io").resources("machinedeployments").verbs("get", "watch").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("get", "watch").
-		addRule().apiGroups("rke-machine.cattle.io").resources("*").verbs("get", "watch")
+		addRule().apiGroups("rke-machine.cattle.io").resources("*").verbs("get", "watch").
+		addRule().apiGroups("metrics.k8s.io").resources("nodemetrics", "nodes").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Manage Storage", "storage-manage", "cluster", false, false, false).
 		addRule().apiGroups("").resources("persistentvolumes").verbs("*").


### PR DESCRIPTION
Reopening as #45657 got closed because of no activity.

Solves https://github.com/rancher/rancher/issues/45849

Similar to https://github.com/rancher/rancher/issues/36116 / https://github.com/rancher/rancher/pull/36493 Role "view nodes" should have permissions to view nodes metrics.

So changing default permissions for view nodes role to include the permission to read node/nodemetrics in the metrics.k8s.io group