### PR TITLE
[DNM] Add a regex checker for listing tokens

### DIFF
--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -178,6 +178,7 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 		return nil, err
 	}
 
+	logrus.Info("*** refreshAttributes ***")
 	allExtTokens, err := r.extTokenStore.ListForUser(user.Name)
 	if err != nil {
 		return nil, err

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -230,6 +230,7 @@ func (m *Manager) getTokens(tokenAuthValue string) ([]v3.Token, int, error) {
 	}
 
 	userID := storedToken.UserID
+	logrus.Info(fmt.Sprintf("TEST - getTokens - username: %s", userID))
 	set := labels.Set(map[string]string{UserIDLabel: userID})
 	tokenList, err := m.tokensClient.List(metav1.ListOptions{LabelSelector: set.AsSelector().String()})
 	if err != nil {

--- a/pkg/controllers/management/auth/user.go
+++ b/pkg/controllers/management/auth/user.go
@@ -354,6 +354,7 @@ func (l *userLifecycle) getTokensByUserName(username string) ([]*v3.Token, error
 }
 
 func (l *userLifecycle) getExtTokensByUserName(userName string) ([]*ext.Token, error) {
+	logrus.Info("*** getExtTokensByUserName ***")
 	objs, err := l.extTokenStore.ListForUser(userName)
 	if err != nil {
 		return nil, fmt.Errorf("error getting ext tokens for user %s: %v", userName, err)

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -59,6 +60,9 @@ const (
 
 	SingularName = "token"
 	PluralName   = SingularName + "s"
+
+	// REGEX for labels
+	labelRegex = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
 )
 
 var GV = schema.GroupVersion{
@@ -559,6 +563,11 @@ func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.Tok
 // ListForUser returns the set of token owned by the named user. It is an
 // internal call invoked by other parts of Rancher
 func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
+	matched, _ := regexp.Match(labelRegex, []byte(userName))
+	if !matched {
+		return &ext.TokenList{}, nil
+	}
+
 	// As internal call this method can use the cache of secrets.
 	// Query the cache using a proper label selector
 	secrets, err := t.secretCache.List(TokenNamespace, labels.Set(map[string]string{

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -599,6 +599,10 @@ func (t *SystemStore) list(isAdmin bool, userName, sessionID string, options *me
 	// Non-system requests always filter the tokens down to those of the current user.
 	// Merge our own selection request (user match!) into the caller's demands
 	logrus.Info(fmt.Sprintf("TEST - list username: %s", userName))
+	matched, _ := regexp.MatchString(labelRegex, userName)
+	if !matched {
+		return &ext.TokenList{}, nil
+	}
 	localOptions, err := ListOptionMerge(isAdmin, userName, options)
 	if err != nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to process list options: %w", err))
@@ -814,6 +818,10 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 	}
 
 	logrus.Info(fmt.Sprintf("TEST  - watch username: %s", userName))
+	matched, _ := regexp.MatchString(labelRegex, userName)
+	if !matched {
+		return consumer, nil
+	}
 	localOptions, err := ListOptionMerge(isAdmin, userName, options)
 	if err != nil {
 		return nil,

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -22,6 +22,7 @@ import (
 	extcore "github.com/rancher/steve/pkg/ext"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -563,6 +564,7 @@ func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.Tok
 // ListForUser returns the set of token owned by the named user. It is an
 // internal call invoked by other parts of Rancher
 func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
+	logrus.Info(fmt.Sprintf("TEST --- username: %s", userName))
 	matched, _ := regexp.Match(labelRegex, []byte(userName))
 	if !matched {
 		return &ext.TokenList{}, nil

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -598,6 +598,7 @@ func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
 func (t *SystemStore) list(isAdmin bool, userName, sessionID string, options *metav1.ListOptions) (*ext.TokenList, error) {
 	// Non-system requests always filter the tokens down to those of the current user.
 	// Merge our own selection request (user match!) into the caller's demands
+	logrus.Info(fmt.Sprintf("TEST - list username: %s", userName))
 	localOptions, err := ListOptionMerge(isAdmin, userName, options)
 	if err != nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to process list options: %w", err))
@@ -812,6 +813,7 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 		ch: make(chan watch.Event, 100),
 	}
 
+	logrus.Info(fmt.Sprintf("TEST  - watch username: %s", userName))
 	localOptions, err := ListOptionMerge(isAdmin, userName, options)
 	if err != nil {
 		return nil,


### PR DESCRIPTION
The integration tests are failing because there's an attempt at listing tokens for a service account, which is not allowed because it has a `:` in the name.

Strictly for testing, DO NOT MERGE