### PR TITLE
Workload test fixes and QOL

### DIFF
--- a/tests/v2/actions/workloads/cronjob/cronjob.go
+++ b/tests/v2/actions/workloads/cronjob/cronjob.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	nginxImageName = "nginx"
+	nginxImageName = "public.ecr.aws/docker/library/nginx"
 )
 
 var CronJobGroupVersionResource = schema.GroupVersionResource{

--- a/tests/v2/actions/workloads/cronjob/verify.go
+++ b/tests/v2/actions/workloads/cronjob/verify.go
@@ -10,7 +10,6 @@ import (
 )
 
 func VerifyCreateCronjob(client *rancher.Client, clusterID string) error {
-	logrus.Info("Creating new project and namespace")
 	_, namespace, err := projectsapi.CreateProjectAndNamespace(client, clusterID)
 	if err != nil {
 		return err
@@ -38,13 +37,12 @@ func VerifyCreateCronjob(client *rancher.Client, clusterID string) error {
 		nil,
 	)
 
-	logrus.Info("Creating new cronjob")
 	cronJobTemplate, err := CreateCronjob(client, clusterID, namespace.Name, "*/1 * * * *", podTemplate)
 	if err != nil {
 		return err
 	}
 
-	logrus.Info("Waiting cronjob comes up active")
+	logrus.Infof("Creating new cronjob %s", cronJobTemplate.Name)
 	err = WatchAndWaitCronjob(client, clusterID, namespace.Name, cronJobTemplate)
 
 	return err

--- a/tests/v2/actions/workloads/daemonset/verify.go
+++ b/tests/v2/actions/workloads/daemonset/verify.go
@@ -9,7 +9,6 @@ import (
 )
 
 func VerifyCreateDaemonSet(client *rancher.Client, clusterID string) error {
-	logrus.Info("Creating new project and namespace")
 	_, namespace, err := projectsapi.CreateProjectAndNamespace(client, clusterID)
 	if err != nil {
 		return err
@@ -21,7 +20,7 @@ func VerifyCreateDaemonSet(client *rancher.Client, clusterID string) error {
 		return err
 	}
 
-	logrus.Info("Waiting daemonset comes up active")
+	logrus.Infof("Waiting for daemonset %s to become active", createdDaemonset.Name)
 	err = charts.WatchAndWaitDaemonSets(client, clusterID, namespace.Name, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + createdDaemonset.Name,
 	})

--- a/tests/v2/actions/workloads/deployment/deployment.go
+++ b/tests/v2/actions/workloads/deployment/deployment.go
@@ -26,9 +26,9 @@ const (
 	defaultNamespace    = "default"
 	port                = "port"
 	DeploymentSteveType = "apps.deployment"
-	nginxImageName      = "nginx"
+	nginxImageName      = "public.ecr.aws/docker/library/nginx"
 	ubuntuImageName     = "ubuntu"
-	redisImageName      = "redis"
+	redisImageName      = "public.ecr.aws/docker/library/redis"
 	podSteveType        = "pod"
 )
 

--- a/tests/v2/actions/workloads/statefulset/statefulset.go
+++ b/tests/v2/actions/workloads/statefulset/statefulset.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	nginxImageName = "nginx"
+	nginxImageName = "public.ecr.aws/docker/library/nginx"
 )
 
 var StatefulsetGroupVersionResource = schema.GroupVersionResource{

--- a/tests/v2/actions/workloads/statefulset/verify.go
+++ b/tests/v2/actions/workloads/statefulset/verify.go
@@ -12,7 +12,6 @@ import (
 )
 
 func VerifyCreateStatefulset(client *rancher.Client, clusterID string) error {
-	logrus.Info("Creating new project and namespace")
 	_, namespace, err := projectsapi.CreateProjectAndNamespace(client, clusterID)
 	if err != nil {
 		return err
@@ -39,13 +38,12 @@ func VerifyCreateStatefulset(client *rancher.Client, clusterID string) error {
 		nil,
 	)
 
-	logrus.Info("Creating new statefulset")
+	logrus.Infof("Creating new statefulset %s", containerName)
 	statefulsetTemplate, err := CreateStatefulset(client, clusterID, namespace.Name, podTemplate, 1)
 	if err != nil {
 		return err
 	}
 
-	logrus.Info("Waiting statefulset comes up active")
 	err = charts.WatchAndWaitStatefulSets(client, clusterID, namespace.Name, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + statefulsetTemplate.Name,
 	})


### PR DESCRIPTION
Issue: dockerhub throttles pulls, this causes the workload tests to fail if several clusters are running them sequentially.
Solution: change the image to point at the public aws ecr registry.

Note: Also added some updates to the logs so they don't spam as much when running the workload tests on several clusters