### PR TITLE
[v2.9] Backport Fix concurrent SA updates for Secrets (#48422)

### DIFF
--- a/pkg/serviceaccounttoken/secret.go
+++ b/pkg/serviceaccounttoken/secret.go
@@ -259,6 +259,8 @@ func createServiceAccountSecret(ctx context.Context, sa *corev1.ServiceAccount, 
 
 // returns true if the secret has changed.
 func annotateSAWithSecret(ctx context.Context, sa *corev1.ServiceAccount, secret *corev1.Secret, saClient clientv1.ServiceAccountInterface, secretClient clientv1.SecretInterface) (*corev1.ServiceAccount, bool, error) {
+	sa = sa.DeepCopy()
+
 	if sa.Annotations == nil {
 		sa.Annotations = map[string]string{}
 	}

--- a/tests/pkg/serviceaccounttoken/mitigation_test.go
+++ b/tests/pkg/serviceaccounttoken/mitigation_test.go
@@ -68,9 +68,7 @@ func TestOptimisticLocking(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				// Sends a DeepCopy because this is theoretically being updated
-				// in different processes.
-				secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.TODO(), nil, clientSet, sa.DeepCopy())
+				secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.TODO(), nil, clientSet, sa)
 				assert.NoError(t, err)
 				assert.NotNil(t, secret)
 				createdSecrets <- *secret


### PR DESCRIPTION
Issue: #48470

Backport of https://github.com/rancher/rancher/pull/48422