### PR TITLE
[main] run custodian on vpn'd node to avoid aws region errors

### DIFF
--- a/tests/scripts/custodian/Dockerfile
+++ b/tests/scripts/custodian/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 WORKDIR /usr/app/src
 
 ARG AWS_ACCESS_KEY_ID
@@ -38,7 +38,7 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 RUN python3 -m venv custodian-venv
 RUN . custodian-venv/bin/activate
-RUN pip3 install c7n c7n_azure c7n_gcp c7n_mailer
+RUN pip3 install c7n c7n_azure c7n_gcp c7n_mailer --break-system-packages
 
 RUN az login -u ${AZURE_CLIENT_ID} --service-principal -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} > /dev/null
 RUN gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS > /dev/null
@@ -48,11 +48,11 @@ CMD for i in `ls *.yaml`; \
     echo $USER_KEYS; \
     for i in `ls *.yaml`; \
     do cat $i | sed -e 's/DONOTDELETEKEYS/'"${DONOTDELETE_KEYS}"'/g' -i $i; done; \
-    if [ "$CUSTODIAN_YAML" = "aws.yaml" ] ; then \
-    custodian run --output-dir=. --region="us-east-2" --dry-run ${CUSTODIAN_YAML}; \
-    custodian run --output-dir=. --region="us-east-1" --dry-run ${CUSTODIAN_YAML}; \
-    custodian run --output-dir=. --region="us-west-1" --dry-run ${CUSTODIAN_YAML}; \
-    custodian run --output-dir=. --region="us-west-2" --dry-run ${CUSTODIAN_YAML}; \
+    if [ "$CUSTODIAN_YAML" = "aws.yaml" || "$CUSTODIAN_YAML" = "untag-to-delete.yaml"] ; then \
+    custodian run --output-dir=. --region="us-east-2" ${CUSTODIAN_YAML}; \
+    custodian run --output-dir=. --region="us-east-1" ${CUSTODIAN_YAML}; \
+    custodian run --output-dir=. --region="us-west-1" ${CUSTODIAN_YAML}; \
+    custodian run --output-dir=. --region="us-west-2" ${CUSTODIAN_YAML}; \
     elif [ "$CUSTODIAN_YAML" = "tag-to-save.yaml" ] ; then \
-    custodian run --output-dir=. --region=$OVERRIDE_REGION --dry-run ${CUSTODIAN_YAML};  \
-    else custodian run --output-dir=. --dry-run ${CUSTODIAN_YAML}; fi; 
+    custodian run --output-dir=. --region=$OVERRIDE_REGION ${CUSTODIAN_YAML};  \
+    else custodian run --output-dir=. ${CUSTODIAN_YAML}; fi; 

--- a/tests/scripts/custodian/Dockerfile
+++ b/tests/scripts/custodian/Dockerfile
@@ -48,7 +48,7 @@ CMD for i in `ls *.yaml`; \
     echo $USER_KEYS; \
     for i in `ls *.yaml`; \
     do cat $i | sed -e 's/DONOTDELETEKEYS/'"${DONOTDELETE_KEYS}"'/g' -i $i; done; \
-    if [ "$CUSTODIAN_YAML" = "aws.yaml" || "$CUSTODIAN_YAML" = "untag-to-delete.yaml"] ; then \
+    if [ "$CUSTODIAN_YAML" = "aws.yaml" || "$CUSTODIAN_YAML" = "untag-to-delete.yaml" ] ; then \
     custodian run --output-dir=. --region="us-east-2" ${CUSTODIAN_YAML}; \
     custodian run --output-dir=. --region="us-east-1" ${CUSTODIAN_YAML}; \
     custodian run --output-dir=. --region="us-west-1" ${CUSTODIAN_YAML}; \

--- a/tests/scripts/custodian/Jenkinsfile
+++ b/tests/scripts/custodian/Jenkinsfile
@@ -1,21 +1,22 @@
 #!groovy
