### PR TITLE
fix: exclude Windows nodes from the upgrade process in imported clusters

### DIFF
--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -181,7 +181,12 @@ func (n *nodeSyncer) sync(key string, node *corev1.Node) (runtime.Object, error)
 		return nil, err
 	} else if ok {
 		node = node.DeepCopy()
-		node.Labels[UpgradeEnabledLabel] = "true"
+		// only linux nodes are supported in imported clusters
+		if node.Labels[corev1.LabelOSStable] == "linux" {
+			node.Labels[UpgradeEnabledLabel] = "true"
+		} else {
+			node.Labels[UpgradeEnabledLabel] = "false"
+		}
 		return n.nodesSyncer.nodeClient.Update(node)
 	}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45030
 
## Problem
Cluster with Windows nodes stuck in "Upgrading" state for imported rke2 cluster.
 
## Solution
When determining whether a cluster K8s version upgrade is needed, skip any Windows nodes and skip Windows nodes if the upgrade was kicked off.
 https://github.com/rancher/rancher/issues/48134#issuecomment-2597336099

## Engineering Testing
### Manual Testing
- Import a rke2 cluster with windows node
- Upgrade the cluster
- Check if windows node was upgraded or not
