### PR TITLE
[main] Fix the image registries for the system-upgrade-controller chart in imported clusters

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -291,10 +291,16 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": "",
+						}},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher-test.io/rancher/system-upgrade-controller",
 						},
 					},
-					"image": map[string]interface{}{
-						"repository": "rancher-test.io/rancher/system-upgrade-controller",
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher-test.io/rancher/kubectl",
+						},
 					},
 				}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/48564 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Since Rancher 2.10, the `system-upgrade-controller` chart is installed into the imported cluster via the systemcharts mechanism.

The `system-upgrade-controller` chart uses two images, which are defined in the values file with the following structure:

```yaml
systemUpgradeController:
  image:
    repository: rancher/system-upgrade-controller
    tag: v0.14.2

kubectl:
  image:
    repository: rancher/kubectl
    tag: v1.31.1
```

Rancher expects the `image` field to be at the top level so that it can append the system registry to the image name correctly:

```yaml
image:
  repository: registry.rancher.com/rancher/system-upgrade-controller
```

Because the structure of the values in this chart differs from the expected format, the private registry is not properly appended to the image names. As a result, Rancher can install the chart in the imported cluster, but the pods fail with an `ErrImagePull` error.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

To resolve the issue, the correct image name which is prefixed with the private registry is generated and set directly in the chart definition, rather than relying on Rancher to inject the values.

Additionally, the logic is updated to skip appending the `image` field to the values when it is unnecessary. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The PR has been tested on a local build, with a workaround applied to set the `ClusterRegistry` in Rancher's configuration, allowing it to handle the local cluster in the same way as a normal imported cluster.

Below are the values passed to the `system-upgrade-controller` app **before** the change:

<img width="1468" alt="Screenshot 2025-01-08 at 9 28 28 AM" src="https://github.com/user-attachments/assets/e8ffa048-3a32-4c65-aa2f-8d3ed3c68f18" />

Below are the values passed to the `system-upgrade-controller` app **after** the change:

<img width="964" alt="Screenshot 2025-01-08 at 4 32 08 PM" src="https://github.com/user-attachments/assets/0b1fa6db-30c5-48c1-b7e9-7adeaecfd39e" />


 
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
The same scenario is provided in the issue:

- Run Rancher in an air-gapped environment with a custom registry
- Set the system-default-registry to the custom registry URI (e.g. docker.example.com)
- Create a RKE2 v1.30.3 cluster in this environment
- Import the RKE2 cluster into Rancher (as a generic cluster)
- Confirm the app is installed successfully using the images from the private registry
- Attempt to kick off an upgrade to a higher version via the Cluster Management UI (e.g. to v1.30.7)
- Confirm the upgrade success


### Regressions Considerations

- Confirm all other managed charts, namely `rancher-webhook` and `rancher-provisioning-capi`, are not affected by this change. 
