### PR TITLE
Bump Rancher Shell for 2.11

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 106.0.0+up0.7.0-rc.3
 provisioningCAPIVersion: 105.0.0+up0.4.0
 cspAdapterMinVersion: 105.0.0+up5.0.1-rc1
-defaultShellVersion: rancher/shell:v0.3.0-rc.2
+defaultShellVersion: rancher/shell:v0.4.0-rc.1
 fleetVersion: 106.0.0+up0.12.0-alpha.14

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion    = "105.0.0+up5.0.1-rc1"
-	DefaultShellVersion     = "rancher/shell:v0.3.0-rc.2"
+	DefaultShellVersion     = "rancher/shell:v0.4.0-rc.1"
 	FleetVersion            = "106.0.0+up0.12.0-alpha.14"
 	ProvisioningCAPIVersion = "105.0.0+up0.4.0"
 	WebhookVersion          = "106.0.0+up0.7.0-rc.3"


### PR DESCRIPTION
# Issue https://github.com/rancher/shell/issues/313

Per title this bumps Rancher Shell to use the new branch (and RC) targeting Rancher 2.11.
This includes the updated helm and updated kubectl versions for the +-1 versions of k8s Rancher 2.11 will support.