### PR TITLE
[v2.11] Make `make quick` quick

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -160,6 +160,7 @@ jobs:
           file: ./package/Dockerfile
           labels: "${{ steps.meta.outputs.labels }}"
           outputs: type=docker,dest=/tmp/rancher-${{ matrix.os }}-${{ env.ARCH }}.tar
+          no-cache: true
       - name: Upload image
         uses: actions/upload-artifact@v4
         with:
@@ -248,6 +249,7 @@ jobs:
           file: ./package/Dockerfile.agent
           labels: "${{ steps.meta.outputs.labels }}"
           outputs: type=docker,dest=/tmp/rancher-agent-${{ matrix.os }}-${{ env.ARCH }}.tar
+          no-cache: true
       - name: Upload image
         uses: actions/upload-artifact@v4
         with:

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -237,15 +237,19 @@ ENV ETCD_UNSUPPORTED_ARCH ${ETCD_UNSUPPORTED_ARCH}
 # Enable exporting of the k3s images as part of the build process.
 FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS images
 
+ENV GOMODCACHE=/root/.cache/go/modcache
+ENV GOCACHE=/root/.cache/go/cache
+
 ENV CATTLE_K3S_VERSION v1.32.1+k3s1
 
 RUN zypper -n install libbtrfs-devel libgpgme-devel
 
 WORKDIR /src
+COPY hack/airgap/go.mod hack/airgap/go.sum /src/
+RUN --mount=type=cache,target=/root/.cache go mod download
 COPY hack/airgap/ /src/
-RUN go mod download
 
-RUN go build -tags k3s_export -o export-images ./...
+RUN --mount=type=cache,target=/root/.cache go build -tags k3s_export -o export-images ./...
 RUN ./export-images -k3s-version ${CATTLE_K3S_VERSION} -output /src/k3s-airgap-images.tar
 
 
@@ -263,16 +267,19 @@ ARG TARGETARCH
 
 WORKDIR /app
 
+ENV GOMODCACHE=/root/.cache/go/modcache
+ENV GOCACHE=/root/.cache/go/cache
+
 # Only invalidate cache if go.mod/go.sum changes.
 COPY go.mod go.sum .
 COPY pkg/apis/go.mod pkg/apis/go.sum pkg/apis/
 COPY pkg/client/go.mod pkg/client/go.sum pkg/client/
-RUN go mod download
+RUN --mount=type=cache,target=/root/.cache go mod download
 
 COPY pkg/ pkg/
 COPY main.go .
 
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o rancher
+RUN --mount=type=cache,target=/root/.cache GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o rancher
 
 FROM base
 
@@ -281,15 +288,15 @@ ENV CATTLE_SERVER_VERSION ${VERSION}
 ENV CATTLE_AGENT_IMAGE ${IMAGE_REPO}/rancher-agent:${VERSION}
 ENV CATTLE_SERVER_IMAGE ${IMAGE_REPO}/rancher
 
-COPY --chown=root:root --chmod=0755 \
+COPY --link --chown=root:root --chmod=0755 \
     --from=build /app/rancher /usr/bin/
-COPY --chown=root:root --chmod=0755 \
+COPY --link --chown=root:root --chmod=0755 \
     --from=images /src/k3s-airgap-images.tar /var/lib/rancher/k3s/agent/images/
-
 COPY --chown=root:root --chmod=0755 \
     package/loglevel \
     package/entrypoint.sh \
     package/jailer.sh /usr/bin/
+
 
 VOLUME /var/lib/rancher
 VOLUME /var/lib/kubelet

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -288,15 +288,14 @@ ENV CATTLE_SERVER_VERSION ${VERSION}
 ENV CATTLE_AGENT_IMAGE ${IMAGE_REPO}/rancher-agent:${VERSION}
 ENV CATTLE_SERVER_IMAGE ${IMAGE_REPO}/rancher
 
-COPY --link --chown=root:root --chmod=0755 \
+COPY --chown=root:root --chmod=0755 \
     --from=build /app/rancher /usr/bin/
-COPY --link --chown=root:root --chmod=0755 \
+COPY --chown=root:root --chmod=0755 \
     --from=images /src/k3s-airgap-images.tar /var/lib/rancher/k3s/agent/images/
 COPY --chown=root:root --chmod=0755 \
     package/loglevel \
     package/entrypoint.sh \
     package/jailer.sh /usr/bin/
