### PR TITLE
[2.10] Backport Cache mitigation

### DIFF
--- a/pkg/agent/cluster/cluster.go
+++ b/pkg/agent/cluster/cluster.go
@@ -78,7 +78,7 @@ func getTokenFromAPI() ([]byte, []byte, error) {
 		}
 		return secret.Data[coreV1.ServiceAccountRootCAKey], secret.Data[coreV1.ServiceAccountTokenKey], nil
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, k8s, sa, "")
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, k8s, sa)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to ensure secret for service account %s/%s: %w", namespace.System, "cattle", err)
 	}

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -27,7 +27,6 @@ import (
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
-	"github.com/rancher/rancher/pkg/utils"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -328,7 +327,7 @@ func GetPlanServiceAccountTokenSecret(secretClient corecontrollers.SecretControl
 	if planSA == nil {
 		return nil, false, fmt.Errorf("planSA was nil")
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), secretClient.Cache(), k8s, planSA, utils.FormatPrefix("local"))
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), secretClient.Cache(), k8s, planSA)
 	if err != nil {
 		return nil, false, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", planSA.Namespace, planSA.Name, err)
 	}

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/rancher/pkg/tls"
-	"github.com/rancher/rancher/pkg/utils"
 	"github.com/rancher/rancher/pkg/wrangler"
 	appcontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps/v1"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -121,7 +120,7 @@ func (h *handler) getBootstrapSecret(namespace, name string, envVars []corev1.En
 	if err != nil {
 		return nil, err
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), h.secretCache, h.k8s, sa, utils.FormatPrefix("local"))
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), h.secretCache, h.k8s, sa)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/dashboard/apiservice/apiservice.go
+++ b/pkg/controllers/dashboard/apiservice/apiservice.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/rancher/pkg/settings"
-	"github.com/rancher/rancher/pkg/utils"
 	"github.com/rancher/rancher/pkg/wrangler"
 	appscontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps/v1"
 	corev1controllers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -149,7 +148,7 @@ func (h *handler) getToken(sa *corev1.ServiceAccount) (string, error) {
 	}
 
 	// create a secret-based token for the service account if one does not exist
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(h.ctx, h.secretsCache, h.k8s, sa, utils.FormatPrefix("local"))
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(h.ctx, h.secretsCache, h.k8s, sa)
 	if err != nil {
 		return "", fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
 	}

--- a/pkg/impersonation/impersonation.go
+++ b/pkg/impersonation/impersonation.go
@@ -12,7 +12,6 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/rancher/pkg/types/config"
-	"github.com/rancher/rancher/pkg/utils"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -105,7 +104,7 @@ func (i *Impersonator) SetUpImpersonation() (*corev1.ServiceAccount, error) {
 
 // GetToken accepts a service account and returns the service account's token.
 func (i *Impersonator) GetToken(sa *corev1.ServiceAccount) (string, error) {
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), i.secretsCache, i.clusterContext.K8sClient, sa, utils.FormatPrefix(i.clusterContext.ClusterName))
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), i.secretsCache, i.clusterContext.K8sClient, sa)
 	if err != nil {
 		return "", fmt.Errorf("error getting secret: %w", err)
 	}
@@ -171,7 +170,7 @@ func (i *Impersonator) createServiceAccount(role *rbacv1.ClusterRole) (*corev1.S
 		}
 	}
 	// create secret for service account if it was not automatically generated
-	_, err = serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), i.secretsCache, i.clusterContext.K8sClient, sa, utils.FormatPrefix(i.clusterContext.ClusterName))
+	_, err = serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), i.secretsCache, i.clusterContext.K8sClient, sa)
 	if err != nil {
 		return nil, fmt.Errorf("impersonation: error ensuring secret for service account %s: %w", name, err)
 	}

