### PR TITLE
fix(rbac): Avoid returning an error when RoleTemplate does not exist

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -201,6 +201,13 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName, clusterContext, 0)
 	if err != nil {
 		c.s.AddCondition(localConditions, condition, failedToCheckReferencedRole, err)
+
+		var notFoundErr *roleTemplateNotFoundErr
+		if errors.As(err, &notFoundErr) {
+			logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", binding.Name, binding.RoleTemplateName)
+			return nil
+		}
+
 		return err
 	}
 	var clusterRoleName string

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
@@ -323,7 +322,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding, 
 	}
 
 	set = map[string]string{string(binding.UID): CrtbInProjectBindingOwner}
-	rbs, err := c.rbLister.List(v1.NamespaceAll, set.AsSelector().Add(requirements...))
+	rbs, err := c.rbLister.List(metav1.NamespaceAll, set.AsSelector().Add(requirements...))
 	if err != nil {
 		c.s.AddCondition(localConditions, condition, failedToListRB, err)
 		return err

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -934,10 +934,6 @@ func buildRule(resource string, verbs map[string]string) v1.PolicyRule {
 	}
 }
 
-type roleTemplateNotFoundErr struct {
-	error
-}
-
 func (m *manager) checkReferencedRoles(roleTemplateName, roleTemplateContext string, depthCounter int) (bool, error) {
 	if depthCounter == rolesCircularSoftLimit {
 		logrus.Warnf("roletemplate has caused %v recursive function calls", rolesCircularSoftLimit)
@@ -947,9 +943,6 @@ func (m *manager) checkReferencedRoles(roleTemplateName, roleTemplateContext str
 	}
 	roleTemplate, err := m.rtLister.Get("", roleTemplateName)
 	if err != nil {
-		if apierrors.IsNotFound(err) && depthCounter == 0 {
-			return false, &roleTemplateNotFoundErr{err}
-		}
 		return false, err
 	}
 

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -934,6 +934,10 @@ func buildRule(resource string, verbs map[string]string) v1.PolicyRule {
 	}
 }
 
+type roleTemplateNotFoundErr struct {
+	error
+}
+
 func (m *manager) checkReferencedRoles(roleTemplateName, roleTemplateContext string, depthCounter int) (bool, error) {
 	if depthCounter == rolesCircularSoftLimit {
 		logrus.Warnf("roletemplate has caused %v recursive function calls", rolesCircularSoftLimit)
@@ -943,6 +947,9 @@ func (m *manager) checkReferencedRoles(roleTemplateName, roleTemplateContext str
 	}
 	roleTemplate, err := m.rtLister.Get("", roleTemplateName)
 	if err != nil {
+		if apierrors.IsNotFound(err) && depthCounter == 0 {
+			return false, &roleTemplateNotFoundErr{err}
+		}
 		return false, err
 	}
 

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -174,6 +174,11 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 	// if roletemplate is not builtin, check if it's inherited/cloned
 	isOwnerRole, err := p.mgr.checkReferencedRoles(binding.RoleTemplateName, projectContext, 0)
 	if err != nil {
+		var notFoundErr *roleTemplateNotFoundErr
+		if errors.As(err, &notFoundErr) {
+			logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", binding.Name, binding.RoleTemplateName)
+			return nil
+		}
 		return err
 	}
 	var projectRoleName string

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -149,7 +150,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 
 	parts := strings.SplitN(binding.ProjectName, ":", 2)
 	if len(parts) < 2 {
-		return fmt.Errorf("cannot determine project and cluster from %v", binding.ProjectName)
+		return fmt.Errorf("cannot determine project and cluster from %s", binding.ProjectName)
 	}
 
 	clusterName := parts[0]
@@ -159,7 +160,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 		return err
 	}
 	if proj == nil {
-		return fmt.Errorf("cannot create binding because project %v was not found", projectName)
+		return fmt.Errorf("cannot create binding because project %s was not found", projectName)
 	}
 
 	cluster, err := p.clusterLister.Get("", clusterName)
@@ -167,25 +168,24 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 		return err
 	}
 	if cluster == nil {
-		return fmt.Errorf("cannot create binding because cluster %v was not found", clusterName)
+		return fmt.Errorf("cannot create binding because cluster %s was not found", clusterName)
 	}
 
-	roleName := strings.ToLower(fmt.Sprintf("%v-clustermember", clusterName))
+	roleName := strings.ToLower(fmt.Sprintf("%s-clustermember", clusterName))
 	// if roletemplate is not builtin, check if it's inherited/cloned
 	isOwnerRole, err := p.mgr.checkReferencedRoles(binding.RoleTemplateName, projectContext, 0)
 	if err != nil {
-		var notFoundErr *roleTemplateNotFoundErr
-		if errors.As(err, &notFoundErr) {
-			logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", binding.Name, binding.RoleTemplateName)
+		if apierrors.IsNotFound(err) {
+			logrus.Warnf("ProjectRoleTemplateBinding %s sets a non-existing role template %s. Skipping.", binding.Name, binding.RoleTemplateName)
 			return nil
 		}
 		return err
 	}
 	var projectRoleName string
 	if isOwnerRole {
-		projectRoleName = strings.ToLower(fmt.Sprintf("%v-projectowner", projectName))
+		projectRoleName = strings.ToLower(fmt.Sprintf("%s-projectowner", projectName))
 	} else {
-		projectRoleName = strings.ToLower(fmt.Sprintf("%v-projectmember", projectName))
+		projectRoleName = strings.ToLower(fmt.Sprintf("%s-projectmember", projectName))
 	}
 
 	subject, err := pkgrbac.BuildSubjectFromRTB(binding)

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -239,7 +239,11 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 
 		rt, err := n.m.rtLister.Get("", prtb.RoleTemplateName)
 		if err != nil {
-			return false, errors.Wrapf(err, "couldn't get role template %v", prtb.RoleTemplateName)
+			if apierrors.IsNotFound(err) {
+				logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", prtb.Name, prtb.RoleTemplateName)
+				continue
+			}
+			return false, err
 		}
 
 		roles := map[string]*v3.RoleTemplate{}

--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/namespace"
 	projectpkg "github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/settings"
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +65,7 @@ func (p *pLifecycle) Remove(project *v3.Project) (runtime.Object, error) {
 	}
 
 	projectID := project.Namespace + ":" + project.Name
-	namespaces, err := p.m.nsIndexer.ByIndex(nsByProjectIndex, projectID)
+	namespaces, err := p.m.nsIndexer.ByIndex(namespace.NsByProjectIndex, projectID)
 	if err != nil {
 		return project, err
 	}

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -103,7 +103,7 @@ func (p *prtbLifecycle) Remove(obj *v3.ProjectRoleTemplateBinding) (runtime.Obje
 
 func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 	if binding.RoleTemplateName == "" {
-		logrus.Warnf("ProjectRoleTemplateBinding %v has no role template set. Skipping.", binding.Name)
+		logrus.Warnf("ProjectRoleTemplateBinding %s has no role template set. Skipping.", binding.Name)
 		return nil
 	}
 	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" {
@@ -112,7 +112,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 	rt, err := p.rtLister.Get("", binding.RoleTemplateName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", binding.Name, binding.RoleTemplateName)
+			logrus.Warnf("ProjectRoleTemplateBinding %s sets a non-existing role template %s. Skipping.", binding.Name, binding.RoleTemplateName)
 			return nil
 		}
 		return err

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -109,10 +109,13 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" {
 		return nil
 	}
-
 	rt, err := p.rtLister.Get("", binding.RoleTemplateName)
 	if err != nil {
-		return fmt.Errorf("couldn't get role template %v: %w", binding.RoleTemplateName, err)
+		if apierrors.IsNotFound(err) {
+			logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", binding.Name, binding.RoleTemplateName)
+			return nil
+		}
+		return err
 	}
 
 	// Get namespaces belonging to project

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/norman/types/slice"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
+	"github.com/rancher/rancher/pkg/namespace"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
@@ -119,7 +120,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 	}
 
 	// Get namespaces belonging to project
-	namespaces, err := p.nsIndexer.ByIndex(nsByProjectIndex, binding.ProjectName)
+	namespaces, err := p.nsIndexer.ByIndex(namespace.NsByProjectIndex, binding.ProjectName)
 	if err != nil {
 		return fmt.Errorf("couldn't list namespaces with project ID %v: %w", binding.ProjectName, err)
 	}
@@ -153,7 +154,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 
 func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding) error {
 	// Get namespaces belonging to project
-	namespaces, err := p.nsIndexer.ByIndex(nsByProjectIndex, binding.ProjectName)
+	namespaces, err := p.nsIndexer.ByIndex(namespace.NsByProjectIndex, binding.ProjectName)
 	if err != nil {
 		return fmt.Errorf("couldn't list namespaces with project ID %v: %w", binding.ProjectName, err)
 	}

--- a/pkg/controllers/managementuser/rbac/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplate_handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	wranglerv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	v1 "k8s.io/api/core/v1"
@@ -122,7 +123,7 @@ func (c *rtSync) syncRT(template *v3.RoleTemplate, usedInProjects bool, prtbs []
 		}
 
 		// Get namespaces belonging to project to update the rolebinding in the namespaces of this project for the user
-		namespaces, err := c.m.nsIndexer.ByIndex(nsByProjectIndex, prtb.ProjectName)
+		namespaces, err := c.m.nsIndexer.ByIndex(namespace.NsByProjectIndex, prtb.ProjectName)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't list namespaces with project ID %v", prtb.ProjectName)
 		}

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -1,9 +1,24 @@
 package namespace
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"fmt"
 
