### PR TITLE
fix: add handler to watch and reconcile default network policies

### DIFF
--- a/pkg/controllers/managementuser/networkpolicy/register.go
+++ b/pkg/controllers/managementuser/networkpolicy/register.go
@@ -73,4 +73,5 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext) {
 	mgmtClusters.AddHandler(ctx, "clusterHandler", clusterHandler.Sync)
 
 	mgmtClusters.AddHandler(ctx, "clusterNetAnnHandler", clusterNetAnnHandler.Sync)
+	npClient.NetworkPolicies("").AddHandler(ctx, "netpol-handler", npmgr.SyncDefaultNetworkPolicies)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
#49765
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Default network policies (np-default, np-default-allow-all) were not being restored when deleted or edited in downstream clusters, leading to inconsistent security postures across namespaces and clusters.
Solution
 
## Solution
A new handler was added to watch and reconcile default network policies created by Rancher in managed clusters.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Manual Testing
Deleted np-default, hn-nodes, and np-default-allow-all in various namespaces and verified they were recreated as expected.

