### PR TITLE
Improve consistency of project scoped secrets controllers

### DIFF
--- a/pkg/controllers/managementuser/secret/project_scoped_secrets.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets.go
@@ -128,7 +128,7 @@ func (n *namespaceHandler) removeUndesiredProjectScopedSecrets(namespace *corev1
 	var errs error
 	for _, secret := range secretsToDelete.UnsortedList() {
 		// secret in namespace does not belong here
-		logrus.Infof("deleting secret %s from namespace %s", secret.Name, secret.Namespace)
+		logrus.Infof("Cleaning project scoped secret %s from namespace %s", secret.Name, secret.Namespace)
 		errs = errors.Join(errs, n.secretClient.Delete(namespace.Name, secret.Name, &metav1.DeleteOptions{}))
 	}
 	return errs
@@ -176,7 +176,7 @@ func (n *namespaceHandler) getNamespacesFromSecret(secret *corev1.Secret) ([]*co
 		return nil, err
 	}
 	if project.GetProjectBackingNamespace() != secret.Namespace {
-		logrus.Tracef("secret [%s] not in the project namespace, not copying", secret.Name)
+		logrus.Tracef("Secret [%s] not in the project namespace, not copying", secret.Name)
 		return nil, nil
 	}
 

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
@@ -1,0 +1,453 @@
+package secret
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	errDefault  = fmt.Errorf("error")
+	errNotFound = apierrors.NewNotFound(schema.GroupResource{}, "error")
+)
+
+func Test_namespaceHandler_getNamespacesFromSecret(t *testing.T) {
+	tests := []struct {
+		name                string
+		secret              *corev1.Secret
+		clusterName         string
+		setupProjectCache   func(*fake.MockCacheInterface[*v3.Project])
+		setupNamespaceCache func(*fake.MockNonNamespacedCacheInterface[*corev1.Namespace])
+		want                []*corev1.Namespace
+		wantErr             bool
+	}{
+		{
+			name: "secret has no labels",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-secret",
+					Labels: nil,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "secret has no project scoped secret label",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+					Labels: map[string]string{
+						"fake-label": "fake-value",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "project not in right cluster",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+					Labels: map[string]string{
+						projectScopedSecretLabel: "p-abc",
+					},
+				},
+			},
+			clusterName: "c-abc",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-abc", "p-abc").Return(nil, errNotFound)
+			},
+			want: nil,
+		},
+		{
+			name: "error getting project",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-secret",
+					Labels: map[string]string{
+						projectScopedSecretLabel: "p-abc",
+					},
+				},
+			},
+			clusterName: "c-abc",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-abc", "p-abc").Return(nil, errDefault)
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "secret not in project backing namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "wrong-namespace",
+					Labels: map[string]string{
+						projectScopedSecretLabel: "p-abc",
+					},
+				},
+			},
+			clusterName: "c-abc",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-abc", "p-abc").Return(&v3.Project{
+					Status: v3.ProjectStatus{
+						BackingNamespace: "c-xyz",
+					},
+				}, nil)
+			},
+			want: nil,
+		},
+		{
+			name: "error listing namespaces",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "c-xyz",
+					Labels: map[string]string{
+						projectScopedSecretLabel: "p-abc",
+					},
+				},
+			},
+			clusterName: "c-xyz",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-xyz", "p-abc").Return(&v3.Project{
+					Status: v3.ProjectStatus{
+						BackingNamespace: "c-xyz",
+					},
+				}, nil)
+			},
+			setupNamespaceCache: func(f *fake.MockNonNamespacedCacheInterface[*corev1.Namespace]) {
+				f.EXPECT().List(gomock.Any()).Return(nil, errDefault)
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "return list of namespaces",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "c-xyz",
+					Labels: map[string]string{
+						projectScopedSecretLabel: "p-abc",
+					},
+				},
+			},
+			clusterName: "c-xyz",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-xyz", "p-abc").Return(&v3.Project{
+					Status: v3.ProjectStatus{
+						BackingNamespace: "c-xyz",
+					},
+				}, nil)
+			},
+			setupNamespaceCache: func(f *fake.MockNonNamespacedCacheInterface[*corev1.Namespace]) {
+				f.EXPECT().List(gomock.Any()).Return([]*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "namespace"}}}, nil)
+			},
+			want: []*corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "namespace"}},
+			},
+		},
+	}
+	ctrl := gomock.NewController(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
+			if tt.setupProjectCache != nil {
+				tt.setupProjectCache(projectCache)
+			}
+			namespaceCache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+			if tt.setupNamespaceCache != nil {
+				tt.setupNamespaceCache(namespaceCache)
+			}
+			n := &namespaceHandler{
+				clusterNamespaceCache: namespaceCache,
+				projectCache:          projectCache,
+				clusterName:           tt.clusterName,
+			}
+			got, err := n.getNamespacesFromSecret(tt.secret)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("namespaceHandler.getNamespacesFromSecret() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("namespaceHandler.getNamespacesFromSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_namespaceHandler_getProjectScopedSecretsFromNamespace(t *testing.T) {
+	tests := []struct {
+		name              string
+		namespace         *corev1.Namespace
+		setupProjectCache func(*fake.MockCacheInterface[*v3.Project])
+		setupSecretCache  func(*fake.MockCacheInterface[*corev1.Secret])
+		want              []*corev1.Secret
+		wantErr           bool
+	}{
+		{
+			name: "namespace is not part of a project",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"fake-label": "fake-value",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "projectID is malformed",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						projectIDLabel: "c-abc123-p-abc123",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "error getting project",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						projectIDLabel: "c-abc123:p-abc123",
+					},
+				},
+			},
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-abc123", "p-abc123").Return(nil, errDefault)
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error listing secrets",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						projectIDLabel: "c-abc123:p-abc123",
+					},
+				},
+			},
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-abc123", "p-abc123").Return(&v3.Project{
+					Status: v3.ProjectStatus{
+						BackingNamespace: "c-abc123-p-abc123",
+					},
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List("c-abc123-p-abc123", gomock.Any()).Return(nil, errDefault)
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "get list of secrets",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						projectIDLabel: "c-abc123:p-abc123",
+					},
+				},
+			},
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().Get("c-abc123", "p-abc123").Return(&v3.Project{
+					Status: v3.ProjectStatus{
+						BackingNamespace: "c-abc123-p-abc123",
+					},
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List("c-abc123-p-abc123", gomock.Any()).Return([]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret"}},
+				}, nil)
+			},
+			want: []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "secret"}}},
+		},
+	}
+	ctrl := gomock.NewController(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
+			if tt.setupProjectCache != nil {
+				tt.setupProjectCache(projectCache)
+			}
+			secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			if tt.setupSecretCache != nil {
+				tt.setupSecretCache(secretCache)
+			}
+			n := &namespaceHandler{
+				managementSecretCache: secretCache,
+				projectCache:          projectCache,
+			}
+			got, err := n.getProjectScopedSecretsFromNamespace(tt.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("namespaceHandler.getProjectScopedSecretsFromNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("namespaceHandler.getProjectScopedSecretsFromNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
+	type args struct {
+		namespace      *corev1.Namespace
+		desiredSecrets map[string]bool
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		setupSecretController func(*fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
+		wantErr               bool
+	}{
+		{
+			name: "error getting secrets",
+			args: args{
+				namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				desiredSecrets: map[string]bool{
+					"secret1": true,
+					"secret2": true,
+				},
+			},
+			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
+					Items: []corev1.Secret{},
+				}, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "desired secrets match existing secrets, no deletion",
+			args: args{
+				namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				desiredSecrets: map[string]bool{
+					"secret1": true,
+					"secret2": true,
+				},
+			},
+			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
+					Items: []corev1.Secret{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret1"},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret2"},
+						},
+					},
+				}, nil)
+			},
+		},
+		{
+			name: "no undesired secrets",
+			args: args{
+				namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				desiredSecrets: map[string]bool{
+					"secret1": true,
+					"secret2": true,
+				},
+			},
+			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
+					Items: []corev1.Secret{},
+				}, nil)
+			},
+		},
+		{
+			name: "remove undesired secrets",
+			args: args{
+				namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				desiredSecrets: map[string]bool{
+					"secret1": true,
+				},
+			},
+			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
+					Items: []corev1.Secret{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret1"},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret2"},
+						},
+					},
+				}, nil)
+				f.EXPECT().Delete("ns1", "secret2", &metav1.DeleteOptions{}).Return(nil)
+			},
+		},
+		{
+			name: "remove multiple secrets",
+			args: args{
+				namespace:      &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				desiredSecrets: map[string]bool{},
+			},
+			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
+					Items: []corev1.Secret{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret1"},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret2"},
+						},
+					},
+				}, nil)
+				f.EXPECT().Delete("ns1", "secret1", &metav1.DeleteOptions{}).Return(nil)
+				f.EXPECT().Delete("ns1", "secret2", &metav1.DeleteOptions{}).Return(nil)
+			},
+		},
+		{
+			name: "error deleting secrets",
+			args: args{
+				namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				desiredSecrets: map[string]bool{
+					"secret1": true,
+				},
+			},
+			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
+					Items: []corev1.Secret{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret1"},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "secret2"},
+						},
+					},
+				}, nil)
+				f.EXPECT().Delete("ns1", "secret2", &metav1.DeleteOptions{}).Return(errDefault)
+			},
+			wantErr: true,
+		},
+	}
+	ctrl := gomock.NewController(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secretController := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			if tt.setupSecretController != nil {
+				tt.setupSecretController(secretController)
+			}
+			n := &namespaceHandler{
+				secretController: secretController,
+			}
+			if err := n.removeUndesiredProjectScopedSecrets(tt.args.namespace, tt.args.desiredSecrets); (err != nil) != tt.wantErr {
+				t.Errorf("namespaceHandler.removeUndesiredProjectScopedSecrets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
@@ -312,10 +312,10 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 		desiredSecrets sets.Set[types.NamespacedName]
 	}
 	tests := []struct {
-		name                  string
-		args                  args
-		setupSecretController func(*fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
-		wantErr               bool
+		name              string
+		args              args
+		setupSecretClient func(*fake.MockClientInterface[*corev1.Secret, *corev1.SecretList])
+		wantErr           bool
 	}{
 		{
 			name: "error getting secrets",
@@ -326,7 +326,7 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 					{Name: "secret2", Namespace: "ns1"}: {},
 				},
 			},
-			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+			setupSecretClient: func(f *fake.MockClientInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{},
 				}, errDefault)
@@ -342,7 +342,7 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 					{Name: "secret2", Namespace: "ns1"}: {},
 				},
 			},
