### PR TITLE
Bump steve to v0.5.10 to fix issue 49288

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ require (
 	github.com/rancher/remotedialer v0.4.4-rc.2
 	github.com/rancher/rke v1.8.0-rc.3
 	github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b
-	github.com/rancher/steve v0.5.9
+	github.com/rancher/steve v0.5.10
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde
 	github.com/rancher/wrangler v1.1.2
 	github.com/rancher/wrangler/v3 v3.2.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -2469,8 +2469,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b h1:uX+XbQgpqpfxfvDI+6uPb1DeeDqEwa7lE+QtYuPCqzU=
 github.com/rancher/shepherd v0.0.0-20241213222351-98e341c77d0b/go.mod h1:urZvZCFSgT+9NVjAV0y8v+pzuqziaS3aYfoMfk9TENw=
-github.com/rancher/steve v0.5.9 h1:qkGE3OZTEpaPyexIynIbdQk5JefWdyGOM85wA9m8EAY=
-github.com/rancher/steve v0.5.9/go.mod h1:8t7f7Etm9oO1iatJxEdnQkuwOFfmCyz3KAJkRWQvJHU=
+github.com/rancher/steve v0.5.10 h1:6z9ip1kp9V3NAxqd3Sg0U+N9OPy8w+JnmvK3CYgodjw=
+github.com/rancher/steve v0.5.10/go.mod h1:8t7f7Etm9oO1iatJxEdnQkuwOFfmCyz3KAJkRWQvJHU=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=


### PR DESCRIPTION
Related to #49288

This change indexes `metadata.annotations[provisioning.cattle.io/management-cluster-display-name]` in `provisioning.cattle.io/clusters`