### PR TITLE
[main] Imperative api setting

### DIFF
--- a/pkg/ext/authenticator.go
+++ b/pkg/ext/authenticator.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	authenticatorNameDefault      = "default"
-	authenticatorNameCertprovider = "cert-provider"
+	authenticatorNameSteveDefault = "default"
+	authenticatorNameRancherUser  = "rancher-user"
 )
 
 type toggle[T any] struct {

--- a/pkg/ext/authenticator.go
+++ b/pkg/ext/authenticator.go
@@ -1,0 +1,164 @@
+package ext
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	authenticatorunion "k8s.io/apiserver/pkg/authentication/request/union"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+)
+
+const (
+	authenticatorNameDefault      = "default"
+	authenticatorNameCertprovider = "cert-provider"
+)
+
+type toggle[T any] struct {
+	enabled bool
+	value   T
+}
+
+var _ authenticator.Request = &ToggleUnionAuthenticator{}
+var _ dynamiccertificates.CAContentProvider = &ToggleUnionAuthenticator{}
+
+type ToggleUnionAuthenticator struct {
+	authenticatorsMu       sync.RWMutex
+	authenticators         map[string]toggle[authenticator.Request]
+	unionAuthenticator     authenticator.Request
+	unionCAContentProvider dynamiccertificates.CAContentProvider
+
+	runnerMu         sync.RWMutex
+	runnerCtxCancels []context.CancelFunc
+}
+
+func NewToggleUnionAuthenticator() *ToggleUnionAuthenticator {
+	a := &ToggleUnionAuthenticator{
+		authenticators: make(map[string]toggle[authenticator.Request]),
+	}
+
+	a.sync()
+
+	return a
+}
+
+// sync synchronizes the internal collection of authenticators and stops and cancels any existing calls to Run.
+func (a *ToggleUnionAuthenticator) sync() {
+	a.authenticatorsMu.Lock()
+	a.runnerMu.Lock()
+	defer a.runnerMu.Unlock()
+	defer a.authenticatorsMu.Unlock()
+
+	logrus.Infof("syncing imperative api authentication providers")
+
+	var authenticators []authenticator.Request
+	var caProviders []dynamiccertificates.CAContentProvider
+
+	for _, toggle := range a.authenticators {
+		if !toggle.enabled {
+			continue
+		}
+
+		authenticators = append(authenticators, toggle.value)
+
+		if provider, ok := toggle.value.(dynamiccertificates.CAContentProvider); ok {
+			caProviders = append(caProviders, provider)
+		}
+	}
+
+	a.unionAuthenticator = authenticatorunion.New(authenticators...)
+	a.unionCAContentProvider = dynamiccertificates.NewUnionCAContentProvider(caProviders...)
+
+	for _, cancel := range a.runnerCtxCancels {
+		cancel()
+	}
+
+	a.runnerCtxCancels = []context.CancelFunc{}
+}
+
+func (a *ToggleUnionAuthenticator) SetEnabled(name string, enabled bool) error {
+	defer a.sync()
+
+	a.authenticatorsMu.Lock()
+	a.authenticatorsMu.Unlock()
+
+	toggle, ok := a.authenticators[name]
+	if !ok {
+		return fmt.Errorf("no authenticator found with name '%s'", name)
+	}
+
+	toggle.enabled = enabled
+	a.authenticators[name] = toggle
+
+	return nil
+}
+
+func (a *ToggleUnionAuthenticator) Add(name string, auth authenticator.Request, enabled bool) {
+	defer a.sync()
+
+	a.authenticatorsMu.Lock()
+	defer a.authenticatorsMu.Unlock()
+
+	a.authenticators[name] = toggle[authenticator.Request]{
+		enabled: enabled,
+		value:   auth,
+	}
+}
+
+func (a *ToggleUnionAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	a.authenticatorsMu.RLock()
+	defer a.authenticatorsMu.RUnlock()
+
+	return a.unionAuthenticator.AuthenticateRequest(req)
+}
+
+// AddListener implements dynamiccertificates.CAContentProvider.
+func (a *ToggleUnionAuthenticator) AddListener(listener dynamiccertificates.Listener) {
+	a.authenticatorsMu.RLock()
+	defer a.authenticatorsMu.RUnlock()
+
+	a.unionCAContentProvider.AddListener(listener)
+}
+
+// CurrentCABundleContent implements dynamiccertificates.CAContentProvider.
+func (a *ToggleUnionAuthenticator) CurrentCABundleContent() []byte {
+	a.authenticatorsMu.RLock()
+	defer a.authenticatorsMu.RUnlock()
+
+	return a.unionCAContentProvider.CurrentCABundleContent()
+}
+
+// Name implements dynamiccertificates.CAContentProvider.
+func (a *ToggleUnionAuthenticator) Name() string {
+	a.authenticatorsMu.RLock()
+	defer a.authenticatorsMu.RUnlock()
+
+	return a.unionCAContentProvider.Name()
+}
+
+// VerifyOptions implements dynamiccertificates.CAContentProvider.
+func (a *ToggleUnionAuthenticator) VerifyOptions() (x509.VerifyOptions, bool) {
+	a.authenticatorsMu.RLock()
+	defer a.authenticatorsMu.RUnlock()
+
+	return a.unionCAContentProvider.VerifyOptions()
+}
+
+func (a *ToggleUnionAuthenticator) Run(ctx context.Context, workers int) {
+	a.runnerMu.Lock()
+	defer a.runnerMu.Unlock()
+
+	runner, ok := a.unionCAContentProvider.(dynamiccertificates.ControllerRunner)
+	if !ok {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	a.runnerCtxCancels = append(a.runnerCtxCancels, cancel)
+
+	runner.Run(ctx, workers)
+}

--- a/pkg/ext/authenticator_test.go
+++ b/pkg/ext/authenticator_test.go
@@ -1,0 +1,136 @@
+package ext
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"slices"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+)
+
+func authenticatorFuncFactory(header string, value string, username string) authenticator.RequestFunc {
+	return func(req *http.Request) (*authenticator.Response, bool, error) {
+		if slices.Contains(req.Header.Values(header), value) {
+			return &authenticator.Response{
+				User: &user.DefaultInfo{
+					Name: username,
+				},
+			}, true, nil
+		}
+
+		return nil, false, nil
+	}
+}
+
+var _ dynamiccertificates.ControllerRunner = &controllerRunner{}
+var _ dynamiccertificates.CAContentProvider = &controllerRunner{}
+var _ authenticator.Request = &controllerRunner{}
+
+type controllerRunner struct {
+	isRunning atomic.Bool
+}
+
+func (r *controllerRunner) AddListener(listener dynamiccertificates.Listener) {
+	panic("unimplemented")
+}
+
+func (r *controllerRunner) CurrentCABundleContent() []byte {
+	panic("unimplemented")
+}
+
+func (r *controllerRunner) Name() string {
+	panic("unimplemented")
+}
+
+func (r *controllerRunner) VerifyOptions() (x509.VerifyOptions, bool) {
+	panic("unimplemented")
+}
+
+func (r *controllerRunner) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return nil, false, nil
+}
+
+func (r *controllerRunner) RunOnce(ctx context.Context) error {
+	panic("will not be called by ToggleUnionAuthenticator")
+}
+
+func (r *controllerRunner) Run(ctx context.Context, nworkers int) {
+	r.isRunning.Store(true)
+	<-ctx.Done()
+	r.isRunning.Store(false)
+}
+
+func TestToggleUnionAuthenticator(t *testing.T) {
+	f1 := authenticatorFuncFactory("Authorization", "Bearer f1", "f1")
+	f2 := authenticatorFuncFactory("Authorization", "Bearer f2", "f2")
+	req := &http.Request{
+		Header: http.Header{
+			"Authorization": []string{"Bearer f1", "Bearer f2"},
+		},
+	}
+
+	auth := NewToggleUnionAuthenticator()
+	auth.Add("f1", f1, false)
+	auth.Add("f2", f2, false)
+
+	resp, ok, err := auth.AuthenticateRequest(req)
+	assert.Nil(t, resp)
+	assert.False(t, ok)
+	assert.NoError(t, err)
+
+	auth.SetEnabled("f1", true)
+	resp, ok, err = auth.AuthenticateRequest(req)
+	assert.Equal(t, "f1", resp.User.GetName())
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	auth.SetEnabled("f1", false)
+	auth.SetEnabled("f2", true)
+	resp, ok, err = auth.AuthenticateRequest(req)
+	assert.Equal(t, "f2", resp.User.GetName())
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestToggleUnionAuthenticatorWithControllerRunners(t *testing.T) {
+	a := &controllerRunner{}
+	b := &controllerRunner{}
+
+	ctx := context.Background()
+
+	auth := NewToggleUnionAuthenticator()
+	auth.Add("a", a, true)
+	auth.Add("b", b, true)
+	go auth.Run(ctx, 0)
+
+	assert.Eventually(t, func() bool {
+		return a.isRunning.Load() && b.isRunning.Load()
+	}, time.Second*5, time.Millisecond*100)
+
+	auth.SetEnabled("a", false)
+	go auth.Run(ctx, 0)
+
+	assert.Eventually(t, func() bool {
+		return !a.isRunning.Load() && b.isRunning.Load()
+	}, time.Second*5, time.Millisecond*100)
+
+	auth.SetEnabled("a", true)
+	auth.SetEnabled("b", false)
+	go auth.Run(ctx, 0)
+	assert.Eventually(t, func() bool {
+		return a.isRunning.Load() && !b.isRunning.Load()
+	}, time.Second*5, time.Millisecond*100)
+
+	auth.SetEnabled("a", false)
+	go auth.Run(ctx, 0)
+	assert.Eventually(t, func() bool {
+		return !a.isRunning.Load() && !b.isRunning.Load()
+	}, time.Second*5, time.Millisecond*100)
+}

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -212,6 +212,8 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 			if err := p.secrets.Delete(Namespace, p.secretName, &metav1.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
 				logrus.Error(err)
 			}
+
+			return nil
 		case <-time.After(certCheckInterval):
 			if err := p.handleCert(); err != nil {
 				logrus.Error(err)
@@ -328,7 +330,7 @@ func (p *rotatingSNIProvider) handleCertEvent(event watch.Event) error {
 		secret := event.Object.(*corev1.Secret)
 		certData, ok := secret.Data[SecretFieldNameCert]
 		if !ok {
-			return fmt.Errorf("secret does not container field '%s'", SecretFieldNameCert)
+			return fmt.Errorf("secret does not contain field '%s'", SecretFieldNameCert)
 		}
 
 		keyData, ok := secret.Data[SecretFieldNameKey]

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -251,7 +251,7 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 			return fmt.Errorf("failed to create secret: %w", err)
 		}
 
-		logrus.Errorf("created imperative api cert secret")
+		logrus.Info("created imperative api cert secret")
 	} else {
 		secret.Data[SecretFieldNameCert] = cert
 		secret.Data[SecretFieldNameKey] = key
@@ -260,7 +260,7 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 			return fmt.Errorf("failed to update secret: %w", err)
 		}
 
-		logrus.Errorf("updated imperative api cert secret")
+		logrus.Info("updated imperative api cert secret")
 	}
 
 	p.cert = cert

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -1,22 +1,226 @@
 package ext
 
 import (
+	"bytes"
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"sync"
+	"time"
 
+	wranglerapiregistrationv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiregistration.k8s.io/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
-	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	netutils "k8s.io/utils/net"
 )
 
