### PR TITLE
adding new pushprox image to image origins

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -239,6 +239,7 @@ var OriginMap = map[string]string{
 	"prometheus-federator":                                    "https://github.com/rancher/prometheus-federator",
 	"pushprox-client":                                         "https://github.com/rancher/PushProx",
 	"pushprox-proxy":                                          "https://github.com/rancher/PushProx",
+	"pushprox":                                                "https://github.com/rancher/PushProx",
 	"rancher":                                                 "https://github.com/rancher/rancher",
 	"rancher-agent":                                           "https://github.com/rancher/rancher",
 	"rancher-csp-adapter":                                     "https://github.com/rancher/csp-adapter",


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/49503

A new `rancher/pushprox` image was created. This PR adds it to the list of image origins