### PR TITLE
[v2.8] Unrc the Shell image version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
 webhookVersion: 103.0.15+up0.4.16
 cspAdapterMinVersion: 103.0.1+up3.0.1
-defaultShellVersion: rancher/shell:v0.1.28-rc.1
+defaultShellVersion: rancher/shell:v0.1.28
 fleetVersion: 103.1.13+up0.9.15

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion = "103.0.1+up3.0.1"
-	DefaultShellVersion  = "rancher/shell:v0.1.28-rc.1"
+	DefaultShellVersion  = "rancher/shell:v0.1.28"
 	FleetVersion         = "103.1.13+up0.9.15"
 	WebhookVersion       = "103.0.15+up0.4.16"
 )


### PR DESCRIPTION
Per title, this un-RCs shell after [QA verification](https://github.com/rancher/shell/issues/316).

~Shell image is still building here: https://github.com/rancher/shell/actions/runs/13528419295/job/37804635595~