### PR TITLE
Update the deprecated k8s node selectors

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -54,7 +54,6 @@ var (
 	controlPlaneTaintsMutex sync.RWMutex
 	controlPlaneTaints      = make(map[string][]corev1.Taint)
 	controlPlaneLabels      = map[string]string{
-		"node-role.kubernetes.io/master":        "true",
 		"node-role.kubernetes.io/controlplane":  "true",
 		"node-role.kubernetes.io/control-plane": "true",
 	}

--- a/pkg/controllers/management/clusterstats/statsaggregator.go
+++ b/pkg/controllers/management/clusterstats/statsaggregator.go
@@ -26,7 +26,6 @@ const (
 	nodeRoleControlPlane       = "node-role.kubernetes.io/controlplane"
 	nodeRoleControlPlaneHyphen = "node-role.kubernetes.io/control-plane"
 	nodeRoleETCD               = "node-role.kubernetes.io/etcd"
-	nodeRoleMaster             = "node-role.kubernetes.io/master"
 	agentVersionUpgraded       = "agent.cluster.cattle.io/upgraded-v1.22"
 
 	// quietPeriod marks the minimum period between sync calls for the same Cluster
@@ -358,7 +357,7 @@ func (s *StatsAggregator) machineChanged(key string, machine *v3.Node) (runtime.
 func isTaintedNoExecuteNoSchedule(m *v3.Node) bool {
 	for _, taint := range m.Spec.InternalNodeSpec.Taints {
 		isETCDOrControlPlane := taint.Key == nodeRoleControlPlane || taint.Key == nodeRoleETCD ||
-			taint.Key == nodeRoleControlPlaneHyphen || taint.Key == nodeRoleMaster
+			taint.Key == nodeRoleControlPlaneHyphen
 		if isETCDOrControlPlane && (taint.Effect == "NoSchedule" || taint.Effect == "NoExecute") {
 			return true
 		}

--- a/pkg/controllers/management/k3sbasedupgrade/template.go
+++ b/pkg/controllers/management/k3sbasedupgrade/template.go
@@ -43,7 +43,7 @@ func generateMasterPlan(version string, concurrency int, drain bool, image, mast
 	masterPlan := genericPlan
 	return generatePlan(masterPlan, masterPlanName, version, image, concurrency, drain, &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
-			Key:      describe.LabelNodeRolePrefix + "master",
+			Key:      describe.LabelNodeRolePrefix + "control-plane",
 			Operator: metav1.LabelSelectorOpIn,
 			Values:   []string{"true"},
 		},
@@ -65,7 +65,7 @@ func generateWorkerPlan(version string, concurrency int, drain bool, image, work
 	return generatePlan(workerPlan, workerPlanName, version, image, concurrency, drain, &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      describe.LabelNodeRolePrefix + "master",
+				Key:      describe.LabelNodeRolePrefix + "control-plane",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			},
 			{
@@ -81,7 +81,7 @@ func configureMasterPlan(masterPlan planv1.Plan, version string, concurrency int
 	return configurePlan(masterPlan, version, concurrency, drain, masterPlanName, &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      describe.LabelNodeRolePrefix + "master",
+				Key:      describe.LabelNodeRolePrefix + "control-plane",
 				Operator: metav1.LabelSelectorOpIn,
 				Values:   []string{"true"},
 			},
@@ -103,7 +103,7 @@ func configureWorkerPlan(workerPlan planv1.Plan, version string, concurrency int
 	return configurePlan(workerPlan, version, concurrency, drain, workerPlanName, &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      describe.LabelNodeRolePrefix + "master",
+				Key:      describe.LabelNodeRolePrefix + "control-plane",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			},
 			{

--- a/pkg/controllers/management/k3sbasedupgrade/template_test.go
+++ b/pkg/controllers/management/k3sbasedupgrade/template_test.go
@@ -68,7 +68,7 @@ func TestGenerateMasterPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"true"},
 						},
@@ -119,7 +119,7 @@ func TestGenerateMasterPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"true"},
 						},
@@ -167,7 +167,7 @@ func TestGenerateMasterPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"true"},
 						},
@@ -239,7 +239,7 @@ func TestGenerateWorkerPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpDoesNotExist,
 						},
 							{
@@ -293,7 +293,7 @@ func TestGenerateWorkerPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpDoesNotExist,
 						},
 							{
@@ -344,7 +344,7 @@ func TestGenerateWorkerPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpDoesNotExist,
 						},
 							{
@@ -407,7 +407,7 @@ func TestConfigureMasterPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"true"},
 						},
@@ -448,7 +448,7 @@ func TestConfigureMasterPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"true"},
 						},
@@ -486,7 +486,7 @@ func TestConfigureMasterPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"true"},
 						},
