### PR TITLE
Remove unnecessary if condition in clusterRepo handler

### DIFF
--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -259,16 +259,7 @@ func (r *repoHandler) download(repository *catalog.ClusterRepo, newStatus *catal
 	downloadTime := metav1.Now()
 	backoff := calculateBackoff(repository, retryPolicy)
 	retriable := false
-	if repoSpec.GitRepo != "" && newStatus.IndexConfigMapName == "" {
-		commit, err = git.Head(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch, repoSpec.InsecureSkipTLSverify, repoSpec.CABundle)
-		if err != nil {
-			retriable = true
-		} else {
-			newStatus.URL = repoSpec.GitRepo
-			newStatus.Branch = repoSpec.GitBranch
-			index, err = git.BuildOrGetIndex(metadata.Namespace, metadata.Name, repoSpec.GitRepo)
-		}
-	} else if repoSpec.GitRepo != "" {
+	if repoSpec.GitRepo != "" {
 		commit, err = git.Update(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch, repoSpec.InsecureSkipTLSverify, repoSpec.CABundle)
 		if err != nil {
 			retriable = true


### PR DESCRIPTION
Please check the issue for more details 

### Summary 

1. There is an unnecessay if condition because of which update of the local git repositories is not happening in non-airgapped clusters as soon as the rancher gets installed. Ofcourse after 1 hour interval, everything gets updated.
