### PR TITLE
Fixes the local upgrade failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+	github.com/rancher/shepherd => github.com/anupama2501/shepherd v0.0.0-20241206235426-3c659cb841a5
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
-	github.com/rancher/shepherd => github.com/anupama2501/shepherd v0.0.0-20241206235426-3c659cb841a5
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
@@ -138,7 +137,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.4.0
 	github.com/rancher/rke v1.7.0-rc.5
-	github.com/rancher/shepherd v0.0.0-20241202220953-1fc27fcb8086
+	github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b
 	github.com/rancher/steve v0.0.0-20241206235902-65129458a74a
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde
 	github.com/rancher/wrangler v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwc
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/anupama2501/shepherd v0.0.0-20241206235426-3c659cb841a5 h1:VG2uaZSO+2lsivoWtN6S57NjxFuY4AhKzMa4uqIXjRk=
+github.com/anupama2501/shepherd v0.0.0-20241206235426-3c659cb841a5/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,6 @@ github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwc
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/anupama2501/shepherd v0.0.0-20241206235426-3c659cb841a5 h1:VG2uaZSO+2lsivoWtN6S57NjxFuY4AhKzMa4uqIXjRk=
-github.com/anupama2501/shepherd v0.0.0-20241206235426-3c659cb841a5/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -840,8 +838,8 @@ github.com/rancher/rke v1.7.0-rc.5 h1:kBRwXTW8CYPXvCcPLISiwGTCvJ8K/+b35D5ES0Icdu
 github.com/rancher/rke v1.7.0-rc.5/go.mod h1:+x++Mvl0A3jIzNLiu8nkraqZXiHg6VPWv0Xl4iQCg+A=
 github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHRkGaJ5v0=
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
-github.com/rancher/shepherd v0.0.0-20241202220953-1fc27fcb8086 h1:+6gSG4oxQHRHrXx3g+j2DSO/o/nuqSHO+cXurS9D+k8=
-github.com/rancher/shepherd v0.0.0-20241202220953-1fc27fcb8086/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
+github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b h1:uX+XbQgpqpfxfvDI+6uPb1DeeDqEwa7lE+QtYuPCqzU=
+github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
 github.com/rancher/steve v0.0.0-20241206235902-65129458a74a h1:1pV2R7q0GD1ST1D+Y76bgccvIL7QagvcLng6CTYm4g8=
 github.com/rancher/steve v0.0.0-20241206235902-65129458a74a/go.mod h1:BuNXoRaqXRbzTm+fXBVkL5WVKL3okX0qBsoFK4Dfluo=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=

--- a/tests/v2/actions/upgradeinput/load.go
+++ b/tests/v2/actions/upgradeinput/load.go
@@ -54,6 +54,7 @@ func LoadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Cluster, er
 			cluster.Name = c.Name
 			cluster.ProvisioningInput = c.ProvisioningInput
 			cluster.FeaturesToTest = c.FeaturesToTest
+			cluster.VersionToUpgrade = c.VersionToUpgrade
 
 			clusters = append(clusters, *cluster)
 		}

--- a/tests/v2/validation/upgrade/kubernetes.go
+++ b/tests/v2/validation/upgrade/kubernetes.go
@@ -46,16 +46,8 @@ func upgradeLocalCluster(u *suite.Suite, testName string, client *rancher.Client
 		u.T().Skip(u.T(), cluster.VersionToUpgrade, "Kubernetes version to upgrade is not provided, skipping the test")
 	}
 