-func certForCommonName(cname string) (dynamiccertificates.SNICertKeyContentProvider, error) {
-	certPem, keyPem, err := certutil.GenerateSelfSignedCertKey(cname, nil, nil)
+const (
+	CertificateBlockType = "CERTIFICATE"
+)
+
+func ipsToStrings(ips []net.IP) []string {
+	ss := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		ss = append(ss, ip.String())
+	}
+	return ss
+}
+
+// GenerateSelfSignedCertKey generates a self-signed certificate.
+// Based on the self-signed cert generate code in client-go: https://pkg.go.dev/k8s.io/client-go/util/cert#GenerateSelfSignedCertKeyWithFixtures
+func GenerateSelfSignedCertKeyWithOpts(host string, expireAfter time.Duration) ([]byte, []byte, error) {
+	validFrom := time.Now().Add(-time.Hour) // valid an hour earlier to avoid flakes due to clock skew
+	maxAge := expireAfter
+
+	caKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate self signed cert: %w", err)
+		return nil, nil, err
+	}
+	// returns a uniform random value in [0, max-1), then add 1 to serial to make it a uniform random value in [1, max).
+	serial, err := cryptorand.Int(cryptorand.Reader, new(big.Int).SetInt64(math.MaxInt64-1))
+	if err != nil {
+		return nil, nil, err
+	}
+	serial = new(big.Int).Add(serial, big.NewInt(1))
+	caTemplate := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s-ca@%d", host, time.Now().Unix()),
+		},
+		NotBefore: validFrom,
+		NotAfter:  validFrom.Add(maxAge),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
 	}
 
