### PR TITLE
[main] Fix vSphere Node Driver Windows Install Script Env Vars 

### DIFF
--- a/pkg/capr/installer/installer.go
+++ b/pkg/capr/installer/installer.go
@@ -188,7 +188,7 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 		if envVar.Value == "" {
 			continue
 		}
-		envVarBuf.WriteString(capr.FormatWindowsEnvVar(envVar, false))
+		envVarBuf.WriteString(capr.FormatWindowsEnvVar(envVar, false) + "\n")
 	}
 	server := ""
 	if settings.ServerURL.Get() != "" {

--- a/pkg/capr/installer/installer_test.go
+++ b/pkg/capr/installer/installer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemtemplate"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,23 @@ func TestInstaller_WindowsInstallScript(t *testing.T) {
 
 	CACertEncoded := systemtemplate.CAChecksum()
 
-	script, err := WindowsInstallScript(context.TODO(), "test", []corev1.EnvVar{}, "localhost", "/var/lib/rancher/rke2")
+	agentVar1 := corev1.EnvVar{
+		Name:  "TestEnvVar1",
+		Value: "TestEnvVarValue",
+	}
+
+	agentVar2 := corev1.EnvVar{
+		Name:  "TestEnvVar2",
+		Value: "TestEnvVarValue",
+	}
+
+	formattedAgentVar1 := capr.FormatWindowsEnvVar(agentVar1, false)
+	formattedAgentVar2 := capr.FormatWindowsEnvVar(agentVar2, false)
+
+	script, err := WindowsInstallScript(context.TODO(), "test", []corev1.EnvVar{
+		agentVar1,
+		agentVar2,
+	}, "localhost", "/var/lib/rancher/rke2")
 
 	// assert
 	a.Nil(err)
@@ -37,4 +54,9 @@ func TestInstaller_WindowsInstallScript(t *testing.T) {
 	a.Contains(string(script), "$env:CSI_PROXY_URL")
 	a.Contains(string(script), "$env:CSI_PROXY_VERSION")
 	a.Contains(string(script), "$env:CSI_PROXY_KUBELET_PATH")
+	a.Contains(string(script), "$env:TestEnvVar1")
+	a.Contains(string(script), "$env:TestEnvVar2")
+
+	// ensure agent env vars are not on the same line
+	a.NotContains(string(script), formattedAgentVar1+formattedAgentVar2)
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48499
 
## Problem

The `WindowsInstallScript` function does not properly append new lines to agent environment variables when generating the rancher-wins install script. In the event that multiple agent environment variables are specified, they will be placed on a single line - preventing rancher-wins from installing. This issue only occurs with vSphere node driver clusters, which is likely why it was not caught when validating other issues relating to proxy env vars.

## Solution
Ensure that each agent environment variable string has a newline appended to it when generating the rancher-wins install script.
 
## Testing

Create a new vSphere cluster using the Rancher UI. Add two agent environment variables in the UI before creating the cluster (the name and value can be arbitrary). Ensure that the node joined successfully, and that `install.ps1` includes both agent environment variables on their own line. 


## Engineering Testing
### Manual Testing

I have provisioned a vSphere cluster using the node driver using the changes in this PR and was able to confirm that the script was properly formatted and that the node joined the cluster without error. 


### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: 
 Added a new unit test to catch this situation

## QA Testing Considerations
I've generated a new Windows 2022 template in vSphere that can be used to test this issue. It's located in the `hostbusters-windows-development-library`
 
### Regressions Considerations
