### PR TITLE
Bump webhook to 0.5.6-rc.2 for the 2.9.6 release.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 104.0.5+up0.5.5
+webhookVersion: 104.0.6+up0.5.6-rc.2
 provisioningCAPIVersion: 104.1.0+up0.3.1
 cspAdapterMinVersion: 104.0.0+up4.0.0
 defaultShellVersion: rancher/shell:v0.2.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,5 +7,5 @@ const (
 	DefaultShellVersion     = "rancher/shell:v0.2.2"
 	FleetVersion            = "104.1.4+up0.10.8-rc.2"
 	ProvisioningCAPIVersion = "104.1.0+up0.3.1"
-	WebhookVersion          = "104.0.5+up0.5.5"
+	WebhookVersion          = "104.0.6+up0.5.6-rc.2"
 )


### PR DESCRIPTION
Related to #48770 