### PR TITLE
Bump Rancher Shell for 2.8

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
 webhookVersion: 103.0.14+up0.4.15
 cspAdapterMinVersion: 103.0.1+up3.0.1
-defaultShellVersion: rancher/shell:v0.1.26
+defaultShellVersion: rancher/shell:v0.1.28-rc.1
 fleetVersion: 103.1.13+up0.9.14-rc.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion = "103.0.1+up3.0.1"
-	DefaultShellVersion  = "rancher/shell:v0.1.26"
+	DefaultShellVersion  = "rancher/shell:v0.1.28-rc.1"
 	FleetVersion         = "103.1.13+up0.9.14-rc.1"
 	WebhookVersion       = "103.0.14+up0.4.15"
 )


### PR DESCRIPTION
## Issue: https://github.com/rancher/shell/issues/316

Per title this bumps Rancher Shell to use the new branch (and RC) targeting Rancher 2.10.