### PR TITLE
Remove hostPort for imperative API

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -83,7 +83,6 @@ spec:
           protocol: TCP
 {{- end}}
         - containerPort: 6666
-          hostPort: 6666
           protocol: TCP
         args:
 {{- if .Values.debug }}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49384
 
## Problem

The `hostPort` defined for imperative API is triggering an issue related to CA cert selection (see linked issue for more detail).
 
## Solution

The easiest fix for this is to simply remove that `hostPort` because we don't need it, we just need the pod to be reachable by a Service.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Deployed Rancher with this chart changed and the APIService for ext.catte.io's status is ok so no regression there.