### PR TITLE
fix token identification

### DIFF
--- a/pkg/api/norman/customization/cred/store.go
+++ b/pkg/api/norman/customization/cred/store.go
@@ -208,7 +208,7 @@ func getHarvesterCredentialTokenNameFromKubeconfig(kubeconfigYaml string) (strin
 			if entry, ok := u.(map[string]any); ok && entry != nil {
 				if user, ok := entry["user"].(map[string]any); ok && user != nil {
 					if token, ok := user["token"].(string); ok && token != "" {
-						if strings.HasPrefix(token, "kubeconfig-user-") {
+						if strings.HasPrefix(token, "kubeconfig-user-") || strings.HasPrefix(token, "kubeconfig-u-") {
 							token, _, _ = strings.Cut(token, ":")
 							return token, nil
 						}


### PR DESCRIPTION
## Issue: #49810 
 
## Problem

When creating a cloud credential for Harvester, an annotation containing the expiration date of the authentication token used in the kubeconfig for the Harvester cluster needs to be set.
To figure out the correct expiration date, the token needs to be identified, but this needs to account for the fact that the token has a different naming scheme for the default admin user and additional users.

As described in [the issue](https://github.com/rancher/rancher/issues/49810#issuecomment-2827389345)
 
## Solution

By matching tokens with either `kubeconfig-user-` prefix or `kubeconfig-u-` prefix, any eligible token is correctly identified.


![Screenshot at 2025-04-24 14-22-57](https://github.com/user-attachments/assets/f7ce1d0c-0fcf-43f6-bd57-4c650888607b)

![Screenshot at 2025-04-24 14-23-38](https://github.com/user-attachments/assets/8ae9e41e-2639-4ed6-a9ea-217506fb5fa0)

As a result, the annotation is correctly added to the cloud credential and both the renewal menu entry as well as the expiration date correctly appear in the cloud credential list view.

![Screenshot at 2025-04-24 14-25-39](https://github.com/user-attachments/assets/c723f177-e62e-48b7-b5bf-3e7e508b7f1e)

## Testing

- Install Harvester (any version)
- Import Harvester cluster
- Create additional user accounts with sufficient privileges to administer the Harvester cluster
- Create cloud credentials as default admin user and as additional user(s). All such cloud credentials should have the `rancher.io/expiration-timestamp` annotation set

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations

- The existing functionality for the default admin user must not be disturbed
- Cloud credentials that are not related to Harvester should not receive the `rancher.io/expiration-timestamp` annotation