### PR TITLE
#45641 - Adjusted Resource Limit Logic

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -457,33 +457,34 @@ func completeQuota(requestedQuota *v32.ResourceQuotaLimit, defaultQuota *v32.Res
 	return toReturn, err
 }
 
-func completeLimit(newLimit *v32.ContainerResourceLimit, defaultLimit *v32.ContainerResourceLimit) (*v32.ContainerResourceLimit, error) {
-	if defaultLimit == nil {
+func completeLimit(nsLimit *v32.ContainerResourceLimit, projectLimit *v32.ContainerResourceLimit) (*v32.ContainerResourceLimit, error) {
+	if projectLimit == nil {
 		return nil, nil
 	}
 
-	newLimitMap, err := convert.EncodeToMap(newLimit)
+	nsLimitMap, err := convert.EncodeToMap(nsLimit)
 	if err != nil {
 		return nil, err
 	}
 
-	defaultLimitMap, err := convert.EncodeToMap(defaultLimit)
+	projectLimitMap, err := convert.EncodeToMap(projectLimit)
 	if err != nil {
 		return nil, err
 	}
 
-	if reflect.DeepEqual(newLimitMap, defaultLimitMap) {
+	if reflect.DeepEqual(nsLimitMap, projectLimitMap) {
 		return nil, nil
 	}
 
-	for key, value := range defaultLimitMap {
-		if _, ok := newLimitMap[key]; !ok {
-			newLimitMap[key] = value
+	// project values are mostly default values
+	for key, value := range projectLimitMap {
+		if _, ok := nsLimitMap[key]; !ok {
+			nsLimitMap[key] = value
 		}
 	}
 
 	resultingLimit := &v32.ContainerResourceLimit{}
-	err = convert.ToObj(newLimitMap, resultingLimit)
+	err = convert.ToObj(nsLimitMap, resultingLimit)
 	return resultingLimit, err
 }
 

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -7,6 +7,12 @@ import (
 	"time"
 
 	"github.com/rancher/norman/types/convert"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	namespaceutil "github.com/rancher/rancher/pkg/namespace"
+	validate "github.com/rancher/rancher/pkg/resourcequota"
+	"github.com/rancher/rancher/pkg/utils"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -14,13 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcache "k8s.io/client-go/tools/cache"
-
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	namespaceutil "github.com/rancher/rancher/pkg/namespace"
-	validate "github.com/rancher/rancher/pkg/resourcequota"
-	"github.com/rancher/rancher/pkg/utils"
 )
 
 const (

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -471,6 +471,10 @@ func completeLimit(existingLimit *v32.ContainerResourceLimit, defaultLimit *v32.
 		return nil, err
 	}
 
+	if reflect.DeepEqual(existingLimitMap, newLimitMap) {
+		return nil, nil
+	}
+
 	for key, existingValue := range existingLimitMap {
 		existingValueQuantity, err := resource.ParseQuantity(existingValue.(string))
 		if err != nil {
@@ -487,19 +491,13 @@ func completeLimit(existingLimit *v32.ContainerResourceLimit, defaultLimit *v32.
 				continue
 			}
 
-			if existingValueQuantity.Cmp(defaultLimitVal) > 0 {
-				newLimitMap[key] = defaultValue
-			} else {
+			if existingValueQuantity.Cmp(defaultLimitVal) < 0 {
 				newLimitMap[key] = existingValue
 			}
 		} else {
 			// if no value is defined in project, we set the proposed value
 			newLimitMap[key] = existingValue
 		}
-	}
-
-	if reflect.DeepEqual(existingLimitMap, newLimitMap) {
-		return nil, nil
 	}
 
 	newLimit := &v32.ContainerResourceLimit{}

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -7,21 +7,21 @@ import (
 	"time"
 
 	"github.com/rancher/norman/types/convert"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcache "k8s.io/client-go/tools/cache"
+
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	validate "github.com/rancher/rancher/pkg/resourcequota"
 	"github.com/rancher/rancher/pkg/utils"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	clientcache "k8s.io/client-go/tools/cache"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
@@ -4,12 +4,12 @@ import (
 	"reflect"
 	"testing"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 )
 
 func TestCompleteLimit(t *testing.T) {

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestCompleteLimit(t *testing.T) {
 	type input struct {
-		newValues     *v32.ContainerResourceLimit
-		defaultValues *v32.ContainerResourceLimit
+		nsValues      *v32.ContainerResourceLimit
+		projectValues *v32.ContainerResourceLimit
 	}
 
 	type expected struct {
@@ -31,11 +31,11 @@ func TestCompleteLimit(t *testing.T) {
 		{
 			name: "limits not set in project",
 			input: input{
-				newValues: &v32.ContainerResourceLimit{
+				nsValues: &v32.ContainerResourceLimit{
 					LimitsCPU:    "1000m",
 					LimitsMemory: "256Mi",
 				},
-				defaultValues: &v32.ContainerResourceLimit{},
+				projectValues: &v32.ContainerResourceLimit{},
 			},
 			expected: expected{
 				expected: &v32.ContainerResourceLimit{
@@ -48,11 +48,11 @@ func TestCompleteLimit(t *testing.T) {
 		{
 			name: "limits set in project - namespace setting equal values",
 			input: input{
-				newValues: &v32.ContainerResourceLimit{
+				nsValues: &v32.ContainerResourceLimit{
 					LimitsCPU:    "1000m",
 					LimitsMemory: "256Mi",
 				},
-				defaultValues: &v32.ContainerResourceLimit{
+				projectValues: &v32.ContainerResourceLimit{
 					LimitsCPU:    "1000m",
 					LimitsMemory: "256Mi",
 				},
@@ -65,11 +65,11 @@ func TestCompleteLimit(t *testing.T) {
 		{
 			name: "limits set in namespace and in project",
 			input: input{
-				newValues: &v32.ContainerResourceLimit{
+				nsValues: &v32.ContainerResourceLimit{
 					LimitsCPU:    "1000m",
 					LimitsMemory: "256Mi",
 				},
-				defaultValues: &v32.ContainerResourceLimit{
+				projectValues: &v32.ContainerResourceLimit{
 					LimitsCPU:    "1200m",
 					LimitsMemory: "512Mi",
 				},
@@ -85,11 +85,11 @@ func TestCompleteLimit(t *testing.T) {
 		{
 			name: "limits set in namespace and requests set in project",
 			input: input{
-				newValues: &v32.ContainerResourceLimit{
+				nsValues: &v32.ContainerResourceLimit{
 					LimitsCPU:    "1000m",
 					LimitsMemory: "256Mi",
 				},
-				defaultValues: &v32.ContainerResourceLimit{
+				projectValues: &v32.ContainerResourceLimit{
 					RequestsCPU:    "100m",
 					RequestsMemory: "128Mi",
 				},
@@ -107,11 +107,11 @@ func TestCompleteLimit(t *testing.T) {
 		{
 			name: "requests set in namespace and limits in project",
 			input: input{
-				newValues: &v32.ContainerResourceLimit{
+				nsValues: &v32.ContainerResourceLimit{
 					RequestsCPU:    "100m",
 					RequestsMemory: "128Mi",
 				},
-				defaultValues: &v32.ContainerResourceLimit{
+				projectValues: &v32.ContainerResourceLimit{
 					LimitsCPU:    "1000m",
 					LimitsMemory: "256Mi",
 				},
@@ -129,13 +129,13 @@ func TestCompleteLimit(t *testing.T) {
 		{
 			name: "requests and limits set in both",
 			input: input{
-				newValues: &v32.ContainerResourceLimit{
+				nsValues: &v32.ContainerResourceLimit{
 					RequestsCPU:    "100m",
 					RequestsMemory: "128Mi",
 					LimitsCPU:      "2000m",
 					LimitsMemory:   "1Gi",
 				},
-				defaultValues: &v32.ContainerResourceLimit{
+				projectValues: &v32.ContainerResourceLimit{
 					RequestsCPU:    "200m",
 					RequestsMemory: "256Mi",
 					LimitsCPU:      "1000m",
@@ -152,11 +152,27 @@ func TestCompleteLimit(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "project values are null",
+			input: input{
+				nsValues: &v32.ContainerResourceLimit{
+					RequestsCPU:    "100m",
+					RequestsMemory: "128Mi",
+					LimitsCPU:      "2000m",
+					LimitsMemory:   "1Gi",
+				},
+				projectValues: nil,
+			},
+			expected: expected{
+				expected: nil,
+				err:      nil,
+			},
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := completeLimit(tt.input.newValues, tt.input.defaultValues)
+			res, err := completeLimit(tt.input.nsValues, tt.input.projectValues)
 			if tt.expected.err != nil {
 				assert.Error(t, err)
 				return

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
@@ -4,12 +4,12 @@ import (
 	"reflect"
 	"testing"
 
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 )
 
 func TestCompleteLimit(t *testing.T) {


### PR DESCRIPTION
## Issue: #45641 
 
## Problem
The user wasn't able to set Limits or Requests for namespace when it wasn't previously defined in project. 
 
## Solution
We changed the logic to the user be able to set the values in namespace and when some value is missing, we copy it from project, this way project values work like default values.
 
## Testing
The repro steps are in the original issue. For the testing, I suggest you to create a new project in the UI and then set some values for Limits or Requests. Then after, create a namespace in that project and add other values. The values you add in namespace will be the ones set, but in case you don't set one or more of them, it will copy it from project if you previously defined it in there.