### PR TITLE
[main] Include secret type field when synchronizing downstream

### DIFF
--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -222,6 +222,7 @@ func (c *ResourceSyncController) sync(key string, obj *corev1.Secret) (runtime.O
 		logrus.Debugf("[resource-sync][secret] creating secret %v/%v in cluster %v", ns, name, c.clusterName)
 
 		newSecret := &corev1.Secret{
+			Type:       obj.Type,
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 			Data:       obj.Data,
 		}


### PR DESCRIPTION
## Issue: #48371 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

As described [here](https://github.com/rancher/rancher/pull/46722#issuecomment-2501605249) when using the resource-sync-controller to synchronize secrets downstream the `Type` field is missed. This results in an upstream `basic-auth` secret being created as a `opaque` secret downstream since the default secret type is opaque.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add `Type` to the secret being created downstream.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Follow the normal testing process for resource-synchronized secrets, but create a basic-auth or dockerconfigjson secret to sync and validate that the type is synchronized as well. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually and added provisioning-tests.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration (v2prov Framework)
  <!--
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

I would suggest just following the test plan created for #46722 - that PR contains the annotations the secret will need in order to test this.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
None - this just adds a single field to the new secret. 

Existing / newly added automated tests that provide evidence there are no regressions:
* added to the v2prov test framework.