### PR TITLE
Fix automatic toleration merge when performing chart upgrades and add support for rke1 tolerations

### DIFF
--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -1149,6 +1149,12 @@ func (s *Operations) AddCpTaintsToTolerations(tolerations []corev1.Toleration) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to list control plane nodes: %w", err)
 	}
+	if len(cpList.Items) == 0 {
+		cpList, err = s.nodes.List(metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/controlplane=true"})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list control plane nodes: %w", err)
+		}
+	}
 	var allTaints []corev1.Taint
 	for _, cp := range cpList.Items {
 		toAdd, _ := taints.GetToDiffTaints(allTaints, cp.Spec.Taints)

--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -319,7 +319,7 @@ func (m *Manager) install(namespace, name, minVersion, exactVersion string, valu
 		desiredValue = map[string]interface{}{}
 	}
 	// if tolerations are already present we don't change them
-	if _, ok := desiredValue["tolerations"]; !ok {
+	if v, ok := desiredValue["tolerations"]; !ok || v == nil {
 		var tolerations []v1.Toleration
 		tolerations, err = m.operation.AddCpTaintsToTolerations(tolerations)
 		if err != nil {


### PR DESCRIPTION
* Fix adding tolerations automatically when spec.tolerations is nil.
* Checking for rke1 control plane label.