### PR TITLE
[2.10] Fix the image registries for the system-upgrade-controller chart in imported clusters

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -291,10 +291,16 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": "",
+						}},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher-test.io/rancher/system-upgrade-controller",
 						},
 					},
-					"image": map[string]interface{}{
-						"repository": "rancher-test.io/rancher/system-upgrade-controller",
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher-test.io/rancher/kubectl",
+						},
 					},
 				}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/48570 

cherry-pick  of https://github.com/rancher/rancher/pull/48633 

Please check the original PR for more information 


--------------

Notes: **the CI failure is not related to the changes in the PR**. 