### PR TITLE
Decrease `rancher/rancher` image size from `2.3 GB` to `1.6GB`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -255,7 +255,7 @@ ARG COMMIT
 ARG RKE_VERSION
 ARG CGO_ENABLED=0
 ARG TAGS="k8s"
-ARG LINKFLAGS="-extldflags -static"
+ARG LINKFLAGS="-extldflags -static -s"
 ARG DEFAULT_VALUES="{\"rke-version\":\"${RKE_VERSION}\"}"
 ARG LDFLAGS="-X github.com/rancher/rancher/pkg/version.Version=${VERSION} -X github.com/rancher/rancher/pkg/version.GitCommit=${COMMIT} -X github.com/rancher/rancher/pkg/settings.InjectDefaults=${DEFAULT_VALUES} ${LINKFLAGS}"
 ARG TARGETOS

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -107,9 +107,9 @@ RUN mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
     # in git.rancher.io
     git config --global url."https://github.com/rancher/".insteadOf https://git.rancher.io/ && \
     # Charts need to be copied into the sha256 value of git url computed in https://github.com/rancher/rancher/blob/5ebda9ac23c06e9647b586ec38aa51cc9ff9b031/pkg/catalogv2/git/download.go#L102 to create a unique folder per url
-    git clone -b $CATTLE_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/charts /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/ && \
-    git clone -b $CATTLE_PARTNER_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974 && \
-    git clone -b $CATTLE_RKE2_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 && \
+    git clone --no-checkout -b $CATTLE_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/charts /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/ && \
+    git clone --no-checkout -b $CATTLE_PARTNER_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974 && \
+    git clone --no-checkout -b $CATTLE_RKE2_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 && \
     # Revert the previous change in git.rancher.io from .gitconfig
     rm "${HOME}/.gitconfig"
 

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -9,7 +9,7 @@ FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS build
 ARG VERSION=${VERSION}
 ARG CGO_ENABLED=0
 ARG TAGS="k8s"
-ARG LINKFLAGS="-extldflags -static"
+ARG LINKFLAGS="-extldflags -static -s"
 ARG LDFLAGS="-X main.VERSION=${VERSION} $LINKFLAGS"
 ARG TARGETOS
 ARG TARGETARCH

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -7,6 +7,13 @@ if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; the
     exit 1
 fi
 
+git_dirs=$(find /var/lib/rancher-data/local-catalogs -type d -name '.git')
+echo "Restoring git repositories: "
+for dir in ${git_dirs[@]}; do
+  echo "- ${dir}"
+  cd "${dir}/.." && git checkout HEAD && cd -
+done
+
 #########################################################################################################################################
 # DISCLAIMER                                                                                                                            #
 # Copied from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37                              #


### PR DESCRIPTION
Decrease the generated `rancher/rancher` image size from `2.3 GB` to `1.6GB`.
The commits should be self-explanatory, but from a high-level:
- Rancher binary debug symbols were removed  (13MB saving).
- The git worktrees for all cloned repositories are being lazy-loaded (~600MB saving).
- The image now only has the dotgit store data, and creates each worktree on first load.

**Latest from `main`**
![image](https://github.com/user-attachments/assets/a6748dfa-e01a-4068-8099-efd7b933f402)

**Latest from `main` + these changes**
![image](https://github.com/user-attachments/assets/8b105ab7-c599-490d-a170-9b80d7bb60b8)

Follow-up from https://github.com/rancher/rancher/pull/45802.