@@ -555,7 +555,7 @@ func TestConfigureWorkerPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpDoesNotExist,
 						},
 							{
@@ -599,7 +599,7 @@ func TestConfigureWorkerPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpDoesNotExist,
 						},
 							{
@@ -640,7 +640,7 @@ func TestConfigureWorkerPlan(t *testing.T) {
 					Version: "test-version",
 					NodeSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "node-role.kubernetes.io/master",
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: metav1.LabelSelectorOpDoesNotExist,
 						},
 							{

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -732,7 +732,7 @@ func determineNodeRoles(machine *apimgmtv3.Node) {
 	if machine.Status.NodeLabels != nil {
 		_, etcd := machine.Status.NodeLabels["node-role.kubernetes.io/etcd"]
 		_, control := machine.Status.NodeLabels["node-role.kubernetes.io/controlplane"]
-		_, master := machine.Status.NodeLabels["node-role.kubernetes.io/master"]
+		_, master := machine.Status.NodeLabels["node-role.kubernetes.io/control-plane"]
 		_, worker := machine.Status.NodeLabels["node-role.kubernetes.io/worker"]
 		machine.Spec.Etcd = etcd
 		machine.Spec.Worker = worker

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer_test.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer_test.go
@@ -19,10 +19,10 @@ func TestDetermineNodeRole(t *testing.T) {
 				Spec: v3.NodeSpec{},
 				Status: v3.NodeStatus{
 					NodeLabels: map[string]string{
-						"node-role.kubernetes.io/etcd":         "true",
-						"node-role.kubernetes.io/controlplane": "true",
-						"node-role.kubernetes.io/master":       "true",
-						"node-role.kubernetes.io/worker":       "true"},
+						"node-role.kubernetes.io/etcd":          "true",
+						"node-role.kubernetes.io/controlplane":  "true",
+						"node-role.kubernetes.io/control-plane": "true",
+						"node-role.kubernetes.io/worker":        "true"},
 				},
 			},
 			expectedNode: &v3.Node{
@@ -33,10 +33,10 @@ func TestDetermineNodeRole(t *testing.T) {
 				},
 				Status: v3.NodeStatus{
 					NodeLabels: map[string]string{
-						"node-role.kubernetes.io/etcd":         "true",
-						"node-role.kubernetes.io/controlplane": "true",
-						"node-role.kubernetes.io/master":       "true",
-						"node-role.kubernetes.io/worker":       "true"},
+						"node-role.kubernetes.io/etcd":          "true",
+						"node-role.kubernetes.io/controlplane":  "true",
+						"node-role.kubernetes.io/control-plane": "true",
+						"node-role.kubernetes.io/worker":        "true"},
 				},
 			},
 		},
@@ -80,7 +80,7 @@ func TestDetermineNodeRole(t *testing.T) {
 			name: "master node label",
 			node: &v3.Node{
 				Status: v3.NodeStatus{
-					NodeLabels: map[string]string{"node-role.kubernetes.io/master": "true"},
+					NodeLabels: map[string]string{"node-role.kubernetes.io/control-plane": "true"},
 				},
 			},
 			expectedNode: &v3.Node{
@@ -90,7 +90,7 @@ func TestDetermineNodeRole(t *testing.T) {
 					Worker:       false,
 				},
 				Status: v3.NodeStatus{
-					NodeLabels: map[string]string{"node-role.kubernetes.io/master": "true"},
+					NodeLabels: map[string]string{"node-role.kubernetes.io/control-plane": "true"},
 				},
 			},
 		},

--- a/pkg/controllers/managementuser/windows/linux_node_taints.go
+++ b/pkg/controllers/managementuser/windows/linux_node_taints.go
@@ -18,16 +18,13 @@ var (
 	}
 	HostOSLabels = []labels.Set{
 		labels.Set(map[string]string{
-			"beta.kubernetes.io/os": "linux",
-		}),
-		labels.Set(map[string]string{
 			"kubernetes.io/os": "linux",
 		}),
 	}
 )
 
 // NodeTaintsController This controller will only run on the cluster with windowsPreferred is true.
