### PR TITLE
Migrate RBAC Job Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+	github.com/rancher/shepherd => github.com/caliskanugur/shepherd v0.0.0-20250221155809-d3471575e775
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -1543,6 +1543,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f h1:7+HZb3PwI0cCUETyMDgPCvSta1y3idwBL8PHwSgelJk=
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/caliskanugur/shepherd v0.0.0-20250221155809-d3471575e775 h1:RR9Uaup99DgM2S75k0NyTIlzvJccxqFflxBOFxi+96Q=
+github.com/caliskanugur/shepherd v0.0.0-20250221155809-d3471575e775/go.mod h1:relMIZBbmYQyZUgVWfomrpHKO0we3AmbrUD0EFYoXyc=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -2465,8 +2467,6 @@ github.com/rancher/rke v1.8.0-rc.2 h1:kW6Or5YFanUkz82p1u4up5PenLZrTuUZg8xCzLmjJU
 github.com/rancher/rke v1.8.0-rc.2/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
 github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHRkGaJ5v0=
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
-github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b h1:uX+XbQgpqpfxfvDI+6uPb1DeeDqEwa7lE+QtYuPCqzU=
-github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
 github.com/rancher/steve v0.5.7 h1:g9JtvlREqVIK0Y93y/krR56ar+bLljfiTY6rDS8gX6k=
 github.com/rancher/steve v0.5.7/go.mod h1:MYfPz1NfqRjsXcc83eV7nR77JqMRu9Ogb5I+WfCd+1o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=

