### PR TITLE
Fix: Harvester Feature Flag

### DIFF
--- a/pkg/controllers/management/feature/feature_handler.go
+++ b/pkg/controllers/management/feature/feature_handler.go
@@ -6,13 +6,19 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	datamanagement "github.com/rancher/rancher/pkg/data/management"
 	"github.com/rancher/rancher/pkg/features"
 	managementv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	normanv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
 )
 
@@ -20,15 +26,17 @@ type handler struct {
 	featuresClient       managementv3.FeatureClient
 	tokensLister         managementv3.TokenCache
 	tokenEnqueue         func(string, time.Duration)
-	nodeDriverController managementv3.NodeDriverController
+	nodeDriverController normanv3.NodeDriverInterface
+	managementContext    *config.ManagementContext
 }
 
-func Register(ctx context.Context, wContext *wrangler.Context) {
+func Register(ctx context.Context, management *config.ManagementContext, wContext *wrangler.Context) {
 	h := handler{
 		featuresClient:       wContext.Mgmt.Feature(),
 		tokensLister:         wContext.Mgmt.Token().Cache(),
 		tokenEnqueue:         wContext.Mgmt.Token().EnqueueAfter,
-		nodeDriverController: wContext.Mgmt.NodeDriver(),
+		nodeDriverController: management.Management.NodeDrivers(""),
+		managementContext:    management,
 	}
 	wContext.Mgmt.Feature().OnChange(ctx, "feature-handler", h.sync)
 }
@@ -48,7 +56,9 @@ func (h *handler) sync(_ string, obj *v3.Feature) (*v3.Feature, error) {
 	}
 
 	if obj.Name == features.Harvester.Name() {
-		return obj, h.toggleHarvesterNodeDriver(obj.Name)
+		if err = h.syncHarvesterNodeDriver(obj); err != nil {
+			return obj, err
+		}
 	}
 
 	if obj.Name == features.HarvesterBaremetalContainerWorkload.Name() {
@@ -94,14 +104,25 @@ func (h *handler) syncHarvesterFeature(obj *v3.Feature) error {
 	return nil
 }
 
-func (h *handler) toggleHarvesterNodeDriver(harvester string) error {
-	if val := features.GetFeatureByName(harvester).Enabled(); val {
-		m, err := h.nodeDriverController.Cache().Get(harvester)
-		if err != nil {
-			return err
+// syncHarvesterNodeDriver ensures that the Harvester node driver is disabled
+// when the Harvester feature is disabled and that the node driver is enabled,
+// when the Harvester feature is enabled - provided that the node driver
+// exists. If it doesn't exist, the node driver is created.
+func (h *handler) syncHarvesterNodeDriver(feat *v3.Feature) error {
+	m, err := h.nodeDriverController.Controller().Lister().Get("", feat.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return datamanagement.AddHarvesterMachineDriver(h.managementContext)
 		}
-		m.Spec.Active = val
-		_, err = h.nodeDriverController.Update(m)
+		return err
+	}
+
+	n := m.DeepCopy()
+	n.Spec.Active = *feat.Spec.Value
+
+	if !reflect.DeepEqual(m, n) {
+		logrus.Infof("updaeting node driver %v", n.Name)
+		_, err = h.nodeDriverController.Update(n)
 		return err
 	}
 	return nil

--- a/pkg/controllers/management/feature/feature_handler.go
+++ b/pkg/controllers/management/feature/feature_handler.go
@@ -109,6 +109,11 @@ func (h *handler) syncHarvesterFeature(obj *v3.Feature) error {
 // when the Harvester feature is enabled - provided that the node driver
 // exists. If it doesn't exist, the node driver is created.
 func (h *handler) syncHarvesterNodeDriver(feat *v3.Feature) error {
+	if feat.Spec.Value == nil {
+		logrus.Debugf("feature %v contains nil value", feat.Name)
+		return nil
+	}
+
 	m, err := h.nodeDriverController.Controller().Lister().Get("", feat.Name)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -121,7 +126,7 @@ func (h *handler) syncHarvesterNodeDriver(feat *v3.Feature) error {
 	n.Spec.Active = *feat.Spec.Value
 
 	if !reflect.DeepEqual(m, n) {
-		logrus.Infof("updaeting node driver %v", n.Name)
+		logrus.Infof("updating node driver %v", n.Name)
 		_, err = h.nodeDriverController.Update(n)
 		return err
 	}

--- a/pkg/controllers/management/wrangler.go
+++ b/pkg/controllers/management/wrangler.go
@@ -23,7 +23,7 @@ func RegisterWrangler(ctx context.Context, wranglerContext *wrangler.Context, ma
 	gke.Register(ctx, wranglerContext, management)
 	clusterupstreamrefresher.Register(ctx, wranglerContext)
 
-	feature.Register(ctx, wranglerContext)
+	feature.Register(ctx, management, wranglerContext)
 
 	if features.ProvisioningV2.Enabled() {
 		if err := authprovisioningv2.Register(ctx, wranglerContext, management); err != nil {

--- a/tests/controllers/feature/feature_test.go
+++ b/tests/controllers/feature/feature_test.go
@@ -8,6 +8,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/feature"
 	"github.com/rancher/rancher/pkg/features"
+	mcm "github.com/rancher/rancher/pkg/multiclustermanager"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/crd"
 	"github.com/stretchr/testify/assert"
@@ -61,8 +62,11 @@ func (s *FeatureTestSuite) SetupSuite() {
 	s.wranglerContext, err = wrangler.NewContext(s.ctx, nil, restCfg)
 	assert.NoError(s.T(), err)
 
+	scaledContext, _, _, err := mcm.BuildScaledContext(s.ctx, s.wranglerContext, &mcm.Options{})
+
+	management, err := scaledContext.NewManagementContext()
 	// Register the feature controller
-	feature.Register(s.ctx, s.wranglerContext)
+	feature.Register(s.ctx, management, s.wranglerContext)
 
 	// Create and start the feature controller factory
 	cf := s.wranglerContext.ControllerFactory.ForResourceKind(schema.GroupVersionResource{


### PR DESCRIPTION
Fix Harvester feature flag enabling/disabling the Harvester node driver. When the Harvester feaature flag is disabled, the Harvester node driver needs to be disabled to, e.g. to prevent trying do download the node driver in an airgapped environment.
When the Harvester feature flag is enabled, the node driver must be enabled too. Should the node driver have been deleted, it must be re-created when the Feature flag is enabled.

related-to: rancher/rancher#48920

## Issue:

GitHub Issue: rancher/rancher#48920
Jira: SURE-9678
 
## Problem

User reported that in an airgapped environment Rancher tries to download the Harvester node driver from the public internet, despite the Harvester feature being disabled.
The download fails of course, but is retried indefintively.

## Solution

Set the `.spec.active` field of the `nodedriver.management.cattle.io/v3` object of the Harvester node driver to `false` when the `.spec.value` of the corresponding `feature.management.cattle.io/v3` object is also `false`.
Similarly, activate the node driver again by setting the field to `true` when the corresponding feature is activated.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_