### PR TITLE
Add -head suffix to make quick tag

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -7,7 +7,7 @@ set -x
 
 # variables
 COMMIT=$(git rev-parse --short HEAD)
-TAG="${TAG:-$(yq '.env.TAG | sub("-.*", "")' < .github/workflows/pull-request.yml)-${COMMIT}}"
+TAG="${TAG:-$(yq '.env.TAG | sub("-.*", "")' < .github/workflows/pull-request.yml)-${COMMIT}}-head"
 OS="${OS:-linux}"
 ARCH="${ARCH:-amd64}"
 REPO="${REPO:-rancher}"


### PR DESCRIPTION
channelserver breaks if dev builds don't have `-head` or `-main`:

https://github.com/rancher/rancher/blob/main/pkg/settings/setting.go#L564-L573

https://github.com/rancher/rancher/blob/main/pkg/channelserver/channelserver.go#L46-L51