### PR TITLE
Migrate RBAC Cronjob Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+	github.com/rancher/shepherd => github.com/caliskanugur/shepherd v0.0.0-20250221155809-d3471575e775
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -1543,6 +1543,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f h1:7+HZb3PwI0cCUETyMDgPCvSta1y3idwBL8PHwSgelJk=
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/caliskanugur/shepherd v0.0.0-20250221155809-d3471575e775 h1:RR9Uaup99DgM2S75k0NyTIlzvJccxqFflxBOFxi+96Q=
+github.com/caliskanugur/shepherd v0.0.0-20250221155809-d3471575e775/go.mod h1:relMIZBbmYQyZUgVWfomrpHKO0we3AmbrUD0EFYoXyc=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -2465,8 +2467,6 @@ github.com/rancher/rke v1.8.0-rc.2 h1:kW6Or5YFanUkz82p1u4up5PenLZrTuUZg8xCzLmjJU
 github.com/rancher/rke v1.8.0-rc.2/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
 github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHRkGaJ5v0=
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
-github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b h1:uX+XbQgpqpfxfvDI+6uPb1DeeDqEwa7lE+QtYuPCqzU=
-github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
 github.com/rancher/steve v0.5.7 h1:g9JtvlREqVIK0Y93y/krR56ar+bLljfiTY6rDS8gX6k=
 github.com/rancher/steve v0.5.7/go.mod h1:MYfPz1NfqRjsXcc83eV7nR77JqMRu9Ogb5I+WfCd+1o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=

--- a/tests/v2/actions/kubeapi/workloads/cronjobs/cronjobs.go
+++ b/tests/v2/actions/kubeapi/workloads/cronjobs/cronjobs.go
@@ -8,6 +8,6 @@ import (
 // using the dynamic client.
 var CronJobGroupVersionResource = schema.GroupVersionResource{
 	Group:    "batch",
-	Version:  "v1beta1",
+	Version:  "v1",
 	Resource: "cronjobs",
 }

--- a/tests/v2/actions/workloads/cronjob/template.go
+++ b/tests/v2/actions/workloads/cronjob/template.go
@@ -1,0 +1,39 @@
+package cronjob
+
+import (
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewCronJobTemplate is a constructor that creates the template for cronjob
+func NewCronJobTemplate(namespaceName, schedule string, podTemplate corev1.PodTemplateSpec) *batchv1.CronJob {
+	cronJobName := namegen.AppendRandomString("testcronjob")
+	var limit int32 = 10
+
+	podTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	cronJobTemplate := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cronJobName,
+			Namespace: namespaceName,
+		},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespaceName,
+				},
+				Spec: batchv1.JobSpec{
+					Template: podTemplate,
+				},
+			},
+			Schedule:                   schedule,
+			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
+			FailedJobsHistoryLimit:     &limit,
+			SuccessfulJobsHistoryLimit: &limit,
+		},
+	}
+
+	return cronJobTemplate
+}

--- a/tests/v2/actions/workloads/cronjob/verify.go
+++ b/tests/v2/actions/workloads/cronjob/verify.go
@@ -37,13 +37,11 @@ func VerifyCreateCronjob(client *rancher.Client, clusterID string) error {
 		nil,
 	)
 
-	cronJobTemplate, err := CreateCronjob(client, clusterID, namespace.Name, "*/1 * * * *", podTemplate)
+	logrus.Info("Creating new cronjob and waiting for it to come up active")
+	_, err = CreateCronJob(client, clusterID, namespace.Name, "*/1 * * * *", podTemplate, true)
 	if err != nil {
 		return err
 	}
-
-	logrus.Infof("Creating new cronjob %s", cronJobTemplate.Name)
-	err = WatchAndWaitCronjob(client, clusterID, namespace.Name, cronJobTemplate)
 
 	return err
 }

--- a/tests/v2/validation/rbac/workloads/README.md
+++ b/tests/v2/validation/rbac/workloads/README.md
@@ -1,0 +1,26 @@
+# RBAC Workloads
+
+## Pre-requisites
+
+- Ensure you have an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, create one first before running this test.
+
+## Test Setup
+
+Your GO suite should be set to `-run ^Test<TestSuite>$`
+
+- To run the rbac_daemonset_test.go, set the GO suite to `-run ^TestRbacDaemonsetTestSuite$`
+- To run the rbac_deployment_test.go, set the GO suite to `-run ^TestRbacDeploymentTestSuite$`
+- To run the rbac_statefulset_test.go, set the GO suite to `-run ^TestRbacStatefulSetTestSuite$`
+- To run the rbac_cronjob_test.go, set the GO suite to `-run ^TestRbacCronJobTestSuite$`
+- To run the rbac_job_test.go, set the GO suite to `-run ^TestRbacJobTestSuite$`
+
+In your config file, set the following:
+
+```yaml
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True #optional
+  cleanup: True #optional
+  clusterName: "cluster_name"
+```

