### PR TITLE
[Main] Bump wins to `v0.5.0-rc.1`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -65,7 +65,7 @@ ENV LINODE_UI_DRIVER_VERSION v0.7.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
 ENV DOCKER_MACHINE_HARVESTER_VERSION v0.7.1
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
-ENV CATTLE_WINS_AGENT_VERSION v0.4.20
+ENV CATTLE_WINS_AGENT_VERSION v0.5.0-rc.1
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}

--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -17,7 +17,7 @@ RUN go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o agent.exe ./cmd/agent
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION} AS builder
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.4.20/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.5.0-rc.1/wins.exe'; \
     \
     Write-Host ('Downloading Wins from {0} ...' -f $URL); \
     curl.exe -sfL $URL -o c:\wins.exe; \

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -104,7 +104,7 @@ var (
 	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
 	CSIProxyAgentURL                    = NewSetting("csi-proxy-agent-url", "https://acs-mirror.azureedge.net/csi-proxy/%[1]s/binaries/csi-proxy-%[1]s.tar.gz")
 	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://github.com/rancher/system-agent/releases/download/v0.3.11/install.sh") // To ensure consistency between SystemAgentInstallScript default value and CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT to utilize the local system-agent-install.sh script when both values are equal.
-	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.4.20/install.ps1")
+	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.5.0-rc.1/install.ps1")
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "") // Defined via environment variable
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")   // Defined via environment variable
 	WinsAgentUpgradeImage               = NewSetting("wins-agent-upgrade-image", "")

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -60,7 +60,7 @@ ENV LINODE_UI_DRIVER_VERSION v0.7.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
 ENV DOCKER_MACHINE_HARVESTER_VERSION v0.6.7
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
-ENV CATTLE_WINS_AGENT_VERSION v0.4.20
+ENV CATTLE_WINS_AGENT_VERSION v0.5.0-rc.1
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/47652

## Problem

Unlike Linux, Windows nodes do not currently upgrade the installed version of the rancher-wins (and thus the system-agent) alongside Rancher upgrades. This is problematic in cases where a given version of Rancher relies on functionality recently added to the system-agent installed on Windows nodes.
 
## Solution
The rancher-wins SUC image has been enhanced to automatically upgrade the installed version if it differs from the version embedded within the currently running version of Rancher. This ensures that nodes are always running the correct version of `rancher-wins` (and thus the `system-agent`) for the given version of Rancher
 
## Testing
+ Setup a released version of Rancher and manually override the `CATTLE_WINS_AGENT_UPGRADE_IMAGE` environment variable to point to `rancher/wins:v0.5.0-rc.1`
    + Using a released version of Rancher ensures that an older version of `rancher-wins` is initially installed
+ Provision a Windows cluster
+ Once the Windows node becomes available, monitor the deployed pods until the SUC job is deployed
+ View the SUC pod logs to confirm that the upgrade was performed as expected
+ SSH or RDP into the Windows node and confirm that `C:\Windows\wins.exe --version` and `C:\etc\rancher\wins\wins.exe --version` returns the expected version (`v0.5.0-rc.1`) 

+ Using a version of Rancher which includes this change, setup a Windows cluster
+ Once the Windows node becomes available, monitor the deployed pods until the SUC job is deployed
+ View the SUC pod logs to confirm that the upgrade was not performed, as the version is already up to date
+ SSH or RDP into the Windows node and confirm that `C:\Windows\wins.exe --version` and `C:\etc\rancher\wins\wins.exe --version` return the expected version (`v0.5.0-rc.1`) 

## Engineering Testing
### Manual Testing
I've done the above 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary:  None, several integration tests have been added directly to rancher/wins

## QA Testing Considerations

This aligns the version of wins installed with the version embedded within Rancher, which includes the potential to downgrade the version if Rancher is downgraded. However, this case cannot currently be tested as there are no previous versions of Rancher which contain the required rancher-wins changes. Ultimately, the process is upgrading and downgrading is the same, but this is still something to consider when drafting the test plan. 

### Regressions Considerations
