### PR TITLE
add token_type to the token response

### DIFF
--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const bearerTokenType = "Bearer"
+
 type sessionGetterRemover interface {
 	Get(code string) (*session.Session, error)
 	Remove(code string) error
@@ -65,6 +67,8 @@ type TokenResponse struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 	// ExpiresIn indicates when id_token and access_token expire.
 	ExpiresIn int `json:"expires_in"`
+	// TokenType is the OAuth 2.0 Token Type value. The value must be Bearer.
+	TokenType string `json:"token_type"`
 }
 
 // RefreshTokenClaims represent claims in the refresh_token
@@ -363,6 +367,7 @@ func (h *tokenHandler) createTokenResponse(rancherToken *v3.Token, oidcClient *v
 	resp := TokenResponse{
 		IDToken:     idTokenString,
 		AccessToken: accessTokenString,
+		TokenType:   bearerTokenType,
 	}
 
 	// create refresh_token

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -558,6 +558,7 @@ func TestTokenEndpoint(t *testing.T) {
 				var tokenResponse TokenResponse
 				err := json.Unmarshal(rec.Body.Bytes(), &tokenResponse)
 				assert.NoError(t, err)
+				assert.Equal(t, tokenResponse.TokenType, bearerTokenType)
 				if test.wantIdTokenClaims != nil {
 					claims := jwt.MapClaims{}
 					_, err := jwt.ParseWithClaims(tokenResponse.IDToken, &claims, func(token *jwt.Token) (interface{}, error) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49931
 
## Problem
the `Token` response does not contain the `token_type` field. This is required according to the OIDC specification (https://openid.net/specs/openid-connect-core-1_0-final.html#TokenResponse)
 
## Solution
Add `token_type` `Bearer` to the token response