### PR TITLE
Fix OIDC provider test

### DIFF
--- a/tests/controllers/oidc/oidc_provider_test.go
+++ b/tests/controllers/oidc/oidc_provider_test.go
@@ -93,6 +93,7 @@ func (s *OIDCProviderSuite) SetupSuite() {
 		crd.CRD{
 			SchemaObject: apimgmtv3.OIDCClient{},
 			NonNamespace: true,
+			Status:       true,
 		},
 	)
 


### PR DESCRIPTION
Previously, the status subresource was not registered in the `envtest` environment, causing patch request to fail. This change explicitly registers the status subresource in `envtest`, aligning test behavior with actual cluster behavior and allowing status patches to function correctly in tests.