-	if clusterResp.Labels[provider] == rke {
-		testConfig.KubernetesVersion = cluster.VersionToUpgrade
-		testName += "Local cluster from " + clusterResp.Version.GitVersion + " to " + testConfig.KubernetesVersion
-	} else if clusterResp.Labels[provider] == rke2 {
-		testConfig.KubernetesVersion = cluster.VersionToUpgrade
-		testName += "Local cluster from " + clusterResp.Version.GitVersion + " to " + testConfig.KubernetesVersion
-	} else {
-		testConfig.KubernetesVersion = cluster.VersionToUpgrade
-		testName += "Local cluster from " + clusterResp.Version.GitVersion + " to " + testConfig.KubernetesVersion
-	}
+	testConfig.KubernetesVersion = cluster.VersionToUpgrade
+	testName += "Local cluster from " + clusterResp.Version.GitVersion + " to " + testConfig.KubernetesVersion
 
 	u.Run(testName, func() {
 		clusterMeta, err := extensionscluster.NewClusterMeta(client, cluster.Name)
@@ -207,7 +199,7 @@ func waitForLocalClusterUpgrade(client *rancher.Client, clusterName string) erro
 		return err
 	}
 
-	err = kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, defaults.FiveSecondTimeout, true, func(ctx context.Context) (done bool, err error) {
+	err = kwait.PollUntilContextTimeout(context.TODO(), 2*time.Second, defaults.FiveSecondTimeout, true, func(ctx context.Context) (done bool, err error) {
 		isUpgrading, err := client.Management.Cluster.ByID(clusterName)
 		if err != nil {
 			return false, err

--- a/tests/v2/validation/upgrade/kubernetes.go
+++ b/tests/v2/validation/upgrade/kubernetes.go
@@ -59,8 +59,6 @@ func upgradeLocalCluster(u *suite.Suite, testName string, client *rancher.Client
 	}
 
 	u.Run(testName, func() {
-		createPreUpgradeWorkloads(u.T(), client, cluster.Name, cluster.FeaturesToTest, nil, containerImage)
-
 		clusterMeta, err := extensionscluster.NewClusterMeta(client, cluster.Name)
 		require.NoError(u.T(), err)
 
@@ -77,13 +75,11 @@ func upgradeLocalCluster(u *suite.Suite, testName string, client *rancher.Client
 		err = waitForLocalClusterUpgrade(client, cluster.Name)
 		require.NoError(u.T(), err)
 
-		upgradedCluster, err := client.Management.Cluster.ByID(updatedCluster.V3.ID)
+		upgradedCluster, err := client.Management.Cluster.ByID(updatedCluster.Meta.ID)
 		require.NoError(u.T(), err)
-		require.Equal(u.T(), testConfig.KubernetesVersion, upgradedCluster.Version.GitVersion)
+		require.Contains(u.T(), testConfig.KubernetesVersion, upgradedCluster.Version.GitVersion)
 
 		logrus.Infof("Local cluster has been upgraded to: %s", upgradedCluster.Version.GitVersion)
-
-		createPostUpgradeWorkloads(u.T(), client, cluster.Name, cluster.FeaturesToTest)
 	})
 }
 

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -52,7 +52,7 @@ func (u *UpgradeKubernetesTestSuite) TestUpgradeKubernetes() {
 			testConfig := clusters.ConvertConfigToClusterConfig(&cluster.ProvisioningInput)
 
 			if cluster.Name == local {
-				upgradeLocalCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, containerImage)
+				upgradeLocalCluster(&u.Suite, tt.name, tt.client, testConfig, cluster, containerImage)
 			} else {
 				upgradeDownstreamCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, nil, containerImage)
 			}

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -1,0 +1,65 @@
+//go:build validation
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/upgradeinput"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+var verifyIngress = true
+
+type UpgradeWorkloadTestSuite struct {
+	suite.Suite
+	session  *session.Session
+	client   *rancher.Client
+	clusters []upgradeinput.Cluster
+}
+
+func (u *UpgradeWorkloadTestSuite) TearDownSuite() {
+	u.session.Cleanup()
+}
+
+func (u *UpgradeWorkloadTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	u.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(u.T(), err)
+
+	u.client = client
+
+	clusters, err := upgradeinput.LoadUpgradeKubernetesConfig(client)
+	require.NoError(u.T(), err)
+
+	u.clusters = clusters
+}
+
+func (u *UpgradeWorkloadTestSuite) TestWorkloadPreUpgrade() {
+	for _, cluster := range u.clusters {
+		cluster := cluster
+		u.Run(cluster.Name, func() {
+			cluster.FeaturesToTest.Ingress = &verifyIngress
+			createPreUpgradeWorkloads(u.T(), u.client, cluster.Name, cluster.FeaturesToTest, nil, containerImage)
+		})
+	}
+}
+
+func (u *UpgradeWorkloadTestSuite) TestWorkloadPostUpgrade() {
+	for _, cluster := range u.clusters {
+		cluster := cluster
+		u.Run(cluster.Name, func() {
+			cluster.FeaturesToTest.Ingress = &verifyIngress
+			createPostUpgradeWorkloads(u.T(), u.client, cluster.Name, cluster.FeaturesToTest)
+		})
+	}
+}
+
+func TestWorkloadUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeWorkloadTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Local upgrade jenkins job fails to upgrade local cluster with a panic    

```
panic.go:114: test panicked: runtime error: index out of range [0] with length 0
12:37:55          github.com/rancher/rancher/tests/v2/validation/upgrade.upgradeLocalCluster(_, {_, _}, _, {_, _}, _, {{0xc000b09bca, 0x5}, {0x0, ...}, ...}, ...)
12:37:55          	/root/go/src/github.com/rancher/rancher/tests/v2/validation/upgrade/kubernetes.go:50 +0x725
12:37:55          github.com/rancher/rancher/tests/v2/validation/upgrade.(*UpgradeKubernetesTestSuite).TestUpgradeKubernetes(0xc000289260)
12:37:55          	/root/go/src/github.com/rancher/rancher/tests/v2/validation/upgrade/kubernetes_test.go:55 +0x26b
```
 
## Solution
This PR fixes two isses: 
1. Local cluster upgrade fix: The issue occurs because the code depends on provisioning input from the configuration. However, in the localUpgrade job, the local cluster is created using Corral,  and there wont be a need for provisioning input in the config. As there is not provisioning input when the function tries to get the kubernetes version it panics. This fix ensures that the Kubernetes version is updated in the config file thats used in the `upgradeLocalCluster`.

2. The current localUpgrade job performs both pre- and post-upgrade checks. Since there was no test file for these checks (or it was removed as part of [PR #46493](https://github.com/rancher/rancher/pull/46493/files#diff-af3f1d321644422fe600c49f8f49eb4289568f5034b25cced8a5bfdc5b2d2677)), the job returns no tests to run. Fix makes use of the existing pre and post upgrade functions and created a test file so that the tests are run before the local cluster upgrade.
```
10:53:25  testing: warning: no tests to run
10:53:25  PASS
10:53:25  ok  	github.com/rancher/rancher/tests/v2/validation/upgrade	0.171s [no tests to run]
```


 
## Testing
Jenkins run

### Note:
I have not made updates for downstreamUpgrade as the localUpgrade focuses on the local cluster upgrade.. Moreover, the upgradeDownstream is also run as part of another [test](https://github.com/rancher/rancher/blob/release/v2.7/tests/v2/validation/upgrade/kubernetes_wins_test.go)