### PR TITLE
Add standard headers and restrict redirects to registered URIs

### DIFF
--- a/pkg/oidc/provider/authorize_test.go
+++ b/pkg/oidc/provider/authorize_test.go
@@ -148,6 +148,21 @@ func TestAuthEndpoint(t *testing.T) {
 
 				return req
 			},
+			mockSetup: func(m mockParams) {
+				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fakeClientName,
+						},
+						Spec: v3.OIDCClientSpec{
+							RedirectURIs: []string{fakeRedirectUri},
+						},
+						Status: v3.OIDCClientStatus{
+							ClientID: fakeClientID,
+						},
+					},
+				}, nil)
+			},
 			wantHttpCode: http.StatusFound,
 			wantRedirect: fakeRedirectUri + "?error=unsupported_response_type&error_description=response+type+not+supported",
 		},
@@ -166,6 +181,21 @@ func TestAuthEndpoint(t *testing.T) {
 				}
 
 				return req
+			},
+			mockSetup: func(m mockParams) {
+				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fakeClientName,
+						},
+						Spec: v3.OIDCClientSpec{
+							RedirectURIs: []string{fakeRedirectUri},
+						},
+						Status: v3.OIDCClientStatus{
+							ClientID: fakeClientID,
+						},
+					},
+				}, nil)
 			},
 			wantHttpCode: http.StatusFound,
 			wantRedirect: fakeRedirectUri + "?error=invalid_request&error_description=challenge_method+not+supported%2C+only+S256+is+supported",
@@ -186,6 +216,21 @@ func TestAuthEndpoint(t *testing.T) {
 
 				return req
 			},
+			mockSetup: func(m mockParams) {
+				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fakeClientName,
+						},
+						Spec: v3.OIDCClientSpec{
+							RedirectURIs: []string{fakeRedirectUri},
+						},
+						Status: v3.OIDCClientStatus{
+							ClientID: fakeClientID,
+						},
+					},
+				}, nil)
+			},
 			wantHttpCode: http.StatusFound,
 			wantRedirect: fakeRedirectUri + "?error=invalid_scope&error_description=missing+openid+scope",
 		},
@@ -205,6 +250,21 @@ func TestAuthEndpoint(t *testing.T) {
 
 				return req
 			},
+			mockSetup: func(m mockParams) {
+				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fakeClientName,
+						},
+						Spec: v3.OIDCClientSpec{
+							RedirectURIs: []string{fakeRedirectUri},
+						},
+						Status: v3.OIDCClientStatus{
+							ClientID: fakeClientID,
+						},
+					},
+				}, nil)
+			},
 			wantHttpCode: http.StatusFound,
 			wantRedirect: fakeRedirectUri + "?error=invalid_scope&error_description=invalid+scope%3A+invalidscope",
 		},
@@ -223,6 +283,21 @@ func TestAuthEndpoint(t *testing.T) {
 				}
 
 				return req
+			},
+			mockSetup: func(m mockParams) {
+				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fakeClientName,
+						},
+						Spec: v3.OIDCClientSpec{
+							RedirectURIs: []string{fakeRedirectUri},
+						},
+						Status: v3.OIDCClientStatus{
+							ClientID: fakeClientID,
+						},
+					},
+				}, nil)
 			},
 			wantHttpCode: http.StatusFound,
 			wantRedirect: fakeRedirectUri + "?error=invalid_request&error_description=missing+code_challenge",
@@ -265,10 +340,10 @@ func TestAuthEndpoint(t *testing.T) {
 
 				return req
 			},
-			wantHttpCode: http.StatusFound,
-			wantRedirect: fakeRedirectUri + "?error=server_error&error_description=error+retrieving+OIDC+client%3A++%22client-id%22+not+found",
+			wantHttpCode: http.StatusBadRequest,
+			wantError:    `{"error":"invalid_request","error_description":"error retrieving OIDC client:  \"client-id\" not found"}`,
 		},
