### PR TITLE
[v2.11] Csp-adapter v6.0.0, bump k8s version support

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 webhookVersion: 106.0.0+up0.7.0-rc.9
 remoteDialerProxyVersion: 106.0.0+up0.4.4-rc.2
 provisioningCAPIVersion: 106.0.0+up0.7.0
-cspAdapterMinVersion: 105.0.0+up5.0.1-rc1
+cspAdapterMinVersion: 106.0.0+up6.0.0-rc1
 defaultShellVersion: rancher/shell:v0.4.0
 fleetVersion: 106.0.0+up0.12.0-beta.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion     = "105.0.0+up5.0.1-rc1"
+	CspAdapterMinVersion     = "106.0.0+up6.0.0-rc1"
 	DefaultShellVersion      = "rancher/shell:v0.4.0"
 	FleetVersion             = "106.0.0+up0.12.0-beta.1"
 	ProvisioningCAPIVersion  = "106.0.0+up0.7.0"


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/48824
 
## Problem
csp-adapter version needs to be updated to one that supports K8s 1.30-1.32 in line with Rancher 2.11
 
## Solution
Update csp-adapter version to 106.0.0+up6.0.0-rc1
 
## Testing
automated testing performed of the changes using the csp-adapter-rancher-e2e-automation script (internal)