### PR TITLE
[v2.10] updated logic for creating cattle-system namespace

### DIFF
--- a/pkg/kontainer-engine/drivers/util/utils.go
+++ b/pkg/kontainer-engine/drivers/util/utils.go
@@ -32,13 +32,22 @@ func UserAgentForCluster(cluster *managementv3.Cluster) string {
 
 // GenerateServiceAccountToken generate a serviceAccountToken for clusterAdmin given a rest clientset
 func GenerateServiceAccountToken(clientset kubernetes.Interface, clusterName string) (string, error) {
-	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cattleNamespace,
-		},
-	}, metav1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return "", err
+	// intentionally first did a get call to check if the namespace already exist
+	// since in case of etcd-restore operation apiserver tries to verify the create namespace call (due to ValidatingWebhookConfiguration)
+	// and the request can fail based on rancher-webhook pod's running status during restore.
+	_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), cattleNamespace, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return "", err
+		}
+		_, err = clientset.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cattleNamespace,
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return "", fmt.Errorf("error creating namespace: %v", err)
+		}
 	}
 
 	serviceAccount := &v1.ServiceAccount{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/48419
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Etcd snapshot restore fails in PostCheck step when GenerateServiceAccountToken is called in some cases. If rke1 cluster k8s upgrade is done with Drain nodes enabled in upgrade strategy and then if we try to restore it to old k8s version using etcd snapshot the restore continuously fails in PostCheck with following error
`
err: Internal error occurred: failed calling webhook "rancher.cattle.io.namespaces.create-non-kubesystem": failed to call webhook: Post "[https://rancher-webhook.cattle-system.svc:443/v1/webhook/validation/namespaces?timeout=10s](https://rancher-webhook.cattle-system.svc/v1/webhook/validation/namespaces?timeout=10s)": dial tcp 10.43.113.34:443: i/o timeout,
`

it happens when Create request is made for the cattle-system namespace. 
Since we are restoring the cluster, It already has a ValidatingWebhookConfiguration  ` rancher.cattle.io` which has a rule to validate namespace creation.
When the APIServer tries to connect to webhook this error occurs. 
the apiserver request to webhook can fail , since rancher webhook pod runs on  worker nodes which are upgraded only after this PostCheck pass.

So if only a GET request is sent then apiserver can respond directly and this webhook error will not occur.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Instead of directly doing a create request for the cattle-namespace, first we a GET request is done to verify if the namespace already exist.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_