### PR TITLE
[CHART] Support user modifying ingress path/pathType

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -54,8 +54,8 @@ spec:
           servicePort: {{ .Values.ingress.servicePort }}
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
-        pathType: ImplementationSpecific
-        path: "/"
+        pathType: {{ .Values.ingress.pathType }}
+        path: {{ .Values.ingress.path }}
         {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -238,3 +238,22 @@ tests:
                     number: 80
               pathType: ImplementationSpecific
               path: /
+- it: should create http rule with non-default path and pathType
+  set:
+    hostname: host.example.com
+    ingress.pathType: Prefix
+    ingress.path: '/*'
+  asserts:
+  - equal:
+      path: spec.rules
+      value:
+        - host: host.example.com
+          http:
+            paths:
+            - backend:
+                service:
+                  name: RELEASE-NAME-rancher
+                  port:
+                    number: 80
+              pathType: Prefix
+              path: "/*"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -62,8 +62,9 @@ ingress:
   includeDefaultExtraAnnotations: true
   extraAnnotations: {}
   ingressClassName: ""
-  path: "/"
+  # Certain ingress controllers will require the pathType or path to be set to a different value.
   pathType: ImplementationSpecific
+  path: "/"
   # backend port number
   servicePort: 80
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -62,6 +62,8 @@ ingress:
   includeDefaultExtraAnnotations: true
   extraAnnotations: {}
   ingressClassName: ""
+  path: "/"
+  pathType: ImplementationSpecific
   # backend port number
   servicePort: 80
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/48522
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Rancher's helm chart hardcodes the `.spec.rules[].http.paths[].path` to `"/"` and `.spec.rules[].http.paths[].pathType` to `ImplementationSpecific` in the ingress crd. It is common practice in other helm charts to allow the user to modify these 2 spec parameters in the values.yaml. The reporter in Issue https://github.com/rancher/rancher/issues/48167 reported:
>on GKE, ingress path should be set to `"/*"` not `"/"` .
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

PR adds `.Values.ingress.path` and `.Values.ingress.pathType` to the ingress template and values.yaml making these parameters configurable while keeping the current default. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Ran the helm-unittest.sh script with no errors.
```bash
% ./dev-scripts/helm-unittest.sh
==> Linting ./

1 chart(s) linted, 0 chart(s) failed

### Chart [ rancher ] ./

2024/12/18 17:53:02 warning: skipped value for rancher.webhook: Not a table.
2024/12/18 17:53:02 warning: skipped value for rancher.fleet: Not a table.
 PASS  Test ConfigMap	tests/configmap_test.yaml
 PASS  Test Deployment	tests/deployment_test.yaml
 PASS  Test Ingress	tests/ingress_test.yaml
 PASS  Test Issuers	tests/issuer_test.yaml
 PASS  Test persistentVolumeClaim	tests/pvc_test.yaml
 PASS  Test Service	tests/service_test.yaml

Charts:      1 passed, 1 total
Test Suites: 6 passed, 6 total
Tests:       112 passed, 112 total
Snapshot:    0 passed, 0 total
Time:        240.076583ms

Updated 2 paths from the index
```

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_