### PR TITLE
[v2.11] Avoid infinite loop on Ext. API cert rotation on watcher error

### DIFF
--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -236,7 +236,7 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 			}
 		case event, ok := <-watcher.ResultChan():
 			if !ok || event.Type == watch.Error {
-				logrus.Error("watcher channel closed: %v", err)
+				logrus.Errorf("watcher channel closed: %v", err)
 				return nil
 			}
 			if err := p.handleCertEvent(event); err != nil {


### PR DESCRIPTION
## Issue: #49667

## Problem

The offending code was introduced in v2.11.0 as part of https://github.com/rancher/rancher/pull/48956.
The for/select loop that reacts to either watch events, canceling and a timer. However, the watch event case does not handle [`Error` events](https://pkg.go.dev/k8s.io/apimachinery/pkg/watch#Interface), which are a signal from the producer aborting the request (normally followed by the channel being closed). Then reading from that closed channel makes the for/select loop to iterate very quickly, while still creating a new `time.After` (and the corresponding inner `Timer`) on every iteration, hence causing high CPU, both due to the rapidly executing loop and GC operations due to the amount of object allocations.
 
## Solution
Reading from the watcher's `ResultChan` now detects if the channel is actually closed or an Error event was received, hence aborting the loop. When that happens, the operation will be retried, creating a new watcher and consumer loop.

We have plans to revisit this logic as part #49200, where we could replace the individual watchers with wrangler functionality.

## Testing

## Engineering Testing
### Manual Testing
Using a single-replica Rancher installation with no downstream clusters, after some time (hours) it will start showing an increase in CPU and memory usage in the Rancher pod. Using a local build with these changes seem make it stable over time.

### Regressions Considerations
No regressions in functionality are expected. If any, failure to properly create a watcher could create some noise though, as it would retry every 10s.