### PR TITLE
[2.9] Deliver windows specific idempotent script

### DIFF
--- a/pkg/capr/planner/certificaterotation.go
+++ b/pkg/capr/planner/certificaterotation.go
@@ -97,11 +97,17 @@ func (p *Planner) rotateCertificatesPlan(controlPlane *rkev1.RKEControlPlane, to
 	}
 
 	if isOnlyWorker(entry) {
-		rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentRestartInstructions(
-			controlPlane,
-			"certificate-rotation/restart",
-			strconv.FormatInt(rotation.Generation, 10),
-			capr.GetRuntimeAgentUnit(controlPlane.Spec.KubernetesVersion))...)
+		if isOnlyWindowsWorker(entry) {
+			rotatePlan.Instructions = append(rotatePlan.Instructions, windowsIdempotentRestartInstructions(
+				"certificate-rotation/restart",
+				strconv.FormatInt(rotation.Generation, 10), "rke2")...)
+		} else {
+			rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentRestartInstructions(
+				controlPlane,
+				"certificate-rotation/restart",
+				strconv.FormatInt(rotation.Generation, 10),
+				capr.GetRuntimeAgentUnit(controlPlane.Spec.KubernetesVersion))...)
+		}
 		return rotatePlan, joinedServer, nil
 	}
 

--- a/pkg/capr/planner/certificaterotation_test.go
+++ b/pkg/capr/planner/certificaterotation_test.go
@@ -256,6 +256,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 		version             string
 		setup               func(mp *mockPlanner)
 		joinServer          string
+		os                  string
 		entryIsControlPlane bool
 		machineGlobalConfig *rkev1.GenericMap
 		expected            expected
@@ -266,6 +267,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			version:             "v1.25.7+k3s1",
 			entryIsControlPlane: true,
 			joinServer:          "my-magic-joinserver",
+			os:                  capr.DefaultMachineOS,
 			setup:               genericSetup,
 			expected: expected{
 				otiIndex: 2,
@@ -289,6 +291,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			version:             "v1.25.7+rke2r1",
 			entryIsControlPlane: true,
 			joinServer:          "my-magic-joinserver",
+			os:                  capr.DefaultMachineOS,
 			setup:               genericSetup,
 			rotateCertificates: &rkev1.RotateCertificates{
 				Generation: 244,
@@ -315,6 +318,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			version:             "v1.25.7+k3s1",
 			entryIsControlPlane: true,
 			joinServer:          "my-magic-joinserver",
+			os:                  capr.DefaultMachineOS,
 			setup:               genericSetup,
 			expected: expected{
 				otiIndex: 4,
@@ -338,6 +342,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			version:             "v1.25.7+rke2r1",
 			entryIsControlPlane: true,
 			joinServer:          "my-magic-joinserver",
+			os:                  capr.DefaultMachineOS,
 			setup:               genericSetup,
 			expected: expected{
 				otiIndex: 5,
@@ -361,6 +366,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			version:             "v1.25.7+rke2r1",
 			entryIsControlPlane: false,
 			joinServer:          "my-magic-joinserver",
+			os:                  capr.DefaultMachineOS,
 			expected: expected{
 				otiIndex: 1,
 				oti: &[]plan.OneTimeInstruction{idempotentRestartInstructions(
@@ -373,10 +379,27 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			},
 		},
 		{
+			name:                "test rke2 Windows worker-only instruction",
+			version:             "v1.25.7+rke2r1",
+			entryIsControlPlane: false,
+			joinServer:          "my-magic-joinserver",
+			os:                  capr.WindowsMachineOS,
+			expected: expected{
+				otiIndex: 0,
+				oti: &[]plan.OneTimeInstruction{windowsIdempotentRestartInstructions(
+					"certificate-rotation/restart",
+					strconv.FormatInt(int64(0), 10),
+					"rke2")[0]}[0],
+				otiCount:   1,
+				joinServer: "",
+			},
+		},
+		{
 			name:                "test k3s worker-only instruction",
 			version:             "v1.25.7+k3s1",
 			entryIsControlPlane: false,
 			joinServer:          "my-magic-joinserver",
+			os:                  capr.DefaultMachineOS,
 			expected: expected{
 				otiIndex: 1,
 				oti: &[]plan.OneTimeInstruction{idempotentRestartInstructions(
@@ -393,6 +416,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			version:             "v1.25.7+k3s1",
 			entryIsControlPlane: true,
 			joinServer:          "my-magic-joinserver",
+			os:                  capr.DefaultMachineOS,
 			setup:               genericSetup,
 			machineGlobalConfig: &rkev1.GenericMap{
 				Data: map[string]interface{}{
@@ -441,7 +465,7 @@ func Test_rotateCertificatesPlan(t *testing.T) {
 			} else {
 				controlPlane.Spec.RotateCertificates = &rkev1.RotateCertificates{}
 			}
-			entry := createTestPlanEntry(capr.DefaultMachineOS)
+			entry := createTestPlanEntry(tt.os)
 			if tt.entryIsControlPlane {
 				entry.Machine.Labels[capr.ControlPlaneRoleLabel] = "true"
 				entry.Metadata.Labels[capr.ControlPlaneRoleLabel] = "true"

--- a/pkg/capr/planner/planentry.go
+++ b/pkg/capr/planner/planentry.go
@@ -146,6 +146,10 @@ func windows(entry *planEntry) bool {
 	return false
 }
 
+func isOnlyWindowsWorker(entry *planEntry) bool {
+	return isOnlyWorker(entry) && windows(entry)
+}
+
 func anyPlanDataExists(entry *planEntry) bool {
 	if entry.Plan != nil {
 		return entry.Plan.PlanDataExists

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -1058,11 +1058,22 @@ func (p *Planner) generatePlanWithConfigFiles(controlPlane *rkev1.RKEControlPlan
 
 		nodePlan, err = addOtherFiles(nodePlan, controlPlane, entry)
 
-		idempotentScriptFile := plan.File{
-			Content: base64.StdEncoding.EncodeToString([]byte(idempotentActionScript)),
-			Path:    idempotentActionScriptPath(controlPlane),
-			Dynamic: true,
-			Minor:   true,
+		var idempotentScriptFile plan.File
+
+		if isOnlyWindowsWorker(entry) {
+			idempotentScriptFile = plan.File{
+				Content: base64.StdEncoding.EncodeToString([]byte(windowsIdempotentActionScript)),
+				Path:    windowsIdempotentActionScriptPath(),
+				Dynamic: true,
+				Minor:   true,
+			}
+		} else {
+			idempotentScriptFile = plan.File{
+				Content: base64.StdEncoding.EncodeToString([]byte(idempotentActionScript)),
+				Path:    idempotentActionScriptPath(controlPlane),
+				Dynamic: true,
+				Minor:   true,
+			}
 		}
 
 		nodePlan.Files = append(nodePlan.Files, idempotentScriptFile)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49197
  
This is a backport of https://github.com/rancher/rancher/pull/49071 for 2.9. The only additional logic is the addition of the `isOnlyWindowsWorker` function. 
