### PR TITLE
[2.8] Fixes the local upgrade failure 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/google/gnostic-models v0.6.8
 	github.com/rancher/cis-operator v1.0.11
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240613212755-3021cf92ff9f
-	github.com/rancher/shepherd v0.0.0-20241025145825-ac788a5e1033
+	github.com/rancher/shepherd v0.0.0-20241223173540-fe59e1018829
 	github.com/rancher/wrangler v1.1.1
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 )

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/rancher/remotedialer v0.4.0 h1:T9yC5bFMsZFVQ6rK0dNrRg6rRb6Zr/4vsig8S0
 github.com/rancher/remotedialer v0.4.0/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
 github.com/rancher/rke v1.5.15 h1:tAwa+1q8tK8/ZBmdfKFIGH40XD3xFQTR/vxTLCK9xxY=
 github.com/rancher/rke v1.5.15/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
-github.com/rancher/shepherd v0.0.0-20241025145825-ac788a5e1033 h1:K+kOyR3WiGuyWbP5sdGdM9iNStWa/xWS6fL4K/R/Q7g=
-github.com/rancher/shepherd v0.0.0-20241025145825-ac788a5e1033/go.mod h1:1TXkmbjCxMEp8Rzzw+ToyrhJYUGDC0lw6uXLe3Ie+M4=
+github.com/rancher/shepherd v0.0.0-20241223173540-fe59e1018829 h1:TCxHwsYHr3kyDpOf0B6SIi5Cr6BvOj9Sffh8iIvHT2U=
+github.com/rancher/shepherd v0.0.0-20241223173540-fe59e1018829/go.mod h1:TShrzwU7msr/DNi1A7ZRUdqpv/gsN4FG9VTYDcIF+1I=
 github.com/rancher/steve v0.0.0-20241029132722-c744f0b17b88 h1:ok5PBtEMAQfE1x9yrdqx344VyqYeIkAWoC1O8dcQUZE=
 github.com/rancher/steve v0.0.0-20241029132722-c744f0b17b88/go.mod h1:v0hTRvX7jcB9Gsq614KS2FpYKz4BydmGne2i3lhRbYI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=

--- a/tests/v2/actions/upgradeinput/load.go
+++ b/tests/v2/actions/upgradeinput/load.go
@@ -54,6 +54,7 @@ func LoadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Cluster, er
 			cluster.Name = c.Name
 			cluster.ProvisioningInput = c.ProvisioningInput
 			cluster.FeaturesToTest = c.FeaturesToTest
+			cluster.VersionToUpgrade = c.VersionToUpgrade
 
 			clusters = append(clusters, *cluster)
 		}

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -52,7 +52,7 @@ func (u *UpgradeKubernetesTestSuite) TestUpgradeKubernetes() {
 			testConfig := clusters.ConvertConfigToClusterConfig(&cluster.ProvisioningInput)
 
 			if cluster.Name == local {
-				upgradeLocalCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, containerImage)
+				upgradeLocalCluster(&u.Suite, tt.name, tt.client, testConfig, cluster, containerImage)
 			} else {
 				upgradeDownstreamCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, nil, containerImage)
 			}

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -1,0 +1,65 @@
+//go:build validation
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/upgradeinput"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+var verifyIngress = true
+
+type UpgradeWorkloadTestSuite struct {
+	suite.Suite
+	session  *session.Session
+	client   *rancher.Client
+	clusters []upgradeinput.Cluster
+}
+
+func (u *UpgradeWorkloadTestSuite) TearDownSuite() {
+	u.session.Cleanup()
+}
+
+func (u *UpgradeWorkloadTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	u.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(u.T(), err)
+
+	u.client = client
+
+	clusters, err := upgradeinput.LoadUpgradeKubernetesConfig(client)
+	require.NoError(u.T(), err)
+
+	u.clusters = clusters
+}
+
+func (u *UpgradeWorkloadTestSuite) TestWorkloadPreUpgrade() {
+	for _, cluster := range u.clusters {
+		cluster := cluster
+		u.Run(cluster.Name, func() {
+			cluster.FeaturesToTest.Ingress = &verifyIngress
+			createPreUpgradeWorkloads(u.T(), u.client, cluster.Name, cluster.FeaturesToTest, nil, containerImage)
+		})
+	}
+}
+
+func (u *UpgradeWorkloadTestSuite) TestWorkloadPostUpgrade() {
+	for _, cluster := range u.clusters {
+		cluster := cluster
+		u.Run(cluster.Name, func() {
+			cluster.FeaturesToTest.Ingress = &verifyIngress
+			createPostUpgradeWorkloads(u.T(), u.client, cluster.Name, cluster.FeaturesToTest)
+		})
+	}
+}
+
+func TestWorkloadUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeWorkloadTestSuite))
+}


### PR DESCRIPTION
 Back port of 
https://github.com/rancher/rancher/pull/48292

### NOTE:
shepeherd changes are yet to be merged for this release. once that is merged, would need to update the go.mod changes in this PR.