-
 
 VOLUME /var/lib/rancher
 VOLUME /var/lib/kubelet

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -246,10 +246,10 @@ RUN zypper -n install libbtrfs-devel libgpgme-devel
 
 WORKDIR /src
 COPY hack/airgap/go.mod hack/airgap/go.sum /src/
-RUN --mount=type=cache,target=/root/.cache go mod download
+RUN --mount=type=cache,target=/root/.cache,id=rancher go mod download
 COPY hack/airgap/ /src/
 
-RUN --mount=type=cache,target=/root/.cache go build -tags k3s_export -o export-images ./...
+RUN --mount=type=cache,target=/root/.cache,id=rancher go build -tags k3s_export -o export-images ./...
 RUN ./export-images -k3s-version ${CATTLE_K3S_VERSION} -output /src/k3s-airgap-images.tar
 
 
@@ -274,12 +274,12 @@ ENV GOCACHE=/root/.cache/go/cache
 COPY go.mod go.sum .
 COPY pkg/apis/go.mod pkg/apis/go.sum pkg/apis/
 COPY pkg/client/go.mod pkg/client/go.sum pkg/client/
-RUN --mount=type=cache,target=/root/.cache go mod download
+RUN --mount=type=cache,target=/root/.cache,id=rancher go mod download
 
 COPY pkg/ pkg/
 COPY main.go .
 
-RUN --mount=type=cache,target=/root/.cache GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o rancher
+RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o rancher
 
 FROM base
 

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -16,16 +16,19 @@ ARG TARGETARCH
 
 WORKDIR /app
 
+ENV GOMODCACHE=/root/.cache/go/modcache
+ENV GOCACHE=/root/.cache/go/cache
+
 # Only invalidate cache if mod files changes.
 COPY go.mod go.sum .
 COPY pkg/apis/go.mod pkg/apis/go.sum pkg/apis/
 COPY pkg/client/go.mod pkg/client/go.sum pkg/client/
-RUN go mod download
+RUN --mount=type=cache,target=/root/.cache go mod download
 
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o agent ./cmd/agent
+RUN --mount=type=cache,target=/root/.cache GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o agent ./cmd/agent
 
 FROM ${RANCHER_IMAGE} AS rancher
 
@@ -74,9 +77,9 @@ ENV CATTLE_RANCHER_WEBHOOK_VERSION=$CATTLE_RANCHER_WEBHOOK_VERSION
 ARG CATTLE_RANCHER_PROVISIONING_CAPI_VERSION
 ENV CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=$CATTLE_RANCHER_PROVISIONING_CAPI_VERSION
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
-COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
-COPY --from=rancher /usr/bin/tini /usr/bin/
-COPY --from=build /app/agent /usr/bin/
+COPY --link --from=rancher /var/lib/rancher-data /var/lib/rancher-data
+COPY --link --from=rancher /usr/bin/tini /usr/bin/
+COPY --link --from=build /app/agent /usr/bin/
 COPY package/loglevel package/run.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
 

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -77,9 +77,9 @@ ENV CATTLE_RANCHER_WEBHOOK_VERSION=$CATTLE_RANCHER_WEBHOOK_VERSION
 ARG CATTLE_RANCHER_PROVISIONING_CAPI_VERSION
 ENV CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=$CATTLE_RANCHER_PROVISIONING_CAPI_VERSION
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
-COPY --link --from=rancher /var/lib/rancher-data /var/lib/rancher-data
-COPY --link --from=rancher /usr/bin/tini /usr/bin/
-COPY --link --from=build /app/agent /usr/bin/
+COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
+COPY --from=rancher /usr/bin/tini /usr/bin/
+COPY --from=build /app/agent /usr/bin/
 COPY package/loglevel package/run.sh package/kubectl-shell.sh package/shell-setup.sh /usr/bin/
 WORKDIR /var/lib/rancher
 

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -23,12 +23,12 @@ ENV GOCACHE=/root/.cache/go/cache
 COPY go.mod go.sum .
 COPY pkg/apis/go.mod pkg/apis/go.sum pkg/apis/
 COPY pkg/client/go.mod pkg/client/go.sum pkg/client/
