### PR TITLE
[HotFix] Rancher should skip charts from OCI if it doesn't have access to #48408

### DIFF
--- a/pkg/catalogv2/oci/client_test.go
+++ b/pkg/catalogv2/oci/client_test.go
@@ -76,11 +76,13 @@ func spinRegistry(layerSize int, chartMediaType, helmManifest bool, testcaseName
 
 		switch r.URL.Path {
 		case "/v2/_catalog":
-			t := `{"repositories": ["testingchart"]}`
+			t := `{"repositories": ["testingchart", "testingchart2"]}`
 			w.Write([]byte(t))
-
 		case "/v2/testingchart/tags/list":
 			t := `{"tags": ["0.1.0","0.0.1","sha256"]}`
+			w.Write([]byte(t))
+		case "/v2/testingchart2/tags/list":
+			t := `{"tags": ["0.1.0"]}`
 			w.Write([]byte(t))
 		case "/v2/testingchart/blobs/" + configDesc.Digest.String():
 			t.FailNow()
@@ -102,6 +104,9 @@ func spinRegistry(layerSize int, chartMediaType, helmManifest bool, testcaseName
 			if _, err := w.Write(manifestJSON); err != nil {
 				assert.NoError(t, err)
 			}
+		case "/v2/testingchart2/manifests/0.1.0":
+			w.WriteHeader(http.StatusForbidden)
+			return
 		}
 	}))
 


### PR DESCRIPTION
The support has requested for a hotfix. 

This PR is related to https://github.com/rancher/rancher/pull/48408.

### Summary 

The OCI Repo when indexing will start ignoring instead of erroring out the charts that the user has no access to. This way even if the user has no SUSE AI subscription can add AppCo successfully. 