### PR TITLE
improving logic for qa custodian

### DIFF
--- a/tests/scripts/custodian/aws.yaml
+++ b/tests/scripts/custodian/aws.yaml
@@ -16,6 +16,7 @@ policies:
     - 'tag:DoNotDelete': absent
     - 'tag:ec2_known_user': absent
     - "tag:DeletesOnFriday": absent
+    - "tag:ec2_unknown_user": absent
     - not: 
       - type: value
         key: tag:Name
@@ -41,6 +42,7 @@ policies:
     - 'tag:DoNotDelete': absent
     - 'tag:ec2_unknown_user': absent
     - "tag:DeletesOnFriday": absent
+    - "tag:ec2_known_user": absent
     - not: 
       - type: value
         key: tag:Name
@@ -104,6 +106,7 @@ policies:
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
     - 'tag:ec2_known_user': absent
+    - "tag:ec2_unknown_user": absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
@@ -128,6 +131,7 @@ policies:
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
     - 'tag:ec2_unknown_user': absent
+    - "tag:ec2_known_user": absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
@@ -184,6 +188,7 @@ policies:
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
     - 'tag:ec2_known_user': absent
+    - "tag:ec2_unknown_user": absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
@@ -218,7 +223,8 @@ policies:
     # nlb is not doNotDelete
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
-    - 'tag:ec2_unknown_user': absent
+    - "tag:ec2_unknown_user": absent
+    - "tag:ec2_known_user": absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value

--- a/tests/scripts/custodian/azure.yaml
+++ b/tests/scripts/custodian/azure.yaml
@@ -1,6 +1,26 @@
 # Azure Policies
 policies:
 # VMs
+- name: azure-terminate-stopped-vms
+  resource: azure.vm
+  filters:
+    - type: instance-view
+      key: statuses[].code
+      op: in
+      value_type: swap
+      value: PowerState/failed
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:known_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: delete
+
 - name: az-mark-unknown-vms-for-deletion
   resource: azure.vm
   description: |


### PR DESCRIPTION
noticed some inconsistencies / better logic for these after seeing it run on prod. 
* azure won't let you tag an instance to delete if its in a failed state
* aws job is tagging instances that have already been matched before