### PR TITLE
[2.11] [Backport] Fix the issue where cattle-node-agent deletes the cattle-credential secret unexpectedly

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -64,7 +64,12 @@ func main() {
 
 		initFeatures()
 
-		go clean.UnusedCattleCredentials()
+		// The cleanup is only performed by the cattle-cluster-agent,
+		// in whose template the CATTLE_CREDENTIAL_NAME environment variable is set
+		if os.Getenv("CATTLE_CREDENTIAL_NAME") != "" {
+			logrus.Infof("starting cattle-credential-cleanup goroutine in the background")
+			go clean.UnusedCattleCredentials()
+		}
 
 		if os.Getenv("CLUSTER_CLEANUP") == "true" {
 			err = clean.Cluster()


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/50156

Backport of the PR https://github.com/rancher/rancher/pull/50158

For details, please check the original PR