### PR TITLE
[v2.10] Allow insecure Prime setups to check Rancher version

### DIFF
--- a/tests/v2/actions/prime/primechecks.go
+++ b/tests/v2/actions/prime/primechecks.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rancher/shepherd/clients/rancher"
 	client "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/rancherversion"
 )
 
 const (
@@ -15,7 +14,7 @@ const (
 
 // CheckUIBrand checks the UI brand of Rancher Prime. If the Rancher instance is not Rancher Prime, the UI brand should be blank.
 func CheckUIBrand(client *rancher.Client, isPrime bool, rancherBrand *client.Setting, brand string) error {
-	if isPrime && brand != rancherBrand.Value {
+	if isPrime && brand != rancherBrand.Default {
 		return fmt.Errorf("error: Rancher Prime UI brand %s does not match defined UI brand %s", rancherBrand.Value, brand)
 	}
 
@@ -23,9 +22,9 @@ func CheckUIBrand(client *rancher.Client, isPrime bool, rancherBrand *client.Set
 }
 
 // CheckVersion checks the if Rancher Prime is set to true and the version of Rancher.
-func CheckVersion(isPrime bool, rancherVersion string, serverConfig *rancherversion.Config) error {
-	if isPrime && rancherVersion != serverConfig.RancherVersion {
-		return fmt.Errorf("error: Rancher Prime: %t | Version: %s", isPrime, serverConfig.RancherVersion)
+func CheckVersion(isPrime bool, rancherVersion string, serverConfig *client.Setting) error {
+	if isPrime && rancherVersion != serverConfig.Value {
+		return fmt.Errorf("error: Rancher Prime: %t | Version: %s", isPrime, serverConfig.Value)
 	}
 
 	return nil

--- a/tests/v2/validation/prime/prime_test.go
+++ b/tests/v2/validation/prime/prime_test.go
@@ -20,6 +20,7 @@ const (
 	systemRegistry = "system-default-registry"
 	localCluster   = "local"
 	uiBrand        = "ui-brand"
+	serverVersion  = "server-version"
 )
 
 type PrimeTestSuite struct {
@@ -63,10 +64,10 @@ func (t *PrimeTestSuite) TestPrimeUIBrand() {
 }
 
 func (t *PrimeTestSuite) TestPrimeVersion() {
-	serverConfig, err := rancherversion.RequestRancherVersion(t.client.RancherConfig.Host)
+	serverVersion, err := t.client.Management.Setting.ByID(serverVersion)
 	require.NoError(t.T(), err)
 
-	checkVersion := prime.CheckVersion(t.isPrime, t.rancherVersion, serverConfig)
+	checkVersion := prime.CheckVersion(t.isPrime, t.rancherVersion, serverVersion)
 	assert.NoError(t.T(), checkVersion)
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Update prime_test.go so insecure Rancher setups pass TestPrimeVersion function](https://github.com/rancher/qa-tasks/issues/1611)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Insecure Rancher Prime setups are not successfully pulling the Rancher version. It is because the certificate is not being recognized. This places a strain on the test from only allowing secure Prime setups from fully completing the test.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Allow insecure and secure Rancher Prime setups to pass.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Jenkins jobs will be provided offline.