### PR TITLE
[v2.10] Pin CAPI chart to 105.1.0+up0.6.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 105.0.0+up0.6.1
-provisioningCAPIVersion: 105.0.0+up0.4.0
+provisioningCAPIVersion: 105.1.0+up0.6.0
 cspAdapterMinVersion: 105.0.0+up5.0.1
 defaultShellVersion: rancher/shell:v0.3.0
 fleetVersion: 105.0.1+up0.11.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,6 +6,6 @@ const (
 	CspAdapterMinVersion    = "105.0.0+up5.0.1"
 	DefaultShellVersion     = "rancher/shell:v0.3.0"
 	FleetVersion            = "105.0.1+up0.11.1"
-	ProvisioningCAPIVersion = "105.0.0+up0.4.0"
+	ProvisioningCAPIVersion = "105.1.0+up0.6.0"
 	WebhookVersion          = "105.0.0+up0.6.1"
 )


### PR DESCRIPTION
Update the CAPI chart to the new version from this PR: https://github.com/rancher/charts/pull/4784

This incorporates two fixes:
- https://github.com/rancher/provisioning/pull/15
- https://github.com/rancher/provisioning/pull/16

The related issues are:
- https://github.com/rancher/rancher/issues/48005
- https://github.com/rancher/rancher/issues/48094