### PR TITLE
[v2.9] Pin CAPI chart to 104.1.0+up0.3.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 104.0.4+up0.5.4
-provisioningCAPIVersion: 104.0.0+up0.3.0
+provisioningCAPIVersion: 104.1.0+up0.3.1
 cspAdapterMinVersion: 104.0.0+up4.0.0
 defaultShellVersion: rancher/shell:v0.2.2
 fleetVersion: 104.1.2+up0.10.6

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,6 +6,6 @@ const (
 	CspAdapterMinVersion    = "104.0.0+up4.0.0"
 	DefaultShellVersion     = "rancher/shell:v0.2.2"
 	FleetVersion            = "104.1.2+up0.10.6"
-	ProvisioningCAPIVersion = "104.0.0+up0.3.0"
+	ProvisioningCAPIVersion = "104.1.0+up0.3.1"
 	WebhookVersion          = "104.0.4+up0.5.4"
 )


### PR DESCRIPTION
Update the CAPI chart to the new version from this PR: https://github.com/rancher/charts/pull/4793

This incorporates one fix:
- https://github.com/rancher/provisioning/pull/17

The related issues are:
- https://github.com/rancher/rancher/issues/48164