### PR TITLE
[2.10] Backport norman bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rancher/lasso v0.0.0-20240924233157-8f384efc8813
 	github.com/rancher/machine v0.15.0-rancher124
-	github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab
+	github.com/rancher/norman v0.5.1
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.4.0
 	github.com/rancher/rke v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/rancher/machine v0.15.0-rancher124 h1:Z/ucp6A48HvqtzWyeGkl9FtiRa8Xafk
 github.com/rancher/machine v0.15.0-rancher124/go.mod h1:9rlwC2p8rZUzJ2u3hunI6nMrPn2qPV9vmIOSmPXqOE4=
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77 h1:k+vzmkZQsH06rZnDr+phskSixG9ByNj9gVdzHcc8nxw=
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
-github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab h1:ihK6See3y/JilqZlc0CG7NXPN+ue5nY9U7xUZUA8M7I=
-github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab/go.mod h1:qX/OG/4wY27xSAcSdRilUBxBumV6Ey2CWpAeaKnBQDs=
+github.com/rancher/norman v0.5.1 h1:jbp49IcX2Hn+N2QA3MHdIXeUG0VgCSIjJs4xnqG+j90=
+github.com/rancher/norman v0.5.1/go.mod h1:qX/OG/4wY27xSAcSdRilUBxBumV6Ey2CWpAeaKnBQDs=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa/go.mod h1:NP3xboG+t2p+XMnrcrJ/L384Ki0Cp3Pww/X+vm5Jcy0=
 github.com/rancher/remotedialer v0.4.0 h1:T9yC5bFMsZFVQ6rK0dNrRg6rRb6Zr/4vsig8S0IJ7ak=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/rancher/eks-operator v1.10.1
 	github.com/rancher/fleet/pkg/apis v0.11.3-beta.1
 	github.com/rancher/gke-operator v1.10.1
-	github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab
+	github.com/rancher/norman v0.5.1
 	github.com/rancher/rke v1.7.1
 	github.com/rancher/wrangler/v3 v3.1.0
 	github.com/sirupsen/logrus v1.9.3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -92,8 +92,8 @@ github.com/rancher/gke-operator v1.10.1 h1:f6B7gqXmKxA0rMP7jE0r68NsEvmMQTF4dhnG7
 github.com/rancher/gke-operator v1.10.1/go.mod h1:sJ0vHrrkDjJZrCOwIKTaaSuPTqrWD1wOr16qlVAM+yQ=
 github.com/rancher/lasso v0.0.0-20240924233157-8f384efc8813 h1:V/LY8pUHZG9Kc+xEDWDOryOnCU6/Q+Lsr9QQEQnshpU=
 github.com/rancher/lasso v0.0.0-20240924233157-8f384efc8813/go.mod h1:IxgTBO55lziYhTEETyVKiT8/B5Rg92qYiRmcIIYoPgI=
-github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab h1:ihK6See3y/JilqZlc0CG7NXPN+ue5nY9U7xUZUA8M7I=
-github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab/go.mod h1:qX/OG/4wY27xSAcSdRilUBxBumV6Ey2CWpAeaKnBQDs=
+github.com/rancher/norman v0.5.1 h1:jbp49IcX2Hn+N2QA3MHdIXeUG0VgCSIjJs4xnqG+j90=
+github.com/rancher/norman v0.5.1/go.mod h1:qX/OG/4wY27xSAcSdRilUBxBumV6Ey2CWpAeaKnBQDs=
 github.com/rancher/rke v1.7.1 h1:P+YhuquNNVdafCYvCX9UhK4P8zpoczU9BCJKp08Lb3w=
 github.com/rancher/rke v1.7.1/go.mod h1:+x++Mvl0A3jIzNLiu8nkraqZXiHg6VPWv0Xl4iQCg+A=
 github.com/rancher/wrangler/v3 v3.1.0 h1:8ETBnQOEcZaR6WBmUSysWW7WnERBOiNTMJr4Dj3UG/s=


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/48480

Backporting changes made in https://github.com/rancher/rancher/pull/48537
 

> Issue:
> https://github.com/rancher/rancher/issues/47694
> 
> Problem
> Outdated version of rancher/norman
> 
> Solution
> Bump version to include https://github.com/rancher/norman/pull/523
> 
> Testing
> Engineering Testing
> Manual Testing
> Install and run rancher with no downstream clusters and pprof enabled
> Take a pprof profile
> Edit the nodeconfig dynamicschema in some way (eg adding a foo: bar annotation)
> Wait for 30-60s
> Take another pprof profile
> Check pprof for increase in types.(*Schemas).embed from the first profile to the second
> Automated Testing
> Test types added/modified:
> Unit
> Integration (Go Framework)
> Integration (v2prov Framework)
> Validation (Go Framework)
> Other - Explain: EXPLAIN
> None
> REMOVE NOT APPLICABLE BULLET POINTS ABOVE
> If "None" - Reason: EXPLAIN THE REASON
> If "None" - GH Issue/PR: LINK TO GH ISSUE/PR TO ADD TESTS
> Summary: TODO
> 
> QA Testing Considerations
> Regressions Considerations
> TODO
> 
> Existing / newly added automated tests that provide evidence there are no regressions:
> 
> TODO