### PR TITLE
Simplifying feature flags: Drops rke2 and installs provisioningv2 by default

### DIFF
--- a/pkg/api/steve/additionalapi.go
+++ b/pkg/api/steve/additionalapi.go
@@ -21,7 +21,7 @@ import (
 )
 
 func AdditionalAPIsPreMCM(config *wrangler.Context) func(http.Handler) http.Handler {
-	if features.RKE2.Enabled() {
+	if features.ProvisioningV2.Enabled() {
 		connectHandler := configserver.New(config)
 		mux := gmux.NewRouter()
 		mux.UseEncodedPath()

--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -65,9 +65,7 @@ func Register(ctx context.Context, wrangler *wrangler.Context, embedded bool, re
 		kubeconfigManager := kubeconfig.New(wrangler)
 		clusterindex.Register(ctx, wrangler)
 		provisioningv2.Register(ctx, wrangler, kubeconfigManager)
-		if features.RKE2.Enabled() {
-			capr.Register(ctx, wrangler, kubeconfigManager)
-		}
+		capr.Register(ctx, wrangler, kubeconfigManager)
 	}
 
 	if features.MCMAgent.Enabled() || features.MCM.Enabled() {

--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -106,7 +106,7 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 	scopedOnRemove(ctx, "auth-prov-v2-crb", clients.RBAC.ClusterRoleBinding(), h.OnRemoveClusterRoleBinding)
 	clients.Provisioning.Cluster().OnChange(ctx, "auth-prov-v2-cluster", h.OnCluster)
 	clients.CRD.CustomResourceDefinition().OnChange(ctx, "auth-prov-v2-crd", h.OnCRD)
-	if features.RKE2.Enabled() {
+	if features.ProvisioningV2.Enabled() {
 		clients.Dynamic.OnChange(ctx, "auth-prov-v2-rke-machine-config", validMachineConfigGVK, h.OnMachineConfigChange)
 	}
 	clients.Provisioning.Cluster().Cache().AddIndexer(byClusterName, func(obj *v1.Cluster) ([]string, error) {

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -37,7 +37,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 	certsexpiration.Register(ctx, cluster)
 	windows.Register(ctx, clusterRec, cluster)
 	nsserviceaccount.Register(ctx, cluster)
-	if features.RKE2.Enabled() {
+	if features.ProvisioningV2.Enabled() {
 		// Just register the snapshot controller if the cluster is administrated by rancher.
 		if clusterRec.Annotations["provisioning.cattle.io/administrated"] == "true" {
 			if features.Provisioningv2ETCDSnapshotBackPopulation.Enabled() {

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -659,7 +659,7 @@ func (h *handler) updateStatus(objs []runtime.Object, cluster *v1.Cluster, statu
 }
 
 func (h *handler) updateFeatureLockedValue(lockValueToTrue bool) error {
-	feature, err := h.featureCache.Get(features.RKE2.Name())
+	feature, err := h.featureCache.Get(features.ProvisioningV2.Name())
 	if err != nil {
 		return err
 	}

--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -7,9 +7,7 @@ func RequiredCRDs() []string {
 	requiredCRDS := BasicCRDs()
 	if features.ProvisioningV2.Enabled() {
 		requiredCRDS = append(requiredCRDS, ProvisioningV2CRDs()...)
-		if features.RKE2.Enabled() {
-			requiredCRDS = append(requiredCRDS, RKE2CRDs()...)
-		}
+		requiredCRDS = append(requiredCRDS, RKE2CRDs()...)
 		if features.EmbeddedClusterAPI.Enabled() {
 			requiredCRDS = append(requiredCRDS, CAPICRDs()...)
 		}
@@ -71,7 +69,6 @@ func CAPICRDs() []string {
 // RKE2CRDs returns a list of CRD names needed for RKE2.
 func RKE2CRDs() []string {
 	return []string{
-		"clusters.provisioning.cattle.io",
 		"custommachines.rke.cattle.io",
 		"etcdsnapshots.rke.cattle.io",
 		"rkebootstraps.rke.cattle.io",

--- a/pkg/crds/provisioningv2/crds.go
+++ b/pkg/crds/provisioningv2/crds.go
@@ -30,9 +30,7 @@ var (
 
 func List() (result []crd.CRD) {
 	result = append(result, provisioning()...)
-	if features.RKE2.Enabled() {
-		result = append(result, rke2()...)
-	}
+	result = append(result, rke2()...)
 	if features.EmbeddedClusterAPI.Enabled() {
 		result = append(result, capi()...)
 	}

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -73,7 +73,7 @@ func addRepos(wrangler *wrangler.Context) error {
 		return err
 	}
 
-	if features.RKE2.Enabled() {
+	if features.ProvisioningV2.Enabled() {
 		if err := addRepo(
 			wrangler,
 			"rancher-rke2-charts",

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -46,15 +46,17 @@ func TestInitializeNil(t *testing.T) {
 }
 
 func TestInitializeFeatures(t *testing.T) {
+	deprecatedFlags := []string{"external-rules", "rke2"}
 	tests := map[string]struct {
 		featureMock func() managementv3.FeatureClient
 		features    map[string]*Feature
 	}{
-		"delete external-rules feature is called": {
+		"delete all deprecated features is called": {
 			featureMock: func() managementv3.FeatureClient {
 				mock := fake.NewMockNonNamespacedControllerInterface[*v3.Feature, *v3.FeatureList](gomock.NewController(t))
-				mock.EXPECT().Delete("external-rules", &metav1.DeleteOptions{})
-
+				for _, flag := range deprecatedFlags {
+					mock.EXPECT().Delete(flag, &metav1.DeleteOptions{})
+				}
 				return mock
 			},
 			features: nil,

--- a/pkg/features/migrate.go
+++ b/pkg/features/migrate.go
@@ -31,7 +31,7 @@ func MigrateFeatures(featuresClient managementv3.FeatureClient, crdClient v1.Cus
 			if err := enableMCMIfPreviouslyEnabled(&feature, featuresClient, crdClient); err != nil {
 				return err
 			}
-		case RKE2.Name():
+		case ProvisioningV2.Name():
 			if err := enableRKE2IfClustersExist(&feature, featuresClient, mgmtClusterClient); err != nil {
 				return err
 			}

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -80,7 +80,7 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		}
 	}
 
-	if features.RKE2.Enabled() {
+	if features.ProvisioningV2.Enabled() {
 		// must migrate system agent data directory first, since update requests will be rejected by webhook if
 		// "CATTLE_AGENT_VAR_DIR" is set within AgentEnvVars.
 		if err := migrateSystemAgentDataDirectory(wranglerContext); err != nil {

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -252,7 +252,6 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 		features.MCM.Name():                            false,
 		features.MCMAgent.Name():                       true,
 		features.Fleet.Name():                          false,
-		features.RKE2.Name():                           false,
 		features.ProvisioningV2.Name():                 false,
 		features.EmbeddedClusterAPI.Name():             false,
 		features.UISQLCache.Name():                     features.UISQLCache.Enabled(),


### PR DESCRIPTION
## Issue: #38049 
 
## Problem
- It is expected to have the `rke2` and `provisioningv2` feature flags enabled (& locked). If otherwise, the upgrade returns warnings about rke2 CRDs not found.
 
## Solution
- Dropping the `rke2` feature flag and enabling+installing `provisioningv2` feature flag by default. Ensuring that this flag is locked as well.
 
## Testing
- TODO

## Engineering Testing
### Manual Testing
- TODO

### Automated Testing
* Test types added/modified:
    * Unit
 
* If "None" - Reason: _EXPLAIN THE REASON_
TODO
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_