### PR TITLE
ext Tokens fixes

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -29,6 +29,7 @@ type UserActivityStatus struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Token is used to authenticate requests to Rancher.

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -863,7 +863,7 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 				case watch.Bookmark:
 					secret, ok := event.Object.(*corev1.Secret)
 					if !ok {
-						logrus.Warnf("tokens: watch: expected secret got %T", secret)
+						logrus.Warnf("tokens: watch: expected secret got %T", event.Object)
 						continue
 					}
 
@@ -883,22 +883,22 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 				default: // watch.Added, watch.Modified, watch.Deleted
 					secret, ok := event.Object.(*corev1.Secret)
 					if !ok {
-						logrus.Warnf("tokens: watch: expected secret got %T", secret)
+						logrus.Warnf("tokens: watch: expected secret got %T", event.Object)
 						continue
 					}
 
 					token, err = tokenFromSecret(secret)
 					if err != nil {
-						logrus.Errorf("tokens: watch: error converting secret %s to token: %s", secret.Name, err)
+						logrus.Errorf("tokens: watch: error converting secret '%s' to token: %s", secret.Name, err)
 						continue
 					}
-				}
 
-				// skipping tokens not owned by the watching
-				// user is not required. The watch filter (see
-				// ListOptionMerge above) takes care of only
-				// asking for owned tokens
-				token.Status.Current = token.Name == sessionID
+					// skipping tokens not owned by the watching
+					// user is not required. The watch filter (see
+					// ListOptionMerge above) takes care of only
+					// asking for owned tokens
+					token.Status.Current = token.Name == sessionID
+				}
 
 				// push to consumer, and terminate ourselves if
 				// the consumer terminated on us

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -625,7 +625,9 @@ func (t *SystemStore) list(fullAccess bool, userName, sessionID string, options 
 
 	return &ext.TokenList{
 		ListMeta: metav1.ListMeta{
-			ResourceVersion: secrets.ResourceVersion,
+			ResourceVersion:    secrets.ResourceVersion,
+			Continue:           secrets.Continue,
+			RemainingItemCount: secrets.RemainingItemCount,
 		},
 		Items: tokens,
 	}, nil

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -880,7 +880,7 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 						logrus.Warnf("tokens: watch: received error event: %s", event.Object.GetObjectKind().GroupVersionKind().String())
 					}
 					continue
