### PR TITLE
[release/v2.10] Distinguish between semver metadata for exact-versioned charts

### DIFF
--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -489,7 +489,7 @@ func desiredVersionAndValues(releases []*release.Release, minVersion, desiredVer
 		}
 
 		if isExact {
-			if !current.Equal(desired) {
+			if !isVersionAndMetadataEqual(current, desired) {
 				return false, desired.String(), desiredValues, nil
 			}
 		}
@@ -518,6 +518,17 @@ func desiredVersionAndValues(releases []*release.Release, minVersion, desiredVer
 		}
 	}
 	return false, desiredVersion, desiredValues, nil
+}
+
+// isVersionAndMetadataEqual is like [semver.Version.Equal] but it also checks whether
+// the metadata is the same.
+//
+// This makes it so that 1.2.3+up4.5.6-rc.1 is not the same as 1.2.3+up4.5.6-rc.2
+// because semver ignores anything after the + sign.
+//
+// Some background on why [semver.Version.Equal] behaves this way: https://github.com/semver/semver/issues/136
+func isVersionAndMetadataEqual(v1, v2 *semver.Version) bool {
+	return v1.Equal(v2) && v1.Metadata() == v2.Metadata()
 }
 
 // hasStatus gets all releases in the given namespace that matches the given name and stateMask and

--- a/pkg/catalogv2/system/system_test.go
+++ b/pkg/catalogv2/system/system_test.go
@@ -339,7 +339,7 @@ func TestIsInstalledExactVersion(t *testing.T) {
 		},
 		{
 			name:           "exact matches current",
-			desiredVersion: "1.0.0",
+			desiredVersion: "1.0.0+up4.5.6-rc.9",
 			desiredValues:  nil,
 			isExact:        true,
 
@@ -350,19 +350,30 @@ func TestIsInstalledExactVersion(t *testing.T) {
 		},
 		{
 			name:           "exact matches current but values changed and got merged",
-			desiredVersion: "1.0.0",
+			desiredVersion: "1.0.0+up4.5.6-rc.9",
 			desiredValues: map[string]any{
 				"foo": "bar",
 			},
 			isExact: true,
 
 			expectedInstalled: false,
-			expectedVersion:   "1.0.0",
+			expectedVersion:   "1.0.0+up4.5.6-rc.9",
 			expectedValues: map[string]any{
 				"name": "Pablo",
 				"foo":  "bar",
 			},
 			expectedErr: false,
+		},
+		{
+			name:           "exact has different metadata than current",
+			desiredVersion: "1.0.0+up4.5.6-rc.10",
+			desiredValues:  standardValues,
+			isExact:        true,
+
+			expectedInstalled: false,
+			expectedVersion:   "1.0.0+up4.5.6-rc.10",
+			expectedValues:    standardValues,
+			expectedErr:       false,
 		},
 	}
 
@@ -372,7 +383,7 @@ func TestIsInstalledExactVersion(t *testing.T) {
 			Info: &release.Info{Status: release.StatusDeployed},
 			Chart: &chart.Chart{
 				Metadata: &chart.Metadata{
-					Version: "1.0.0",
+					Version: "1.0.0+up4.5.6-rc.9",
 				},
 			},
 			Config: standardValues,


### PR DESCRIPTION
**Backport**

Backport of https://github.com/rancher/rancher/pull/49717

---

## Issue: https://github.com/rancher/charts-build-scripts/issues/100

This is part of that issue and is necessary along with https://github.com/rancher/charts-build-scripts/pull/202 to correctly support multiple RCs in rancher/charts. This will prevent breaking the CI whenever we bump webhook for example (or worse when both webhook and fleet are bumped at the same time).
 
## Problem

The thing that deploys charts treats a version `106.0.0+up0.7.0-rc.10` as equal to `106.0.0+up0.7.0-rc.11`. So even if we pin the webhook (most commonly during development) to a newer version (say `106.0.0+up0.7.0-rc.10`) but the older version is running, the charts deployer will NOT deploy the newer version and it'll keep running the old one. (**Note:** this is only a problem in development, not for released Rancher. For released Rancher, we only release unRCd version which a new patch release)

This happens because we use the semver library and when doing a comparison, it doesn't compare the metadata part (`+up...`). 
 
## Solution

For "exact" version (eg: when we're pinning for a very specific version), we now include the metadata in the comparison.

**Note:** There are a few other calls to .Equal in that method, but they deal with minVersion. I wasn't sure what the behavior should be when we only provide a minVersion, so opted to _just_ check the metadata for "exact" version.
 
## Testing

Updated the relevant unit tests.