-			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+			setupSecretClient: func(f *fake.MockClientInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
@@ -364,7 +364,7 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 					{Name: "secret2", Namespace: "ns1"}: {},
 				},
 			},
-			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+			setupSecretClient: func(f *fake.MockClientInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{},
 				}, nil)
@@ -378,7 +378,7 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 					{Name: "secret1", Namespace: "ns1"}: {},
 				},
 			},
-			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+			setupSecretClient: func(f *fake.MockClientInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
@@ -398,7 +398,7 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 				namespace:      &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
 				desiredSecrets: sets.Set[types.NamespacedName]{},
 			},
-			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+			setupSecretClient: func(f *fake.MockClientInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
@@ -421,7 +421,7 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 					{Name: "secret1", Namespace: "ns1"}: {},
 				},
 			},
-			setupSecretController: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+			setupSecretClient: func(f *fake.MockClientInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
@@ -440,12 +440,12 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			secretController := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
-			if tt.setupSecretController != nil {
-				tt.setupSecretController(secretController)
+			secretClient := fake.NewMockClientInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			if tt.setupSecretClient != nil {
+				tt.setupSecretClient(secretClient)
 			}
 			n := &namespaceHandler{
-				secretController: secretController,
+				secretClient: secretClient,
 			}
 			if err := n.removeUndesiredProjectScopedSecrets(tt.args.namespace, tt.args.desiredSecrets); (err != nil) != tt.wantErr {
 				t.Errorf("namespaceHandler.removeUndesiredProjectScopedSecrets() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -67,7 +67,7 @@ func Bootstrap(ctx context.Context, mgmt *config.ScaledContext, cluster *config.
 }
 
 func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *apimgmtv3.Cluster) {
-	register(ctx, cluster)
+	RegisterProjectScopedSecretHandler(ctx, cluster)
 
 	resourceSyncController := &ResourceSyncController{
 		upstreamSecrets:   mgmt.Core.Secrets(clusterRec.Spec.FleetWorkspaceName),

--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -11,7 +11,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/rancher/norman/controller"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/capr"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
@@ -21,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 // SecretController listens for secret CUD in management API
@@ -32,7 +30,6 @@ import (
 // and creates the secrets in the cluster namespace
 
 const (
-	projectIDLabel             = "field.cattle.io/projectId"
 	create                     = "create"
 	update                     = "update"
 	projectNamespaceAnnotation = "management.cattle.io/system-namespace"
@@ -50,14 +47,6 @@ var (
 	// also included is "" to support copying into the same ns the secret is in
 	approvedPreBootstrapTargetNamespaces = []string{"kube-system", ""}
 )
-
-type Controller struct {
-	secrets                   v1.SecretInterface
-	clusterNamespaceLister    v1.NamespaceLister
-	managementNamespaceLister v1.NamespaceLister
-	projectLister             v3.ProjectLister
-	clusterName               string
-}
 
 type ResourceSyncController struct {
 	upstreamSecrets   v1.SecretInterface
@@ -78,31 +67,7 @@ func Bootstrap(ctx context.Context, mgmt *config.ScaledContext, cluster *config.
 }
 
 func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *apimgmtv3.Cluster) {
-	starter := cluster.DeferredStart(ctx, func(ctx context.Context) error {
-		registerDeferred(ctx, cluster)
-		return nil
-	})
-
-	projectLister := cluster.Management.Management.Projects("").Controller().Lister()
-	secrets := cluster.Management.Core.Secrets("")
-	secrets.AddHandler(ctx, "secret-deferred", func(key string, obj *corev1.Secret) (runtime.Object, error) {
-		if obj == nil {
-			return nil, nil
-		}
-
-		_, err := projectLister.Get(cluster.ClusterName, obj.Namespace)
-		if errors.IsNotFound(err) {
-			return obj, nil
-		} else if err != nil {
-			return obj, err
-		}
-
-		if !strings.HasPrefix(obj.Name, "default-token-") {
-			return obj, starter()
-		}
-
-		return obj, nil
-	})
+	register(ctx, cluster)
 
 	resourceSyncController := &ResourceSyncController{
 		upstreamSecrets:   mgmt.Core.Secrets(clusterRec.Spec.FleetWorkspaceName),
@@ -252,245 +217,4 @@ func (c *ResourceSyncController) sync(key string, obj *corev1.Secret) (runtime.O
 
 	obj.Annotations[syncedAtAnnotation] = time.Now().Format(time.RFC3339)
 	return obj, nil
-}
-
-func registerDeferred(ctx context.Context, cluster *config.UserContext) {
-	clusterSecretsClient := cluster.Core.Secrets("")
-	s := &Controller{
-		secrets:                   clusterSecretsClient,
-		clusterNamespaceLister:    cluster.Core.Namespaces("").Controller().Lister(),
-		managementNamespaceLister: cluster.Management.Core.Namespaces("").Controller().Lister(),
-		projectLister:             cluster.Management.Management.Projects(cluster.ClusterName).Controller().Lister(),
-		clusterName:               cluster.ClusterName,
-	}
-
-	n := &NamespaceController{
-		clusterSecretsClient: clusterSecretsClient,
-		managementSecrets:    cluster.Management.Core.Secrets("").Controller().Lister(),
-		projectCache:         cluster.Management.Management.Projects("").Controller().Lister(),
-	}
-	cluster.Core.Namespaces("").AddHandler(ctx, "secretsController", n.sync)
-
-	sync := v1.NewSecretLifecycleAdapter(fmt.Sprintf("secretsController_%s", cluster.ClusterName), true,
-		cluster.Management.Core.Secrets(""), s)
-
-	cluster.Management.Core.Secrets("").AddHandler(ctx, "secretsController", func(key string, obj *corev1.Secret) (runtime.Object, error) {
-		if obj == nil {
-			logrus.Tracef("secretsController: AddHandler: obj is nil, calling sync")
-			return sync(key, nil)
-		}
-		if !controller.ObjectInCluster(cluster.ClusterName, obj) {
-			logrus.Tracef("secretsController: AddHandler: obj [%s] is not in cluster [%s], returning nil", obj.Name, cluster.ClusterName)
-			return nil, nil
-		}
-
-		if obj.Type == corev1.SecretTypeServiceAccountToken {
-			logrus.Tracef("secretsController: AddHandler: obj [%s] is Service Account token, skipping", obj.Name)
-			return nil, nil
-		}
-
-		if obj.Labels != nil {
-			if obj.Labels["cattle.io/creator"] == "norman" {
-				logrus.Tracef("secretsController: AddHandler: obj [%s] labels in [%s] contain cattle.io/creator=norman, calling sync", obj.Name, cluster.ClusterName)
-				return sync(key, obj)
-			}
-		}
-
-		return nil, nil
-	})
-}
-
-type NamespaceController struct {
-	clusterSecretsClient v1.SecretInterface
-	managementSecrets    v1.SecretLister
-	projectCache         v3.ProjectLister
-}
-
-func (n *NamespaceController) sync(key string, obj *corev1.Namespace) (runtime.Object, error) {
-	if obj == nil || obj.DeletionTimestamp != nil {
-		return nil, nil
-	}
-	logrus.Tracef("secretsController: sync called for key [%s] in namespace [%s]", key, obj.Name)
-	// field.cattle.io/projectId value is <cluster name>:<project name>
-	logrus.Tracef("secretsController: sync: key [%s], obj.Annotations[projectIDLabel]: [%s]", key, obj.Annotations[projectIDLabel])
-	if obj.Annotations[projectIDLabel] != "" {
-		clusterName, projectName, found := strings.Cut(obj.Annotations[projectIDLabel], ":")
-		if !found {
-			logrus.Debugf("secretsController: sync: namespace %s projectId annotation %s is malformed, should be <cluster name>:<project name>", obj.Name, obj.Annotations[projectIDLabel])
-			return nil, nil
-		}
-
-		p, err := n.projectCache.Get(clusterName, projectName)
-		if err != nil {
-			return nil, fmt.Errorf("secretsController: sync: error getting project %s for namespace %s: %w", projectName, obj.Name, err)
-		}
-
-		backingNamespace := p.GetProjectBackingNamespace()
-		secrets, err := n.managementSecrets.List(backingNamespace, labels.NewSelector())
-		if err != nil {
-			return nil, err
-		}
-
-		logrus.Tracef("secretsController: sync: length of secrets for project [%s] in namespace [%s] is %d", projectName, obj.Name, len(secrets))
-		for _, secret := range secrets {
-			// skip service account token secrets
-			if secret.Type == corev1.SecretTypeServiceAccountToken {
-				logrus.Tracef("secretsController: AddHandler: secret [%s] is Service Account token, skipping", secret.Name)
-				continue
-			}
-			namespacedSecret := getNamespacedSecret(secret, obj.Name)
-			if _, err := n.clusterSecretsClient.GetNamespaced(namespacedSecret.Namespace, namespacedSecret.Name, metav1.GetOptions{}); err == nil {
-				continue
-			}
-			logrus.Infof("Creating secret [%s] into namespace [%s]", namespacedSecret.Name, obj.Name)
-			_, err := n.clusterSecretsClient.Create(namespacedSecret)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				return nil, err
-			}
-		}
-	}
-	return nil, nil
-}
-
-func (s *Controller) Create(obj *corev1.Secret) (runtime.Object, error) {
-	logrus.Tracef("secretsController: Create called for [%s]", obj.Name)
-	return nil, s.createOrUpdate(obj, create)
-}
-
-func (s *Controller) Updated(obj *corev1.Secret) (runtime.Object, error) {
-	logrus.Tracef("secretsController: Updated called for [%s]", obj.Name)
-	return nil, s.createOrUpdate(obj, update)
-}
-
-func (s *Controller) Remove(obj *corev1.Secret) (runtime.Object, error) {
-	logrus.Tracef("secretsController: Remove called for [%s]", obj.Name)
-	clusterNamespaces, err := s.getClusterNamespaces(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, namespace := range clusterNamespaces {
-		logrus.Infof("Deleting secret [%s] in namespace [%s]", obj.Name, namespace.Name)
-		if err := s.secrets.DeleteNamespaced(namespace.Name, obj.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-			return nil, err
-		}
-	}
-	return nil, nil
-}
-
-func (s *Controller) getClusterNamespaces(obj *corev1.Secret) ([]*corev1.Namespace, error) {
-	logrus.Tracef("secretsController: getClusterNamespaces called for [%s]", obj.Name)
-	var toReturn []*corev1.Namespace
-	projectNamespace, err := s.managementNamespaceLister.Get("", obj.Namespace)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			logrus.Warnf("Project namespace [%s] can't be found", obj.Namespace)
-			return toReturn, nil
-		}
-		return toReturn, err
-	}
-	if projectNamespace.Annotations == nil {
-		return toReturn, nil
-	}
-	if val, ok := projectNamespace.Annotations[projectNamespaceAnnotation]; !(ok && val == "true") {
-		return toReturn, nil
-	}
-
-	// Ignore projects from other clusters. Project namespace name = project name, so use it to locate the project
-	_, err = s.projectLister.Get(s.clusterName, projectNamespace.Name)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return toReturn, nil
-		}
-		return toReturn, err
-	}
-
-	namespaces, err := s.clusterNamespaceLister.List("", labels.NewSelector())
-	if err != nil {
-		return toReturn, err
-	}
-	// system project namespace name == project.Name
-	projectID := obj.Namespace
-
-	for _, namespace := range namespaces {
-		parts := strings.Split(namespace.Annotations[projectIDLabel], ":")
-		if len(parts) == 2 && parts[1] == projectID {
-			toReturn = append(toReturn, namespace)
-		}
-	}
-	return toReturn, nil
-}
-
-func (s *Controller) createOrUpdate(obj *corev1.Secret, action string) error {
-	logrus.Tracef("secretsController: createOrUpdate called for [%s]", obj.Name)
-	if obj.Annotations[projectIDLabel] != "" {
-		parts := strings.Split(obj.Annotations[projectIDLabel], ":")
-		if len(parts) == 2 {
-			if parts[0] != s.clusterName {
-				return nil
-			}
-		}
-	}
-	clusterNamespaces, err := s.getClusterNamespaces(obj)
-	if err != nil {
-		return err
-	}
-	for _, namespace := range clusterNamespaces {
-		if !namespace.DeletionTimestamp.IsZero() {
-			continue
-		}
-		// copy the secret into namespace
-		namespacedSecret := getNamespacedSecret(obj, namespace.Name)
-		switch action {
-		case create:
-			if _, err := s.secrets.GetNamespaced(namespacedSecret.Namespace, namespacedSecret.Name, metav1.GetOptions{}); err == nil {
-				continue
-			}
-			logrus.Infof("Copying secret [%s] into namespace [%s]", namespacedSecret.Name, namespace.Name)
-			_, err := s.secrets.Create(namespacedSecret)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				return err
-			}
-		case update:
-			if existing, err := s.secrets.GetNamespaced(namespacedSecret.Namespace, namespacedSecret.Name, metav1.GetOptions{}); err == nil &&
-				reflect.DeepEqual(existing.Data, namespacedSecret.Data) {
-				continue
-			}
-			logrus.Infof("Updating secret [%s] into namespace [%s]", namespacedSecret.Name, namespace.Name)
-			_, err := s.secrets.Update(namespacedSecret)
-			if err != nil && !errors.IsNotFound(err) {
-				return err
-			} else if errors.IsNotFound(err) {
-				logrus.Infof("Updating secret [%s] returned NotFound, creating secret [%s] into namespace [%s]", namespacedSecret.Name, namespacedSecret.Name, namespace.Name)
-				_, err := s.secrets.Create(namespacedSecret)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func getNamespacedSecret(obj *corev1.Secret, namespace string) *corev1.Secret {
-	namespacedSecret := &corev1.Secret{}
-	namespacedSecret.Name = obj.Name
-	namespacedSecret.Kind = obj.Kind
-	namespacedSecret.Data = obj.Data
-	namespacedSecret.StringData = obj.StringData
-	namespacedSecret.Namespace = namespace
-	namespacedSecret.Type = obj.Type
-	namespacedSecret.Annotations = make(map[string]string)
-	namespacedSecret.Labels = make(map[string]string)
-	copyMap(namespacedSecret.Annotations, obj.Annotations)
-	copyMap(namespacedSecret.Labels, obj.Labels)
-	namespacedSecret.Annotations[userSecretAnnotation] = "true"
-	return namespacedSecret
-}
-
-func copyMap(dst map[string]string, src map[string]string) {
-	for k, v := range src {
-		dst[k] = v
-	}
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50093
 
## Problem
The primary desire of this change is to re-introduce the project scoped secrets feature in a well defined way. Currently it's an available feature by enabling the `Legacy` feature flag, and is only supported through Norman. It's possible to trigger the controllers used by Norman by applying specific annotations and then manually triggering the namespace controllers. There's also no tests around this feature.

## Solution
Took this as an opportunity to re-work the controllers that implement the project scoped secret feature. Some key points:

- Using Wrangler controllers and clients
- Unit tests
- Improved comments, logging and readability
- Splitting it into it's own file

The new (or at least more complete) functionality is as follows:

1. Secrets in the local cluster with the label `management.cattle.io/project-scoped-secret: <projectID>` that are in the project's backing namespace get copied to each downstream namespace within the project
2. Editing the project scoped secret from the local cluster causes the copied secrets to be updated
3. Removing the project scoped secret from the local cluster deletes all copies
4. Moving a downstream namespace with a copy of the secret from one project to another deletes the secret
5. Moving a downstream namespace without a copy of the secret from a project to one that contains a project scoped secret gets a copy added
6. Deleting a namespace removes the secret (this is default kubernetes behaviour)

 
Importantly, I removed the existing project scoped secrets controllers. It will not delete the secrets, but it will no longer trigger updates or add the project scoped secret to new namespaces. A follow up item will migrate those secrets so when 2.12 is released, it will move over all the project scoped secrets.

## Testing

## Engineering Testing
### Manual Testing
Manually tested the above functionality

### Automated Testing
* Test types added/modified:
    * Unit

Summary: Working on implementing integration tests using `envtest`, but there are challenges given this feature requires a local cluster and a downstream cluster. If I make a breakthrough, I'll add those tests to this PR

## QA Testing Considerations
The list of functionality above are the key testing areas. As long as those work I think this is considered complete.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_