### PR TITLE
[2.10] Have both cleanup scripts reference their yml from the current branch

### DIFF
--- a/cleanup/binding-clean.sh
+++ b/cleanup/binding-clean.sh
@@ -6,7 +6,7 @@ CLEAR='\033[0m'
 RED='\033[0;31m'
 
 # Location of the yaml to use to deploy the cleanup job
-yaml_url=https://raw.githubusercontent.com/rancher/rancher/master/cleanup/binding-clean.yaml
+yaml_url=https://raw.githubusercontent.com/rancher/rancher/release/v2.10/cleanup/binding-clean.yaml
 
 # 120 is equal to a minute as the sleep is half a second
 timeout=120

--- a/cleanup/user-cluster.sh
+++ b/cleanup/user-cluster.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Location of the yaml to use to deploy the cleanup job
-yaml_url=https://raw.githubusercontent.com/rancher/rancher/master/cleanup/user-cluster.yml
+yaml_url=https://raw.githubusercontent.com/rancher/rancher/release/v2.10/cleanup/user-cluster.yml
 
 # 120 is equal to a minute as the sleep is half a second
 timeout=120


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/48318

## Issue: Discovered during QA testing of https://github.com/rancher/rancher/issues/43343

Works towards resolving https://github.com/rancher/rancher/issues/47402
 
## Testing

Repro steps in https://github.com/rancher/rancher/issues/43343 are valid, specifically workarounds in [this comment](https://github.com/rancher/rancher/issues/43343#issuecomment-2521230888) should no longer be required