### PR TITLE
Add handling for nil openLdapConfigs

### DIFF
--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -258,7 +258,7 @@ func (p *ldapProvider) getLDAPConfig(genericClient objectclient.GenericClient) (
 
 	if p.samlSearchProvider() && ldapConfigKey[p.providerName] != "" {
 		subLdapConfig, ok := storedLdapConfigMap[ldapConfigKey[p.providerName]]
-		if !ok {
+		if !ok || subLdapConfig == nil {
 			return nil, nil, ErrorNotConfigured{}
 		}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48791
 
## Problem
If the `openLdapConfig` of a SAML auth provider (ie shibboleth or okta) is set to `nil` (or `null` in the UI) Rancher panics.
 
## Solution
Return a `ErrorNotConfigured` when the `openLdapConfig` is set to `nil`
 
## Testing
## Engineering Testing
### Manual Testing
Manually tested by setting the `openLdapConfig` to `null` in the UI for an Okta provider.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: Added a unit test for this and for a couple other code paths as well.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_