### PR TITLE
fix: add retry mechanism for GetOrCreateRDPConnectSecret

### DIFF
--- a/pkg/ext/rdp.go
+++ b/pkg/ext/rdp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -15,7 +16,9 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,6 +28,13 @@ const (
 	certSecretName   = "api-extension-ca-name"
 	certServerName   = "api-extension-tls-name"
 )
+
+var rdpSecretBackoff = wait.Backoff{
+	Steps:    7,
+	Duration: 15 * time.Second,
+	Factor:   2.0,
+	Jitter:   0.1,
+}
 
 func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wrangler.Context) error {
 	if features.MCMAgent.Enabled() {
@@ -46,9 +56,22 @@ func RDPStart(ctx context.Context, restConfig *rest.Config, wranglerContext *wra
 		return err
 	}
 
-	connectSecret, err := GetOrCreateRDPConnectSecret(wranglerContext.Core.Secret())
-	if err != nil {
-		return err
+	var connectSecret string
+	var retryErr error
+	retryCount := 0
+
+	// Retry to get or create the connect secret for approx 15 minutes
+	retry.OnError(rdpSecretBackoff, func(err error) bool {
+		retryCount++
+		logrus.Errorf("RDPClient: error getting connect secret (retry #%d), will retry: %s", retryCount, err.Error())
+		return true
+	}, func() error {
+		connectSecret, retryErr = GetOrCreateRDPConnectSecret(wranglerContext.Core.Secret())
+		return retryErr
+	})
+
+	if retryErr != nil {
+		return retryErr
 	}
 
 	remoteDialerProxyClient, err := proxyclient.New(


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/49750

## Problem
At startup, Rancher attempts to create the `api-extension` Secret for the `remotedialer-proxy` (RDP). If the `rancher-webhook` is not ready or transiently unavailable, this Secret creation fails. Without a retry mechanism, this leads to a fatal error, causing the Rancher pod to crash and enter a crash loop, especially during upgrades or initial cluster bring-up.

## Solution
This PR introduces retry logic for creating/retrieving the RDP connect secret. This configuration attempts to get or generate the secret for approximately 15 minutes.