### PR TITLE
OIDC provider - Remove OIDCClient Secret if patch fails

### DIFF
--- a/pkg/controllers/management/oidcprovider/controller.go
+++ b/pkg/controllers/management/oidcprovider/controller.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	corev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	v1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -84,11 +84,11 @@ func (c *oidcClientController) onChange(_ string, oidcClient *v3.OIDCClient) (*v
 	}
 
 	k8sSecret, err := c.secretCache.Get(secretNamespace, clientID)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 	// generate client secret and store it in a k8s secret.
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		clientSecret, err := c.generator.GenerateClientSecret()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate client secret: %w", err)
@@ -114,7 +114,7 @@ func (c *oidcClientController) onChange(_ string, oidcClient *v3.OIDCClient) (*v
 				clientSecretName: clientSecret,
 			},
 		})
-		if err != nil && !kerrors.IsAlreadyExists(err) {
+		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("failed to create client secret: %w", err)
 		}
 

--- a/pkg/controllers/management/oidcprovider/controller.go
+++ b/pkg/controllers/management/oidcprovider/controller.go
@@ -3,6 +3,7 @@ package oidcprovider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -16,7 +17,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	corev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -83,11 +84,11 @@ func (c *oidcClientController) onChange(_ string, oidcClient *v3.OIDCClient) (*v
 	}
 
 	k8sSecret, err := c.secretCache.Get(secretNamespace, clientID)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return nil, err
 	}
 	// generate client secret and store it in a k8s secret.
-	if errors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		clientSecret, err := c.generator.GenerateClientSecret()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate client secret: %w", err)
@@ -113,7 +114,7 @@ func (c *oidcClientController) onChange(_ string, oidcClient *v3.OIDCClient) (*v
 				clientSecretName: clientSecret,
 			},
 		})
-		if err != nil && !errors.IsAlreadyExists(err) {
+		if err != nil && !kerrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("failed to create client secret: %w", err)
 		}
 
@@ -125,11 +126,13 @@ func (c *oidcClientController) onChange(_ string, oidcClient *v3.OIDCClient) (*v
 		}
 		patchBytes, err := json.Marshal(patchData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create clientID status patch: %w", err)
+			// delete previously created secret as it will be created when a new clientID is generated in the next reconciliation loop
+			return nil, errors.Join(c.secretClient.Delete(secretNamespace, clientID, &metav1.DeleteOptions{}), fmt.Errorf("failed to create clientID status patch: %w", err))
 		}
 		oidcClient, err = c.oidcClient.Patch(oidcClient.Name, types.MergePatchType, patchBytes, "status")
 		if err != nil {
-			return nil, fmt.Errorf("failed to apply clientID status patch: %w", err)
+			// delete previously created secret as it will be created when a new clientID is generated in the next reconciliation loop
+			return nil, errors.Join(c.secretClient.Delete(secretNamespace, clientID, &metav1.DeleteOptions{}), fmt.Errorf("failed to apply clientID status patch: %w", err))
 		}
 	}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48317
 
## Problem
A secret is created for each `OIDCClient` to store the `ClientSecret`, using the `ClientID` as the secret's name. The `OIDCClient` controller generates a new secret whenever `OIDCClient.Status.ClientID` is missing. This status field is updated after the secret is successfully created. If the controller fails to patch `OIDCClient.Status.ClientID`, the absence of this field will cause a new secret to be created on each reconciliation loop.

## Solution
Delete the secret if an error occurs while patching the `OIDCClient` to update `Status.ClientID`
 
## Testing
Unit test added