### PR TITLE
Allow deploying k3s clusters using embedded SQLite instead of etcd

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -111,7 +111,8 @@ func addRoleConfig(config map[string]interface{}, controlPlane *rkev1.RKEControl
 	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
 	if isInitNode(entry) {
 		// If this node is the init node, it should not be joined to anything. Clear the joinServer URL.
-		if runtime == capr.RuntimeK3S {
+		if _, ok := config["cluster-init"]; !ok && runtime == capr.RuntimeK3S {
+			// Initialize embedded etcd, unless explictly overridden by the user.
 			config["cluster-init"] = true
 		}
 		joinServer = "-"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/44911
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When deploying a k3s cluster, rancher unconditionally sets cluster-init which forces the use of embedded etcd, which has [documented](https://docs.k3s.io/datastore/ha-embedded) performance issues on Raspberry Pi and other devices. For these use cases, it would be desirable to use sqlite instead.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Allow the user to override cluster-init to false in the machineGlobalConfig / machineSelectorConfig, which will initialize k3s with the sqlite datastore instead.