### PR TITLE
[v2.11] Update snapshot object if it already exists to match indexer criteria

### DIFF
--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
@@ -193,6 +193,11 @@ func (h *handler) OnDownstreamChange(_ string, downstream *k3s.ETCDSnapshotFile)
 		logrus.Debugf("%s creating snapshot %s", logPrefix, upstream.Name)
 
 		_, err = h.etcdSnapshotController.Create(upstream)
+		// snapshot may exist on a previous version of Rancher but fail to indexer criteria, update in this case
+		if apierrors.IsAlreadyExists(err) {
+			logrus.Debugf("%s snapshot %s already exists but does not match indexer criteria, updating", logPrefix, upstream.Name)
+			_, err = h.etcdSnapshotController.Update(upstream)
+		}
 		return downstream, err
 	} else if len(upstreamSnapshots) > 1 {
 		logrus.Warnf("%s multiple snapshots objects found for snapshot %s", logPrefix, downstream.Name)


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/49893

## Issue: <!-- link the issue or issues this PR resolves here --> #49875
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If an s3 snapshot was created on a previous version of Rancher, it may not have the required `etcdsnapshot.rke.io/snapshot-name` annotation for correlating snapshots with the `by-etcd-snapshot-name` indexer.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
If the error received when creating the `etcdsnapshot.rke.cattle.io` object is a 409 `AlreadyExists` error, then just update the object.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, and added unit tests.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

- Create manual and s3 snapshot on previous version of Rancher.
- Upgrade Rancher
- Confirm Rancher logs do not endlessly spew logs regarding the snapshot already existing