### PR TITLE
[main] Imperative api rotating certs

### DIFF
--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -212,6 +212,8 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 			if err := p.secrets.Delete(Namespace, p.secretName, &metav1.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
 				logrus.Error(err)
 			}
+
+			return nil
 		case <-time.After(certCheckInterval):
 			if err := p.handleCert(); err != nil {
 				logrus.Error(err)
@@ -328,7 +330,7 @@ func (p *rotatingSNIProvider) handleCertEvent(event watch.Event) error {
 		secret := event.Object.(*corev1.Secret)
 		certData, ok := secret.Data[SecretFieldNameCert]
 		if !ok {
-			return fmt.Errorf("secret does not container field '%s'", SecretFieldNameCert)
+			return fmt.Errorf("secret does not contain field '%s'", SecretFieldNameCert)
 		}
 
 		keyData, ok := secret.Data[SecretFieldNameKey]

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -251,7 +251,7 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 			return fmt.Errorf("failed to create secret: %w", err)
 		}
 
-		logrus.Errorf("created imperative api cert secret")
+		logrus.Info("created imperative api cert secret")
 	} else {
 		secret.Data[SecretFieldNameCert] = cert
 		secret.Data[SecretFieldNameKey] = key
@@ -260,7 +260,7 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 			return fmt.Errorf("failed to update secret: %w", err)
 		}
 
-		logrus.Errorf("updated imperative api cert secret")
+		logrus.Info("updated imperative api cert secret")
 	}
 
 	p.cert = cert

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -1,22 +1,226 @@
 package ext
 
 import (
+	"bytes"
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"sync"
+	"time"
 
+	wranglerapiregistrationv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiregistration.k8s.io/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
-	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	netutils "k8s.io/utils/net"
 )
 
-func certForCommonName(cname string) (dynamiccertificates.SNICertKeyContentProvider, error) {
-	certPem, keyPem, err := certutil.GenerateSelfSignedCertKey(cname, nil, nil)
+const (
+	CertificateBlockType = "CERTIFICATE"
+)
+
+func ipsToStrings(ips []net.IP) []string {
+	ss := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		ss = append(ss, ip.String())
+	}
+	return ss
+}
+
+// GenerateSelfSignedCertKey generates a self-signed certificate.
+// Based on the self-signed cert generate code in client-go: https://pkg.go.dev/k8s.io/client-go/util/cert#GenerateSelfSignedCertKeyWithFixtures
+func GenerateSelfSignedCertKeyWithOpts(host string, expireAfter time.Duration) ([]byte, []byte, error) {
+	validFrom := time.Now().Add(-time.Hour) // valid an hour earlier to avoid flakes due to clock skew
+	maxAge := expireAfter
+
+	caKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate self signed cert: %w", err)
+		return nil, nil, err
+	}
+	// returns a uniform random value in [0, max-1), then add 1 to serial to make it a uniform random value in [1, max).
+	serial, err := cryptorand.Int(cryptorand.Reader, new(big.Int).SetInt64(math.MaxInt64-1))
+	if err != nil {
+		return nil, nil, err
+	}
+	serial = new(big.Int).Add(serial, big.NewInt(1))
+	caTemplate := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s-ca@%d", host, time.Now().Unix()),
+		},
+		NotBefore: validFrom,
+		NotAfter:  validFrom.Add(maxAge),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
 	}
 
