### PR TITLE
reduce saml log chatter

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -317,10 +317,7 @@ func (s *Provider) FinalizeSamlLogout(w http.ResponseWriter, r *http.Request) {
 		log.Debugf("SAML [FinalizeSamlLogout]: response validation failed: %v", err)
 		if parseErr, ok := err.(*saml.InvalidResponseError); ok {
 			// Note: If access to the response itself is needed (debugging)
-			// just add `parseErr.Response` to the log statement, like:
-			//
-			// log.Debugf("SAML RESPONSE: ===\n%s\n===\nSAML NOW: %s\nSAML ERROR: %s",
-			//	parseErr.Response, parseErr.Now, parseErr.PrivateErr)
+			// just add `parseErr.Response` to the log statement.
 
 			log.Debugf("SAML NOW: %s\nSAML ERROR: %s",
 				parseErr.Now, parseErr.PrivateErr)

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -316,8 +316,14 @@ func (s *Provider) FinalizeSamlLogout(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Debugf("SAML [FinalizeSamlLogout]: response validation failed: %v", err)
 		if parseErr, ok := err.(*saml.InvalidResponseError); ok {
-			log.Debugf("SAML RESPONSE: ===\n%s\n===\nSAML NOW: %s\nSAML ERROR: %s",
-				parseErr.Response, parseErr.Now, parseErr.PrivateErr)
+			// Note: If access to the response itself is needed (debugging)
+			// just add `parseErr.Response` to the log statement, like:
+			//
+			// log.Debugf("SAML RESPONSE: ===\n%s\n===\nSAML NOW: %s\nSAML ERROR: %s",
+			//	parseErr.Response, parseErr.Now, parseErr.PrivateErr)
+
+			log.Debugf("SAML NOW: %s\nSAML ERROR: %s",
+				parseErr.Now, parseErr.PrivateErr)
 		}
 
 		rURL, errParse := url.Parse(redirectURL)

--- a/pkg/auth/providers/saml/saml_handlers.go
+++ b/pkg/auth/providers/saml/saml_handlers.go
@@ -41,10 +41,7 @@ func (s *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			if parseErr, ok := err.(*saml.InvalidResponseError); ok {
 				// Note: If access to the response itself is needed (debugging)
-				// just add `parseErr.Response` to the log statement, like:
-				//
-				// log.Debugf("SAML RESPONSE: ===\n%s\n===\nSAML NOW: %s\nSAML ERROR: %s",
-				//	parseErr.Response, parseErr.Now, parseErr.PrivateErr)
+				// just add `parseErr.Response` to the log statement.
 
 				log.Debugf("SAML NOW: %s\nSAML ERROR: %s",
 					parseErr.Now, parseErr.PrivateErr)

--- a/pkg/auth/providers/saml/saml_handlers.go
+++ b/pkg/auth/providers/saml/saml_handlers.go
@@ -40,8 +40,14 @@ func (s *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Debugf("SAML [ServeHTTP]: assertion validation failed: %q", err)
 
 			if parseErr, ok := err.(*saml.InvalidResponseError); ok {
-				log.Debugf("SAML RESPONSE: ===\n%s\n===\nSAML NOW: %s\nSAML ERROR: %s",
-					parseErr.Response, parseErr.Now, parseErr.PrivateErr)
+				// Note: If access to the response itself is needed (debugging)
+				// just add `parseErr.Response` to the log statement, like:
+				//
+				// log.Debugf("SAML RESPONSE: ===\n%s\n===\nSAML NOW: %s\nSAML ERROR: %s",
+				//	parseErr.Response, parseErr.Now, parseErr.PrivateErr)
+
+				log.Debugf("SAML NOW: %s\nSAML ERROR: %s",
+					parseErr.Now, parseErr.PrivateErr)
 			}
 
 			redirectURL := r.URL.Host + "/login?errorCode=403"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
 
## Problem

Large rancher log chatter around the SAML login/logout flow, useful only for internal debugging.
 
## Solution

Remove the most expensive/large  element from the logs.
 
## Testing
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_