### PR TITLE
[main] Fix the issue where VM not being deleted from the cloud

### DIFF
--- a/pkg/nodeconfig/archive.go
+++ b/pkg/nodeconfig/archive.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/jailer"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 )
 
@@ -174,12 +176,16 @@ func extractConfig(baseDir, extractedConfig string) error {
 			if err != nil {
 				return fmt.Errorf("error reinitializing config (Mkdirall). Config Dir: %v. Dir: %v. Error: %v", baseDir, info.Name(), err)
 			}
-
-			// Make sure to preserve the directory UID and GID.
-			if err = os.Chown(filePath, header.Uid, header.Gid); err != nil {
-				return fmt.Errorf("error changing ownership of directory %s: %w", filePath, err)
+			if os.Getenv("CATTLE_DEV_MODE") == "" && settings.UnprivilegedJailUser.Get() == "true" {
+				if err := jailer.SetJailOwnership(filePath); err != nil {
+					return fmt.Errorf("error updating perms for %s: %w", filePath, err)
+				}
+			} else {
+				// Make sure to preserve the directory UID and GID.
+				if err = os.Chown(filePath, header.Uid, header.Gid); err != nil {
+					return fmt.Errorf("error changing ownership of directory %s: %w", filePath, err)
+				}
 			}
-
 			continue
 		}
 
@@ -187,12 +193,16 @@ func extractConfig(baseDir, extractedConfig string) error {
 		if err != nil {
 			return fmt.Errorf("error reinitializing config (OpenFile). Config Dir: %v. File: %v. Error: %v", baseDir, info.Name(), err)
 		}
-
-		// Make sure to preserve the file UID and GID.
-		if err = os.Chown(filePath, header.Uid, header.Gid); err != nil {
-			return fmt.Errorf("error changing ownership of file %s: %w", filePath, err)
+		if os.Getenv("CATTLE_DEV_MODE") == "" && settings.UnprivilegedJailUser.Get() == "true" {
+			if err := jailer.SetJailOwnership(filePath); err != nil {
+				return fmt.Errorf("error updating perms for %s: %w", filePath, err)
+			}
+		} else {
+			// Make sure to preserve the file UID and GID.
+			if err = os.Chown(filePath, header.Uid, header.Gid); err != nil {
+				return fmt.Errorf("error changing ownership of file %s: %w", filePath, err)
+			}
 		}
-
 		_, err = io.Copy(file, tarReader)
 		file.Close()
 		if err != nil {

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/rancher/pkg/encryptedstore"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	"github.com/rancher/rancher/pkg/jailer"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -172,7 +173,7 @@ func (m *NodeConfig) Restore() error {
 		return fmt.Errorf("error extracting node config into %s: %w", m.fullMachinePath, err)
 	}
 
-	if os.Getenv("CATTLE_DEV_MODE") == "" {
+	if os.Getenv("CATTLE_DEV_MODE") == "" && settings.UnprivilegedJailUser.Get() == "true" {
 		if err := jailer.SetJailOwnership(m.fullMachinePath); err != nil {
 			return fmt.Errorf("error updating perms for extracted config dir %s: %w", m.fullMachinePath, err)
 		}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/48320

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

After upgrading from 2.9.2 to 2.9.4, deleting a downstream RKE1 cluster node (e.g., scaling down a node pool) created before the upgrade results in the node being successfully removed from Rancher and the downstream cluster. However, the VM remains undeleted on the infrastructure provider. 

The root cause is a file permission issue preventing `rancher-machine`, running as a non-root user, from accessing the necessary files to delete the machine.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Set the file permissions properly during the file creation process. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The fix was validated using a custom build of Rancher from this branch. Following the same steps outlined in the issue, the VMs are now correctly removed from the infrastructure provider as expected. Digital Ocean was used as the infrastructure provider for validation.

### Automated Testing

n/a 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
Testing should include the scenarios outlined in the issue and extend to multiple infrastructure providers for comprehensive validation.


### Regressions Considerations
 
- Cluster provisioning in general
- for existing RKE1 or RKE2/K3s clusters created before upgrading Rancher
	- deletion of  "old" nodes
	- addition and deletion of new nodes 
- Deletion nodes of newly-created  RKE1 or RKE2/K3s clusters