-node {
+
+node("vsphere-vpn-1") {
   def rootPath = "/root/go/src/github.com/rancher/rancher/tests/scripts/"
   def job_name = "${JOB_NAME}"
-  if (job_name.contains('/')) { 
+  if (job_name.contains('/')) {
     job_names = job_name.split('/')
-    job_name = job_names[job_names.size() - 1] 
+    job_name = job_names[job_names.size() - 1]
   }
   def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
   def imageName = "qa-custodian-${job_name}${env.BUILD_NUMBER}"
   def testResultsOut = "results.xml"
   def envFile = ".env"
   def rancherConfig = "rancher_env.config"
-  def awsYaml="aws.yaml"
-  def azureYaml="azure.yaml"
-  def gcpYaml="gcp.yaml"
+  def awsYaml = "aws.yaml"
+  def azureYaml = "azure.yaml"
+  def gcpYaml = "gcp.yaml"
   if ("${env.CUSTODIAN_YAML}" != "null" && "${env.CUSTODIAN_YAML}" != "") {
-    yamlToRun="${env.CUSTODIAN_YAML}"
+    yamlToRun = "${env.CUSTODIAN_YAML}"
   }
   def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
@@ -23,64 +24,70 @@ node {
   }
   def repo = scm.userRemoteConfigs
   if ("${env.REPO}" != "null" && "${env.REPO}" != "") {
-    repo = [[url: "${env.REPO}"]]
+    repo = [
+      [url: "${env.REPO}"]
+    ]
   }
   withFolderProperties {
     paramsMap = []
     params.each {
       if (it.value && it.value.trim() != "") {
-          paramsMap << "$it.key=$it.value"
+        paramsMap << "$it.key=$it.value"
       }
     }
     withEnv(paramsMap) {
-      withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
-                        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+      withCredentials([string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
 
-                        string(credentialsId: 'DONOTDELETE_KEYS', variable: 'DONOTDELETE_KEYS'),
-                        string(credentialsId: 'USER_KEYS', variable: 'USER_KEYS'),
+        string(credentialsId: 'DONOTDELETE_KEYS', variable: 'DONOTDELETE_KEYS'),
+        string(credentialsId: 'USER_KEYS', variable: 'USER_KEYS'),
 
-                        string(credentialsId: 'AZURE_AKS_SUBSCRIPTION_ID', variable: 'AZURE_AKS_SUBSCRIPTION_ID'),
-                        string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
-                        string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
-                        string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+        string(credentialsId: 'AZURE_AKS_SUBSCRIPTION_ID', variable: 'AZURE_AKS_SUBSCRIPTION_ID'),
+        string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
+        string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+        string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
 
-                        string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+        string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
 
-                        string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
+        string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")
+      ]) {
         stage('Checkout') {
           deleteDir()
           checkout([
-                    $class: 'GitSCM',
-                    branches: [[name: "*/${branch}"]],
-                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
-                    userRemoteConfigs: repo
-                  ])
+            $class: 'GitSCM',
+            branches: [
+              [name: "*/${branch}"]
+            ],
+            extensions: scm.extensions + [
+              [$class: 'CleanCheckout']
+            ],
+            userRemoteConfigs: repo
+          ])
         }
-        dir ("./tests/scripts/custodian/") {
+        dir("./tests/scripts/custodian/") {
           stage('Build Docker Image') {
             try {
               def decoded = new String(RANCHER_GKE_CREDENTIAL.decodeBase64())
               writeFile file: 'google_credentials.json', text: decoded
               sh "docker build -t ${imageName} -f Dockerfile . --build-arg AWS_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\" --build-arg AWS_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\" --build-arg AZURE_AKS_SUBSCRIPTION_ID=\"${AZURE_AKS_SUBSCRIPTION_ID}\" --build-arg AZURE_TENANT_ID=\"${AZURE_TENANT_ID}\" --build-arg AZURE_CLIENT_ID=\"${AZURE_CLIENT_ID}\" --build-arg AZURE_CLIENT_SECRET=\"${AZURE_CLIENT_SECRET}\" --build-arg RANCHER_LINODE_ACCESSKEY=\"${RANCHER_LINODE_ACCESSKEY}\""
-            }
-          catch(err) {
-                  echo 'Docker Build had partial failures...'
-                  echo "${err}"
+            } catch (err) {
+              echo 'Docker Build had partial failures...'
+              echo "${err}"
             }
           }
           stage('Run Docker Image for Adding Tags') {
-              // if a user only wants to run the test using a subset of keys, they can pass in OVERRIDE_REGION
-              if ("${env.OVERRIDE_REGION}" != "null" && "${env.OVERRIDE_REGION}" != "") {
+            // if a user only wants to run the test using a subset of keys, they can pass in OVERRIDE_REGION
+            if ("${env.OVERRIDE_REGION}" != "null" && "${env.OVERRIDE_REGION}" != "") {
               sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"add-friday-tags.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName} "
-              } else {
-                echo "No OVERRIDE_REGION passed in, running all tests"
-              }
+            } else {
+              echo "No OVERRIDE_REGION passed in, running all tests"
+            }
           }
-          stage('Run Docker Image for AWS,Azure, and GCP'){
+          stage('Run Docker Image for AWS,Azure, and GCP') {
             sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${CUSTODIAN_YAML}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName}"
           }
         } // dir 
       } // creds
     } // folder properties
-  } 
-}// node
+  }
+} // node

