### PR TITLE
Use management cluster reference for imported clusters

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -308,9 +308,49 @@ func mgmtClusterName() (string, error) {
 	return name.SafeConcatName("c", "m", rand[:8]), nil
 }
 
+func (h *handler) updateImportedCluster(cluster *v1.Cluster, status v1.ClusterStatus, mgmtCluster *v3.Cluster) ([]runtime.Object, v1.ClusterStatus, error) {
+	newCluster := &v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        mgmtCluster.Name,
+			Labels:      mgmtCluster.Labels,
+			Annotations: mgmtCluster.Annotations,
+		},
+		Spec: mgmtCluster.Spec,
+	}
+
+	if features.ProvisioningV2FleetWorkspaceBackPopulation.Enabled() {
+		if forcedFleetWorkspaceName, ok := cluster.Annotations[fleetWorkspaceNameAnn]; ok && forcedFleetWorkspaceName != "" { // force set the fleet workspace name
+			newCluster.Spec.FleetWorkspaceName = forcedFleetWorkspaceName
+		}
+		// backpopulateMgmtClusterFleetWorkspaceName() is not required, newCluster already has FleetWorkspaceName from mgmt cluster
+	}
+
+	delete(cluster.Annotations, creatorIDAnn)
+	status.FleetWorkspaceName = newCluster.Spec.FleetWorkspaceName
+
+	normalizedCluster, err := NormalizeCluster(newCluster, cluster.Spec.RKEConfig == nil)
+	if err != nil {
+		return nil, status, err
+	}
+
+	return h.updateStatus([]runtime.Object{
+		normalizedCluster,
+	}, cluster, status, newCluster)
+}
+
 // createNewCluster creates a homologated clusters.management.cattle.io/v3 object based on a
 // clusters.provisioning.cattle.io/v1 object and the spec of the clusters.management.cattle.io/v3 object passed in.
