### PR TITLE
Migrate RBAC Daemonset Tests

### DIFF
--- a/tests/v2/actions/workloads/daemonset/verify.go
+++ b/tests/v2/actions/workloads/daemonset/verify.go
@@ -3,9 +3,7 @@ package daemonset
 import (
 	projectsapi "github.com/rancher/rancher/tests/v2/actions/projects"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func VerifyCreateDaemonSet(client *rancher.Client, clusterID string) error {
@@ -14,16 +12,10 @@ func VerifyCreateDaemonSet(client *rancher.Client, clusterID string) error {
 		return err
 	}
 
-	logrus.Info("Creating new daemonset")
-	createdDaemonset, err := CreateDaemonset(client, clusterID, namespace.Name, 1, "", "", false, false)
+	logrus.Info("Creating new daemonset and waiting for daemonset to come up active")
+	_, err = CreateDaemonset(client, clusterID, namespace.Name, 1, "", "", false, false, true)
 	if err != nil {
 		return err
 	}
-
-	logrus.Infof("Waiting for daemonset %s to become active", createdDaemonset.Name)
-	err = charts.WatchAndWaitDaemonSets(client, clusterID, namespace.Name, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + createdDaemonset.Name,
-	})
-
 	return err
 }

--- a/tests/v2/validation/rbac/clusterandprojectroles/manage_workloads_role_test.go
+++ b/tests/v2/validation/rbac/clusterandprojectroles/manage_workloads_role_test.go
@@ -268,12 +268,8 @@ func (mw *ManageWorkloadsRoleTestSuite) TestManageWorkloadsRoleForDaemonSets() {
 	workloadUser, workloadUserClient := mw.testSetupWorkloadUserAndAddToProject(adminProject)
 
 	log.Infof("As user %s, create a new DaemonSet in the namespace within the project %s.", workloadUser.Name, adminProject.Name)
-	createdDaemonSet, err := daemonset.CreateDaemonset(workloadUserClient, mw.cluster.ID, adminNamespace.Name, 1, "", "", false, false)
+	createdDaemonSet, err := daemonset.CreateDaemonset(workloadUserClient, mw.cluster.ID, adminNamespace.Name, 1, "", "", false, false, true)
 	require.NoError(mw.T(), err, "Failed to create the DaemonSet.")
-	err = charts.WatchAndWaitDaemonSets(workloadUserClient, mw.cluster.ID, adminNamespace.Name, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + createdDaemonSet.Name,
-	})
-	require.NoError(mw.T(), err)
 
 	log.Infof("As user %s, list the DaemonSet %s.", workloadUser.Username, createdDaemonSet.Name)
 	downstreamContext, err := workloadUserClient.WranglerContext.DownStreamClusterWranglerContext(mw.cluster.ID)
@@ -293,11 +289,7 @@ func (mw *ManageWorkloadsRoleTestSuite) TestManageWorkloadsRoleForDaemonSets() {
 		getDaemonSet.Labels = make(map[string]string)
 	}
 	getDaemonSet.Labels["updated"] = "true"
-	updatedDaemonSet, err := daemonset.UpdateDaemonset(workloadUserClient, mw.cluster.ID, adminNamespace.Name, getDaemonSet)
-	require.NoError(mw.T(), err)
-	err = charts.WatchAndWaitDaemonSets(workloadUserClient, mw.cluster.ID, adminNamespace.Name, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + updatedDaemonSet.Name,
-	})
+	updatedDaemonSet, err := daemonset.UpdateDaemonset(workloadUserClient, mw.cluster.ID, adminNamespace.Name, getDaemonSet, true)
 	require.NoError(mw.T(), err)
 
 	updatedDaemonSet, err = downstreamContext.Apps.DaemonSet().Get(adminNamespace.Name, updatedDaemonSet.Name, metav1.GetOptions{})

