### PR TITLE
[2.11] [Backport] Fix flaky-test Test_Provisioning_Custom_ThreeNodeWithTaints

### DIFF
--- a/pkg/controllers/capr/unmanaged/controller.go
+++ b/pkg/controllers/capr/unmanaged/controller.go
@@ -246,6 +246,14 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 		annotations[capr.TaintsAnnotation] = string(data)
 	}
 
+	annotationWithTaints := func() map[string]string {
+		m := map[string]string{}
+		if annotations[capr.TaintsAnnotation] != "" {
+			m[capr.TaintsAnnotation] = annotations[capr.TaintsAnnotation]
+		}
+		return m
+	}
+
 	return []runtime.Object{
 		&rkev1.RKEBootstrap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -260,17 +268,19 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 		},
 		&rkev1.CustomMachine{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      machineName,
-				Namespace: capiCluster.Namespace,
-				Labels:    labels,
+				Name:        machineName,
+				Namespace:   capiCluster.Namespace,
+				Labels:      labels,
+				Annotations: annotationWithTaints(),
 			},
 		},
 		&capi.Machine{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      machineName,
-				Namespace: capiCluster.Namespace,
-				Labels:    labels,
+				Name:        machineName,
+				Namespace:   capiCluster.Namespace,
+				Labels:      labels,
+				Annotations: annotationWithTaints(),
 			},
 			Spec: capi.MachineSpec{
 				ClusterName: capiCluster.Name,


### PR DESCRIPTION
**Do Not Merge Until v2.11.1 is released.** 

Issue: https://github.com/rancher/rancher/issues/49983

Cherry-pick from https://github.com/rancher/rancher/pull/49923