--- a/tests/v2/validation/rbac/workloads/rbac_cronjob_test.go
+++ b/tests/v2/validation/rbac/workloads/rbac_cronjob_test.go
@@ -1,0 +1,347 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+
+package workloads
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/projects"
+	"github.com/rancher/rancher/tests/v2/actions/rbac"
+	"github.com/rancher/rancher/tests/v2/actions/workloads/cronjob"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/users"
+	"github.com/rancher/shepherd/extensions/workloads"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+type RbacCronJobTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (rcj *RbacCronJobTestSuite) TearDownSuite() {
+	rcj.session.Cleanup()
+}
+
+func (rcj *RbacCronJobTestSuite) SetupSuite() {
+	rcj.session = session.NewSession()
+
+	client, err := rancher.NewClient("", rcj.session)
+	require.NoError(rcj.T(), err)
+	rcj.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in rcj")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(rcj.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rcj.client, clusterName)
+	require.NoError(rcj.T(), err, "Error getting cluster ID")
+	rcj.cluster, err = rcj.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rcj.T(), err)
+}
+
+func (rcj *RbacCronJobTestSuite) createPodTemplate() corev1.PodTemplateSpec {
+	containerName := namegen.AppendRandomString("testcontainer")
+	pullPolicy := corev1.PullAlways
+
+	containerTemplate := workloads.NewContainer(
+		containerName,
+		rbac.ImageName,
+		pullPolicy,
+		[]corev1.VolumeMount{},
+		[]corev1.EnvFromSource{},
+		nil, nil, nil,
+	)
+
+	podTemplate := workloads.NewPodTemplate(
+		[]corev1.Container{containerTemplate},
+		[]corev1.Volume{},
+		[]corev1.LocalObjectReference{},
+		nil, nil,
+	)
+
+	return podTemplate
+}
+
+func (rcj *RbacCronJobTestSuite) TestCreateCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate cronjob creation as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, create a cronjob", tt.role.String())
+			podTemplate := rcj.createPodTemplate()
+			_, err = cronjob.CreateCronJob(userClient, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rcj.T(), err, "failed to create cronjob")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestListCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate listing cronjob as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, create a cronjob in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := rcj.createPodTemplate()
+			createdCronJob, err := cronjob.CreateCronJob(rcj.client, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+			assert.NoError(rcj.T(), err, "failed to create cronjob")
+
+			log.Infof("As a %v, list the cronjob", tt.role.String())
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+			cronJobList, err := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String(), rbac.ReadOnly.String():
+				assert.NoError(rcj.T(), err, "failed to list cronjob")
+				assert.Equal(rcj.T(), len(cronJobList.Items), 1)
+				assert.Equal(rcj.T(), cronJobList.Items[0].Name, createdCronJob.Name)
+			case rbac.ClusterMember.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestUpdateCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate updating cronjob as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, create a cronjob in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := rcj.createPodTemplate()
+			createdCronJob, err := cronjob.CreateCronJob(rcj.client, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+			assert.NoError(rcj.T(), err, "failed to create cronjob")
+
+			log.Infof("As a %v, update the cronjob %s with a new label.", tt.role.String(), createdCronJob.Name)
+			adminContext, err := rcj.client.WranglerContext.DownStreamClusterWranglerContext(rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			latestCronJob, err := adminContext.Batch.CronJob().Get(namespace.Name, createdCronJob.Name, metav1.GetOptions{})
+			assert.NoError(rcj.T(), err, "Failed to list cronjob.")
+
+			if latestCronJob.Labels == nil {
+				latestCronJob.Labels = make(map[string]string)
+			}
+			latestCronJob.Labels["updated"] = "true"
+
+			_, err = standardUserContext.Batch.CronJob().Update(latestCronJob)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rcj.T(), err, "failed to update cronjob")
+				updatedCronJob, err := standardUserContext.Batch.CronJob().Get(namespace.Name, createdCronJob.Name, metav1.GetOptions{})
+				assert.NoError(rcj.T(), err, "Failed to list the cronjob after updating labels.")
+				assert.Equal(rcj.T(), "true", updatedCronJob.Labels["updated"], "job label update failed.")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestDeleteCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate deleting cronjob as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespace(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, create a cronjob in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := rcj.createPodTemplate()
+			createdCronJob, err := cronjob.CreateCronJob(rcj.client, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+			assert.NoError(rcj.T(), err, "failed to create cronjob")
+
+			log.Infof("As a %v, delete the cronjob", tt.role.String())
+			standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+			err = standardUserContext.Batch.CronJob().Delete(namespace.Name, createdCronJob.Name, &metav1.DeleteOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rcj.T(), err, "failed to delete cronjob")
+				err := kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+					updatedCronJobList, pollErr := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+					if pollErr != nil {
+						return false, fmt.Errorf("failed to list cron jobs: %w", pollErr)
+					}
+
+					if len(updatedCronJobList.Items) == 0 {
+						return true, nil
+					}
+					return false, nil
+				})
+				assert.NoError(rcj.T(), err)
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestCrudCronJobAsClusterMember() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	role := rbac.ClusterMember.String()
+	log.Infof("Create a standard user.")
+	user, userClient, err := rbac.SetupUser(rcj.client, rbac.StandardUser.String())
+	require.NoError(rcj.T(), err)
+
+	log.Infof("Add the user to the downstream cluster with role %s", role)
+	err = users.AddClusterRoleToUser(rcj.client, rcj.cluster, user, role, nil)
+	require.NoError(rcj.T(), err)
+
+	log.Infof("As a %v, create a project and a namespace in the project.", role)
+	_, namespace, err := projects.CreateProjectAndNamespace(userClient, rcj.cluster.ID)
+	require.NoError(rcj.T(), err)
+
+	log.Infof("As a %v, create a cronjob in the namespace %v", role, namespace.Name)
+	podTemplate := rcj.createPodTemplate()
+	createdCronJob, err := cronjob.CreateCronJob(userClient, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+	require.NoError(rcj.T(), err, "failed to create cronjob")
+
+	log.Infof("As a %v, list the cronjob", role)
+	standardUserContext, err := userClient.WranglerContext.DownStreamClusterWranglerContext(rcj.cluster.ID)
+	assert.NoError(rcj.T(), err)
+	cronJobList, err := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rcj.T(), err, "failed to list cronjobs")
+	require.Equal(rcj.T(), len(cronJobList.Items), 1)
+	require.Equal(rcj.T(), cronJobList.Items[0].Name, createdCronJob.Name)
+
+	log.Infof("As a %v, update the cronjob %s with a new label.", role, createdCronJob.Name)
+	latestCronJob, err := standardUserContext.Batch.CronJob().Get(namespace.Name, createdCronJob.Name, metav1.GetOptions{})
+	assert.NoError(rcj.T(), err, "Failed to get the latest cronjob.")
+
+	if latestCronJob.Labels == nil {
+		latestCronJob.Labels = make(map[string]string)
+	}
+	latestCronJob.Labels["updated"] = "true"
+
+	_, err = standardUserContext.Batch.CronJob().Update(latestCronJob)
+	require.NoError(rcj.T(), err, "failed to update cronjob")
+	updatedCronJobList, err := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rcj.T(), err, "Failed to list the cronjob after updating labels.")
+	require.Equal(rcj.T(), "true", updatedCronJobList.Items[0].Labels["updated"], "job label update failed.")
+
+	log.Infof("As a %v, delete the cronjob", role)
+	err = standardUserContext.Batch.CronJob().Delete(namespace.Name, createdCronJob.Name, &metav1.DeleteOptions{})
+	require.NoError(rcj.T(), err, "failed to delete cronjob")
+	err = kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+		updatedCronJobList, pollErr := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+		if pollErr != nil {
+			return false, fmt.Errorf("failed to list cron jobs: %w", pollErr)
+		}
+
+		if len(updatedCronJobList.Items) == 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(rcj.T(), err)
+}
+
+func TestRbacCronJobTestSuite(t *testing.T) {
+	suite.Run(t, new(RbacCronJobTestSuite))
+}


### PR DESCRIPTION
**Issue**: https://github.com/rancher/qa-tasks/issues/1342

This is one of the several upcoming PRs aimed at migrating the RBAC workload tests from Python to Go. **This PR specifically includes tests for **CronJob** only.**

**Note**: Backport PRs will be created once this gets approved