-RUN --mount=type=cache,target=/root/.cache go mod download
+RUN --mount=type=cache,target=/root/.cache,id=rancher go mod download
 
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN --mount=type=cache,target=/root/.cache GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o agent ./cmd/agent
+RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o agent ./cmd/agent
 
 FROM ${RANCHER_IMAGE} AS rancher
 


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/49633. The original description has been copy pasted here.

---

## Issue

`make quick` is pretty slow when developing Rancher. I don't use it for that reason, instead I use `make build` because it's much quicker (because dapper currently caches go build better than our dockerfiles).

This PR attempt to make `make quick` much faster by leveraging "more modern" docker build features: [RUN --mount=type=cache](https://docs.docker.com/reference/dockerfile/#run---mounttypecache).

First, the result..

### Results

**TL;DR**

|Step|Before changes|After changes|Speed up|
|:---  |    ----:|   ----:|   ----:|
|Cold build|~5m7s|~3m18s|1.55x|
|No changes|~7s|~7s|1x|
|Editing Go file|~3m21s|~29s|6.9x|
|Updating go.mod|~4m54s|~49s|6.0x|

<details>
<summary>Gimme `time` output</summary>



Here are the results from two scenarios I typically run into: (1) editing Go files directly in Rancher and (2) dependency changes in go.mod (either due to manual upgrades or git rebase). 

**Cold build**

Without PR:

```
real    5m7.062s
user    0m2.030s
sys     0m1.131s
```

With PR: Faster because go mod download was cached for the agent image so we didn't need to download those deps twice.

```
real    3m18.150s
user    0m2.028s
sys     0m1.153s
```

**No changes**

I just re-run `make quick` right after another `make quick` with no changes. Not very practical test but shows us the minimum amount of time a build will take.

Without PR:

```
real    0m6.233s
user    0m0.774s
sys     0m0.495s
```

With PR:

```
real    0m5.133s
user    0m0.845s
sys     0m0.461s
```

**Editing Go file**

This scenario is pretty simple. I'll edit an error message in file `pkg/wrangler/context.go` and compare how long that took to build. Each command simply runs `time make quick`.

Without PR:

```
real    3m21.571s
user    0m1.040s
sys     0m0.608s
```

With PR:

```
real    0m27.922s
user    0m0.814s
sys     0m0.426s
```

**Updating go.mod**

This scenario changes the Steve import from `v0.6.1` to `e1061a86cd67b47ca8a0a6b23c12dc6ce1a952a5`

Without PR:

```
real    4m54.650s
user    0m1.414s
sys     0m0.832s
```

With PR:

```
real    0m47.342s
user    0m0.913s
sys     0m0.464s
```

</details>

## Explanation

Using `--mount=type=cache,target=/root/.cache` in `RUN` directives helps us in two ways.

For `go mod download` commands, even if that layer needs to be re-run (due to a dependency change), the Go modules will most often be cached in that cache directory (the PR sets `GOMODCACHE=/root/.cache/go/modcache`) which means it doesn't need to download ALL the dependencies if only a single one changes. (Also note that both `Dockerfile` and `Dockerfile.agent` download go deps, which with these changes only need to be downloaded once now)

For `go build` commands, the compiler caches build artifacts to speed up compilation. Our current Dockerfile never keeps this information so the compiler ends up having to re-build everything even if a single file changes. With the changes, we're caching this in `GOCACHE` (`/root/.cache/go/cache`), so now compilation should be much shorter. (Think how much dependencies we have that Go has to go through, which rarely changes when doing the usual code-compile-test loop).

## The cache

The caches from `--mount=type=cache` are not used when docker build is provided with `--no-cache`. I believe we want this for SLSA reasons (cc: @pjbgf), but for developing I think it's a must to have the improved caching.

**Note:** Don't forget to run `docker buildx prune` once in a while to delete unused cached.

## Future improvement

Currently, building the agent image depends on the whole Rancher image being built. However, we see that we only need a subset of the rancher image:

```
COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
COPY --from=rancher /usr/bin/tini /usr/bin/
```

We should be able to build only the agent image when needed instead of going through both. (Of 30s build, rancher takes ~20s and the agent ~10s, so for building the agent image we should be able to shave off another 20s or so I think..)

Here's my attempt at this: https://github.com/rancher/rancher/pull/49636. 

---

cc: @pmatseykanets I'd be curious what kind of numbers you get with this, I remember your compile time to be pretty slow.