### PR TITLE
fix(rbac): No error when a ClusterRoleTemplateBinding is not found

### DIFF
--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -103,6 +103,14 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding, remoteC
 	if err != nil {
 		err = fmt.Errorf("couldn't get role template %v: %w", binding.RoleTemplateName, err)
 		c.s.AddCondition(remoteConditions, condition, failedToGetRoleTemplate, err)
+		if apierrors.IsNotFound(err) {
+			logrus.Warnf(
+				"ClusterRoleTemplateBinding %v does not have RoleTemplate %v. Role template not found. Skipping.",
+				binding.Name,
+				binding.RoleTemplateName,
+			)
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
During the crtb loop when a ClusterRoleTemplateBinding is not found from the api the sync loop will not return an error.

All the other errors during the ClusterRoleTemplateBinding loop are returned.

## Issue

[48580](https://github.com/rancher/rancher/issues/48580)
 
## Problem

Rancher logs are flooded with repeated error message when a Cluster role template is missing.

## Solution

When a ClusterRoleTemplateBinding is not found during the crbt sync loop, simply return no error and log the fact that the crbt is not found instead of returning an error, returning an error simply floods the log with the same message because the crbt is deleted so it cannot be found in another sync.


## Testing

Automated tests added