### PR TITLE
[v2.10] Fix AGENT_IMAGE var and labels not set correctly

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -66,6 +66,7 @@ RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECT
 LABEL io.cattle.agent=true
 
 ARG RANCHER_REPO=rancher
+ARG VERSION=${VERSION}
 ENV AGENT_IMAGE ${RANCHER_REPO}/rancher-agent:${VERSION}
 # For now, this value needs to be manually synced with the one in the main Dockerfile. This pins downstream webhook's version.
 ARG CATTLE_RANCHER_WEBHOOK_VERSION


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/48940

It looks like the env var `AGENT_IMAGE` in the agent image is not set correctly in `head` and `v2.10.2`, `v2.10.1` and `v2.10.0`. Also, some labels are set wrong because they also depend on `${VERSION}`.

This is because we're missing the `ARG VERSION=${VERSION}` line in the final image.

So we get the following:

```
$ docker run -it --entrypoint sh rancher/rancher-agent:v2
.10.0
sh-4.4# env | grep AGENT_IMAGE
AGENT_IMAGE=rancher/rancher-agent:

$ docker inspect rancher/rancher-agent:v2.10.0 | jq '.[].Config.Labels."org.opensuse.reference"' -r
rancher/rancher-agent:
``` 

Here's what it's supposed to look like:

```
$ docker run -it --entrypoint sh registry.suse.com/ranche
r/rancher-agent:v2.9.6
sh-4.4# env | grep AGENT_IMAGE
AGENT_IMAGE=rancher/rancher-agent:v2.9.6

$ docker run -it --entrypoint sh registry.suse.com/rancher/rancher-agent:v2.8.12
sh-4.4# env | grep AGENT_IMAGE
AGENT_IMAGE=rancher/rancher-agent:v2.8.12
```

`release/v2.9` and `release/v2.8` are unaffected.


The `docker buildx --check ...` command (or really the `--check` parameter) would help finding this. There are still some warnings left which I'm not addressing in this PR:


```
WARNING: LegacyKeyValueFormat - https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/
"ENV key=value" should be used instead of legacy "ENV key value" format
./package/Dockerfile.agent:76
--------------------
  74 |     ARG CATTLE_RANCHER_PROVISIONING_CAPI_VERSION
  75 |     ENV CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=$CATTLE_RANCHER_PROVISIONING_CAPI_VERSION
  76 | >>> ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
  77 |     COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
  78 |     COPY --from=rancher /usr/bin/tini /usr/bin/
--------------------
```