### PR TITLE
[main] Bump Shell to version with k8s support for 2.12

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,5 +2,5 @@ webhookVersion: 107.0.0+up0.8.0-rc.3
 remoteDialerProxyVersion: 106.0.0+up0.4.4
 provisioningCAPIVersion: 106.0.0+up0.7.0
 cspAdapterMinVersion: 106.0.0+up6.0.0-rc1
-defaultShellVersion: rancher/shell:v0.4.0
+defaultShellVersion: rancher/shell:v0.5.0-rc.2
 fleetVersion: 107.0.0+up0.13.0-alpha.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion     = "106.0.0+up6.0.0-rc1"
-	DefaultShellVersion      = "rancher/shell:v0.4.0"
+	DefaultShellVersion      = "rancher/shell:v0.5.0-rc.2"
 	FleetVersion             = "107.0.0+up0.13.0-alpha.2"
 	ProvisioningCAPIVersion  = "106.0.0+up0.7.0"
 	RemoteDialerProxyVersion = "106.0.0+up0.4.4"


### PR DESCRIPTION
This is related to: https://github.com/rancher/shell/issues/340