--- a/pkg/kontainer-engine/drivers/util/utils.go
+++ b/pkg/kontainer-engine/drivers/util/utils.go
@@ -6,7 +6,6 @@ import (
 
 	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
-	"github.com/rancher/rancher/pkg/utils"
 	rketypes "github.com/rancher/rke/types"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
@@ -102,7 +101,7 @@ func GenerateServiceAccountToken(clientset kubernetes.Interface, clusterName str
 	if serviceAccount, err = clientset.CoreV1().ServiceAccounts(cattleNamespace).Get(context.Background(), serviceAccount.Name, metav1.GetOptions{}); err != nil {
 		return "", fmt.Errorf("error getting service account: %w", err)
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, clientset, serviceAccount, utils.FormatPrefix(clusterName))
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, clientset, serviceAccount)
 	if err != nil {
 		return "", fmt.Errorf("error ensuring secret for service account: %w", err)
 	}

--- a/pkg/serviceaccounttoken/secret.go
+++ b/pkg/serviceaccounttoken/secret.go
@@ -3,14 +3,16 @@ package serviceaccounttoken
 import (
 	"context"
 	"fmt"
-	"sync"
+	"strings"
 	"time"
 
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -20,6 +22,10 @@ const (
 	// ServiceAccountSecretLabel is the label used to search for the secret belonging to a service account.
 	ServiceAccountSecretLabel = "cattle.io/service-account.name"
 
+	// ServiceAccountSecretRefAnnotation is applied to the ServiceAccount to
+	// reference the secret that was created.
+	ServiceAccountSecretRefAnnotation = "rancher.io/service-account.secret-ref"
+
 	serviceAccountSecretAnnotation = "kubernetes.io/service-account.name"
 )
 
@@ -28,35 +34,13 @@ const (
 // as long as it can wrap it in a simplified lambda with this signature.
 type secretLister func(namespace string, selector labels.Selector) ([]*corev1.Secret, error)
 
-var lockMap sync.Map
-
-func getLock(key string) *sync.Mutex {
-	actual, _ := lockMap.LoadOrStore(key, &sync.Mutex{})
-	return actual.(*sync.Mutex)
-}
-
 // EnsureSecretForServiceAccount gets or creates a service account token Secret for the provided Service Account.
-//
-// If lockPrefix is provided, this is used as a prefix for the lock to provide
-// context for concurrent requests. No concurrent creates will be allowed for a
-// service account.
-//
-// The lockPrefix should be of the same format as a generateName e.g. cluster-
-//
-// For example, if this is "cluster-1" and the ServiceAccount is
-// "default:test-sa" subsequent requests to create a ServiceAccount with the
-// same name in "cluster-1" will be blocked until the first request has
-// completed.
-//
-// Note: This mutex is per-replica, currently there's no attempt to co-ordinate
-// across replicas.
-func EnsureSecretForServiceAccount(ctx context.Context, secretsCache corecontrollers.SecretCache, clientSet kubernetes.Interface, sa *corev1.ServiceAccount, lockPrefix string) (*corev1.Secret, error) {
+func EnsureSecretForServiceAccount(ctx context.Context, secretsCache corecontrollers.SecretCache, clientSet kubernetes.Interface, sa *corev1.ServiceAccount) (*corev1.Secret, error) {
 	if sa == nil {
 		return nil, fmt.Errorf("could not ensure secret for invalid service account")
 	}
-	logrus.Tracef("EnsureSecretForServiceAccount for %s:%s", sa.Namespace, sa.Name)
+	logrus.Tracef("EnsureSecretForServiceAccount for %s", logKeyFromObject(sa))
 
-	lockKey := fmt.Sprintf("%v%v-%v", lockPrefix, sa.Namespace, sa.Name)
 	secretClient := clientSet.CoreV1().Secrets(sa.Namespace)
 	var secretLister secretLister
 	if secretsCache != nil {
@@ -79,13 +63,30 @@ func EnsureSecretForServiceAccount(ctx context.Context, secretsCache corecontrol
 
 	secret, err := ServiceAccountSecret(ctx, sa, secretLister, secretClient)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
+		return nil, fmt.Errorf("error looking up secret for service account %s: %w", logKeyFromObject(sa), err)
 	}
 
 	if secret == nil {
-		secret, err = createServiceAccountSecret(ctx, sa, secretLister, secretClient, lockKey)
+		secret, err = createServiceAccountSecret(ctx, sa, secretLister, secretClient)
 		if err != nil {
 			return nil, err
+		}
+
+		sa, updated, err := annotateSAWithSecret(ctx, sa, secret, clientSet.CoreV1().ServiceAccounts(sa.Namespace), secretClient)
+		if err != nil {
+			return nil, err
+		}
+
+		if updated {
+			secretRef, err := secretRefFromSA(sa)
+			if err != nil {
+				return nil, err
+			}
+
+			secret, err = clientSet.CoreV1().Secrets(secretRef.Namespace).Get(ctx, secretRef.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("reloading referenced secret for SA %s: %w", logKeyFromObject(sa), err)
+			}
 		}
 	}
 
@@ -93,7 +94,7 @@ func EnsureSecretForServiceAccount(ctx context.Context, secretsCache corecontrol
 		return secret, nil
 	}
 
-	logrus.Infof("EnsureSecretForServiceAccount: waiting for secret [%s:%s] for service account [%s:%s] to be populated with token", secret.Namespace, secret.Name, sa.Namespace, sa.Name)
+	logrus.Infof("EnsureSecretForServiceAccount: waiting for secret %s for service account %s to be populated with token", logKeyFromObject(secret), logKeyFromObject(sa))
 	backoff := wait.Backoff{
 		Duration: 2 * time.Millisecond,
 		Cap:      100 * time.Millisecond,
@@ -106,10 +107,10 @@ func EnsureSecretForServiceAccount(ctx context.Context, secretsCache corecontrol
 		// use the secret client, rather than the secret getter, to circumvent the cache
 		secret, err = secretClient.Get(ctx, secret.Name, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
+			return false, fmt.Errorf("error ensuring secret for service account %s: %w", logKeyFromObject(sa), err)
 		}
 		if len(secret.Data[corev1.ServiceAccountTokenKey]) > 0 {
-			logrus.Infof("EnsureSecretForServiceAccount: got the service account token for service account [%s:%s] in %s %s ", sa.GetNamespace(), sa.GetName(), time.Now().Sub(start), lockPrefix)
+			logrus.Infof("EnsureSecretForServiceAccount: got the service account token for service account %s in %s", logKeyFromObject(sa), time.Now().Sub(start))
 			return true, nil
 		}
 		return false, nil
@@ -153,18 +154,39 @@ func serviceAccountSecretPrefix(sa *corev1.ServiceAccount) string {
 }
 
 // ServiceAccountSecret returns the secret for the given Service Account.
-// If there are more than one, it returns the first. Can return a nil secret
-// and a nil error if no secret is found
+// Can return a nil secret and a nil error if no secret is found
 func ServiceAccountSecret(ctx context.Context, sa *corev1.ServiceAccount, secretLister secretLister, secretClient clientv1.SecretInterface) (*corev1.Secret, error) {
 	if sa == nil {
 		return nil, fmt.Errorf("cannot get secret for nil service account")
 	}
 
+	annotations := sa.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	secretAnn := annotations[ServiceAccountSecretRefAnnotation]
+	if secretAnn != "" {
+		secret, err := secretFromSA(ctx, sa, secretClient)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		// If secret is nil drops down to find by listing secrets.
+		if secret != nil {
+			return secret, nil
+		}
+		logrus.Infof("ServiceAccount secret did not exist for ServiceACcount %s falling back to listing mechanism", sa.Name)
+	}
+
+	return findSecretForSA(ctx, sa, secretLister, secretClient)
+}
+
+func findSecretForSA(ctx context.Context, sa *corev1.ServiceAccount, secretLister secretLister, secretClient clientv1.SecretInterface) (*corev1.Secret, error) {
 	secrets, err := secretLister(sa.Namespace, labels.SelectorFromSet(map[string]string{
 		ServiceAccountSecretLabel: sa.Name,
 	}))
 	if err != nil {
-		return nil, fmt.Errorf("could not get secrets for service account: %w", err)
+		return nil, fmt.Errorf("could not get secrets for service account %s: %w", sa.Name, err)
 	}
 
 	if len(secrets) < 1 {
@@ -182,16 +204,37 @@ func ServiceAccountSecret(ctx context.Context, sa *corev1.ServiceAccount, secret
 			continue
 		}
 
-		logrus.Warnf("EnsureSecretForServiceAccount: secret [%s:%s] is invalid for service account [%s], deleting", s.Namespace, s.Name, sa.Name)
+		logrus.Warnf("EnsureSecretForServiceAccount: secret %s is invalid for service account [%s], deleting", logKeyFromObject(s), sa.Name)
 		err = secretClient.Delete(ctx, s.Name, metav1.DeleteOptions{})
 		if err != nil {
 			// we don't want to return the delete failure since the success/failure of the cleanup shouldn't affect
 			// the ability of the caller to use any identified, valid secret
-			logrus.Errorf("unable to delete secret [%s:%s]: %v", s.Namespace, s.Name, err)
+			logrus.Errorf("unable to delete secret %s: %v", logKeyFromObject(s), err)
 		}
 	}
 
 	return result, nil
+}
+
+func secretFromSA(ctx context.Context, sa *corev1.ServiceAccount, secretClient clientv1.SecretInterface) (*corev1.Secret, error) {
+	secretRef, err := secretRefFromSA(sa)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := secretClient.Get(ctx, secretRef.Name, metav1.GetOptions{})
+	if err != nil {
+		// During the encryption key update this can fail for deleted secrets.
+		// This manifests as an Internal Error from K8s.
+		// In this case, we can ignore it and let a secret be created.
+		if !apierrors.IsInternalError(err) {
+			return nil, fmt.Errorf("could not get secret for service account: %w", err)
+		}
+		logrus.Infof("internal error when getting a secret %s - not using the secret", secret.Name)
+		return nil, nil
+	}
+
+	return secret, nil
 }
 
 func isSecretForServiceAccount(secret *corev1.Secret, sa *corev1.ServiceAccount) bool {
@@ -204,29 +247,70 @@ func isSecretForServiceAccount(secret *corev1.Secret, sa *corev1.ServiceAccount)
 	return sa.Name == annotation
 }
 
-func createServiceAccountSecret(ctx context.Context, sa *corev1.ServiceAccount, secretLister secretLister, secretClient clientv1.SecretInterface, lockKey string) (*corev1.Secret, error) {
-	mutex := getLock(lockKey)
-	mutex.Lock()
-	defer func(key string) {
-		mutex.Unlock()
-		lockMap.Delete(lockKey)
-	}(lockKey)
-
-	// We could have been waiting for the Mutex to unlock in a parallel run of
-	// createServiceAccountSecret - check again for the secret existing.
-	secret, err := ServiceAccountSecret(ctx, sa, secretLister, secretClient)
-	if err != nil {
-		return nil, err
-	}
-	if secret != nil {
-		return secret, nil
-	}
-
+func createServiceAccountSecret(ctx context.Context, sa *corev1.ServiceAccount, secretLister secretLister, secretClient clientv1.SecretInterface) (*corev1.Secret, error) {
 	sc := SecretTemplate(sa)
-	secret, err = secretClient.Create(ctx, sc, metav1.CreateOptions{})
+	secret, err := secretClient.Create(ctx, sc, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
+		return nil, fmt.Errorf("error ensuring secret for service account %s: %w", logKeyFromObject(sa), err)
 	}
 
 	return secret, nil
+}
+
+// returns true if the secret has changed.
+func annotateSAWithSecret(ctx context.Context, sa *corev1.ServiceAccount, secret *corev1.Secret, saClient clientv1.ServiceAccountInterface, secretClient clientv1.SecretInterface) (*corev1.ServiceAccount, bool, error) {
+	if sa.Annotations == nil {
+		sa.Annotations = map[string]string{}
+	}
+	secretAnnotation := secret.Namespace + "/" + secret.Name
+
+	// If the SA is already annotated with the secret already
+	if ann := sa.Annotations[ServiceAccountSecretRefAnnotation]; ann == secretAnnotation {
+		return sa, false, nil
+	}
+
+	sa.Annotations[ServiceAccountSecretRefAnnotation] = secretAnnotation
+
+	updated, err := saClient.Update(ctx, sa, metav1.UpdateOptions{})
+	if err == nil {
+		return updated, false, nil
+	}
+	if !apierrors.IsConflict(err) {
+		logrus.Debugf("Failed to update ServiceAccount for %s: %s", logKeyFromObject(sa), err)
+		return nil, false, err
+	}
+
+	// Rollback the optimistically created secret
+	logrus.Infof("Rolling back ServiceAccount secret for %s", logKeyFromObject(secret))
+	if err := secretClient.Delete(ctx, secret.Name, metav1.DeleteOptions{}); err != nil {
+		return nil, false, fmt.Errorf("deleting optimistically locked secret for %s - %s: %w", logKeyFromObject(secret), logKeyFromObject(sa), err)
+	}
+	// Load the version that triggered the issue
+	logrus.Debugf("Reloading ServiceAccount %s", logKeyFromObject(sa))
+	updated, err = saClient.Get(ctx, sa.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, false, fmt.Errorf("getting updated service account %s: %w", logKeyFromObject(sa), err)
+	}
+
+	return updated, true, nil
+
+}
+
+func logKeyFromObject(obj metav1.Object) string {
+	return fmt.Sprintf("[%s:%s]", obj.GetNamespace(), obj.GetName())
+}
+
+func secretRefFromSA(sa *corev1.ServiceAccount) (*types.NamespacedName, error) {
+	if sa.Annotations == nil {
+		return nil, nil
+	}
+	if ann := sa.Annotations[ServiceAccountSecretRefAnnotation]; ann != "" {
+		elements := strings.Split(ann, "/")
+		if len(elements) != 2 {
+			return nil, fmt.Errorf("too many elements parsing ServiceAccount secret reference: %s", ann)
+		}
+		return &types.NamespacedName{Namespace: elements[0], Name: elements[1]}, nil
+	}
+
+	return nil, nil
 }

--- a/pkg/tunnelserver/peermanager.go
+++ b/pkg/tunnelserver/peermanager.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rancher/rancher/pkg/peermanager"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/rancher/pkg/settings"
-	"github.com/rancher/rancher/pkg/utils"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -78,7 +77,7 @@ func getTokenFromToken(ctx context.Context, tokenBytes []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(ctx, nil, client, sa, utils.FormatPrefix("local"))
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(ctx, nil, client, sa)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,23 +19,6 @@ func FormatResourceList(resources v1.ResourceList) string {
 	return strings.Join(resourceStrings, ",")
 }
 
-// FormatPrefix converts the provided string into a form suitable for use as a
-// generateName prefix.
-//
-// It does this by converting to lower-case and appending a "-" character.
-func FormatPrefix(s string) string {
-	if s == "" {
-		return s
-	}
-
-	s = strings.ToLower(s)
-	if !strings.HasSuffix(s, "-") {
-		s = s + "-"
-	}
-
-	return s
-}
-
 // IsPlainIPV6 will return true if the given address is a plain IPV6 address and not encapsulated or similar.
 func IsPlainIPV6(address string) bool {
 	if net.ParseIP(address) != nil && strings.Count(address, ":") >= 2 {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,34 +2,6 @@ package utils
 
 import "testing"
 
-func TestFormatPrefix(t *testing.T) {
-	testStrings := []struct {
-		s    string
-		want string
-	}{
-		{
-			"example", "example-",
-		},
-		{
-			"Test", "test-",
-		},
-		{
-			"another-", "another-",
-		},
-		{
-			"", "",
-		},
-	}
-
-	for _, tt := range testStrings {
-		t.Run(tt.s, func(t *testing.T) {
-			if v := FormatPrefix(tt.s); v != tt.want {
-				t.Errorf("FormatPrefix() got %v, want %v", v, tt.want)
-			}
-		})
-	}
-}
-
 func TestIsPlainIPV6(t *testing.T) {
 	testCases := []struct {
 		ip       string

--- a/tests/pkg/serviceaccounttoken/mitigation_test.go
+++ b/tests/pkg/serviceaccounttoken/mitigation_test.go
@@ -1,0 +1,158 @@
+package serviceaccounttoken
+
+import (
+	"context"
+	"slices"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/serviceaccounttoken"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// This tests that creation of secrets for SAs doesn't result in lots of secrets
+// being created.
+//
+// This uses envtest (which uses the kube-apiserver and etcd) to test the
+// functionality.
+//
+// Additional tests should be run within the envtest context. You need to be
+// careful around removing resources.
+//
+// This spawns a goroutine that fakes the Kubernetes controller that updates
+// Service Account secrets with a fake token.
+func TestOptimisticLocking(t *testing.T) {
+	testEnv := &envtest.Environment{}
+	restCfg, err := testEnv.Start()
+	assert.NoError(t, err)
+	defer testEnv.Stop()
+
+	clientSet, err := kubernetes.NewForConfig(restCfg)
+	assert.NoError(t, err)
+	k8sClient := clientSet.CoreV1()
+
+	t.Run("creating a secret", func(t *testing.T) {
+		sa, err := k8sClient.ServiceAccounts("default").Create(context.TODO(),
+			&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sa",
+					Namespace: "default",
+				},
+			}, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		defer func() {
+			err = k8sClient.ServiceAccounts("default").Delete(context.TODO(), sa.GetName(), metav1.DeleteOptions{})
+			assert.NoError(t, err)
+		}()
+
+		ctx := context.Background()
+
+		cancelCtx, cancel := context.WithCancel(ctx) // used to shutdown the goroutine
+		go fakePopulateSecret(cancelCtx, t, k8sClient, sa)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		createdSecrets := make(chan corev1.Secret, 10)
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// Sends a DeepCopy because this is theoretically being updated
+				// in different processes.
+				secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.TODO(), nil, clientSet, sa.DeepCopy())
+				assert.NoError(t, err)
+				assert.NotNil(t, secret)
+				createdSecrets <- *secret
+			}()
+		}
+		wg.Wait()
+
+		secrets, err := k8sClient.Secrets("default").List(context.TODO(), metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Len(t, secrets.Items, 1)
+		createdSecret := &secrets.Items[0]
+
+		sa, err = k8sClient.ServiceAccounts("default").Get(context.TODO(), sa.GetName(), metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		assert.Equal(t, sa.Annotations[serviceaccounttoken.ServiceAccountSecretRefAnnotation], keyFromObject(createdSecret).String())
+		assert.Equal(t, string(createdSecret.Data["token"]), "this-is-not-a-real-key")
+
+		var createdUIDs []string
+		for i := 0; i < 10; i++ {
+			c := <-createdSecrets
+			if c.ObjectMeta.UID != "" {
+				createdUIDs = append(createdUIDs, string(c.ObjectMeta.UID))
+			}
+		}
+		sort.Strings(createdUIDs)
+		uniqueUIDs := slices.Compact(createdUIDs)
+		assert.Equal(t, 1, len(uniqueUIDs))
+	})
+}
+
+// this is a fake reconciler for ServiceAccount secrets.
+func fakePopulateSecret(ctx context.Context, t *testing.T, k8sClient typedcorev1.CoreV1Interface, sa *corev1.ServiceAccount) {
+	t.Helper()
+	watcher, err := k8sClient.Secrets("default").Watch(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set(map[string]string{serviceaccounttoken.ServiceAccountSecretLabel: sa.GetName()}).String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Stop()
+
+	for {
+		select {
+		case e, ok := <-watcher.ResultChan():
+			if !ok {
+				return
+			}
+
+			switch e.Type {
+			case watch.Added:
+				secret := e.Object.(*corev1.Secret).DeepCopy()
+				if secret.ObjectMeta.UID == "" {
+					continue
+				}
+				secret.Data = map[string][]byte{
+					corev1.ServiceAccountTokenKey: []byte("this-is-not-a-real-key"),
+				}
+				_, err = k8sClient.Secrets("default").Update(context.TODO(), secret, metav1.UpdateOptions{})
+				if err != nil {
+					if !apierrors.IsGone(err) {
+						t.Logf("error updating Secret %s: %s", keyFromObject(secret), err)
+					}
+				}
+			case watch.Error:
+				t.Logf("got an error in the secret populator: %s", err)
+				return
+			}
+		case <-ctx.Done():
+			t.Log("shutting down fake secret populator")
+			return
+		}
+
+	}
+}
+
+func keyFromObject(obj interface {
+	GetNamespace() string
+	GetName() string
+}) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}

--- a/tests/v2/integration/serviceaccount/serviceaccounttoken_test.go
+++ b/tests/v2/integration/serviceaccount/serviceaccounttoken_test.go
@@ -72,10 +72,11 @@ func (s *ServiceAccountSuite) TestSingleSecretForServiceAccount() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, clientset, serviceAccount, "cluster-")
+			_, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), nil, clientset, serviceAccount.DeepCopy())
 			s.Require().NoError(err)
 		}()
 	}
+	wg.Wait()
 
 	pollInterval := 500 * time.Millisecond
 	err = wait.Poll(pollInterval, 5*time.Second, func() (done bool, err error) {


### PR DESCRIPTION

## Issue: https://github.com/rancher/rancher/issues/48157 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Backport of https://github.com/rancher/rancher/pull/47273

Mitigate the impact of the client cache on detecting secrets.

When we can't find a secret in EnsureSecretForServiceAccount, create a secret and annotate the ServiceAccount that it's for with the secret reference.

If we get a conflict error doing this, then rollback the newly created secret.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_