### PR TITLE
Bump Rancher Shell for 2.10

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 105.0.2+up0.6.3
 provisioningCAPIVersion: 105.1.0+up0.6.0
 cspAdapterMinVersion: 105.0.0+up5.0.1
-defaultShellVersion: rancher/shell:v0.3.0
+defaultShellVersion: rancher/shell:v0.3.1-rc.1
 fleetVersion: 105.0.4+up0.11.4-rc.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion    = "105.0.0+up5.0.1"
-	DefaultShellVersion     = "rancher/shell:v0.3.0"
+	DefaultShellVersion     = "rancher/shell:v0.3.1-rc.1"
 	FleetVersion            = "105.0.4+up0.11.4-rc.2"
 	ProvisioningCAPIVersion = "105.1.0+up0.6.0"
 	WebhookVersion          = "105.0.2+up0.6.3"


### PR DESCRIPTION
## Issue: https://github.com/rancher/shell/issues/314
 
Per title this bumps Rancher Shell to use the new branch (and RC) targeting Rancher 2.10.