### PR TITLE
Updating tags for the cluster templates provisioning tests

### DIFF
--- a/tests/v2/validation/clustertemplates/provisioning/clustertemplate_export_test.go
+++ b/tests/v2/validation/clustertemplates/provisioning/clustertemplate_export_test.go
@@ -1,3 +1,5 @@
+//go:build (validation || infra.rke1 || cluster.nodedriver || stress) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !cluster.any && !sanity
+
 package clustertemplates
 
 import (

--- a/tests/v2/validation/clustertemplates/provisioning/provisioning_clustertemplate_test.go
+++ b/tests/v2/validation/clustertemplates/provisioning/provisioning_clustertemplate_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || sanity) && !infra.any && !infra.aks && !infra.eks && !infra.rke2k3s && !infra.gke && !infra.rke1 && !cluster.any && !cluster.custom && !cluster.nodedriver && !extended && !stress
+//go:build (validation || infra.rke1 || cluster.nodedriver || stress) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !cluster.any && !sanity
 
 package clustertemplates
 

--- a/tests/v2/validation/clustertemplates/rbac/clustertemplate_test.go
+++ b/tests/v2/validation/clustertemplates/rbac/clustertemplate_test.go
@@ -1,3 +1,5 @@
+//go:build (validation || infra.rke1 || cluster.nodedriver || stress) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !cluster.any && !sanity
+
 package rbac
 
 import (


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Go build tags were missing from the tests as a result these tests are failing in the recurring runs. 
 
 
## Solution
Added go build tags and added `stress` tag for this to be a bi-weekly run.

