### PR TITLE
Remove invalid node/kontainer drivers

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -48,49 +48,6 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 
 	if err := creator.addCustomDriver(
-		"baiducloudcontainerengine",
-		"https://drivers.rancher.cn/kontainer-engine-driver-baidu/0.2.0/kontainer-engine-driver-baidu-linux",
-		"4613e3be3ae5487b0e21dfa761b95de2144f80f98bf76847411e5fcada343d5e",
-		"https://drivers.rancher.cn/kontainer-engine-driver-baidu/0.2.0/component.js",
-		false,
-		"drivers.rancher.cn", "*.baidubce.com",
-	); err != nil {
-		return err
-	}
-
-	if err := creator.addCustomDriver(
-		"aliyunkubernetescontainerservice",
-		"https://drivers.rancher.cn/kontainer-engine-driver-aliyun/0.2.6/kontainer-engine-driver-aliyun-linux",
-		"8a5360269ec803e3d8cf2c9cc94c66879da03a1fd2b580912c1a83454509c84c",
-		"https://drivers.rancher.cn/pandaria/ui/cluster-driver-aliyun/0.1.1/component.js",
-		false,
-		"*.aliyuncs.com",
-	); err != nil {
-		return err
-	}
-
-	if err := creator.addCustomDriver(
-		"tencentkubernetesengine",
-		"https://drivers.rancher.cn/kontainer-engine-driver-tencent/0.3.0/kontainer-engine-driver-tencent-linux",
-		"ad5406502daf826874889963d7bdaed78db4689f147889ecf97394bc4e8d3d76",
-		"",
-		false,
-		"*.tencentcloudapi.com", "*.qcloud.com",
-	); err != nil {
-		return err
-	}
-
-	if err := creator.addCustomDriver(
-		"huaweicontainercloudengine",
-		"https://drivers.rancher.cn/kontainer-engine-driver-huawei/0.1.2/kontainer-engine-driver-huawei-linux",
-		"0b6c1dfaa477a60a3bd9f8a60a55fcafd883866c2c5c387aec75b95d6ba81d45",
-		"",
-		false,
-		"*.myhuaweicloud.com",
-	); err != nil {
-		return err
-	}
-	if err := creator.addCustomDriver(
 		"oraclecontainerengine",
 		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.8.3/kontainer-engine-driver-oke-linux",
 		"7bfde567e6d478f1da8d36531f765d348bff1cd3abe83c70ddf7766f46112170",
@@ -111,14 +68,23 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 		return err
 	}
 
-	return creator.addCustomDriver(
+	if err := creator.addCustomDriver(
 		"opentelekomcloudcontainerengine",
 		"https://otc-rancher.obs.eu-de.otc.t-systems.com/cluster/driver/1.1.1/kontainer-engine-driver-otccce_linux_amd64.tar.gz",
 		"0998586e1949c826430b10d6b78ee74f2a97769bede0bdd1178c1865a2607065",
 		"https://otc-rancher.obs.eu-de.otc.t-systems.com/cluster/ui/v1.2.1/component.js",
 		false,
 		"*.otc.t-systems.com",
-	)
+	); err != nil {
+		return err
+	}
+
+	creator.deleteKontainerDriver("baiducloudcontainerengine", "https://drivers.rancher.cn")
+	creator.deleteKontainerDriver("aliyunkubernetescontainerservice", "https://drivers.rancher.cn")
+	creator.deleteKontainerDriver("tencentkubernetesengine", "https://drivers.rancher.cn")
+	creator.deleteKontainerDriver("huaweicontainercloudengine", "https://drivers.rancher.cn")
+
+	return nil
 }
 
 func cleanupImportDriver(creator driverCreator) error {
@@ -206,4 +172,28 @@ func (c *driverCreator) addCustomDriver(name, url, checksum, uiURL string, activ
 		}
 	}
 	return nil
+}
+
+// Delete a deprecated or invalid kontainer driver. Don't return errors to avoid affecting
+// Rancher's startup, as the driver will be removed on the next restart.
+func (c *driverCreator) deleteKontainerDriver(name, urlPrefix string) {
+	driver, err := c.drivers.Get(name, v1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			logrus.Warnf("Error getting kontainer driver %s for deletion: %v", name, err)
+		}
+		return
+	}
+
+	// Don't delete if the driver is active or if the url is not the expected invalid one,
+	// as it was likely modified.
+	if driver.Spec.Active || !strings.HasPrefix(driver.Spec.URL, urlPrefix) {
+		logrus.Infof("Not deleting active or modified kontainer driver %s", name)
+		return
+	}
+
+	logrus.Infof("Deleting kontainer driver %s", name)
+	if err := c.drivers.Delete(name, &v1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		logrus.Warnf("Error deleting node driver %s: %v", name, err)
+	}
 }