--- a/tests/v2/actions/workloads/job/job.go
+++ b/tests/v2/actions/workloads/job/job.go
@@ -1,0 +1,86 @@
+package job
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/v2/actions/kubeapi/workloads/jobs"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/wait"
+	"github.com/rancher/shepherd/pkg/wrangler"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// CreateJob is a helper to create a job in a namespace
+func CreateJob(client *rancher.Client, clusterID, namespaceName string, podTemplate corev1.PodTemplateSpec, watchJob bool) (*batchv1.Job, error) {
+	var ctx *wrangler.Context
+	var err error
+
+	if clusterID != "local" {
+		ctx, err = client.WranglerContext.DownStreamClusterWranglerContext(clusterID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get downstream context: %w", err)
+		}
+	} else {
+		ctx = client.WranglerContext
+	}
+
+	jobTemplate := NewJobTemplate(namespaceName, podTemplate)
+	createdJob, err := ctx.Batch.Job().Create(&jobTemplate)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create job: %w", err)
+	}
+
+	if watchJob {
+		err = WatchAndWaitJob(client, clusterID, namespaceName, createdJob)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return createdJob, nil
+}
+
+// WatchAndWaitJob is a helper to watch and wait for job to be active
+func WatchAndWaitJob(client *rancher.Client, clusterID, namespaceName string, job *batchv1.Job) error {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return err
+	}
+
+	jobResource := dynamicClient.Resource(jobs.JobGroupVersionResource).Namespace(namespaceName)
+
+	watchJobInterface, err := jobResource.Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + job.Name,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	return wait.WatchWait(watchJobInterface, func(event watch.Event) (bool, error) {
+		jobUnstructured, ok := event.Object.(*unstructured.Unstructured)
+		if !ok {
+			return false, fmt.Errorf("failed to cast to unstructured object")
+		}
+
+		job := &batchv1.Job{}
+		err := scheme.Scheme.Convert(jobUnstructured, job, jobUnstructured.GroupVersionKind())
+		if err != nil {
+			return false, err
+		}
+
+		if job.Status.Active > 0 {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/tests/v2/actions/workloads/job/template.go
+++ b/tests/v2/actions/workloads/job/template.go
@@ -1,0 +1,25 @@
+package job
+
+import (
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewJobTemplate is a constructor that creates the template for jobs
+func NewJobTemplate(namespaceName string, podTemplate corev1.PodTemplateSpec) batchv1.Job {
+	jobName := namegen.AppendRandomString("testjob")
+
+	podTemplate.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+
+	return batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespaceName,
+		},
+		Spec: batchv1.JobSpec{
+			Template: podTemplate,
+		},
+	}
+}

--- a/tests/v2/validation/rbac/workloads/README.md
+++ b/tests/v2/validation/rbac/workloads/README.md
@@ -1,0 +1,26 @@
+# RBAC Workloads
+
+## Pre-requisites
+
+- Ensure you have an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, create one first before running this test.
+
+## Test Setup
+
+Your GO suite should be set to `-run ^Test<TestSuite>$`
+
+- To run the rbac_daemonset_test.go, set the GO suite to `-run ^TestRbacDaemonsetTestSuite$`
+- To run the rbac_deployment_test.go, set the GO suite to `-run ^TestRbacDeploymentTestSuite$`
+- To run the rbac_statefulset_test.go, set the GO suite to `-run ^TestRbacStatefulSetTestSuite$`
+- To run the rbac_cronjob_test.go, set the GO suite to `-run ^TestRbacCronJobTestSuite$`
+- To run the rbac_job_test.go, set the GO suite to `-run ^TestRbacJobTestSuite$`
+
+In your config file, set the following:
+
+```yaml
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True #optional
+  cleanup: True #optional
+  clusterName: "cluster_name"
+```

--- a/tests/v2/validation/rbac/workloads/rbac_job_test.go
+++ b/tests/v2/validation/rbac/workloads/rbac_job_test.go
@@ -1,0 +1,347 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+
+package workloads
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/projects"
+	"github.com/rancher/rancher/tests/v2/actions/rbac"
+	"github.com/rancher/rancher/tests/v2/actions/workloads/job"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/extensions/workloads"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+type RbacJobTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (rj *RbacJobTestSuite) TearDownSuite() {
+	rj.session.Cleanup()
+}
+
+func (rj *RbacJobTestSuite) SetupSuite() {
+	rj.session = session.NewSession()
+
+	client, err := rancher.NewClient("", rj.session)
+	require.NoError(rj.T(), err)
+	rj.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in rj")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(rj.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rj.client, clusterName)
+	require.NoError(rj.T(), err, "Error getting cluster ID")
+	rj.cluster, err = rj.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rj.T(), err)
+}
+
+func (rj *RbacJobTestSuite) createPodTemplate() corev1.PodTemplateSpec {
+	containerName := namegen.AppendRandomString("testcontainer")
+	pullPolicy := corev1.PullAlways
+
+	containerTemplate := workloads.NewContainer(
+		containerName,
+		rbac.ImageName,
+		pullPolicy,
+		[]corev1.VolumeMount{},
+		[]corev1.EnvFromSource{},
+		nil, nil, nil,
+	)
+
+	podTemplate := workloads.NewPodTemplate(
+		[]corev1.Container{containerTemplate},
+		[]corev1.Volume{},
+		[]corev1.LocalObjectReference{},
+		nil, nil,
+	)
+
+	return podTemplate
+}
+
+func (rj *RbacJobTestSuite) TestCreateJob() {
+	subSession := rj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rj.Run("Validate job creation as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rj.client, rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rj.client, tt.member, tt.role.String(), rj.cluster, adminProject)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("As a %v, create a job", tt.role.String())
+			podTemplate := rj.createPodTemplate()
+			_, err = job.CreateJob(userClient, rj.cluster.ID, namespace.Name, podTemplate, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rj.T(), err, "failed to create job")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rj.T(), err)
+				assert.True(rj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rj *RbacJobTestSuite) TestListJob() {
+	subSession := rj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rj.Run("Validate listing job as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rj.client, rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rj.client, tt.member, tt.role.String(), rj.cluster, adminProject)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("As a %v, create a job in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := rj.createPodTemplate()
+			createdJob, err := job.CreateJob(rj.client, rj.cluster.ID, namespace.Name, podTemplate, true)
+			assert.NoError(rj.T(), err, "failed to create job")
+
+			log.Infof("As a %v, list the job", tt.role.String())
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+			jobList, err := standardUserContext.Batch.Job().List(namespace.Name, metav1.ListOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String(), rbac.ReadOnly.String():
+				assert.NoError(rj.T(), err, "failed to list job")
+				assert.Equal(rj.T(), len(jobList.Items), 1)
+				assert.Equal(rj.T(), jobList.Items[0].Name, createdJob.Name)
+			case rbac.ClusterMember.String():
+				assert.Error(rj.T(), err)
+				assert.True(rj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rj *RbacJobTestSuite) TestUpdateJob() {
+	subSession := rj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rj.Run("Validate updating job as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rj.client, rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rj.client, tt.member, tt.role.String(), rj.cluster, adminProject)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("As a %v, create a job in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := rj.createPodTemplate()
+			createdJob, err := job.CreateJob(rj.client, rj.cluster.ID, namespace.Name, podTemplate, true)
+			assert.NoError(rj.T(), err, "failed to create job")
+
+			log.Infof("As a %v, update the job %s with a new label.", tt.role.String(), createdJob.Name)
+			adminContext, err := rj.client.WranglerContext.DownStreamClusterWranglerContext(rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+
+			latestJob, err := adminContext.Batch.Job().Get(namespace.Name, createdJob.Name, metav1.GetOptions{})
+			assert.NoError(rj.T(), err, "Failed to list job.")
+
+			if latestJob.Labels == nil {
+				latestJob.Labels = make(map[string]string)
+			}
+			latestJob.Labels["updated"] = "true"
+
+			_, err = standardUserContext.Batch.Job().Update(latestJob)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rj.T(), err, "failed to update job")
+				updatedJob, err := standardUserContext.Batch.Job().Get(namespace.Name, createdJob.Name, metav1.GetOptions{})
+				assert.NoError(rj.T(), err, "Failed to list the job after updating labels.")
+				assert.Equal(rj.T(), "true", updatedJob.Labels["updated"], "job label update failed.")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rj.T(), err)
+				assert.True(rj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rj *RbacJobTestSuite) TestDeleteJob() {
+	subSession := rj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rj.Run("Validate deleting job as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rj.client, rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rj.client, tt.member, tt.role.String(), rj.cluster, adminProject)
+			assert.NoError(rj.T(), err)
+
+			log.Infof("As a %v, create a job in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := rj.createPodTemplate()
+			createdJob, err := job.CreateJob(rj.client, rj.cluster.ID, namespace.Name, podTemplate, true)
+			assert.NoError(rj.T(), err, "failed to create job")
+
+			log.Infof("As a %v, delete the job", tt.role.String())
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rj.cluster.ID)
+			assert.NoError(rj.T(), err)
+			err = standardUserContext.Batch.Job().Delete(namespace.Name, createdJob.Name, &metav1.DeleteOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rj.T(), err, "failed to delete job")
+				err := kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+					updatedJobList, pollErr := standardUserContext.Batch.Job().List(namespace.Name, metav1.ListOptions{})
+					if pollErr != nil {
+						return false, fmt.Errorf("failed to list jobs: %w", pollErr)
+					}
+
+					if len(updatedJobList.Items) == 0 {
+						return true, nil
+					}
+					return false, nil
+				})
+				assert.NoError(rj.T(), err)
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rj.T(), err)
+				assert.True(rj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rj *RbacJobTestSuite) TestCrudJobAsClusterMember() {
+	subSession := rj.session.NewSession()
+	defer subSession.Cleanup()
+
+	role := rbac.ClusterMember.String()
+	log.Infof("Create a standard user.")
+	user, userClient, err := rbac.SetupUser(rj.client, rbac.StandardUser.String())
+	require.NoError(rj.T(), err)
+
+	log.Infof("Add the user to the downstream cluster with role %s", role)
+	err = users.AddClusterRoleToUser(rj.client, rj.cluster, user, role, nil)
+	require.NoError(rj.T(), err)
+
+	log.Infof("As a %v, create a project and a namespace in the project.", role)
+	_, namespace, err := projects.CreateProjectAndNamespace(userClient, rj.cluster.ID)
+	require.NoError(rj.T(), err)
+
+	log.Infof("As a %v, create a job in the namespace %v", role, namespace.Name)
+	podTemplate := rj.createPodTemplate()
+	createdJob, err := job.CreateJob(userClient, rj.cluster.ID, namespace.Name, podTemplate, true)
+	require.NoError(rj.T(), err, "failed to create job")
+
+	log.Infof("As a %v, list the job", role)
+	standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rj.cluster.ID)
+	assert.NoError(rj.T(), err)
+	jobList, err := standardUserContext.Batch.Job().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rj.T(), err, "failed to list jobs")
+	require.Equal(rj.T(), len(jobList.Items), 1)
+	require.Equal(rj.T(), jobList.Items[0].Name, createdJob.Name)
+
+	log.Infof("As a %v, update the job %s with a new label.", role, createdJob.Name)
+	latestJob, err := standardUserContext.Batch.Job().Get(namespace.Name, createdJob.Name, metav1.GetOptions{})
+	assert.NoError(rj.T(), err, "Failed to get the latest job.")
+
+	if latestJob.Labels == nil {
+		latestJob.Labels = make(map[string]string)
+	}
+	latestJob.Labels["updated"] = "true"
+
+	_, err = standardUserContext.Batch.Job().Update(latestJob)
+	require.NoError(rj.T(), err, "failed to update job")
+	updatedJobList, err := standardUserContext.Batch.Job().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rj.T(), err, "Failed to list the job after updating labels.")
+	require.Equal(rj.T(), "true", updatedJobList.Items[0].Labels["updated"], "job label update failed.")
+
+	log.Infof("As a %v, delete the job", role)
+	err = standardUserContext.Batch.Job().Delete(namespace.Name, createdJob.Name, &metav1.DeleteOptions{})
+	require.NoError(rj.T(), err, "failed to delete job")
+	err = kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+		updatedJobList, pollErr := standardUserContext.Batch.Job().List(namespace.Name, metav1.ListOptions{})
+		if pollErr != nil {
+			return false, fmt.Errorf("failed to list jobs: %w", pollErr)
+		}
+
+		if len(updatedJobList.Items) == 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(rj.T(), err)
+}
+
+func TestRbacJobTestSuite(t *testing.T) {
+	suite.Run(t, new(RbacJobTestSuite))
+}


### PR DESCRIPTION
**Issue**: https://github.com/rancher/qa-tasks/issues/1342

This is one of the several upcoming PRs aimed at migrating the RBAC workload tests from Python to Go. **This PR specifically includes tests for Job only.**

**Note**: Backport PRs will be created once this gets approved
