### PR TITLE
[2.9] Remove spot instances from provisioning and integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,12 @@ env:
   IMAGE_AGENT: ${{ github.repository_owner }}/rancher-agent
 jobs:
   test:
-    runs-on: runs-on,runner=8cpu-linux-x64,image=legacy-cgroups-for-x64,run-id=${{ github.run_id }}
+    runs-on:
+      - runs-on
+      - spot=false
+      - runner=8cpu-linux-x64
+      - image=legacy-cgroups-for-x64
+      - run-id=${{ github.run_id }}
     timeout-minutes: 60
     env:
       K3D_VERSION: v5.7.1
@@ -38,7 +43,7 @@ jobs:
           sudo rm -rf /opt/ghc
           # removes android sdk
           sudo rm -rf /usr/local/lib/android
-      - id: env 
+      - id: env
         name: Setup Dependencies Env Variables
         uses: ./.github/actions/setup-build-env
       - name: Download Docker images artifact

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -32,7 +32,12 @@ jobs:
           V2PROV_TEST_RUN_REGEX: "^Test_PreBootstrap_.*$"
           CATTLE_FEATURES: "provisioningprebootstrap=true"
     name: Provisioning tests
-    runs-on: runs-on,runner=8cpu-linux-x64,image=legacy-cgroups-for-x64,run-id=${{ github.run_id }}
+    runs-on:
+      - runs-on
+      - spot=false
+      - runner=8cpu-linux-x64
+      - image=legacy-cgroups-for-x64
+      - run-id=${{ github.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/49441