### PR TITLE
Allow read-only access to CRD definitions for the base and standard Rancher users

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -92,7 +92,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
-		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch").
+		addRule().apiGroups("apiextensions.k8s.io").resources("customresourcedefinitions").verbs("get", "list", "watch")
 
 	// TODO user should be dynamically authorized to only see herself
 	// TODO enable when groups are "in". they need to be self-service
@@ -411,7 +412,8 @@ func addUserRules(role *roleBuilder) *roleBuilder {
 		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
-		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch").
+		addRule().apiGroups("apiextensions.k8s.io").resources("customresourcedefinitions").verbs("get", "list", "watch")
 	return role
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/48621
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The issue came up in regards to the [Kubeconfig Public API](https://github.com/rancher/rancher/issues/48621) but really is applicable to any Imperative API resource that doesn't support/implement `patch` operation.

When a standard or base rancher user attempts to create an imperative API resource e.g. `kubeconfigs.ext.cattle.io`, which doesn't implement `patch` operation, the validation fails for them with the following error:

```
kubectl --context ext2 create -f  -<<EOF
apiVersion: ext.cattle.io/v1
kind: Kubeconfig
spec:
  clusters: [c-m-tbgzfbgf]
EOF

error: error validating "STDIN": error validating data: failed to check CRD: failed to list CRDs: customresourcedefinitions.apiextensions.k8s.io is forbidden: User "u-s857n" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope; if you choose to ignore these errors, turn validation off with --validate=false
```

It seems like `kubectl` tries to to detect if the resource implements `patch` and if it doesn't, [falls back](https://github.com/kubernetes/cli-runtime/blob/a4a139befc2e0ac935f4c640a038a3678d41d539/pkg/resource/query_param_verifier_v3.go#L112-L143) to openapi v2 and CRDs
The same validation logic is shared across

- kubectl [create]( https://github.com/kubernetes/kubectl/blob/370dc1d47de8823cd70b162cb53c5835b39e20b0/pkg/cmd/create/create.go#L240)
- kubectl [apply]( https://github.com/kubernetes/kubectl/blob/370dc1d47de8823cd70b162cb53c5835b39e20b0/pkg/cmd/apply/apply.go#L297)
- kubectl [replace]( https://github.com/kubernetes/kubectl/blob/370dc1d47de8823cd70b162cb53c5835b39e20b0/pkg/cmd/replace/replace.go#L200)

And standard and base Rancher users don't have permissions to list `customresourcedefinitions`.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Allow to `get`, `list`, and `watch` the `customresourcedefinitions` in the `apiextensions.k8s.io` api group to standard and base users.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A