### PR TITLE
[main] Adjust dockerfile to fix builds on arm+macos

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -9,6 +9,7 @@ ARG CATTLE_KDM_BRANCH=dev-v2.11
 ARG VERSION=${VERSION}
 
 FROM registry.suse.com/bci/bci-micro:15.6 AS final
+RUN : # No-op command to create an explicit layer - this fixes a weird buildkit/buildx bug on macos arm
 
 # Temporary build stage image
 FROM registry.suse.com/bci/bci-base:15.6 AS chroot-builder


### PR DESCRIPTION
# Issue
On MacOS with ARM (could affect other systems too who knows), I am seeing this error:
```
------
 > [chroot-builder-server 1/2] COPY --from=final / /chroot/:
------
Dockerfile:27
--------------------
  25 |
  26 |     FROM chroot-builder AS chroot-builder-server
  27 | >>> COPY --from=final / /chroot/
  28 |     RUN zypper refresh && \
  29 |         zypper --installroot /chroot -n in --no-recommends \
--------------------
ERROR: failed to solve: failed to commit 4slhj7et8e43m0aekstqi0378 to 7ois4967oz61ftl23vgg0le77 during finalize: failed to stat active key during commit: snapshot 4slhj7et8e43m0aekstqi0378 does not exist: not found
```

The cause of this seems related to the `final` layer not being created or in the build cache. I was able to verify that adding any `RUN` directive to this - initially an `echo` - will fix the platform specific bug. I tried ensuring I have newest `buildkit` version and confirmed I already was fully updated.

In the end, we don't even need the `echo` part, so the PR here just adds the necessary "no-op RUN".