-var projectIDAnnotation = "field.cattle.io/projectId"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/relatedresource"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
 
+const (
+	NsByProjectIndex        = "authz.cluster.cattle.io/ns-by-project"
+	PrtbByRoleTemplateIndex = "prtb-rt-index"
+	projectIDAnnotation     = "field.cattle.io/projectId"
+)
+
+// NsByProjectID is an index that selects namespaces based on the projectIDAnnotation
 func NsByProjectID(obj interface{}) ([]string, error) {
 	ns, ok := obj.(*v1.Namespace)
 	if !ok {
@@ -15,4 +30,56 @@ func NsByProjectID(obj interface{}) ([]string, error) {
 	}
 
 	return []string{}, nil
+}
+
+// PrtbByRoleTemplateName is an index that selects PRTBs by the Role Template name
+func PrtbByRoleTemplateName(prtb *v3.ProjectRoleTemplateBinding) ([]string, error) {
+	if prtb == nil {
+		return []string{}, nil
+	}
+	return []string{prtb.RoleTemplateName}, nil
+}
+
+// NsEnqueuer is a helper struct for enqueuing Namespaces
+type NsEnqueuer struct {
+	PrtbCache mgmtv3.ProjectRoleTemplateBindingCache
+	NsIndexer cache.Indexer
+}
+
+// RoleTemplateEnqueueNamespace enqueues namespaces when a Role Template with PRTBs in that namespace is updated
+func (n *NsEnqueuer) RoleTemplateEnqueueNamespace(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	rt, ok := obj.(*v3.RoleTemplate)
+	if !ok {
+		logrus.Errorf("unable to convert object: %[1]v, type %[1]T to a cluster", obj)
+		return nil, nil
+	}
+
+	// Get PRTBs by field RoleTemplateName
+	prtbs, err := n.PrtbCache.GetByIndex(PrtbByRoleTemplateIndex, rt.Name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get prtbs for rt %s from indexer: %w", rt.Name, err)
+	}
+
+	// Get Namespaces of PRTBs
+	namespaceNames := []string{}
+	for _, prtb := range prtbs {
+		namespaces, err := n.NsIndexer.ByIndex(NsByProjectIndex, prtb.ProjectName)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get namespaces for prtb %s from indexer: %w", prtb.Name, err)
+		}
+		for _, ns := range namespaces {
+			namespace, _ := ns.(*v1.Namespace)
+			namespaceNames = append(namespaceNames, namespace.Name)
+		}
+	}
+
+	namespaceKeys := make([]relatedresource.Key, 0, len(namespaceNames))
+	for _, ns := range namespaceNames {
+		namespaceKeys = append(namespaceKeys, relatedresource.Key{Name: ns})
+	}
+
+	return namespaceKeys, nil
 }

