### PR TITLE
Don't update LastTransitionTime for a condition that hasn't changed

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -576,6 +576,8 @@ func (grb *globalRoleBindingLifecycle) purgeInvalidNamespacedRBs(rbs []*v1.RoleB
 	return returnError
 }
 
+// updateStatus updates the Status field of the GRB. localConditions are created in each reconciliation loop.
+// Status is only update if any condition has changed.
 func (c *globalRoleBindingLifecycle) updateStatus(grb *apisv3.GlobalRoleBinding, localConditions []metav1.Condition) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		grbFromCluster, err := c.grbLister.Get(grb.Name)
@@ -598,6 +600,7 @@ func (c *globalRoleBindingLifecycle) updateStatus(grb *apisv3.GlobalRoleBinding,
 			}
 		}
 
+		status.KeepLastTransitionTimeIfConditionHasNotChanged(localConditions, grbFromCluster.Status.LocalConditions)
 		grbFromCluster.Status.LastUpdateTime = c.status.TimeNow().Format(time.RFC3339)
 		grbFromCluster.Status.ObservedGenerationLocal = grb.ObjectMeta.Generation
 		grbFromCluster.Status.LocalConditions = localConditions

--- a/pkg/controllers/status/status.go
+++ b/pkg/controllers/status/status.go
@@ -71,3 +71,19 @@ func CompareConditions(s1 []metav1.Condition, s2 []metav1.Condition) bool {
 
 	return true
 }
+
+// KeepLastTransitionTimeIfConditionHasNotChanged update conditions LastTransitionTime with the value from conditionsFromCluster
+// if condition is the same
+func KeepLastTransitionTimeIfConditionHasNotChanged(conditions []metav1.Condition, conditionsFromCluster []metav1.Condition) {
+	for _, cFromCluster := range conditionsFromCluster {
+		for i := 0; i < len(conditions); i++ {
+			c := &conditions[i]
+			if c.Type == cFromCluster.Type &&
+				c.Status == cFromCluster.Status &&
+				c.Reason == cFromCluster.Reason &&
+				c.Message == cFromCluster.Message {
+				c.LastTransitionTime = cFromCluster.LastTransitionTime
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48809
 
## Problem
The `lastTransitionTime` for conditions are being updated even though its status hasn't changed.
  
## Solution
Dont update `lastTransitionTime` if the condition hasn't changed
 
## Testing
Unit tests added