### PR TITLE
Don't display SummaryRemote in Status if the GlobalRole is not admin

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -213,6 +213,7 @@ func TestCreateUpdate(t *testing.T) {
 					Status: v3.GlobalRoleBindingStatus{
 						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
+						Summary:        status.SummaryCompleted,
 						LocalConditions: []metav1.Condition{
 							{
 								Type:               clusterPermissionsReconciled,
@@ -334,6 +335,7 @@ func TestCreateUpdate(t *testing.T) {
 					UserName:       userName,
 					Status: v3.GlobalRoleBindingStatus{
 						LastUpdateTime: mockTime().Format(time.RFC3339),
+						Summary:        status.SummaryCompleted,
 						SummaryLocal:   status.SummaryCompleted,
 						LocalConditions: []metav1.Condition{
 							{
@@ -772,6 +774,7 @@ func TestCreateUpdate(t *testing.T) {
 					Status: v3.GlobalRoleBindingStatus{
 						LastUpdateTime: mockTime().Format(time.RFC3339),
 						SummaryLocal:   status.SummaryCompleted,
+						Summary:        status.SummaryCompleted,
 						LocalConditions: []metav1.Condition{
 							{
 								Type:               clusterPermissionsReconciled,

--- a/pkg/controllers/managementuser/rbac/globalrolebinding_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/globalrolebinding_handler_test.go
@@ -140,16 +140,6 @@ func TestSync(t *testing.T) {
 						Builtin: true,
 					}, nil
 				}
-				state.grbListerMock.EXPECT().Get(grb.Name).Return(&v3.GlobalRoleBinding{
-					GlobalRoleName: "gr",
-				}, nil)
-				state.grbClientMock.EXPECT().UpdateStatus(&v3.GlobalRoleBinding{
-					GlobalRoleName: "gr",
-					Status: v3.GlobalRoleBindingStatus{
-						LastUpdateTime: mockTime().Format(time.RFC3339),
-						SummaryRemote:  status.SummaryCompleted,
-					},
-				})
 			},
 		},
 		"error getting GlobalRole": {

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -330,6 +330,42 @@ func TestIsAdminGlobalRole(t *testing.T) {
 			},
 			wantResult: false,
 		},
+		"is not admin role- has admin for NonResourceURLs, but not for Resources": {
+			stateSetup: func(state grbTestState) {
+				state.grListerMock.GetFunc = func(namespace string, name string) (*apimgmtv3.GlobalRole, error) {
+					return &apimgmtv3.GlobalRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gr",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:           []string{"*"},
+								NonResourceURLs: []string{"*"},
+							},
+						},
+					}, nil
+				}
+			},
+			wantResult: false,
+		},
+		"is not admin role- has admin for Resources, but not for NonResourceURLs": {
+			stateSetup: func(state grbTestState) {
+				state.grListerMock.GetFunc = func(namespace string, name string) (*apimgmtv3.GlobalRole, error) {
+					return &apimgmtv3.GlobalRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gr",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"*"},
+								APIGroups: []string{"*"},
+								Resources: []string{"*"},
+							},
+						},
+					}, nil
+				}
+			},
+		},
 		"error getting GlobalRole": {
 			stateSetup: func(state grbTestState) {
 				state.grListerMock.GetFunc = func(namespace string, name string) (*apimgmtv3.GlobalRole, error) {

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -8,7 +9,10 @@ import (
 
 	"github.com/rancher/norman/types"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -257,4 +261,102 @@ func TestGetRTBLabel(t *testing.T) {
 			}
 		})
 	}
+}
+
+type grbTestState struct {
+	grListerMock *fakes.GlobalRoleListerMock
+}
+
+func TestIsAdminGlobalRole(t *testing.T) {
+	err := errors.New("unexpected error")
+	tests := map[string]struct {
+		stateSetup  func(state grbTestState)
+		inputObject *v3.GlobalRoleBinding
+		wantResult  bool
+		wantError   error
+	}{
+		"is builtin admin role": {
+			stateSetup: func(state grbTestState) {
+				state.grListerMock.GetFunc = func(namespace string, name string) (*apimgmtv3.GlobalRole, error) {
+					return &apimgmtv3.GlobalRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: GlobalAdmin,
+						},
+						Builtin: true,
+					}, nil
+				}
+			},
+			wantResult: true,
+		},
+		"is admin role": {
+			stateSetup: func(state grbTestState) {
+				state.grListerMock.GetFunc = func(namespace string, name string) (*apimgmtv3.GlobalRole, error) {
+					return &apimgmtv3.GlobalRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gr",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"*"},
+								APIGroups: []string{"*"},
+								Resources: []string{"*"},
+							},
+							{
+								Verbs:           []string{"*"},
+								NonResourceURLs: []string{"*"},
+							},
+						},
+					}, nil
+				}
+			},
+			wantResult: true,
+		},
+		"is not admin role": {
+			stateSetup: func(state grbTestState) {
+				state.grListerMock.GetFunc = func(namespace string, name string) (*apimgmtv3.GlobalRole, error) {
+					return &apimgmtv3.GlobalRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gr",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"get"},
+								APIGroups: []string{""},
+								Resources: []string{"pods"},
+							},
+						},
+					}, nil
+				}
+			},
+			wantResult: false,
+		},
+		"error getting GlobalRole": {
+			stateSetup: func(state grbTestState) {
+				state.grListerMock.GetFunc = func(namespace string, name string) (*apimgmtv3.GlobalRole, error) {
+					return nil, err
+				}
+			},
+			wantResult: false,
+			wantError:  err,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			grListerMock := fakes.GlobalRoleListerMock{}
+			state := grbTestState{
+				grListerMock: &grListerMock,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+
+			isAdmin, err := IsAdminGlobalRole("", state.grListerMock)
+
+			assert.Equal(t, test.wantResult, isAdmin)
+			assert.Equal(t, test.wantError, err)
+		})
+	}
+
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48790
 
## Problem
We only create resources in the downstream clusters for admin `GlobalRoles`. The GRB status includes `observedGenerationRemote`, `summaryRemote` for non-admin `GlobalRoles` which are intended only for admin GlobalRoles.
 
## Solution
Don't display `observedGenerationRemote`, `summaryRemote` for non-admin `GlobalRoles` 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
Unit tests
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
