### PR TITLE
feat: updatepsa for project level

### DIFF
--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -101,6 +101,7 @@ func Register(ctx context.Context, workload *config.UserContext) {
 		crIndexer:           crInformer.GetIndexer(),
 		crbIndexer:          crbInformer.GetIndexer(),
 		rtLister:            management.Management.RoleTemplates("").Controller().Lister(),
+		prtbLister:          management.Management.ProjectRoleTemplateBindings("").Controller().Lister(),
 		rbLister:            workload.RBAC.RoleBindings("").Controller().Lister(),
 		crbLister:           workload.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		crLister:            workload.RBAC.ClusterRoles("").Controller().Lister(),
@@ -165,6 +166,7 @@ type managerInterface interface {
 type manager struct {
 	workload            *config.UserContext
 	rtLister            v3.RoleTemplateLister
+	prtbLister          v3.ProjectRoleTemplateBindingLister
 	prtbIndexer         cache.Indexer
 	crtbIndexer         cache.Indexer
 	nsIndexer           cache.Indexer

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
-	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -484,13 +484,29 @@ func addManageNSPermission(clusterRole *rbacv1.ClusterRole, projectName string) 
 	clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
 		APIGroups:     []string{management.GroupName},
 		Verbs:         []string{manageNSVerb},
-		Resources:     []string{apisV3.ProjectResourceName},
+		Resources:     []string{v32.ProjectResourceName},
 		ResourceNames: []string{projectName},
 	})
 	if clusterRole.Annotations == nil {
 		clusterRole.Annotations = map[string]string{}
 	}
 	return clusterRole
+}
+
+func addUpdatePSAPermission(cr *rbacv1.ClusterRole, projectName string) *rbacv1.ClusterRole {
+	if cr.Rules == nil {
+		cr.Rules = []rbacv1.PolicyRule{}
+	}
+	cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
+		APIGroups:     []string{management.GroupName},
+		Verbs:         []string{updatePSAVerb},
+		Resources:     []string{v32.ProjectResourceName},
+		ResourceNames: []string{projectName},
+	})
+	if cr.Annotations == nil {
+		cr.Annotations = map[string]string{}
+	}
+	return cr
 }
 
 func crByNS(obj interface{}) ([]string, error) {

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -360,7 +360,7 @@ func TestCreateProjectNSRole(t *testing.T) {
 		m := newManager(withClusterRoles(clusterRoles, &clientErrs{createError: test.createError}))
 
 		roleName := fmt.Sprintf(projectNSGetClusterRoleNameFmt, test.projectName, projectNSVerbToSuffix[test.verb])
-		err := m.createProjectNSRole(roleName, test.verb, test.namespace, test.projectName)
+		err := m.createProjectNSRole(roleName, test.verb, test.namespace, test.projectName, false)
 
 		crMock := m.clusterRoles.(*fakes.ClusterRoleInterfaceMock)
 		calls := crMock.CreateCalls()

--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -11,7 +11,6 @@ import (
 	projectpkg "github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/settings"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -98,22 +97,6 @@ func isUpdatepsaAllowed(prt *v32.RoleTemplate, projectName string) bool {
 		},
 		prt.Rules...,
 	)
-}
-
-func addUpdatePSAPermission(cr *rbacv1.ClusterRole, projectName string) *rbacv1.ClusterRole {
-	if cr.Rules == nil {
-		cr.Rules = []rbacv1.PolicyRule{}
-	}
-	cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
-		APIGroups:     []string{management.GroupName},
-		Verbs:         []string{updatePSAVerb},
-		Resources:     []string{v32.ProjectResourceName},
-		ResourceNames: []string{projectName},
-	})
-	if cr.Annotations == nil {
-		cr.Annotations = map[string]string{}
-	}
-	return cr
 }
 
 func (p *pLifecycle) Updated(project *v3.Project) (runtime.Object, error) {

--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -82,6 +82,9 @@ func (p *pLifecycle) prtbLookup(projectName string) (*v32.RoleTemplate, error) {
 	if err != nil {
 		return nil, err
 	}
+	if roleTemplate.Context != "project" {
+		return nil, fmt.Errorf("roletemplate must have context of type 'project'")
+	}
 	return roleTemplate, nil
 }
 

--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -41,7 +41,7 @@ func (p *pLifecycle) Create(project *v3.Project) (runtime.Object, error) {
 		var psa bool
 		// here we ensure that the requisites to add updatepsa rule are met.
 		if suffix == projectNSVerbToSuffix[projectNSEditVerb] {
-			rt, err := p.prtbLookup(project.Name)
+			rt, err := p.rtLookup(project.Name)
 			if err != nil {
 				return project, err
 			}
@@ -58,8 +58,8 @@ func (p *pLifecycle) Create(project *v3.Project) (runtime.Object, error) {
 	return project, err
 }
 
-// prtbLookup retrieves the roletemplate associated with the given project.
-func (p *pLifecycle) prtbLookup(projectName string) (*v32.RoleTemplate, error) {
+// rtLookup retrieves the roletemplate associated with the given project.
+func (p *pLifecycle) rtLookup(projectName string) (*v32.RoleTemplate, error) {
 	prtbs, err := p.m.prtbLister.List(projectName, labels.Everything())
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/managementuser/rbac/project_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/project_handler_test.go
@@ -149,6 +149,7 @@ func TestCreate(t *testing.T) {
 									ObjectMeta: metav1.ObjectMeta{
 										Name: "special-project-role-template",
 									},
+									Context: "project",
 									Rules: []rbacv1.PolicyRule{
 										{
 											APIGroups:     []string{"management.cattle.io"},
@@ -163,6 +164,7 @@ func TestCreate(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Name: "special-project-role-template",
 								},
+								Context: "project",
 								Rules: []rbacv1.PolicyRule{
 									{
 										APIGroups:     []string{"management.cattle.io"},

--- a/pkg/controllers/managementuser/rbac/project_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/project_handler_test.go
@@ -125,14 +125,14 @@ func TestCreate(t *testing.T) {
 								return nil, test.getErr
 							}
 							return []*v3.ProjectRoleTemplateBinding{
-								&v3.ProjectRoleTemplateBinding{
+								{
 									ObjectMeta: metav1.ObjectMeta{
 										Name:      "creator-project-owner",
 										Namespace: projectName,
 									},
 									RoleTemplateName: "project-owner",
 								},
-								&v3.ProjectRoleTemplateBinding{
+								{
 									ObjectMeta: metav1.ObjectMeta{
 										Name:      "prtb-12345",
 										Namespace: projectName,


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48721
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Currently, updatepsa is only available to Cluster Roles and not Project Roles due to security concern. Customer wants the ability to assign this to a Project Role.
 
## Solution
Allow user to update PSA when admin grant access to do it.
This PR adds support for reading `updatepsa` from associated RoleTemplate and add an RBAC rule to allow the user to manage the PSA labels on namespaces.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
#### Prerequisites
Run rancher and use the modified version of the webhook [here](https://github.com/rancher/webhook/pull/798).

#### Steps
1. Create a standard user on rancher.
2. Apply the following `RoleTemplate` to the cluster:
```yaml
apiVersion: management.cattle.io/v3
builtin: false
context: project
description: this is a test
displayName: UpdatePSA
external: false
hidden: false
kind: RoleTemplate
metadata:
  name: project-role-template
rules:
  - apiGroups:
      - management.cattle.io
    resources:
      - projects
    verbs:
      - updatepsa
```
3. Create a new Project named: `pr-without-psa`, binding the user to have "Member" role.
4. Create a new Project named: `pr-with-psa`, binding the user to have "UpdatePSA" role.
5. Create a namespace within the `pr-without-psa` project (this should work).
6. Create a namespace within the `pr-without-psa` project, by selecting 'Enforce' on 'Pod Security Admission' (this shouldn't work - because the user has Member permissions).
7. Create a namespace within the `pr-with-psa` project (this should work).
8. Create a namespace within the `pr-with-psa` project, by selecting 'Enforce' on 'Pod Security Admission' (this should work - because the user has UpdatePSA permissions).
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_