### PR TITLE
[v2.10] [aks-operator] List only supported Kubernetes versions

### DIFF
--- a/pkg/api/norman/customization/aks/listers.go
+++ b/pkg/api/norman/customization/aks/listers.go
@@ -287,8 +287,14 @@ func listKubernetesVersions(ctx context.Context, cap *Capabilities) ([]byte, int
 
 	var kubernetesVersions []string
 	for _, v := range res.Values {
-		for version := range v.PatchVersions {
-			kubernetesVersions = append(kubernetesVersions, version)
+		if v.Capabilities.SupportPlan != nil {
+			for _, supportPlan := range v.Capabilities.SupportPlan {
+				if *supportPlan == armcontainerservice.KubernetesSupportPlanKubernetesOfficial {
+					for version := range v.PatchVersions {
+						kubernetesVersions = append(kubernetesVersions, version)
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
We want to list only official Kubernetes versions and skip LTS which required additional paid support in Azure

Issue: https://github.com/rancher/aks-operator/issues/717 (cherry picked from commit f9879edd52f3df6ee678eb56d25e2be698b2ab81)

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_