### PR TITLE
[v2.11] Csp-adapter v6.0.0 un-rc

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 webhookVersion: 106.0.0+up0.7.0-rc.10
 remoteDialerProxyVersion: 106.0.0+up0.4.4-rc.2
 provisioningCAPIVersion: 106.0.0+up0.7.0
-cspAdapterMinVersion: 106.0.0+up6.0.0-rc1
+cspAdapterMinVersion: 106.0.0+up6.0.0
 defaultShellVersion: rancher/shell:v0.4.0
 fleetVersion: 106.0.0+up0.12.0-rc.5

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion     = "106.0.0+up6.0.0-rc1"
+	CspAdapterMinVersion     = "106.0.0+up6.0.0"
 	DefaultShellVersion      = "rancher/shell:v0.4.0"
 	FleetVersion             = "106.0.0+up0.12.0-rc.5"
 	ProvisioningCAPIVersion  = "106.0.0+up0.7.0"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 This PR un-rc's csp-adapter v6.0.0.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
On an EKS cluster, install locally built rancher with cspAdapterMinVersion: 106.0.0+up6.0.0
Validated the support config and license entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.
