### PR TITLE
fix lookup of LB when using OR'd values

### DIFF
--- a/tests/scripts/custodian/aws.yaml
+++ b/tests/scripts/custodian/aws.yaml
@@ -180,7 +180,7 @@ policies:
   filters:
      # nlb name not in accepted user keys
     - type: value
-      key: LoadBalancerArn
+      key: LoadBalancerName
       op: regex
       #doesNOTcontain
       value:  "^((?!USERKEYS).)*$"
@@ -192,7 +192,7 @@ policies:
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
-        key: LoadBalancerArn
+        key: LoadBalancerName
         op: regex
         value:  "^.*DONOTDELETEKEYS.*$"
   actions:
@@ -217,7 +217,7 @@ policies:
   filters:
     # nlb is named with accepted user key
     - type: value
-      key: LoadBalancerArn
+      key: LoadBalancerName
       op: regex
       value:  "^.*USERKEYS.*$"
     # nlb is not doNotDelete
@@ -228,7 +228,7 @@ policies:
     - "tag:DeletesOnFriday": absent
     - not: 
       - type: value
-        key: LoadBalancerArn
+        key: LoadBalancerName
         op: regex
         value:  "^.*DONOTDELETEKEYS.*$"
   actions:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 noticed that LBs weren't being cleaned up by the custodian as often as they should. Turns out the ARN lookup doesn't like keys with `|`

lookup by name instead fixes the issue. 
![image](https://github.com/user-attachments/assets/a4548334-b053-4f41-a55d-4d560b12259a)
