### PR TITLE
Improve Azure Client logging for group resources

### DIFF
--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -238,7 +238,7 @@ func (c AzureMSGraphClient) listGroupMemberships(ctx context.Context, userID str
 		group, ok := do.(*models.Group)
 		if !ok {
 			if _, ok := do.(*models.DirectoryRole); !ok {
-				logrus.Errorf("[%s] Page Iterator received incorrect value of type %T: %#v", providerLogPrefix, do, do)
+				logrus.Debugf("[%s] Groups Iterator received unexpected value of type %T: %#v", providerLogPrefix, do, do)
 			}
 			return true
 		}

--- a/pkg/auth/providers/azure/clients/ms_graph_client_test.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client_test.go
@@ -76,7 +76,8 @@ func TestMSGraphClient_ListUsers(t *testing.T) {
 		displayNames = append(displayNames, v.DisplayName)
 	}
 
-	assert.Len(t, users, 91)
+	// Note these can change because of changes in the remote service
+	assert.Len(t, users, 191)
 }
 
 func TestMSGraphClient_ListUsers_with_filter(t *testing.T) {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/48425

This reduces the "unknown resource" message to a Debug which will prevent unexpected resources (that we skip) from being logged out.