-	content, err := dynamiccertificates.NewStaticSNICertKeyContent("self-signed-imperative", certPem, keyPem, cname)
+	caDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create static cert content: %w", err)
+		return nil, nil, err
+	}
+
+	caCertificate, err := x509.ParseCertificate(caDERBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	priv, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	// returns a uniform random value in [0, max-1), then add 1 to serial to make it a uniform random value in [1, max).
+	serial, err = cryptorand.Int(cryptorand.Reader, new(big.Int).SetInt64(math.MaxInt64-1))
+	if err != nil {
+		return nil, nil, err
+	}
+	serial = new(big.Int).Add(serial, big.NewInt(1))
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s@%d", host, time.Now().Unix()),
+		},
+		NotBefore: validFrom,
+		NotAfter:  validFrom.Add(maxAge),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
+		template.IPAddresses = append(template.IPAddresses, ip)
+	} else {
+		template.DNSNames = append(template.DNSNames, host)
+	}
+
+	derBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, caCertificate, &priv.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Generate cert, followed by ca
+	certBuffer := bytes.Buffer{}
+	if err := pem.Encode(&certBuffer, &pem.Block{Type: CertificateBlockType, Bytes: derBytes}); err != nil {
+		return nil, nil, err
+	}
+	if err := pem.Encode(&certBuffer, &pem.Block{Type: CertificateBlockType, Bytes: caDERBytes}); err != nil {
+		return nil, nil, err
+	}
+
+	// Generate key
+	keyBuffer := bytes.Buffer{}
+	if err := pem.Encode(&keyBuffer, &pem.Block{Type: keyutil.RSAPrivateKeyBlockType, Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		return nil, nil, err
+	}
+
+	return certBuffer.Bytes(), keyBuffer.Bytes(), nil
+}
+
+var _ dynamiccertificates.SNICertKeyContentProvider = &rotatingSNIProvider{}
+var _ dynamiccertificates.Notifier = &rotatingSNIProvider{}
+var _ dynamiccertificates.CertKeyContentProvider = &rotatingSNIProvider{}
+
+type rotatingSNIProvider struct {
+	name     string
+	sninames []string
+
+	listeners []dynamiccertificates.Listener
+
+	expiresAfter time.Duration
+
+	certMu sync.RWMutex
+	cert   []byte
+	key    []byte
+}
+
+func NewSNIProviderForCname(name string, cnames []string) (*rotatingSNIProvider, error) {
+	content := &rotatingSNIProvider{
+		name:         name,
+		sninames:     cnames,
+		expiresAfter: time.Hour * 24 * 365,
 	}
 
 	return content, nil
+}
+
+func (p *rotatingSNIProvider) AddListener(listener dynamiccertificates.Listener) {
+	p.listeners = append(p.listeners, listener)
+}
+
+func (p *rotatingSNIProvider) SNINames() []string {
+	return p.sninames
+}
+
+func (p *rotatingSNIProvider) Name() string {
+	return p.name
+}
+
+func (p *rotatingSNIProvider) CurrentCertKeyContent() ([]byte, []byte) {
+	p.certMu.RLock()
+	defer p.certMu.RUnlock()
+
+	return bytes.Clone(p.cert), bytes.Clone(p.key)
+}
+
+func (p *rotatingSNIProvider) Run(ctx context.Context) {
+	logrus.Info("starting extension api cert rotator")
+	defer logrus.Info("stopping extension api cert rotator")
+
+	if err := p.updateCerts(); err != nil {
+		logrus.WithError(err).Errorf("initial cert rotation failed")
+	}
+
+	go wait.Until(func() {
+		if err := p.updateCerts(); err != nil {
+			logrus.WithError(err).Error("failed to update extension api cert")
+		}
+	}, p.expiresAfter, ctx.Done())
+
+	<-ctx.Done()
+}
+
+func (p *rotatingSNIProvider) updateCerts() error {
+	logrus.Info("updating extension api cert")
+
+	cert, key, err := GenerateSelfSignedCertKeyWithOpts("extension-api", p.expiresAfter)
+	if err != nil {
+		return fmt.Errorf("failed to generate self signed cert: %w", err)
+	}
+
+	p.certMu.Lock()
+	p.cert = cert
+	p.key = key
+	p.certMu.Unlock()
+
+	for _, listener := range p.listeners {
+		listener.Enqueue()
+	}
+
+	return nil
+}
+
+type listenerFunc func()
+
+func (f listenerFunc) Enqueue() {
+	f()
+}
+
+func ApiServiceCertListener(provider dynamiccertificates.SNICertKeyContentProvider, apiservice wranglerapiregistrationv1.APIServiceController) dynamiccertificates.Listener {
+	return listenerFunc(func() {
+		logrus.Info("api service cert updated")
+		caBundle, _ := provider.CurrentCertKeyContent()
+		if err := CreateOrUpdateAPIService(apiservice, caBundle); err != nil {
+			logrus.WithError(err).Error("failed to update api service")
+		}
+	})
 }

