### PR TITLE
Link Ext Tokens and Useractivities

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -115,6 +115,9 @@ type TokenStatus struct {
 	LastUpdateTime string `json:"lastUpdateTime"`
 	// LastUsedAt is the timestamp of the last time the token was used to authenticate.
 	LastUsedAt *metav1.Time `json:"lastUsedAt,omitempty"`
+	// LastActivitySeen is the timestamp of the last time user activity
+	// (mouse movement, interaction, ...) was reported for the token.
+	LastActivitySeen *metav1.Time `json:"lastActivitySeen,omitempty"`
 }
 
 // Implement the TokenAccessor interface

--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -175,3 +175,11 @@ func (t *Token) GetProviderInfo() map[string]string {
 func (t *Token) GetLastUsedAt() *metav1.Time {
 	return t.Status.LastUsedAt
 }
+
+func (t *Token) GetLastActivitySeen() *metav1.Time {
+	return t.Status.LastActivitySeen
+}
+
+func (t *Token) GetCreationTime() metav1.Time {
+	return t.CreationTimestamp
+}

--- a/pkg/apis/ext.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/ext.cattle.io/v1/zz_generated_deepcopy.go
@@ -138,6 +138,10 @@ func (in *TokenStatus) DeepCopyInto(out *TokenStatus) {
 		in, out := &in.LastUsedAt, &out.LastUsedAt
 		*out = (*in).DeepCopy()
 	}
+	if in.LastActivitySeen != nil {
+		in, out := &in.LastActivitySeen, &out.LastActivitySeen
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -89,6 +89,14 @@ func (t *Token) GetLastUsedAt() *metav1.Time {
 	return t.LastUsedAt
 }
 
+func (t *Token) GetLastActivitySeen() *metav1.Time {
+	return t.ActivityLastSeenAt
+}
+
+func (t *Token) GetCreationTime() metav1.Time {
+	return t.CreationTimestamp
+}
+
 // +genclient
 // +kubebuilder:skipversion
 // +genclient:nonNamespaced

--- a/pkg/auth/accessor/accessor.go
+++ b/pkg/auth/accessor/accessor.go
@@ -39,4 +39,8 @@ type TokenAccessor interface {
 	GetGroupPrincipals() []v3.Principal
 	// GetLastUsedAt returns the time of the token's last use.
 	GetLastUsedAt() *metav1.Time
+	// GetLastActivitySeen returns the time of the last recorded activity for the token
+	GetLastActivitySeen() *metav1.Time
+	// GetCreationTime returns the creation time of the token
+	GetCreationTime() metav1.Time
 }

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1227,11 +1227,11 @@ func secretFromToken(token *ext.Token, oldBackendLabels, oldBackendAnnotations m
 	secret.StringData[FieldUserID] = token.Spec.UserID
 
 	// status elements
-	lastUsedAsString := ""
+	lastUsedAtAsString := ""
 	if token.Status.LastUsedAt != nil {
-		lastUsedAsString = token.Status.LastUsedAt.Format(time.RFC3339)
+		lastUsedAtAsString = token.Status.LastUsedAt.Format(time.RFC3339)
 	}
-	secret.StringData[FieldLastUsedAt] = lastUsedAsString
+	secret.StringData[FieldLastUsedAt] = lastUsedAtAsString
 	secret.StringData[FieldHash] = token.Status.Hash
 	secret.StringData[FieldLastUpdateTime] = token.Status.LastUpdateTime
 	secret.StringData[FieldLastActivitySeen] = ""
@@ -1317,8 +1317,8 @@ func tokenFromSecret(secret *corev1.Secret) (*ext.Token, error) {
 	}
 
 	var lastUsedAt *metav1.Time
-	if lastUsedAsString := string(secret.Data[FieldLastUsedAt]); lastUsedAsString != "" {
-		lastUsed, err := time.Parse(time.RFC3339, lastUsedAsString)
+	if lastUsedAtAsString := string(secret.Data[FieldLastUsedAt]); lastUsedAtAsString != "" {
+		lastUsed, err := time.Parse(time.RFC3339, lastUsedAtAsString)
 		if err != nil {
 			return token, fmt.Errorf("failed to parse lastUsed data: %w", err)
 		}

--- a/pkg/ext/stores/useractivity/store.go
+++ b/pkg/ext/stores/useractivity/store.go
@@ -169,7 +169,7 @@ func (s *Store) Create(ctx context.Context,
 	}
 	objUserActivity.Status.ExpiresAt = newIdleTimeout.Time.Format(time.RFC3339)
 
-	// discard the changes if this is a dr-run
+	// discard the changes if this is a dry-run
 	if dryRun {
 		return objUserActivity, nil
 	}

--- a/pkg/ext/stores/useractivity/store.go
+++ b/pkg/ext/stores/useractivity/store.go
@@ -10,7 +10,9 @@ import (
 
 	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	v3Legacy "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
@@ -37,9 +39,9 @@ var timeNow = func() time.Time {
 // +k8s:openapi-gen=false
 // +k8s:deepcopy-gen=false
 type Store struct {
-	tokens     v3.TokenClient
-	tokenCache v3.TokenCache
-	userCache  v3.UserCache
+	tokens        v3.TokenClient             // direct access for patching of v3 tokens
+	userCache     v3.UserCache               // cached fetch of v3 users
+	extTokenStore *exttokenstore.SystemStore // unified fetch of v3 and ext tokens; patching of ext tokens
 }
 
 var GV = schema.GroupVersion{
@@ -57,9 +59,9 @@ var GVR = ext.SchemeGroupVersion.WithResource(ext.UserActivityResourceName)
 
 func New(wranglerCtx *wrangler.Context) *Store {
 	return &Store{
-		tokens:     wranglerCtx.Mgmt.Token(),
-		tokenCache: wranglerCtx.Mgmt.Token().Cache(),
-		userCache:  wranglerCtx.Mgmt.User().Cache(),
+		tokens:        wranglerCtx.Mgmt.Token(),
+		userCache:     wranglerCtx.Mgmt.User().Cache(),
+		extTokenStore: exttokenstore.NewSystemFromWrangler(wranglerCtx),
 	}
 }
 
@@ -131,13 +133,13 @@ func (s *Store) Create(ctx context.Context,
 	}
 
 	// retrieve auth token
-	authToken, err := s.tokenCache.Get(authTokenID)
+	authToken, err := s.extTokenStore.Fetch(authTokenID)
 	if err != nil {
 		return nil, apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("error getting request token %s: %w", authTokenID, err))
 	}
 
 	// retrieve activity token
-	activityToken, err := s.tokenCache.Get(objUserActivity.Name)
+	activityToken, err := s.extTokenStore.Fetch(objUserActivity.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, apierrors.NewBadRequest(fmt.Sprintf("token not found %s: %v", objUserActivity.Name, err))
@@ -167,8 +169,13 @@ func (s *Store) Create(ctx context.Context,
 	}
 	objUserActivity.Status.ExpiresAt = newIdleTimeout.Time.Format(time.RFC3339)
 
-	// if it's not a dry-run, commit the changes
-	if !dryRun {
+	// discard the changes if this is a dr-run
+	if dryRun {
+		return objUserActivity, nil
+	}
+
+	switch activityToken.(type) {
+	case *v3Legacy.Token:
 		patch, err := json.Marshal([]struct {
 			Op    string `json:"op"`
 			Path  string `json:"path"`
@@ -183,7 +190,14 @@ func (s *Store) Create(ctx context.Context,
 		}
 		_, err = s.tokens.Patch(activityToken.GetName(), types.JSONPatchType, patch)
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("failed to store activityLastSeenAt to token %s: %w", activityToken.GetName(), err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("failed to store activityLastSeenAt to token %s: %w",
+				activityToken.GetName(), err))
+		}
+	case *ext.Token:
+		err := s.extTokenStore.UpdateLastActivitySeen(activityToken.GetName(), newIdleTimeout.Time)
+		if err != nil {
+			return nil, apierrors.NewInternalError(fmt.Errorf("failed to store activityLastSeenAt to ext token %s: %w",
+				activityToken.GetName(), err))
 		}
 	}
 
@@ -210,13 +224,13 @@ func (s *Store) Get(ctx context.Context,
 	}
 
 	// retrieve auth token
-	authToken, err := s.tokenCache.Get(authTokenID)
+	authToken, err := s.extTokenStore.Fetch(authTokenID)
 	if err != nil {
 		return nil, apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("error getting request token %s: %w", authTokenID, err))
 	}
 
 	// retrieve activity token
-	activityToken, err := s.tokenCache.Get(name)
+	activityToken, err := s.extTokenStore.Fetch(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, apierrors.NewBadRequest(fmt.Sprintf("token not found %s: %v", name, err))
@@ -233,14 +247,14 @@ func (s *Store) Get(ctx context.Context,
 	// crafting UserActivity from requested Token name.
 	ua := &ext.UserActivity{
 		ObjectMeta: metav1.ObjectMeta{
-			CreationTimestamp: activityToken.CreationTimestamp,
+			CreationTimestamp: activityToken.GetCreationTime(),
 			Name:              name,
 		},
 		Status: ext.UserActivityStatus{},
 	}
 
-	if activityToken.ActivityLastSeenAt != nil {
-		ua.Status.ExpiresAt = activityToken.ActivityLastSeenAt.String()
+	if lastActivity := activityToken.GetLastActivitySeen(); lastActivity != nil {
+		ua.Status.ExpiresAt = lastActivity.String()
 	} else {
 		ua.Status.ExpiresAt = metav1.Time{}.String()
 	}
@@ -288,29 +302,39 @@ func first(values []string) string {
 	return ""
 }
 
-func validateActivityToken(auth, activity *v3Legacy.Token) error {
+func validateActivityToken(auth, activity accessor.TokenAccessor) error {
 	// verify auth and activity token have the same userID
-	if auth.UserID != activity.UserID {
-		return apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("request token %s and activity token %s have different users", auth.Name, activity.Name))
+	if auth.GetUserID() != activity.GetUserID() {
+		return apierrors.NewForbidden(GVR.GroupResource(), "",
+			fmt.Errorf("request token %s and activity token %s have different users",
+				auth.GetName(), activity.GetName()))
 	}
 
 	// verify auth and activity token has the same auth provider
-	if auth.AuthProvider != activity.AuthProvider {
-		return apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("request token %s and activity token %s have different auth providers", auth.Name, activity.Name))
+	if auth.GetAuthProvider() != activity.GetAuthProvider() {
+		return apierrors.NewForbidden(GVR.GroupResource(), "",
+			fmt.Errorf("request token %s and activity token %s have different auth providers",
+				auth.GetName(), activity.GetName()))
 	}
 
 	// verify auth and activity token has the same auth user principal
-	if auth.UserPrincipal.Name != activity.UserPrincipal.Name {
-		return apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("request token %s and activity token %s have different user principals", auth.Name, activity.Name))
+	if auth.GetUserPrincipal().Name != activity.GetUserPrincipal().Name {
+		return apierrors.NewForbidden(GVR.GroupResource(), "",
+			fmt.Errorf("request token %s and activity token %s have different user principals",
+				auth.GetName(), activity.GetName()))
 	}
 
-	// verify activity token is of the expected kind
-	if activity.Labels[TokenKind] != "session" {
-		return apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("activity token %s is not a session token", activity.Name))
+	// verify that activity token is a session token
+	if activity.GetIsDerived() {
+		return apierrors.NewForbidden(GVR.GroupResource(), "",
+			fmt.Errorf("activity token %s is not a session token",
+				activity.GetName()))
 	}
 
-	if activity.Enabled != nil && !*activity.Enabled {
-		return apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("activity token %s is disabled", activity.Name))
+	if !activity.GetIsEnabled() {
+		return apierrors.NewForbidden(GVR.GroupResource(), "",
+			fmt.Errorf("activity token %s is disabled",
+				activity.GetName()))
 	}
 
 	return nil

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -405,6 +405,12 @@ func schema_pkg_apis_extcattleio_v1_TokenStatus(ref common.ReferenceCallback) co
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"lastActivitySeen": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastActivitySeen is the timestamp of the last time user activity (mouse movement, interaction, ...) was reported for the token.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 				Required: []string{"current", "expired", "expiresAt", "lastUpdateTime"},
 			},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Support ext tokens in user activities.
 
## Problem

The new user activities currently support only v3 tokens.
 
## Solution

The stores for user activities and ext tokens were extended so that UA is able to work with ext tokens.

## Testing
## Engineering Testing
### Manual Testing

Passes unit tests.

<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_