### PR TITLE
Add backingnamespace field to projects

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -21,6 +21,8 @@ var (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="BACKINGNAMESPACE",type="string",JSONPath=".status.backingNamespace"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Project is a group of namespaces.
 // Projects are used to create a multi-tenant environment within a Kubernetes cluster by managing namespace operations,
@@ -51,6 +53,10 @@ type ProjectStatus struct {
 	// Conditions are a set of indicators about aspects of the project.
 	// +optional
 	Conditions []ProjectCondition `json:"conditions,omitempty"`
+
+	// BackingNamespace is the name of the namespace that contains resources associated with the project.
+	// +optional
+	BackingNamespace string `json:"backingNamespace,omitempty"`
 }
 
 // ProjectCondition is the status of an aspect of the project.

--- a/pkg/client/generated/management/v3/zz_generated_project.go
+++ b/pkg/client/generated/management/v3/zz_generated_project.go
@@ -7,6 +7,7 @@ import (
 const (
 	ProjectType                               = "project"
 	ProjectFieldAnnotations                   = "annotations"
+	ProjectFieldBackingNamespace              = "backingNamespace"
 	ProjectFieldClusterID                     = "clusterId"
 	ProjectFieldConditions                    = "conditions"
 	ProjectFieldContainerDefaultResourceLimit = "containerDefaultResourceLimit"
@@ -29,6 +30,7 @@ const (
 type Project struct {
 	types.Resource
 	Annotations                   map[string]string       `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	BackingNamespace              string                  `json:"backingNamespace,omitempty" yaml:"backingNamespace,omitempty"`
 	ClusterID                     string                  `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
 	Conditions                    []ProjectCondition      `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	ContainerDefaultResourceLimit *ContainerResourceLimit `json:"containerDefaultResourceLimit,omitempty" yaml:"containerDefaultResourceLimit,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_project_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_project_status.go
@@ -1,10 +1,12 @@
 package client
 
 const (
-	ProjectStatusType            = "projectStatus"
-	ProjectStatusFieldConditions = "conditions"
+	ProjectStatusType                  = "projectStatus"
+	ProjectStatusFieldBackingNamespace = "backingNamespace"
+	ProjectStatusFieldConditions       = "conditions"
 )
 
 type ProjectStatus struct {
-	Conditions []ProjectCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	BackingNamespace string             `json:"backingNamespace,omitempty" yaml:"backingNamespace,omitempty"`
+	Conditions       []ProjectCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 }

--- a/pkg/crds/yaml/generated/management.cattle.io_projects.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_projects.yaml
@@ -14,7 +14,14 @@ spec:
     singular: project
   scope: Namespaced
   versions:
-  - name: v3
+  - additionalPrinterColumns:
+    - jsonPath: .status.backingNamespace
+      name: BACKINGNAMESPACE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v3
     schema:
       openAPIV3Schema:
         description: |-
@@ -270,6 +277,10 @@ spec:
           status:
             description: Status is the most recently observed status of the project.
             properties:
+              backingNamespace:
+                description: BackingNamespace is the name of the namespace that contains
+                  resources associated with the project.
+                type: string
               conditions:
                 description: Conditions are a set of indicators about aspects of the
                   project.
@@ -306,3 +317,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}


### PR DESCRIPTION
Introducing a new field to projects to contain what namespace to store PRTBs and project scoped secrets. Subsequent PRs will properly fill the field, but first we need the field to exist.