### PR TITLE
Make sure all helm release secrets are deleted in integration tests before moving on

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,7 +92,6 @@ jobs:
         run: |
           mkdir -p bin
           curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${{ steps.env.outputs.CATTLE_KDM_BRANCH }}/data.json > bin/data.json
-      ## Helm Setup end
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Issue : https://github.com/rancher/rancher/issues/49896 https://github.com/rancher/rancher/issues/49457

Test Name   :  TestUpgradeToBrokenVersion
Test 1 of 10 :    ✅     
Test 2 of 10 :    ✅      
Test 3 of 10 :    ✅     
Test 4 of 10 :    ✅     
Test 5 of 10 :    ✅     
Test 6 of 10 :    ✅      
Test 7 of 10 :    ✅     
Test 8 of 10 :    👎🏽  Failed, the app aks-operator from the previous testcase didn't uninstall properly.    

🔨  Made a fix to uninstall properly like in other integration tests.  Restarting the count. 
     
Test Name   :  TestUpgradeToBrokenVersion, TestUpgradeChartToLatestVersion
Test 1 of 10 :   ✅       
Test 2 of 10 :  👎🏽 Failed, investigating....Adding more logs to find the reason...same as above the previous testcase didn't uninstall properly. 

🔨  Added more asserts to confirm if the app has recieved delete event. Restarting the count. Also, I have completely changed the logic of uninstalling a chart and this time I am waiting for the helm release secrets to be completely deleted. So, restarting the count now...

Test Name   :  TestUpgradeToBrokenVersion, TestUpgradeChartToLatestVersion
Test 1 of 10 :   ✅          
Test 2 of 10 :  ✅        
Test 3 of 10 :  ✅       
Test 4 of 10 :  ✅        
Test 5 of 10 :  ✅         
Test 6 of 10 :  ✅         
Test 7 of 10 :  ✅        
Test 8 of 10 :  ✅ 
Test 9 of 10 :  ✅ 
Test 10 of 10 : ✅  Failed but not these two tests. 