### PR TITLE
[main] Bump `rancher-wins` to `v0.5.0`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -65,7 +65,7 @@ ENV LINODE_UI_DRIVER_VERSION v0.7.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
 ENV DOCKER_MACHINE_HARVESTER_VERSION v1.0.2
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
-ENV CATTLE_WINS_AGENT_VERSION v0.5.0-rc.2
+ENV CATTLE_WINS_AGENT_VERSION v0.5.0
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}

--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -17,7 +17,7 @@ RUN go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o agent.exe ./cmd/agent
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION} AS builder
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.5.0-rc.2/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.5.0/wins.exe'; \
     \
     Write-Host ('Downloading Wins from {0} ...' -f $URL); \
     curl.exe -sfL $URL -o c:\wins.exe; \

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -104,7 +104,7 @@ var (
 	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
 	CSIProxyAgentURL                    = NewSetting("csi-proxy-agent-url", "https://acs-mirror.azureedge.net/csi-proxy/%[1]s/binaries/csi-proxy-%[1]s.tar.gz")
 	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://github.com/rancher/system-agent/releases/download/v0.3.12/install.sh") // To ensure consistency between SystemAgentInstallScript default value and CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT to utilize the local system-agent-install.sh script when both values are equal.
-	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.5.0-rc.2/install.ps1")
+	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.5.0/install.ps1")
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "") // Defined via environment variable
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")   // Defined via environment variable
 	WinsAgentUpgradeImage               = NewSetting("wins-agent-upgrade-image", "")

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -60,7 +60,7 @@ ENV LINODE_UI_DRIVER_VERSION v0.7.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
 ENV DOCKER_MACHINE_HARVESTER_VERSION v0.6.7
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
-ENV CATTLE_WINS_AGENT_VERSION v0.5.0-rc.2
+ENV CATTLE_WINS_AGENT_VERSION v0.5.0
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}


### PR DESCRIPTION
This PR bumps wins from `v0.5.0-rc.2` to the release `v0.5.0`. `v0.5.0` was already released with rancher `v2.10.2`, and uses the same commit as `v0.5.0-rc.2`.