### PR TITLE
fix: add check for empty nodes before calling getClusterCNI on nodes[0]

### DIFF
--- a/pkg/controllers/managementuser/networkpolicy/netpol.go
+++ b/pkg/controllers/managementuser/networkpolicy/netpol.go
@@ -186,7 +186,12 @@ func (npmgr *netpolMgr) handleHostNetwork(clusterNamespace string) error {
 		return fmt.Errorf("couldn't list nodes err=%v", err)
 	}
 
-	cni, err := npmgr.getClusterCNI(clusterNamespace, nodes[0])
+	var node *corev1.Node
+	if len(nodes) > 0 {
+		node = nodes[0]
+	}
+
+	cni, err := npmgr.getClusterCNI(clusterNamespace, node)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48654

## Problem
```
github.com/rancher/rancher/pkg/controllers/managementuser/networkpolicy.(*netpolMgr).handleHostNetwork(0xc00509c6e0, {0xc0052f2aa0, 0x7}) /app/pkg/controllers/managementuser/networkpolicy/netpol.go:189 +0xee5
```

The panic is caused by [this line](https://github.com/rancher/rancher/blob/v2.9.0/pkg/controllers/managementuser/networkpolicy/netpol.go#L189) where it doesn't confirm the nodes list is not empty before accessing to node[0].
 
## Solution
Added a condition to ensure `nodes` is not empty before calling `getClusterCNI`, preventing potential index out-of-range errors.  
 