### PR TITLE
Allow imported config to be created and updated

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -151,7 +151,7 @@ type ClusterSpec struct {
 	Internal                            bool                        `json:"internal" norman:"nocreate,noupdate"`
 	K3sConfig                           *K3sConfig                  `json:"k3sConfig,omitempty"`
 	Rke2Config                          *Rke2Config                 `json:"rke2Config,omitempty"`
-	ImportedConfig                      *ImportedConfig             `json:"importedConfig,omitempty" norman:"nocreate,noupdate"`
+	ImportedConfig                      *ImportedConfig             `json:"importedConfig,omitempty"`
 	GoogleKubernetesEngineConfig        *MapStringInterface         `json:"googleKubernetesEngineConfig,omitempty"`
 	AzureKubernetesServiceConfig        *MapStringInterface         `json:"azureKubernetesServiceConfig,omitempty"`
 	AmazonElasticContainerServiceConfig *MapStringInterface         `json:"amazonElasticContainerServiceConfig,omitempty"`


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/13063 

UI is blocked because API currently doesn't allow creates or updates on `ImportedConfig`, this is an issue for private registry url for imported clusters. This works correctly with `kubectl`. 