--- a/pkg/data/management/kontainerdriver_data_test.go
+++ b/pkg/data/management/kontainerdriver_data_test.go
@@ -1,0 +1,102 @@
+package management
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Test_removeKontainerDriverByURLPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *fakes.KontainerDriverInterfaceMock
+		prefix     string
+		wantDelete bool
+	}{
+		{
+			name: "inactive_match_delete",
+			client: &fakes.KontainerDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.KontainerDriver, error) {
+					return &v3.KontainerDriver{
+						Spec: v3.KontainerDriverSpec{
+							Active: false,
+							URL:    "https://foo.test/foo/kontainer-engine-driver-foo",
+						},
+					}, nil
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix:     "https://foo.test",
+			wantDelete: true,
+		},
+		{
+			name: "inactive_nomatch_nodelete",
+			client: &fakes.KontainerDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.KontainerDriver, error) {
+					return &v3.KontainerDriver{
+						Spec: v3.KontainerDriverSpec{
+							Active: false,
+							URL:    "https://bar.test/foo/kontainer-engine-driver-foo",
+						},
+					}, nil
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix: "https://foo.test",
+		},
+		{
+			name: "active_match_nodelete",
+			client: &fakes.KontainerDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.KontainerDriver, error) {
+					return &v3.KontainerDriver{
+						Spec: v3.KontainerDriverSpec{
+							Active: true,
+							URL:    "https://foo.test/foo/kontainer-engine-driver-foo",
+						},
+					}, nil
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix: "https://foo.test",
+		},
+		{
+			name: "get_notfound_nodelete",
+			client: &fakes.KontainerDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.KontainerDriver, error) {
+					return nil, errors.NewNotFound(schema.GroupResource{}, "")
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix: "https://foo.test",
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			creator := driverCreator{
+				drivers: tt.client,
+			}
+			creator.deleteKontainerDriver("", tt.prefix)
+
+			if tt.wantDelete {
+				assert.Equal(t, 1, len(tt.client.DeleteCalls()))
+			} else {
+				assert.Equal(t, 0, len(tt.client.DeleteCalls()))
+			}
+		})
+	}
+}

--- a/pkg/data/management/machinedriver_data_test.go
+++ b/pkg/data/management/machinedriver_data_test.go
@@ -1,0 +1,99 @@
+package management
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Test_removeMachineDriverByURLPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     *fakes.NodeDriverInterfaceMock
+		prefix     string
+		wantDelete bool
+	}{
+		{
+			name: "inactive_match_delete",
+			client: &fakes.NodeDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.NodeDriver, error) {
+					return &v3.NodeDriver{
+						Spec: v3.NodeDriverSpec{
+							Active: false,
+							URL:    "https://foo.test/foo/docker-machine-driver-foo",
+						},
+					}, nil
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix:     "https://foo.test",
+			wantDelete: true,
+		},
+		{
+			name: "inactive_nomatch_nodelete",
+			client: &fakes.NodeDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.NodeDriver, error) {
+					return &v3.NodeDriver{
+						Spec: v3.NodeDriverSpec{
+							Active: false,
+							URL:    "https://bar.test/foo/docker-machine-driver-foo",
+						},
+					}, nil
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix: "https://foo.test",
+		},
+		{
+			name: "active_match_nodelete",
+			client: &fakes.NodeDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.NodeDriver, error) {
+					return &v3.NodeDriver{
+						Spec: v3.NodeDriverSpec{
+							Active: true,
+							URL:    "https://foo.test/foo/docker-machine-driver-foo",
+						},
+					}, nil
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix: "https://foo.test",
+		},
+		{
+			name: "get_notfound_nodelete",
+			client: &fakes.NodeDriverInterfaceMock{
+				GetFunc: func(name string, opts v1.GetOptions) (*v3.NodeDriver, error) {
+					return nil, errors.NewNotFound(schema.GroupResource{}, "")
+				},
+				DeleteFunc: func(name string, options *v1.DeleteOptions) error {
+					return nil
+				},
+			},
+			prefix: "https://foo.test",
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			deleteMachineDriver("", tt.prefix, tt.client)
+
+			if tt.wantDelete {
+				assert.Equal(t, 1, len(tt.client.DeleteCalls()))
+			} else {
+				assert.Equal(t, 0, len(tt.client.DeleteCalls()))
+			}
+		})
+	}
+}

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -576,14 +576,14 @@ def ns_count(client, count):
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
     kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 11
+    assert len(kds) == 7
 
     kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 11
+    assert len(kds) == 7
 
     kds = user_factory('kontainerdrivers-manage').client. \
         list_kontainer_driver()
-    assert len(kds) == 11
+    assert len(kds) == 7
 
     kds = user_factory('settings-manage').client.list_kontainer_driver()
     assert len(kds) == 0


### PR DESCRIPTION
## Issues:
https://github.com/rancher/rancher/issues/48758
https://github.com/rancher/rancher/issues/48759
 
## Problem
Some node and kontainer driver objects that Rancher automatically creates have URLs that are no longer active, and can be removed.
 
## Solution
Remove the node and kontainer drivers.

This is done alongside the code that used to add them.
1. New installations of rancher will just no longer add the invalid drivers.
2. If the drivers exist, are inactive, and their url has the prefix for the invalid domain, they are removed. This is to handle upgrades in installations that already had the object.

They are only removed if they are inactive and domain in its URL matches the invalid one. This is to account for cases where a user hosted the driver somewhere else and edited the same driver object with a different and valid url.

For kontainer drivers, there is a [bug](https://github.com/rancher/rancher/issues/38165) that causes upgrades not to have an effect on the driver, so there could be rancher installations that were successively upgraded and have a kontainer driver with the invalid domain but an older version. This is why the the url is matched by the invalid domain prefix. Node drivers are also removed in this way for consistency.
 
## Engineering Testing
### Manual Testing
- Checked that the drivers are not present after freshly running rancher (as a local process).
- Ran rancher as a local process without the commits, so that the drivers were installed, then ran with the commits, and verified that they were removed, to simulate an upgrade.

## QA Testing Considerations

I recommend testing the two cases:
- Fresh installation: the drivers should not be present (neither the node drivers nor the cluster drivers).
- Upgrade: install an older version of rancher that doesn't include this PR, check that all the drivers are present (and disabled), upgrade rancher to a version with the PR, and check that they are removed.