### PR TITLE
fix projectId for downstream clusters

### DIFF
--- a/pkg/api/norman/store/scoped/store.go
+++ b/pkg/api/norman/store/scoped/store.go
@@ -25,7 +25,9 @@ func NewScopedStore(key string, store types.Store, pLister v3.ProjectLister) *St
 					return data, nil
 				}
 				v := convert.ToString(data[key])
-				if !strings.HasSuffix(v, ":"+convert.ToString(data[client.ProjectFieldNamespaceId])) && strings.ReplaceAll(v, "-", ":") != strings.ReplaceAll(convert.ToString(data[client.ProjectFieldNamespaceId]), "-", ":") {
+				ns := convert.ToString(data[client.ProjectFieldNamespaceId])
+				if !strings.HasSuffix(v, ":"+ns) && strings.Replace(v, ":", "-", 1) != ns {
+
 					data[key] = data[client.ProjectFieldNamespaceId]
 				}
 

--- a/pkg/api/norman/store/scoped/store.go
+++ b/pkg/api/norman/store/scoped/store.go
@@ -25,7 +25,7 @@ func NewScopedStore(key string, store types.Store, pLister v3.ProjectLister) *St
 					return data, nil
 				}
 				v := convert.ToString(data[key])
-				if !strings.HasSuffix(v, ":"+convert.ToString(data[client.ProjectFieldNamespaceId])) && v != strings.Replace(convert.ToString(data[client.ProjectFieldNamespaceId]), "-", ":", 1) {
+				if !strings.HasSuffix(v, ":"+convert.ToString(data[client.ProjectFieldNamespaceId])) && strings.ReplaceAll(v, "-", ":") != strings.ReplaceAll(convert.ToString(data[client.ProjectFieldNamespaceId]), "-", ":") {
 					data[key] = data[client.ProjectFieldNamespaceId]
 				}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49940
 
## Problem
Project and project members not displaying on Cluster and Project Members page. The issue is that the UI expects the `projectId` in the format `c-m-xxxx:p-yyy`, but it has been updated to match the project namespace name `c-xxxx-p-yyy`. This only affects downstream clusters because [this condition](https://github.com/rancher/rancher/blob/main/pkg/api/norman/store/scoped/store.go#L28) works for the local cluster as the name does not contain a `-`.

## Solution
Replace all `-` when comparing the strings, so it also works for clusters with `-` in their name
 
## Testing
Unit tests added.
[Unit test](https://github.com/raulcabello/rancher/blob/e39fb1859f1cad1be09bf49403530111a3debbae/pkg/api/norman/store/scoped/store_test.go#L152) for local cluster is passing without the fix in this PR
[Unit test](https://github.com/raulcabello/rancher/blob/e39fb1859f1cad1be09bf49403530111a3debbae/pkg/api/norman/store/scoped/store_test.go#L163) for downstream cluster is **not** passing without the fix in this PR. It passes with this fix.