### PR TITLE
[2.11] Add new Rancher chart value fields

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -60,11 +60,10 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 
 {{- define "linux-node-selector-terms" -}}
 {{- $key := "kubernetes.io/os" -}}
-- matchExpressions:
-  - key: {{ $key }}
-    operator: NotIn
-    values:
-    - windows
+- key: {{ $key }}
+  operator: NotIn
+  values:
+  - windows
 {{- end -}}
 
 {{- define "system_default_registry" -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -61,11 +61,15 @@ spec:
 {{- end }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms: {{ include "linux-node-selector-terms" . | nindent 14 }}
+            nodeSelectorTerms:
+              - matchExpressions: {{ include "linux-node-selector-terms" . | nindent 16 }}
+              {{- if .Values.extraNodeSelectorTerms }}
+              {{- toYaml .Values.extraNodeSelectorTerms | nindent 16 }}
+              {{- end }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
-{{- if .Values.extraTolerations }}
-{{ toYaml .Values.extraTolerations | indent 8 }}
-{{- end }}
+      {{- if .Values.extraTolerations }}
+      {{- toYaml .Values.extraTolerations | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}
@@ -173,8 +177,9 @@ spec:
           timeoutSeconds: {{.Values.readinessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           failureThreshold: {{.Values.readinessProbe.failureThreshold }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
         volumeMounts:
 {{- if .Values.additionalTrustedCAs }}
         - mountPath: /etc/pki/trust/anchors/ca-additional.pem
@@ -217,6 +222,9 @@ spec:
         volumeMounts:
         - mountPath: /var/log/auditlog
           name: audit-log
+        {{- if .Values.auditLog.resources }}
+        resources: {{- toYaml .Values.auditLog.resources | nindent 10 }}
+        {{- end }}
   {{- end }}
 {{- end }}
       volumes:

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -560,3 +560,135 @@ tests:
           effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"
+- it: sets extraNodeSelectorTerms
+  set:
+    extraNodeSelectorTerms:
+      - key: topology.kubernetes.io/zone
+        operator: In
+        values:
+          - us-north
+  asserts:
+    - exists:
+        path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1]
+    - equal:
+        path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1]
+        value:
+          key: topology.kubernetes.io/zone
+          operator: In
+          values:
+            - us-north
+- it: allows `resources` to be defined on Rancher pod
+  set:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 500m
+        memory: 500Mi
+  asserts:
+    - exists:
+        path: spec.template.spec.containers[0].resources
+    - equal:
+        path: spec.template.spec.containers[0].resources
+        value:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+- it: doesn't use Rancher pod `resources` on Audit Log sidecar
+  set:
+    auditLog:
+      level: 3
+    resources:
+      requests:
+        cpu: 9000m
+        memory: 900Mi
+      limits:
+        cpu: 9000m
+        memory: 9000Mi
+  asserts:
+    - exists:
+        path: spec.template.spec.containers[1]
+    - notExists:
+        path: spec.template.spec.containers[1].resources
+    - exists:
+        path: spec.template.spec.containers[0].resources
+    - equal:
+        path: spec.template.spec.containers[0].resources
+        value:
+          requests:
+            cpu: 9000m
+            memory: 900Mi
+          limits:
+            cpu: 9000m
+            memory: 9000Mi
+- it: allows `resources` to be defined on Rancher audit log sidecar pod
+  set:
+    auditLog:
+      level: 3
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+        limits:
+          cpu: 500m
+          memory: 500Mi
+  asserts:
+    - exists:
+        path: spec.template.spec.containers[1].resources
+    - equal:
+        path: spec.template.spec.containers[1].resources
+        value:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+    - notExists:
+        path: spec.template.spec.containers[0].resources
+- it: allows different `resources` for Rancher pod and audit log sidecar pod
+  set:
+    auditLog:
+      level: 3
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+        limits:
+          cpu: 500m
+          memory: 500Mi
+    resources:
+      requests:
+        cpu: 9000m
+        memory: 900Mi
+      limits:
+        cpu: 9000m
+        memory: 9000Mi
+  asserts:
+    - exists:
+        path: spec.template.spec.containers[0].resources
+    - equal:
+        path: spec.template.spec.containers[0].resources
+        value:
+          requests:
+            cpu: 9000m
+            memory: 900Mi
+          limits:
+            cpu: 9000m
+            memory: 9000Mi
+    - exists:
+        path: spec.template.spec.containers[1].resources
+    - equal:
+        path: spec.template.spec.containers[1].resources
+        value:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -554,3 +554,9 @@ tests:
   asserts:
     - exists:
         path: spec.template.spec.tolerations[1]
+    - equal:
+        path: spec.template.spec.tolerations[1]
+        value:
+          effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,9 @@ auditLog:
   maxBackup: 1
   maxSize: 100
 
+  # Set pod resource requests/limits for Audit log sidecar (ONLY used if destination=sidecar).
+  resources: {}
+
   # Image for collecting rancher audit logs.
   # Important: update pkg/image/export/resolve.go when this default image is changed, so that it's reflected accordingly in rancher-images.txt generated for air-gapped setups.
   image:
@@ -181,6 +184,14 @@ startupProbe:
 
 # Additional taints to tolerate
 extraTolerations: {}
+
+# Additional node selector terms for the rancher deployment
+# Ex:
+#  - key: topology.kubernetes.io/zone
+#    operator: In
+#    values:
+#      - us-north-42
+extraNodeSelectorTerms: {}
 
 livenessProbe:
   timeoutSeconds: 5


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45516#issuecomment-2551871584
 
## Problem
Rancher's chart doesn't allow much control over certain aspects due to requirements of the system. Specifically the requirement/expectation that "Rancher expects to be the sole application on and owning the 'local' cluster".

Some of these related values can be - with an acceptable amount of risk - be exposed to users for configuring _additional_ values. This applies to areas like Node Selector / Affinity / Tolerations and some what to `resources`. Overall it's probably OK if users add to the required rancher rules, but they still need to use them with care to ensure it fits their specific use-case.
 
## Solution
Add new helm chart values to control these areas that can be modified in an additive manner with lower risk.
 
## Testing
For Sidecar resources, try using:
```
auditLog:
  level: 3
  resources:
    requests:
      cpu: 100m
      memory: 200Mi
    limits:
      cpu: 500m
      memory: 500Mi
```

You should see the sidecar container has resources set. Note, level must be set for this container to render into the chart at all. So it should be tested with and without `auditLog.resources`.


For the new, `extraNodeSelectorTerms` field try:
```
extraNodeSelectorTerms:
  - key: topology.kubernetes.io/zone
    operator: In
    values:
      - us-north-42
```

## Engineering Testing
### Manual Testing
Used `helm template` command to debug render chart with varying options.
Used debug chart to upgrade 2.10.0 rancher with values that use new options.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit: Added Helm Unit tests

## QA Testing Considerations
Similar to testing for: https://github.com/rancher/rancher/issues/47584

We should verify the new values render the correct Chart manifests (also covered by helm-unit tests). And also verify that the deployed Rancher resources have matching configs.
 
### Regressions Considerations
N/A