--- a/pkg/namespace/namespace_test.go
+++ b/pkg/namespace/namespace_test.go
@@ -1,0 +1,281 @@
+package namespace
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/rancher/wrangler/v3/pkg/relatedresource"
+	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+var defaultErr = fmt.Errorf("error")
+
+type DummyIndexer struct {
+	cache.Store
+	namespaces map[string][]*v1.Namespace
+	err        error
+}
+
+func (d *DummyIndexer) Index(indexName string, obj interface{}) ([]interface{}, error) {
+	return nil, nil
+}
+
+func (d *DummyIndexer) IndexKeys(indexName, indexKey string) ([]string, error) {
+	return []string{}, nil
+}
+
+func (d *DummyIndexer) ListIndexFuncValues(indexName string) []string {
+	return []string{}
+}
+func (d *DummyIndexer) ByIndex(indexName, indexKey string) ([]interface{}, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	namespaces := d.namespaces[indexKey]
+	var interfaces []interface{}
+	for _, ns := range namespaces {
+		interfaces = append(interfaces, ns)
+	}
+	return interfaces, nil
+}
+
+func (d *DummyIndexer) GetIndexers() cache.Indexers {
+	return nil
+}
+
+func (d *DummyIndexer) AddIndexers(newIndexers cache.Indexers) error {
+	return nil
+}
+
+func TestNsByProjectID(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  interface{}
+		want []string
+	}{
+		{
+			name: "Wrong type",
+			obj:  &v1.Pod{},
+			want: []string{},
+		},
+		{
+			name: "Matching annotation",
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						projectIDAnnotation: "test-namespace",
+					},
+				},
+			},
+			want: []string{"test-namespace"},
+		},
+		{
+			name: "No annotation",
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"bad-annotation": "test-namespace",
+					},
+				},
+			},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// NsByProjectID can't return an error, no need to check
+			got, _ := NsByProjectID(tt.obj)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NsByProjectID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrtbByRoleTemplateName(t *testing.T) {
+	tests := []struct {
+		name string
+		prtb *v3.ProjectRoleTemplateBinding
+		want []string
+	}{
+		{
+			name: "nil prtb",
+			prtb: nil,
+			want: []string{},
+		},
+		{
+			name: "return prtb roletemplate name",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				RoleTemplateName: "test-roletemplate",
+			},
+			want: []string{"test-roletemplate"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := PrtbByRoleTemplateName(tt.prtb)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PrtbByRoleTemplateName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNsEnqueuer_RoleTemplateEnqueueNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		obj       runtime.Object
+		nsIndexer cache.Indexer
+		prtbCache func() ([]*v3.ProjectRoleTemplateBinding, error)
+		want      []relatedresource.Key
+		wantErr   bool
+	}{
+		{
+			name: "nil object returns nil",
+			obj:  nil,
+			want: nil,
+		},
+		{
+			name: "object is not a RoleTemplate",
+			obj:  &v3.ProjectRoleTemplateBinding{},
+			want: nil,
+		},
+		{
+			name: "error getting PRTBs",
+			obj: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+				},
+			},
+			prtbCache: func() ([]*v3.ProjectRoleTemplateBinding, error) { return nil, defaultErr },
+			want:      nil,
+			wantErr:   true,
+		},
+		{
+			name: "no PRTBs",
+			obj: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+				},
+			},
+			prtbCache: func() ([]*v3.ProjectRoleTemplateBinding, error) {
+				return []*v3.ProjectRoleTemplateBinding{}, nil
+			},
+			want: []relatedresource.Key{},
+		},
+		{
+			name: "error getting namespaces",
+			obj: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+				},
+			},
+			prtbCache: func() ([]*v3.ProjectRoleTemplateBinding, error) {
+				return []*v3.ProjectRoleTemplateBinding{
+					{
+						ProjectName: "test-project",
+					},
+				}, nil
+			},
+			nsIndexer: &DummyIndexer{
+				err: defaultErr,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "multiple namespaces match",
+			obj: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+				},
+			},
+			nsIndexer: &DummyIndexer{
+				namespaces: map[string][]*v1.Namespace{
+					"test-project": {
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-namespace2"},
+						},
+					},
+				},
+			},
+			prtbCache: func() ([]*v3.ProjectRoleTemplateBinding, error) {
+				return []*v3.ProjectRoleTemplateBinding{
+					{
+						ProjectName: "test-project",
+					},
+				}, nil
+			},
+			want: []relatedresource.Key{
+				{Name: "test-namespace"},
+				{Name: "test-namespace2"},
+			},
+		},
+		{
+			name: "multiple prtbs match",
+			obj: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+				},
+			},
+			nsIndexer: &DummyIndexer{
+				namespaces: map[string][]*v1.Namespace{
+					"test-project": {{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"},
+					}},
+					"test-project2": {{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-namespace2"},
+					}},
+				},
+			},
+			prtbCache: func() ([]*v3.ProjectRoleTemplateBinding, error) {
+				return []*v3.ProjectRoleTemplateBinding{
+					{
+						ProjectName: "test-project",
+					},
+					{
+						ProjectName: "test-project2",
+					},
+				}, nil
+			},
+			want: []relatedresource.Key{
+				{Name: "test-namespace"},
+				{Name: "test-namespace2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			prtbCache := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
+			if tt.prtbCache != nil {
+				prtbCache.EXPECT().GetByIndex(gomock.Any(), gomock.Any()).Return(tt.prtbCache())
+			}
+
+			n := &NsEnqueuer{
+				PrtbCache: prtbCache,
+				NsIndexer: tt.nsIndexer,
+			}
+
+			got, err := n.RoleTemplateEnqueueNamespace("", "", tt.obj)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NsEnqueuer.RoleTemplateEnqueueNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NsEnqueuer.RoleTemplateEnqueueNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: #48224
 
## Problem

When a RoleTemplate is removed, those projects where a member was granted that RoleTemplate will error reconciling with the following error:
```
handler namespace-auth: couldn't get role template rt-2bmwx: roletemplates.management.cattle.io "rt-2bmwx" not found, requeuing
```
It will be retried indefinitely although rate limited to a maximum of 2 minutes wait.
 
## Solution

Returning an error makes the handler(s) to be retried. Instead just log a warning message and skip that PRTB.