### PR TITLE
Adds CP taints to Fleet's local cluster tolerations

### DIFF
--- a/tests/v2prov/tests/fleet/fleetcluster_test.go
+++ b/tests/v2prov/tests/fleet/fleetcluster_test.go
@@ -99,7 +99,7 @@ func Test_Fleet_Cluster(t *testing.T) {
 	for _, container := range agent.Spec.Template.Spec.InitContainers {
 		require.Empty(container.Resources)
 	}
-	require.Len(agent.Spec.Template.Spec.Containers, 2)
+	require.Len(agent.Spec.Template.Spec.Containers, 1)
 	for _, container := range agent.Spec.Template.Spec.Containers {
 		require.Empty(container.Resources)
 	}
@@ -139,7 +139,7 @@ func Test_Fleet_Cluster(t *testing.T) {
 		require.Equal(resourceReq.Limits, container.Resources.Limits)
 		require.Equal(resourceReq.Requests, container.Resources.Requests)
 	}
-	require.Len(agent.Spec.Template.Spec.Containers, 2)
+	require.Len(agent.Spec.Template.Spec.Containers, 1)
 	for _, container := range agent.Spec.Template.Spec.Containers {
 		require.Equal(resourceReq.Limits, container.Resources.Limits)
 		require.Equal(resourceReq.Requests, container.Resources.Requests)


### PR DESCRIPTION
Adds the control plane nodes taints to tolerations in the local cluster created by Fleet. Those tolerations will be propagated to the Fleet agent, that will be scheduled successfully in a cluster with all nodes tainted.

Refers to: https://github.com/rancher/rancher/issues/49101

## Issue: https://github.com/rancher/rancher/issues/49101
 
## Problem
Taints in Control Plane are not propagated as toleration to the local Fleet cluster.
In a cluster with all nodes tainted the Fleet Agent won't be scheduled due to those taints.
 
## Solution
Copy all taints in the Control Plane as tolerations to the Fleet's local cluster.
Those tolerations will be assigned to the Fleet agent that will be scheduled.
 
## Testing

## Engineering Testing
### Manual Testing
Deploy rancher in a cluster with all nodes tainted. (Use --set to pass tolerations to the helm chart)
For example:
```bash
--set "extraTolerations[0].key=key1" --set "extraTolerations[0].value=value" --set "extraTolerations[0].effect=NoSchedule"
```
Check that the local agent created by Fleet is correctly scheduled (does not stay in the `Pending` state)

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit 