-	content, err := dynamiccertificates.NewStaticSNICertKeyContent("self-signed-imperative", certPem, keyPem, cname)
+	caDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create static cert content: %w", err)
+		return nil, nil, err
+	}
+
+	caCertificate, err := x509.ParseCertificate(caDERBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	priv, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	// returns a uniform random value in [0, max-1), then add 1 to serial to make it a uniform random value in [1, max).
+	serial, err = cryptorand.Int(cryptorand.Reader, new(big.Int).SetInt64(math.MaxInt64-1))
+	if err != nil {
+		return nil, nil, err
+	}
+	serial = new(big.Int).Add(serial, big.NewInt(1))
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s@%d", host, time.Now().Unix()),
+		},
+		NotBefore: validFrom,
+		NotAfter:  validFrom.Add(maxAge),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
+		template.IPAddresses = append(template.IPAddresses, ip)
+	} else {
+		template.DNSNames = append(template.DNSNames, host)
+	}
+
+	derBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, caCertificate, &priv.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Generate cert, followed by ca
+	certBuffer := bytes.Buffer{}
+	if err := pem.Encode(&certBuffer, &pem.Block{Type: CertificateBlockType, Bytes: derBytes}); err != nil {
+		return nil, nil, err
+	}
+	if err := pem.Encode(&certBuffer, &pem.Block{Type: CertificateBlockType, Bytes: caDERBytes}); err != nil {
+		return nil, nil, err
+	}
+
+	// Generate key
+	keyBuffer := bytes.Buffer{}
+	if err := pem.Encode(&keyBuffer, &pem.Block{Type: keyutil.RSAPrivateKeyBlockType, Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		return nil, nil, err
+	}
+
+	return certBuffer.Bytes(), keyBuffer.Bytes(), nil
+}
+
+var _ dynamiccertificates.SNICertKeyContentProvider = &rotatingSNIProvider{}
+var _ dynamiccertificates.Notifier = &rotatingSNIProvider{}
+var _ dynamiccertificates.CertKeyContentProvider = &rotatingSNIProvider{}
+
+type rotatingSNIProvider struct {
+	name     string
+	sninames []string
+
+	listeners []dynamiccertificates.Listener
+
+	expiresAfter time.Duration
+
+	certMu sync.RWMutex
+	cert   []byte
+	key    []byte
+}
+
+func NewSNIProviderForCname(name string, cnames []string) (*rotatingSNIProvider, error) {
+	content := &rotatingSNIProvider{
+		name:         name,
+		sninames:     cnames,
+		expiresAfter: time.Hour * 24 * 365,
 	}
 
 	return content, nil
+}
+
+func (p *rotatingSNIProvider) AddListener(listener dynamiccertificates.Listener) {
+	p.listeners = append(p.listeners, listener)
+}
+
+func (p *rotatingSNIProvider) SNINames() []string {
+	return p.sninames
+}
+
+func (p *rotatingSNIProvider) Name() string {
+	return p.name
+}
+
+func (p *rotatingSNIProvider) CurrentCertKeyContent() ([]byte, []byte) {
+	p.certMu.RLock()
+	defer p.certMu.RUnlock()
+
+	return bytes.Clone(p.cert), bytes.Clone(p.key)
+}
+
+func (p *rotatingSNIProvider) Run(ctx context.Context) {
+	logrus.Info("starting extension api cert rotator")
+	defer logrus.Info("stopping extension api cert rotator")
+
+	if err := p.updateCerts(); err != nil {
+		logrus.WithError(err).Errorf("initial cert rotation failed")
+	}
+
+	go wait.Until(func() {
+		if err := p.updateCerts(); err != nil {
+			logrus.WithError(err).Error("failed to update extension api cert")
+		}
+	}, p.expiresAfter, ctx.Done())
+
+	<-ctx.Done()
+}
+
+func (p *rotatingSNIProvider) updateCerts() error {
+	logrus.Info("updating extension api cert")
+
+	cert, key, err := GenerateSelfSignedCertKeyWithOpts("extension-api", p.expiresAfter)
+	if err != nil {
+		return fmt.Errorf("failed to generate self signed cert: %w", err)
+	}
+
+	p.certMu.Lock()
+	p.cert = cert
+	p.key = key
+	p.certMu.Unlock()
+
+	for _, listener := range p.listeners {
+		listener.Enqueue()
+	}
+
+	return nil
+}
+
+type listenerFunc func()
+
+func (f listenerFunc) Enqueue() {
+	f()
+}
+
+func ApiServiceCertListener(provider dynamiccertificates.SNICertKeyContentProvider, apiservice wranglerapiregistrationv1.APIServiceController) dynamiccertificates.Listener {
+	return listenerFunc(func() {
+		logrus.Info("api service cert updated")
+		caBundle, _ := provider.CurrentCertKeyContent()
+		if err := CreateOrUpdateAPIService(apiservice, caBundle); err != nil {
+			logrus.WithError(err).Error("failed to update api service")
+		}
+	})
 }

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -254,10 +254,15 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 	}
 
 	p.certMu.Lock()
