### PR TITLE
Bump Go toolchain to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher
 
 go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.27 // for compatibilty with docker 20.10.x

--- a/hack/airgap/go.mod
+++ b/hack/airgap/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/airgap
 
 go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/containers/common v0.60.0

--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -2,7 +2,7 @@ ARG SERVERCORE_VERSION
 ARG ARCH=amd64
 ARG VERSION=dev
 
-FROM library/golang:1.23.5 as build
+FROM library/golang:1.23.6 as build
 
 WORKDIR C:/app
 COPY . .

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/pkg/apis
 
 go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 replace (
 	k8s.io/api => k8s.io/api v0.31.1

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/pkg/client
 
 go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab

--- a/tests/v2/validation/steve/vai/scripts/script.sh
+++ b/tests/v2/validation/steve/vai/scripts/script.sh
@@ -4,6 +4,7 @@ set -e
 MAX_RETRIES=3
 BUILD_TIMEOUT=300  # 5 minutes timeout
 CACHE_DIR="/var/cache/vai-query"
+GO_VERSION="1.23.6"
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] $1"
@@ -45,13 +46,13 @@ check_go() {
 # Install Go with retries
 install_go() {
     mkdir -p $CACHE_DIR
-    GO_ARCHIVE="$CACHE_DIR/go1.23.5.linux-amd64.tar.gz"
+    GO_ARCHIVE="$CACHE_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
 
     for i in $(seq 1 $MAX_RETRIES); do
         log "Attempting to install Go (attempt $i of $MAX_RETRIES)..."
 
         if [ ! -f "$GO_ARCHIVE" ]; then
-            if ! curl -L -o "$GO_ARCHIVE" https://go.dev/dl/go1.23.5.linux-amd64.tar.gz --insecure; then
+            if ! curl -L -o "$GO_ARCHIVE" "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" --insecure; then
                 error "Failed to download Go (attempt $i)"
                 continue
             fi


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The new BCI golang stable image registry.suse.com/bci/golang:1.23 is now available.

```sh
docker pull registry.suse.com/bci/golang:1.23
docker inspect registry.suse.com/bci/golang:1.23 | grep GOLANG_VERSION
                "GOLANG_VERSION=1.23.6",
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Match the Go toolchain to the one in the new bci/golang:1.23 image.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A