### PR TITLE
Decouples mgmtCluster client/cache initialization from MCM feature

### DIFF
--- a/pkg/controllers/provisioningv2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/controller.go
@@ -60,6 +60,8 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 		clusterCache:      clients.Provisioning.Cluster().Cache(),
 		clusterController: clients.Provisioning.Cluster(),
 		capiClusters:      clients.CAPI.Cluster().Cache(),
+		mgmtClusterCache:  clients.Mgmt.Cluster().Cache(),
+		mgmtClusterClient: clients.Mgmt.Cluster(),
 		rkeControlPlane:   clients.RKE.RKEControlPlane().Cache(),
 		etcdSnapshotCache: clients.RKE.ETCDSnapshot().Cache(),
 		capiMachineCache:  clients.CAPI.Machine().Cache(),
@@ -67,8 +69,6 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 
 	if features.MCM.Enabled() {
 		h.dynamicSchema = clients.Mgmt.DynamicSchema().Cache()
-		h.mgmtClusterCache = clients.Mgmt.Cluster().Cache()
-		h.mgmtClusterClient = clients.Mgmt.Cluster()
 	}
 
 	clients.Dynamic.OnChange(ctx, "rke-dynamic", matchRKENodeGroup, h.infraWatch)


### PR DESCRIPTION
## Issue: #42909 
 
## Problem
Even with MCM feature flag disabled, rancher tries to fetch managementCluster cache and reports some benign errors.
 
## Solution
As the management cluster can operate without MCM, its cache population has been refactored to occur regardless of the feature’s state.
 
## Testing
[NOTE: test cases should include both **traditional Rancher** environments and **Rancher-on-Harvester**.]
- Deploy Rancher with MCM feature disabled
- Rancher pod logs should no longer report management cache to be `nil`.
- Observe the behavior during upgrades too.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
- None: No application logic is directly modified by this change, structural change.

Summary: 
- The `management cluster is nil` errors reported were expected, as the managment cluster cache was initialised here only when the MCM feature flag was enabled, but the cache was retrieve in either situation.
- Upon further analysis, we are eliminating the dependency on MCM feature flag (i.e. [populating the cache](https://github.com/rancher/rancher/blob/main/pkg/controllers/provisioningv2/provisioningcluster/controller.go#L70) irrespective of MCM's state).
- The rationale is that even with MCM disabled, there is still a local management cluster that needs to be managed, & a provisioning cluster object of the same.

## QA Testing Considerations
To confirm correctness, test cases should include both **traditional Rancher** environments and **Rancher-on-Harvester** scenarios. (as the issue is primarily observed on rancher-on-harvester)
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_