### PR TITLE
[v2.9] Backport fix: add check for empty nodes before calling getClusterCNI on nodes[0]

### DIFF
--- a/pkg/controllers/managementuser/networkpolicy/netpol.go
+++ b/pkg/controllers/managementuser/networkpolicy/netpol.go
@@ -186,7 +186,12 @@ func (npmgr *netpolMgr) handleHostNetwork(clusterNamespace string) error {
 		return fmt.Errorf("couldn't list nodes err=%v", err)
 	}
 
-	cni, err := npmgr.getClusterCNI(clusterNamespace, nodes[0])
+	var node *corev1.Node
+	if len(nodes) > 0 {
+		node = nodes[0]
+	}
+
+	cni, err := npmgr.getClusterCNI(clusterNamespace, node)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49097

Original/Merged PR: https://github.com/rancher/rancher/pull/49072