### PR TITLE
Fix Harvester Baremetal Container Feature Flag

### DIFF
--- a/pkg/controllers/management/feature/feature_handler.go
+++ b/pkg/controllers/management/feature/feature_handler.go
@@ -58,7 +58,10 @@ func (h *handler) sync(_ string, obj *v3.Feature) (*v3.Feature, error) {
 	}
 
 	if obj.Name == features.Harvester.Name() {
-		return obj, h.syncHarvesterNodeDriver(obj)
+		if err = h.syncHarvesterBaremetalContainerWorkloadFeature(obj); err != nil {
+			return obj, err
+		}
+		return obj, h.syncHarvesterNodeDriver(obj.Name)
 	}
 
 	if obj.Name == features.HarvesterBaremetalContainerWorkload.Name() {
@@ -134,6 +137,27 @@ func (h *handler) syncHarvesterNodeDriver(feature *v3.Feature) error {
 	_, err = h.nodeDriverController.Update(driver)
 	if err != nil {
 		h.featureEnqueue(feature.Name, 10*time.Second)
+	}
+	return nil
+}
+
+// syncHarvesterBaremetalContainerWorkloadFeature ensures that the Harvester
+// baremetal container workload feature is disabled when the Harvester feature
+// is disabled.
+func (h *handler) syncHarvesterBaremetalContainerWorkloadFeature(feat *v3.Feature) error {
+	if !*feat.Spec.Value {
+		baremetal, err := h.featuresClient.Get(features.HarvesterBaremetalContainerWorkload.Name(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		update := baremetal.DeepCopy()
+		*update.Spec.Value = false
+		if !reflect.DeepEqual(baremetal, update) {
+			if _, err = h.featuresClient.Update(update); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/controllers/management/feature/feature_handler.go
+++ b/pkg/controllers/management/feature/feature_handler.go
@@ -61,7 +61,7 @@ func (h *handler) sync(_ string, obj *v3.Feature) (*v3.Feature, error) {
 		if err = h.syncHarvesterBaremetalContainerWorkloadFeature(obj); err != nil {
 			return obj, err
 		}
-		return obj, h.syncHarvesterNodeDriver(obj.Name)
+		return obj, h.syncHarvesterNodeDriver(obj)
 	}
 
 	if obj.Name == features.HarvesterBaremetalContainerWorkload.Name() {
@@ -145,7 +145,7 @@ func (h *handler) syncHarvesterNodeDriver(feature *v3.Feature) error {
 // baremetal container workload feature is disabled when the Harvester feature
 // is disabled.
 func (h *handler) syncHarvesterBaremetalContainerWorkloadFeature(feat *v3.Feature) error {
-	if !*feat.Spec.Value {
+	if feat.Spec.Value != nil && !*feat.Spec.Value {
 		baremetal, err := h.featuresClient.Get(features.HarvesterBaremetalContainerWorkload.Name(), metav1.GetOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
Fix Harvester baremetal container workload feature flag. The Harvester baremetal container workload feature flag depends on the Harvester feature flag. This fix disables the Harvester baremetal container workload feature flag when the Harvester feature flag is disabled.

related-to: rancher/rancher#48922

## Issue:

GitHub Issue: rancher/rancher#48922
 
## Problem

The dependency of the Harvester baremetal container workload feature on the Harvester feature is insufficiently modeled in the code base. As a result it's possible for a user to end up with the Harvester baremetal container workload feature enabled, but with the Harvester feature disabled.
 
## Solution

When the Harvester feature is disabled, automatically also disable the Harevester baremetal container workload feature.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_