### PR TITLE
split secretkeyhash out of cluster auth token into a kube secret

### DIFF
--- a/pkg/apis/cluster.cattle.io/v3/types.go
+++ b/pkg/apis/cluster.cattle.io/v3/types.go
@@ -32,9 +32,12 @@ type ClusterAuthToken struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	UserName      string       `json:"userName"`
-	LastUsedAt    *metav1.Time `json:"lastUsedAt,omitempty"`
-	ExpiresAt     string       `json:"expiresAt,omitempty"`
-	SecretKeyHash string       `json:"hash"`
-	Enabled       bool         `json:"enabled"`
+	UserName   string       `json:"userName"`
+	LastUsedAt *metav1.Time `json:"lastUsedAt,omitempty"`
+	ExpiresAt  string       `json:"expiresAt,omitempty"`
+
+	// SecretKeyHash is deprecated. Its function is taken over by a kube
+	// Secret which can be configured to encrypt the value at rest.
+	SecretKeyHash string `json:"hash"`
+	Enabled       bool   `json:"enabled"`
 }

--- a/pkg/controllers/managementuser/clusterauthtoken/common/user.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/common/user.go
@@ -7,12 +7,14 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens/hashers"
 	clusterv3 "github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3"
 	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewClusterAuthToken creates a new cluster auth token from a given token and it's hashed value.
+// NewClusterAuthToken creates a new cluster auth token from a given token.
+// The hashed value is managed separately.
 // Does not create the token in the remote cluster.
