### PR TITLE
[release/v2.11] fix upstream spec initialization for eks cluster

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -172,28 +172,28 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 		logrus.Infof("waiting for cluster EKS [%s] create failure to be resolved", cluster.Name)
 		return e.SetFalse(cluster, apimgmtv3.ClusterConditionProvisioned, failureMessage)
 	case "active":
-		if cluster.Spec.EKSConfig.Imported {
-			if cluster.Status.EKSStatus.UpstreamSpec == nil {
-				// non imported clusters will have already had upstream spec set
-				return e.setInitialUpstreamSpec(cluster)
-			}
 
-			if apimgmtv3.ClusterConditionPending.IsUnknown(cluster) {
-				cluster = cluster.DeepCopy()
-				apimgmtv3.ClusterConditionPending.True(cluster)
-				cluster, err = e.ClusterClient.Update(cluster)
-				if err != nil {
-					return cluster, err
-				}
+		if cluster.Status.EKSStatus.UpstreamSpec == nil {
+			// for imported clusters cluster.Status.EKSStatus.UpstreamSpec will be nil initially so has to be set
+
+			// for non imported clusters if eksClusterConfig is in active phase but still the UpstreamSpec is not set
+			// this means there were some failures while initialising UpstreamSpec when the eksClusterConfig was in creating phase
+			// and those failures were resolved so the config status became active so UpstreamSpec can be set now
+			return e.setInitialUpstreamSpec(cluster)
+		}
+
+		if cluster.Spec.EKSConfig.Imported && apimgmtv3.ClusterConditionPending.IsUnknown(cluster) {
+			cluster = cluster.DeepCopy()
+			apimgmtv3.ClusterConditionPending.True(cluster)
+			cluster, err = e.ClusterClient.Update(cluster)
+			if err != nil {
+				return cluster, err
+
 			}
 		}
 
 		if apimgmtv3.ClusterConditionUpdated.IsFalse(cluster) && strings.HasPrefix(apimgmtv3.ClusterConditionUpdated.GetMessage(cluster), "[Syncing error") {
 			return cluster, fmt.Errorf(apimgmtv3.ClusterConditionUpdated.GetMessage(cluster))
-		}
-
-		if cluster.Status.EKSStatus.UpstreamSpec == nil {
-			return cluster, fmt.Errorf("initial upstreamSpec on cluster [%s] has not been set, unable to continue", cluster.Name)
 		}
 
 		// EKS cluster must have at least one node to run cluster agent. The best way to verify

--- a/pkg/controllers/management/eks/eks_cluster_handler_test.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler_test.go
@@ -1,7 +1,6 @@
 package eks
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -125,23 +124,6 @@ func Test_onClusterChange_UpdateNodePool(t *testing.T) {
 	}
 	if !capr.Provisioned.IsTrue(cluster) || !capr.Updated.IsUnknown(cluster) {
 		t.Errorf("provisioned status should be True, updated status should be Unknown and cluster returned successfully")
-	}
-}
-
-func Test_onClusterChange_Active_nilUpstreamSpec(t *testing.T) {
-	mockOperatorController = getMockEksOperatorController(t, "active")
-	mockCluster, err := getMockV3Cluster(MockActiveClusterFilename)
-	if err != nil {
-		t.Errorf("error getting mock v3 cluster: %s", err)
-	}
-	mockCluster.Name = "test"
-	mockCluster.Status.EKSStatus.UpstreamSpec = nil
-
-	_, err = mockOperatorController.onClusterChange("", &mockCluster)
-
-	exp := fmt.Errorf("initial upstreamSpec on cluster [test] has not been set, unable to continue")
-	if err.Error() != exp.Error() {
-		t.Errorf("expected error %q but got %q", exp, err)
 	}
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/48366
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 backport PR of https://github.com/rancher/rancher/pull/50047 cherry-picked from https://github.com/rancher/rancher/pull/50047/commits/458954b82fa9bce3638f87f6fa6ac8642420bb4d
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_