### PR TITLE
[v2.10] remove validation for empty nodegroups in EKS cluster

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -543,9 +543,6 @@ func validateEKSNodegroups(spec *v32.ClusterSpec) error {
 	if nodegroups == nil {
 		return nil
 	}
-	if len(nodegroups) == 0 {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("must have at least one nodegroup"))
-	}
 
 	var errors []string
 


### PR DESCRIPTION
Eliminate the requirement for at least one nodegroup in the EKS cluster validation process.

https://github.com/rancher/rancher/issues/49723