### PR TITLE
[v2.9.7] Backport: exclude Windows nodes from the upgrade process in imported clusters

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/rancher/pkg/ref"
 	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -217,14 +218,17 @@ func (h *handler) nodesNeedUpgrade(cluster *mgmtv3.Cluster, version string) (boo
 		return false, err
 	}
 	for _, node := range v3NodeList {
-		isNewer, err := nodesyncer.IsNewerVersion(node.Status.InternalNodeStatus.NodeInfo.KubeletVersion, version)
-		if err != nil {
-			return false, err
-		}
-		if isNewer {
-			logrus.Debugf("[k3s-based-upgrader] cluster [%s] version [%s] is newer than observed node [%s] version [%s]",
-				cluster.Name, version, node.Name, node.Status.InternalNodeStatus.NodeInfo.KubeletVersion)
-			return true, nil
+		// if node is windows, skip upgrade check
+		if os, ok := node.Status.NodeLabels[corev1.LabelOSStable]; ok && os != "windows" {
+			isNewer, err := nodesyncer.IsNewerVersion(node.Status.InternalNodeStatus.NodeInfo.KubeletVersion, version)
+			if err != nil {
+				return false, err
+			}
+			if isNewer {
+				logrus.Debugf("[k3s-based-upgrader] cluster [%s] version [%s] is newer than observed node [%s] version [%s]",
+					cluster.Name, version, node.Name, node.Status.InternalNodeStatus.NodeInfo.KubeletVersion)
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -181,7 +181,12 @@ func (n *nodeSyncer) sync(key string, node *corev1.Node) (runtime.Object, error)
 		return nil, err
 	} else if ok {
 		node = node.DeepCopy()
-		node.Labels[UpgradeEnabledLabel] = "true"
+		// only linux nodes are supported in imported clusters
+		if node.Labels[corev1.LabelOSStable] == "linux" {
+			node.Labels[UpgradeEnabledLabel] = "true"
+		} else {
+			node.Labels[UpgradeEnabledLabel] = "false"
+		}
 		return n.nodesSyncer.nodeClient.Update(node)
 	}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48959
Original/Merged PR: https://github.com/rancher/rancher/pull/48879