### PR TITLE
[2.9] [48441] Add stv-aggregation secret to system-agent-upgrader suc plan

### DIFF
--- a/pkg/controllers/capr/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagent.go
@@ -281,6 +281,12 @@ func installer(cluster *rancherv1.Cluster, secretName string) []runtime.Object {
 				},
 			},
 			ServiceAccountName: systemAgentUpgraderServiceAccountName,
+			// envFrom is still the source of CATTLE_ vars in plan, however secrets will trigger an update when changed.
+			Secrets: []upgradev1.SecretSpec{
+				{
+					Name: "stv-aggregation",
+				},
+			},
 			Upgrade: &upgradev1.ContainerSpec{
 				Image: image.ResolveWithCluster(upgradeImage[0], cluster),
 				Env:   env,
@@ -340,6 +346,9 @@ func installer(cluster *rancherv1.Cluster, secretName string) []runtime.Object {
 		},
 	}
 
+	// The stv-aggregation secret is managed separately, and SUC will trigger a plan upgrade automatically when the
+	// secret is updated. This prevents us from having to manually update the plan every time the secret changes
+	// (which is not often, and usually never).
 	if cluster.Spec.RedeploySystemAgentGeneration != 0 {
 		plan.Spec.Secrets = append(plan.Spec.Secrets, upgradev1.SecretSpec{
 			Name: generationSecretName,


### PR DESCRIPTION
Backport of #48569

## Issue: <!-- link the issue or issues this PR resolves here --> #48441
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When the `stv-aggregation` secret changes, which is used to populate the `system-agent-upgrader` SUC plan, SUC will not check the contents of the secret, and thus the plan will not be updated.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Utilize the `secrets` feature within SUC.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, confirming the values from the secret were used and changing the secret results in the plan being applied.