### PR TITLE
Downstream Role Template Handler

### DIFF
--- a/pkg/controllers/management/auth/project_cluster/cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/cluster_handler.go
@@ -115,7 +115,7 @@ func (l *clusterLifecycle) Sync(key string, orig *apisv3.Cluster) (runtime.Objec
 		}
 	}
 
-	if err := createMembershipRoles(obj, "cluster", l.crClient); err != nil {
+	if err := createMembershipRoles(obj, l.crClient); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controllers/management/auth/project_cluster/common.go
+++ b/pkg/controllers/management/auth/project_cluster/common.go
@@ -6,6 +6,8 @@ import (
 
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	"github.com/rancher/rancher/pkg/rbac"
+
 	crbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	"github.com/sirupsen/logrus"
 	v12 "k8s.io/api/core/v1"
@@ -80,55 +82,84 @@ func reconcileResourceToNamespace(obj runtime.Object, controller string, nsListe
 }
 
 // createMembershipRoles creates 2 cluster roles: an owner role and a member role. To be used to create project/cluster membership roles.
-func createMembershipRoles(obj runtime.Object, resourceType string, crClient crbacv1.ClusterRoleController) error {
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return fmt.Errorf("error accessing object %v: %w", obj, err)
-	}
-	typeInfo, err := meta.TypeAccessor(obj)
-	if err != nil {
-		return fmt.Errorf("error accessing object type %v: %w", obj, err)
+func createMembershipRoles(obj runtime.Object, crClient crbacv1.ClusterRoleController) error {
+	var resourceName, resourceType string
+	var isCluster bool
+	switch v := obj.(type) {
+	case *apisv3.Project:
+		resourceType = apisv3.ProjectResourceName
+		resourceName = v.GetName()
+	case *apisv3.Cluster:
+		isCluster = true
+		resourceType = apisv3.ClusterResourceName
+		resourceName = v.GetName()
+	default:
+		return fmt.Errorf("cannot create membership roles for unsupported type %T", v)
 	}
 
-	rules := []rbacv1.PolicyRule{
-		{
-			APIGroups:     []string{"management.cattle.io"},
-			Resources:     []string{resourceType},
-			ResourceNames: []string{accessor.GetName()},
-			Verbs:         []string{"get"},
+	ownerRef, err := newOwnerReference(obj)
+	if err != nil {
+		return err
+	}
+
+	var annotations map[string]string
+	if isCluster {
+		annotations = map[string]string{clusterNameLabel: resourceName}
+	}
+
+	memberRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            resourceName + "-member",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+			Annotations:     annotations,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{apisv3.SchemeGroupVersion.Group},
+				Resources:     []string{resourceType},
+				ResourceNames: []string{resourceName},
+				Verbs:         []string{"get"},
+			},
 		},
 	}
-
-	objectMeta := metav1.ObjectMeta{
-		Name: accessor.GetName() + "-member",
-		OwnerReferences: []metav1.OwnerReference{
+	ownerRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            resourceName + "-owner",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+			Annotations:     annotations,
+		},
+		Rules: []rbacv1.PolicyRule{
 			{
-				APIVersion: typeInfo.GetAPIVersion(),
-				Kind:       typeInfo.GetKind(),
-				Name:       accessor.GetName(),
-				UID:        accessor.GetUID(),
+				APIGroups:     []string{apisv3.SchemeGroupVersion.Group},
+				Resources:     []string{resourceType},
+				ResourceNames: []string{resourceName},
+				Verbs:         []string{rbacv1.VerbAll},
 			},
 		},
 	}
 
-	if resourceType == "cluster" {
-		objectMeta.Annotations = map[string]string{clusterNameLabel: accessor.GetName()}
-	}
-
-	memberRole := &rbacv1.ClusterRole{
-		ObjectMeta: objectMeta,
-		Rules:      rules,
-	}
-	if _, err := crClient.Create(memberRole); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	ownerRole := memberRole
-	ownerRole.Name = accessor.GetName() + "-owner"
-	ownerRole.Rules[0].Verbs = []string{"*"}
-	if _, err := crClient.Create(ownerRole); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+	for _, cr := range []*rbacv1.ClusterRole{memberRole, ownerRole} {
+		if err := rbac.CreateOrUpdateResource(cr, crClient, rbac.AreClusterRolesSame); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func newOwnerReference(obj runtime.Object) (metav1.OwnerReference, error) {
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return metav1.OwnerReference{}, fmt.Errorf("error accessing object type %v: %w", obj, err)
+	}
+	typeInfo, err := meta.TypeAccessor(obj)
+	if err != nil {
+		return metav1.OwnerReference{}, fmt.Errorf("error accessing object type %v: %w", obj, err)
+	}
+	return metav1.OwnerReference{
+		APIVersion: typeInfo.GetAPIVersion(),
+		Kind:       typeInfo.GetKind(),
+		Name:       metadata.GetName(),
+		UID:        metadata.GetUID(),
+	}, nil
 }

--- a/pkg/controllers/management/auth/project_cluster/project_handler.go
+++ b/pkg/controllers/management/auth/project_cluster/project_handler.go
@@ -85,7 +85,7 @@ func (l *projectLifecycle) Sync(key string, orig *apisv3.Project) (runtime.Objec
 		return nil, err
 	}
 
-	if err := createMembershipRoles(obj, "cluster", l.crClient); err != nil {
+	if err := createMembershipRoles(obj, l.crClient); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/convert"
 	wranglerv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/controllers/management/auth/roletemplates"
+	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac/roletemplates"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
 	typescorev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"

--- a/pkg/controllers/managementuser/rbac/roletemplates/register.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/register.go
@@ -9,7 +9,8 @@ import (
 func Register(ctx context.Context, workload *config.UserContext) {
 	management := workload.Management.WithAgent("rbac-role-templates")
 
-	management.Management.ClusterRoleTemplateBindings("").AddLifecycle(ctx, "cluster-crtb-handler", newCRTBLifecycle(workload))
+	// FIXME: is this needed? wrong copy&paste?
+	// management.Management.ClusterRoleTemplateBindings("").AddLifecycle(ctx, "cluster-crtb-handler", newCRTBLifecycle(workload))
 
 	rth := newRoleTemplateHandler(workload)
 	management.Wrangler.Mgmt.RoleTemplate().OnChange(ctx, "cluster-roletemplate-change-handler", rth.OnChange)

--- a/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler_test.go
@@ -1,0 +1,142 @@
+package roletemplates
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_clusterRolesForRoleTemplate(t *testing.T) {
+	sampleRule := rbacv1.PolicyRule{
+		Verbs:     []string{"get", "list"},
+		Resources: []string{"secrets"},
+		APIGroups: []string{""},
+	}
+	sampleExternalRule := rbacv1.PolicyRule{
+		Verbs:     []string{rbacv1.VerbAll},
+		Resources: []string{"configmaps"},
+		APIGroups: []string{""},
+	}
+	samplePromotedRule := rbacv1.PolicyRule{
+		Verbs:     []string{"get", "list"},
+		Resources: []string{"persistentvolumes"},
+		APIGroups: []string{""},
+	}
+	tests := []struct {
+		name   string
+		rt     *v3.RoleTemplate
+		verify func(*testing.T, []*rbacv1.ClusterRole)
+	}{
+		{
+			name: "roletemplates with cluster context creates rules and aggregating clusterroles",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myroletemplate",
+				},
+				Context:       "cluster",
+				Rules:         []rbacv1.PolicyRule{sampleRule},
+				ExternalRules: []rbacv1.PolicyRule{sampleExternalRule},
+			},
+			verify: func(t *testing.T, roles []*rbacv1.ClusterRole) {
+				if got, want := len(roles), 2; got != want {
+					t.Errorf("expected %d roles but got %d", want, got)
+				}
+				for i, want := range []string{"myroletemplate", "myroletemplate-aggregator"} {
+					if got := roles[i].Name; got != want {
+						t.Errorf("role[%d] have incorrect name, got %q, want %q", i, got, want)
+					}
+				}
+				if got, want := len(roles[0].Rules), 2; got != want {
+					t.Errorf("expected role to have 2 rules but got %d", len(roles))
+				}
+				if got := roles[1].AggregationRule; got == nil || len(got.ClusterRoleSelectors) == 0 {
+					t.Errorf("expected aggregation rule not to be empty")
+				}
+			},
+		},
+		{
+			name: "roletemplates with project context creates rules and aggregating clusterroles",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myroletemplate",
+				},
+				Context: "project",
+				Rules:   []rbacv1.PolicyRule{sampleRule},
+			},
+			verify: func(t *testing.T, roles []*rbacv1.ClusterRole) {
+				if got, want := len(roles), 2; got != want {
+					t.Errorf("expected %d roles but got %d", want, got)
+				}
+				for i, want := range []string{"myroletemplate", "myroletemplate-aggregator"} {
+					if got := roles[i].Name; got != want {
+						t.Errorf("role[%d] have incorrect name, got %q, want %q", i, got, want)
+					}
+				}
+				if got, want := len(roles[0].Rules), 1; got != want {
+					t.Errorf("expected role to have %d rules but got %d", want, got)
+				}
+				if got := roles[1].AggregationRule; got == nil || len(got.ClusterRoleSelectors) == 0 {
+					t.Errorf("expected aggregation rule not to be empty")
+				}
+			},
+		},
+		{
+			name: "roletemplates with project context and promoted rules create extra clusterroles for global resources",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myroletemplate",
+				},
+				Context: "project",
+				Rules:   []rbacv1.PolicyRule{samplePromotedRule},
+			},
+			verify: func(t *testing.T, roles []*rbacv1.ClusterRole) {
+				if got, want := len(roles), 4; got != want {
+					t.Errorf("expected %d roles but got %d", want, got)
+				}
+				for i, want := range []string{"myroletemplate", "myroletemplate-aggregator", "myroletemplate-promoted", "myroletemplate-promoted-aggregator"} {
+					if got := roles[i].Name; got != want {
+						t.Errorf("role[%d] have incorrect name, got %q, want %q", i, got, want)
+					}
+				}
+				if got, want := len(roles[2].Rules), 1; got != want {
+					t.Errorf("expected role to have %d rules but got %d", want, got)
+				}
+				if got := roles[3].AggregationRule; got == nil || len(got.ClusterRoleSelectors) == 0 {
+					t.Errorf("expected aggregation rule not to be empty")
+				}
+			},
+		},
+		{
+			name: "roletemplates with project context and role template names an extra clusterroles for global resources",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myroletemplate",
+				},
+				Context:           "project",
+				RoleTemplateNames: []string{"some-roletemplate"},
+			},
+			verify: func(t *testing.T, roles []*rbacv1.ClusterRole) {
+				if got, want := len(roles), 3; got != want {
+					t.Errorf("expected %d roles but got %d", want, got)
+				}
+				for i, want := range []string{"myroletemplate", "myroletemplate-aggregator", "myroletemplate-promoted-aggregator"} {
+					if got := roles[i].Name; got != want {
+						t.Errorf("role[%d] have incorrect name, got %q, want %q", i, got, want)
+					}
+				}
+				if got := roles[2].AggregationRule; got == nil || len(got.ClusterRoleSelectors) == 0 {
+					t.Errorf("expected aggregation rule not to be empty")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clusterRolesForRoleTemplate(tt.rt)
+			tt.verify(t, got)
+		})
+	}
+}

--- a/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler_test.go
@@ -3,8 +3,7 @@ package roletemplates
 import (
 	"testing"
 
-	"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -419,7 +419,7 @@ func BuildAggregatingClusterRole(rt *v3.RoleTemplate, nameTransformer func(strin
 	aggregatingCRName := AggregatedClusterRoleNameFor(crName)
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: crName,
+			Name: aggregatingCRName,
 			// Label so other cluster roles can aggregate this one
 			Labels: map[string]string{
 				aggregationLabel: aggregatingCRName,


### PR DESCRIPTION
Follow-up on #47455 (to be merged/cherry-picked into that branch)

Includes:
- Refactor `createMembershipRoles` to extract type from object (avoiding string parameter)
- Rename unused key args from `OnChange`/`OnRemove`
- Merge `AreClusterRolesSame` and `AreAggregatingClusterRolesSame`. Also add tests
- Refactor to extract `BuildClusterRole*` functions into a function returning just the list, for easier testing
- **Fix aggregator `ClusterRole` name**
- **Comment out possibly incorrect CRTBLifecycle registration**
- Add tests for `clusterRolesForRoleTemplate`