### PR TITLE
#49252 - Uninstalling RDP when Imperative API is off

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -338,7 +338,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 
 				return features.ImperativeApiExtension.Enabled() && ext.RDPEnabled()
 			},
-			Uninstall:       false,
+			Uninstall:       !features.ImperativeApiExtension.Enabled(),
 			RemoveNamespace: false,
 		},
 	}

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -662,6 +662,10 @@ func Test_ChartInstallation(t *testing.T) {
 				// system-upgrade-controller
 				// nothing to do in this case
 
+				// remotedialer-proxy
+				mocks.manager.EXPECT().Uninstall(namespace.System, "remotedialer-proxy").Return(nil)
+				mocks.manager.EXPECT().Remove(namespace.System, "remotedialer-proxy")
+
 				// rancher-operator
 				mocks.manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
 				mocks.manager.EXPECT().Remove(operatorNamespace, "rancher-operator")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#49252
 
## Problem
Rancher was keeping RDP even with Imperative API disabled. 
 
## Solution
Changed the Uninstall flag to indicate to Rancher it can remove RDP