--- a/tests/v2/validation/rbac/secrets/rbac_registry_secrets_test.go
+++ b/tests/v2/validation/rbac/secrets/rbac_registry_secrets_test.go
@@ -177,7 +177,7 @@ func (rbrs *RbacRegistrySecretTestSuite) TestUpdateRegistrySecret() {
 		subSession := rbrs.session.NewSession()
 		defer subSession.Cleanup()
 
-		rbrs.Run("Validate updating secret as user with role "+tt.role.String(), func() {
+		rbrs.Run("Validate updating registry secret as user with role "+tt.role.String(), func() {
 			log.Info("Create a project and a namespace in the projects.")
 			adminProject, namespace, err := projects.CreateProjectAndNamespace(rbrs.client, rbrs.cluster.ID)
 			assert.NoError(rbrs.T(), err)

--- a/tests/v2/validation/rbac/workloads/README.md
+++ b/tests/v2/validation/rbac/workloads/README.md
@@ -1,0 +1,26 @@
+# RBAC Workloads
+
+## Pre-requisites
+
+- Ensure you have an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, create one first before running this test.
+
+## Test Setup
+
+Your GO suite should be set to `-run ^Test<TestSuite>$`
+
+- To run the rbac_daemonset_test.go, set the GO suite to `-run ^TestRbacDaemonsetTestSuite$`
+- To run the rbac_deployment_test.go, set the GO suite to `-run ^TestRbacDeploymentTestSuite$`
+- To run the rbac_statefulset_test.go, set the GO suite to `-run ^TestRbacStatefulSetTestSuite$`
+- To run the rbac_cronjob_test.go, set the GO suite to `-run ^TestRbacCronJobTestSuite$`
+- To run the rbac_job_test.go, set the GO suite to `-run ^TestRbacJobTestSuite$`
+
+In your config file, set the following:
+
+```yaml
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True #optional
+  cleanup: True #optional
+  clusterName: "cluster_name"
+```

--- a/tests/v2/validation/rbac/workloads/rbac_daemonset_test.go
+++ b/tests/v2/validation/rbac/workloads/rbac_daemonset_test.go
@@ -1,0 +1,283 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+
+package workloads
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/projects"
+	"github.com/rancher/rancher/tests/v2/actions/rbac"
+	"github.com/rancher/rancher/tests/v2/actions/workloads/daemonset"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type RbacDaemonsetTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (rds *RbacDaemonsetTestSuite) TearDownSuite() {
+	rds.session.Cleanup()
+}
+
+func (rds *RbacDaemonsetTestSuite) SetupSuite() {
+	rds.session = session.NewSession()
+
+	client, err := rancher.NewClient("", rds.session)
+	require.NoError(rds.T(), err)
+	rds.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in rds")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(rds.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rds.client, clusterName)
+	require.NoError(rds.T(), err, "Error getting cluster ID")
+	rds.cluster, err = rds.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rds.T(), err)
+}
+
+func (rds *RbacDaemonsetTestSuite) TestCreateDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate daemonset creation as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset", tt.role.String())
+			_, err = daemonset.CreateDaemonset(userClient, rds.cluster.ID, namespace.Name, 1, "", "", false, false, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rds.T(), err, "failed to create daemonset")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestListDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate listing daemonset as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset in the namespace %v", rbac.Admin, namespace.Name)
+			createdDaemonset, err := daemonset.CreateDaemonset(rds.client, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+			assert.NoError(rds.T(), err, "failed to create daemonset")
+
+			log.Infof("As a %v, list the daemonset", tt.role.String())
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+			daemonsetList, err := standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String(), rbac.ReadOnly.String():
+				assert.NoError(rds.T(), err, "failed to list daemonset")
+				assert.Equal(rds.T(), len(daemonsetList.Items), 1)
+				assert.Equal(rds.T(), daemonsetList.Items[0].Name, createdDaemonset.Name)
+			case rbac.ClusterMember.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestUpdateDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate updating daemonset as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset in the namespace %v", rbac.Admin, namespace.Name)
+			createdDaemonset, err := daemonset.CreateDaemonset(rds.client, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+			assert.NoError(rds.T(), err, "failed to create daemonset")
+
+			log.Infof("As a %v, update the daemonSet %s with a new label.", tt.role.String(), createdDaemonset.Name)
+			if createdDaemonset.Labels == nil {
+				createdDaemonset.Labels = make(map[string]string)
+			}
+			createdDaemonset.Labels["updated"] = "true"
+			updatedDaemonSet, err := daemonset.UpdateDaemonset(userClient, rds.cluster.ID, namespace.Name, createdDaemonset, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rds.T(), err, "failed to update daemonset")
+				standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rds.cluster.ID)
+				assert.NoError(rds.T(), err)
+				updatedDaemonSet, err = standardUserContext.Apps.DaemonSet().Get(namespace.Name, updatedDaemonSet.Name, metav1.GetOptions{})
+				assert.NoError(rds.T(), err, "Failed to get the updated daemonSet after updating labels.")
+				assert.Equal(rds.T(), "true", updatedDaemonSet.Labels["updated"], "DaemonSet label update failed.")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestDeleteDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate deleting daemonset as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset in the namespace %v", rbac.Admin, namespace.Name)
+			createdDaemonset, err := daemonset.CreateDaemonset(rds.client, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+			assert.NoError(rds.T(), err, "failed to create daemonset")
+
+			log.Infof("As a %v, delete the daemonset", tt.role.String())
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+			err = standardUserContext.Apps.DaemonSet().Delete(namespace.Name, createdDaemonset.Name, &metav1.DeleteOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rds.T(), err, "failed to delete daemonset")
+				daemonsetList, err := standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+				assert.NoError(rds.T(), err)
+				assert.Equal(rds.T(), len(daemonsetList.Items), 0)
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestCrudDaemonsetAsClusterMember() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	role := rbac.ClusterMember.String()
+	log.Infof("Create a standard user.")
+	user, userClient, err := rbac.SetupUser(rds.client, rbac.StandardUser.String())
+	require.NoError(rds.T(), err)
+
+	log.Infof("Add the user to the downstream cluster with role %s", role)
+	err = users.AddClusterRoleToUser(rds.client, rds.cluster, user, role, nil)
+	require.NoError(rds.T(), err)
+
+	log.Infof("As a %v, create a project and a namespace in the project.", role)
+	_, namespace, err := projects.CreateProjectAndNamespace(userClient, rds.cluster.ID)
+	require.NoError(rds.T(), err)
+
+	log.Infof("As a %v, create a daemonset in the namespace %v", role, namespace.Name)
+	createdDaemonset, err := daemonset.CreateDaemonset(userClient, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+	require.NoError(rds.T(), err, "failed to create daemonset")
+
+	log.Infof("As a %v, list the daemonset", role)
+	standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rds.cluster.ID)
+	require.NoError(rds.T(), err)
+	daemonsetList, err := standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rds.T(), err, "failed to list daemonset")
+	require.Equal(rds.T(), len(daemonsetList.Items), 1)
+	require.Equal(rds.T(), daemonsetList.Items[0].Name, createdDaemonset.Name)
+
+	log.Infof("As a %v, update the daemonSet %s with a new label.", role, createdDaemonset.Name)
+	if createdDaemonset.Labels == nil {
+		createdDaemonset.Labels = make(map[string]string)
+	}
+	createdDaemonset.Labels["updated"] = "true"
+	updatedDaemonSet, err := daemonset.UpdateDaemonset(userClient, rds.cluster.ID, namespace.Name, createdDaemonset, true)
+	require.NoError(rds.T(), err, "failed to update daemonset")
+	updatedDaemonSet, err = standardUserContext.Apps.DaemonSet().Get(namespace.Name, updatedDaemonSet.Name, metav1.GetOptions{})
+	require.NoError(rds.T(), err, "Failed to get the updated daemonSet after updating labels.")
+	require.Equal(rds.T(), "true", updatedDaemonSet.Labels["updated"], "DaemonSet label update failed.")
+
+	log.Infof("As a %v, delete the daemonset", role)
+	err = standardUserContext.Apps.DaemonSet().Delete(namespace.Name, createdDaemonset.Name, &metav1.DeleteOptions{})
+	require.NoError(rds.T(), err, "failed to delete daemonset")
+	daemonsetList, err = standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rds.T(), err)
+	require.Equal(rds.T(), len(daemonsetList.Items), 0)
+}
+
+func TestRbacDaemonsetTestSuite(t *testing.T) {
+	suite.Run(t, new(RbacDaemonsetTestSuite))
+}


### PR DESCRIPTION
**Issue**: https://github.com/rancher/qa-tasks/issues/1342

This is one of the several upcoming PRs aimed at migrating the RBAC workload tests from Python to Go. **This PR specifically includes tests for DaemonSet only.**

**Note**: Backport PRs will be created once this gets approved
