### PR TITLE
[main] Always reset failure counts on existing plans

### DIFF
--- a/pkg/capr/planner/etcdcreate.go
+++ b/pkg/capr/planner/etcdcreate.go
@@ -65,9 +65,7 @@ func (p *Planner) runEtcdSnapshotCreate(controlPlane *rkev1.RKEControlPlane, tok
 // Notably, this function will blatantly ignore drain and concurrency options, as during an etcd snapshot operation, there is no necessity to drain nodes.
 func (p *Planner) runEtcdSnapshotManagementServiceStart(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, clusterPlan *plan.Plan, include roleFilter, operation string) error {
 	// Generate and deliver desired plan for the bootstrap/init node first.
-	if err := p.reconcile(controlPlane, tokensSecret, clusterPlan, true, bootstrapTier, isEtcd, isNotInitNodeOrIsDeleting,
-		"1", "", controlPlane.Spec.UpgradeStrategy.ControlPlaneDrainOptions,
-		-1, 1, false, true); err != nil {
+	if err := p.reconcile(controlPlane, tokensSecret, clusterPlan, true, bootstrapTier, isEtcd, isNotInitNodeOrIsDeleting, "1", "", controlPlane.Spec.UpgradeStrategy.ControlPlaneDrainOptions, -1, 1, false); err != nil {
 		return err
 	}
 

--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -672,7 +672,7 @@ func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane,
 			stopPlan.Instructions = append(stopPlan.Instructions, generateRemoveTLSAndCredDirInstructions(controlPlane)...)
 		}
 		if !equality.Semantic.DeepEqual(server.Plan.Plan, stopPlan) {
-			if err := p.store.UpdatePlan(server, stopPlan, joinedServer, 0, 0, true); err != nil {
+			if err := p.store.UpdatePlan(server, stopPlan, joinedServer, 0, 0); err != nil {
 				return err
 			}
 			updated = true


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/47652

## Problem
In all previously released versions of Rancher, the `rancher-wins` service does have its underlying binary automatically upgraded to the latest version after an upgrade of the Rancher server. This behavior differs from Linux, and forces users to reprovision their Windows nodes in order to receive the latest enhancements within the `system-agent` (which is embedded in `rancher-wins`). This has resulted in unnecessary conditional logic within Rancher to account for behavior differences on nodes joined to the same cluster.

While implementing https://github.com/rancher/rancher/issues/46620 for Windows nodes, an issue was encountered where plan failures would not be accurately reported as out-dated versions of `rancher-wins` did not contain the necessary `system-agent` changes. To address this, Rancher was updated to conditionally update the `failure-count` property on Windows plans such that it is only set for newly provisioned nodes running the latest version of `rancher-wins`. 

This change was effectively a stop gap, and should be considered as tech debt.
 
## Solution

Revert the changes made in https://github.com/rancher/rancher/pull/47651. The changes raised in https://github.com/rancher/wins/pull/260 will update the windows SUC image to automatically upgrade the underlying `wins.exe` binary used by `rancher-wins`, ensuring that the proper version of the system-agent is installed onto all Windows nodes. 
 
## Testing
+ Provision a windows cluster using a commit associated released version of Rancher, like 2.9.3
+ Ensure that the windows node plan failure count is set to 1 
+ Upgrade the rancher server to a commit running a newer version of rancher, like 2.9.4 or 2.10
+ Ensure that the windows node plan failure count it updated to 5 

## Engineering Testing
### Manual Testing

I've done the above

### Automated Testing


## QA Testing Considerations


### Regressions Considerations
