### PR TITLE
Store user-provided cluster name on clusters.provisioning.cattle.io/v1

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller_test.go
+++ b/pkg/controllers/provisioningv2/cluster/controller_test.go
@@ -39,6 +39,7 @@ func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 				Spec: v3.ClusterSpec{
 					ClusterSpecBase:    v3.ClusterSpecBase{},
 					FleetWorkspaceName: "test-fleet-workspace-name",
+					DisplayName:        "test-cluster",
 				},
 			},
 			expected: true,
@@ -111,6 +112,7 @@ func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
 			case "test-default":
 				assert.Nil(t, provCluster.Spec.ClusterAgentDeploymentCustomization)
 				assert.Nil(t, provCluster.Spec.FleetAgentDeploymentCustomization)
+				assert.Equal(t, provCluster.Annotations[mgmtClusterDisplayNameAnn], tt.cluster.Spec.DisplayName)
 			case "test-cluster-agent-customization":
 				assert.Equal(t, getTestClusterAgentCustomizationV1(), provCluster.Spec.ClusterAgentDeploymentCustomization)
 				assert.Equal(t, getTestFleetAgentCustomizationV1(), provCluster.Spec.FleetAgentDeploymentCustomization)


### PR DESCRIPTION
UI requires a field or annotation on the provisioning cluster object that has the user entered cluster name. For more details, see: https://github.com/rancher/rancher/issues/48509 