### PR TITLE
WIP `make generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ $(TARGETS): .dapper
 
 .DEFAULT_GOAL := ci
 
+generate:
+	@$(MAKE) quick TARGET="generate"
+
 quick-agent:
 	@$(MAKE) quick TARGET="agent"
 

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ quick-server:
 $(DEV_TARGETS):
 	./dev-scripts/$@
 
-.PHONY: $(TARGETS) $(DEV_TARGETS) quick-agent quick-server
+.PHONY: $(TARGETS) $(DEV_TARGETS) quick-agent quick-server generate

--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -64,3 +64,13 @@ if [ -z "$TARGET" ] || [ "$TARGET" = "agent" ]; then
     --target agent \
     --file ./package/Dockerfile .
 fi
+
+if [ "$TARGET" = "generate" ]; then
+  # start the builds
+  docker buildx build \
+    $BUILD_ARGS \
+    --platform="${OS}/${ARCH}" \
+    --target generate \
+    --output=type=local,dest="." \
+    --file ./package/Dockerfile .
+fi

--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -32,35 +32,33 @@ xargs -n2 docker save -o ./k3s-airgap-images.tar <<< "${AIRGAP_IMAGES}"
 # download kontainer driver metadata
 curl -sLf https://releases.rancher.com/kontainer-driver-metadata/"${CATTLE_KDM_BRANCH}"/data.json > ./data.json
 
-if [ -z $TARGET ] || [ $TARGET = "server" ]; then
+BUILD_ARGS=""
+BUILD_ARGS="$BUILD_ARGS --build-arg VERSION=${TAG}"
+BUILD_ARGS="$BUILD_ARGS --build-arg ARCH=${ARCH}"
+BUILD_ARGS="$BUILD_ARGS --build-arg IMAGE_REPO=${REPO}"
+BUILD_ARGS="$BUILD_ARGS --build-arg COMMIT=${COMMIT}"
+BUILD_ARGS="$BUILD_ARGS --build-arg RKE_VERSION=${RKE_VERSION}"
+BUILD_ARGS="$BUILD_ARGS --build-arg CATTLE_RANCHER_WEBHOOK_VERSION=${CATTLE_RANCHER_WEBHOOK_VERSION}"
+BUILD_ARGS="$BUILD_ARGS --build-arg CATTLE_REMOTEDIALER_PROXY_VERSION=${CATTLE_REMOTEDIALER_PROXY_VERSION}"
+BUILD_ARGS="$BUILD_ARGS --build-arg CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=${CATTLE_RANCHER_PROVISIONING_CAPI_VERSION}"
+BUILD_ARGS="$BUILD_ARGS --build-arg CATTLE_CSP_ADAPTER_MIN_VERSION=${CATTLE_CSP_ADAPTER_MIN_VERSION}"
+BUILD_ARGS="$BUILD_ARGS --build-arg CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION}"
+BUILD_ARGS="$BUILD_ARGS --build-arg RANCHER_TAG=${TAG}"
+BUILD_ARGS="$BUILD_ARGS --build-arg RANCHER_REPO=${REPO}"
+
+if [ -z "$TARGET" ] || [ "$TARGET" = "server" ]; then
   # start the builds
   docker buildx build \
-    --build-arg VERSION="${TAG}" \
-    --build-arg ARCH="${ARCH}" \
-    --build-arg IMAGE_REPO="${REPO}" \
-    --build-arg COMMIT="${COMMIT}" \
-    --build-arg RKE_VERSION="${RKE_VERSION}" \
-    --build-arg CATTLE_RANCHER_WEBHOOK_VERSION="${CATTLE_RANCHER_WEBHOOK_VERSION}" \
-    --build-arg CATTLE_REMOTEDIALER_PROXY_VERSION="${CATTLE_REMOTEDIALER_PROXY_VERSION}" \
-    --build-arg CATTLE_RANCHER_PROVISIONING_CAPI_VERSION="${CATTLE_RANCHER_PROVISIONING_CAPI_VERSION}" \
-    --build-arg CATTLE_CSP_ADAPTER_MIN_VERSION="${CATTLE_CSP_ADAPTER_MIN_VERSION}" \
-    --build-arg CATTLE_FLEET_VERSION="${CATTLE_FLEET_VERSION}" \
+    $BUILD_ARGS \
     --tag "${REPO}"/rancher:"${TAG}" \
     --platform="${OS}/${ARCH}" \
     --target server \
     --file ./package/Dockerfile .
 fi
 
-if [ -z $TARGET ] || [ $TARGET = "agent" ]; then
+if [ -z "$TARGET" ] || [ "$TARGET" = "agent" ]; then
   docker buildx build \
-    --build-arg VERSION="${TAG}" \
-    --build-arg ARCH="${ARCH}" \
-    --build-arg RANCHER_TAG="${TAG}" \
-    --build-arg RANCHER_REPO="${REPO}" \
-    --build-arg COMMIT="${COMMIT}" \
-    --build-arg RKE_VERSION="${RKE_VERSION}" \
-    --build-arg CATTLE_RANCHER_WEBHOOK_VERSION="${CATTLE_RANCHER_WEBHOOK_VERSION}" \
-    --build-arg CATTLE_RANCHER_PROVISIONING_CAPI_VERSION="${CATTLE_RANCHER_PROVISIONING_CAPI_VERSION}" \
+    $BUILD_ARGS \
     --tag "${REPO}"/rancher-agent:"${TAG}" \
     --platform="${OS}/${ARCH}" \
     --target agent \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,6 +5,8 @@ ARG PARTNER_CHART_DEFAULT_BRANCH=main
 ARG RKE2_CHART_DEFAULT_BRANCH=main
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ARG CATTLE_KDM_BRANCH=dev-v2.11
+ARG CONTROLLER_GEN_VERSION=v0.17.1
+ARG MOCKGEN_VERSION=v0.5.0
 
 ARG VERSION=${VERSION}
 
@@ -324,6 +326,17 @@ COPY pkg/client/go.mod pkg/client/go.sum pkg/client/
 RUN --mount=type=cache,target=/root/.cache,id=rancher go mod download
 RUN --mount=type=cache,target=/root/.cache,id=rancher cd pkg/apis && go mod download
 RUN --mount=type=cache,target=/root/.cache,id=rancher cd pkg/client && go mod download
+
+
+FROM --platform=$BUILDPLATFORM rancher-go-builder AS generate-build
+ARG CONTROLLER_GEN_VERSION
+RUN --mount=type=cache,target=/root/.cache,id=rancher go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
+ARG MOCKGEN_VERSION
+RUN --mount=type=cache,target=/root/.cache,id=rancher go install go.uber.org/mock/mockgen@${MOCKGEN_VERSION}
+COPY . .
+RUN --mount=type=cache,target=/root/.cache,id=rancher go generate ./...
+FROM scratch as generate
+COPY --from=generate-build /app/pkg /pkg
 
 
 FROM --platform=$BUILDPLATFORM rancher-go-builder AS server-build


### PR DESCRIPTION
# Issue

There's currently two ways to run `go generate ./...` in the Rancher repo:

1. Run it on your local machine using `go`

This requires the developer to install tools necessary for go generate like controller-gen and mockgen. That's fine, but controller-gen is annoying because we need to install the correct version otherwise the generated CRDs will have different output (version number changes).

2. Run it inside dapper with `./.dapper go generate ./...`
 
This is what we do in webhook's [Bump webhook in rancher/rancher](https://github.com/rancher/webhook/blob/main/.github/workflows/scripts/release-against-rancher.sh#L89). It relies on `DAPPER_MODE=bind` which may or may not be available (?mac?). We're trying to get rid of dapper so long term would like to get rid of this.

# Solution

Use Docker multi-stage build with `--output=type=local,dest=<target>` to run `go generate ./...` in Docker and output the results to the host.

Benefits:
- No longer need to install codegen tools locally
- Cached result (if files don't change)
- Not using Dapper

# Explanation for local output

One feature of Dapper that made it useful was copying files back to the host using [DAPPER_OUTPUT](https://github.com/rancher/rancher/blob/baa73dccbdcfba94b1769a3772a3850e484a8b83/Dockerfile.dapper#L93).

We can now replicate that with just regular docker, simply by combining `FROM scratch AS <target>` and `--output=type=local,dest=</path/to/host>`. The pattern looks like the following:

```dockerfile
# Running some build commands or whatever
FROM golang AS binary-build
COPY main.go .
RUN go build -o foo

# Empty image with **only** the files we want to output to the host
FROM scratch AS binary
COPY --from=binary-build /foo /foo
```

Then, we can run the following command to build the binary using docker and output it in `bin` directory.

```
docker buildx build --output=type=local,dest=./bin --target=binary .
```

This will output ALL the files in the stage `binary` to `./bin` on the host.

---

I moved all `--build-arg` to a variable, that way it's easier to maintain and arguments that aren't used won't affect the build.

Added `generate` target to Makefile, now just run `make generate` to run codegen.