### PR TITLE
Change CRTB Status lastUpdatedTime format 

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -391,7 +391,7 @@ func (c *crtbLifecycle) updateStatus(crtb *v3.ClusterRoleTemplateBinding, localC
 			}
 		}
 
-		crtbFromCluster.Status.LastUpdateTime = timeNow().String()
+		crtbFromCluster.Status.LastUpdateTime = timeNow().Format(time.RFC3339)
 		crtbFromCluster.Status.ObservedGenerationLocal = crtb.ObjectMeta.Generation
 		crtbFromCluster.Status.LocalConditions = localConditions
 		crtbFromCluster, err = c.crtbClient.UpdateStatus(crtbFromCluster)

--- a/pkg/controllers/management/auth/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/crtb_handler_test.go
@@ -450,7 +450,7 @@ func TestUpdateStatus(t *testing.T) {
 					},
 				},
 			},
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbSubjectAndBindingExist := &v3.ClusterRoleTemplateBinding{
@@ -473,7 +473,7 @@ func TestUpdateStatus(t *testing.T) {
 					},
 				},
 			},
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbSubjectError := &v3.ClusterRoleTemplateBinding{
@@ -488,17 +488,17 @@ func TestUpdateStatus(t *testing.T) {
 					},
 				},
 			},
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbEmptyStatus := &v3.ClusterRoleTemplateBinding{
 		Status: v3.ClusterRoleTemplateBindingStatus{
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbEmptyStatusRemoteComplete := &v3.ClusterRoleTemplateBinding{
 		Status: v3.ClusterRoleTemplateBindingStatus{
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 			SummaryRemote:  status.SummaryCompleted,
 		},
 	}
@@ -524,7 +524,7 @@ func TestUpdateStatus(t *testing.T) {
 								},
 							},
 						},
-						LastUpdateTime: mockTime.String(),
+						LastUpdateTime: mockTime.Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
 					},
 				})
@@ -556,7 +556,7 @@ func TestUpdateStatus(t *testing.T) {
 								},
 							},
 						},
-						LastUpdateTime: mockTime.String(),
+						LastUpdateTime: mockTime.Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
 						SummaryRemote:  status.SummaryCompleted,
 						Summary:        status.SummaryCompleted,
@@ -583,7 +583,7 @@ func TestUpdateStatus(t *testing.T) {
 								},
 							},
 						},
-						LastUpdateTime: mockTime.String(),
+						LastUpdateTime: mockTime.Format(time.RFC3339),
 						SummaryLocal:   status.SummaryError,
 						Summary:        status.SummaryError,
 					},
@@ -609,7 +609,7 @@ func TestUpdateStatus(t *testing.T) {
 								},
 							},
 						},
-						LastUpdateTime: mockTime.String(),
+						LastUpdateTime: mockTime.Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
 					},
 				})

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
@@ -597,7 +598,7 @@ func (c *globalRoleBindingLifecycle) updateStatus(grb *apisv3.GlobalRoleBinding,
 			}
 		}
 