--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -254,10 +254,15 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 	}
 
 	p.certMu.Lock()
-	defer p.certMu.Unlock()
 
 	p.cert = cert
 	p.key = key
+
+	defer p.certMu.Unlock()
+
+	for _, listener := range p.listeners {
+		listener.Enqueue()
+	}
 
 	return nil
 }

--- a/pkg/ext/certs_test.go
+++ b/pkg/ext/certs_test.go
@@ -1,0 +1,291 @@
+package ext
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type watcher struct {
+	name      string
+	eventChan chan watch.Event
+}
+
+func (w *watcher) Stop() {
+	close(w.eventChan)
+}
+
+func (w *watcher) ResultChan() <-chan watch.Event {
+	return w.eventChan
+}
+
+type mapStore[T runtime.Object] struct {
+	mu sync.RWMutex
+	m  map[string]T
+
+	watchMu sync.RWMutex
+	watches []*watcher
+}
+
+func (s *mapStore[T]) Get(n string) (T, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if v, ok := s.m[n]; ok {
+		return v, nil
+	}
+
+	var v T
+	return v, fmt.Errorf("not found")
+}
+
+func (s *mapStore[T]) Create(n string, v T) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.m[n]; ok {
+		return apierrors.NewAlreadyExists(schema.GroupResource{}, n)
+	}
+
+	s.m[n] = v
+
+	s.handleEvent(n, watch.Added)
+
+	return nil
+}
+
+func (s *mapStore[T]) Update(n string, v T) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.m[n]; !ok {
+		return apierrors.NewNotFound(schema.GroupResource{}, n)
+	}
+
+	s.m[n] = v
+	s.handleEvent(n, watch.Added)
+
+	return nil
+}
+
+func (s *mapStore[T]) Delete(n string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.m[n]; !ok {
+		return apierrors.NewNotFound(schema.GroupResource{}, n)
+	}
+
+	delete(s.m, n)
+
+	return nil
+}
+
+func (s *mapStore[T]) Watch(name string) watch.Interface {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+
+	eventChan := make(chan watch.Event, 100)
+	watcher := &watcher{
+		name:      name,
+		eventChan: eventChan,
+	}
+	s.watches = append(s.watches, watcher)
+
+	defer func() {
+		if v, ok := s.m[name]; ok {
+			eventChan <- watch.Event{
+				Type:   watch.Added,
+				Object: v,
+			}
+		}
+	}()
+
+	return watcher
+}
+
+func (s *mapStore[T]) handleEvent(name string, kind watch.EventType) {
+	s.watchMu.RLock()
+	defer s.watchMu.RUnlock()
+
+	v := s.m[name]
+	for _, w := range s.watches {
+		if w.name == name {
+			w.eventChan <- watch.Event{
+				Type:   kind,
+				Object: v,
+			}
+		}
+	}
+}
+
+func setupMockController(t *testing.T, store *mapStore[*corev1.Secret]) *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList] {
+	t.Helper()
+
+	get := func(namespace string, name string, _ metav1.GetOptions) (*corev1.Secret, error) {
+		secret, err := store.Get(fmt.Sprintf("%s/%s", namespace, name))
+		if err != nil {
+			return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+		}
+		return secret, nil
+	}
+	create := func(secret *corev1.Secret) (*corev1.Secret, error) {
+		if err := store.Create(fmt.Sprintf("%s/%s", secret.Namespace, secret.Name), secret); err != nil {
+			return nil, apierrors.NewAlreadyExists(schema.GroupResource{}, secret.Name)
+		}
+		return secret, nil
+	}
+	update := func(secret *corev1.Secret) (*corev1.Secret, error) {
+		if err := store.Update(fmt.Sprintf("%s/%s", secret.Namespace, secret.Name), secret); err != nil {
+			return nil, apierrors.NewNotFound(schema.GroupResource{}, secret.Name)
+		}
+
+		return secret, nil
+	}
+	delete := func(namespace string, name string, _ *metav1.DeleteOptions) error {
+		if err := store.Delete(fmt.Sprintf("%s/%s", namespace, name)); err != nil {
+			return apierrors.NewNotFound(schema.GroupResource{}, name)
+		}
+
+		return nil
+	}
+	watch := func(namespace string, _ metav1.ListOptions) (watch.Interface, error) {
+		watcher := store.Watch(fmt.Sprintf("%s/%s", namespace, ""))
+
+		return watcher, nil
+	}
+
+	controller := gomock.NewController(t)
+	secretMock := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](controller)
+	secretMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(get).AnyTimes()
+	secretMock.EXPECT().Create(gomock.Any()).DoAndReturn(create).AnyTimes()
+	secretMock.EXPECT().Update(gomock.Any()).DoAndReturn(update).AnyTimes()
+	secretMock.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(delete).AnyTimes()
+	secretMock.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(watch).AnyTimes()
+
+	return secretMock
+}
+
+func setup(t *testing.T) (*rotatingSNIProvider, *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList], *mapStore[*corev1.Secret]) {
+	t.Helper()
+
+	store := &mapStore[*corev1.Secret]{
+		m: make(map[string]*corev1.Secret),
+	}
+	secretMock := setupMockController(t, store)
+
+	provider, err := NewSNIProviderForCname(
+		"test-provider",
+		[]string{
+			fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace),
+		},
+		secretMock)
+	assert.NoError(t, err)
+
+	return provider, secretMock, store
+}
+
+func TestRotatingSNIProviderNoExistingSecret(t *testing.T) {
+	provider, secretMock, store := setup(t)
+	stopChan := make(chan struct{})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		err := provider.Run(stopChan)
+		assert.NoError(t, err)
+
+		wg.Done()
+	}()
+
+	wait.Until(func() {
+		_, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+
+		if err == nil {
+			close(stopChan)
+		} else {
+			assert.NoError(t, client.IgnoreNotFound(err))
+		}
+	}, time.Second*1, stopChan)
+
+	wg.Wait()
+
+	secret, err := store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	assert.Error(t, err)
+	assert.Nil(t, secret)
+}
+
+func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
+	provider, secretMock, store := setup(t)
+	stopChan := make(chan struct{})
+
+	initialCert, initialCa, err := GenerateSelfSignedCertKeyWithOpts(fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace), time.Second*5)
+	assert.NoError(t, err)
+
+	err = store.Create(fmt.Sprintf("%s/%s", Namespace, provider.secretName), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      provider.secretName,
+			Namespace: Namespace,
+		},
+		Data: map[string][]byte{
+			SecretFieldNameCert: initialCert,
+			SecretFieldNameKey:  initialCa,
+		},
+	})
+	assert.NoError(t, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		err := provider.Run(stopChan)
+		assert.NoError(t, err)
+
+		wg.Done()
+	}()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		cert := secret.Data[SecretFieldNameCert]
+		ca := secret.Data[SecretFieldNameKey]
+		if !bytes.Equal(initialCert, cert) && !bytes.Equal(initialCa, ca) {
+			cancel()
+		}
+	}, time.Second)
+
+	secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	cert := secret.Data[SecretFieldNameCert]
+	assert.NotEqual(t, initialCert, cert)
+
+	ca := secret.Data[SecretFieldNameKey]
+	assert.NotEqual(t, initialCa, ca)
+
+	close(stopChan)
+
+	wg.Wait()
+
+	secret, err = store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	assert.Error(t, err)
+	assert.Nil(t, secret)
+}

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -3,10 +3,10 @@ package ext
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/ext/listener"
 	extstores "github.com/rancher/rancher/pkg/ext/stores"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/wrangler"
