### PR TITLE
Fix go vet issues

### DIFF
--- a/pkg/controllers/management/auth/globalroles/fleetworkspace_binding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/fleetworkspace_binding_handler_test.go
@@ -98,7 +98,7 @@ func TestReconcileFleetWorkspacePermissionsBindings(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionTrue,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             fleetWorkspacePermissionReconciled,
 				},
 			},
@@ -127,7 +127,7 @@ func TestReconcileFleetWorkspacePermissionsBindings(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionTrue,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             fleetWorkspacePermissionReconciled,
 				},
 			},
@@ -254,7 +254,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToGetGlobalRole,
 					Message:            "GlobalRole.management.cattle.io \"gr\" not found",
 				},
@@ -273,7 +273,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileResourceRulesBindings,
 					Message:            "couldn't list fleetWorkspaces: unexpected error",
 				},
@@ -295,7 +295,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileResourceRulesBindings,
 					Message:            "couldn't create RoleBinding: unexpected error",
 				},
@@ -322,7 +322,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileResourceRulesBindings,
 					Message:            "couldn't delete RoleBinding: unexpected error",
 				},
@@ -350,7 +350,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileResourceRulesBindings,
 					Message:            "couldn't create RoleBinding: unexpected error",
 				},
@@ -372,7 +372,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "couldn't create ClusterRoleBinding: unexpected error",
 				},
@@ -397,7 +397,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "couldn't delete ClusterRoleBinding: unexpected error",
 				},
@@ -422,7 +422,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "unexpected error",
 				},
@@ -448,7 +448,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "unexpected error",
 				},
@@ -471,7 +471,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "couldn't delete ClusterRoleBinding: unexpected error",
 				},
@@ -492,7 +492,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "couldn't get ClusterRoleBinding: unexpected error",
 				},
@@ -513,7 +513,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "couldn't create ClusterRoleBinding: unexpected error",
 				},
@@ -534,7 +534,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "couldn't get ClusterRole: unexpected error",
 				},
@@ -563,7 +563,7 @@ func TestReconcileFleetWorkspacePermissionsBindings_errors(t *testing.T) {
 				{
 					Type:               fleetWorkspacePermissionReconciled,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.Time{mockTime()},
+					LastTransitionTime: metav1.NewTime(mockTime()),
 					Reason:             failedToReconcileWorkspaceVerbsBindings,
 					Message:            "couldn't clean up ClusterRoleBinding: unexpected error",
 				},

--- a/tests/pkg/serviceaccounttoken/mitigation_test.go
+++ b/tests/pkg/serviceaccounttoken/mitigation_test.go
@@ -107,7 +107,8 @@ func fakePopulateSecret(ctx context.Context, t *testing.T, k8sClient typedcorev1
 		LabelSelector: labels.Set(map[string]string{serviceaccounttoken.ServiceAccountSecretLabel: sa.GetName()}).String(),
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+		return
 	}
 	defer watcher.Stop()
 
@@ -141,7 +142,6 @@ func fakePopulateSecret(ctx context.Context, t *testing.T, k8sClient typedcorev1
 			t.Log("shutting down fake secret populator")
 			return
 		}
-
 	}
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

```
go vet ./...
# github.com/rancher/rancher/pkg/controllers/management/auth/globalroles
# [github.com/rancher/rancher/pkg/controllers/management/auth/globalroles]
pkg/controllers/management/auth/globalroles/fleetworkspace_binding_handler_test.go:101:26: k8s.io/apimachinery/pkg/apis/meta/v1.Time struct literal uses unkeyed fields
...
# github.com/rancher/rancher/tests/pkg/serviceaccounttoken
# [github.com/rancher/rancher/tests/pkg/serviceaccounttoken]
tests/pkg/serviceaccounttoken/mitigation_test.go:62:3: call to (*testing.T).Fatal from a non-test goroutine (fakePopulateSecret calls (*testing.T).Fatal)
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Fix issues identified by `go vet`

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A