### PR TITLE
Adds the missing REPO parameter

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -9,12 +9,13 @@ This script uses `docker buildx` in order to enable cross-building of different
 architecture images. To build an image for your current OS and architecture, run
 from the Rancher project root:
 ```shell
-TAG="localhost:5000/my-test-repo/image:tag" make quick
+REPO="localhost:5000/my-test-repo/image" TAG="tag" make quick
 ```
 
 If you wish to cross-build for a different architecture, set the variable `ARCH`:
 ```shell
-TAG="localhost:5000/my-test-repo/image:tag" \
+REPO="localhost:5000/my-test-repo/image" \
+  TAG="tag" \
   ARCH="amd64" \
   make quick
 ```


### PR DESCRIPTION
## Issue: #49081 
 
## Problem
The commands specified in the Developing Rancher section of [developing.md](https://github.com/rancher/rancher/blob/main/docs/development.md), value of `TAG` is expected to be `tag` of the image, and `REPO` should be as the required repository.
 
## Solution
Set the repository value to `REPO` variable and just the tag value to `TAG`.
 
* Test types added/modified:
    * None
* If "None" - Reason:  
    - No application logic is modified by this change - doc change