-// It will add taints to the v1.Node.Spec.Taints to the nodes with label beta.kubernetes.io/os=linux.
+// It will add taints to the v1.Node.Spec.Taints to the nodes with label kubernetes.io/os=linux.
 type NodeTaintsController struct {
 	nodeClient apicorev1.NodeInterface
 }

--- a/pkg/controllers/managementuser/windows/node_test.go
+++ b/pkg/controllers/managementuser/windows/node_test.go
@@ -20,7 +20,7 @@ type testcase struct {
 
 var (
 	windowsNodeLabel = map[string]string{
-		"beta.kubernetes.io/os": "windows",
+		"kubernetes.io/os": "windows",
 	}
 )
 

--- a/pkg/settings/agent_customization.go
+++ b/pkg/settings/agent_customization.go
@@ -10,7 +10,7 @@ const (
         {
           "matchExpressions": [
             {
-              "key": "beta.kubernetes.io/os",
+              "key": "kubernetes.io/os",
               "operator": "NotIn",
               "values": [
                 "windows"
@@ -54,7 +54,7 @@ const (
         "preference": {
           "matchExpressions": [
             {
-              "key": "node-role.kubernetes.io/master",
+              "key": "node-role.kubernetes.io/control-plane",
               "operator": "In",
               "values": [
                 "true"

--- a/pkg/settings/agent_customization.go
+++ b/pkg/settings/agent_customization.go
@@ -50,20 +50,6 @@ const (
         }
       },
       {
-        "weight": 100,
-        "preference": {
-          "matchExpressions": [
-            {
-              "key": "node-role.kubernetes.io/control-plane",
-              "operator": "In",
-              "values": [
-                "true"
-              ]
-            }
-          ]
-        }
-      },
-      {
         "weight": 1,
         "preference": {
           "matchExpressions": [

--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -86,7 +86,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "c806f310d6bd5aac20e1876f1aa5ac9f932cee248a13b55dcb2321b6b9713836",
+				"cattle-cluster-agent": "de4c14250ecab17d8f14f5e42d6c9096318e49ba8621f3e2e4b4bac7c6f15f80",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -140,7 +140,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "c806f310d6bd5aac20e1876f1aa5ac9f932cee248a13b55dcb2321b6b9713836",
+				"cattle-cluster-agent": "de4c14250ecab17d8f14f5e42d6c9096318e49ba8621f3e2e4b4bac7c6f15f80",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -197,7 +197,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "1d201f3252e790ce7748982014e3941bea38896ff63176eebd56741110c243ca",
+				"cattle-cluster-agent": "acefadd59268701232c3226bd5d435bba3fa0e449eda5b5858af17c910ed994f",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -245,7 +245,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 			token:      "some-dummy-token",
 			agentImage: "my/agent:image",
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "0dec67921e95c4a7321c1bceea9f4c33c2ed32c8f1ddb2292ce0006d809ebf04",
+				"cattle-cluster-agent": "8e648ee72f5f35e48c67ce914d4cbcc1b1ec23543c6a3c10a4e494c2078ef7c5",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -147,9 +147,6 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
-      - effect: NoSchedule
-        key: "node-role.kubernetes.io/master"
-        operator: "Exists"
       - effect: NoExecute
         key: "node-role.kubernetes.io/etcd"
         operator: "Exists"
@@ -166,9 +163,6 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
-        operator: "Exists"
-      - effect: NoSchedule
-        key: "node-role.kubernetes.io/master"
         operator: "Exists"
       {{- end }}
       {{- if .AppendTolerations }}
@@ -256,7 +250,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows
@@ -265,20 +259,11 @@ spec:
                   values:
                     - "true"
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows
                 - key: node-role.kubernetes.io/control-plane
-                  operator: In
-                  values:
-                    - "true"
-              - matchExpressions:
-                - key: beta.kubernetes.io/os
-                  operator: NotIn
-                  values:
-                    - windows
-                - key: node-role.kubernetes.io/master
                   operator: In
                   values:
                     - "true"


### PR DESCRIPTION
## Issue: #44521
 
## Problem
The node selector is hardcoded, which is deprecated with k8s v1.14, hence leads to warnings while applying the templates.
 
## Solution
This commit:
- Removes the `cattle-node-agent-windows` daemonset from the template, as it's no longer being used since `rke1` deprecation.
- Cleans up `SystemTemplate()` by removing `isWindowsCluster` parameter, which is no longer relevant post Windows support deprecation
- Replaces the other occurrences of deprecated label `beta.kubernetes.io/os` with `kubernetes.io/os`.
- Replaces occurrences of deprecated node role `"node-role.kubernetes.io/master"` with `"node-role.kubernetes.io/control-plane"`.
- Updates the checksum for affected resources in the tests.
 
## Testing
Steps in the GitHub issue are valid.
reference doc: https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters#registering-a-cluster

## Engineering Testing
### Manual Testing
- Deployed rancher with custom image with the changes, and tried importing an existing cluster as downstream cluster.
- Applied the imported template to an existing cluster, do not see the warnings any more.

### Automated Testing
* Test types modified:
    * Unit

Summary:
- Removes deprecated Kubernetes label references and cleans up related code.

## QA Testing Considerations
Since this change affects both the `cattle-cluster-agent` deployment and the `node-agent` daemonSets, upgrade scenarios must be validated thoroughly. Specifically to:
1. If any existing downstream clusters have dependency on windows agent, validate if anything breaks in the behaviour after upgrade.  
2. Ensure that existing clusters running older versions upgrade smoothly without issues in:
   - Agent Deployment behaviour
   - Node Agent DaemonSet behaviour
3. Ensure, all the control-plane/master node workloads gets scheduled as expected on the node with `node-role.kubernetes.io/control-plane` label and runs without any failures.

- Validate post-upgrade behaviour to confirm that:
   - The workloads continue functioning as expected.
   - The import template generates updated node selector keys (`kubernetes.io/os` & `node-role.kubernetes.io/control-plane`).
   - No deprecated values (`beta.kubernetes.io/os` & `node-role.kubernetes.io/maste`) are left behind.
   - Confirm the obsolete Windows DaemonSet is properly removed and doesn't break the template rendering.
 
### Regressions Considerations
- With k8s v1.18, the `beta.kubernetes.io/os` label was eventually removed, which could have introduced unintended behaviour in Rancher running on clusters with k8s > v1.18. Specifically, any node selectors relying on this label to exclude Windows nodes might have silently failed, allowing pods to schedule on Windows nodes or causing them to remain unscheduled.
- With this change, we’ve replaced the deprecated label with the stable `kubernetes.io/os`. This restores the intended behaviour of preventing pods from running on Windows nodes. Therefore, it’s important to validate that this change preserves the correct scheduling behaviour, especially in upgrade and mixed-node scenarios, and doesn’t introduce regressions in workload placement logic.

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_