### PR TITLE
Fix invalid memory access

### DIFF
--- a/pkg/apis/management.cattle.io/v3/global_types.go
+++ b/pkg/apis/management.cattle.io/v3/global_types.go
@@ -47,3 +47,9 @@ const (
 	ExperimentalFeatureKey   = "feature.cattle.io/experimental"
 	ExperimentalFeatureValue = "true"
 )
+
+func (f *Feature) SetValue(value bool) {
+	if f.Spec.Value == nil || *f.Spec.Value != value {
+		f.Spec.Value = &[]bool{value}[0]
+	}
+}

--- a/pkg/apis/management.cattle.io/v3/global_types_test.go
+++ b/pkg/apis/management.cattle.io/v3/global_types_test.go
@@ -1,0 +1,37 @@
+package v3
+
+import (
+	"testing"
+)
+
+func Test_setValue(t *testing.T) {
+	f := &Feature{
+		Spec: FeatureSpec{
+			Value: nil,
+		},
+	}
+
+	if f.Spec.Value != nil {
+		t.Fail()
+	}
+
+	// Check if setting value to true works, if the value was previously unset
+	f.SetValue(true)
+	if f.Spec.Value == nil || *f.Spec.Value != true {
+		t.Fail()
+	}
+
+	// Check that setting a value _again_ doesn't change the pointer
+	ptr := f.Spec.Value
+	f.SetValue(true)
+	if f.Spec.Value != ptr {
+		t.Fail()
+	}
+
+	// Check that setting the value to a different value works, if the value was
+	// previously set
+	f.SetValue(false)
+	if f.Spec.Value == nil || *f.Spec.Value != false {
+		t.Fail()
+	}
+}

--- a/pkg/controllers/management/feature/feature_handler.go
+++ b/pkg/controllers/management/feature/feature_handler.go
@@ -94,9 +94,7 @@ func (h *handler) syncHarvesterFeature(obj *v3.Feature) error {
 			return fmt.Errorf("error fetching feature %s: %w", features.Harvester.Name(), err)
 		}
 		harvesterFeatureCopy := harvesterFeature.DeepCopy()
-		if harvesterFeatureCopy.Spec.Value == nil || !*harvesterFeatureCopy.Spec.Value {
-			harvesterFeatureCopy.Spec.Value = &[]bool{true}[0]
-		}
+		harvesterFeatureCopy.SetValue(true)
 		if !reflect.DeepEqual(harvesterFeature, harvesterFeatureCopy) {
 			if _, err := h.featuresClient.Update(harvesterFeatureCopy); err != nil {
 				return fmt.Errorf("error updating Harvester feature %s: %w", obj.Name, err)
@@ -152,7 +150,7 @@ func (h *handler) syncHarvesterBaremetalContainerWorkloadFeature(feat *v3.Featur
 		}
 
 		update := baremetal.DeepCopy()
-		update.Spec.Value = func() *bool { v := false; return &v }()
+		update.SetValue(false)
 		if !reflect.DeepEqual(baremetal, update) {
 			if _, err = h.featuresClient.Update(update); err != nil {
 				return err

--- a/pkg/controllers/management/feature/feature_handler.go
+++ b/pkg/controllers/management/feature/feature_handler.go
@@ -152,7 +152,7 @@ func (h *handler) syncHarvesterBaremetalContainerWorkloadFeature(feat *v3.Featur
 		}
 
 		update := baremetal.DeepCopy()
-		*update.Spec.Value = false
+		update.Spec.Value = func() *bool { v := false; return &v }()
 		if !reflect.DeepEqual(baremetal, update) {
 			if _, err = h.featuresClient.Update(update); err != nil {
 				return err

--- a/pkg/features/migrate.go
+++ b/pkg/features/migrate.go
@@ -81,7 +81,7 @@ func enableRKE2IfClustersExist(feature *v3.Feature, featuresClient managementv3.
 	for _, c := range clusters.Items {
 		if imported.IsAdministratedByProvisioningCluster(&c) {
 			feature = feature.DeepCopy()
-			feature.Spec.Value = &[]bool{true}[0]
+			feature.SetValue(true)
 			feature.Status.LockedValue = feature.Spec.Value
 
 			_, err = featuresClient.Update(feature)


### PR DESCRIPTION
Fix invalied memory access when syncronizing the Harvester feature flag and the Harvester Baremetal Container Workloads feature flag.

The update of the Harvester Baremetal Container Workload feature flag contained an invalid memory access at the point where the new value of that feature flag is set.

The problem was that a feature flag's value is a pointer to a boolean that may be nil. The nil check was only performed for the Harvester feature flag, but not for the Harvester Baremetal Container Workload Feature flag. As a result, when syncronizing the two feature flags, depending on whether the Harvester Baremetal Container Workload feature flag had been set before or not, there could be an assignment to the memory address pointed to by a nil pointer - which is invalid.

In case the Harvester Baremetal Container Workload feature flag was not previously set, the `update.Spec.Value` and assigning to it would be an invalid memory access.

This is fixed by assigning directly to the pointer instead of assigning to the address poited to by the pointer, since now the pointer can be nil or not and will always take the new value.

related-to: rancher/rancher#49303

## Issue: https://github.com/rancher/rancher/issues/49303

## Problem
Invalid memory access (assignment to nil pointer) in case a feature flag had not been set before.

## Solution
Modified the assignment to be always a valid memory access, regardless of whether the lvalue is a nil pointer or not.

## Testing

1. Bring up rancher in docker
1. Navigate to UI --> Global Settings --> Feature Flags --> Deactivate the harvester feature
1. Observe: the Rancher container does no longer crash with a panic

## Engineering Testing
### Manual Testing
Same steps as described above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_