### PR TITLE
Run UI plugin handlers only in upstream cluster

### DIFF
--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -272,7 +272,8 @@ func (r *Rancher) Start(ctx context.Context) error {
 	if err := steveapi.Setup(ctx, r.Steve, r.Wrangler); err != nil {
 		return err
 	}
-	if features.UIExtension.Enabled() {
+
+	if features.MCM.Enabled() && features.UIExtension.Enabled() {
 		plugin.Register(ctx, r.Wrangler)
 	}
 


### PR DESCRIPTION
Please check the issue for more details 

### Summary

- Extension is a top level feature and should only run in upstream cluster.