### PR TITLE
fix: remove Drained condition from machine status if schedulable

### DIFF
--- a/pkg/controllers/managementuser/nodesyncer/cordonfieldssyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/cordonfieldssyncer.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/rancher/pkg/auth/tokens"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/kubectl"
 	nodehelper "github.com/rancher/rancher/pkg/node"
 	"github.com/sirupsen/logrus"
@@ -29,7 +28,7 @@ const (
 var nodeMapLock = sync.Mutex{}
 var toIgnoreErrs = []string{"--ignore-daemonsets", "--delete-emptydir-data", "--force", "did not complete within", "global timeout reached"}
 
-func (m *nodesSyncer) syncCordonFields(key string, obj *v3.Node) (runtime.Object, error) {
+func (m *nodesSyncer) syncCordonFields(key string, obj *v32.Node) (runtime.Object, error) {
 	if obj == nil || obj.DeletionTimestamp != nil || obj.Spec.DesiredNodeUnschedulable == "" {
 		return nil, nil
 	}
@@ -67,7 +66,7 @@ func (m *nodesSyncer) syncCordonFields(key string, obj *v3.Node) (runtime.Object
 	return obj, err
 }
 
-func (d *nodeDrain) drainNode(key string, obj *v3.Node) (runtime.Object, error) {
+func (d *nodeDrain) drainNode(key string, obj *v32.Node) (runtime.Object, error) {
 	if obj == nil || obj.DeletionTimestamp != nil || obj.Spec.DesiredNodeUnschedulable == "" {
 		return nil, nil
 	}
@@ -112,7 +111,7 @@ func (d *nodeDrain) drainNode(key string, obj *v3.Node) (runtime.Object, error) 
 	return nil, nil
 }
 
-func (d *nodeDrain) updateNode(node *v3.Node, updateFunc func(node *v3.Node, originalErr error, kubeErr error), originalErr error, kubeErr error) (*v3.Node, error) {
+func (d *nodeDrain) updateNode(node *v32.Node, updateFunc func(node *v32.Node, originalErr error, kubeErr error), originalErr error, kubeErr error) (*v32.Node, error) {
 	updatedObj, err := d.machines.Update(node)
 	if err != nil && errors.IsConflict(err) {
 		// retrying twelve times, if conflict error still exists, give up
@@ -135,7 +134,7 @@ func (d *nodeDrain) updateNode(node *v3.Node, updateFunc func(node *v3.Node, ori
 	return updatedObj, err
 }
 
-func (d *nodeDrain) drain(ctx context.Context, obj *v3.Node, nodeName string, cancel context.CancelFunc) {
+func (d *nodeDrain) drain(ctx context.Context, obj *v32.Node, nodeName string, cancel context.CancelFunc) {
 	defer deleteFromContextMap(d.nodesToContext, obj.Name)
 
 	for {
@@ -194,7 +193,7 @@ func (d *nodeDrain) drain(ctx context.Context, obj *v3.Node, nodeName string, ca
 			}
 		}
 		if !stopped {
-			nodeCopy := updatedObj.(*v3.Node).DeepCopy()
+			nodeCopy := updatedObj.(*v32.Node).DeepCopy()
 			setConditionComplete(nodeCopy, err, kubeErr)
 			_, updateErr := d.updateNode(nodeCopy, setConditionComplete, err, kubeErr)
 			if kubeErr != nil || updateErr != nil {
@@ -212,7 +211,7 @@ func (d *nodeDrain) drain(ctx context.Context, obj *v3.Node, nodeName string, ca
 	}
 }
 
-func (d *nodeDrain) resetDesiredNodeUnschedulable(obj *v3.Node) error {
+func (d *nodeDrain) resetDesiredNodeUnschedulable(obj *v32.Node) error {
 	nodeCopy := obj.DeepCopy()
 	removeDrainCondition(nodeCopy)
 	nodeCopy.Spec.DesiredNodeUnschedulable = ""
@@ -275,7 +274,7 @@ func filterErrorMsg(msg string, nodeName string) string {
 	return strings.Join(upd, "\n")
 }
 
-func removeDrainCondition(obj *v3.Node) {
+func removeDrainCondition(obj *v32.Node) {
 	exists := false
 	for _, condition := range obj.Status.Conditions {
 		if condition.Type == "Drained" {
@@ -314,13 +313,13 @@ func ignoreErr(msg string) (bool, bool) {
 	return false, false
 }
 
-func setConditionDraining(node *v3.Node, err error, kubeErr error) {
+func setConditionDraining(node *v32.Node, err error, kubeErr error) {
 	v32.NodeConditionDrained.Unknown(node)
 	v32.NodeConditionDrained.Reason(node, "")
 	v32.NodeConditionDrained.Message(node, "")
 }
 
-func setConditionComplete(node *v3.Node, err error, kubeErr error) {
+func setConditionComplete(node *v32.Node, err error, kubeErr error) {
 	if err == nil {
 		v32.NodeConditionDrained.True(node)
 	} else {

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -879,6 +879,15 @@ func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *apimgmtv
 	cleanStatus(machine)
 	apimgmtv3.NodeConditionRegistered.True(machine)
 	apimgmtv3.NodeConditionRegistered.Message(machine, "registered with kubernetes")
+
+	// remove the "Drained" condition from the machine's status conditions
+	// only if the machine is schedulable (i.e., not unschedulable)
+	// and set DesiredNodeUnschedulable to empty string
+	if !machine.Spec.InternalNodeSpec.Unschedulable {
+		removeDrainCondition(machine)
+		machine.Spec.DesiredNodeUnschedulable = ""
+	}
+
 	return machine, nil
 }
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39867
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
If a node is drained via UI and then uncordoned via kubectl uncordon <node> UI continues to display it as State = Drained.
 
## Solution
Check if the underlying node is schedulable; if it is, then remove the Drained condition from the machine's status conditions.
 
## Testing
Repro steps in the GitHub issue are valid.

## Engineering Testing
### Manual Testing
After applying the fix, I followed the repro steps from the issue, and the problem did not reproduce.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_