@@ -146,7 +146,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 
 	// Only need to listen on localhost because that port will be reached
 	// from a remotedialer tunnel on localhost
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", Port))
+	ln, err := listener.NewListener(fmt.Sprintf(":%d", Port))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tcp listener: %w", err)
 	}
@@ -226,6 +226,8 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		sniProvider: sniProvider,
 
 		authenticator: toggleAuthenticator,
+
+		listener: ln,
 	}
 	wranglerContext.Mgmt.Setting().OnChange(ctx, "imperative-api-extension", settingController.sync)
 

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -148,7 +148,6 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 	case "true":
 		logrus.Info("creating imperative extension apiserver resources")
 
-		wranglerContext.Core.Secret()
 		sniProvider, err := NewSNIProviderForCname(
 			"imperative-api-sni-provider",
 			[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)},

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -161,7 +161,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		sniProvider.AddListener(ApiServiceCertListener(sniProvider, wranglerContext.API.APIService()))
 
 		go func() {
-			if err := sniProvider.Run(ctx); err != nil {
+			if err := sniProvider.Run(ctx.Done()); err != nil {
 				logrus.Errorf("sni provider failed: %s", err)
 			}
 		}()

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -162,17 +162,14 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		sniProvider.AddListener(ApiServiceCertListener(sniProvider, wranglerContext.API.APIService()))
 
 		go func() {
-			sniProvider.Run(ctx)
+			if err := sniProvider.Run(ctx); err != nil {
+				logrus.Errorf("sni provider failed: %s", err)
+			}
 		}()
 
 		additionalSniProviders = append(additionalSniProviders, sniProvider)
 
 		if err := CreateOrUpdateService(wranglerContext.Core.Service()); err != nil {
-			return nil, fmt.Errorf("failed to create or update APIService: %w", err)
-		}
-
-		caBundle, _ := sniProvider.CurrentCertKeyContent()
-		if err := CreateOrUpdateAPIService(wranglerContext.API.APIService(), caBundle); err != nil {
 			return nil, fmt.Errorf("failed to create or update APIService: %w", err)
 		}
 

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -148,7 +148,13 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 	case "true":
 		logrus.Info("creating imperative extension apiserver resources")
 
-		sniProvider, err := NewSNIProviderForCname("imperative-api-sni-provider", []string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)})
+		wranglerContext.Core.Secret()
+		sniProvider, err := NewSNIProviderForCname(
+			"imperative-api-sni-provider",
+			[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)},
+			wranglerContext.Core.Secret(),
+		)
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate cert for target service: %w", err)
 		}

