### PR TITLE
[main] Ensure downstream PC exists

### DIFF
--- a/pkg/cluster/agent_customization.go
+++ b/pkg/cluster/agent_customization.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	PriorityClassName        = "cattle-cluster-agent-priority-class"
+	PriorityClassKind        = "priorityclass"
 	PodDisruptionBudgetName  = "cattle-cluster-agent-pod-disruption-budget"
 	PriorityClassDescription = "Rancher managed Priority Class for the cattle-cluster-agent"
 )

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -116,6 +116,22 @@ func Drain(ctx context.Context, kubeConfig *clientcmdapi.Config, nodeName string
 	return output, fmt.Sprint(cmd.Stderr), err
 }
 
+func GetNonNamespacedResource(kubeConfig *clientcmdapi.Config, resourceKind, resourceName string) ([]byte, error) {
+	kubeConfigFile, err := writeKubeConfig(kubeConfig)
+	defer cleanup(kubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("kubectl",
+		"--kubeconfig",
+		kubeConfigFile.Name(),
+		"get",
+		resourceKind,
+		resourceName,
+	)
+	return runWithHTTP2(cmd)
+}
+
 func cleanup(files ...*os.File) {
 	for _, file := range files {
 		if file == nil {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48995
 
## Problem
When enabling scheduling customization on imported clusters, the cluster agent deployment eventually has its `priorityClassName` field removed. This is due to the `clusterDeploy` controller only setting the PC reference on the manifest during updates to the PC definition. In the event that the cluster agent is changed outside of the PC definition, the reference is lost. This can happen due to the agent environment variables being changed, or agent features being automatically adjusted by the Rancher server. Additionally, as the `clusterDeploy` controller only compares the status and spec to determine if the PC has been created, it is possible that the cluster agent may fail to redeploy if the PC is deleted from the downstream cluster

## Solution

If the agent manifest needs to be reapplied due to a change unrelated to the priority class, query the downstream cluster to ensure that the PC exists. If it does not exist but should, recreate the PC before templating the manifest. This ensures that the PC is always present in the downstream cluster and the reference is always set on the cluster agent deployment manifest. 

## Testing
+ Provision an imported cluster with the scheduling customization feature enabled 
+ After the cluster becomes available, ensure that the PC reference is present on the cluster agent deployment and pod 
+ Delete the PC from the downstream cluster
+ Modify the cluster agent configuration to force a redeployment
   + this can be done by updating the agent env vars or enabled features
+ Ensure that the PC is recreated and the reference is still included in the deployment and pod
+ Repeat the above for other cluster types 

## Engineering Testing
### Manual Testing
I've done the above 

### Automated Testing
* Test types added/modified:
    * Unit
  
## QA Testing Considerations


### Regressions Considerations