-	defer p.certMu.Unlock()
 
 	p.cert = cert
 	p.key = key
+
+	defer p.certMu.Unlock()
+
+	for _, listener := range p.listeners {
+		listener.Enqueue()
+	}
 
 	return nil
 }

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -159,9 +159,9 @@ func NewSNIProviderForCname(name string, cnames []string, secrets wranglercorev1
 
 		sninames: cnames,
 
-		expiresAfter: time.Hour * 24 * 365,
+		expiresAfter: time.Hour * 24 * 90,
 
-		secrets: secrets,
+                secrets: secrets,
 	}
 
 	return content, nil

--- a/pkg/ext/certs_test.go
+++ b/pkg/ext/certs_test.go
@@ -1,0 +1,291 @@
+package ext
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type watcher struct {
+	name      string
+	eventChan chan watch.Event
+}
+
+func (w *watcher) Stop() {
+	close(w.eventChan)
+}
+
+func (w *watcher) ResultChan() <-chan watch.Event {
+	return w.eventChan
+}
+
+type mapStore[T runtime.Object] struct {
+	mu sync.RWMutex
+	m  map[string]T
+
+	watchMu sync.RWMutex
+	watches []*watcher
+}
+
+func (s *mapStore[T]) Get(n string) (T, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if v, ok := s.m[n]; ok {
+		return v, nil
+	}
+
+	var v T
+	return v, fmt.Errorf("not found")
+}
+
+func (s *mapStore[T]) Create(n string, v T) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.m[n]; ok {
+		return apierrors.NewAlreadyExists(schema.GroupResource{}, n)
+	}
+
+	s.m[n] = v
+
+	s.handleEvent(n, watch.Added)
+
+	return nil
+}
+
+func (s *mapStore[T]) Update(n string, v T) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.m[n]; !ok {
+		return apierrors.NewNotFound(schema.GroupResource{}, n)
+	}
+
+	s.m[n] = v
+	s.handleEvent(n, watch.Added)
+
+	return nil
+}
+
+func (s *mapStore[T]) Delete(n string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.m[n]; !ok {
+		return apierrors.NewNotFound(schema.GroupResource{}, n)
+	}
+
+	delete(s.m, n)
+
+	return nil
+}
+
+func (s *mapStore[T]) Watch(name string) watch.Interface {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+
+	eventChan := make(chan watch.Event, 100)
+	watcher := &watcher{
+		name:      name,
+		eventChan: eventChan,
+	}
+	s.watches = append(s.watches, watcher)
+
+	defer func() {
+		if v, ok := s.m[name]; ok {
+			eventChan <- watch.Event{
+				Type:   watch.Added,
+				Object: v,
+			}
+		}
+	}()
+
+	return watcher
+}
+
+func (s *mapStore[T]) handleEvent(name string, kind watch.EventType) {
+	s.watchMu.RLock()
+	defer s.watchMu.RUnlock()
+
+	v := s.m[name]
+	for _, w := range s.watches {
+		if w.name == name {
+			w.eventChan <- watch.Event{
+				Type:   kind,
+				Object: v,
+			}
+		}
+	}
+}
+
+func setupMockController(t *testing.T, store *mapStore[*corev1.Secret]) *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList] {
+	t.Helper()
+
+	get := func(namespace string, name string, _ metav1.GetOptions) (*corev1.Secret, error) {
+		secret, err := store.Get(fmt.Sprintf("%s/%s", namespace, name))
+		if err != nil {
+			return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+		}
+		return secret, nil
+	}
+	create := func(secret *corev1.Secret) (*corev1.Secret, error) {
+		if err := store.Create(fmt.Sprintf("%s/%s", secret.Namespace, secret.Name), secret); err != nil {
+			return nil, apierrors.NewAlreadyExists(schema.GroupResource{}, secret.Name)
+		}
+		return secret, nil
+	}
+	update := func(secret *corev1.Secret) (*corev1.Secret, error) {
+		if err := store.Update(fmt.Sprintf("%s/%s", secret.Namespace, secret.Name), secret); err != nil {
+			return nil, apierrors.NewNotFound(schema.GroupResource{}, secret.Name)
+		}
+
+		return secret, nil
+	}
+	delete := func(namespace string, name string, _ *metav1.DeleteOptions) error {
+		if err := store.Delete(fmt.Sprintf("%s/%s", namespace, name)); err != nil {
+			return apierrors.NewNotFound(schema.GroupResource{}, name)
+		}
+
+		return nil
+	}
+	watch := func(namespace string, _ metav1.ListOptions) (watch.Interface, error) {
+		watcher := store.Watch(fmt.Sprintf("%s/%s", namespace, ""))
+
+		return watcher, nil
+	}
+
+	controller := gomock.NewController(t)
+	secretMock := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](controller)
+	secretMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(get).AnyTimes()
+	secretMock.EXPECT().Create(gomock.Any()).DoAndReturn(create).AnyTimes()
+	secretMock.EXPECT().Update(gomock.Any()).DoAndReturn(update).AnyTimes()
+	secretMock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(delete).AnyTimes()
+	secretMock.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(watch).AnyTimes()
+
+	return secretMock
+}
+
+func setup(t *testing.T) (*rotatingSNIProvider, *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList], *mapStore[*corev1.Secret]) {
+	t.Helper()
+
+	store := &mapStore[*corev1.Secret]{
+		m: make(map[string]*corev1.Secret),
+	}
+	secretMock := setupMockController(t, store)
+
+	provider, err := NewSNIProviderForCname(
+		"test-provider",
+		[]string{
+			fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace),
+		},
+		secretMock)
+	assert.NoError(t, err)
+
+	return provider, secretMock, store
+}
+
+func TestRotatingSNIProviderNoExistingSecret(t *testing.T) {
+	provider, secretMock, store := setup(t)
+	stopChan := make(chan struct{})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		err := provider.Run(stopChan)
+		assert.NoError(t, err)
+
+		wg.Done()
+	}()
+
+	wait.Until(func() {
+		_, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+
+		if err == nil {
+			close(stopChan)
+		} else {
+			assert.NoError(t, client.IgnoreNotFound(err))
+		}
+	}, time.Second*1, stopChan)
+
+	wg.Wait()
+
+	secret, err := store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	assert.Error(t, err)
+	assert.Nil(t, secret)
+}
+
+func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
+	provider, secretMock, store := setup(t)
+	stopChan := make(chan struct{})
+
+	initialCert, initialCa, err := GenerateSelfSignedCertKeyWithOpts(fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace), time.Second*5)
+	assert.NoError(t, err)
+
+	err = store.Create(fmt.Sprintf("%s/%s", Namespace, provider.secretName), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      provider.secretName,
+			Namespace: Namespace,
+		},
+		Data: map[string][]byte{
+			SecretFieldNameCert: initialCert,
+			SecretFieldNameKey:  initialCa,
+		},
+	})
+	assert.NoError(t, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		err := provider.Run(stopChan)
+		assert.NoError(t, err)
+
+		wg.Done()
+	}()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		cert := secret.Data[SecretFieldNameCert]
+		ca := secret.Data[SecretFieldNameKey]
+		if !bytes.Equal(initialCert, cert) && !bytes.Equal(initialCa, ca) {
+			cancel()
+		}
+	}, time.Second)
+
+	secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	cert := secret.Data[SecretFieldNameCert]
+	assert.NotEqual(t, initialCert, cert)
+
+	ca := secret.Data[SecretFieldNameKey]
+	assert.NotEqual(t, initialCa, ca)
+
+	close(stopChan)
+
+	wg.Wait()
+
+	secret, err = store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	assert.Error(t, err)
+	assert.Nil(t, secret)
+}

