### PR TITLE
Remove references to removed project.cattle.io CRDs

### DIFF
--- a/pkg/api/steve/disallow/disallow.go
+++ b/pkg/api/steve/disallow/disallow.go
@@ -29,14 +29,11 @@ var (
 		"settings": true,
 	}
 	disallowGet = map[string]bool{
-		"preferences":               true,
-		"sourcecodecredentials":     true,
-		"sourcecodeproviderconfigs": true,
-		"sourcecoderepositories":    true,
-		"templatecontents":          true,
-		"templates":                 true,
-		"templateversions":          true,
-		"tokens":                    true,
+		"preferences":      true,
+		"templatecontents": true,
+		"templates":        true,
+		"templateversions": true,
+		"tokens":           true,
 	}
 )
 

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -25,7 +25,6 @@ const (
 )
 
 var projectManagementPlaneResources = map[string]string{
-	"sourcecodeproviderconfigs":   "project.cattle.io",
 	"projectroletemplatebindings": "management.cattle.io",
 	"secrets":                     "",
 }

--- a/pkg/controllers/management/auth/roletemplates/roletemplate_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/roletemplate_handler.go
@@ -24,7 +24,6 @@ var (
 	}
 	projectManagementPlaneResources = map[string]string{
 		"apps":                        "project.cattle.io",
-		"sourcecodeproviderconfigs":   "project.cattle.io",
 		"projectroletemplatebindings": "management.cattle.io",
 		"secrets":                     "",
 	}

--- a/pkg/controllers/management/auth/roletemplates/roletemplate_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/roletemplate_handler_test.go
@@ -732,11 +732,6 @@ func Test_getManagementPlaneRules(t *testing.T) {
 					Verbs:     []string{"*"},
 				},
 				{
-					Resources: []string{"sourcecodeproviderconfigs"},
-					APIGroups: []string{"project.cattle.io"},
-					Verbs:     []string{"*"},
-				},
-				{
 					Resources: []string{"projectroletemplatebindings"},
 					APIGroups: []string{"management.cattle.io"},
 					Verbs:     []string{"*"},

--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -367,16 +367,6 @@ func (m *Migrator) CreateOrUpdateAADCertSecret(secretName string, rkeConfig *rke
 	return m.createOrUpdateSecretForCredential(secretName, SecretNamespace, rkeConfig.CloudProvider.AzureCloudProvider.AADClientCertPassword, nil, owner, "cluster", "aadcert")
 }
 
-// CreateOrUpdateSourceCodeProviderConfigSecret accepts an optional secret name and a client secret or
-// private key for a SourceCodeProviderConfig and creates a Secret for the credential if there is one.
-// If an owner is passed, the owner is set as an owner reference on the Secret.
-// It returns a reference to the Secret if one was created. If the returned Secret is not nil and there is no error,
-// the caller is responsible for un-setting the secret data, setting a reference to the Secret, and
-// updating the Cluster object, if applicable.
-func (m *Migrator) CreateOrUpdateSourceCodeProviderConfigSecret(secretName string, credential string, owner runtime.Object, provider string) (*corev1.Secret, error) {
-	return m.createOrUpdateSecretForCredential(secretName, SecretNamespace, credential, nil, owner, "sourcecodeproviderconfig", provider)
-}
-
 // CreateOrUpdateHarvesterCloudConfigSecret accepts an optional secret name and a client secret or
 // harvester cloud-provider-config and creates a Secret for the credential if there is one.
 // If an owner is passed, the owner is set as an owner reference on the Secret.

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -98,8 +98,6 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch").
-		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").
-		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch").
 		addRule().apiGroups("apiextensions.k8s.io").resources("customresourcedefinitions").verbs("get", "list", "watch")
 
@@ -210,7 +208,6 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("ui.cattle.io").resources("navlinks").verbs("get", "list", "watch").
 		addRule().apiGroups("").resources("nodes").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectroletemplatebindings").verbs("*").
-		addRule().apiGroups("project.cattle.io").resources("sourcecodeproviderconfigs").verbs("*").
 		addRule().apiGroups("").resources("namespaces").verbs("create").
 		addRule().apiGroups("").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("storage.k8s.io").resources("storageclasses").verbs("get", "list", "watch").
@@ -416,8 +413,6 @@ func addUserRules(role *roleBuilder) *roleBuilder {
 		addRule().apiGroups("management.cattle.io").resources("rkeaddons").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("cisconfigs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("cisbenchmarkversions").verbs("get", "list", "watch").
-		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").
-		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch").


### PR DESCRIPTION
## Issue: 
 
## Problem
Several `project.cattle.io` CRDs were removed with this PR in 2.7 https://github.com/rancher/rancher/pull/38579. However, a few references were missed. Specifically, `sourcecodeproviderconfigs`, `sourcecoderepositories` and `sourcecodecredentials`. 
 
## Solution
Removed all references to those resources.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_