-func NewClusterAuthToken(token *managementv3.Token, hashedValue string) (*clusterv3.ClusterAuthToken, error) {
+func NewClusterAuthToken(token *managementv3.Token) (*clusterv3.ClusterAuthToken, error) {
 	tokenEnabled := token.Enabled == nil || *token.Enabled
 	result := &clusterv3.ClusterAuthToken{
 		ObjectMeta: metav1.ObjectMeta{
@@ -21,16 +23,45 @@ func NewClusterAuthToken(token *managementv3.Token, hashedValue string) (*cluste
 		TypeMeta: metav1.TypeMeta{
 			Kind: "ClusterAuthToken",
 		},
-		UserName:      token.UserID,
-		SecretKeyHash: hashedValue,
-		ExpiresAt:     token.ExpiresAt,
-		Enabled:       tokenEnabled,
+		UserName:  token.UserID,
+		ExpiresAt: token.ExpiresAt,
+		Enabled:   tokenEnabled,
 	}
 	return result, nil
 }
 
-// VerifyClusterAuthToken verifies that a provided secret key is valid for the given clusterAuthToken.
-func VerifyClusterAuthToken(secretKey string, clusterAuthToken *clusterv3.ClusterAuthToken) error {
+// NewClusterAuthSecret creates a new secret from the given token and its hash value
+// The cluster auth token is managed separately.
+// Does not create the secret in the remote cluster.
+func NewClusterAuthSecret(token *managementv3.Token, hashedValue string) (*corev1.Secret, error) {
+	result := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ClusterAuthSecretName(token.ObjectMeta.Name),
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Secret",
+		},
+		Data: map[string][]byte{
+			"hash": []byte(hashedValue),
+		},
+	}
+	return result, nil
+}
+
+// ClusterAuthSecretName computes the name of the cluster auth secret for a
+// token T from the name of T.
+func ClusterAuthSecretName(tokenName string) string {
+	return "cat-" + tokenName
+}
+
+// ClusterAuthSecretValue extracts the token hash stored in the secret.
+func ClusterAuthSecretValue(clusterAuthSecret *corev1.Secret) string {
+	return string(clusterAuthSecret.Data["hash"])
+}
+
+// VerifyClusterAuthToken verifies that a provided secret key is valid for the
+// given clusterAuthToken and hashed value.
+func VerifyClusterAuthToken(secretKey string, clusterAuthToken *clusterv3.ClusterAuthToken, clusterAuthSecret *corev1.Secret) error {
 	if !clusterAuthToken.Enabled {
 		return fmt.Errorf("token is not enabled")
 	}
@@ -45,9 +76,11 @@ func VerifyClusterAuthToken(secretKey string, clusterAuthToken *clusterv3.Cluste
 			return fmt.Errorf("auth expired at %s", expiresAt)
 		}
 	}
-	hasher, err := hashers.GetHasherForHash(clusterAuthToken.SecretKeyHash)
+
+	hashedValue := ClusterAuthSecretValue(clusterAuthSecret)
+	hasher, err := hashers.GetHasherForHash(hashedValue)
 	if err != nil {
 		return fmt.Errorf("unable to get hasher for clusterAuthToken %s/%s, err: %w", clusterAuthToken.Name, clusterAuthToken.Namespace, err)
 	}
-	return hasher.VerifyHash(clusterAuthToken.SecretKeyHash, secretKey)
+	return hasher.VerifyHash(hashedValue, secretKey)
 }

--- a/pkg/controllers/managementuser/clusterauthtoken/common/user_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/common/user_test.go
@@ -25,9 +25,12 @@ func TestValidUser(t *testing.T) {
 	hasher := hashers.GetHasher()
 	hashedValue, err := hasher.CreateHash(token.Token)
 	assert.NoError(t, err, "got an error but did not expect one")
-	clusterAuthToken, err := NewClusterAuthToken(&token, hashedValue)
+	clusterAuthToken, err := NewClusterAuthToken(&token)
 	assert.Nil(t, err)
-	assert.Nil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken))
+	clusterAuthSecret, err := NewClusterAuthSecret(&token, hashedValue)
+	assert.Nil(t, err)
+	assert.Nil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken,
+		clusterAuthSecret))
 }
 
 func TestInvalidPassword(t *testing.T) {
@@ -35,8 +38,10 @@ func TestInvalidPassword(t *testing.T) {
 	hasher := hashers.GetHasher()
 	hashedValue, err := hasher.CreateHash(token.Token)
 	assert.NoError(t, err, "got an error but did not expect one")
-	clusterAuthToken, _ := NewClusterAuthToken(&token, hashedValue)
-	assert.NotNil(t, VerifyClusterAuthToken(token.Token+":wrong!", clusterAuthToken))
+	clusterAuthToken, _ := NewClusterAuthToken(&token)
+	clusterAuthSecret, _ := NewClusterAuthSecret(&token, hashedValue)
+	assert.NotNil(t, VerifyClusterAuthToken(token.Token+":wrong!",
+		clusterAuthToken, clusterAuthSecret))
 }
 
 func TestExpired(t *testing.T) {
@@ -45,8 +50,9 @@ func TestExpired(t *testing.T) {
 	hashedValue, err := hasher.CreateHash(token.Token)
 	assert.NoError(t, err, "got an error but did not expect one")
 	token.ExpiresAt = time.Now().Add(-time.Minute).Format(time.RFC3339)
-	clusterAuthToken, _ := NewClusterAuthToken(&token, hashedValue)
-	assert.NotNil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken))
+	clusterAuthToken, _ := NewClusterAuthToken(&token)
+	clusterAuthSecret, _ := NewClusterAuthSecret(&token, hashedValue)
+	assert.NotNil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken, clusterAuthSecret))
 }
 
 func TestNotExpired(t *testing.T) {
@@ -55,8 +61,9 @@ func TestNotExpired(t *testing.T) {
 	hashedValue, err := hasher.CreateHash(token.Token)
 	assert.NoError(t, err, "got an error but did not expect one")
 	token.ExpiresAt = time.Now().Add(time.Minute).Format(time.RFC3339)
-	clusterAuthToken, _ := NewClusterAuthToken(&token, hashedValue)
-	assert.Nil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken))
+	clusterAuthToken, _ := NewClusterAuthToken(&token)
+	clusterAuthSecret, _ := NewClusterAuthSecret(&token, hashedValue)
+	assert.Nil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken, clusterAuthSecret))
 }
 
 func TestInvalidExpiresAt(t *testing.T) {
@@ -65,6 +72,7 @@ func TestInvalidExpiresAt(t *testing.T) {
 	hashedValue, err := hasher.CreateHash(token.Token)
 	assert.NoError(t, err, "got an error but did not expect one")
 	token.ExpiresAt = "some invalid time stamp"
-	clusterAuthToken, _ := NewClusterAuthToken(&token, hashedValue)
-	assert.NotNil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken))
+	clusterAuthToken, _ := NewClusterAuthToken(&token)
+	clusterAuthSecret, _ := NewClusterAuthSecret(&token, hashedValue)
+	assert.NotNil(t, VerifyClusterAuthToken(token.Token, clusterAuthToken, clusterAuthSecret))
 }

--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -63,6 +63,8 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext) {
 	clusterUserAttributeLister := cluster.Cluster.ClusterUserAttributes(namespace).Controller().Lister()
 	clusterConfigMap := cluster.Core.ConfigMaps(namespace)
 	clusterConfigMapLister := cluster.Core.ConfigMaps(namespace).Controller().Lister()
+	clusterSecret := cluster.Core.Secrets(namespace)
+	clusterSecretLister := cluster.Core.Secrets(namespace).Controller().Lister()
 	tokenIndexer := tokenInformer.GetIndexer()
 	userLister := cluster.Management.Management.Users("").Controller().Lister()
 	userAttribute := cluster.Management.Management.UserAttributes("")
@@ -88,6 +90,8 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext) {
 			tokenIndexer,
 			userLister,
 			userAttributeLister,
+			clusterSecret,
+			clusterSecretLister,
 		})
 
 	cluster.Management.Management.Users("").AddHandler(ctx, userController, (&userHandler{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#49473 
 
## Problem

The cluster auth token CRD exposes the hash of the token secret at rest.

## Solution

The field `SecretKeyHash` of the CRD is deprecated.
The information is stored in a kube secret instead.
kube secrets can be configured globally to be encrypted at rest.
 
:warning: Needs an adjunct PR in kube-api-auth, where the hash is used to verify tokens
:warning: Needs a way to migrate from the old to the new form, when upgrading an installation. This part, when specified, requires input from security

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_