--- a/pkg/ext/listener/listener.go
+++ b/pkg/ext/listener/listener.go
@@ -1,0 +1,155 @@
+package listener
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+type listenerState int
+
+const (
+	listenerStateUnknown listenerState = iota
+	listenerStateStarted
+	listenerStateStopped
+	listenerStateClosed
+)
+
+var _ net.Listener = &Listener{}
+
+type Listener struct {
+	addr net.Addr
+	ln   *WaitLoader[net.Listener]
+
+	stateMu sync.RWMutex
+	state   listenerState
+}
+
+// NewListener creates a new listener with the provided factory, initially in the stopped state. Currently only supports TCP listeners.
+func NewListener(addr string) (*Listener, error) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve listener address:c %w", err)
+	}
+
+	return &Listener{
+		addr: tcpAddr,
+		ln:   NewWaitLoader[net.Listener](),
+
+		state: listenerStateStopped,
+	}, nil
+}
+
+// Start signals to start the underlying listener and unblocks any calls to Accept. Calls will fail if the listener is already started or closed.
+func (l *Listener) Start() error {
+	l.stateMu.Lock()
+	defer l.stateMu.Unlock()
+
+	switch l.state {
+	case listenerStateStarted:
+		return fmt.Errorf("cannot start an already started listener")
+	case listenerStateClosed:
+		return fmt.Errorf("cannot start a closed listener")
+	case listenerStateUnknown:
+		return fmt.Errorf("listener is in an unknown state")
+	}
+
+	ln, err := net.Listen("tcp", l.addr.String())
+	if err != nil {
+		return fmt.Errorf("failed to create listener: %w", err)
+	}
+
+	l.ln.Set(ln)
+
+	l.state = listenerStateStarted
+
+	return nil
+}
+
+// Stop signals to close the underlying listener. Any calls to Accept will block until Start is called. Calls will fail if the listener is already stopped or closed.
+func (l *Listener) Stop() error {
+	l.stateMu.Lock()
+	defer l.stateMu.Unlock()
+
+	switch l.state {
+	case listenerStateStopped:
+		return fmt.Errorf("listener is already stopped")
+	case listenerStateClosed:
+		return fmt.Errorf("listener is closed")
+	case listenerStateUnknown:
+		return fmt.Errorf("listener is in an unknown state")
+	}
+
+	l.state = listenerStateStopped
+
+	ln := l.ln.Load()
+	l.ln.Unset()
+
+	if err := ln.Close(); err != nil {
+		return fmt.Errorf("failed to close listener: %w", err)
+	}
+
+	return nil
+}
+
+func (l *Listener) ignoreError(err error) bool {
+	l.stateMu.RLock()
+	defer l.stateMu.RUnlock()
+
+	if l.state != listenerStateStopped {
+		return false
+	}
+
+	opErr, ok := err.(*net.OpError)
+	if !ok {
+		return false
+	}
+
+	if opErr.Source == nil {
+		return true
+	}
+
+	return false
+
+}
+
+func (l *Listener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.ln.Load().Accept()
+		if err == nil {
+			return conn, err
+		}
+
+		if l.ignoreError(err) {
+			logrus.Infof("listener was closed, waiting for another connection")
+		} else {
+			return nil, err
+		}
+	}
+}
+
+func (l *Listener) Close() error {
+	l.stateMu.Lock()
+	defer l.stateMu.Unlock()
+
+	if l.state != listenerStateStarted {
+		return nil
+	}
+
+	ln := l.ln.Load()
+	l.ln.Unset()
+
+	l.state = listenerStateClosed
+
+	if err := ln.Close(); err != nil {
+		return fmt.Errorf("failed to close listener: %w", err)
+	}
+
+	return nil
+}
+
+func (l *Listener) Addr() net.Addr {
+	return l.addr
+}

