### PR TITLE
[backport v2.10] Handles IPv6 addresses during Rancher peer communication

### DIFF
--- a/pkg/tunnelserver/peermanager.go
+++ b/pkg/tunnelserver/peermanager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/rancher/pkg/peermanager"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/utils"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -167,7 +168,11 @@ func (p *peerManager) addRemovePeers(endpoints *v1.Endpoints) {
 
 	toCreate, toDelete, _ := set.Diff(newSet, p.peers)
 	for _, ip := range toCreate {
-		p.server.AddPeer(fmt.Sprintf(p.urlFormat, ip), ip, p.token)
+		urlSafeIP := ip
+		if utils.IsPlainIPV6(ip) {
+			urlSafeIP = fmt.Sprintf("[%s]", ip)
+		}
+		p.server.AddPeer(fmt.Sprintf(p.urlFormat, urlSafeIP), ip, p.token)
 	}
 	for _, ip := range toDelete {
 		p.server.RemovePeer(ip)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"sort"
 	"strings"
 
@@ -21,8 +21,9 @@ func FormatResourceList(resources v1.ResourceList) string {
 
 // IsPlainIPV6 will return true if the given address is a plain IPV6 address and not encapsulated or similar.
 func IsPlainIPV6(address string) bool {
-	if net.ParseIP(address) != nil && strings.Count(address, ":") >= 2 {
-		return true
+	ipAddr, err := netip.ParseAddr(address)
+	if err != nil {
+		return false
 	}
-	return false
+	return ipAddr.Is6()
 }


### PR DESCRIPTION
## Issue: #50136 
 
## Problem
The formatting performed for websocket URL is not ipv6 compatible.
 
## Solution
backport PR of https://github.com/rancher/rancher/pull/50047 cherry-picked from https://github.com/rancher/rancher/commit/c9b65852391036244e7a03b3fe3ec2c08b005d20
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_