### PR TITLE
[2.11] remove validation for empty nodegroups in EKS cluster

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -517,9 +517,6 @@ func validateEKSNodegroups(spec *v32.ClusterSpec) error {
 	if nodegroups == nil {
 		return nil
 	}
-	if len(nodegroups) == 0 {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("must have at least one nodegroup"))
-	}
 
 	var errors []string
 


### PR DESCRIPTION
Eliminate the requirement for at least one nodegroup in the EKS cluster validation process. This change allows for empty nodegroups without triggering an error.

https://github.com/rancher/rancher/issues/49724