### PR TITLE
Add timeout when checking if a S3 bucket exists

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -229,6 +229,10 @@ var (
 	// debug purposes.
 	RKE2ChartDefaultURL = NewSetting("rke2-chart-default-url", "https://git.rancher.io/")
 
+	// S3BucketCheckTimeout is the timeout for checking if an s3 bucket for etcd backups exists,
+	// in the go duration string format.
+	S3BucketCheckTimeout = NewSetting("s3-bucket-check-timeout", "30s")
+
 	// SystemDefaultRegistry is the default container registry used for images.
 	// The environmental variable "CATTLE_BASE_REGISTRY" controls the default value of this setting.
 	SystemDefaultRegistry = NewSetting("system-default-registry", os.Getenv("CATTLE_BASE_REGISTRY"))


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43720
 
## Problem
When creating or updating a RKE1 cluster configured with a S3 bucket for storing ETCD backups, the store functions check if the bucket exists. This was done without a timeout, so if S3 wasn't reachable, it could take a long and system-dependent time for the check to fail. These functions hold a lock while doing this check, as part of a mechanism for ensuring unique cluster names. This meant that no new cluster could be created as long as the the request didn't fail and the lock was held.
 
## Solution
This commit adds a 30s timeout to the check, and a setting for this timeout so that users in laggy environments can easily increase it if needed.
 
## Testing

## Engineering Testing
### Manual Testing
1. Checked if normal cluster creation with S3 etcd backups works: created cluster, created a snapshot, and checked if the snapshot appears in the S3 web console.
2. Blocked S3 and created cluster, checked that an error message appears after 30s (the new default timeout).
3. Created a new cluster, without S3 etcd buckets, checked that it works (which means the lock was no longer held).
4. Changed timeout setting to an invalid duration, checked that the error message was logged, and that failure happened at 30s.
5. Changed timeout setting to 5s (using kubectl), checked that cluster creation fails after 5s, while s3 is still blocked.
6. Unblocked s3, tried again, checked that it worked: checked that the snapshot appears in s3.

### Automated Testing
* Test types added/modified:
    * None
* If "None" - Reason: No existing unit tests for the affected file to add to, and blocking S3 on an automated integration test is non-trivial.

## QA Testing Considerations

I recommend following the script from "Engineering Testing" above. Step 3 should be done right after step 2 is done, to validate that the lock wasn't being held anymore (without this PR, the lock might be released after a very long time).

A few points:
- Make sure the cluster being created to test this is RKE1, only in this case the buggy code is executed. Configure S3 ETCD backups in the "advanced options" part. The cluster itself doesn't need to be on AWS, only the backups.
- When checking the timeout, verify that an error message is shown in the UI, it should say something ending in "context deadline exceeded".
- There are many system-specific ways to block access to S3, but it's important for this to cause a timeout, and not cause the connection to return immediately in error.