### PR TITLE
Only create management plane and promoted cluster roles when they exist

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/roletemplate_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/roletemplate_handler.go
@@ -107,14 +107,14 @@ func (r *roleTemplateHandler) getManagementClusterRoles(rt *v3.RoleTemplate, rul
 			rbac.BuildClusterRole(crNameTransformer(rtName), rtName, rules),
 			rbac.BuildAggregatingClusterRole(rt, crNameTransformer),
 		}, nil
-	} else {
-		ok, err := r.areThereInheritedManagementPlaneRules(rt.RoleTemplateNames, crNameTransformer)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			return []*rbacv1.ClusterRole{rbac.BuildAggregatingClusterRole(rt, crNameTransformer)}, nil
-		}
+	}
+
+	ok, err := r.areThereInheritedManagementPlaneRules(rt.RoleTemplateNames, crNameTransformer)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return []*rbacv1.ClusterRole{rbac.BuildAggregatingClusterRole(rt, crNameTransformer)}, nil
 	}
 
 	return nil, nil

--- a/pkg/controllers/management/auth/roletemplates/roletemplate_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/roletemplate_handler_test.go
@@ -347,6 +347,184 @@ func Test_OnChange(t *testing.T) {
 				}).Return(nil, nil)
 			},
 		},
+		{
+			name: "inheriting mgmt plane rules, cluster role",
+			rt: &v3.RoleTemplate{
+				Context: "cluster",
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "roletemplate",
+					APIVersion: "management.cattle.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+					UID:  "UID123",
+				},
+				Rules:             []rbacv1.PolicyRule{getRoleTemplates},
+				RoleTemplateNames: []string{"child-rt"},
+			},
+			setupClusterRoleController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get("child-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
+				m.EXPECT().Create(&rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-rt-project-mgmt-aggregator",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "test-rt",
+								Kind:       "roletemplate",
+								APIVersion: "management.cattle.io",
+								UID:        "UID123",
+							},
+						},
+						Labels:      map[string]string{"management.cattle.io/aggregates": "test-rt-project-mgmt-aggregator"},
+						Annotations: map[string]string{"authz.cluster.cattle.io/clusterrole-owner": "test-rt"},
+					},
+					AggregationRule: &rbacv1.AggregationRule{
+						ClusterRoleSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{"management.cattle.io/aggregates": "test-rt-project-mgmt"},
+							},
+							{
+								MatchLabels: map[string]string{"management.cattle.io/aggregates": "child-rt-project-mgmt-aggregator"},
+							},
+						},
+					},
+				}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-cluster-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get("child-rt-cluster-mgmt-aggregator", metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
+				m.EXPECT().Create(&rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-rt-cluster-mgmt-aggregator",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "test-rt",
+								Kind:       "roletemplate",
+								APIVersion: "management.cattle.io",
+								UID:        "UID123",
+							},
+						},
+						Labels:      map[string]string{"management.cattle.io/aggregates": "test-rt-cluster-mgmt-aggregator"},
+						Annotations: map[string]string{"authz.cluster.cattle.io/clusterrole-owner": "test-rt"},
+					},
+					AggregationRule: &rbacv1.AggregationRule{
+						ClusterRoleSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{"management.cattle.io/aggregates": "test-rt-cluster-mgmt"},
+							},
+							{
+								MatchLabels: map[string]string{"management.cattle.io/aggregates": "child-rt-cluster-mgmt-aggregator"},
+							},
+						},
+					},
+				}).Return(nil, nil)
+			},
+		},
+		{
+			name: "inheriting mgmt plane rules, project role",
+			rt: &v3.RoleTemplate{
+				Context: "project",
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "roletemplate",
+					APIVersion: "management.cattle.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+					UID:  "UID123",
+				},
+				Rules:             []rbacv1.PolicyRule{getRoleTemplates},
+				RoleTemplateNames: []string{"child-rt"},
+			},
+			setupClusterRoleController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get("child-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
+				m.EXPECT().Create(&rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-rt-project-mgmt-aggregator",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "test-rt",
+								Kind:       "roletemplate",
+								APIVersion: "management.cattle.io",
+								UID:        "UID123",
+							},
+						},
+						Labels:      map[string]string{"management.cattle.io/aggregates": "test-rt-project-mgmt-aggregator"},
+						Annotations: map[string]string{"authz.cluster.cattle.io/clusterrole-owner": "test-rt"},
+					},
+					AggregationRule: &rbacv1.AggregationRule{
+						ClusterRoleSelectors: []metav1.LabelSelector{
+							{
+								MatchLabels: map[string]string{"management.cattle.io/aggregates": "test-rt-project-mgmt"},
+							},
+							{
+								MatchLabels: map[string]string{"management.cattle.io/aggregates": "child-rt-project-mgmt-aggregator"},
+							},
+						},
+					},
+				}).Return(nil, nil)
+			},
+		},
+		{
+			name: "inherited roles have no mgmt plane rules",
+			rt: &v3.RoleTemplate{
+				Context: "cluster",
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "roletemplate",
+					APIVersion: "management.cattle.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+					UID:  "UID123",
+				},
+				Rules:             []rbacv1.PolicyRule{getRoleTemplates},
+				RoleTemplateNames: []string{"child-rt"},
+			},
+			setupClusterRoleController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
+				m.EXPECT().Get("child-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get("child-rt-cluster-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errNotFound)
+			},
+		},
+		{
+			name: "error getting inherited project mgmt role",
+			rt: &v3.RoleTemplate{
+				Context: "cluster",
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "roletemplate",
+					APIVersion: "management.cattle.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+					UID:  "UID123",
+				},
+				Rules:             []rbacv1.PolicyRule{getRoleTemplates},
+				RoleTemplateNames: []string{"child-rt"},
+			},
+			setupClusterRoleController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
+				m.EXPECT().Get("child-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errDefault)
+				m.EXPECT().Get("child-rt-cluster-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errNotFound)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error getting inherited cluster mgmt role",
+			rt: &v3.RoleTemplate{
+				Context: "cluster",
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "roletemplate",
+					APIVersion: "management.cattle.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rt",
+					UID:  "UID123",
+				},
+				Rules:             []rbacv1.PolicyRule{getRoleTemplates},
+				RoleTemplateNames: []string{"child-rt"},
+			},
+			setupClusterRoleController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
+				m.EXPECT().Get("child-rt-cluster-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
 	}
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {

--- a/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
@@ -135,9 +135,7 @@ func (rth *roleTemplateHandler) buildPromotedClusterRoles(rt *v3.RoleTemplate) (
 		clusterRoles = append(clusterRoles, rbac.BuildClusterRole(rbac.PromotedClusterRoleNameFor(rt.Name), rt.Name, promotedRules))
 	}
 
-	// It's possible for this role to have no rules if there are no promoted rules in any of the inherited RoleTemplates or in the promoted ClusterRole
-	// but without fetching all those RoleTemplates and looking through their rules, it's not possible to prevent this ahead of time as the Rules in
-	// an aggregating cluster role only get populated at run time
+	// If there are promoted rules or inherited promoted rules, an aggregating cluster role will be what PRTBs bind to.
 	clusterRoles = append(clusterRoles, rbac.BuildAggregatingClusterRole(rt, rbac.PromotedClusterRoleNameFor))
 
 	return clusterRoles, rules, nil

--- a/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/slice"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,7 +42,10 @@ func (rth *roleTemplateHandler) OnChange(_ string, rt *v3.RoleTemplate) (*v3.Rol
 		return nil, nil
 	}
 
-	clusterRoles := clusterRolesForRoleTemplate(rt)
+	clusterRoles, err := rth.clusterRolesForRoleTemplate(rt)
+	if err != nil {
+		return nil, err
+	}
 	for _, cr := range clusterRoles {
 		if err := rbac.CreateOrUpdateResource(cr, rth.crController, rbac.AreClusterRolesSame); err != nil {
 			return nil, err
@@ -57,13 +61,18 @@ func (rth *roleTemplateHandler) OnChange(_ string, rt *v3.RoleTemplate) (*v3.Rol
 }
 
 // clusterRolesForRoleTemplate builds and returns all needed Cluster Roles for the RoleTemplate using the given rules.
-func clusterRolesForRoleTemplate(rt *v3.RoleTemplate) []*rbacv1.ClusterRole {
+func (rth *roleTemplateHandler) clusterRolesForRoleTemplate(rt *v3.RoleTemplate) ([]*rbacv1.ClusterRole, error) {
 	res := []*rbacv1.ClusterRole{}
 
 	if rt.Context == projectContext {
 		// ClusterRoles for promoted rules
 		var promotedClusterRoles []*rbacv1.ClusterRole
-		promotedClusterRoles, rt.Rules = buildPromotedClusterRoles(rt)
+		var err error
+		promotedClusterRoles, rt.Rules, err = rth.buildPromotedClusterRoles(rt)
+		if err != nil {
+			return nil, err
+		}
+
 		res = append(res, promotedClusterRoles...)
 	}
 
@@ -73,7 +82,7 @@ func clusterRolesForRoleTemplate(rt *v3.RoleTemplate) []*rbacv1.ClusterRole {
 	}
 	res = append(res, rbac.BuildAggregatingClusterRole(rt, rbac.ClusterRoleNameFor))
 
-	return res
+	return res, nil
 }
 
 // OnRemove deletes all ClusterRoles created by the RoleTemplate
@@ -106,14 +115,19 @@ func (rth *roleTemplateHandler) OnRemove(_ string, rt *v3.RoleTemplate) (*v3.Rol
 
 // buildPromotedClusterRoles looks for promoted rules in a project role template and creates required promoted cluster roles.
 // It also returns the role template rules with the promoted rules removed.
-func buildPromotedClusterRoles(rt *v3.RoleTemplate) ([]*rbacv1.ClusterRole, []rbacv1.PolicyRule) {
+func (rth *roleTemplateHandler) buildPromotedClusterRoles(rt *v3.RoleTemplate) ([]*rbacv1.ClusterRole, []rbacv1.PolicyRule, error) {
 	clusterRoles := []*rbacv1.ClusterRole{}
 
 	promotedRules, rules := extractPromotedRules(rt.Rules)
 
-	// If there are no promoted rules and no inherited RoleTemplates, no need for additional cluster roles
-	if len(promotedRules) == 0 && len(rt.RoleTemplateNames) == 0 {
-		return clusterRoles, rules
+	inheritedPromotedRules, err := rth.areThereInheritedPromotedRules(rt.RoleTemplateNames)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// If there are no promoted rules and no inherited RoleTemplates with promoted rules, no need for additional cluster roles
+	if len(promotedRules) == 0 && !inheritedPromotedRules {
+		return clusterRoles, rules, nil
 	}
 
 	if len(promotedRules) != 0 {
@@ -126,7 +140,20 @@ func buildPromotedClusterRoles(rt *v3.RoleTemplate) ([]*rbacv1.ClusterRole, []rb
 	// an aggregating cluster role only get populated at run time
 	clusterRoles = append(clusterRoles, rbac.BuildAggregatingClusterRole(rt, rbac.PromotedClusterRoleNameFor))
 
-	return clusterRoles, rules
+	return clusterRoles, rules, nil
+}
+
+// areThereInheritedPromotedRules checks if any of the inherited RoleTemplates contain promoted rules. If none do, return false.
+func (rth *roleTemplateHandler) areThereInheritedPromotedRules(inheritedRoleTemplates []string) (bool, error) {
+	for _, rt := range inheritedRoleTemplates {
+		_, err := rth.crController.Get(rbac.AggregatedClusterRoleNameFor(rbac.PromotedClusterRoleNameFor(rt)), metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		} else if !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+	return false, nil
 }
 
 var promotedRulesForProjects = map[string]string{


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/49231
https://github.com/rancher/rancher/issues/49224
 
## Problem
When a RoleTemplate inherits another RoleTemplate with management plane rules, it doesn't create an aggregation cluster role for those management plane rules. That means any user bound to the parent RoleTemplate doesn't inherit all the rules properly.
 
## Solution
For promoted rules in the downstream cluster, I had originally designed it so that an aggregating cluster role would be created if the roletemplate inherited any other roletemplates. Instead of doing that for management plane resources, I instead look at each inherited role template for any management plane resources. I also modified promoted rules to work the same way.
 
## Testing
The repro steps in both issues are accurate

## Engineering Testing
### Manual Testing

I tested by performing the tests in the github issues. I also tested the following case:
- Create a `child-role` with no management plane rules
- Create a `parent-role` with no management plane rules that inherits `child-role`
- Create a `grandparent-role` with no management plane rules that inherits `parent-role`
- Update `child-role` to add a management plane rule
- Verify that `parent-role` and `grandparent-role` have aggregation cluster roles created that include the management plane rules

### Automated Testing

* Test types added/modified:
    * Unit

Summary: Added unit tests to cover the new method of inheriting special rules.

## QA Testing Considerations
There is an issue with how it deletes these additional cluster roles. That's part of a large problem where the handler isn't deleting unused cluster roles properly https://github.com/rancher/rancher/issues/49262. That's going to be a separate effort to fix.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_