### PR TITLE
#49286 - Deactivate RDPClient if it's in downstream cluster

### DIFF
--- a/pkg/ext/rdp.go
+++ b/pkg/ext/rdp.go
@@ -27,6 +27,10 @@ const (
 )
 
 func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wrangler.Context) error {
+	if features.MCMAgent.Enabled() {
+		return nil
+	}
+
 	if !RDPEnabled() {
 		return DeleteRDPConnectSecret(wranglerContext.Core.Secret())
 	}
@@ -66,10 +70,6 @@ func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wra
 }
 
 func RDPEnabled() bool {
-	if features.MCMAgent.Enabled() {
-		return false
-	}
-
 	if !features.ImperativeApiExtension.Enabled() {
 		return false
 	}

--- a/pkg/ext/rdp.go
+++ b/pkg/ext/rdp.go
@@ -31,7 +31,7 @@ func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wra
 		return nil
 	}
 
-	if !RDPEnabled() {
+	if !features.ImperativeApiExtension.Enabled() || !RDPEnabled() {
 		return DeleteRDPConnectSecret(wranglerContext.Core.Secret())
 	}
 
@@ -70,10 +70,6 @@ func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wra
 }
 
 func RDPEnabled() bool {
-	if !features.ImperativeApiExtension.Enabled() {
-		return false
-	}
-
 	switch os.Getenv(rdpEnabledEnvVar) {
 	case "true":
 		return false

--- a/pkg/ext/rdp.go
+++ b/pkg/ext/rdp.go
@@ -27,7 +27,7 @@ const (
 )
 
 func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wrangler.Context) error {
-	if !features.ImperativeApiExtension.Enabled() || !RDPEnabled() {
+	if !RDPEnabled() {
 		return DeleteRDPConnectSecret(wranglerContext.Core.Secret())
 	}
 
@@ -66,6 +66,14 @@ func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wra
 }
 
 func RDPEnabled() bool {
+	if features.MCMAgent.Enabled() {
+		return false
+	}
+
+	if !features.ImperativeApiExtension.Enabled() {
+		return false
+	}
+
 	switch os.Getenv(rdpEnabledEnvVar) {
 	case "true":
 		return false


### PR DESCRIPTION
## Issue: #49286 
 
## Problem
RDPClient is trying to connect to RDP in downstream cluster. RDP will not be deployed to downstream what makes RDPClient to keep trying and printing messages forever. 
 
## Solution
Deactivate RDPClient when rancher is deployed in downstream cluster
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_