### PR TITLE
Skip empty tolerations to fix repeated system chart install

### DIFF
--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -325,7 +325,7 @@ func (m *Manager) install(namespace, name, minVersion, exactVersion string, valu
 		tolerations, err = m.operation.AddCpTaintsToTolerations(tolerations)
 		if err != nil {
 			logrus.Warnf("failed to add tolerations for control plane taints: %v", err)
-		} else {
+		} else if len(tolerations) > 0 {
 			desiredValue["tolerations"] = tolerations
 		}
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
#50176

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When there is no taint, the tolerations in the actual chart values is nil. But because `jsonpatch.MergePatch()` removes null fields, the expected chart values have no tolerations field. The `desiredVersionAndValues()` function considers the chart values do not match and the chart should be upgraded. It leads to repeated system chart installation.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Skip adding empty tolerations to the chart values.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Please follow the steps in the linked issue.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually tested. With this fix, the number of `helm-operation-` pods is reduced to 5 in a fresh install. There is no repeated system chart install anymore.

### Automated Testing
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_