-				default: // watch.Added, watch.Modified, watch.Deleted
+				case watch.Added, watch.Modified, watch.Deleted:
 					secret, ok := event.Object.(*corev1.Secret)
 					if !ok {
 						logrus.Warnf("tokens: watch: expected secret got %T", event.Object)
@@ -898,6 +898,9 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 					// ListOptionMerge above) takes care of only
 					// asking for owned tokens
 					token.Status.Current = token.Name == sessionID
+				default:
+					logrus.Warnf("tokens: watch: received and ignored unknown event: '%s'", event.Type)
+					continue
 				}
 
 				// push to consumer, and terminate ourselves if

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -1347,6 +1347,11 @@ func Test_SystemStore_List(t *testing.T) {
 			opts: &metav1.ListOptions{},
 			err:  nil,
 			toks: &ext.TokenList{
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "1",
+					Continue:           "true",
+					RemainingItemCount: pointer.Int64(2),
+				},
 				Items: []ext.Token{
 					properToken,
 				},
@@ -1355,6 +1360,11 @@ func Test_SystemStore_List(t *testing.T) {
 				secrets.EXPECT().
 					List("cattle-tokens", gomock.Any()).
 					Return(&corev1.SecretList{
+						ListMeta: metav1.ListMeta{
+							ResourceVersion:    "1",
+							Continue:           "true",
+							RemainingItemCount: pointer.Int64(2),
+						},
 						Items: []corev1.Secret{
 							properSecret,
 						},
@@ -1368,6 +1378,11 @@ func Test_SystemStore_List(t *testing.T) {
 			opts:    &metav1.ListOptions{},
 			err:     nil,
 			toks: &ext.TokenList{
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "",
+					Continue:           "",
+					RemainingItemCount: nil,
+				},
 				Items: []ext.Token{
 					properTokenCurrent,
 				},
@@ -1388,6 +1403,11 @@ func Test_SystemStore_List(t *testing.T) {
 			opts: &metav1.ListOptions{},
 			err:  nil,
 			toks: &ext.TokenList{
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "",
+					Continue:           "",
+					RemainingItemCount: nil,
+				},
 				Items: []ext.Token{
 					properToken,
 				},

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -706,7 +706,7 @@ func Test_Store_Watch(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: "update"})
+		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Modified})
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
@@ -720,7 +720,7 @@ func Test_Store_Watch(t *testing.T) {
 
 		event, more := (<-consumer.ResultChan()) // receive update event
 		assert.True(t, more)
-		assert.Equal(t, watch.EventType("update"), event.Type)
+		assert.Equal(t, watch.Modified, event.Type)
 		assert.Equal(t, &properToken, event.Object)
 
 		watcher.Done() // close backend channel
@@ -744,7 +744,7 @@ func Test_Store_Watch(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: "update"})
+		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Modified})
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
@@ -758,7 +758,7 @@ func Test_Store_Watch(t *testing.T) {
 
 		event, more := (<-consumer.ResultChan()) // receive update event
 		assert.True(t, more)
-		assert.Equal(t, watch.EventType("update"), event.Type)
+		assert.Equal(t, watch.Modified, event.Type)
 		assert.Equal(t, &properTokenCurrent, event.Object)
 
 		watcher.Done() // close backend channel
@@ -782,7 +782,7 @@ func Test_Store_Watch(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		watcher := NewWatcherFor(watch.Event{Object: &corev1.Namespace{}, Type: "ERROR"})
+		watcher := NewWatcherFor(watch.Event{Object: &corev1.Namespace{}, Type: watch.Error})
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
@@ -815,7 +815,7 @@ func Test_Store_Watch(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		watcher := NewWatcherFor(watch.Event{Object: &corev1.Namespace{}, Type: "BOOKMARK"})
+		watcher := NewWatcherFor(watch.Event{Object: &corev1.Namespace{}, Type: watch.Bookmark})
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
@@ -848,7 +848,7 @@ func Test_Store_Watch(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: "BOOKMARK"})
+		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Bookmark})
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
@@ -862,7 +862,7 @@ func Test_Store_Watch(t *testing.T) {
 
 		event, more := (<-consumer.ResultChan()) // receive update event
 		assert.True(t, more)
-		assert.Equal(t, watch.EventType("BOOKMARK"), event.Type)
+		assert.Equal(t, watch.Bookmark, event.Type)
 		assert.Equal(t, &ext.Token{
 			ObjectMeta: metav1.ObjectMeta{
 				ResourceVersion: "",

--- a/pkg/generated/controllers/ext.cattle.io/v1/interface.go
+++ b/pkg/generated/controllers/ext.cattle.io/v1/interface.go
@@ -46,7 +46,7 @@ type version struct {
 }
 
 func (v *version) Token() TokenController {
-	return generic.NewController[*v1.Token, *v1.TokenList](schema.GroupVersionKind{Group: "ext.cattle.io", Version: "v1", Kind: "Token"}, "tokens", true, v.controllerFactory)
+	return generic.NewNonNamespacedController[*v1.Token, *v1.TokenList](schema.GroupVersionKind{Group: "ext.cattle.io", Version: "v1", Kind: "Token"}, "tokens", v.controllerFactory)
 }
 
 func (v *version) UserActivity() UserActivityController {

--- a/pkg/generated/controllers/ext.cattle.io/v1/token.go
+++ b/pkg/generated/controllers/ext.cattle.io/v1/token.go
@@ -36,17 +36,17 @@ import (
 
 // TokenController interface for managing Token resources.
 type TokenController interface {
-	generic.ControllerInterface[*v1.Token, *v1.TokenList]
+	generic.NonNamespacedControllerInterface[*v1.Token, *v1.TokenList]
 }
 
 // TokenClient interface for managing Token resources in Kubernetes.
 type TokenClient interface {
-	generic.ClientInterface[*v1.Token, *v1.TokenList]
+	generic.NonNamespacedClientInterface[*v1.Token, *v1.TokenList]
 }
 
 // TokenCache interface for retrieving Token resources in memory.
 type TokenCache interface {
-	generic.CacheInterface[*v1.Token]
+	generic.NonNamespacedCacheInterface[*v1.Token]
 }
 
 // TokenStatusHandler is executed for every added or modified Token. Should return the new status to be updated


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

- Throwing away `Bookmark` and `Error` watch event types
- Not passing through all ListMeta fields
- Not having `+genclient:nonNamespaced` directive on the `Token` to generate correct controllers
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Process `Bookmark` and `Error` watch event types
- Pass through `Continue` and `RemainingItemCount` field
- Add `+genclient:nonNamespaced` directive to the `Token` type
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_