### PR TITLE
[v2.10] Fix local search unicode

### DIFF
--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -443,6 +443,10 @@ func indexField(field string, maxIndex int) []string {
 	var fieldIndexes []string
 	for i := 2; i <= maxIndex; i++ {
 		simplified := []rune(simplifyString(field))
+
+		// This calculates the string to be indexed after it has been
+		// simplified because it may now be shorter than it was when maxIndex
+		// was calculated for the call to indexField.
 		fi := string(simplified)[0:min(len(simplified), i)]
 
 		fieldIndexes = append(fieldIndexes, strings.ToLower(fi))

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -405,23 +405,23 @@ func userSearchIndexer(obj interface{}) ([]string, error) {
 	}
 	fieldIndexes := sets.New[string]()
 
-	fieldIndexes.Insert(indexField(user.Username, minOf(len(user.Username), searchIndexDefaultLen))...)
-	fieldIndexes.Insert(indexField(user.DisplayName, minOf(len(user.DisplayName), searchIndexDefaultLen))...)
-	fieldIndexes.Insert(indexField(user.ObjectMeta.Name, minOf(len(user.ObjectMeta.Name), searchIndexDefaultLen))...)
+	fieldIndexes.Insert(indexField(user.Username, min(len(user.Username), searchIndexDefaultLen))...)
+	fieldIndexes.Insert(indexField(user.DisplayName, min(len(user.DisplayName), searchIndexDefaultLen))...)
+	fieldIndexes.Insert(indexField(user.ObjectMeta.Name, min(len(user.ObjectMeta.Name), searchIndexDefaultLen))...)
 
 	splitToLower := func(s string, limit int) []string {
 		var lowers []string
 		for _, v := range strings.Fields(s) {
 			lv := strings.ToLower(v)
-			lowers = append(lowers, lv[:minOf(limit, len(lv))])
+			lowers = append(lowers, lv[:min(limit, len(lv))])
 		}
 
 		return lowers
 	}
 
-	fieldIndexes.Insert(splitToLower(user.Username, minOf(len(user.Username), searchIndexDefaultLen))...)
-	fieldIndexes.Insert(splitToLower(user.DisplayName, minOf(len(user.DisplayName), searchIndexDefaultLen))...)
-	fieldIndexes.Insert(splitToLower(user.ObjectMeta.Name, minOf(len(user.ObjectMeta.Name), searchIndexDefaultLen))...)
+	fieldIndexes.Insert(splitToLower(user.Username, min(len(user.Username), searchIndexDefaultLen))...)
+	fieldIndexes.Insert(splitToLower(user.DisplayName, min(len(user.DisplayName), searchIndexDefaultLen))...)
+	fieldIndexes.Insert(splitToLower(user.ObjectMeta.Name, min(len(user.ObjectMeta.Name), searchIndexDefaultLen))...)
 
 	return fieldIndexes.UnsortedList(), nil
 }
@@ -433,26 +433,19 @@ func groupSearchIndexer(obj interface{}) ([]string, error) {
 	}
 	var fieldIndexes []string
 
-	fieldIndexes = append(fieldIndexes, indexField(group.DisplayName, minOf(len(group.DisplayName), searchIndexDefaultLen))...)
-	fieldIndexes = append(fieldIndexes, indexField(group.ObjectMeta.Name, minOf(len(group.ObjectMeta.Name), searchIndexDefaultLen))...)
+	fieldIndexes = append(fieldIndexes, indexField(group.DisplayName, min(len(group.DisplayName), searchIndexDefaultLen))...)
+	fieldIndexes = append(fieldIndexes, indexField(group.ObjectMeta.Name, min(len(group.ObjectMeta.Name), searchIndexDefaultLen))...)
 
 	return fieldIndexes, nil
-}
-
-func minOf(length int, defaultLen int) int {
-	if length < defaultLen {
-		return length
-	}
-	return defaultLen
 }
 
 func indexField(field string, maxIndex int) []string {
 	var fieldIndexes []string
 	for i := 2; i <= maxIndex; i++ {
-		fi := string([]rune(simplifyString(field))[0:i])
-		fieldIndexes = append(fieldIndexes, strings.TrimFunc(strings.ToLower(fi), func(r rune) bool {
-			return r == 0
-		}))
+		simplified := []rune(simplifyString(field))
+		fi := string(simplified)[0:min(len(simplified), i)]
+
+		fieldIndexes = append(fieldIndexes, strings.ToLower(fi))
 	}
 
 	return fieldIndexes

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -412,7 +412,8 @@ func userSearchIndexer(obj interface{}) ([]string, error) {
 	splitToLower := func(s string, limit int) []string {
 		var lowers []string
 		for _, v := range strings.Fields(s) {
-			lowers = append(lowers, strings.ToLower(v)[:minOf(limit, len(v))])
+			lv := strings.ToLower(v)
+			lowers = append(lowers, lv[:minOf(limit, len(lv))])
 		}
 
 		return lowers
@@ -448,8 +449,10 @@ func minOf(length int, defaultLen int) int {
 func indexField(field string, maxIndex int) []string {
 	var fieldIndexes []string
 	for i := 2; i <= maxIndex; i++ {
-		fieldIndexes = append(fieldIndexes, strings.ToLower(
-			string([]rune(simplifyString(field))[0:i])))
+		fi := string([]rune(simplifyString(field))[0:i])
+		fieldIndexes = append(fieldIndexes, strings.TrimFunc(strings.ToLower(fi), func(r rune) bool {
+			return r == 0
+		}))
 	}
 
 	return fieldIndexes

--- a/pkg/auth/providers/local/local_auth_provider_test.go
+++ b/pkg/auth/providers/local/local_auth_provider_test.go
@@ -218,6 +218,17 @@ func TestUserSearchIndexer(t *testing.T) {
 				"u-6", "u-67", "u-678", "u-6789",
 			},
 		},
+		{
+			// Non-Unicode string lower-cased to ASCII.
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "u-99900",
+				},
+				Username:    "\u212ael",
+				DisplayName: "\u212aelvin Smith",
+			},
+			wantIndexed: []string{"ke", "kel", "kelv", "kelvi", "kelvin", "smith", "u-", "u-9", "u-99", "u-999", "u-9990"},
+		},
 	}
 
 	for _, tt := range indexerTests {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48180
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When the string is lower-cased to a shorter-string because it becomes an ASCII character when lower-cased, this was causing an issue when slicing the string for indexing because the slice length was too long.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This necessitates two small changes, one to recalculate the length for the sub-slice _after_ lower-casing the string, and the other is to trim \x00 characters because the length is predetermined in `indexField`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Create a user with a character that is lower-cased to an ASCII character e.g. https://www.compart.com/en/unicode/U+212A and it will crash-loop on startup during the indexing.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_