--- a/pkg/ext/certs_test.go
+++ b/pkg/ext/certs_test.go
@@ -244,8 +244,8 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 			Namespace: Namespace,
 		},
 		Data: map[string][]byte{
-			SecretFieldNameCert: initialCert,
-			SecretFieldNameKey:  initialCa,
+			corev1.TLSCertKey:       initialCert,
+			corev1.TLSPrivateKeyKey: initialCa,
 		},
 	})
 	assert.NoError(t, err)
@@ -265,8 +265,8 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 		secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
 		assert.NoError(t, err)
 
-		cert := secret.Data[SecretFieldNameCert]
-		ca := secret.Data[SecretFieldNameKey]
+		cert := secret.Data[corev1.TLSCertKey]
+		ca := secret.Data[corev1.TLSPrivateKeyKey]
 		if !bytes.Equal(initialCert, cert) && !bytes.Equal(initialCa, ca) {
 			cancel()
 		}
@@ -275,10 +275,10 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 	secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
 	assert.NoError(t, err)
 
-	cert := secret.Data[SecretFieldNameCert]
+	cert := secret.Data[corev1.TLSCertKey]
 	assert.NotEqual(t, initialCert, cert)
 
-	ca := secret.Data[SecretFieldNameKey]
+	ca := secret.Data[corev1.TLSPrivateKeyKey]
 	assert.NotEqual(t, initialCa, ca)
 
 	close(stopChan)

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -148,7 +148,6 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 	case "true":
 		logrus.Info("creating imperative extension apiserver resources")
 
