### PR TITLE
Delete Fleet gitjob chart values

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -122,15 +122,11 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		},
 	}
 
-	gitjobChartValues := make(map[string]interface{})
-
 	if envVal, ok := os.LookupEnv("HTTP_PROXY"); ok {
 		fleetChartValues["proxy"] = envVal
-		gitjobChartValues["proxy"] = envVal
 	}
 	if envVal, ok := os.LookupEnv("NO_PROXY"); ok {
 		fleetChartValues["noProxy"] = envVal
-		gitjobChartValues["noProxy"] = envVal
 	}
 
 	// add priority class value
@@ -140,11 +136,6 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		}
 	} else {
 		fleetChartValues[priorityClassKey] = priorityClassName
-		gitjobChartValues[priorityClassKey] = priorityClassName
-	}
-
-	if len(gitjobChartValues) > 0 {
-		fleetChartValues["gitjob"] = gitjobChartValues
 	}
 
 	extraValues, err := h.chartsConfig.GetChartValues(fleetconst.ChartName)

--- a/pkg/controllers/dashboard/fleetcharts/controller_test.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller_test.go
@@ -71,9 +71,6 @@ func Test_ChartInstallation(t *testing.T) {
 					"gitops": map[string]interface{}{
 						"enabled": features.Gitops.Enabled(),
 					},
-					"gitjob": map[string]interface{}{
-						"priorityClassName": priorityClassName,
-					},
 					"priorityClassName": priorityClassName,
 				}
 
@@ -124,9 +121,6 @@ func Test_ChartInstallation(t *testing.T) {
 					},
 					"gitops": map[string]interface{}{
 						"enabled": features.Gitops.Enabled(),
-					},
-					"gitjob": map[string]interface{}{
-						"priorityClassName": priorityClassName,
 					},
 					"priorityClassName": priorityClassName,
 				}
@@ -216,8 +210,6 @@ leaderElection:
   leaseDuration: 2s
 bootstrap:
   enabled: true
-gitjob:
-  debug: true
 `},
 			newManager: func(ctrl *gomock.Controller) chart.Manager {
 				settings.ConfigMapName.Set("pass")
@@ -239,10 +231,6 @@ gitjob:
 					},
 					"gitops": map[string]interface{}{
 						"enabled": features.Gitops.Enabled(),
-					},
-					"gitjob": map[string]interface{}{
-						"priorityClassName": priorityClassName,
-						"debug":             true,
 					},
 					"priorityClassName": priorityClassName,
 					"leaderElection": map[string]interface{}{


### PR DESCRIPTION
The `gitjob` chart is no longer used.

Refers to: https://github.com/rancher/fleet/issues/2987