### PR TITLE
Ensure we do not ship ext tokens in 2.12 with Name as a free variable, and other fixes

### DIFF
--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -635,11 +635,11 @@ func (t *SystemStore) list(fullAccess bool, userName, sessionID string, options 
 
 // update implements the core resource updating/modification of tokens
 func (t *Store) update(ctx context.Context, token *ext.Token, options *metav1.UpdateOptions) (*ext.Token, error) {
-	user, _, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore, "update")
+	user, fullAccess, isRancherUser, err := t.auth.UserName(ctx, &t.SystemStore, "update")
 	if err != nil {
 		return nil, err
 	}
-	if !isRancherUser || !userMatch(user, token) {
+	if !fullAccess && (!isRancherUser || !userMatch(user, token)) {
 		return nil, apierrors.NewNotFound(GVR.GroupResource(), token.Name)
 	}
 

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -380,6 +380,12 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 		return nil, err
 	}
 
+	// reject any attempt to specify status fields
+	emptyStatus := ext.TokenStatus{}
+	if token.Status != emptyStatus {
+		return nil, apierrors.NewBadRequest("Token is invalid: status is not empty")
+	}
+
 	user, err := t.userClient.Get(token.Spec.UserID)
 	if err != nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to retrieve user %s: %w",

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	reflect "reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -682,6 +683,19 @@ func (t *SystemStore) update(sessionID string, fullPermission bool, token *ext.T
 
 	if token.Spec.Kind != currentToken.Spec.Kind {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("rejecting change of token %s: forbidden to edit kind",
+			token.Name))
+	}
+
+	if token.Spec.UserPrincipal.Name != currentToken.Spec.UserPrincipal.Name ||
+		token.Spec.UserPrincipal.DisplayName != currentToken.Spec.UserPrincipal.DisplayName ||
+		token.Spec.UserPrincipal.LoginName != currentToken.Spec.UserPrincipal.LoginName ||
+		token.Spec.UserPrincipal.ProfilePicture != currentToken.Spec.UserPrincipal.ProfilePicture ||
+		token.Spec.UserPrincipal.PrincipalType != currentToken.Spec.UserPrincipal.PrincipalType ||
+		token.Spec.UserPrincipal.Me != currentToken.Spec.UserPrincipal.Me ||
+		token.Spec.UserPrincipal.MemberOf != currentToken.Spec.UserPrincipal.MemberOf ||
+		token.Spec.UserPrincipal.Provider != currentToken.Spec.UserPrincipal.Provider ||
+		!reflect.DeepEqual(token.Spec.UserPrincipal.ExtraInfo, currentToken.Spec.UserPrincipal.ExtraInfo) {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("rejecting change of token %s: forbidden to edit principal data",
 			token.Name))
 	}
 

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -990,6 +990,38 @@ func Test_Store_Create(t *testing.T) {
 					Return(nil, nil)
 			},
 		},
+		{
+			name: "reject non-empty status",
+			err:  apierrors.NewBadRequest("Token is invalid: status is not empty"),
+			tok: &ext.Token{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "hello",
+				},
+				Spec: ext.TokenSpec{
+					UserID: "world",
+				},
+				Status: ext.TokenStatus{
+					Value: "kajdfk;das",
+				},
+			},
+			opts: &metav1.CreateOptions{},
+			storeSetup: func( // configure store backend clients
+				space *fake.MockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				scache *fake.MockCacheInterface[*corev1.Secret],
+				users *fake.MockNonNamespacedCacheInterface[*v3.User],
+				token *fake.MockNonNamespacedCacheInterface[*v3.Token],
+				timer *MocktimeHandler,
+				hasher *MockhashHandler,
+				auth *MockauthHandler) {
+
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return("world", false, true, nil)
+
+				space.EXPECT().Create(gomock.Any()).
+					Return(nil, nil)
+			},
+		},
 		// token generation and hash errors -- no mocking -- unable to induce and test
 		{
 			name: "user retrieval error",

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -2024,6 +2024,27 @@ func Test_SystemStore_Update(t *testing.T) {
 			err: apierrors.NewBadRequest("rejecting change of token bogus: forbidden to edit user id"),
 		},
 		{
+			name:     "reject principal change",
+			fullPerm: true,
+			opts:     &metav1.UpdateOptions{},
+			token: func() *ext.Token {
+				changed := properToken.DeepCopy()
+				changed.Spec.UserPrincipal.DisplayName = "dummy"
+				return changed
+			}(),
+			storeSetup: func(
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				scache *fake.MockCacheInterface[*corev1.Secret],
+				timer *MocktimeHandler,
+				hasher *MockhashHandler,
+				auth *MockauthHandler) {
+				scache.EXPECT().
+					Get("cattle-tokens", "bogus").
+					Return(&properSecret, nil)
+			},
+			err: apierrors.NewBadRequest("rejecting change of token bogus: forbidden to edit principal data"),
+		},
+		{
 			name:     "reject kind change",
 			fullPerm: true,
 			opts:     &metav1.UpdateOptions{},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

See #50148 
 
## Problem

See RFD `Imperative API Object Naming` for our decision to reject allowing arbitrary names for token resources.
Plus bugs found during testing and working with ext tokens.
 
## Solution

Rewrite of create to the new validations needed, plus adding the missing validations shown by the issues.

## Testing

Added/changed unit tests of the token store to cover the new/changed validations.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_