### PR TITLE
[main] remove validation for empty nodegroups in EKS cluster

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -517,9 +517,6 @@ func validateEKSNodegroups(spec *v32.ClusterSpec) error {
 	if nodegroups == nil {
 		return nil
 	}
-	if len(nodegroups) == 0 {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, "must have at least one nodegroup")
-	}
 
 	var errors []string
 


### PR DESCRIPTION
### Issue

- Eliminate the requirement for at least one nodegroup in the EKS cluster validation process.
- Remove Norman API validation related to managed node groups.

### Required

- [ ] Update the UI to send an empty array ([]) instead of null when all managed node groups are removed.

### Related

- https://github.com/rancher/rancher/issues/45972