### PR TITLE
[main] change over to using kubectl port-forward from script rather than hostPort

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -157,6 +157,11 @@ push_cattle_agent_image()
   echo "registry-cache pod found! waiting for pod to be running"
   kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml wait --for=condition=ready pod/registry-cache -n default
 
+  # things are a little weird here - we are port-forwarding in to the registry cache but 
+  # want to listen to the docker address so the docker daemon can hit this process.
+  kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml port-forward -n default svc/registry-cache 5000:5000 --address 172.17.0.2 & 
+  sleep 1
+
   # we're referring to the docker IP of the current pod...but since the docker socket is from the host localhost
   # won't work. so we refer to it by the internal docker IP of the container to make it all work.
   echo "setting up credentials"

--- a/tests/v2prov/registry/registry.go
+++ b/tests/v2prov/registry/registry.go
@@ -192,7 +192,6 @@ func createOrGetPod(clients *clients.Clients, podName string, pullThrough bool) 
 						{
 							Name:          "http",
 							ContainerPort: 5000,
-							HostPort:      5000,
 						},
 					},
 				},


### PR DESCRIPTION
During #47563 I modified the `registry-cache` a little bit to expose a hostPort. This didn't cause issues over here but I am curious if this is causing problems when running the KDM provisioning tests as they are failing sometimes now and this was the only change made.

This PR removes the hostPort on the container and instead just uses a `kubectl port-forward` from the dapper container to allow pushing into the cluster's registry cache. 