### PR TITLE
Make sure only a positive number is sent to rand.Int63n func

### DIFF
--- a/pkg/controllers/dashboard/helm/repo_oci.go
+++ b/pkg/controllers/dashboard/helm/repo_oci.go
@@ -347,7 +347,9 @@ func calculateBackoff(clusterRepo *catalog.ClusterRepo, policy retryPolicy) time
 	h.SetSeed(maphash.MakeSeed())
 	rand := rand.New(rand.NewSource(int64(h.Sum64())))
 	temp := float64(policy.MinWait) * math.Pow(2, float64(clusterRepo.Status.NumberOfRetries))
-	backoff := time.Duration(temp*(1-0.2)) + time.Duration(rand.Int63n(int64(2*0.2*temp)))
+	// rand.Int63n panics if jitter <= 0
+	jitter := int64(math.Max(1, 2*0.2*temp))
+	backoff := time.Duration(temp*(1-0.2)) + time.Duration(rand.Int63n(jitter))
 	if backoff < policy.MinWait {
 		return policy.MinWait
 	}


### PR DESCRIPTION
Please check the JIRA issue SURE-9732 for more details.

Fixes https://github.com/rancher/rancher/issues/49001

### Summary 
- A panic occurs if rand.Int63 is sent a zero or negaitve number. So adding code to avoid it.