### PR TITLE
Remove remote dialer code from Fleet dashboard

### DIFF
--- a/pkg/data/dashboard/fleet.go
+++ b/pkg/data/dashboard/fleet.go
@@ -3,10 +3,7 @@ package dashboard
 import (
 	"reflect"
 
-	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/features"
-	fleetconst "github.com/rancher/rancher/pkg/fleet"
-	mngtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/wrangler"
 	rbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	v1 "k8s.io/api/rbac/v1"
@@ -46,44 +43,7 @@ func AddFleetRoles(wrangler *wrangler.Context) error {
 		return nil
 	}
 
-	if err := ensureWebhookAPIService(wrangler.Mgmt.APIService()); err != nil {
-		return err
-	}
-
 	return ensureFleetRoles(wrangler.RBAC)
-}
-
-func ensureWebhookAPIService(apiservices mngtv3.APIServiceClient) error {
-	apiService := &v3.APIService{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: apiServiceName,
-		},
-
-		Spec: v3.APIServiceSpec{
-			SecretName:      "stv-aggregation",
-			SecretNamespace: fleetconst.ReleaseNamespace,
-			Paths: []string{
-				"/fleet/webhook",
-			},
-		},
-	}
-
-	existing, err := apiservices.Get(apiService.Name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	} else if errors.IsNotFound(err) {
-		if _, err := apiservices.Create(apiService); err != nil {
-			return err
-		}
-	} else {
-		if !reflect.DeepEqual(existing.Spec, apiService.Spec) {
-			existing.Spec = apiService.Spec
-			if _, err := apiservices.Update(existing); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func ensureFleetRoles(rbac rbacv1.Interface) error {


### PR DESCRIPTION
That code is no longer needed.

## Issue: [fleet#2676](https://github.com/rancher/fleet/issues/2676)
 
## Problem

Context:  `Gitjob`, an old resource used by Fleet <0.10, used [steve](https://github.com/rancher/steve) code in the context of exposing git jobs via an API service object.
It is unclear whether that feature has ever worked, as there was a mismatch between secret names used ([stv-aggregation](https://github.com/rancher/rancher/commit/a94662178cd7874807a604fad5dec0f2dd8ba57c) in `rancher/rancher` vs [steve-aggregation](https://github.com/rancher/gitjob/commit/cc95fddcdd98d5f910977776f6da78c8c5c87a21#diff-df64e37f2222b761c62bd8bf32c0347aae0fe1f46ff6acf0e66c2b61bd30d761) in `rancher/gitjob`).
 
## Solution
This removes the mentioned remote dialer code.
 
## Testing
N/A (functionality did not work and was not used)
## Engineering Testing
### Manual Testing
N/A (functionality did not work and was not used)

### Automated Testing
N/A (functionality did not work and was not used)