### PR TITLE
Add `commonLabels` and `podLabels` support for injecting additional labels

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -42,6 +42,9 @@ app: {{ template "rancher.fullname" . }}
 chart: {{ template "rancher.chartname" . }}
 heritage: {{ .Release.Service }}
 release: {{ .Release.Name }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 # Windows Support

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       labels:
         app: {{ template "rancher.fullname" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: {{ template "rancher.fullname" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -123,6 +123,12 @@ replicas: 3
 # Set priorityClassName to avoid eviction
 priorityClassName: rancher-critical
 
+# Set additional labels to apply to all resources.
+commonLabels: {}
+
+# Set additional labels to apply on the Rancher pods.
+podLabels: {}
+
 # Set pod resource requests/limits for Rancher.
 resources: {}
 


### PR DESCRIPTION
## Problem

There are certain scenarios where it is required to inject additional custom labels into existing Kubernetes services. In our particular use case, we need to inject labels related to a well-known observability platform. However, Rancher (and its related charts) does not provide this support, and we would prefer to not have to inject these labels using a bespoke mutating webhook or policy engine.

## Solution

Add support for commonLabels and podLabels:

- `commonLabels`: Labels defined here will be applied inside the `rancher.labels` helper function. This means a "common label" will be applied on all objects created using this Helm chart.
- `podLabels`: Labels defined here will applied only on the `rancher` server pods.

## Testing

## Engineering Testing
### Manual Testing

Generate manifests using `helm template` and confirming that labels defined in `commonLabels` and `commonLabels` are rendered as expected.