### PR TITLE
[v2.11] Use default transport as a base for k8s client in steve aggregation

### DIFF
--- a/pkg/api/steve/proxy/proxy.go
+++ b/pkg/api/steve/proxy/proxy.go
@@ -213,14 +213,15 @@ func (h *Handler) dialer(ctx context.Context, network, address string) (net.Conn
 }
 
 func (h *Handler) next(clusterID, prefix string) (http.Handler, error) {
+	ht := http.DefaultTransport.(*http.Transport).Clone()
+	ht.Proxy = nil
+	ht.DialContext = h.dialer
 	cfg := &rest.Config{
 		// this is bogus, the dialer will change it to 127.0.0.1:6080, but the clusterID is used to lookup the tunnel
 		// connect
 		Host:      "http://" + clusterID,
 		UserAgent: rest.DefaultKubernetesUserAgent() + " cluster " + clusterID,
-		Transport: &http.Transport{
-			DialContext: h.dialer,
-		},
+		Transport: ht,
 	}
 
 	next := proxy.ImpersonatingHandler(prefix, cfg)


### PR DESCRIPTION
## Issue: #49727
Backports #49655
