### PR TITLE
updating custodian rules for azure to avoid overwriting op labels

### DIFF
--- a/tests/scripts/custodian/azure.yaml
+++ b/tests/scripts/custodian/azure.yaml
@@ -11,7 +11,6 @@ policies:
       value: PowerState/failed
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
-    - 'tag:known_user': absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
@@ -36,6 +35,7 @@ policies:
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
     - 'tag:known_user': absent
+    - 'tag:unknown_user': absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
@@ -62,6 +62,7 @@ policies:
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
     - 'tag:unknown_user': absent
+    - 'tag:known_user': absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
@@ -106,6 +107,7 @@ policies:
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
     - 'tag:known_user': absent
+    - 'tag:unknown_user': absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
@@ -132,6 +134,7 @@ policies:
     - 'tag:doNotDelete': absent
     - 'tag:DoNotDelete': absent
     - 'tag:unknown_user': absent
+    - 'tag:known_user': absent
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value


### PR DESCRIPTION
azure instances had the same problem that aws had on friday; re-tagging instances before deleting them. 