+// It ensures the management cluster remains the source of truth for imported clusters after cluster creation.
 func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus, spec v3.ClusterSpec) ([]runtime.Object, v1.ClusterStatus, error) {
+	if cluster.Spec.RKEConfig == nil {
+		mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
+		if err == nil {
+			return h.updateImportedCluster(cluster, status, mgmtCluster)
+		} else if !apierror.IsNotFound(err) {
+			return nil, status, err
+		}
+	}
+
 	spec.DisplayName = cluster.Name
 	spec.Description = cluster.Annotations["field.cattle.io/description"]
 	spec.DefaultPodSecurityAdmissionConfigurationTemplateName = cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName

--- a/pkg/controllers/provisioningv2/cluster/controller_test.go
+++ b/pkg/controllers/provisioningv2/cluster/controller_test.go
@@ -24,6 +24,65 @@ func TestRegexp(t *testing.T) {
 	assert.False(t, mgmtNameRegexp.MatchString("ac-12345b"))
 }
 
+func TestController_updateImportedCluster(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     *v1.Cluster
+		mgmtCluster *v3.Cluster
+	}{
+		{
+			name: "test-override",
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"foo": "bar"},
+					Annotations: map[string]string{"test.io": "true"},
+				},
+				Spec: v1.ClusterSpec{
+					ClusterAgentDeploymentCustomization: getTestClusterAgentCustomizationV1(),
+				},
+			},
+			mgmtCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"foo": "bar2"},
+					Annotations: map[string]string{"test.io": "false"},
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: getTestClusterAgentCustomizationV3Updated(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			clusterCache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](mockCtrl)
+			clusterCache.EXPECT().Get(gomock.AssignableToTypeOf("")).Return(tt.mgmtCluster, nil).AnyTimes()
+
+			h := handler{
+				mgmtClusterCache: clusterCache,
+			}
+
+			obj, _, err := h.updateImportedCluster(tt.cluster, tt.cluster.Status, tt.mgmtCluster)
+
+			assert.Nil(t, err)
+
+			jsonData, _ := json.Marshal(obj[0])
+			var legacyCluster v3.Cluster
+			json.Unmarshal(jsonData, &legacyCluster)
+
+			switch tt.name {
+			case "test-override":
+				assert.Equal(t, tt.mgmtCluster.Labels, legacyCluster.Labels)
+				assert.Equal(t, tt.mgmtCluster.Annotations, legacyCluster.Annotations)
+				assert.Equal(t, tt.mgmtCluster.Spec.ClusterAgentDeploymentCustomization, legacyCluster.Spec.ClusterAgentDeploymentCustomization)
+			}
+		})
+	}
+}
+
 func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -138,6 +197,7 @@ func TestController_createNewCluster(t *testing.T) {
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: v1.ClusterSpec{
+					RKEConfig:                           &v1.RKEConfig{},
 					ClusterAgentDeploymentCustomization: getTestClusterAgentCustomizationV1(),
 					FleetAgentDeploymentCustomization:   getTestFleetAgentCustomizationV1(),
 				},
@@ -151,10 +211,17 @@ func TestController_createNewCluster(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clusterCache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](mockCtrl)
 	clusterCache.EXPECT().Get(gomock.AssignableToTypeOf("")).Return(&v3.Cluster{}, nil).AnyTimes()
+	featureCache := fake.NewMockNonNamespacedCacheInterface[*v3.Feature](mockCtrl)
+	rkeLockedValue := true
+	featureCache.EXPECT().Get(gomock.AssignableToTypeOf("")).Return(&v3.Feature{
+		ObjectMeta: metav1.ObjectMeta{Name: "rke2"},
+		Status:     v3.FeatureStatus{LockedValue: &rkeLockedValue},
+	}, nil).AnyTimes()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := handler{
 				mgmtClusterCache: clusterCache,
+				featureCache:     featureCache,
 			}
 
 			obj, _, err := h.createNewCluster(tt.cluster, tt.cluster.Status, tt.clusterSpec)
@@ -190,6 +257,22 @@ func getTestClusterAgentCustomizationV3() *v3.AgentDeploymentCustomization {
 		AppendTolerations:            getTestClusterAgentToleration(),
 		OverrideAffinity:             getTestClusterAgentAffinity(),
 		OverrideResourceRequirements: getTestClusterAgentResourceReq(),
+	}
+}
+
+func getTestClusterAgentCustomizationV3Updated() *v3.AgentDeploymentCustomization {
+	resourceRequirements := &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("700"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("250Mi"),
+		},
+	}
+	return &v3.AgentDeploymentCustomization{
+		AppendTolerations:            getTestClusterAgentToleration(),
+		OverrideAffinity:             getTestClusterAgentAffinity(),
+		OverrideResourceRequirements: resourceRequirements,
 	}
 }
 


### PR DESCRIPTION
Imported clusters should not override fields on the management cluster based on the provisioning cluster. Instead, the management cluster should remain the source of truth. With v2.11, the UI will send all requests for imported clusters to `clusters.management.cattle.io` (https://github.com/rancher/dashboard/issues/13151) but this fix is required so updates to the management cluster aren't lost for clusters created prior to v2.11. 

Rancher webhook will be updated to return an error on update calls to provisioning clusters, making the change in behavior explicit.

## Issue
https://github.com/rancher/rancher/issues/48700
https://github.com/rancher/rancher/issues/47593 
 
## Problem
When importing a cluster, the UI sends a POST request to `v1/provisioning.cattle.io.clusters`, creating a v1 object. Rancher then generates the corresponding v3 object.

When updating an imported cluster, the UI sends a PUT request to `v3/clusters/{cluster-name}`, modifying the `cluster.management.cattle.io` (v3) object. Rancher then syncs v1 and v3, overriding user-set values with those from the original v1 object created during import. 
 
## Solution
With v2.11, the UI will send all requests for imported clusters to `clusters.management.cattle.io`, and Rancher will generate the corresponding `provisioning.cattle.io.cluster`.

This fix ensures that updates to the management cluster aren't lost for imported clusters created prior to v2.11. 
 
## Testing
Manual + updated test file 