-		"redirect uri not registed": {
+		"redirect uri not registered": {
 			mockSetup: func(m mockParams) {
 				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
 					{
@@ -299,8 +374,8 @@ func TestAuthEndpoint(t *testing.T) {
 
 				return req
 			},
-			wantHttpCode: http.StatusFound,
-			wantRedirect: fakeRedirectUri + "?error=invalid_request&error_description=redirect_uri+https%3A%2F%2Fwww.rancher.com+is+not+registered",
+			wantHttpCode: http.StatusBadRequest,
+			wantError:    `{"error":"invalid_request","error_description":"redirect_uri is not registered"}`,
 		},
 	}
 
@@ -326,6 +401,8 @@ func TestAuthEndpoint(t *testing.T) {
 			h.authEndpoint(rec, test.req())
 
 			assert.Equal(t, test.wantHttpCode, rec.Code)
+			assert.Equal(t, rec.Header().Get("X-Content-Type-Options"), "nosniff")
+			assert.Equal(t, rec.Header().Get("X-Frame-Options"), "SAMEORIGIN")
 			if test.wantRedirect != "" {
 				assert.Equal(t, test.wantRedirect, rec.Header().Get("Location"))
 			}

--- a/pkg/oidc/provider/error/error.go
+++ b/pkg/oidc/provider/error/error.go
@@ -46,6 +46,8 @@ func WriteError(errStr string, errDescription string, code int, w http.ResponseW
 		Error:            errStr,
 		ErrorDescription: errDescription,
 	}
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	err := json.NewEncoder(w).Encode(oidcErr)
@@ -67,6 +69,7 @@ func RedirectWithError(redirectURI string, errString string, description string,
 		q.Set("state", state)
 	}
 	u.RawQuery = q.Encode()
-
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	http.Redirect(w, r, u.String(), http.StatusFound)
 }

--- a/pkg/oidc/provider/error/error_test.go
+++ b/pkg/oidc/provider/error/error_test.go
@@ -19,6 +19,8 @@ func TestWriteError(t *testing.T) {
 
 	WriteError(errorMessage, errorDescription, errorCode, rec)
 
+	assert.Equal(t, rec.Header().Get("X-Content-Type-Options"), "nosniff")
+	assert.Equal(t, rec.Header().Get("X-Frame-Options"), "SAMEORIGIN")
 	assert.Equal(t, errorCode, rec.Code)
 	assert.JSONEq(t, `{"error":"`+errorMessage+`","error_description":"`+errorDescription+`"}`, strings.TrimSpace(rec.Body.String()))
 }
@@ -34,6 +36,8 @@ func TestRedirectWithError(t *testing.T) {
 
 	RedirectWithError(redirectURI, errorMessage, errorDescription, state, rec, &http.Request{})
 
+	assert.Equal(t, rec.Header().Get("X-Content-Type-Options"), "nosniff")
+	assert.Equal(t, rec.Header().Get("X-Frame-Options"), "SAMEORIGIN")
 	assert.Equal(t, 302, rec.Code)
 	assert.Equal(t, redirectURI+"?error="+errorMessage+"&error_description="+errorDescription+"&state="+state, rec.Header().Get("Location"))
 }

--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -118,6 +118,8 @@ func (h *tokenHandler) tokenEndpoint(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		err = json.NewEncoder(w).Encode(tokenResponse)
 		if err != nil {
 			oidcerror.WriteError(oidcerror.ServerError, "failed to encode token response", http.StatusInternalServerError, w)
@@ -131,6 +133,8 @@ func (h *tokenHandler) tokenEndpoint(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		err = json.NewEncoder(w).Encode(tokenResponse)
 		if err != nil {
 			oidcerror.WriteError(oidcerror.ServerError, "failed to encode refresh token response", http.StatusInternalServerError, w)

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -552,6 +552,8 @@ func TestTokenEndpoint(t *testing.T) {
 
 			h.tokenEndpoint(rec, test.req())
 
+			assert.Equal(t, rec.Header().Get("X-Content-Type-Options"), "nosniff")
+			assert.Equal(t, rec.Header().Get("X-Frame-Options"), "SAMEORIGIN")
 			if test.wantError != "" {
 				assert.JSONEq(t, test.wantError, strings.TrimSpace(rec.Body.String()))
 			} else {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48317
 
Adds the X-Content-Type-Options: nosniff and X-Frame-Options: DENY HTTP headers to enhance content handling and framing behavior in browsers.

Updates redirect logic to prevent redirects to non-registered URIs. If an unregistered URI is provided, the API will now respond with a 400 Bad Request error instead of performing the redirect.

