### PR TITLE
updating fleet provisioning to be hardened by default

### DIFF
--- a/tests/v2/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
+++ b/tests/v2/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
@@ -60,7 +60,7 @@ func (f *FleetWithProvisioningTestSuite) SetupSuite() {
 		Spec: v1alpha1.GitRepoSpec{
 			Repo:            fleet.ExampleRepo,
 			Branch:          fleet.BranchName,
-			Paths:           []string{fleet.GitRepoPathLinux},
+			Paths:           []string{"hardened"},
 			CorrectDrift:    &v1alpha1.CorrectDrift{},
 			ImageScanCommit: v1alpha1.CommitSpec{AuthorName: "", AuthorEmail: ""},
 			Targets: []v1alpha1.GitTarget{
@@ -156,6 +156,7 @@ func (f *FleetWithProvisioningTestSuite) TestHardenedAfterAddedGitRepo() {
 
 		provisioningConfig.Hardened = true
 		provisioningConfig.MachinePools = tt.machinePools
+		provisioningConfig.PSACT = string(provisioninginput.RancherRestricted)
 
 		f.Run(tt.name, func() {
 			logrus.Info("Deploying public fleet gitRepo")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 supports https://github.com/rancher/qa-tasks/issues/1619

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
fleet wasn't deploying on hardened clusters
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
created new fleet in the example repo, this PR points the hardened provisioning + fleet case to the new hardened example. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
via jenkins