### PR TITLE
[main] Remove whitespace when generating agent yaml

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -174,7 +174,7 @@ spec:
       {{- if .AppendTolerations }}
 {{ .AppendTolerations | indent 6 }}
       {{- end }}
-      {{ if .EnablePriorityClass }}
+      {{- if .EnablePriorityClass }}
       priorityClassName: cattle-cluster-agent-priority-class
       {{- end }}
       containers:
@@ -546,7 +546,7 @@ kind: PriorityClass
 metadata:
   name: cattle-cluster-agent-priority-class
 value: {{ .PriorityClassValue }}
-{{ if .PreemptionPolicy }}
+{{- if .PreemptionPolicy }}
 preemptionPolicy: {{ .PreemptionPolicy }}
 {{- end }}
 description: {{ .Description }}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48995
 
## Problem
Two if statements in the cluster agent manifest template did not include `-`, resulting in unintended white space in the resulting yaml. After testing the feature using the latest alpha, I'm able to confirm that this does not have a functional impact on the linked issue, but should be addressed to generate clean yaml.
 
## Solution
Update the if statements to prevent unintentional whitespace. 
 
## Testing
I provisioned an rke2 cluster with this change and confirmed that the agent manifest placed on disk no longer has an unintended newline. I confirmed that the agent deploys properly with the expected fields.

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
n/a

Existing / newly added automated tests that provide evidence there are no regressions:
n/a