-		wranglerContext.Core.Secret()
 		sniProvider, err := NewSNIProviderForCname(
 			"imperative-api-sni-provider",
 			[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)},

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -161,7 +161,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		sniProvider.AddListener(ApiServiceCertListener(sniProvider, wranglerContext.API.APIService()))
 
 		go func() {
-			if err := sniProvider.Run(ctx); err != nil {
+			if err := sniProvider.Run(ctx.Done()); err != nil {
 				logrus.Errorf("sni provider failed: %s", err)
 			}
 		}()

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -162,17 +162,14 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		sniProvider.AddListener(ApiServiceCertListener(sniProvider, wranglerContext.API.APIService()))
 
 		go func() {
-			sniProvider.Run(ctx)
+			if err := sniProvider.Run(ctx); err != nil {
+				logrus.Errorf("sni provider failed: %s", err)
+			}
 		}()
 
 		additionalSniProviders = append(additionalSniProviders, sniProvider)
 
 		if err := CreateOrUpdateService(wranglerContext.Core.Service()); err != nil {
-			return nil, fmt.Errorf("failed to create or update APIService: %w", err)
-		}
-
-		caBundle, _ := sniProvider.CurrentCertKeyContent()
-		if err := CreateOrUpdateAPIService(wranglerContext.API.APIService(), caBundle); err != nil {
 			return nil, fmt.Errorf("failed to create or update APIService: %w", err)
 		}
 

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -148,7 +148,13 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 	case "true":
 		logrus.Info("creating imperative extension apiserver resources")
 
-		sniProvider, err := NewSNIProviderForCname("imperative-api-sni-provider", []string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)})
+		wranglerContext.Core.Secret()
+		sniProvider, err := NewSNIProviderForCname(
+			"imperative-api-sni-provider",
+			[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)},
+			wranglerContext.Core.Secret(),
+		)
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate cert for target service: %w", err)
 		}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/48915
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The certs currently generated for the imperative api `APIService` will expire in ~1 year and will not be replaced. We should have control over how long the certs are valid for, and be able to replace them before they expire to ensure minimal downtime fro the imperative api.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Store the certs in a `Secret` and monitor the `Secret` for expiring certs and update the underlying extension api cert provider whenever the cert is changed.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Installed rancher with the imperative api enabled and modified expiration times. Let it run until the cert expires and a new one replaces it and update the associated `Secret` and `APIService`

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_