### PR TITLE
[main] add flag for controlling APIService app label selector

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
 {{- end }}
         - name: IMPERATIVE_API_DIRECT
           value: "true"
-        - name: EXTENSION_API_APP_SELECTOR
+        - name: IMPERATIVE_API_APP_SELECTOR
           value: {{ template "rancher.fullname" . }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -151,6 +151,8 @@ spec:
 {{- end }}
         - name: IMPERATIVE_API_DIRECT
           value: "true"
+        - name: EXTENSION_API_APP_SELECTOR
+          value: {{ template "rancher.fullname" }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -152,7 +152,7 @@ spec:
         - name: IMPERATIVE_API_DIRECT
           value: "true"
         - name: EXTENSION_API_APP_SELECTOR
-          value: {{ template "rancher.fullname" }}
+          value: {{ template "rancher.fullname" . }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
         value: RELEASE-NAME-rancher
       - name: IMPERATIVE_API_DIRECT
         value: "true"
-      - name: EXTENSION_API_APP_SELECTOR
+      - name: IMPERATIVE_API_APP_SELECTOR
         value: RELEASE-NAME-rancher
 - it: should default imagePullPolicy to IfNotPresent
   asserts:

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -52,6 +52,8 @@ tests:
         value: RELEASE-NAME-rancher
       - name: IMPERATIVE_API_DIRECT
         value: "true"
+      - name: EXTENSION_API_APP_SELECTOR
+        value: RELEASE-NAME-rancher
 - it: should default imagePullPolicy to IfNotPresent
   asserts:
   - equal:

--- a/main.go
+++ b/main.go
@@ -153,6 +153,13 @@ func main() {
 			Usage:       "Declare specific feature values on start up. Example: \"kontainer-driver=true\" - kontainer driver feature will be enabled despite false default value",
 			Destination: &config.Features,
 		},
+		cli.StringFlag{
+			Name:        "extension-api-app-selector",
+			EnvVar:      "EXTENSION_API_APP_SELECTOR",
+			Value:       "rancher",
+			Usage:       "Defines the value to use the constructing the label selector for the imperative api APIService",
+			Destination: &config.ExtensionOpts.AppSelector,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -153,13 +153,6 @@ func main() {
 			Usage:       "Declare specific feature values on start up. Example: \"kontainer-driver=true\" - kontainer driver feature will be enabled despite false default value",
 			Destination: &config.Features,
 		},
-		cli.StringFlag{
-			Name:        "extension-api-app-selector",
-			EnvVar:      "EXTENSION_API_APP_SELECTOR",
-			Value:       "rancher",
-			Usage:       "Defines the value to use the constructing the label selector for the imperative api APIService",
-			Destination: &config.ExtensionOpts.AppSelector,
-		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -28,9 +29,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	imperativeApiExtensionEnvVar = "IMPERATIVE_API_APP_SELECTOR"
+)
+
 type Options struct {
 	// AppSelector is the expected value for the "app" label on the rancher service.
 	AppSelector string
+}
+
+func DefaultOptions() Options {
+	return Options{
+		AppSelector: os.Getenv(imperativeApiExtensionEnvVar),
+	}
 }
 
 const (

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -84,6 +84,7 @@ type Options struct {
 	AuditLevel        int
 	Features          string
 	ClusterRegistry   string
+	ExtensionOpts     ext.Options
 }
 
 type Rancher struct {
@@ -202,7 +203,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext)
+	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, opts.ExtensionOpts)
 	if err != nil {
 		return nil, fmt.Errorf("extension api server: %w", err)
 	}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -84,7 +84,6 @@ type Options struct {
 	AuditLevel        int
 	Features          string
 	ClusterRegistry   string
-	ExtensionOpts     ext.Options
 }
 
 type Rancher struct {
@@ -203,7 +202,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, opts.ExtensionOpts)
+	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, ext.DefaultOptions())
 	if err != nil {
 		return nil, fmt.Errorf("extension api server: %w", err)
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/50370
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When creating the `APIService` for the imperative api we use a hardcoded label selector `"app": "rancher"`. If the user install rancher via helm chart using a release name name that is not "rancher" the APIService will not function. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Provide a command line flag to control the value for the `app` label the `APIService` is selecting for.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

1. Build new rancher chart with `scripts/chart/build chart`
2. If testing off of the dev brancher build the rancher image `make quick` or `make quick-server`
3. Install the built rancher chart pointing to either the rancher head image or the image built in the previous step `helm upgrade --install --create-namespace --namespace cattle-system --set rancherImage=<image_repository> --set rancherImageTag=<image_tag> rancher-test build/chart/rancher`
4. Test that the imperative api is working as expected. You should see something like this:

```
> kubectl get useractivity
Error from server (MethodNotAllowed): the server does not allow this method on the requested resource
```
