### PR TITLE
[Backport v2.9][CHART] Support additional taints tolerations

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms: {{ include "linux-node-selector-terms" . | nindent 14 }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+{{- if .Values.extraTolerations }}
+{{ toYaml .Values.extraTolerations | indent 8 }}
+{{- end }}
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -545,3 +545,12 @@ tests:
         content:
           name: CATTLE_NAMESPACE
           value: NAMESPACE
+- it: sets extraTolerations
+  set:
+    extraTolerations:
+      - key: "node.cloudprovider.kubernetes.io/uninitialized"
+        value: "true"
+        effect: "NoSchedule"
+  asserts:
+    - exists:
+        path: spec.template.spec.tolerations[1]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -181,6 +181,10 @@ startupProbe:
   timeoutSeconds: 5
   periodSeconds: 10
   failureThreshold: 12
+
+# Additional taints to tolerate
+extraTolerations: {}
+
 livenessProbe:
   timeoutSeconds: 5
   periodSeconds: 30


### PR DESCRIPTION
A backport of recent chart change: https://github.com/rancher/rancher/pull/47038