### PR TITLE
Add log statements to testcase for more visibility on flakiness

### DIFF
--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -952,6 +952,7 @@ func (c *ClusterRepoTestSuite) testClusterRepoRetries(params ClusterRepoParams) 
 
 		for _, condition := range cr.Status.Conditions {
 			if v1.RepoCondition(condition.Type) == v1.RepoDownloaded {
+				logrus.Infof("Condition Status (Actual/Wanted): %s/%s, Number of Retries (Actual/Wanted): %d/%d", condition.Status, corev1.ConditionFalse, cr.Status.NumberOfRetries, retryNumber)
 				if condition.Status == corev1.ConditionFalse && cr.Status.NumberOfRetries == retryNumber {
 					retryNumber++
 					return false, nil


### PR DESCRIPTION
Issue : https://github.com/rancher/rancher/issues/49668


- Couldn't reproduce the flakiness in the CI for 10 runs. 

Test Name   :  GitRepoRetries
Test 1 of 10 :        ✅ 
Test 2 of 10 :        ✅ 
Test 3 of 10 :        ✅ 
Test 4 of 10 :        ✅ 
Test 5 of 10 :        ✅  
Test 6 of 10 :        ✅ 
Test 7 of 10 :        ✅ 
Test 8 of 10 :        ✅ 
Test 9 of 10 :        ✅ 
Test 10 of 10 :       ✅ 


- I am adding a log statement to understand the flakiness. This will be temporary until I understand the root cause of flakiness. It might be annoying to see these log statements in the CI temporarily. 
