### PR TITLE
ext token ttl mishandling of edge cases when comparing

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -62,8 +62,10 @@ type TokenSpec struct {
 	// +optional
 	Description string `json:"description,omitempty"`
 	// TTL is the time-to-live of the token, in milliseconds.
-	// The default, 30 days, is indicated by the value `0`.
-	// Setting a value < 0 indicates that the token should not expire.
+	// Setting a value < 0 represents +infinity, i.e. a token which does not expire.
+	// The default is indicated by the value `0`.
+	// This default is provided by the `auth-token-max-ttl-minutes` setting.
+	// Note that this default is also the maximum specifiable TTL.
 	// +optional
 	TTL int64 `json:"ttl"`
 	// Enabled indicates an active token. The default (`null`) indicates an

--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -66,6 +66,7 @@ type TokenSpec struct {
 	// The default is indicated by the value `0`.
 	// This default is provided by the `auth-token-max-ttl-minutes` setting.
 	// Note that this default is also the maximum specifiable TTL.
+	// A value <= 0 there enables non-expiring tokens.
 	// +optional
 	TTL int64 `json:"ttl"`
 	// Enabled indicates an active token. The default (`null`) indicates an

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1291,43 +1291,43 @@ func tokenFromSecret(secret *corev1.Secret) (*ext.Token, error) {
 
 	// system - kubernetes uid
 	if token.ObjectMeta.UID = types.UID(string(secret.Data[FieldUID])); token.ObjectMeta.UID == "" {
-		return token, fmt.Errorf("kube uid missing")
+		return nil, fmt.Errorf("kube uid missing")
 	}
 
 	// system - finalizers - decode the field and place into the token
 	if err := json.Unmarshal(secret.Data[FieldFinalizers], &token.Finalizers); err != nil {
-		return token, err
+		return nil, err
 	}
 
 	// system - owner references - decode the field and place into the token
 	if err := json.Unmarshal(secret.Data[FieldOwnerReferences], &token.OwnerReferences); err != nil {
-		return token, err
+		return nil, err
 	}
 
 	// system - labels - decode the field and place into the token
 	if err := json.Unmarshal(secret.Data[FieldLabels], &token.Labels); err != nil {
-		return token, err
+		return nil, err
 	}
 
 	// system - annotations - decode the fields and place into the token
 	if err := json.Unmarshal(secret.Data[FieldAnnotations], &token.Annotations); err != nil {
-		return token, err
+		return nil, err
 	}
 
 	// spec - user id, required
 	if token.Spec.UserID = string(secret.Data[FieldUserID]); token.Spec.UserID == "" {
-		return token, fmt.Errorf("user id missing")
+		return nil, fmt.Errorf("user id missing")
 	}
 
 	// spec - user principal, required
 	if err := json.Unmarshal(secret.Data[FieldPrincipal], &token.Spec.UserPrincipal); err != nil {
-		return token, err
+		return nil, err
 	}
 	if token.Spec.UserPrincipal.Name == "" {
-		return token, fmt.Errorf("principal id missing")
+		return nil, fmt.Errorf("principal id missing")
 	}
 	if token.Spec.UserPrincipal.Provider == "" {
-		return token, fmt.Errorf("auth provider missing")
+		return nil, fmt.Errorf("auth provider missing")
 	}
 
 	// spec - optional elements
@@ -1336,46 +1336,46 @@ func tokenFromSecret(secret *corev1.Secret) (*ext.Token, error) {
 
 	enabled, err := strconv.ParseBool(string(secret.Data[FieldEnabled]))
 	if err != nil {
-		return token, err
+		return nil, err
 	}
 	token.Spec.Enabled = &enabled
 
 	ttl, err := strconv.ParseInt(string(secret.Data[FieldTTL]), 10, 64)
 	if err != nil {
-		return token, err
+		return nil, err
 	}
 
 	// clamp and inject default on retrieval
 	ttl, err = clampMaxTTL(ttl)
 	if err != nil {
-		return token, err
+		return nil, err
 	}
 
 	token.Spec.TTL = ttl
 
 	// status information
 	if token.Status.Hash = string(secret.Data[FieldHash]); token.Status.Hash == "" {
-		return token, fmt.Errorf("token hash missing")
+		return nil, fmt.Errorf("token hash missing")
 	}
 
 	if token.Status.LastUpdateTime = string(secret.Data[FieldLastUpdateTime]); token.Status.LastUpdateTime == "" {
-		return token, fmt.Errorf("last update time missing")
+		return nil, fmt.Errorf("last update time missing")
 	}
 
 	lastUsedAt, err := decodeTime("lastUsedAt", secret.Data[FieldLastUsedAt])
 	if err != nil {
-		return token, err
+		return nil, err
 	}
 	token.Status.LastUsedAt = lastUsedAt
 
 	lastActivitySeen, err := decodeTime("lastActivitySeen", secret.Data[FieldLastActivitySeen])
 	if err != nil {
-		return token, err
+		return nil, err
 	}
 	token.Status.LastActivitySeen = lastActivitySeen
 
 	if err := setExpired(token); err != nil {
-		return token, fmt.Errorf("failed to set expiration information: %w", err)
+		return nil, fmt.Errorf("failed to set expiration information: %w", err)
 	}
 
 	return token, nil

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1244,12 +1244,12 @@ func secretFromToken(token *ext.Token, oldBackendLabels, oldBackendAnnotations m
 
 	// spec values
 
-	// injects default on creation
+	// injects default on creation and update
 	ttl, err := clampMaxTTL(token.Spec.TTL)
 	if err != nil {
 		return nil, err
 	}
-	// pass back to caller (Create)
+	// pass back to caller (Create, Update)
 	token.Spec.TTL = ttl
 
 	secret.StringData[FieldDescription] = token.Spec.Description
@@ -1344,13 +1344,6 @@ func tokenFromSecret(secret *corev1.Secret) (*ext.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// clamp and inject default on retrieval
-	ttl, err = clampMaxTTL(ttl)
-	if err != nil {
-		return nil, err
-	}
-
 	token.Spec.TTL = ttl
 
 	// status information

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1471,7 +1471,7 @@ func maxTTL() (int64, error) {
 	return maxTTL.Milliseconds(), nil
 }
 
-// ttlGreater compares the two TTL as and b. It returns true if a is greater than b.
+// ttlGreater compares the two TTL a and b. It returns true if a is greater than b.
 // Important special cases for TTL:
 // Any value < 0 represents +infinity.
 // A value > 0 is that many milliseconds.

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -180,6 +180,54 @@ func init() {
 	properTokenCurrent.Status.Current = true
 }
 
+func Test_ttlGreater(t *testing.T) {
+
+	tests := []struct {
+		name string
+		a    int64
+		b    int64
+		want bool
+	}{
+		{
+			name: "infinities",
+			a:    -1,
+			b:    -2,
+			want: false,
+		},
+		{
+			name: "left infinite",
+			a:    -3,
+			b:    40,
+			want: true,
+		},
+		{
+			name: "right infinite",
+			a:    40,
+			b:    -2,
+			want: false,
+		},
+		{
+			name: "plain left > right",
+			a:    10,
+			b:    1,
+			want: true,
+		},
+		{
+			name: "plain left <= right",
+			a:    10,
+			b:    11,
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			have := ttlGreater(test.a, test.b)
+			assert.Equal(t, have, test.want)
+		})
+	}
+}
+
 func Test_Store_Delete(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Delete
 	// Here we test the actions and checks done before delegation to the

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -180,66 +180,6 @@ func init() {
 	properTokenCurrent.Status.Current = true
 }
 
-func Test_ttlGreater(t *testing.T) {
-
-	tests := []struct {
-		name string
-		a    int64
-		b    int64
-		want bool
-	}{
-		{
-			name: "infinities",
-			a:    -1,
-			b:    -2,
-			want: false,
-		},
-		{
-			name: "left infinite",
-			a:    -3,
-			b:    40,
-			want: true,
-		},
-		{
-			name: "right infinite",
-			a:    40,
-			b:    -2,
-			want: false,
-		},
-		{
-			name: "left 30d",
-			a:    0,
-			b:    1,
-			want: true,
-		},
-		{
-			name: "right 30d",
-			a:    1,
-			b:    0,
-			want: false,
-		},
-		{
-			name: "plain left > right",
-			a:    10,
-			b:    1,
-			want: true,
-		},
-		{
-			name: "plain left <= right",
-			a:    10,
-			b:    11,
-			want: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			have := ttlGreater(test.a, test.b)
-			assert.Equal(t, have, test.want)
-		})
-	}
-}
-
 func Test_Store_Delete(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Delete
 	// Here we test the actions and checks done before delegation to the

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -180,6 +180,66 @@ func init() {
 	properTokenCurrent.Status.Current = true
 }
 
+func Test_ttlGreater(t *testing.T) {
+
+	tests := []struct {
+		name string
+		a    int64
+		b    int64
+		want bool
+	}{
+		{
+			name: "infinities",
+			a:    -1,
+			b:    -2,
+			want: false,
+		},
+		{
+			name: "left infinite",
+			a:    -3,
+			b:    40,
+			want: true,
+		},
+		{
+			name: "right infinite",
+			a:    40,
+			b:    -2,
+			want: false,
+		},
+		{
+			name: "left 30d",
+			a:    0,
+			b:    1,
+			want: true,
+		},
+		{
+			name: "right 30d",
+			a:    1,
+			b:    0,
+			want: false,
+		},
+		{
+			name: "plain left > right",
+			a:    10,
+			b:    1,
+			want: true,
+		},
+		{
+			name: "plain left <= right",
+			a:    10,
+			b:    11,
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			have := ttlGreater(test.a, test.b)
+			assert.Equal(t, have, test.want)
+		})
+	}
+}
+
 func Test_Store_Delete(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Delete
 	// Here we test the actions and checks done before delegation to the

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -324,7 +324,7 @@ func schema_pkg_apis_extcattleio_v1_TokenSpec(ref common.ReferenceCallback) comm
 					},
 					"ttl": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TTL is the time-to-live of the token, in milliseconds. Setting a value < 0 represents +infinity, i.e. a token which does not expire. The default is indicated by the value `0`. This default is provided by the `auth-token-max-ttl-minutes` setting. Note that this default is also the maximum specifiable TTL.",
+							Description: "TTL is the time-to-live of the token, in milliseconds. Setting a value < 0 represents +infinity, i.e. a token which does not expire. The default is indicated by the value `0`. This default is provided by the `auth-token-max-ttl-minutes` setting. Note that this default is also the maximum specifiable TTL. A value <= 0 there enables non-expiring tokens.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -324,7 +324,7 @@ func schema_pkg_apis_extcattleio_v1_TokenSpec(ref common.ReferenceCallback) comm
 					},
 					"ttl": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TTL is the time-to-live of the token, in milliseconds. The default, 30 days, is indicated by the value `0`. Setting a value < 0 indicates that the token should not expire.",
+							Description: "TTL is the time-to-live of the token, in milliseconds. Setting a value < 0 represents +infinity, i.e. a token which does not expire. The default is indicated by the value `0`. This default is provided by the `auth-token-max-ttl-minutes` setting. Note that this default is also the maximum specifiable TTL.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

No issue. During the discussion about https://github.com/rancher/rancher/issues/49588 it was realized that the
comparison of TTL values forgot to properly handle special cases (infinity, default).

## Problem

See above
 
## Solution

A custom comparison function is used to handle all edge cases properly.
 
## Testing

Added unit tests for the new comparator.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_