### PR TITLE
Add machinepool CRD for capi-controller-manager workaround

### DIFF
--- a/pkg/crds/provisioningv2/crds.go
+++ b/pkg/crds/provisioningv2/crds.go
@@ -21,6 +21,8 @@ var (
 		"MachineDeployment":  true,
 		"MachineSet":         true,
 		"Cluster":            true,
+		// The capi-controller-manager will get stuck in a restart loop until a version is released with the fix for https://github.com/kubernetes-sigs/cluster-api/issues/11775
+		"MachinePool": true,
 	}
 
 	//go:embed capi-crds.yaml capi-webhooks.yaml


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/kubernetes-sigs/cluster-api/issues/11775?notification_referrer_id=NT_kwDOAgOwGLQxNDU0NzM2NTkzNzozMzc5NjEyMA#event-16143919259
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

capi-controller-manager's cluster controller is stuck in a restart loop due to the absence of the machine pool CRD.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Workaround to add CAPI machine pool CRD to list of CRDs to generate to prevent the capi-controller-manager's cluster controller from getting stuck in a restart loop.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, it is covered in the CAPI bump to v1.9.4.