--- a/pkg/ext/listener/listener_test.go
+++ b/pkg/ext/listener/listener_test.go
@@ -1,0 +1,71 @@
+package listener
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	addr = "localhost:8081"
+)
+
+func TestListener(t *testing.T) {
+	ln, err := NewListener(addr)
+	require.NoError(t, err)
+	defer ln.Stop()
+
+	err = ln.Start()
+	require.NoError(t, err, assert.FailNow)
+
+	srv := &http.Server{
+		Addr: "",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("Hello, World!"))
+		}),
+	}
+
+	client := http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Logf("failed to serve: %s", err)
+		}
+	}()
+	defer srv.Close()
+
+	resp, err := client.Get("http://" + addr)
+	assert.NoError(t, err)
+
+	data, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, string(data), "Hello, World!")
+
+	err = ln.Stop()
+	require.NoError(t, err)
+
+	err = ln.Start()
+	require.NoError(t, err, assert.FailNow)
+
+	assert.Eventually(t, func() bool {
+		newResp, err := client.Get("http://" + addr)
+		if !assert.NoError(t, err) {
+			return false
+		}
+
+		ok := true
+
+		newData, err := io.ReadAll(newResp.Body)
+		ok = ok && assert.NoError(t, err)
+		ok = ok && assert.Equal(t, string(newData), "Hello, World!")
+
+		return ok
+	}, time.Second*5, time.Millisecond*100)
+}

--- a/pkg/ext/listener/loader.go
+++ b/pkg/ext/listener/loader.go
@@ -1,0 +1,50 @@
+package listener
+
+import (
+	"sync"
+)
+
+// WaitLoader blocks until the underlying value is set.
+type WaitLoader[T any] struct {
+	locker sync.RWMutex
+
+	vMu sync.RWMutex
+	v   *T
+}
+
+func NewWaitLoader[T any]() *WaitLoader[T] {
+	wl := &WaitLoader[T]{}
+	wl.Unset()
+	return wl
+}
+
+// Load blocks until there is a value to return.
+func (w *WaitLoader[T]) Load() T {
+	w.locker.RLock()
+	defer w.locker.RUnlock()
+
+	return *w.v
+}
+
+// Set the value and unblock any calls to Load.
+func (w *WaitLoader[T]) Set(v T) {
+	w.vMu.Lock()
+	defer w.vMu.Unlock()
+
+	w.v = &v
+
+	// To avoid unlocking an unlocked mutex, frist try to lock it.
+	// If unlocked this will take the lock before unlocking
+	// If locked this will just unlock
+	_ = w.locker.TryLock()
+	w.locker.Unlock()
+}
+
+// Unset the value and unublock calls to Load.
+func (w *WaitLoader[T]) Unset() {
+	w.vMu.Lock()
+	defer w.vMu.Unlock()
+
+	_ = w.locker.TryLock()
+	w.v = nil
+}

