### PR TITLE
Fix flaky-test Test_Provisioning_Custom_ThreeNodeWithTaints

### DIFF
--- a/pkg/controllers/capr/unmanaged/controller.go
+++ b/pkg/controllers/capr/unmanaged/controller.go
@@ -246,6 +246,14 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 		annotations[capr.TaintsAnnotation] = string(data)
 	}
 
+	annotationWithTaints := func() map[string]string {
+		m := map[string]string{}
+		if annotations[capr.TaintsAnnotation] != "" {
+			m[capr.TaintsAnnotation] = annotations[capr.TaintsAnnotation]
+		}
+		return m
+	}
+
 	return []runtime.Object{
 		&rkev1.RKEBootstrap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -260,17 +268,19 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 		},
 		&rkev1.CustomMachine{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      machineName,
-				Namespace: capiCluster.Namespace,
-				Labels:    labels,
+				Name:        machineName,
+				Namespace:   capiCluster.Namespace,
+				Labels:      labels,
+				Annotations: annotationWithTaints(),
 			},
 		},
 		&capi.Machine{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      machineName,
-				Namespace: capiCluster.Namespace,
-				Labels:    labels,
+				Name:        machineName,
+				Namespace:   capiCluster.Namespace,
+				Labels:      labels,
+				Annotations: annotationWithTaints(),
 			},
 			Spec: capi.MachineSpec{
 				ClusterName: capiCluster.Name,


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/49895

Set the taint annotation on the CAPI customMachine and Machine for custom clusters 

When provisioning a custom K3s cluster where all roles are assigned to each node, 
an issue arises if the first machine to register has a taint that is not tolerated 
by the rancher-cluster-agent or other K3s addon components. In this case, no 
other machine can complete the registration process because the only available node 
is unschedulable due to the taint. As a result, the cluster remains with a single 
tainted node, and provisioning cannot proceed.

This occurs because the taint information is not set on the corresponding CAPI 
Machine object - specifically, the rke.cattle.io/taints annotation is missing. 
Without this annotation, Rancher does not apply the necessary tolerations when 
rendering templates for the rancher-cluster-agent. This issue does not affect 
node-driver K3s clusters, where taints are properly propagated to the CAPI Machine 
objects.

With this change, cattle-cluster-agent will be able to run, so the K3s cluster will become 
active and accessible in Rancher UI. K3s components are still pending for allocating to a 
node. 