### PR TITLE
bump kubeVersion in rancher chart for 1.32 max version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
 version: %VERSION%
 appVersion: %APP_VERSION%
-kubeVersion: < 1.32.0-0
+kubeVersion: < 1.33.0-0
 home: https://rancher.com
 icon: https://raw.githubusercontent.com/rancher/ui/master/public/assets/images/logos/welcome-cow.svg
 keywords:


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49124