### PR TITLE
Fix nested inheritance in RoleTemplates

### DIFF
--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
@@ -66,6 +66,11 @@ func (p *prtbHandler) OnChange(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 		return nil, nil
 	}
 
+	// Handle cluster role bindings for special permissions.
+	if err := p.reconcileClusterRoleBindings(prtb); err != nil {
+		return nil, err
+	}
+
 	if err := p.reconcileBindings(prtb); err != nil {
 		return nil, err
 	}
@@ -85,11 +90,6 @@ func (p *prtbHandler) OnChange(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 func (p *prtbHandler) reconcileBindings(prtb *v3.ProjectRoleTemplateBinding) error {
 	subject, err := rbac.BuildSubjectFromRTB(prtb)
 	if err != nil {
-		return err
-	}
-
-	// Handle cluster role bindings for special permissions.
-	if err := p.reconcileClusterRoleBindings(prtb); err != nil {
 		return err
 	}
 

--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler_test.go
@@ -281,7 +281,6 @@ func Test_prtbHandler_reconcileBindings(t *testing.T) {
 			name: "error checking if role template is external",
 			prtb: defaultPRTB.DeepCopy(),
 			setupControllers: func(c controllers) {
-				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errNotFound)
 				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errDefault)
 			},
 			wantErr: true,
@@ -290,7 +289,7 @@ func Test_prtbHandler_reconcileBindings(t *testing.T) {
 			name: "error getting namespaces",
 			prtb: defaultPRTB.DeepCopy(),
 			setupControllers: func(c controllers) {
-				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errNotFound).Times(2)
+				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errNotFound)
 				c.nsController.EXPECT().List(namespaceListOptions).Return(nil, errDefault)
 			},
 			wantErr: true,
@@ -299,7 +298,7 @@ func Test_prtbHandler_reconcileBindings(t *testing.T) {
 			name: "error creating role binding",
 			prtb: defaultPRTB.DeepCopy(),
 			setupControllers: func(c controllers) {
-				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errNotFound).Times(2)
+				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errNotFound)
 				c.nsController.EXPECT().List(namespaceListOptions).Return(&corev1.NamespaceList{
 					Items: []corev1.Namespace{
 						{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
@@ -316,7 +315,7 @@ func Test_prtbHandler_reconcileBindings(t *testing.T) {
 			name: "create role binding in multiple namespaces",
 			prtb: defaultPRTB.DeepCopy(),
 			setupControllers: func(c controllers) {
-				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errNotFound).Times(2)
+				c.rtController.EXPECT().Get(defaultPRTB.RoleTemplateName, metav1.GetOptions{}).Return(nil, errNotFound)
 				c.nsController.EXPECT().List(namespaceListOptions).Return(&corev1.NamespaceList{
 					Items: []corev1.Namespace{
 						{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -442,7 +442,7 @@ func BuildAggregatingClusterRole(rt *v3.RoleTemplate, nameTransformer func(strin
 	// aggregate every inherited role template
 	for _, roleTemplateName := range rt.RoleTemplateNames {
 		labelSelector := metav1.LabelSelector{
-			MatchLabels: map[string]string{aggregationLabel: nameTransformer(roleTemplateName)},
+			MatchLabels: map[string]string{aggregationLabel: AggregatedClusterRoleNameFor(nameTransformer(roleTemplateName))},
 		}
 		roleTemplateLabels = append(roleTemplateLabels, labelSelector)
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49231
 
Related to cluster role aggregation https://github.com/rancher/rancher/issues/46077

## Problem
RoleTemplate inheritance was only working 1 level deep, so any nested inheritance wasn't capturing all the rules inherited.
 
## Solution
The aggregation rule used was referencing the original cluster roles, not their aggregated versions. Modified that to make sure it was referencing the right one to aggregate.

As an additional change, I slightly re-arranged the prtb-handler better resemble the other handlers. 
 
## Testing

The instructions in the bug issue are correct and minimal.

## Engineering Testing
### Manual Testing
If you have nested inheritance where RT-A inherits RT-B which inherits RT-C, RT-A contains all the rules of RT-B and RT-C.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: New unit tests to ensure the aggregation rules use the correct labels.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_