### PR TITLE
Upgrade release job fixes.

### DIFF
--- a/tests/v2/validation/pipeline/releaseupgrade/main.go
+++ b/tests/v2/validation/pipeline/releaseupgrade/main.go
@@ -314,16 +314,23 @@ func NewRancherClusterConfiguration(cluster pipeline.RancherCluster, newConfigNa
 
 	upgradeConfig := new(upgradeinput.Config)
 	config.LoadAndUpdateConfig(upgradeinput.ConfigurationFileKey, upgradeConfig, func() {
+		if isRKE1 {
+			provisioningConfig.RKE1KubernetesVersions = []string{cluster.KubernetesVersionToUpgrade}
+		} else if isRKE2 {
+			provisioningConfig.RKE2KubernetesVersions = []string{cluster.KubernetesVersionToUpgrade}
+		} else {
+			provisioningConfig.K3SKubernetesVersions = []string{cluster.KubernetesVersionToUpgrade}
+		}
 		clusters := []upgradeinput.Cluster{
 			{
-				VersionToUpgrade: cluster.KubernetesVersionToUpgrade,
-				FeaturesToTest:   cluster.FeaturesToTest,
+				ProvisioningInput: *provisioningConfig,
+				FeaturesToTest:    cluster.FeaturesToTest,
 			},
 		}
 		upgradeConfig.Clusters = clusters
 	})
 
-	return
+	return nil
 }
 
 //	NewRancherLocalClusterConfiguration is a function that accepts single cluster from the cluster matrix's local field.


### PR DESCRIPTION
Revert "Update kubernetes.go"

## Issue: Fixes a config issue that caused the k8s upgrade to fail. 
 
## Problem
The k8s upgrade job has a different config structure and the k8s version needs to be stored in the provisioning input/(rke1/rke2/k3s) section.
 
## Solution
added some logic to set the appropriate provisioning input values.
 
## Testing
Tested during release testing
