### PR TITLE
[2.11] Remove spot instances from provisioning and integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,11 @@ env:
   REPO: ${{ github.repository_owner }}
 jobs:
   test:
-    runs-on: runs-on,runner=16cpu-linux-x64,ram=64,run-id=${{ github.run_id }}
+    runs-on:
+      - runs-on
+      - spot=false
+      - runner=16cpu-linux-x64
+      - run-id=${{ github.run_id }}
     timeout-minutes: 60
     env:
       K3D_VERSION: v5.7.1
@@ -32,7 +36,7 @@ jobs:
           sudo systemctl restart docker
       - name: Setup Environment Variables
         uses: ./.github/actions/setup-tag-env
-      - id: env 
+      - id: env
         name: Setup Dependencies Env Variables
         uses: ./.github/actions/setup-build-env
       - name: Download Docker images artifact

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -35,7 +35,11 @@ jobs:
           V2PROV_TEST_RUN_REGEX: "^Test_PreBootstrap_.*$"
           CATTLE_FEATURES: "provisioningprebootstrap=true"
     name: Provisioning tests
-    runs-on: runs-on,runner=16cpu-linux-x64,ram=64,run-id=${{ github.run_id }}
+    runs-on:
+      - runs-on
+      - spot=false
+      - runner=16cpu-linux-x64
+      - run-id=${{ github.run_id }}
     env:
       # this is due to the dapper pod having a host-port on the registry-cache container
       # we can hit this registry from dapper OR the host docker if we use the docker IP


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/49441