### PR TITLE
[v2.10] fix: Check if upstreamSpec is nil

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler_test.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler_test.go
@@ -1,12 +1,14 @@
 package eks
 
 import (
-	"github.com/rancher/rancher/pkg/capr"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/capr"
+
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 )
 
 const (
@@ -123,6 +125,23 @@ func Test_onClusterChange_UpdateNodePool(t *testing.T) {
 	}
 	if !capr.Provisioned.IsTrue(cluster) || !capr.Updated.IsUnknown(cluster) {
 		t.Errorf("provisioned status should be True, updated status should be Unknown and cluster returned successfully")
+	}
+}
+
+func Test_onClusterChange_Active_nilUpstreamSpec(t *testing.T) {
+	mockOperatorController = getMockEksOperatorController(t, "active")
+	mockCluster, err := getMockV3Cluster(MockActiveClusterFilename)
+	if err != nil {
+		t.Errorf("error getting mock v3 cluster: %s", err)
+	}
+	mockCluster.Name = "test"
+	mockCluster.Status.EKSStatus.UpstreamSpec = nil
+
+	_, err = mockOperatorController.onClusterChange("", &mockCluster)
+
+	exp := fmt.Errorf("initial upstreamSpec on cluster [test] has not been set, unable to continue")
+	if err.Error() != exp.Error() {
+		t.Errorf("expected error %q but got %q", exp, err)
 	}
 }
 


### PR DESCRIPTION
## Issue: #48144  
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
If an error occurs when the upstream state is being constructed, `.status.eksStatus.upstreamSpec` will remain nil causing a panic later when it is accessed. This PR check if field is nil and returns an error to avoid a panic.

This is a forward port of #48298 .

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 Added a nil check to prevent panic.
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_