--- a/tests/scripts/custodian/Jenkinsfile
+++ b/tests/scripts/custodian/Jenkinsfile
@@ -79,7 +79,7 @@ node("vsphere-vpn-1") {
             stage('Run Docker Image for Adding Tags') {
               // if a user only wants to run the test using a subset of keys, they can pass in OVERRIDE_REGION
               if ("${env.OVERRIDE_REGION}" != "null" && "${env.OVERRIDE_REGION}" != "") {
-                sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"tag-to-save.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName} "
+                sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"tag-to-save.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${TAG_USER_KEYS}\" ${imageName} "
               } else {
                 echo "No OVERRIDE_REGION passed in, running all tests"
               }

--- a/tests/scripts/custodian/Jenkinsfile
+++ b/tests/scripts/custodian/Jenkinsfile
@@ -65,27 +65,35 @@ node("vsphere-vpn-1") {
           ])
         }
         dir("./tests/scripts/custodian/") {
-          stage('Build Docker Image') {
-            try {
-              def decoded = new String(RANCHER_GKE_CREDENTIAL.decodeBase64())
-              writeFile file: 'google_credentials.json', text: decoded
-              sh "docker build -t ${imageName} -f Dockerfile . --build-arg AWS_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\" --build-arg AWS_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\" --build-arg AZURE_AKS_SUBSCRIPTION_ID=\"${AZURE_AKS_SUBSCRIPTION_ID}\" --build-arg AZURE_TENANT_ID=\"${AZURE_TENANT_ID}\" --build-arg AZURE_CLIENT_ID=\"${AZURE_CLIENT_ID}\" --build-arg AZURE_CLIENT_SECRET=\"${AZURE_CLIENT_SECRET}\" --build-arg RANCHER_LINODE_ACCESSKEY=\"${RANCHER_LINODE_ACCESSKEY}\""
-            } catch (err) {
-              echo 'Docker Build had partial failures...'
-              echo "${err}"
+          try {
+            stage('Build Docker Image') {
+              try {
+                def decoded = new String(RANCHER_GKE_CREDENTIAL.decodeBase64())
+                writeFile file: 'google_credentials.json', text: decoded
+                sh "docker build -t ${imageName} -f Dockerfile . --build-arg AWS_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\" --build-arg AWS_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\" --build-arg AZURE_AKS_SUBSCRIPTION_ID=\"${AZURE_AKS_SUBSCRIPTION_ID}\" --build-arg AZURE_TENANT_ID=\"${AZURE_TENANT_ID}\" --build-arg AZURE_CLIENT_ID=\"${AZURE_CLIENT_ID}\" --build-arg AZURE_CLIENT_SECRET=\"${AZURE_CLIENT_SECRET}\" --build-arg RANCHER_LINODE_ACCESSKEY=\"${RANCHER_LINODE_ACCESSKEY}\""
+              } catch (err) {
+                echo 'Docker Build had partial failures...'
+                echo "${err}"
+              }
             }
-          }
-          stage('Run Docker Image for Adding Tags') {
-            // if a user only wants to run the test using a subset of keys, they can pass in OVERRIDE_REGION
-            if ("${env.OVERRIDE_REGION}" != "null" && "${env.OVERRIDE_REGION}" != "") {
-              sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"add-friday-tags.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName} "
-            } else {
-              echo "No OVERRIDE_REGION passed in, running all tests"
+            stage('Run Docker Image for Adding Tags') {
+              // if a user only wants to run the test using a subset of keys, they can pass in OVERRIDE_REGION
+              if ("${env.OVERRIDE_REGION}" != "null" && "${env.OVERRIDE_REGION}" != "") {
+                sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"tag-to-save.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName} "
+              } else {
+                echo "No OVERRIDE_REGION passed in, running all tests"
+              }
             }
+            stage('Run Docker Image for AWS,Azure, and GCP') {
+              sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${CUSTODIAN_YAML}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName}"
+            }
+          } catch (err) {
+            echo "error during custodian run"
           }
-          stage('Run Docker Image for AWS,Azure, and GCP') {
-            sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${CUSTODIAN_YAML}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName}"
-          }
+
+          sh "docker stop ${testContainer}"
+          sh "docker rm -v ${testContainer}"
+          sh "docker rmi -f ${imageName}"
         } // dir 
       } // creds
     } // folder properties


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/1634
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
aws custodian was giving errors when ran on jenkins, but not locally.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
since jenkins runs on aws nodes, the region the node was in affects which regions custodian could be checked against. Hard coding custodian to use the vpn'd node.

also updated the dockerfile to use 24.04
 