-		grbFromCluster.Status.LastUpdateTime = c.status.TimeNow().String()
+		grbFromCluster.Status.LastUpdateTime = c.status.TimeNow().Format(time.RFC3339)
 		grbFromCluster.Status.ObservedGenerationLocal = grb.ObjectMeta.Generation
 		grbFromCluster.Status.LocalConditions = localConditions
 		grbFromCluster, err = c.grbClient.UpdateStatus(grbFromCluster)

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -211,7 +211,7 @@ func TestCreateUpdate(t *testing.T) {
 					GlobalRoleName: gr.Name,
 					UserName:       userName,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
 						LocalConditions: []metav1.Condition{
 							{
@@ -333,7 +333,7 @@ func TestCreateUpdate(t *testing.T) {
 					GlobalRoleName: gr.Name,
 					UserName:       userName,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
 						LocalConditions: []metav1.Condition{
 							{
@@ -444,7 +444,7 @@ func TestCreateUpdate(t *testing.T) {
 					GlobalRoleName: gr.Name,
 					UserName:       userName,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryError,
 						Summary:        status.SummaryError,
 						LocalConditions: []metav1.Condition{
@@ -553,7 +553,7 @@ func TestCreateUpdate(t *testing.T) {
 					GlobalRoleName: gr.Name,
 					UserName:       userName,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryError,
 						Summary:        status.SummaryError,
 						LocalConditions: []metav1.Condition{
@@ -663,7 +663,7 @@ func TestCreateUpdate(t *testing.T) {
 					GlobalRoleName: gr.Name,
 					UserName:       userName,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryError,
 						Summary:        status.SummaryError,
 						LocalConditions: []metav1.Condition{
@@ -770,7 +770,7 @@ func TestCreateUpdate(t *testing.T) {
 					GlobalRoleName: gr.Name,
 					UserName:       userName,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
 						LocalConditions: []metav1.Condition{
 							{

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -268,7 +268,7 @@ func (c *crtbLifecycle) updateStatus(crtb *v3.ClusterRoleTemplateBinding, remote
 			}
 		}
 
-		crtbFromCluster.Status.LastUpdateTime = timeNow().String()
+		crtbFromCluster.Status.LastUpdateTime = timeNow().Format(time.RFC3339)
 		crtbFromCluster.Status.ObservedGenerationRemote = crtb.ObjectMeta.Generation
 		crtbFromCluster.Status.RemoteConditions = remoteConditions
 		crtbFromCluster, err = c.crtbClient.UpdateStatus(crtbFromCluster)

--- a/pkg/controllers/managementuser/rbac/crtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler_test.go
@@ -318,7 +318,7 @@ func TestUpdateStatus(t *testing.T) {
 					},
 				},
 			},
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbClusterRoleBindingExists := &v3.ClusterRoleTemplateBinding{
@@ -333,7 +333,7 @@ func TestUpdateStatus(t *testing.T) {
 					},
 				},
 			},
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbSubjectError := &v3.ClusterRoleTemplateBinding{
@@ -348,17 +348,17 @@ func TestUpdateStatus(t *testing.T) {
 					},
 				},
 			},
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbEmptyStatus := &v3.ClusterRoleTemplateBinding{
 		Status: v3.ClusterRoleTemplateBindingStatus{
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 		},
 	}
 	crtbEmptyStatusLocalComplete := &v3.ClusterRoleTemplateBinding{
 		Status: v3.ClusterRoleTemplateBindingStatus{
-			LastUpdateTime: mockTime.String(),
+			LastUpdateTime: mockTime.Format(time.RFC3339),
 			SummaryLocal:   status.SummaryCompleted,
 		},
 	}
@@ -385,7 +385,7 @@ func TestUpdateStatus(t *testing.T) {
 							},
 						},
 						SummaryRemote:  status.SummaryCompleted,
-						LastUpdateTime: mockTime.String(),
+						LastUpdateTime: mockTime.Format(time.RFC3339),
 					},
 				})
 
@@ -420,7 +420,7 @@ func TestUpdateStatus(t *testing.T) {
 						SummaryRemote:  status.SummaryCompleted,
 						SummaryLocal:   status.SummaryCompleted,
 						Summary:        status.SummaryCompleted,
-						LastUpdateTime: mockTime.String(),
+						LastUpdateTime: mockTime.Format(time.RFC3339),
 					},
 				})
 
@@ -446,7 +446,7 @@ func TestUpdateStatus(t *testing.T) {
 						},
 						SummaryRemote:  status.SummaryError,
 						Summary:        status.SummaryError,
-						LastUpdateTime: mockTime.String(),
+						LastUpdateTime: mockTime.Format(time.RFC3339),
 					},
 				})
 

--- a/pkg/controllers/managementuser/rbac/globalrolebinding_handler.go
+++ b/pkg/controllers/managementuser/rbac/globalrolebinding_handler.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/rancher/norman/types/slice"
 	apisv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -214,7 +215,7 @@ func (c *grbHandler) updateStatus(grb *apisv3.GlobalRoleBinding, remoteCondition
 				break
 			}
 		}
-		grbFromCluster.Status.LastUpdateTime = c.status.TimeNow().String()
+		grbFromCluster.Status.LastUpdateTime = c.status.TimeNow().Format(time.RFC3339)
 		grbFromCluster.Status.ObservedGenerationRemote = grb.ObjectMeta.Generation
 		grbFromCluster.Status.RemoteConditions = remoteConditions
 		grbFromCluster, err = c.grbClient.UpdateStatus(grbFromCluster)

--- a/pkg/controllers/managementuser/rbac/globalrolebinding_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/globalrolebinding_handler_test.go
@@ -69,7 +69,7 @@ func TestSync(t *testing.T) {
 				state.grbClientMock.EXPECT().UpdateStatus(&v3.GlobalRoleBinding{
 					GlobalRoleName: rbac.GlobalAdmin,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryRemote:  status.SummaryCompleted,
 						RemoteConditions: []metav1.Condition{
 							{
@@ -113,7 +113,7 @@ func TestSync(t *testing.T) {
 				state.grbClientMock.EXPECT().UpdateStatus(&v3.GlobalRoleBinding{
 					GlobalRoleName: rbac.GlobalAdmin,
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryRemote:  status.SummaryCompleted,
 						RemoteConditions: []metav1.Condition{
 							{
@@ -146,7 +146,7 @@ func TestSync(t *testing.T) {
 				state.grbClientMock.EXPECT().UpdateStatus(&v3.GlobalRoleBinding{
 					GlobalRoleName: "gr",
 					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().String(),
+						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryRemote:  status.SummaryCompleted,
 					},
 				})


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/44663
 
Update the `CRTB` and `GRB` Status fields to ensure the `lastUpdatedTime` format matches the format of other fields by using `time.RFC3339`