### PR TITLE
Fix "superfluous WriteHeader" warning from pkg/version handler

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -50,5 +50,4 @@ func (h *versionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	rw.Write(body)
-	rw.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
## Problem
Logs include a recurrent warning:
```
http: superfluous response.WriteHeader call from github.com/rancher/rancher/pkg/version.(*versionHandler).ServeHTTP (version.go:53)
```
which happens every time that `${rancherURL}/rancherversion` is accessed. This error can be considered just a warning, since the actual response includes a HTTP 200 code, but still it shouldn't happen.
 
## Solution

According to [the standard library documentation](https://pkg.go.dev/net/http#ResponseWriter.Write):
> If [ResponseWriter.WriteHeader] has not yet been called, Write calls WriteHeader(http.StatusOK) before writing the data.
This means that our `WriteHeader` call is redundant and not needed. If we wanted to customize the code, it should be done before any `ResponseWriter.Write`.

## Testing
Built and tested locally by querying at `/rancherversion` and observing the error message no longer appears in the logs.