### PR TITLE
[main] Imperative api setting

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -82,6 +82,11 @@ spec:
           hostPort: {{ int .Values.hostPort }}
           protocol: TCP
 {{- end}}
+{{- if .Values.imperativeExtensionApi.enabled }}
+        - containerPort: 6666
+          hostPort: 6666
+          protocol: TCP
+{{- end}}
         args:
 {{- if .Values.debug }}
         - "--debug"
@@ -146,6 +151,10 @@ spec:
 {{- if .Values.agentTLSMode }}
         - name: CATTLE_AGENT_TLS_MODE
           value: "{{ .Values.agentTLSMode }}"
+{{- end }}
+{{- if .Values.imperativeExtensionApi.enabled }}
+        - name: IMPERATIVE_EXTENSION_API
+          value: "true"
 {{- end }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -153,7 +153,7 @@ spec:
           value: "{{ .Values.agentTLSMode }}"
 {{- end }}
 {{- if .Values.imperativeExtensionApi.enabled }}
-        - name: IMPERATIVE_EXTENSION_API
+        - name: CATTLE_IMPERATIVE_API_EXTENSION
           value: "true"
 {{- end }}
 {{- if .Values.extraEnv }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -82,6 +82,7 @@ spec:
           hostPort: {{ int .Values.hostPort }}
           protocol: TCP
 {{- end}}
+# This port is a temporary workaround until https://github.com/rancher/rancher/issues/47091 is resolved
 {{- if .Values.imperativeExtensionApi.enabled }}
         - containerPort: 6666
           hostPort: 6666

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -691,4 +691,13 @@ tests:
           limits:
             cpu: 500m
             memory: 500Mi
-
+- it: supports enabling the imperative extensions api
+  set:
+    imperativeExtensionApi:
+      enabled: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: CATTLE_IMPERATIVE_API_EXTENSION
+        value: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -209,3 +209,6 @@ webhook: ""
 # helm values to use when installing the fleet chart.
 # helm values set here will override all other global values used when installing the fleet chart.
 fleet: ""
+
+imperativeExtensionApi:
+  enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -211,4 +211,4 @@ webhook: ""
 fleet: ""
 
 imperativeExtensionApi:
-  enabled: true
+  enabled: false

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,8 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.31.1
 	oras.land/oras-go => oras.land/oras-go v1.2.2 // for docker 20.10.x compatibility
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.8.3
+
+	github.com/rancher/steve => /home/wrinkle/workspaces/joshmeranda/rancher-steve
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.12.0-alpha.2
 	github.com/rancher/gke-operator v1.10.0
 	github.com/rancher/kubernetes-provider-detector v0.1.5
-	github.com/rancher/lasso v0.0.0-20241202185148-04649f379358
+	github.com/rancher/lasso v0.0.0-20250123080302-9325fed68518
 	github.com/rancher/machine v0.15.0-rancher125
 	github.com/rancher/norman v0.5.1
 	github.com/rancher/rancher/pkg/client v0.0.0

--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,6 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.31.1
 	oras.land/oras-go => oras.land/oras-go v1.2.2 // for docker 20.10.x compatibility
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.8.3
-
-	github.com/rancher/steve => /home/wrinkle/workspaces/joshmeranda/rancher-steve
 )
 
 require (
@@ -144,7 +142,7 @@ require (
 	github.com/rancher/remotedialer v0.4.0
 	github.com/rancher/rke v1.7.0-rc.5
 	github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b
-	github.com/rancher/steve v0.5.3
+	github.com/rancher/steve v0.5.5
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde
 	github.com/rancher/wrangler v1.1.2
 	github.com/rancher/wrangler/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -2439,8 +2439,8 @@ github.com/rancher/helm/v3 v3.16.1-rancher1/go.mod h1:r+xBHHP20qJeEqtvBXMf7W35QD
 github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM7QmfO4OedvFE3QwXiH60I=
 github.com/rancher/kubernetes-provider-detector v0.1.5/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
-github.com/rancher/lasso v0.0.0-20241202185148-04649f379358 h1:pJwgJXPt4fi0ysXsJcl28rvxhx/Z/9SNCDwFOEyeGu0=
-github.com/rancher/lasso v0.0.0-20241202185148-04649f379358/go.mod h1:IxgTBO55lziYhTEETyVKiT8/B5Rg92qYiRmcIIYoPgI=
+github.com/rancher/lasso v0.0.0-20250123080302-9325fed68518 h1:aElNUJg6kxTvs/e4yfMEkk0Dgzo/lyHl85xDqP+FC+A=
+github.com/rancher/lasso v0.0.0-20250123080302-9325fed68518/go.mod h1:stR7zYyew1IOnKYV5vFx1kXX5/pUoKeo5K5c78qAdV8=
 github.com/rancher/machine v0.15.0-rancher125 h1:J8HfJH0xm/ECwwHc6gSEBKLMKokZ6qP4tCLxO9iOdnQ=
 github.com/rancher/machine v0.15.0-rancher125/go.mod h1:9rlwC2p8rZUzJ2u3hunI6nMrPn2qPV9vmIOSmPXqOE4=
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77 h1:k+vzmkZQsH06rZnDr+phskSixG9ByNj9gVdzHcc8nxw=
@@ -2457,8 +2457,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b h1:uX+XbQgpqpfxfvDI+6uPb1DeeDqEwa7lE+QtYuPCqzU=
 github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
-github.com/rancher/steve v0.5.3 h1:PT272zc8Od3e8alRAgTAurw04oDj3C4JxfbPiEZEqro=
-github.com/rancher/steve v0.5.3/go.mod h1:yJrMTNPpw+sI082vdhYU+iBwPNO16CSxS+ruhomltJU=
+github.com/rancher/steve v0.5.5 h1:ldYJbjPCvsQR71bzSNqXfkN8gP0K/FH28MF/PcIpd24=
+github.com/rancher/steve v0.5.5/go.mod h1:ri4wF3Mt+x8WylEG+zuTYXPf11Yxt1D4yq3lDrco858=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=

--- a/main.go
+++ b/main.go
@@ -153,6 +153,12 @@ func main() {
 			Usage:       "Declare specific feature values on start up. Example: \"kontainer-driver=true\" - kontainer driver feature will be enabled despite false default value",
 			Destination: &config.Features,
 		},
+		cli.BoolFlag{
+			Name:        "imperative-extension-api",
+			EnvVar:      "IMPERATIVE_EXTENSION_API",
+			Usage:       "Enable the rancher imperative api",
+			Destination: &config.EnableImperativeAPIExtension,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -153,12 +153,6 @@ func main() {
 			Usage:       "Declare specific feature values on start up. Example: \"kontainer-driver=true\" - kontainer driver feature will be enabled despite false default value",
 			Destination: &config.Features,
 		},
-		cli.BoolFlag{
-			Name:        "imperative-extension-api",
-			EnvVar:      "IMPERATIVE_EXTENSION_API",
-			Usage:       "Enable the rancher imperative api",
-			Destination: &config.EnableImperativeAPIExtension,
-		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -1,0 +1,22 @@
+package ext
+
+import (
+	"fmt"
+
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func certForCommonName(cname string) (dynamiccertificates.SNICertKeyContentProvider, error) {
+	certPem, keyPem, err := certutil.GenerateSelfSignedCertKey(cname, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate self signed cert: %w", err)
+	}
+
+	content, err := dynamiccertificates.NewStaticSNICertKeyContent("self-signed-imperative", certPem, keyPem, cname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create static cert content: %w", err)
+	}
+
+	return content, nil
+}

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	extstores "github.com/rancher/rancher/pkg/ext/stores"
 	"github.com/rancher/rancher/pkg/features"
-	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	steveext "github.com/rancher/steve/pkg/ext"
 	steveserver "github.com/rancher/steve/pkg/server"
@@ -158,7 +158,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 	)
 
 	var additionalSniProviders []dynamiccertificates.SNICertKeyContentProvider
-	switch settings.ImperativeApiExtension.Get() {
+	switch os.Getenv("CATTLE_IMPERATIVE_API_EXTENSION") {
 	case "true":
 		logrus.Info("creating imperative extension apiserver resources")
 

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -35,7 +35,6 @@ const (
 	// The main kube-apiserver will connect to that port (through a tunnel).
 	Port              = 6666
 	APIServiceName    = "v1.ext.cattle.io"
-	CACertSecretName  = "imperative-api-extension-ca"
 	TargetServiceName = "imperative-api-extension"
 	Namespace         = "cattle-system"
 )
@@ -51,8 +50,8 @@ func CreateOrUpdateAPIService(apiservice wranglerapiregistrationv1.APIServiceCon
 			GroupPriorityMinimum: 100,
 			CABundle:             caBundle,
 			Service: &apiregv1.ServiceReference{
-				Namespace: "cattle-system",
-				Name:      "imperative-api-extension",
+				Namespace: Namespace,
+				Name:      TargetServiceName,
 				Port:      &port,
 			},
 			Version:         "v1",

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -202,18 +202,9 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	var extensionAPIServer steveserver.ExtensionAPIServer
-	if strings.EqualFold(settings.ImperativeApiExtension.Get(), "true") {
-		logrus.Info("starting extension api server")
-		extensionAPIServer, err = ext.NewExtensionAPIServer(ctx, wranglerContext)
-		if err != nil {
-			return nil, fmt.Errorf("extension api server: %w", err)
-		}
-	} else {
-		logrus.Debug("not starting extension api server, cleaning up resources")
-		if err := ext.CleanupExtensionAPIServer(wranglerContext); err != nil {
-			return nil, fmt.Errorf("failed to cleanup extension api server: %w", err)
-		}
+	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext)
+	if err != nil {
+		return nil, fmt.Errorf("extension api server: %w", err)
 	}
 
 	steve, err := steveserver.New(ctx, restConfig, &steveserver.Options{

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -198,10 +198,6 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	if err := dashboardapi.Register(ctx, wranglerContext); err != nil {
-		return nil, err
-	}
-
 	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext)
 	if err != nil {
 		return nil, fmt.Errorf("extension api server: %w", err)
@@ -279,6 +275,10 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 }
 
 func (r *Rancher) Start(ctx context.Context) error {
+	if err := dashboardapi.Register(ctx, r.Wrangler); err != nil {
+		return err
+	}
+
 	if err := steveapi.Setup(ctx, r.Steve, r.Wrangler); err != nil {
 		return err
 	}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -67,24 +67,23 @@ import (
 const encryptionConfigUpdate = "provisioner.cattle.io/encrypt-migrated"
 
 type Options struct {
-	ACMEDomains                  cli.StringSlice
-	AddLocal                     string
-	Embedded                     bool
-	BindHost                     string
-	HTTPListenPort               int
-	HTTPSListenPort              int
-	K8sMode                      string
-	Debug                        bool
-	Trace                        bool
-	NoCACerts                    bool
-	AuditLogPath                 string
-	AuditLogMaxage               int
-	AuditLogMaxsize              int
-	AuditLogMaxbackup            int
-	AuditLevel                   int
-	Features                     string
-	ClusterRegistry              string
-	EnableImperativeAPIExtension bool
+	ACMEDomains       cli.StringSlice
+	AddLocal          string
+	Embedded          bool
+	BindHost          string
+	HTTPListenPort    int
+	HTTPSListenPort   int
+	K8sMode           string
+	Debug             bool
+	Trace             bool
+	NoCACerts         bool
+	AuditLogPath      string
+	AuditLogMaxage    int
+	AuditLogMaxsize   int
+	AuditLogMaxbackup int
+	AuditLevel        int
+	Features          string
+	ClusterRegistry   string
 }
 
 type Rancher struct {
@@ -199,9 +198,8 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	// temporary workaround to enable the imperative api extensionfor testing
-	if opts.EnableImperativeAPIExtension {
-		settings.ImperativeApiExtension.Set("true")
+	if err := dashboardapi.Register(ctx, wranglerContext); err != nil {
+		return nil, err
 	}
 
 	var extensionAPIServer steveserver.ExtensionAPIServer
@@ -290,10 +288,6 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 }
 
 func (r *Rancher) Start(ctx context.Context) error {
-	if err := dashboardapi.Register(ctx, r.Wrangler); err != nil {
-		return err
-	}
-
 	if err := steveapi.Setup(ctx, r.Steve, r.Wrangler); err != nil {
 		return err
 	}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -345,6 +345,8 @@ var (
 	// UnprivilegedJailUser controls whether jailed commands execute under a separate (unprivileged/non-root) user
 	// account. Setting it to false is only recommended for testing and development environments.
 	UnprivilegedJailUser = NewSetting("unprivileged-jail-user", "true")
+
+	ImperativeApiExtension = NewSetting("imperative-api-extension", "false")
 )
 
 // FullShellImage returns the full private registry name of the rancher shell image.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/47035
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Needed feature flag for extension server as well as integrating new authentication features from the steve extension server.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added new setting and cli to allow toggling extension server. When enabled, create new `APIService` and `Service` to route traffic requesting resources from `ext.cattle.io`. Generated new SNI certs for apiservice `caBundle` to authenticate requests coming from the kube apiserver.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

1. build charts with `scripts/chart/build chart`
2. Add a test type including a sample store (see https://github.com/joshmeranda/rancher-rancher/blob/imperative-api-setting/pkg/apis/ext.cattle.io/v1/types.go and https://github.com/joshmeranda/rancher-rancher/blob/imperative-api-setting/pkg/ext/stores/install.go for details)
3. Install rancher to k3s with `helm upgrade --install --create-namespace --namespace cattle-system --set hostname=rancher.local.com --set rancherImage=joshmeranda/rancher --set rancherImageTag=test --set replicas=1 --set imperativeExtensionApi.enabled=true --set rancherImagePullPolicy=Always rancher ./build/chart/rancher`
4. Log in via web browser
5. Check `<rancher-host>/apis/ext.cattle.io/v1` to check for registered types:

```
{
  "kind": "APIResourceList",
  "apiVersion": "v1",
  "groupVersion": "ext.cattle.io/v1",
  "resources": [
    {
      "name": "testtypes",
      "singularName": "testtype",
      "namespaced": false,
      "group": "ext.cattle.io",
      "version": "v1",
      "kind": "TestType",
      "verbs": [
        "create",
        "delete",
        "get",
        "list",
        "patch",
        "update",
        "watch"
      ]
    }
  ]
}
```

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_

depends on https://github.com/rancher/steve/pull/434