### PR TITLE
[main] Imperative api feature

### DIFF
--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -143,8 +143,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 	}
 
 	var additionalSniProviders []dynamiccertificates.SNICertKeyContentProvider
-	feature := features.GetFeatureByName(features.ImperativeApiExtension.Name())
-	if feature.Enabled() {
+	if features.ImperativeApiExtension.Enabled() {
 		logrus.Info("creating imperative extension apiserver resources")
 
 		sniProvider, err := certForCommonName(fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace))

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 
 	extstores "github.com/rancher/rancher/pkg/ext/stores"
@@ -144,8 +143,8 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 	}
 
 	var additionalSniProviders []dynamiccertificates.SNICertKeyContentProvider
-	switch os.Getenv("CATTLE_IMPERATIVE_API_EXTENSION") {
-	case "true":
+	feature := features.GetFeatureByName(features.ImperativeApiExtension.Name())
+	if feature.Enabled() {
 		logrus.Info("creating imperative extension apiserver resources")
 
 		sniProvider, err := certForCommonName(fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace))
@@ -170,7 +169,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		}
 
 		authenticators = append(authenticators, defaultAuthenticator)
-	default:
+	} else {
 		logrus.Info("deleting imperative extension apiserver resources")
 
 		if err := CleanupExtensionAPIServer(wranglerContext); err != nil {

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -162,6 +162,13 @@ var (
 		false,
 		true,
 		true)
+
+	ImperativeApiExtension = newFeature(
+		"imperative-api-extension",
+		"Enable imperative API extension as a k8s aggregation layer as proxy to the kube apiserver",
+		true,
+		false,
+		true)
 )
 
 type Feature struct {

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -166,7 +166,7 @@ var (
 	ImperativeApiExtension = newFeature(
 		"imperative-api-extension",
 		"Enable imperative API extension as a k8s aggregation layer as proxy to the kube apiserver",
-		true,
+		false,
 		false,
 		true)
 )

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -348,8 +348,6 @@ var (
 	// UnprivilegedJailUser controls whether jailed commands execute under a separate (unprivileged/non-root) user
 	// account. Setting it to false is only recommended for testing and development environments.
 	UnprivilegedJailUser = NewSetting("unprivileged-jail-user", "true")
-
-	ImperativeApiExtension = NewSetting("imperative-api-extension", "false")
 )
 
 // FullShellImage returns the full private registry name of the rancher shell image.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/47035 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Currently the imperative API only checks an envvar to determine if the imperative api should be enabled. This does not allow users to enable or disable it via UI. Due to the current setting, rancher server, and steve initialization workflow it does not make sense to support toggling the imperative api at runtime. Since rancher setting do not easily support restart rancher on change, we need a feature to support the desired functionality. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_

closes https://github.com/rancher/rancher/pull/49112