### PR TITLE
[v2.10] replace delete-local-data flag with delete-emptydir-data

### DIFF
--- a/pkg/api/norman/customization/node/node.go
+++ b/pkg/api/norman/customization/node/node.go
@@ -28,7 +28,7 @@ import (
 	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 )
 
-var toIgnoreErrs = []string{"--ignore-daemonsets", "--delete-local-data", "--force", "did not complete within"}
+var toIgnoreErrs = []string{"--ignore-daemonsets", "--delete-emptydir-data", "--force", "did not complete within"}
 var allowedStates = map[string]bool{"active": true, "cordoned": true, "draining": true, "drained": true}
 
 // Formatter for Node

--- a/pkg/controllers/managementuser/nodesyncer/cordonfieldssyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/cordonfieldssyncer.go
@@ -27,7 +27,7 @@ const (
 )
 
 var nodeMapLock = sync.Mutex{}
-var toIgnoreErrs = []string{"--ignore-daemonsets", "--delete-local-data", "--force", "did not complete within", "global timeout reached"}
+var toIgnoreErrs = []string{"--ignore-daemonsets", "--delete-emptydir-data", "--force", "did not complete within", "global timeout reached"}
 
 func (m *nodesSyncer) syncCordonFields(key string, obj *v3.Node) (runtime.Object, error) {
 	if obj == nil || obj.DeletionTimestamp != nil || obj.Spec.DesiredNodeUnschedulable == "" {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -278,7 +278,7 @@ func GetDrainFlags(node *v3.Node) []string {
 		ignoreDaemonSets = *input.IgnoreDaemonSets
 	}
 	return []string{
-		fmt.Sprintf("--delete-local-data=%v", input.DeleteLocalData),
+		fmt.Sprintf("--delete-emptydir-data=%v", input.DeleteLocalData),
 		fmt.Sprintf("--force=%v", input.Force),
 		fmt.Sprintf("--grace-period=%v", input.GracePeriod),
 		fmt.Sprintf("--ignore-daemonsets=%v", ignoreDaemonSets),


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/48375
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 delete-local-data flag was removed in k8s v1.31 so the cluster upgrades with drain enabled are failing.

ref: https://github.com/kubernetes/kubernetes/blob/8a39b6062060ffb4fba52f53c011bd00428db194/CHANGELOG/CHANGELOG-1.31.md?plain=1#L1197


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_