### PR TITLE
Use default transport as a base for k8s client in steve aggregation

### DIFF
--- a/pkg/api/steve/proxy/proxy.go
+++ b/pkg/api/steve/proxy/proxy.go
@@ -214,6 +214,7 @@ func (h *Handler) dialer(ctx context.Context, network, address string) (net.Conn
 
 func (h *Handler) next(clusterID, prefix string) (http.Handler, error) {
 	ht := http.DefaultTransport.(*http.Transport).Clone()
+	ht.Proxy = nil
 	ht.DialContext = h.dialer
 	cfg := &rest.Config{
 		// this is bogus, the dialer will change it to 127.0.0.1:6080, but the clusterID is used to lookup the tunnel

--- a/pkg/api/steve/proxy/proxy.go
+++ b/pkg/api/steve/proxy/proxy.go
@@ -213,14 +213,14 @@ func (h *Handler) dialer(ctx context.Context, network, address string) (net.Conn
 }
 
 func (h *Handler) next(clusterID, prefix string) (http.Handler, error) {
+	ht := http.DefaultTransport.(*http.Transport).Clone()
+	ht.DialContext = h.dialer
 	cfg := &rest.Config{
 		// this is bogus, the dialer will change it to 127.0.0.1:6080, but the clusterID is used to lookup the tunnel
 		// connect
 		Host:      "http://" + clusterID,
 		UserAgent: rest.DefaultKubernetesUserAgent() + " cluster " + clusterID,
-		Transport: &http.Transport{
-			DialContext: h.dialer,
-		},
+		Transport: ht,
 	}
 
 	next := proxy.ImpersonatingHandler(prefix, cfg)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49592
 
## Problem

A new `http.Transport` is created from scratch for every new `rest.Config` (every request to the Steve aggregation API running downstream). However, this `http.Transport` does not include sane defaults, as opposed to `http.DefaultTransport`, especially `IdleConnTimeout` is not set. This, combined with the use of a `remotedialer` connection, makes connections to stay idle and never closed, causing the problem described in the parent issue. 
 
## Solution
We could just set `IdleConnTimeout` to a non-zero value, making the client close the connections after the specified time. However, it's just cleaner to get a copy of the `DefaultTransport` and then apply any required customizations (the dialer in this case).

(An alternative fix in steve was created [here](https://github.com/rancher/steve/pull/576), but this solution should be less invasive).
 
## Testing
The symptoms are easily reproducible by observing `session_server_total_add_connections` and `session_server_total_remove_connections` Prometheus metrics with label `addr="127.0.0.1:6080"` only every increase while performing requests of the aggregation API (`/k8s/clusters/{clusterID}/v1/`) or simply using the cluster explorer to navigate through a downstream cluster's resources.
With this patch, we can observe how remotedialer connections are closed exactly after the specified `IddleConnTimeout` (90s by default), which means the HTTP connections were finally closed, also allowing the transport (remotedialer) free up the associated resources.

## Engineering Testing
### Manual Testing
I built this locally and performed the testing mentioned above.

## QA Testing Considerations

An environment with at least 1 downstream cluster is needed to verify this problem. Also, it's recommended to install rancher-monitoring in the upstream for better accessibility to the metrics, although it should be possible to check the `/metrics` endpoint from Rancher directly (only if Running rancher in single-replica mode).
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Not expected