### PR TITLE
fix garbage collection broken by ext tokens?

### DIFF
--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -21,6 +21,7 @@ import (
 	extcore "github.com/rancher/steve/pkg/ext"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -225,6 +226,8 @@ func (t *Store) Create(
 	obj runtime.Object,
 	createValidation rest.ValidateObjectFunc,
 	options *metav1.CreateOptions) (runtime.Object, error) {
+	logrus.Debug("ext.cattle.io/token create")
+
 	if createValidation != nil {
 		err := createValidation(ctx, obj)
 		if err != nil {
@@ -250,6 +253,8 @@ func (t *Store) Delete(
 	name string,
 	deleteValidation rest.ValidateObjectFunc,
 	options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	logrus.Debugf("ext.cattle.io/token delete [%s]", name)
+
 	// locate resource first
 	obj, err := t.get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
@@ -279,6 +284,8 @@ func (t *Store) Get(
 	ctx context.Context,
 	name string,
 	options *metav1.GetOptions) (runtime.Object, error) {
+	logrus.Debugf("ext.cattle.io/token get [%s]", name)
+
 	return t.get(ctx, name, options)
 }
 
@@ -294,6 +301,8 @@ func (t *Store) NewList() runtime.Object {
 func (t *Store) List(
 	ctx context.Context,
 	internaloptions *metainternalversion.ListOptions) (runtime.Object, error) {
+	logrus.Debug("ext.cattle.io/token list")
+
 	options, err := extcore.ConvertListOptions(internaloptions)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
@@ -320,6 +329,8 @@ func (t *Store) Update(
 	updateValidation rest.ValidateObjectUpdateFunc,
 	forceAllowCreate bool,
 	options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	logrus.Debugf("ext.cattle.io/token update [%s]", name)
+
 	return extcore.CreateOrUpdate(ctx, name, objInfo, createValidation,
 		updateValidation, forceAllowCreate, options,
 		t.get, t.create, t.update)
@@ -329,6 +340,8 @@ func (t *Store) Update(
 func (t *Store) Watch(
 	ctx context.Context,
 	internaloptions *metainternalversion.ListOptions) (watch.Interface, error) {
+	logrus.Debug("ext.cattle.io/token watch")
+
 	options, err := extcore.ConvertListOptions(internaloptions)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
@@ -338,6 +351,8 @@ func (t *Store) Watch(
 
 // create implements the core resource creation for tokens
 func (t *Store) create(ctx context.Context, token *ext.Token, options *metav1.CreateOptions) (*ext.Token, error) {
+	logrus.Debugf("ext.cattle.io/token /create [%s]", token.Name)
+
 	userName, _, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore)
 	if err != nil {
 		return nil, err
@@ -353,6 +368,8 @@ func (t *Store) create(ctx context.Context, token *ext.Token, options *metav1.Cr
 }
 
 func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, token *ext.Token, options *metav1.CreateOptions) (*ext.Token, error) {
+	logrus.Debugf("ext.cattle.io/token sys.create [%s]", token.Name)
+
 	// check if the user does not wish to actually change anything
 	dryRun := options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll
 
@@ -474,6 +491,8 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 
 // delete implements the core resource destruction for tokens
 func (t *Store) delete(ctx context.Context, token *ext.Token, options *metav1.DeleteOptions) error {
+	logrus.Debugf("ext.cattle.io/token /delete [%s]", token.Name)
+
 	user, isAdmin, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore)
 	if err != nil {
 		return err
@@ -486,6 +505,8 @@ func (t *Store) delete(ctx context.Context, token *ext.Token, options *metav1.De
 }
 
 func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
+	logrus.Debugf("ext.cattle.io/token sys.delete [%s]", name)
+
 	err := t.secretClient.Delete(TokenNamespace, name, options)
 	if err == nil {
 		return nil
@@ -498,6 +519,8 @@ func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
 
 // get implements the core resource retrieval for tokens
 func (t *Store) get(ctx context.Context, name string, options *metav1.GetOptions) (*ext.Token, error) {
+	logrus.Debugf("ext.cattle.io/token /get [%s]", name)
+
 	userName, isAdmin, _, err := t.auth.UserName(ctx, &t.SystemStore)
 	if err != nil {
 		return nil, err
@@ -520,6 +543,8 @@ func (t *Store) get(ctx context.Context, name string, options *metav1.GetOptions
 }
 
 func (t *SystemStore) Get(name, sessionID string, options *metav1.GetOptions) (*ext.Token, error) {
+	logrus.Debugf("ext.cattle.io/token sys.get [%s] (%s)", name, sessionID)
+
 	// Core token retrieval from backing secrets
 	// We try to go through the fast cache as much as we can.
 	var err error
@@ -548,6 +573,8 @@ func (t *SystemStore) Get(name, sessionID string, options *metav1.GetOptions) (*
 
 // list implements the core resource listing of tokens
 func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.TokenList, error) {
+	logrus.Debug("ext.cattle.io/token /list")
+
 	userName, isAdmin, _, err := t.auth.UserName(ctx, &t.SystemStore)
 	if err != nil {
 		return nil, err
@@ -559,6 +586,8 @@ func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.Tok
 // ListForUser returns the set of token owned by the named user. It is an
 // internal call invoked by other parts of Rancher
 func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
+	logrus.Debugf("ext.cattle.io/token sys.list-for-user [%s]", userName)
+
 	// As internal call this method can use the cache of secrets.
 	// Query the cache using a proper label selector
 	secrets, err := t.secretCache.List(TokenNamespace, labels.Set(map[string]string{
@@ -585,22 +614,27 @@ func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
 }
 
 func (t *SystemStore) list(isAdmin bool, userName, sessionID string, options *metav1.ListOptions) (*ext.TokenList, error) {
+	logrus.Debugf("ext.cattle.io/token sys.list admin=%v [%s]", isAdmin, sessionID)
+
 	// Non-system requests always filter the tokens down to those of the current user.
 	// Merge our own selection request (user match!) into the caller's demands
 	localOptions, err := ListOptionMerge(isAdmin, userName, options)
 	if err != nil {
+		logrus.Errorf("ext.cattle.io/token sys.list admin=%v [%s] merge error: %v", isAdmin, sessionID, err)
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to process list options: %w", err))
 	}
 	empty := metav1.ListOptions{}
 	if localOptions == empty {
 		// The setup indicated that we can bail out. I.e the
 		// options ask for something which cannot match.
+		logrus.Debugf("ext.cattle.io/token sys.list admin=%v [%s] quick empty", isAdmin, sessionID)
 		return &ext.TokenList{}, nil
 	}
 
 	// Core token listing from backing secrets
 	secrets, err := t.secretClient.List(TokenNamespace, localOptions)
 	if err != nil {
+		logrus.Errorf("ext.cattle.io/token sys.list admin=%v [%s] list error: %v", isAdmin, sessionID, err)
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", err))
 	}
 
@@ -616,6 +650,8 @@ func (t *SystemStore) list(isAdmin bool, userName, sessionID string, options *me
 		token.Status.Current = token.Name == sessionID
 		tokens = append(tokens, *token)
 	}
+
+	logrus.Debugf("ext.cattle.io/token sys.list admin=%v [%s] reporting %d", isAdmin, sessionID, len(tokens))
 	return &ext.TokenList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: secrets.ResourceVersion,
@@ -626,6 +662,8 @@ func (t *SystemStore) list(isAdmin bool, userName, sessionID string, options *me
 
 // update implements the core resource updating/modification of tokens
 func (t *Store) update(ctx context.Context, token *ext.Token, options *metav1.UpdateOptions) (*ext.Token, error) {
+	logrus.Debugf("ext.cattle.io/token /update [%s]", token.Name)
+
 	user, _, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore)
 	if err != nil {
 		return nil, err
@@ -645,6 +683,8 @@ func (t *SystemStore) Update(token *ext.Token, options *metav1.UpdateOptions) (*
 
 func (t *SystemStore) update(sessionID string, fullPermission bool, token *ext.Token,
 	options *metav1.UpdateOptions) (*ext.Token, error) {
+	logrus.Debugf("ext.cattle.io/token sys.update [%s] full=%v", sessionID, fullPermission)
+
 	// check if the user does not wish to actually change anything
 	dryRun := options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll
 
@@ -725,6 +765,8 @@ func (t *SystemStore) update(sessionID string, fullPermission bool, token *ext.T
 // UpdateLastUsedAt patches the last-used-at information of the token.
 // Called during authentication.
 func (t *SystemStore) UpdateLastUsedAt(name string, now time.Time) error {
+	logrus.Debugf("ext.cattle.io/token sys.update-last-used-at [%s]", name)
+
 	// Operate directly on the backend secret holding the token
 	nowEncoded := base64.StdEncoding.EncodeToString([]byte(now.Format(time.RFC3339)))
 	patch, err := json.Marshal([]struct {
@@ -747,6 +789,8 @@ func (t *SystemStore) UpdateLastUsedAt(name string, now time.Time) error {
 // UpdateLastActivitySeen patches the last-activity-seen information of the token.
 // Called from the ext user activity store.
 func (t *SystemStore) UpdateLastActivitySeen(name string, now time.Time) error {
+	logrus.Debugf("ext.cattle.io/token sys.update-last-activity-seen [%s]", name)
+
 	// Operate directly on the backend secret holding the token
 	nowEncoded := base64.StdEncoding.EncodeToString([]byte(now.Format(time.RFC3339)))
 	patch, err := json.Marshal([]struct {
@@ -769,6 +813,8 @@ func (t *SystemStore) UpdateLastActivitySeen(name string, now time.Time) error {
 // Disable patches the enabled flag of the token.
 // Called by refreshAttributes.
 func (t *SystemStore) Disable(name string) error {
+	logrus.Debugf("ext.cattle.io/token sys.disable [%s]", name)
+
 	// Operate directly on the backend secret holding the token
 	patch, err := json.Marshal([]struct {
 		Op    string `json:"op"`
@@ -789,6 +835,8 @@ func (t *SystemStore) Disable(name string) error {
 
 // watch implements the core resource watcher for tokens
 func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.Interface, error) {
+	logrus.Debug("ext.cattle.io/token /watch")
+
 	userName, isAdmin, _, err := t.auth.UserName(ctx, &t.SystemStore)
 	if err != nil {
 		return nil, err
@@ -1025,6 +1073,7 @@ func (tp *tokenHasher) MakeAndHashSecret() (string, string, error) {
 func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore) (string, bool, bool, error) {
 	userInfo, ok := request.UserFrom(ctx)
 	if !ok {
+		logrus.Errorf("ext.cattle.io/token username: context has no user info")
 		return "", false, false, apierrors.NewInternalError(fmt.Errorf("context has no user info"))
 	}
 
@@ -1035,6 +1084,7 @@ func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore) (string, 
 		ResourceRequest: true,
 	})
 	if err != nil {
+		logrus.Errorf("ext.cattle.io/token username: authorization error: %v", err)
 		return "", false, false, err
 	}
 	isAdmin := decision == authorizer.DecisionAllow
@@ -1043,17 +1093,20 @@ func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore) (string, 
 	userName := userInfo.GetName()
 	if !strings.Contains(userName, ":") { // E.g. system:admin
 		// potentially a rancher user
+		logrus.Debugf("ext.cattle.io/token username: %s, check in rancher", userName)
 		_, err := store.userClient.Get(userName)
 		if err == nil {
 			// definitely a rancher user
 			isRancherUser = true
 		} else if !apierrors.IsNotFound(err) {
+			logrus.Errorf("ext.cattle.io/token username: user retrieval error: %v", err)
 			// some general error
 			return "", false, false,
 				apierrors.NewInternalError(fmt.Errorf("error getting user %s: %w", userName, err))
 		} // else: not a rancher user, may still be an admin
 	} // else: some system user, not a rancher user, may still be an admin
 
+	logrus.Debugf("ext.cattle.io/token username: %s admin=%v rancher=%v", userName, isAdmin, isRancherUser)
 	return userName, isAdmin, isRancherUser, nil
 }
 

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1088,9 +1088,15 @@ func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore) (string, 
 		return "", false, false, err
 	}
 	isAdmin := decision == authorizer.DecisionAllow
-
 	isRancherUser := false
 	userName := userInfo.GetName()
+
+	// Treat user responsible for kube garbage collection as admin, i.e. let
+	// it see all, no restrictions
+	if userName == "system:kube-controller-manager" {
+		isAdmin = true
+	}
+
 	if !strings.Contains(userName, ":") { // E.g. system:admin
 		// potentially a rancher user
 		logrus.Debugf("ext.cattle.io/token username: %s, check in rancher", userName)

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -21,7 +21,6 @@ import (
 	extcore "github.com/rancher/steve/pkg/ext"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -226,8 +225,6 @@ func (t *Store) Create(
 	obj runtime.Object,
 	createValidation rest.ValidateObjectFunc,
 	options *metav1.CreateOptions) (runtime.Object, error) {
-	logrus.Debug("ext.cattle.io/token create")
-
 	if createValidation != nil {
 		err := createValidation(ctx, obj)
 		if err != nil {
@@ -253,8 +250,6 @@ func (t *Store) Delete(
 	name string,
 	deleteValidation rest.ValidateObjectFunc,
 	options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	logrus.Debugf("ext.cattle.io/token delete [%s]", name)
-
 	// locate resource first
 	obj, err := t.get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
@@ -284,8 +279,6 @@ func (t *Store) Get(
 	ctx context.Context,
 	name string,
 	options *metav1.GetOptions) (runtime.Object, error) {
-	logrus.Debugf("ext.cattle.io/token get [%s]", name)
-
 	return t.get(ctx, name, options)
 }
 
@@ -301,8 +294,6 @@ func (t *Store) NewList() runtime.Object {
 func (t *Store) List(
 	ctx context.Context,
 	internaloptions *metainternalversion.ListOptions) (runtime.Object, error) {
-	logrus.Debug("ext.cattle.io/token list")
-
 	options, err := extcore.ConvertListOptions(internaloptions)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
@@ -329,8 +320,6 @@ func (t *Store) Update(
 	updateValidation rest.ValidateObjectUpdateFunc,
 	forceAllowCreate bool,
 	options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	logrus.Debugf("ext.cattle.io/token update [%s]", name)
-
 	return extcore.CreateOrUpdate(ctx, name, objInfo, createValidation,
 		updateValidation, forceAllowCreate, options,
 		t.get, t.create, t.update)
@@ -340,8 +329,6 @@ func (t *Store) Update(
 func (t *Store) Watch(
 	ctx context.Context,
 	internaloptions *metainternalversion.ListOptions) (watch.Interface, error) {
-	logrus.Debug("ext.cattle.io/token watch")
-
 	options, err := extcore.ConvertListOptions(internaloptions)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
@@ -351,8 +338,6 @@ func (t *Store) Watch(
 
 // create implements the core resource creation for tokens
 func (t *Store) create(ctx context.Context, token *ext.Token, options *metav1.CreateOptions) (*ext.Token, error) {
-	logrus.Debugf("ext.cattle.io/token /create [%s]", token.Name)
-
 	userName, _, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore, "create")
 	if err != nil {
 		return nil, err
@@ -368,8 +353,6 @@ func (t *Store) create(ctx context.Context, token *ext.Token, options *metav1.Cr
 }
 
 func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, token *ext.Token, options *metav1.CreateOptions) (*ext.Token, error) {
-	logrus.Debugf("ext.cattle.io/token sys.create [%s]", token.Name)
-
 	// check if the user does not wish to actually change anything
 	dryRun := options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll
 
@@ -491,8 +474,6 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 
 // delete implements the core resource destruction for tokens
 func (t *Store) delete(ctx context.Context, token *ext.Token, options *metav1.DeleteOptions) error {
-	logrus.Debugf("ext.cattle.io/token /delete [%s]", token.Name)
-
 	user, fullAccess, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore, "delete")
 	if err != nil {
 		return err
@@ -505,8 +486,6 @@ func (t *Store) delete(ctx context.Context, token *ext.Token, options *metav1.De
 }
 
 func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
-	logrus.Debugf("ext.cattle.io/token sys.delete [%s]", name)
-
 	err := t.secretClient.Delete(TokenNamespace, name, options)
 	if err == nil {
 		return nil
@@ -519,8 +498,6 @@ func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
 
 // get implements the core resource retrieval for tokens
 func (t *Store) get(ctx context.Context, name string, options *metav1.GetOptions) (*ext.Token, error) {
-	logrus.Debugf("ext.cattle.io/token /get [%s]", name)
-
 	userName, fullAccess, _, err := t.auth.UserName(ctx, &t.SystemStore, "get")
 	if err != nil {
 		return nil, err
@@ -543,8 +520,6 @@ func (t *Store) get(ctx context.Context, name string, options *metav1.GetOptions
 }
 
 func (t *SystemStore) Get(name, sessionID string, options *metav1.GetOptions) (*ext.Token, error) {
-	logrus.Debugf("ext.cattle.io/token sys.get [%s] (%s)", name, sessionID)
-
 	// Core token retrieval from backing secrets
 	// We try to go through the fast cache as much as we can.
 	var err error
@@ -573,8 +548,6 @@ func (t *SystemStore) Get(name, sessionID string, options *metav1.GetOptions) (*
 
 // list implements the core resource listing of tokens
 func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.TokenList, error) {
-	logrus.Debug("ext.cattle.io/token /list")
-
 	userName, fullAccess, _, err := t.auth.UserName(ctx, &t.SystemStore, "list")
 	if err != nil {
 		return nil, err
@@ -586,8 +559,6 @@ func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.Tok
 // ListForUser returns the set of token owned by the named user. It is an
 // internal call invoked by other parts of Rancher
 func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
-	logrus.Debugf("ext.cattle.io/token sys.list-for-user [%s]", userName)
-
 	// As internal call this method can use the cache of secrets.
 	// Query the cache using a proper label selector
 	secrets, err := t.secretCache.List(TokenNamespace, labels.Set(map[string]string{
@@ -614,27 +585,22 @@ func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
 }
 
 func (t *SystemStore) list(fullAccess bool, userName, sessionID string, options *metav1.ListOptions) (*ext.TokenList, error) {
-	logrus.Debugf("ext.cattle.io/token sys.list full=%v [%s]", fullAccess, sessionID)
-
 	// Non-system requests always filter the tokens down to those of the current user.
 	// Merge our own selection request (user match!) into the caller's demands
 	localOptions, err := ListOptionMerge(fullAccess, userName, options)
 	if err != nil {
-		logrus.Errorf("ext.cattle.io/token sys.list full=%v [%s] merge error: %v", fullAccess, sessionID, err)
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to process list options: %w", err))
 	}
 	empty := metav1.ListOptions{}
 	if localOptions == empty {
 		// The setup indicated that we can bail out. I.e the
 		// options ask for something which cannot match.
-		logrus.Debugf("ext.cattle.io/token sys.list full=%v [%s] quick empty", fullAccess, sessionID)
 		return &ext.TokenList{}, nil
 	}
 
 	// Core token listing from backing secrets
 	secrets, err := t.secretClient.List(TokenNamespace, localOptions)
 	if err != nil {
-		logrus.Errorf("ext.cattle.io/token sys.list full=%v [%s] list error: %v", fullAccess, sessionID, err)
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", err))
 	}
 
@@ -651,7 +617,6 @@ func (t *SystemStore) list(fullAccess bool, userName, sessionID string, options 
 		tokens = append(tokens, *token)
 	}
 
-	logrus.Debugf("ext.cattle.io/token sys.list full=%v [%s] reporting %d", fullAccess, sessionID, len(tokens))
 	return &ext.TokenList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: secrets.ResourceVersion,
@@ -662,8 +627,6 @@ func (t *SystemStore) list(fullAccess bool, userName, sessionID string, options 
 
 // update implements the core resource updating/modification of tokens
 func (t *Store) update(ctx context.Context, token *ext.Token, options *metav1.UpdateOptions) (*ext.Token, error) {
-	logrus.Debugf("ext.cattle.io/token /update [%s]", token.Name)
-
 	user, _, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore, "update")
 	if err != nil {
 		return nil, err
@@ -683,8 +646,6 @@ func (t *SystemStore) Update(token *ext.Token, options *metav1.UpdateOptions) (*
 
 func (t *SystemStore) update(sessionID string, fullPermission bool, token *ext.Token,
 	options *metav1.UpdateOptions) (*ext.Token, error) {
-	logrus.Debugf("ext.cattle.io/token sys.update [%s] full=%v", sessionID, fullPermission)
-
 	// check if the user does not wish to actually change anything
 	dryRun := options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll
 
@@ -765,8 +726,6 @@ func (t *SystemStore) update(sessionID string, fullPermission bool, token *ext.T
 // UpdateLastUsedAt patches the last-used-at information of the token.
 // Called during authentication.
 func (t *SystemStore) UpdateLastUsedAt(name string, now time.Time) error {
-	logrus.Debugf("ext.cattle.io/token sys.update-last-used-at [%s]", name)
-
 	// Operate directly on the backend secret holding the token
 	nowEncoded := base64.StdEncoding.EncodeToString([]byte(now.Format(time.RFC3339)))
 	patch, err := json.Marshal([]struct {
@@ -789,8 +748,6 @@ func (t *SystemStore) UpdateLastUsedAt(name string, now time.Time) error {
 // UpdateLastActivitySeen patches the last-activity-seen information of the token.
 // Called from the ext user activity store.
 func (t *SystemStore) UpdateLastActivitySeen(name string, now time.Time) error {
-	logrus.Debugf("ext.cattle.io/token sys.update-last-activity-seen [%s]", name)
-
 	// Operate directly on the backend secret holding the token
 	nowEncoded := base64.StdEncoding.EncodeToString([]byte(now.Format(time.RFC3339)))
 	patch, err := json.Marshal([]struct {
@@ -813,8 +770,6 @@ func (t *SystemStore) UpdateLastActivitySeen(name string, now time.Time) error {
 // Disable patches the enabled flag of the token.
 // Called by refreshAttributes.
 func (t *SystemStore) Disable(name string) error {
-	logrus.Debugf("ext.cattle.io/token sys.disable [%s]", name)
-
 	// Operate directly on the backend secret holding the token
 	patch, err := json.Marshal([]struct {
 		Op    string `json:"op"`
@@ -835,8 +790,6 @@ func (t *SystemStore) Disable(name string) error {
 
 // watch implements the core resource watcher for tokens
 func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.Interface, error) {
-	logrus.Debug("ext.cattle.io/token /watch")
-
 	userName, fullAccess, _, err := t.auth.UserName(ctx, &t.SystemStore, "watch")
 	if err != nil {
 		return nil, err
@@ -1073,7 +1026,6 @@ func (tp *tokenHasher) MakeAndHashSecret() (string, string, error) {
 func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore, verb string) (string, bool, bool, error) {
 	userInfo, ok := request.UserFrom(ctx)
 	if !ok {
-		logrus.Error("ext.cattle.io/token username: context has no user info")
 		return "", false, false, apierrors.NewInternalError(fmt.Errorf("context has no user info"))
 	}
 
@@ -1084,7 +1036,6 @@ func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore, verb stri
 		ResourceRequest: true,
 	})
 	if err != nil {
-		logrus.Errorf("ext.cattle.io/token username: authorization error: %v", err)
 		return "", false, false, err
 	}
 
@@ -1095,20 +1046,17 @@ func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore, verb stri
 
 	if !strings.Contains(userName, ":") { // E.g. system:admin
 		// potentially a rancher user
-		logrus.Debugf("ext.cattle.io/token username: %s, check in rancher", userName)
 		_, err := store.userClient.Get(userName)
 		if err == nil {
 			// definitely a rancher user
 			isRancherUser = true
 		} else if !apierrors.IsNotFound(err) {
-			logrus.Errorf("ext.cattle.io/token username: user retrieval error: %v", err)
 			// some general error
 			return "", false, false,
 				apierrors.NewInternalError(fmt.Errorf("error getting user %s: %w", userName, err))
 		} // else: not a rancher user, may still be an admin
 	} // else: some system user, not a rancher user, may still be an admin
 
-	logrus.Debugf("ext.cattle.io/token username: %s full=%v rancher=%v", userName, fullAccess, isRancherUser)
 	return userName, fullAccess, isRancherUser, nil
 }
 

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -184,7 +184,7 @@ func Test_Store_Delete(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("laber", false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
@@ -208,7 +208,7 @@ func Test_Store_Delete(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("laber", false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
@@ -230,7 +230,7 @@ func Test_Store_Delete(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		users.EXPECT().Cache().Return(nil)
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("", false, false, apierrors.NewInternalError(invalidContext))
 		secrets.EXPECT().Cache().Return(nil)
 
@@ -249,7 +249,7 @@ func Test_Store_Delete(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdl/ksjlkds", false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
@@ -272,7 +272,7 @@ func Test_Store_Delete(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil).Times(2)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
@@ -303,7 +303,7 @@ func Test_Store_Get(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdl/ksjlkds", false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
@@ -326,7 +326,7 @@ func Test_Store_Get(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
@@ -349,7 +349,7 @@ func Test_Store_Get(t *testing.T) {
 		auth := NewMockauthHandler(ctrl)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("bogus")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
@@ -377,7 +377,7 @@ func Test_Store_Update(t *testing.T) {
 
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdl/ksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -401,7 +401,7 @@ func Test_Store_Update(t *testing.T) {
 
 		users.EXPECT().Cache().Return(nil)
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 		secrets.EXPECT().Cache().Return(scache)
 		scache.EXPECT().
@@ -453,7 +453,7 @@ func Test_Store_Watch(t *testing.T) {
 			Return(nil, someerror)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -476,7 +476,7 @@ func Test_Store_Watch(t *testing.T) {
 			Return(NewWatcher(), nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 
 		todo, cancel := context.WithCancel(context.TODO())
@@ -511,7 +511,7 @@ func Test_Store_Watch(t *testing.T) {
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -544,7 +544,7 @@ func Test_Store_Watch(t *testing.T) {
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -577,7 +577,7 @@ func Test_Store_Watch(t *testing.T) {
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -612,7 +612,7 @@ func Test_Store_Watch(t *testing.T) {
 		}).Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdl/ksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -645,7 +645,7 @@ func Test_Store_Watch(t *testing.T) {
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -683,7 +683,7 @@ func Test_Store_Watch(t *testing.T) {
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("bogus")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("lkajdlksjlkds", false, true, nil)
 
 		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
@@ -740,7 +740,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("lkajdlksjlkds", false, true, nil)
 			},
 		},
@@ -759,7 +759,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				space.EXPECT().Create(gomock.Any()).
@@ -785,7 +785,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				space.EXPECT().Create(gomock.Any()).
@@ -818,7 +818,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				space.EXPECT().Create(gomock.Any()).
@@ -853,7 +853,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				space.EXPECT().Create(gomock.Any()).
@@ -890,7 +890,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				// fail fetch of session token, v3 and ext
@@ -933,7 +933,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				// session token fetch for user principal
@@ -980,7 +980,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				// session token fetch for user principal
@@ -1037,7 +1037,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				// session token fetch for user principal
@@ -1094,7 +1094,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				// session token fetch for user principal
@@ -1159,7 +1159,7 @@ func Test_Store_Create(t *testing.T) {
 				hasher *MockhashHandler,
 				auth *MockauthHandler) {
 
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any()).
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("world", false, true, nil)
 
 				// session token fetch for user principal

--- a/pkg/ext/stores/tokens/zz_token_fakes.go
+++ b/pkg/ext/stores/tokens/zz_token_fakes.go
@@ -130,9 +130,9 @@ func (mr *MockauthHandlerMockRecorder) SessionID(ctx any) *gomock.Call {
 }
 
 // UserName mocks base method.
-func (m *MockauthHandler) UserName(ctx context.Context, store *SystemStore) (string, bool, bool, error) {
+func (m *MockauthHandler) UserName(ctx context.Context, store *SystemStore, verb string) (string, bool, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UserName", ctx, store)
+	ret := m.ctrl.Call(m, "UserName", ctx, store, verb)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(bool)
@@ -141,7 +141,7 @@ func (m *MockauthHandler) UserName(ctx context.Context, store *SystemStore) (str
 }
 
 // UserName indicates an expected call of UserName.
-func (mr *MockauthHandlerMockRecorder) UserName(ctx, store any) *gomock.Call {
+func (mr *MockauthHandlerMockRecorder) UserName(ctx, store, verb any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserName", reflect.TypeOf((*MockauthHandler)(nil).UserName), ctx, store)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserName", reflect.TypeOf((*MockauthHandler)(nil).UserName), ctx, store, verb)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

See #49588 
 
## Problem

The kube controller manager responsible for resource GC attempts to list ext tokens using a SA which is not recognized as admin. This subsequently causes an error listing the secrets, as the SA name is not a proper label selector. This failure to list then in turn breaks the GC code.
 
## Solution

The GC SA is detected by (hardwired) name, and then treated as having admin permissions, to list all tokens.
 
## Testing

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_