### PR TITLE
[main] fix upstream spec initialization for eks cluster

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler_test.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler_test.go
@@ -1,7 +1,6 @@
 package eks
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -125,23 +124,6 @@ func Test_onClusterChange_UpdateNodePool(t *testing.T) {
 	}
 	if !capr.Provisioned.IsTrue(cluster) || !capr.Updated.IsUnknown(cluster) {
 		t.Errorf("provisioned status should be True, updated status should be Unknown and cluster returned successfully")
-	}
-}
-
-func Test_onClusterChange_Active_nilUpstreamSpec(t *testing.T) {
-	mockOperatorController = getMockEksOperatorController(t, "active")
-	mockCluster, err := getMockV3Cluster(MockActiveClusterFilename)
-	if err != nil {
-		t.Errorf("error getting mock v3 cluster: %s", err)
-	}
-	mockCluster.Name = "test"
-	mockCluster.Status.EKSStatus.UpstreamSpec = nil
-
-	_, err = mockOperatorController.onClusterChange("", &mockCluster)
-
-	exp := fmt.Errorf("initial upstreamSpec on cluster [test] has not been set, unable to continue")
-	if err.Error() != exp.Error() {
-		t.Errorf("expected error %q but got %q", exp, err)
 	}
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/48366
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
to fix issue https://github.com/rancher/rancher/issues/48144 a check was added in PR https://github.com/rancher/rancher/pull/48298 which throws error in case the upstreamSpec is nil.
The UpstreamSpec field is only populated while the config is in creating phase.
Due to missing DescribeAddon Permission  the upstreamSpec was not being set. And the EksClusterConfig was in updating phase since addon configuration is done after the cluster is created. Even after the permission is resolved the cluster handler was not populating the upstreamSpec since there were failures when the eksClusterConfig was in creating stage.
And the error `initial upstreamSpec on cluster .. has not been set, unable to continue` was being thrown causing the cluster to be stuck in waiting state.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 added initialization of UpstreamSpec field in case it is nil in for non imported clusters as well when the eksClusterConfig is in active phase.
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_