### PR TITLE
[backport 2.9] Include secret type field when synchronizing downstream

### DIFF
--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -223,6 +223,7 @@ func (c *ResourceSyncController) sync(key string, obj *corev1.Secret) (runtime.O
 		logrus.Debugf("[resource-sync][secret] creating secret %v/%v in cluster %v", ns, name, c.clusterName)
 
 		newSecret := &corev1.Secret{
+			Type:       obj.Type,
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 			Data:       obj.Data,
 		}


### PR DESCRIPTION
## Issue: [#48757](https://github.com/rancher/rancher/issues/48757)

This is a backport of https://github.com/rancher/rancher/issues/48371