--- a/pkg/ext/listener/loader_test.go
+++ b/pkg/ext/listener/loader_test.go
@@ -1,0 +1,77 @@
+package listener
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	DefaultBlockingTestTimeout = time.Second * 5
+)
+
+func assertBlocksUntil(t *testing.T, blocker func(), unblocker func(), timeout time.Duration) {
+	t.Helper()
+
+	blockChan := make(chan struct{})
+
+	go func() {
+		blocker()
+		close(blockChan)
+	}()
+
+	unblocker()
+
+	select {
+	case <-blockChan:
+	case <-time.After(timeout):
+		t.Error("blocker func in not unblocked by unblocker func")
+	}
+}
+
+func TestLoaderLoadBlocksUntilSet(t *testing.T) {
+	wl := NewWaitLoader[int]()
+
+	assertBlocksUntil(
+		t,
+		func() {
+			wl.Load()
+		},
+		func() {
+			wl.Set(0)
+		},
+		DefaultBlockingTestTimeout,
+	)
+}
+
+func TestLoaderLoadDoesNotBlockAfterSec(t *testing.T) {
+	wl := NewWaitLoader[int]()
+
+	assertBlocksUntil(
+		t,
+		func() {
+			wl.Load()
+			wl.Load()
+		},
+		func() {
+			wl.Set(0)
+		},
+		DefaultBlockingTestTimeout,
+	)
+}
+
+func TestLoaderUnsetBlocksLoadUntilSet(t *testing.T) {
+	wl := NewWaitLoader[int]()
+	wl.Set(0)
+	wl.Unset()
+
+	assertBlocksUntil(
+		t,
+		func() {
+			wl.Load()
+		},
+		func() {
+			wl.Set(0)
+		},
+		DefaultBlockingTestTimeout,
+	)
+}

--- a/pkg/ext/setting.go
+++ b/pkg/ext/setting.go
@@ -1,0 +1,72 @@
+package ext
+
+import (
+	"fmt"
+	"sync"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
+	wranglerapiregistrationv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiregistration.k8s.io/v1"
+	wranglercorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+)
+
+type settingController struct {
+	services    wranglercorev1.ServiceController
+	apiservices wranglerapiregistrationv1.APIServiceController
+
+	sniProvider *rotatingSNIProvider
+
+	valueMu sync.Mutex
+	value   string
+
+	stopChan chan struct{}
+}
+
+// func (c *SettingController) sync(_ context.Context, _ string, obj *v3.Setting) (runtime.Object, error) {
+func (c *settingController) sync(_ string, obj *v3.Setting) (*v3.Setting, error) {
+	if obj == nil || obj.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	if obj.Name != settings.ImperativeApiExtension.Name {
+		return obj, nil
+	}
+
+	c.valueMu.Lock()
+	defer c.valueMu.Unlock()
+
+	if c.value == obj.Value {
+		return obj, nil
+	}
+
+	switch obj.Value {
+	case "true":
+		// todo: create extension API server resources
+		logrus.Info("creating imperative extension apiserver resources")
+
+		c.stopChan = make(chan struct{})
+
+		go func() {
+			if err := c.sniProvider.Run(c.stopChan); err != nil {
+				logrus.Errorf("sni provider failed: %s", err)
+			}
+		}()
+
+		if err := CreateOrUpdateService(c.services); err != nil {
+			return nil, fmt.Errorf("failed to create or update APIService: %w", err)
+		}
+	default:
+		logrus.Info("cleaning up imperative extension apiserver resources")
+
+		close(c.stopChan)
+
+		if err := CleanupExtensionAPIServer(c.services, c.apiservices); err != nil {
+			return nil, err
+		}
+	}
+
+	c.value = obj.Value
+
+	return nil, nil
+}

--- a/pkg/ext/setting.go
+++ b/pkg/ext/setting.go
@@ -17,6 +17,8 @@ type settingController struct {
 
 	sniProvider *rotatingSNIProvider
 
+	authenticator *ToggleUnionAuthenticator
+
 	stopChanMu sync.Mutex
 	stopChan   chan struct{}
 }
@@ -44,6 +46,8 @@ func (c *settingController) sync(_ string, obj *v3.Setting) (*v3.Setting, error)
 		c.stopChan = make(chan struct{})
 		c.stopChanMu.Unlock()
 
+		c.authenticator.SetEnabled(authenticatorNameSteveDefault, true)
+
 		go func() {
 			if err := c.sniProvider.Run(c.stopChan); err != nil {
 				logrus.Errorf("sni provider failed: %s", err)
@@ -64,6 +68,8 @@ func (c *settingController) sync(_ string, obj *v3.Setting) (*v3.Setting, error)
 		close(c.stopChan)
 		c.stopChan = nil
 		c.stopChanMu.Unlock()
+
+		c.authenticator.SetEnabled(authenticatorNameSteveDefault, false)
 
 		if err := CleanupExtensionAPIServer(c.services, c.apiservices); err != nil {
 			return nil, err


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Follow up work for: https://github.com/rancher/rancher/issues/47035
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Because of the way the rancher settings system work and the order in which we need to create the extension server, steve server, and rancher server we must delay creating some resources until after rancher has started to prevent storing setting in k8s prematurely. To do this, I added a setting sync controller to watch for changes to the `imperative-api-extension`.

When the setting's value is `true` (case insensitive) we:

1. Update the authentication used by Steve to allow authentication on SNI certs rather than just rancher user auth headers (allows the apiserver to communicate with the extension api)
2. Start our SNI cert provider to generate (and regenerate) self-signed certs
3. Start the listener for the imperative api server listener
4. Create the `ApiService` and `Service` to point the apiserver at rancher

When the setting is `false` (or anything other than `true`) we:

1. Put the imperative api listener in a blocking state (to close the port)
2. Only support rancher user auth headers
3. Stop the SNI cert provider
4. Cleanup the `ApiService` and `Service` for the extension server
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_

blocked by https://github.com/rancher/rancher/pull/48956