### PR TITLE
Getting the k8s versions based on rancher version

### DIFF
--- a/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.ha
+++ b/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.ha
@@ -9,10 +9,13 @@ node {
       job_name = job_names[job_names.size() - 1] 
     }
 
+    def config = env.CONFIG
     def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
     def setupContainer = "${job_name}${env.BUILD_NUMBER}_setup"
     def configGeneratorContainer = "${job_name}${env.BUILD_NUMBER}_generator"
     def cleanupContainer = "${job_name}${env.BUILD_NUMBER}_cleanup"
+    def validationVolume = "ValidationSharedVolume-${job_name}${env.BUILD_NUMBER}"
+    def testRancherVersions = "testrancherk8s.yaml"
 
     def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
 
@@ -29,6 +32,7 @@ node {
     def rancherConfig = "rancher_env.config"
     def branch = "release/v2.8"
     def defaultTag = "validation"
+    def localConfigFileName = ""
 
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
@@ -111,23 +115,123 @@ node {
           dir ("./") {
             try {
               stage('Configure and Build') {
+                config = config.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)
+                config = config.replace('${AWS_ACCESS_KEY_ID}', env.AWS_ACCESS_KEY_ID)
                 if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
                   dir("./tests/v2/validation/.ssh") {
                     def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
                     writeFile file: AWS_SSH_KEY_NAME, text: decoded
                   }
                 }
+                
+                try{
+                  sh "./tests/v2/validation/build.sh"
+                  
+                  sh "docker volume create --name ${validationVolume}"
+
+                  sh "docker run -v ${validationVolume}:/root  --name ${setupContainer} -t -e RANCHER_VERSION=\$RANCHER_VERSION " +
+                  " -e RANCHER_VERSION_TO_UPGRADE=\$RANCHER_VERSION_TO_UPGRADE " +
+                  "${imageName} sh -c \"${workPath}pipeline/scripts/rancher_k8s_version.sh\""
+
+                  sh "docker cp ${setupContainer}:/root/go/src/github.com/rancher/rancher/testrancherk8s.yaml ./"
+
+                  println "contents of test rancher versions: ./${testRancherVersions}"
+                  
+                 def rancherRKE2Version = sh(
+                      script: "grep -E '^rancherRKE2Version:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE2 version ${rancherRKE2Version}"
+
+
+                  def rancherRKE2VersionToUpgrade = sh(
+                      script: "grep 'rancherRKE2VersionToUpgrade' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE2 version to upgrade ${rancherRKE2VersionToUpgrade}"
+                  
+                  def rancherK3sVersion = sh(
+                      script: "grep -E '^rancherK3sVersion:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher K3s version ${rancherK3sVersion}"
+                  
+                  def rancherK3sVersionToUpgrade = sh(
+                      script: "grep 'rancherK3sVersionToUpgrade' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher K3s version to upgrade ${rancherK3sVersionToUpgrade}"
+                  
+                  def rancherRKEVersion = sh(
+                      script: "grep -E '^rancherRKEVersion:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE version ${rancherRKEVersion}"
+                  
+                  def rancherRKEVersionToUpgrade = sh(
+                      script: "grep 'rancherRKEVersionToUpgrade' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE version to upgrade ${rancherRKEVersionToUpgrade}"
+                  
+                  def rancherVersion = sh(
+                      script: "grep 'rancherVersion:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher version ${rancherVersion}"
+                  
+                  def rancherImageTag = sh(
+                      script: "grep 'rancherImageTag:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher rancher image tag version ${rancherImageTag}"
+
+                  def rancherVersionToUpgrade = sh(
+                      script: "grep 'rancherVersionToUpgrade:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher version to upgrade ${rancherVersionToUpgrade}"
+                  
+                  def rancherImageTagToUpgrade = sh(
+                      script: "grep 'rancherImageTagToUpgrade:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher image tag to upgrade version ${rancherImageTagToUpgrade}"
+
+                config = config.replace('${RANCHER_RKE2_VERSION}', rancherRKE2Version)
+                config = config.replace('${RANCHER_RKE2_VERSION_TO_UPGRADE}', rancherRKE2VersionToUpgrade)
+                config = config.replace('${RANCHER_K3S_VERSION}', rancherK3sVersion)
+                config = config.replace('${RANCHER_K3S_VERSION_TO_UPGRADE}', rancherK3sVersionToUpgrade)
+                config = config.replace('${RANCHER_RKE_VERSION}', rancherRKEVersion)
+                config = config.replace('${RANCHER_RKE_VERSION_TO_UPGRADE}', rancherRKEVersionToUpgrade)
+                config = config.replace('${RANCHER_VERSION}', rancherVersion)
+                config = config.replace('${RANCHER_IMAGE_TAG}', rancherImageTag)
+                config = config.replace('${RANCHER_VERSION_TO_UPGRADE}', rancherVersionToUpgrade)
+                config = config.replace('${RANCHER_IMAGE_TAG_TO_UPGRADE}', rancherImageTagToUpgrade)
+                }catch (err){
+                    sh "docker stop ${setupContainer}"
+                    sh "docker rm -v ${setupContainer}"
+                    sh "docker volume rm -f ${validationVolume}"
+                    sh "docker rmi ${imageName}"
+                  }
+
+
+                sh "docker stop ${setupContainer}"
+                sh "docker rm -v ${setupContainer}"
+                sh "docker volume rm -f ${validationVolume}"
+                sh "docker rmi ${imageName}"
+
 
                 dir("./tests/v2/validation") {
                   def filename = "config.yaml"
-                  def configContents = env.CONFIG
 
-                  writeFile file: filename, text: configContents
+                  writeFile file: filename, text: config
                   env.CATTLE_TEST_CONFIG = workPath+filename
                 }
 
                 sh "./tests/v2/validation/configure.sh"
                 sh "./tests/v2/validation/build.sh"
+
               }
               stage('Setup') {
                 sh returnStdout: true, script: 'wget -qO ./yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64'
@@ -272,8 +376,17 @@ node {
 
                 for (int i = 0; i < configs.size(); i++) {
                   def configName = configs[i]
+                  if (configName.contains('local')) {
+                    echo "skipping pushing local to the global variable"
+                    localConfigFileName = "$configName"
+                    continue
+                  }
                   echo "pushing ${configName} to the global variable"
                   configFiles << "${configName}"
+                }
+                
+                dir("./${patchedConfigsDir}") {
+                  sh "docker cp ${configGeneratorContainer}:${rootPath}${configsDir}/${localConfigFileName} ."
                 }
 
                 println "Removing the tagged image"
@@ -290,7 +403,7 @@ node {
                  configFiles.each {
                    def configPath = "./${configsDir}/$it"
                    def absoluteConfigPath = "${rootPath}${configsDir}/$it"
-
+                   
                    def testCase = sh (
                      script: "./yq '.testCases.provisioningTestCase'  ${configPath}",
                      returnStdout: true
@@ -338,11 +451,12 @@ node {
                   echo "Cluster mapping had failures: " + err
                   }
                 }
+                echo "pushing ${localConfigFileName} to the global variable"
+                configFiles << "${localConfigFileName}"
               }
               stage('Run preupgrade checks') {
                 try {
                   jobs = [:]
-
                   configFiles.each {
                     try {
                       def configPath = "./${configsDir}/$it"
@@ -393,6 +507,7 @@ node {
 
                 build job: 'rancher-v3_ha_upgrade', parameters: upgradeParams
               }
+
               stage('Run postupgrade checks') {
                 try {
                   jobs = [:]

--- a/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.local
+++ b/tests/v2/validation/pipeline/Jenkinsfile.release.upgrade.local
@@ -32,6 +32,7 @@ node {
     def rancherConfig = "rancher_env.config"
     def qaseRun = "testrun"
     def testRunConfig = "testrunconfig.yaml"
+    def testRancherVersions = "testrancherk8s.yaml"
 
     def config = env.CONFIG
     def filename = "config.yaml"
@@ -174,52 +175,90 @@ node {
                   }
                 }
 
-                scriptPath = "./rancher/tests/v2/validation/pipeline/scripts/rancher_k8s_version.sh"
-                
-                def rancherK8sVersions = ""
-                try {
-                  rancherK8sVersions = sh(
-                    script: """
-                      if [ -f ${scriptPath} ]; then
-                      chmod +x ${scriptPath}
-                      ${scriptPath}
-                      else
-                        echo "Script not found!"
-                        exit 1
-                    fi
-                    """,
-                    returnStdout: true
-                  ).trim()
+                try{
+                  sh "docker build . -f ./rancher/tests/v2/validation/Dockerfile.e2e -t ${imageName}"
+                  
+                  sh "docker volume create --name ${validationVolume}"
 
-                  def lines = []
-                  if (rancherK8sVersions != "") {
-                    lines = rancherK8sVersions.split('\n')
+                  sh "docker run -v ${validationVolume}:/root  --name ${buildTestContainer} -t " +
+                  "${imageName} sh -c \"${workPath}pipeline/scripts/rancher_k8s_version.sh\""
+
+                  sh "docker cp ${buildTestContainer}:/root/go/src/github.com/rancher/rancher/testrancherk8s.yaml ./"
+
+                  if (sh(script: "test -s ./${testRancherVersions} && echo 'not_empty' || echo 'empty'", returnStdout: true).trim() == "empty") {
+                      error "ERROR: (${testRancherVersions}) is empty or missing!"
                   }
+                      
+                 def rancherRKE2Version = sh(
+                      script: "grep -E '^rancherRKE2Version:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE2 version ${rancherRKE2Version}"
 
-                  if (lines.size() >= 8) {
-                    def rancherImageTag = lines[0].replace("Latest Rancher Version: ", "").trim()
-                    def rancherVersion = rancherImageTag.replace("v", "")
-                    def preUpgradeRKE2K8s = lines[2]?.trim()
-                    def postUpgradeRKE2K8s = lines[3]?.trim()
-                    def preUpgradeK3sK8s = lines[4]?.trim()
-                    def postUpgradeK3sK8s = lines[5]?.trim()
-                    def preUpgradeRKE1K8s = lines[6]?.trim()
-                    def postUpgradeRKE1K8s = lines[7]?.trim()
+
+                  def rancherRKE2VersionToUpgrade = sh(
+                      script: "grep 'rancherRKE2VersionToUpgrade' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE2 version to upgrade ${rancherRKE2VersionToUpgrade}"
+                  
+                  def rancherK3sVersion = sh(
+                      script: "grep -E '^rancherK3sVersion:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher K3s version ${rancherK3sVersion}"
+                  
+                  def rancherK3sVersionToUpgrade = sh(
+                      script: "grep 'rancherK3sVersionToUpgrade' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher K3s version to upgrade ${rancherK3sVersionToUpgrade}"
+                  
+                  def rancherRKEVersion = sh(
+                      script: "grep -E '^rancherRKEVersion:' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE version ${rancherRKEVersion}"
+                  
+                  def rancherRKEVersionToUpgrade = sh(
+                      script: "grep 'rancherRKEVersionToUpgrade' ./${testRancherVersions} | awk '{print \$2}'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher RKE version to upgrade ${rancherRKEVersionToUpgrade}"
+                  
+                  def rancherVersion = sh(
+                      script: "grep 'rancherVersion:' ./${testRancherVersions} | awk '{print \$2}' | grep -v '^\$'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher rancher version ${rancherVersion}"
+                  
+                  def rancherImageTag = sh(
+                      script: "grep 'rancherImageTag:' ./${testRancherVersions} | awk '{print \$2}' | grep -v '^\$'",
+                      returnStdout: true
+                    ).trim()
+                  println "Rancher rancher image tag version ${rancherImageTag}"
 
                     config = config.replace('${RANCHER_VERSION}', rancherVersion)
                     config = config.replace('${RANCHER_IMAGE_TAG}', rancherImageTag)
-                    config = config.replace('${RANCHER_RKE2_VERSION}', preUpgradeRKE2K8s)
-                    config = config.replace('${RANCHER_RKE2_VERSION_TO_UPGRADE}', postUpgradeRKE2K8s)
-                    config = config.replace('${RANCHER_K3S_VERSION}', preUpgradeK3sK8s)
-                    config = config.replace('${RANCHER_K3S_VERSION_TO_UPGRADE}', postUpgradeK3sK8s)
-                    config = config.replace('${RANCHER_RKE1_VERSION}', preUpgradeRKE1K8s)
-                    config = config.replace('${RANCHER_RKE1_VERSION_TO_UPGRADE}', postUpgradeRKE1K8s)
-                  }
+                    config = config.replace('${RANCHER_RKE2_VERSION}', rancherRKE2Version)
+                    config = config.replace('${RANCHER_RKE2_VERSION_TO_UPGRADE}', rancherRKE2VersionToUpgrade)
+                    config = config.replace('${RANCHER_K3S_VERSION}', rancherK3sVersion)
+                    config = config.replace('${RANCHER_K3S_VERSION_TO_UPGRADE}', rancherK3sVersionToUpgrade)
+                    config = config.replace('${RANCHER_RKE1_VERSION}', rancherVersion)
+                    config = config.replace('${RANCHER_RKE1_VERSION_TO_UPGRADE}', rancherRKEVersionToUpgrade)
                 } catch (err) {
                   echo "Unable to get the versions of Rancher and Kubernetes: ${err}"
                   error "Rancher and k8s versions cannot be retrieved."
+                  sh "docker stop ${buildTestContainer}"
+                  sh "docker rm -v ${buildTestContainer}"
+                  sh "docker volume rm -f ${validationVolume}"
+                  sh "docker rmi ${imageName}"
                 }
-                
+                sh "docker stop ${buildTestContainer}"
+                sh "docker rm -v ${buildTestContainer}"
+                sh "docker volume rm -f ${validationVolume}"
+                sh "docker rmi ${imageName}"
+
                 dir("./rancher/tests/v2/validation") {
                   writeFile file: filename, text: config
                   
@@ -238,6 +277,7 @@ node {
               }
               stage("Build Environment") {
                 try {
+                    
                   sh "docker run -v ${validationVolume}:/root --name ${buildTestContainer} -t --env-file ${envFile} " +
                   "${imageName} sh -c \"${workPath}pipeline/scripts/setup_environment.sh;${workPath}pipeline/scripts/build_qase_auto_testrun.sh\""
 

--- a/tests/v2/validation/pipeline/rancherversion/main.go
+++ b/tests/v2/validation/pipeline/rancherversion/main.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+
+	"os"
+	"sort"
+
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type RancherK8sVersions struct {
+	RancherImageTag             string `json:"rancherImageTag" yaml:"rancherImageTag"`
+	RancherImageTagToUpgrade    string `json:"rancherImageTagToUpgrade" yaml:"rancherImageTagToUpgrade"`
+	RancherVersion              string `json:"rancherVersion" yaml:"rancherVersion"`
+	RancherVersionToUpgrade     string `json:"rancherVersionToUpgrade" yaml:"rancherVersionToUpgrade"`
+	RancherRKE2Version          string `json:"rancherRKE2Version" yaml:"rancherRKE2Version"`
+	RancherRKE2VersionToUpgrade string `json:"rancherRKE2VersionToUpgrade" yaml:"rancherRKE2VersionToUpgrade"`
+	RancherK3sVersion           string `json:"rancherK3sVersion" yaml:"rancherK3sVersion"`
+	RancherK3sVersionToUpgrade  string `json:"rancherK3sVersionToUpgrade" yaml:"rancherK3sVersionToUpgrade"`
+	RancherRKEVersion           string `json:"rancherRKEVersion" yaml:"rancherRKEVersion"`
+	RancherRKEVersionToUpgrade  string `json:"rancherRKEVersionToUpgrade" yaml:"rancherRKEVersionToUpgrade"`
+}
+
+var (
+	rancherVersion            = os.Getenv("RANCHER_VERSION")
+	rancherVersionToUpgrade   = os.Getenv("RANCHER_VERSION_TO_UPGRADE")
+)
+
+const (
+	baseURL                 = "https://prime.ribs.rancher.io/"
+	rke2K3sVersionFilterURL = "/rancher-images.txt"
+	rkeVersionFilterURL     = "/rancher-rke-k8s-versions.txt"
+	rke2Filter              = `rancher/hardened-kubernetes:v\d+\.\d+\.\d+(-rke2r\d)?`
+	k3sFilter               = `rancher/k3s-upgrade:v\d+\.\d+\.\d+(-k3s\d)`
+	fileName                = "rancher-images.txt"
+	fileNameUpgradeVersion  = "rancher-images-pre-release-versions.txt"
+)
+
+func main() {
+	var err error
+	urlb := baseURL + "index.html"
+
+	communityBaseURL          := "https://github.com/rancher/rancher/releases/download/" + rancherVersion + "/rancher-images.txt"
+	communityBaseURLToUpgrade := "https://github.com/rancher/rancher/releases/download/" + rancherVersionToUpgrade + "/rancher-images.txt"
+	primeRelease              := true
+	primeReleaseToUpgrade     := false
+	
+	rancherChartVersion, err := extractRancherVersion(urlb, rancherVersion)
+	if err != nil {
+		return
+	}
+	if rancherChartVersion == "" {
+		rancherChartVersion = rancherVersion
+		primeRelease = false
+		err = downloadFile(communityBaseURL, fileName)
+		if err != nil {
+			fmt.Println("Failed to download Rancher images file:", err)
+			return
+		}
+	}
+	if rancherVersionToUpgrade != "" {
+		err = downloadFile(communityBaseURLToUpgrade, fileNameUpgradeVersion)
+		data, err := os.ReadFile(fileNameUpgradeVersion)
+		if string(data) == "Not Found" {
+			primeReleaseToUpgrade = true
+		} else if err != nil {
+			return
+		}
+	}
+
+	logrus.Info("Rancher version: " + rancherChartVersion)
+
+	k8sImageBaseUrl := baseURL + "rancher/" + rancherChartVersion
+
+	rke2K3sK8sVersionsUrl := k8sImageBaseUrl + rke2K3sVersionFilterURL
+	rkeK8sVersionsUrl := k8sImageBaseUrl + rkeVersionFilterURL
+
+	rke2K8sVersion, err := extractRke2K3sVersions(rke2K3sK8sVersionsUrl, rke2Filter, primeRelease, primeReleaseToUpgrade)
+	if err != nil {
+		return
+	}
+
+	k3sK8sVersion, err := extractRke2K3sVersions(rke2K3sK8sVersionsUrl, k3sFilter, primeRelease, primeReleaseToUpgrade)
+	if err != nil {
+		return
+	}
+
+	rkeK8sVersion, err := extractRkeVersions(rkeK8sVersionsUrl, primeRelease, primeReleaseToUpgrade)
+	if err != nil {
+		return
+	}
+
+	rancherK8sVersions := RancherK8sVersions{}
+
+	if rancherVersionToUpgrade != "" {
+		rancherK8sVersions.RancherVersionToUpgrade = rancherVersionToUpgrade
+		rancherK8sVersions.RancherImageTagToUpgrade = rancherVersionToUpgrade
+	}
+
+	rancherK8sVersions.RancherImageTag = rancherChartVersion
+	rancherK8sVersions.RancherVersion = strings.Trim(rancherChartVersion, "v")
+	rancherK8sVersions.RancherRKE2Version = rke2K8sVersion[0]
+	rancherK8sVersions.RancherRKE2VersionToUpgrade = rke2K8sVersion[1]
+	rancherK8sVersions.RancherK3sVersion = k3sK8sVersion[0]
+	rancherK8sVersions.RancherK3sVersionToUpgrade = k3sK8sVersion[1]
+	rancherK8sVersions.RancherRKEVersion = rkeK8sVersion[0]
+	rancherK8sVersions.RancherRKEVersionToUpgrade = rkeK8sVersion[1]
+
+	logrus.Info("Here are the rancher versions ", rancherK8sVersions)
+
+	err = writeToConfigFile(rancherK8sVersions)
+	if err != nil {
+		logrus.Error("error writiing test run config: ", err)
+	}
+
+}
+
+// getResponseData extracts the data from the given URL and returns the response body as a byte slice.
+func getResponseData(urlb string) ([]byte, error) {
+	logrus.Info("This is the urlb", urlb)
+	resp, err := http.Get(urlb)
+	if err != nil {
+		fmt.Printf("Error fetching URL: %v\n", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	responseData, err := io.ReadAll(resp.Body)
+
+	return responseData, err
+}
+
+// getRke2K3sVersionMap extracts the rke2 and k3s version map from the rancher-images.txt for a community release and
+// prime.ribs.rancher.io for a prime released version of rancher.
+func getRke2K3sVersionMap(urlb, matchFilter, file string, primeRelease bool) (latestVersions []*version.Version, err error) {
+	var k8sVersionData []byte
+	versionFilter := regexp.MustCompile(matchFilter)
+	if primeRelease {
+		k8sVersionData, err = getResponseData(urlb)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		k8sVersionData, err = os.ReadFile(file)
+
+		logrus.Info("This is the k8sVersionData")
+		if string(k8sVersionData) == "Not Found" {
+			return nil, errors.New("Community version file is empty")
+		}
+	}
+	versions := versionFilter.FindAllStringSubmatch(string(k8sVersionData), -1)
+
+	if len(versions) == 0 {
+		fmt.Println("No versions found in the response.")
+		return nil, err
+	}
+
+	majorMinorVersionGroups := make(map[string][]*version.Version)
+	for _, ver := range versions {
+		ver := strings.Split(ver[0], ":")
+		if len(ver) > 1 {
+			finalVersion, err := version.NewVersion(ver[1])
+			if err != nil {
+				return nil, err
+			}
+			majorMinorVersion := finalVersion.Segments()
+			if len(majorMinorVersion) >= 2 {
+				majorMinor := fmt.Sprintf("%d.%d", majorMinorVersion[0], majorMinorVersion[1])
+				majorMinorVersionGroups[majorMinor] = append(majorMinorVersionGroups[majorMinor], finalVersion)
+			}
+		}
+	}
+
+	for _, group := range majorMinorVersionGroups {
+		sort.Sort(version.Collection(group))
+		latestVersions = append(latestVersions, group[len(group)-1])
+	}
+	sort.Sort(version.Collection(latestVersions))
+
+	return latestVersions, nil
+}
+
+// extractRke2K3sVersions is a helper that returns the rke2 and k3s versions from the provided rancher release versions
+func extractRke2K3sVersions(urlb, matchFilter string, primeRelease, primeReleaseToUpgrade bool) (k8sVersions []string, err error) {
+	latestVersions, err := getRke2K3sVersionMap(urlb, matchFilter, fileName, primeRelease)
+	var k8sVersionUpgrade []*version.Version
+
+	for i, ver := range latestVersions {
+		modifiedVersionStr := strings.Replace(ver.String(), "-", "+", 1)
+		newVersion, err := version.NewVersion("v" + modifiedVersionStr)
+		if err != nil {
+			fmt.Printf("Error parsing version: %v\n", err)
+			continue
+		}
+		latestVersions[i] = newVersion
+	}
+
+	if rancherVersionToUpgrade != "" {
+		re := regexp.MustCompile(`v[0-9]+\.[0-9]+\.[0-9]+`)
+		urlb = re.ReplaceAllString(urlb, rancherVersionToUpgrade)
+		k8sVersionUpgrade, err = getRke2K3sVersionMap(urlb, matchFilter, fileNameUpgradeVersion, primeReleaseToUpgrade)
+		if err != nil {
+			return nil, err
+		}
+		k8sVersions = append(k8sVersions, latestVersions[len(latestVersions)-1].Original())
+		if len(k8sVersionUpgrade) > 0 {
+			latestUpgradeVersion := k8sVersionUpgrade[len(k8sVersionUpgrade)-1].Original()
+			latestUpgradeVersion = strings.Replace("v"+latestUpgradeVersion, "-", "+", 1)
+			k8sVersions = append(k8sVersions, latestVersions[len(latestVersions)-1].Original(), latestUpgradeVersion)
+		}
+	} else {
+		k8sVersions = append(k8sVersions, latestVersions[len(latestVersions)-2].Original(), latestVersions[len(latestVersions)-1].Original())
+	}
+
+	logrus.Info("Getting the version", k8sVersions)
+	return k8sVersions, nil
+}
+
+// getRkeVersionMap is a helper that obtains the rke1 k8s versions from the downloaded rancher-images.txt for a community version
+// and extracts the versions for a prime release from prime.ribs.rancher.io
+func getRkeVersionMap(urlb, file string, primeRelease bool) ([]string, error) {
+	var versions []string
+	if primeRelease {
+		k8sVersionData, err := getResponseData(urlb)
+		if err != nil {
+			return nil, err
+		}
+		if len(k8sVersionData) == 0 {
+			return nil, fmt.Errorf("Empty list")
+		}
+
+		k8sVersions := strings.TrimSpace(string(k8sVersionData))
+
+		versions = strings.Split(k8sVersions, "\n")
+		if len(versions) > 4 {
+			return nil, fmt.Errorf("Unexpected count of versions %s", versions)
+		}
+	} else {
+		k8sVersions, err := os.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		versionFilter := regexp.MustCompile("rancher/hyperkube:(v[0-9]+.[0-9]+.[0-9]+-rancher[0-9]+)")
+		allRKE1Versions := versionFilter.FindAllStringSubmatch(string(k8sVersions), -1)
+		if len(allRKE1Versions) == 0 {
+			return nil, errors.New("No RKE1 versions found.")
+		}
+		for _, ver := range allRKE1Versions {
+			if len(ver) > 1 {
+				versions = append(versions, ver[1])
+			}
+		}
+	}
+	return versions, nil
+}
+
+// extractRkeVersions is a helper that returns the RKE1 k8s versions
+func extractRkeVersions(urlb string, primeRelease, primeReleaseToUpgrade bool) (k8sVersions []string, err error) {
+	versions, err := getRkeVersionMap(urlb, fileName, primeRelease)
+	if err != nil {
+		return nil, err
+	}
+
+	var k8sVersionToUpgrade []string
+	if rancherVersionToUpgrade != "" {
+		re := regexp.MustCompile(`v[0-9]+\.[0-9]+\.[0-9]+`)
+		urlb = re.ReplaceAllString(urlb, rancherVersionToUpgrade)
+		k8sVersionToUpgrade, err = getRkeVersionMap(urlb, fileNameUpgradeVersion, primeReleaseToUpgrade)
+		if err != nil {
+			return nil, err
+		}
+		k8sVersions = append(k8sVersions, versions[len(versions)-1], k8sVersionToUpgrade[len(k8sVersionToUpgrade)-1])
+
+	} else {
+		k8sVersions = append(k8sVersions, versions[len(versions)-2], versions[len(versions)-1])
+	}
+
+	return k8sVersions, err
+}
+
+// extractRancherVersion is a helper uses prime.ribs.rancher.io to get the latest if no version provided, returns empty
+// if the provided version is a community release
+func extractRancherVersion(urlb, rancherVersion string) (string, error) {
+	rancherVersionData, err := getResponseData(urlb)
+	if err != nil {
+		return "", err
+	}
+
+	versionFilter := regexp.MustCompile(`<b class="release-title-tag">(v\d+\.\d+\.\d+)</b>`)
+	ids := versionFilter.FindAllStringSubmatch(string(rancherVersionData), -1)
+
+	if len(ids) == 0 {
+		fmt.Println("No matching `id` fields found in the response.")
+		return "", err
+	}
+	var versions []*version.Version
+	for _, id := range ids {
+		if len(id) > 1 {
+			ver, err := version.NewVersion(id[1])
+			if err != nil {
+				return "", err
+			}
+			if rancherVersion == ver.Original() {
+				return ver.Original(), nil
+			}
+			versions = append(versions, ver)
+		}
+	}
+
+	sort.Sort(version.Collection(versions))
+	if rancherVersion == "" {
+		rancherVersion = "v" + versions[len(versions)-1].String()
+		return rancherVersion, nil
+	}
+	return "", nil
+}
+
+// downloadFile is a helper that downloads the community release images and copies the contents to a file named rancher-images.txt
+// copies the contents to a file named rancher-images-pre-release-versions.txt for rancher pre-release versions.
+func downloadFile(url, file string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Printf("Error fetching URL: %v\n", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(file)
+	if err != nil {
+		fmt.Printf("Error creating file: %v\n", err)
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+// writeToConfigFile is a helper that adds the struct RancherK8sVersions to a file testrancherk8s.yaml.
+func writeToConfigFile(config RancherK8sVersions) error {
+	yamlConfig, err := yaml.Marshal(config)
+
+	dir, dirErr := os.Getwd()
+	if dirErr != nil {
+		logrus.Errorf("Failed to get current directory: %v", dirErr)
+	} else {
+		logrus.Infof("Current directory: %s", dir)
+	}
+
+	if err != nil {
+		return err
+	}
+	file := "testrancherk8s.yaml"
+
+	absFilePath, absErr := filepath.Abs(file)
+	if absErr != nil {
+		logrus.Warnf("Failed to resolve absolute file path: %v", absErr)
+		logrus.Infof("File created at (relative): %s", file)
+	} else {
+		logrus.Infof("YAML file successfully created at: %s", absFilePath)
+	}
+
+	return os.WriteFile(file, yamlConfig, 0644)
+}

--- a/tests/v2/validation/pipeline/scripts/rancher_k8s_version.sh
+++ b/tests/v2/validation/pipeline/scripts/rancher_k8s_version.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
+set -e
+cd $(dirname $0)/../../../../../
 
-latest_rancher_version=$(curl -s https://prime.ribs.rancher.io/index.html | grep  "release-v[0-9]*" | sort -V | tail -n 1 |  sed -E 's/.*release-(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-echo "Latest Rancher Version: $latest_rancher_version"
+echo "Getting go rancher version "
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/validation/rancherversion ./tests/v2/validation/pipeline/rancherversion
 
-rke2_k8s_versions=$(curl -s "https://prime.ribs.rancher.io/rancher/${latest_rancher_version}/rancher-images.txt" | grep "rancher/hardened-kubernetes:" | awk -F':' '{print $2}'  | awk -F '-build' '{print $1}' | sort -V | awk -F '.' '
-        {versions[$1"."$2] = $0} 
-        END {
-            for (v in versions) print versions[v]""
-        }' | sed 's/-rke2/+rke2/'| sort -V | tail -n 2)
-
-k3s_k8s_versions=$(curl -s "https://prime.ribs.rancher.io/rancher/${latest_rancher_version}/rancher-images.txt" | grep "rancher/k3s-upgrade:" | awk -F':' '{print $2}'  | awk -F '-build' '{print $1}' | sort -V | awk -F '.' '
-        {versions[$1"."$2] = $0} 
-        END {
-            for (v in versions) print versions[v]""
-        }' | sed 's/-k3s/+k3s/' | sort -V | tail -n 2)
-
-rke1_k8s_versions=$(curl -s "https://prime.ribs.rancher.io/rancher/${latest_rancher_version}/rancher-rke-k8s-versions.txt"  | sort -V | tail -n 2)
-
-echo "Latest Kubernetes Versions: "
-echo -e "$rke2_k8s_versions\n$k3s_k8s_versions\n$rke1_k8s_versions"
-
-
+echo "running rancher versions script to get the latest k8s versions"
+tests/v2/validation/rancherversion

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -52,9 +52,9 @@ func (u *UpgradeKubernetesTestSuite) TestUpgradeKubernetes() {
 			testConfig := clusters.ConvertConfigToClusterConfig(&cluster.ProvisioningInput)
 
 			if cluster.Name == local {
-				upgradeLocalCluster(&u.Suite, tt.name, tt.client, testConfig, cluster, containerImage)
+				upgradeLocalCluster(&u.Suite, tt.name, tt.client, testConfig, cluster)
 			} else {
-				upgradeDownstreamCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, nil, containerImage)
+				upgradeDownstreamCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, nil)
 			}
 		}
 	}

--- a/tests/v2/validation/upgrade/kubernetes_wins_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_wins_test.go
@@ -68,7 +68,7 @@ func (u *UpgradeWindowsKubernetesTestSuite) TestUpgradeWindowsKubernetes() {
 			}
 
 			testConfig := clusters.ConvertConfigToClusterConfig(&cluster.ProvisioningInput)
-			upgradeDownstreamCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, tt.nodeSelector, windowsContainerImage)
+			upgradeDownstreamCluster(&u.Suite, tt.name, tt.client, cluster.Name, testConfig, cluster, tt.nodeSelector)
 		}
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/1642
 
## Problem
Current ha upgrade checks have manually adding the k8s versions. This has to be done for different cluster types which could be a tedious process. 
 
## Solution
Following are the changes made to ha_upgrade job:
1. Created a script that extracts the k8s versions of the cluster types from https://prime.ribs.rancher.io/index.html. Script expects a rancher version and a rancher version to upgrade provided as environment variables for which 2 new parameters are introduced in the jenkins job.  It still expects the user to provide ha url, chart version etc that are required for the ha deploy job.
2. Made changes to the local upgrade checks as it obtains the latest version of rancher and also the k8s versions from the same script.
3. Made some changes to the downstream upgrade function [here](https://github.com/rancher/rancher/blob/6d3e1301832c24cf022ed67456a15efdcb960cfa/tests/v2/validation/upgrade/kubernetes.go#L91).

~Note: This works for prime versions only. If a rancher version is not tagged as prime, jenkins job should include the k8s versions accordingly.~
 
## Testing
Jenkins run.

