### PR TITLE
[backport v2.11] fix token identification

### DIFF
--- a/pkg/api/norman/customization/cred/store.go
+++ b/pkg/api/norman/customization/cred/store.go
@@ -208,7 +208,7 @@ func getHarvesterCredentialTokenNameFromKubeconfig(kubeconfigYaml string) (strin
 			if entry, ok := u.(map[string]any); ok && entry != nil {
 				if user, ok := entry["user"].(map[string]any); ok && user != nil {
 					if token, ok := user["token"].(string); ok && token != "" {
-						if strings.HasPrefix(token, "kubeconfig-user-") {
+						if strings.HasPrefix(token, "kubeconfig-user-") || strings.HasPrefix(token, "kubeconfig-u-") {
 							token, _, _ = strings.Cut(token, ":")
 							return token, nil
 						}


### PR DESCRIPTION
## Issues:

original issue: rancher/rancher#49810
backport issue: rancher/rancher#50039
 
## Problem

When creating a cloud credential for Harvester, an annotation containing the expiration date of the authentication token used in the kubeconfig for the Harvester cluster needs to be set.
To figure out the correct expiration date, the token needs to be identified, but this needs to account for the fact that the token has a different naming scheme for the default admin user and additional users.

As described in https://github.com/rancher/rancher/issues/49810#issuecomment-2827389345
 
## Solution

As described in rancher/rancher#50028
This is a backport of #50028 to v2.11 branch.
 
## Testing

As described in rancher/rancher#50028

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_