### PR TITLE
[release/v2.10] Make sure to limit variables in calculateBackOff func 

### DIFF
--- a/pkg/controllers/dashboard/helm/repo_oci.go
+++ b/pkg/controllers/dashboard/helm/repo_oci.go
@@ -347,8 +347,13 @@ func calculateBackoff(clusterRepo *catalog.ClusterRepo, policy retryPolicy) time
 	h.SetSeed(maphash.MakeSeed())
 	rand := rand.New(rand.NewSource(int64(h.Sum64())))
 	temp := float64(policy.MinWait) * math.Pow(2, float64(clusterRepo.Status.NumberOfRetries))
-	// rand.Int63n panics if jitter <= 0
-	jitter := int64(math.Max(1, 2*0.2*temp))
+	if temp > math.MaxInt64 {
+		temp = math.MaxInt64 / 3
+	}
+	jitter := int64(2 * 0.2 * temp)
+	if jitter <= 0 {
+		jitter = 1
+	}
 	backoff := time.Duration(temp*(1-0.2)) + time.Duration(rand.Int63n(jitter))
 	if backoff < policy.MinWait {
 		return policy.MinWait

--- a/pkg/controllers/dashboard/helm/repo_oci_test.go
+++ b/pkg/controllers/dashboard/helm/repo_oci_test.go
@@ -527,3 +527,72 @@ func TestShouldSkip(t *testing.T) {
 		})
 	}
 }
+func TestCalculateBackoff(t *testing.T) {
+	testCases := []struct {
+		name           string
+		clusterRepo    *catalog.ClusterRepo
+		retryPolicy    retryPolicy
+		expectedErrMsg string
+	}{
+		{
+			name: "Check if retry number is 0",
+			clusterRepo: &catalog.ClusterRepo{
+				Status: catalog.RepoStatus{
+					NumberOfRetries: 0,
+				},
+			},
+			retryPolicy: retryPolicy{
+				MinWait:  10 * time.Second,
+				MaxWait:  30 * time.Minute,
+				MaxRetry: 5,
+			},
+		},
+		{
+			name: "Check if retry number is 1",
+			clusterRepo: &catalog.ClusterRepo{
+				Status: catalog.RepoStatus{
+					NumberOfRetries: 1,
+				},
+			},
+			retryPolicy: retryPolicy{
+				MinWait:  10 * time.Second,
+				MaxWait:  30 * time.Minute,
+				MaxRetry: 5,
+			},
+		},
+		{
+			name: "Check if retry number is 2",
+			clusterRepo: &catalog.ClusterRepo{
+				Status: catalog.RepoStatus{
+					NumberOfRetries: 2,
+				},
+			},
+			retryPolicy: retryPolicy{
+				MinWait:  10 * time.Second,
+				MaxWait:  30 * time.Minute,
+				MaxRetry: 5,
+			},
+		},
+		{
+			name: "Check if retry number is 100",
+			clusterRepo: &catalog.ClusterRepo{
+				Status: catalog.RepoStatus{
+					NumberOfRetries: 100,
+				},
+			},
+			retryPolicy: retryPolicy{
+				MinWait:  10 * time.Second,
+				MaxWait:  30 * time.Minute,
+				MaxRetry: 5,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			backoff := calculateBackoff(testCase.clusterRepo, testCase.retryPolicy)
+			assert.GreaterOrEqual(t, backoff, testCase.retryPolicy.MinWait, "calculateBackoff() = %v, want greater than or equal to 10 seconds", backoff)
+			assert.LessOrEqual(t, backoff, testCase.retryPolicy.MaxWait, "calculateBackoff() = %v, want less than or equal to 30 minutes", backoff)
+		})
+	}
+}

--- a/pkg/controllers/dashboard/plugin/controller.go
+++ b/pkg/controllers/dashboard/plugin/controller.go
@@ -168,8 +168,13 @@ func calculateBackoff(numberOfRetries int) time.Duration {
 	h.SetSeed(maphash.MakeSeed())
 	rand := rand.New(rand.NewSource(int64(h.Sum64())))
 	temp := float64(minWait) * math.Pow(2, float64(numberOfRetries))
-	// rand.Int63n panics if jitter <= 0
-	jitter := int64(math.Max(1, 2*0.2*temp))
+	if temp > math.MaxInt64 {
+		temp = math.MaxInt64 / 3
+	}
+	jitter := int64(2 * 0.2 * temp)
+	if jitter <= 0 {
+		jitter = 1
+	}
 	backoff := time.Duration(temp*(1-0.2)) + time.Duration(rand.Int63n(jitter))
 	if backoff < minWait {
 		return minWait

--- a/pkg/controllers/dashboard/plugin/controller_test.go
+++ b/pkg/controllers/dashboard/plugin/controller_test.go
@@ -1,0 +1,44 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_calculateBackoff(t *testing.T) {
+	tests := []struct {
+		name            string
+		numberOfRetries int
+	}{
+		{
+			name:            "initial retry",
+			numberOfRetries: 0,
+		},
+		{
+			name:            "second retry",
+			numberOfRetries: 1,
+		},
+		{
+			name:            "third retry",
+			numberOfRetries: 2,
+		},
+		{
+			name:            "large number of retries",
+			numberOfRetries: 100,
+		},
+		{
+			name:            "very large number of retries",
+			numberOfRetries: 10000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateBackoff(tt.numberOfRetries)
+			assert.GreaterOrEqual(t, got, 10*time.Second, "calculateBackoff() = %v, want greater than or equal to 10 seconds", got)
+			assert.LessOrEqual(t, got, 30*time.Minute, "calculateBackoff() = %v, want less than or equal to 30 minutes", got)
+		})
+	}
+}


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/49047

Summary
This issue was reopened because now, we are able to reproduce it clearly.