### PR TITLE
Preserve the order of machine provisioning arguments

### DIFF
--- a/pkg/controllers/capr/machineprovision/args.go
+++ b/pkg/controllers/capr/machineprovision/args.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -324,7 +323,12 @@ func toArgs(driverName string, args map[string]any, cluster *rancherv1.Cluster) 
 		cmd = append(cmd, fmt.Sprintf("--harvester-cluster-name=%s", cluster.Name))
 	}
 
-	sort.Strings(cmd)
+	// Intentionally leave the slice unsorted.
+	// Re‑ordering values that map to the same CLI flag
+	// (e.g. multiple --vmwarevsphere-network entries) would change their
+	// positional semantics and can alter how the driver wires the node.
+	// Preserve the exact order the user provided.
+	// sort.Strings(cmd)
 	return
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fix #42285
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
vmwaresphere node driver doesn't respect the configured network order

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Don't sort the rancher machine arguments when running the provisioning. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Steps to reproduce are valid in the issue.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_