### PR TITLE
[2.9] unRC wrangler to v3.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/rancher/steve v0.0.0-20241031174805-c4ebbe629ff1
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde
 	github.com/rancher/wrangler v1.1.2
-	github.com/rancher/wrangler/v3 v3.0.1-rc.4
+	github.com/rancher/wrangler/v3 v3.0.1
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1538,8 +1538,8 @@ github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eac
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
-github.com/rancher/wrangler/v3 v3.0.1-rc.4 h1:TOFp9Vv+D+O52MeuTM9M/aTT6OB/QZMoBchPfTSFMSc=
-github.com/rancher/wrangler/v3 v3.0.1-rc.4/go.mod h1:cGBYMrchAW13we6LlubfXAv1EJ3z0QzsXiGKTPr+IXg=
+github.com/rancher/wrangler/v3 v3.0.1 h1:vFsvTYpilYGLCpe6FadsoCnK5A+S0t0dE4C83Anorok=
+github.com/rancher/wrangler/v3 v3.0.1/go.mod h1:cGBYMrchAW13we6LlubfXAv1EJ3z0QzsXiGKTPr+IXg=
 github.com/redis/go-redis/v9 v9.6.1 h1:HHDteefn6ZkTtY5fGUE8tj8uy85AHk6zP7CpzIAM0y4=
 github.com/redis/go-redis/v9 v9.6.1/go.mod h1:0C0c6ycQsdpVNQpxb1njEQIqkx5UcsM8FJCQLgE9+RA=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/rancher/gke-operator v1.9.5
 	github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9
 	github.com/rancher/rke v1.6.5
-	github.com/rancher/wrangler/v3 v3.0.1-rc.4
+	github.com/rancher/wrangler/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -100,8 +100,8 @@ github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9 h1:AlRMRs5mHJcdiK83
 github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9/go.mod h1:dyjfXBsNiroPWOdUZe7diUOUSLf6HQ/r2kEpwH/8zas=
 github.com/rancher/rke v1.6.5 h1:rnzftebMzbUWekttvfRfloJPm+/ktlv3GuDldJnJhVM=
 github.com/rancher/rke v1.6.5/go.mod h1:ZDmcz3aeBsuORheojvGRxUJQS6NKRcpLTPXoY5N2y4c=
-github.com/rancher/wrangler/v3 v3.0.1-rc.4 h1:TOFp9Vv+D+O52MeuTM9M/aTT6OB/QZMoBchPfTSFMSc=
-github.com/rancher/wrangler/v3 v3.0.1-rc.4/go.mod h1:cGBYMrchAW13we6LlubfXAv1EJ3z0QzsXiGKTPr+IXg=
+github.com/rancher/wrangler/v3 v3.0.1 h1:vFsvTYpilYGLCpe6FadsoCnK5A+S0t0dE4C83Anorok=
+github.com/rancher/wrangler/v3 v3.0.1/go.mod h1:cGBYMrchAW13we6LlubfXAv1EJ3z0QzsXiGKTPr+IXg=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
As wrangler v3.0.1 is released, refer to the release artifact rather than the last rc4 candidate: https://github.com/rancher/wrangler/releases/tag/v3.0.1