### PR TITLE
[backport 2.10] Include secret type field when synchronizing downstream 

### DIFF
--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -222,6 +222,7 @@ func (c *ResourceSyncController) sync(key string, obj *corev1.Secret) (runtime.O
 		logrus.Debugf("[resource-sync][secret] creating secret %v/%v in cluster %v", ns, name, c.clusterName)
 
 		newSecret := &corev1.Secret{
+			Type:       obj.Type,
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 			Data:       obj.Data,
 		}


### PR DESCRIPTION
## Issue: [#48756](https://github.com/rancher/rancher/issues/48756)<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->


This is a backport of https://github.com/rancher/rancher/issues/48371