### PR TITLE
RKE2/K3s provider re-work

### DIFF
--- a/tests/v2/actions/machinepools/amazonec2_machine_config.go
+++ b/tests/v2/actions/machinepools/amazonec2_machine_config.go
@@ -1,15 +1,13 @@
 package machinepools
 
 import (
-	"github.com/rancher/shepherd/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
-	AWSKind                              = "Amazonec2Config"
-	AWSPoolType                          = "rke-machine-config.cattle.io.amazonec2config"
-	AWSResourceConfig                    = "amazonec2configs"
-	AWSMachineConfigConfigurationFileKey = "awsMachineConfigs"
+	AWSKind           = "Amazonec2Config"
+	AWSPoolType       = "rke-machine-config.cattle.io.amazonec2config"
+	AWSResourceConfig = "amazonec2configs"
 )
 
 type AWSMachineConfigs struct {
@@ -35,19 +33,16 @@ type AWSMachineConfig struct {
 
 // NewAWSMachineConfig is a constructor to set up rke-machine-config.cattle.io.amazonec2config. It returns an *unstructured.Unstructured
 // that CreateMachineConfig uses to created the rke-machine-config
-func NewAWSMachineConfig(generatedPoolName, namespace string) []unstructured.Unstructured {
-	var awsMachineConfigs AWSMachineConfigs
-	config.LoadConfig(AWSMachineConfigConfigurationFileKey, &awsMachineConfigs)
+func NewAWSMachineConfig(machineConfigs MachineConfigs, generatedPoolName, namespace string) []unstructured.Unstructured {
 	var multiConfig []unstructured.Unstructured
-
-	for _, awsMachineConfig := range awsMachineConfigs.AWSMachineConfig {
+	for _, awsMachineConfig := range machineConfigs.AmazonEC2MachineConfigs.AWSMachineConfig {
 		machineConfig := unstructured.Unstructured{}
 		machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
 		machineConfig.SetKind(AWSKind)
 		machineConfig.SetGenerateName(generatedPoolName)
 		machineConfig.SetNamespace(namespace)
 
-		machineConfig.Object["region"] = awsMachineConfigs.Region
+		machineConfig.Object["region"] = machineConfigs.AmazonEC2MachineConfigs.Region
 		machineConfig.Object["ami"] = awsMachineConfig.AMI
 		machineConfig.Object["iamInstanceProfile"] = awsMachineConfig.IAMInstanceProfile
 		machineConfig.Object["instanceType"] = awsMachineConfig.InstanceType
@@ -68,12 +63,10 @@ func NewAWSMachineConfig(generatedPoolName, namespace string) []unstructured.Uns
 }
 
 // GetAWSMachineRoles returns a list of roles from the given machineConfigs
-func GetAWSMachineRoles() []Roles {
-	var awsMachineConfigs AWSMachineConfigs
-	config.LoadConfig(AWSMachineConfigConfigurationFileKey, &awsMachineConfigs)
+func GetAWSMachineRoles(machineConfigs MachineConfigs) []Roles {
 	var allRoles []Roles
 
-	for _, awsMachineConfig := range awsMachineConfigs.AWSMachineConfig {
+	for _, awsMachineConfig := range machineConfigs.AmazonEC2MachineConfigs.AWSMachineConfig {
 		allRoles = append(allRoles, awsMachineConfig.Roles)
 	}
 

--- a/tests/v2/actions/machinepools/azure_machine_config.go
+++ b/tests/v2/actions/machinepools/azure_machine_config.go
@@ -1,15 +1,13 @@
 package machinepools
 
 import (
-	"github.com/rancher/shepherd/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
-	AzureKind                              = "AzureConfig"
-	AzurePoolType                          = "rke-machine-config.cattle.io.azureconfig"
-	AzureResourceConfig                    = "azureconfigs"
-	AzureMachineConfigConfigurationFileKey = "azureMachineConfigs"
+	AzureKind           = "AzureConfig"
+	AzurePoolType       = "rke-machine-config.cattle.io.azureconfig"
+	AzureResourceConfig = "azureconfigs"
 )
 
 type AzureMachineConfigs struct {
@@ -45,12 +43,9 @@ type AzureMachineConfig struct {
 
 // NewAzureMachineConfig is a constructor to set up rke-machine-config.cattle.io.azureconfig. It returns an *unstructured.Unstructured
 // that CreateMachineConfig uses to created the rke-machine-config
-func NewAzureMachineConfig(generatedPoolName, namespace string) []unstructured.Unstructured {
-	var azureMachineConfigs AzureMachineConfigs
-	config.LoadConfig(AzureMachineConfigConfigurationFileKey, &azureMachineConfigs)
+func NewAzureMachineConfig(machineConfigs MachineConfigs, generatedPoolName, namespace string) []unstructured.Unstructured {
 	var multiConfig []unstructured.Unstructured
-
-	for _, azureMachineConfig := range azureMachineConfigs.AzureMachineConfig {
+	for _, azureMachineConfig := range machineConfigs.AzureMachineConfigs.AzureMachineConfig {
 		machineConfig := unstructured.Unstructured{}
 		machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
 		machineConfig.SetKind(AzureKind)
@@ -61,7 +56,7 @@ func NewAzureMachineConfig(generatedPoolName, namespace string) []unstructured.U
 		machineConfig.Object["diskSize"] = azureMachineConfig.DiskSize
 		machineConfig.Object["dns"] = azureMachineConfig.DNS
 		machineConfig.Object["location"] = azureMachineConfig.Location
-		machineConfig.Object["environment"] = azureMachineConfigs.Environment
+		machineConfig.Object["environment"] = machineConfigs.AzureMachineConfigs.Environment
 		machineConfig.Object["faultDomainCount"] = azureMachineConfig.FaultDomainCount
 		machineConfig.Object["image"] = azureMachineConfig.Image
 		machineConfig.Object["managedDisks"] = azureMachineConfig.ManagedDisks
@@ -88,12 +83,10 @@ func NewAzureMachineConfig(generatedPoolName, namespace string) []unstructured.U
 }
 
 // GetAzureMachineRoles returns a list of roles from the given machineConfigs
-func GetAzureMachineRoles() []Roles {
-	var azureMachineConfigs AzureMachineConfigs
-	config.LoadConfig(AzureMachineConfigConfigurationFileKey, &azureMachineConfigs)
+func GetAzureMachineRoles(machineConfigs MachineConfigs) []Roles {
 	var allRoles []Roles
 
-	for _, azureMachineConfig := range azureMachineConfigs.AzureMachineConfig {
+	for _, azureMachineConfig := range machineConfigs.AzureMachineConfigs.AzureMachineConfig {
 		allRoles = append(allRoles, azureMachineConfig.Roles)
 	}
 

--- a/tests/v2/actions/machinepools/digitalocean_machine_config.go
+++ b/tests/v2/actions/machinepools/digitalocean_machine_config.go
@@ -1,15 +1,13 @@
 package machinepools
 
 import (
-	"github.com/rancher/shepherd/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
-	DOKind                              = "DigitaloceanConfig"
-	DOPoolType                          = "rke-machine-config.cattle.io.digitaloceanconfig"
-	DOResourceConfig                    = "digitaloceanconfigs"
-	DOMachineConfigConfigurationFileKey = "doMachineConfigs"
+	DOKind           = "DigitaloceanConfig"
+	DOPoolType       = "rke-machine-config.cattle.io.digitaloceanconfig"
+	DOResourceConfig = "digitaloceanconfigs"
 )
 
 type DOMachineConfigs struct {
@@ -36,12 +34,9 @@ type DOMachineConfig struct {
 
 // NewDigitalOceanMachineConfig is a constructor to set up rke-machine-config.cattle.io.digitaloceanconfig. It returns an *unstructured.Unstructured
 // that CreateMachineConfig uses to created the rke-machine-config
-func NewDigitalOceanMachineConfig(generatedPoolName, namespace string) []unstructured.Unstructured {
-	var doMachineConfigs DOMachineConfigs
-	config.LoadConfig(DOMachineConfigConfigurationFileKey, &doMachineConfigs)
+func NewDigitalOceanMachineConfig(machineConfigs MachineConfigs, generatedPoolName, namespace string) []unstructured.Unstructured {
 	var multiConfig []unstructured.Unstructured
-
-	for _, doMachineConfig := range doMachineConfigs.DOMachineConfig {
+	for _, doMachineConfig := range machineConfigs.DOMachineConfigs.DOMachineConfig {
 		machineConfig := unstructured.Unstructured{}
 		machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
 		machineConfig.SetKind(DOKind)
@@ -54,7 +49,7 @@ func NewDigitalOceanMachineConfig(generatedPoolName, namespace string) []unstruc
 		machineConfig.Object["ipv6"] = doMachineConfig.IPV6
 		machineConfig.Object["monitoring"] = doMachineConfig.Monitoring
 		machineConfig.Object["privateNetworking"] = doMachineConfig.PrivateNetworking
-		machineConfig.Object["region"] = doMachineConfigs.Region
+		machineConfig.Object["region"] = machineConfigs.DOMachineConfigs.Region
 		machineConfig.Object["size"] = doMachineConfig.Size
 		machineConfig.Object["sshKeyContents"] = doMachineConfig.SSHKeyContents
 		machineConfig.Object["sshKeyFingerprint"] = doMachineConfig.SSHKeyFingerprint
@@ -71,12 +66,10 @@ func NewDigitalOceanMachineConfig(generatedPoolName, namespace string) []unstruc
 }
 
 // GetDOMachineRoles returns a list of roles from the given machineConfigs
-func GetDOMachineRoles() []Roles {
-	var doMachineConfigs DOMachineConfigs
-	config.LoadConfig(DOMachineConfigConfigurationFileKey, &doMachineConfigs)
+func GetDOMachineRoles(machineConfigs MachineConfigs) []Roles {
 	var allRoles []Roles
 
-	for _, doMachineConfig := range doMachineConfigs.DOMachineConfig {
+	for _, doMachineConfig := range machineConfigs.DOMachineConfigs.DOMachineConfig {
 		allRoles = append(allRoles, doMachineConfig.Roles)
 	}
 

--- a/tests/v2/actions/machinepools/harvester_machine_config.go
+++ b/tests/v2/actions/machinepools/harvester_machine_config.go
@@ -1,15 +1,13 @@
 package machinepools
 
 import (
-	"github.com/rancher/shepherd/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
-	HarvesterKind                              = "HarvesterConfig"
-	HarvesterPoolType                          = "rke-machine-config.cattle.io.harvesterconfig"
-	HarvesterResourceConfig                    = "harvesterconfigs"
-	HarvesterMachineConfigConfigurationFileKey = "harvesterMachineConfigs"
+	HarvesterKind           = "HarvesterConfig"
+	HarvesterPoolType       = "rke-machine-config.cattle.io.harvesterconfig"
+	HarvesterResourceConfig = "harvesterconfigs"
 )
 
 type HarvesterMachineConfigs struct {
@@ -31,12 +29,9 @@ type HarvesterMachineConfig struct {
 
 // NewHarvesterMachineConfig is a constructor to set up rke-machine-config.cattle.io.harvesterconfig.
 // It returns an *unstructured.Unstructured that CreateMachineConfig uses to created the rke-machine-config
-func NewHarvesterMachineConfig(generatedPoolName, namespace string) []unstructured.Unstructured {
-	var harvesterMachineConfigs HarvesterMachineConfigs
-	config.LoadConfig(HarvesterMachineConfigConfigurationFileKey, &harvesterMachineConfigs)
+func NewHarvesterMachineConfig(machineConfigs MachineConfigs, generatedPoolName, namespace string) []unstructured.Unstructured {
 	var multiConfig []unstructured.Unstructured
-
-	for _, harvesterMachineConfig := range harvesterMachineConfigs.HarvesterMachineConfig {
+	for _, harvesterMachineConfig := range machineConfigs.HarvesterMachineConfigs.HarvesterMachineConfig {
 		machineConfig := unstructured.Unstructured{}
 		machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
 		machineConfig.SetKind(HarvesterKind)
@@ -49,7 +44,7 @@ func NewHarvesterMachineConfig(generatedPoolName, namespace string) []unstructur
 		machineConfig.Object["memorySize"] = harvesterMachineConfig.MemorySize
 		machineConfig.Object["networkName"] = harvesterMachineConfig.NetworkName
 		machineConfig.Object["imageName"] = harvesterMachineConfig.ImageName
-		machineConfig.Object["vmNamespace"] = harvesterMachineConfigs.VMNamespace
+		machineConfig.Object["vmNamespace"] = machineConfigs.HarvesterMachineConfigs.VMNamespace
 		machineConfig.Object["sshUser"] = harvesterMachineConfig.SSHUser
 
 		multiConfig = append(multiConfig, machineConfig)
@@ -59,12 +54,10 @@ func NewHarvesterMachineConfig(generatedPoolName, namespace string) []unstructur
 }
 
 // GetHarvesterMachineRoles returns a list of roles from the given machineConfigs
-func GetHarvesterMachineRoles() []Roles {
-	var harvesterMachineConfigs HarvesterMachineConfigs
-	config.LoadConfig(HarvesterMachineConfigConfigurationFileKey, &harvesterMachineConfigs)
+func GetHarvesterMachineRoles(machineConfigs MachineConfigs) []Roles {
 	var allRoles []Roles
 
-	for _, harvesterMachineConfig := range harvesterMachineConfigs.HarvesterMachineConfig {
+	for _, harvesterMachineConfig := range machineConfigs.HarvesterMachineConfigs.HarvesterMachineConfig {
 		allRoles = append(allRoles, harvesterMachineConfig.Roles)
 	}
 

--- a/tests/v2/actions/machinepools/linode_machine_config.go
+++ b/tests/v2/actions/machinepools/linode_machine_config.go
@@ -1,15 +1,13 @@
 package machinepools
 
 import (
-	"github.com/rancher/shepherd/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
-	LinodeKind                              = "LinodeConfig"
-	LinodePoolType                          = "rke-machine-config.cattle.io.linodeconfig"
-	LinodeResourceConfig                    = "linodeconfigs"
-	LinodeMachineConfigConfigurationFileKey = "linodeMachineConfigs"
+	LinodeKind           = "LinodeConfig"
+	LinodePoolType       = "rke-machine-config.cattle.io.linodeconfig"
+	LinodeResourceConfig = "linodeconfigs"
 )
 
 type LinodeMachineConfigs struct {
@@ -37,12 +35,9 @@ type LinodeMachineConfig struct {
 
 // NewLinodeMachineConfig is a constructor to set up rke-machine-config.cattle.io.linodeconfigs. It returns an *unstructured.Unstructured
 // that CreateMachineConfig uses to created the rke-machine-config
-func NewLinodeMachineConfig(generatedPoolName, namespace string) []unstructured.Unstructured {
-	var linodeMachineConfigs LinodeMachineConfigs
-	config.LoadConfig(LinodeMachineConfigConfigurationFileKey, &linodeMachineConfigs)
+func NewLinodeMachineConfig(machineConfigs MachineConfigs, generatedPoolName, namespace string) []unstructured.Unstructured {
 	var multiConfig []unstructured.Unstructured
-
-	for _, linodeMachineConfig := range linodeMachineConfigs.LinodeMachineConfig {
+	for _, linodeMachineConfig := range machineConfigs.LinodeMachineConfigs.LinodeMachineConfig {
 		machineConfig := unstructured.Unstructured{}
 		machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
 		machineConfig.SetKind(LinodeKind)
@@ -54,7 +49,7 @@ func NewLinodeMachineConfig(generatedPoolName, namespace string) []unstructured.
 		machineConfig.Object["dockerPort"] = linodeMachineConfig.DockerPort
 		machineConfig.Object["image"] = linodeMachineConfig.Image
 		machineConfig.Object["instanceType"] = linodeMachineConfig.InstanceType
-		machineConfig.Object["region"] = linodeMachineConfigs.Region
+		machineConfig.Object["region"] = machineConfigs.LinodeMachineConfigs.Region
 		machineConfig.Object["rootPass"] = linodeMachineConfig.RootPass
 		machineConfig.Object["sshPort"] = linodeMachineConfig.SSHPort
 		machineConfig.Object["sshUser"] = linodeMachineConfig.SSHUser
@@ -73,12 +68,10 @@ func NewLinodeMachineConfig(generatedPoolName, namespace string) []unstructured.
 }
 
 // GetLinodeMachineRoles returns a list of roles from the given machineConfigs
-func GetLinodeMachineRoles() []Roles {
-	var linodeMachineConfigs LinodeMachineConfigs
-	config.LoadConfig(LinodeMachineConfigConfigurationFileKey, &linodeMachineConfigs)
+func GetLinodeMachineRoles(machineConfigs MachineConfigs) []Roles {
 	var allRoles []Roles
 
-	for _, linodeMachineConfig := range linodeMachineConfigs.LinodeMachineConfig {
+	for _, linodeMachineConfig := range machineConfigs.LinodeMachineConfigs.LinodeMachineConfig {
 		allRoles = append(allRoles, linodeMachineConfig.Roles)
 	}
 

--- a/tests/v2/actions/machinepools/vsphere_machine_config.go
+++ b/tests/v2/actions/machinepools/vsphere_machine_config.go
@@ -1,15 +1,13 @@
 package machinepools
 
 import (
-	"github.com/rancher/shepherd/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
-	VmwaresphereKind                               = "VmwarevsphereConfig"
-	VmwarevsphereType                              = "rke-machine-config.cattle.io.vmwarevsphereconfig"
-	VmwarevsphereConfig                            = "vmwarevsphereconfigs"
-	VmwarevsphereMachineConfigConfigurationFileKey = "vmwarevsphereMachineConfigs"
+	VmwaresphereKind    = "VmwarevsphereConfig"
+	VmwarevsphereType   = "rke-machine-config.cattle.io.vmwarevsphereconfig"
+	VmwarevsphereConfig = "vmwarevsphereconfigs"
 )
 
 type VmwarevsphereMachineConfigs struct {
@@ -54,12 +52,9 @@ type VmwarevsphereMachineConfig struct {
 
 // NewVSphereMachineConfig is a constructor to set up rke-machine-config.cattle.io.vmwarevsphereconfig. It returns an *unstructured.Unstructured
 // that CreateMachineConfig uses to created the rke-machine-config
-func NewVSphereMachineConfig(generatedPoolName, namespace string) []unstructured.Unstructured {
-	var vmwarevsphereMachineConfigs VmwarevsphereMachineConfigs
-	config.LoadConfig(VmwarevsphereMachineConfigConfigurationFileKey, &vmwarevsphereMachineConfigs)
+func NewVSphereMachineConfig(machineConfigs MachineConfigs, generatedPoolName, namespace string) []unstructured.Unstructured {
 	var multiConfig []unstructured.Unstructured
-
-	for _, vsphereMachineConfig := range vmwarevsphereMachineConfigs.VmwarevsphereMachineConfig {
+	for _, vsphereMachineConfig := range machineConfigs.VmwareMachineConfigs.VmwarevsphereMachineConfig {
 		machineConfig := unstructured.Unstructured{}
 		machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
 		machineConfig.SetKind(VmwaresphereKind)
@@ -75,17 +70,17 @@ func NewVSphereMachineConfig(generatedPoolName, namespace string) []unstructured
 		machineConfig.Object["cpuCount"] = vsphereMachineConfig.CPUCount
 		machineConfig.Object["creationType"] = vsphereMachineConfig.CreationType
 		machineConfig.Object["customAttribute"] = vsphereMachineConfig.CustomAttribute
-		machineConfig.Object["datacenter"] = vmwarevsphereMachineConfigs.Datacenter
-		machineConfig.Object["datastore"] = vmwarevsphereMachineConfigs.Datastore
+		machineConfig.Object["datacenter"] = machineConfigs.VmwareMachineConfigs.Datacenter
+		machineConfig.Object["datastore"] = machineConfigs.VmwareMachineConfigs.Datastore
 		machineConfig.Object["datastoreCluster"] = vsphereMachineConfig.DatastoreCluster
-		machineConfig.Object["datastoreUrl"] = vmwarevsphereMachineConfigs.DatastoreURL
+		machineConfig.Object["datastoreUrl"] = machineConfigs.VmwareMachineConfigs.DatastoreURL
 		machineConfig.Object["diskSize"] = vsphereMachineConfig.DiskSize
-		machineConfig.Object["folder"] = vmwarevsphereMachineConfigs.Folder
-		machineConfig.Object["hostsystem"] = vmwarevsphereMachineConfigs.Hostsystem
+		machineConfig.Object["folder"] = machineConfigs.VmwareMachineConfigs.Folder
+		machineConfig.Object["hostsystem"] = machineConfigs.VmwareMachineConfigs.Hostsystem
 		machineConfig.Object["memorySize"] = vsphereMachineConfig.MemorySize
 		machineConfig.Object["network"] = vsphereMachineConfig.Network
 		machineConfig.Object["os"] = vsphereMachineConfig.OS
-		machineConfig.Object["pool"] = vmwarevsphereMachineConfigs.Pool
+		machineConfig.Object["pool"] = machineConfigs.VmwareMachineConfigs.Pool
 		machineConfig.Object["sshPassword"] = vsphereMachineConfig.SSHPassword
 		machineConfig.Object["sshPort"] = vsphereMachineConfig.SSHPort
 		machineConfig.Object["sshUser"] = vsphereMachineConfig.SSHUser
@@ -103,12 +98,10 @@ func NewVSphereMachineConfig(generatedPoolName, namespace string) []unstructured
 	return multiConfig
 }
 
-func GetVsphereMachineRoles() []Roles {
-	var vmwarevsphereMachineConfigs VmwarevsphereMachineConfigs
-	config.LoadConfig(VmwarevsphereMachineConfigConfigurationFileKey, &vmwarevsphereMachineConfigs)
+func GetVsphereMachineRoles(machineConfigs MachineConfigs) []Roles {
 	var allRoles []Roles
 
-	for _, vsphereMachineConfig := range vmwarevsphereMachineConfigs.VmwarevsphereMachineConfig {
+	for _, vsphereMachineConfig := range machineConfigs.VmwareMachineConfigs.VmwarevsphereMachineConfig {
 		allRoles = append(allRoles, vsphereMachineConfig.Roles)
 	}
 

--- a/tests/v2/actions/pipeline/configuration.go
+++ b/tests/v2/actions/pipeline/configuration.go
@@ -112,7 +112,7 @@ func UpdateRKE2ImageFields(provider, image, sshUser, volumeType string, isCustom
 	case provisioninginput.AWSProviderName.String():
 		if !isCustom {
 			machineConfig := new(machinepools.AWSMachineConfigs)
-			config.LoadAndUpdateConfig(machinepools.AWSMachineConfigConfigurationFileKey, machineConfig, func() {
+			config.LoadAndUpdateConfig(machinepools.AWSMachineConfigsKey, machineConfig, func() {
 				for i := range machineConfig.AWSMachineConfig {
 					machineConfig.AWSMachineConfig[i].AMI = image
 					machineConfig.AWSMachineConfig[i].SSHUser = sshUser
@@ -130,7 +130,7 @@ func UpdateRKE2ImageFields(provider, image, sshUser, volumeType string, isCustom
 		}
 	case provisioninginput.AzureProviderName.String():
 		machineConfig := new(machinepools.AzureMachineConfigs)
-		config.LoadAndUpdateConfig(machinepools.AzureMachineConfigConfigurationFileKey, machineConfig, func() {
+		config.LoadAndUpdateConfig(machinepools.AzureMachineConfigsKey, machineConfig, func() {
 			for i := range machineConfig.AzureMachineConfig {
 				machineConfig.AzureMachineConfig[i].Image = image
 				machineConfig.AzureMachineConfig[i].SSHUser = sshUser
@@ -138,7 +138,7 @@ func UpdateRKE2ImageFields(provider, image, sshUser, volumeType string, isCustom
 		})
 	case provisioninginput.DOProviderName.String():
 		machineConfig := new(machinepools.DOMachineConfigs)
-		config.LoadAndUpdateConfig(machinepools.DOMachineConfigConfigurationFileKey, machineConfig, func() {
+		config.LoadAndUpdateConfig(machinepools.DOMachineConfigsKey, machineConfig, func() {
 			for i := range machineConfig.DOMachineConfig {
 				machineConfig.DOMachineConfig[i].Image = image
 				machineConfig.DOMachineConfig[i].SSHUser = sshUser
@@ -146,7 +146,7 @@ func UpdateRKE2ImageFields(provider, image, sshUser, volumeType string, isCustom
 		})
 	case provisioninginput.HarvesterProviderName.String():
 		machineConfig := new(machinepools.HarvesterMachineConfigs)
-		config.LoadAndUpdateConfig(machinepools.HarvesterMachineConfigConfigurationFileKey, machineConfig, func() {
+		config.LoadAndUpdateConfig(machinepools.HarvesterMachineConfigsKey, machineConfig, func() {
 			for i := range machineConfig.HarvesterMachineConfig {
 				machineConfig.HarvesterMachineConfig[i].ImageName = image
 				machineConfig.HarvesterMachineConfig[i].SSHUser = sshUser
@@ -154,7 +154,7 @@ func UpdateRKE2ImageFields(provider, image, sshUser, volumeType string, isCustom
 		})
 	case provisioninginput.LinodeProviderName.String():
 		machineConfig := new(machinepools.LinodeMachineConfigs)
-		config.LoadAndUpdateConfig(machinepools.LinodeMachineConfigConfigurationFileKey, machineConfig, func() {
+		config.LoadAndUpdateConfig(machinepools.LinodeMachineConfigsKey, machineConfig, func() {
 			for i := range machineConfig.LinodeMachineConfig {
 				machineConfig.LinodeMachineConfig[i].Image = image
 				machineConfig.LinodeMachineConfig[i].SSHUser = sshUser

--- a/tests/v2/actions/provisioning/permutations/permutations.go
+++ b/tests/v2/actions/provisioning/permutations/permutations.go
@@ -28,6 +28,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	extensionscharts "github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
 	wloads "github.com/rancher/shepherd/extensions/workloads"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
@@ -129,8 +130,11 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 
 					switch clusterType {
 					case RKE2ProvisionCluster, K3SProvisionCluster:
+						credentialSpec := cloudcredentials.LoadCloudCredential(string(nodeProvider.Name))
+						machineConfigSpec := machinepools.LoadMachineConfigs(string(nodeProvider.Name))
+
 						testClusterConfig.KubernetesVersion = kubeVersion
-						clusterObject, err = provisioning.CreateProvisioningCluster(client, *nodeProvider, testClusterConfig, hostnameTruncation)
+						clusterObject, err = provisioning.CreateProvisioningCluster(client, *nodeProvider, credentialSpec, testClusterConfig, machineConfigSpec, hostnameTruncation)
 						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 

--- a/tests/v2/actions/provisioning/providers.go
+++ b/tests/v2/actions/provisioning/providers.go
@@ -25,14 +25,15 @@ import (
 )
 
 type CloudCredFunc func(rancherClient *rancher.Client, credentials cloudcredentials.CloudCredential) (*v1.SteveAPIObject, error)
-type MachinePoolFunc func(generatedPoolName, namespace string) []unstructured.Unstructured
+type MachinePoolFunc func(machineConfig machinepools.MachineConfigs, generatedPoolName, namespace string) []unstructured.Unstructured
+type MachineRolesFunc func(machineConfig machinepools.MachineConfigs) []machinepools.Roles
 
 type Provider struct {
 	Name                               provisioninginput.ProviderName
 	MachineConfigPoolResourceSteveType string
 	MachinePoolFunc                    MachinePoolFunc
 	CloudCredFunc                      CloudCredFunc
-	Roles                              []machinepools.Roles
+	GetMachineRolesFunc                MachineRolesFunc
 }
 
 // CreateProvider returns all machine and cloud credential
@@ -46,7 +47,7 @@ func CreateProvider(name string) Provider {
 			MachineConfigPoolResourceSteveType: machinepools.AWSPoolType,
 			MachinePoolFunc:                    machinepools.NewAWSMachineConfig,
 			CloudCredFunc:                      aws.CreateAWSCloudCredentials,
-			Roles:                              machinepools.GetAWSMachineRoles(),
+			GetMachineRolesFunc:                machinepools.GetAWSMachineRoles,
 		}
 		return provider
 	case name == provisioninginput.AzureProviderName.String():
@@ -55,7 +56,7 @@ func CreateProvider(name string) Provider {
 			MachineConfigPoolResourceSteveType: machinepools.AzurePoolType,
 			MachinePoolFunc:                    machinepools.NewAzureMachineConfig,
 			CloudCredFunc:                      azure.CreateAzureCloudCredentials,
-			Roles:                              machinepools.GetAzureMachineRoles(),
+			GetMachineRolesFunc:                machinepools.GetAzureMachineRoles,
 		}
 		return provider
 	case name == provisioninginput.DOProviderName.String():
@@ -64,7 +65,7 @@ func CreateProvider(name string) Provider {
 			MachineConfigPoolResourceSteveType: machinepools.DOPoolType,
 			MachinePoolFunc:                    machinepools.NewDigitalOceanMachineConfig,
 			CloudCredFunc:                      digitalocean.CreateDigitalOceanCloudCredentials,
-			Roles:                              machinepools.GetDOMachineRoles(),
+			GetMachineRolesFunc:                machinepools.GetDOMachineRoles,
 		}
 		return provider
 	case name == provisioninginput.LinodeProviderName.String():
@@ -73,7 +74,7 @@ func CreateProvider(name string) Provider {
 			MachineConfigPoolResourceSteveType: machinepools.LinodePoolType,
 			MachinePoolFunc:                    machinepools.NewLinodeMachineConfig,
 			CloudCredFunc:                      linode.CreateLinodeCloudCredentials,
-			Roles:                              machinepools.GetLinodeMachineRoles(),
+			GetMachineRolesFunc:                machinepools.GetLinodeMachineRoles,
 		}
 		return provider
 	case name == provisioninginput.HarvesterProviderName.String():
@@ -82,7 +83,7 @@ func CreateProvider(name string) Provider {
 			MachineConfigPoolResourceSteveType: machinepools.HarvesterPoolType,
 			MachinePoolFunc:                    machinepools.NewHarvesterMachineConfig,
 			CloudCredFunc:                      harvester.CreateHarvesterCloudCredentials,
-			Roles:                              machinepools.GetHarvesterMachineRoles(),
+			GetMachineRolesFunc:                machinepools.GetHarvesterMachineRoles,
 		}
 		return provider
 	case name == provisioninginput.VsphereProviderName.String():
@@ -91,7 +92,7 @@ func CreateProvider(name string) Provider {
 			MachineConfigPoolResourceSteveType: machinepools.VmwarevsphereType,
 			MachinePoolFunc:                    machinepools.NewVSphereMachineConfig,
 			CloudCredFunc:                      vsphere.CreateVsphereCloudCredentials,
-			Roles:                              machinepools.GetVsphereMachineRoles(),
+			GetMachineRolesFunc:                machinepools.GetVsphereMachineRoles,
 		}
 		return provider
 	default:

--- a/tests/v2/validation/provisioning/hostnametruncation/hostname_truncation_test.go
+++ b/tests/v2/validation/provisioning/hostnametruncation/hostname_truncation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
 	"github.com/rancher/rancher/tests/v2/actions/reports"
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/pkg/config"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
@@ -104,7 +105,10 @@ func (r *HostnameTruncationTestSuite) TestProvisioningRKE2ClusterTruncation() {
 
 				rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], r.clustersConfig)
 
-				clusterObject, err := provisioning.CreateProvisioningCluster(r.client, *rke2Provider, testConfig, hostnamePools)
+				credentialSpec := cloudcredentials.LoadCloudCredential(string(rke2Provider.Name))
+				machineConfigSpec := machinepools.LoadMachineConfigs(string(rke2Provider.Name))
+
+				clusterObject, err := provisioning.CreateProvisioningCluster(r.client, *rke2Provider, credentialSpec, testConfig, machineConfigSpec, hostnamePools)
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(r.T(), err)
 

--- a/tests/v2/validation/provisioning/registries/registry_test.go
+++ b/tests/v2/validation/provisioning/registries/registry_test.go
@@ -7,6 +7,7 @@ import (
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/tests/v2/actions/clusters"
+	"github.com/rancher/rancher/tests/v2/actions/machinepools"
 	provisioning "github.com/rancher/rancher/tests/v2/actions/provisioning"
 	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
@@ -15,6 +16,7 @@ import (
 	"github.com/rancher/shepherd/clients/corral"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
@@ -337,7 +339,10 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 
 				k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
-				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, testConfig, nil)
+				credentialSpec := cloudcredentials.LoadCloudCredential(string(k3sProvider.Name))
+				machineConfigSpec := machinepools.LoadMachineConfigs(string(k3sProvider.Name))
+
+				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, credentialSpec, testConfig, machineConfigSpec, nil)
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
@@ -357,7 +362,10 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 
 				k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
-				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, testConfig, nil)
+				credentialSpec := cloudcredentials.LoadCloudCredential(string(k3sProvider.Name))
+				machineConfigSpec := machinepools.LoadMachineConfigs(string(k3sProvider.Name))
+
+				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, credentialSpec, testConfig, machineConfigSpec, nil)
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
@@ -403,7 +411,10 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 
 				rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
-				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, testConfig, nil)
+				credentialSpec := cloudcredentials.LoadCloudCredential(string(rke2Provider.Name))
+				machineConfigSpec := machinepools.LoadMachineConfigs(string(rke2Provider.Name))
+
+				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, credentialSpec, testConfig, machineConfigSpec, nil)
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
@@ -421,7 +432,10 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 
 				rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
-				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, testConfig, nil)
+				credentialSpec := cloudcredentials.LoadCloudCredential(string(rke2Provider.Name))
+				machineConfigSpec := machinepools.LoadMachineConfigs(string(rke2Provider.Name))
+
+				clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, credentialSpec, testConfig, machineConfigSpec, nil)
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 

--- a/tests/v2/validation/provisioning/rke2/agent_customization_test.go
+++ b/tests/v2/validation/provisioning/rke2/agent_customization_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/v2/actions/clusters"
+	"github.com/rancher/rancher/tests/v2/actions/machinepools"
 	"github.com/rancher/rancher/tests/v2/actions/provisioning"
 	"github.com/rancher/rancher/tests/v2/actions/provisioning/permutations"
 	"github.com/rancher/rancher/tests/v2/actions/provisioninginput"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	shepherdclusters "github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	"github.com/rancher/shepherd/extensions/users"
@@ -194,7 +196,10 @@ func (r *RKE2AgentCustomizationTestSuite) TestFailureProvisioningRKE2ClusterAgen
 		testClusterConfig := clusters.ConvertConfigToClusterConfig(r.provisioningConfig)
 		testClusterConfig.KubernetesVersion = kubeVersions[0]
 
-		_, err = provisioning.CreateProvisioningCluster(client, *rke2Provider, testClusterConfig, nil)
+		credentialSpec := cloudcredentials.LoadCloudCredential(string(rke2Provider.Name))
+		machineConfigSpec := machinepools.LoadMachineConfigs(string(rke2Provider.Name))
+
+		_, err = provisioning.CreateProvisioningCluster(client, *rke2Provider, credentialSpec, testClusterConfig, machineConfigSpec, nil)
 		require.Error(r.T(), err)
 	}
 }


### PR DESCRIPTION
Purpose: to allow the new generic permutations to access all parts of the config files. 

Additional notes: 
1. This will not break old permutations which will allow us to slowly convert over without having to do 1 large PR. 
2. Longterm this will allow us to deprecate provisioning input if we so choose (not the current goal but something to keep in mind)
3. This will only affect RKE2/K3s (rke1 should will be unaffected)
4. Updated machine_configs to be inline with the design path we took for old/new credentials i.e loader function into a struct that has all provider versions of a config (vsphere machine config, aws.... etc)
