### PR TITLE
Don't ignore errors when retrieving authentication token ID

### DIFF
--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -424,7 +424,7 @@ func (t *Store) Get(
 
 	session, err := t.auth.SessionID(ctx)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
 	}
 
 	token.Status.Current = token.Name == session
@@ -571,7 +571,7 @@ func (t *Store) Update(
 
 	sessionID, err := t.auth.SessionID(ctx)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(err)
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
 	}
 
 	resultToken, err := t.SystemStore.update(sessionID, false, oldToken, newToken, options)
@@ -623,7 +623,7 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 
 	session, err := t.auth.SessionID(ctx)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
 	}
 
 	// Get token of the request and use its principal as ours. Any attempt
@@ -785,7 +785,7 @@ func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.Tok
 
 	session, err := t.auth.SessionID(ctx)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
 	}
 
 	return t.SystemStore.list(fullAccess, userInfo.GetName(), session, options)
@@ -1044,7 +1044,7 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 
 	sessionID, err := t.auth.SessionID(ctx)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
 	}
 
 	// watch the backend secrets for changes and transform their events into

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1378,7 +1378,9 @@ func SessionID(ctx context.Context) (string, error) {
 
 	tokenIDs := extras[common.ExtraRequestTokenID]
 	if len(tokenIDs) != 1 {
-		return "", fmt.Errorf("context principal extras has no request token id")
+		// log only because we get internal requests (watch setup) without token id
+		logrus.Debugf("context principal extras has no unique request token id: %d", len(tokenIDs))
+		return "", nil
 	}
 
 	tokenID := tokenIDs[0]

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -625,7 +625,9 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 	if err != nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
 	}
-
+	if authTokenID == "" {
+		return nil, apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("missing authentication token ID"))
+	}
 	// Get token of the request and use its principal as ours. Any attempt
 	// by the user to set their own information for the principal is
 	// discarded and written over. No checks are made, no errors are thrown.
@@ -1372,10 +1374,6 @@ func SessionID(ctx context.Context) (string, error) {
 	}
 
 	extras := userInfo.GetExtra()
-	if extras == nil {
-		return "", fmt.Errorf("context principal has no extras")
-	}
-
 	tokenIDs := extras[common.ExtraRequestTokenID]
 	if len(tokenIDs) != 1 {
 		// log only because we get internal requests (watch setup) without token id

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -511,7 +511,7 @@ func Test_Store_Get(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -534,7 +534,7 @@ func Test_Store_Get(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("bogus")
+		auth.EXPECT().SessionID(gomock.Any()).Return("bogus", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -593,7 +593,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -626,7 +626,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -662,7 +662,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -697,7 +697,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -731,7 +731,7 @@ func Test_Store_Watch(t *testing.T) {
 			LabelSelector: UserIDLabel + "=lkajdl/ksjlkds",
 		}).Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdl/ksjlkds"}, false, true, nil)
 
@@ -762,7 +762,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -792,7 +792,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("bogus")
+		auth.EXPECT().SessionID(gomock.Any()).Return("bogus", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -826,7 +826,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -861,7 +861,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -892,7 +892,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: properUser}, false, true, nil)
 
@@ -1003,7 +1003,7 @@ func Test_Store_Create(t *testing.T) {
 		},
 		{
 			name: "provider/principal retrieval error",
-			err:  apierrors.NewInternalError(fmt.Errorf("unable to fetch unknown token session-token")),
+			err:  apierrors.NewInternalError(fmt.Errorf("unable to fetch unknown token \"session-token\"")),
 			tok: &ext.Token{
 				Spec: ext.TokenSpec{
 					UserID: "world",
@@ -1025,7 +1025,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// fail fetch of session token, v3 and ext
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").
 					Return(nil, someerror)
 				scache.EXPECT().Get("cattle-tokens", "session-token").
@@ -1059,7 +1059,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -1097,7 +1097,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -1145,7 +1145,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -1193,7 +1193,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -1249,7 +1249,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{

--- a/pkg/ext/stores/tokens/zz_token_fakes.go
+++ b/pkg/ext/stores/tokens/zz_token_fakes.go
@@ -117,11 +117,12 @@ func (m *MockauthHandler) EXPECT() *MockauthHandlerMockRecorder {
 }
 
 // SessionID mocks base method.
-func (m *MockauthHandler) SessionID(ctx context.Context) string {
+func (m *MockauthHandler) SessionID(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SessionID", ctx)
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SessionID indicates an expected call of SessionID.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#51332
 
## Problem

The retrieval of the session id from the request context swallows lower errors in one place, instead of passing them through. 
 
## Solution

pass the errors, and abort properly in the higher levels
 
## Testing

Updated unit tests.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_