### PR TITLE
added pre upgrade hook

### DIFF
--- a/chart/scripts/pre-upgrade-hook.sh
+++ b/chart/scripts/pre-upgrade-hook.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Global counters
+declare -A COUNTS
+RESOURCES_FOUND=false
+
+check_prerequisites() {
+  local missing_tools=()
+
+  for tool in kubectl jq; do
+    command -v "$tool" &>/dev/null || missing_tools+=("$tool")
+  done
+
+  if [ ${#missing_tools[@]} -gt 0 ]; then
+    echo "Missing required tools: ${missing_tools[*]}"
+    exit 1
+  fi
+}
+
+print_resource_table() {
+  local kind="$1"
+  local items="$2"
+
+  local count
+  count=$(wc -l <<< "$items")
+  COUNTS["$kind"]=$count
+  RESOURCES_FOUND=true
+
+  echo "Found $count $kind resource(s):"
+
+  IFS=$'\n' read -r -d '' -a lines < <(printf '%s\0' "$items")
+
+  local max_ns_len=9
+  local max_name_len=4
+  local max_display_len=12
+
+  for line in "${lines[@]}"; do
+    IFS=$'\t' read -r ns name display <<< "$line"
+    (( ${#ns} > max_ns_len )) && max_ns_len=${#ns}
+    (( ${#name} > max_name_len )) && max_name_len=${#name}
+    (( ${#display} > max_display_len )) && max_display_len=${#display}
+  done
+
+  printf "%-${max_ns_len}s  %-${max_name_len}s  %-${max_display_len}s\n" "NAMESPACE" "NAME" "DISPLAY NAME"
+  printf "%-${max_ns_len}s  %-${max_name_len}s  %-${max_display_len}s\n" \
+    "$(printf '%*s' "$max_ns_len" '' | tr ' ' '-')" \
+    "$(printf '%*s' "$max_name_len" '' | tr ' ' '-')" \
+    "$(printf '%*s' "$max_display_len" '' | tr ' ' '-')"
+
+  for line in "${lines[@]}"; do
+    IFS=$'\t' read -r ns name display <<< "$line"
+    printf "%-${max_ns_len}s  %-${max_name_len}s  %-${max_display_len}s\n" "$ns" "$name" "$display"
+  done
+
+  echo
+}
+
+detect_resource() {
+  local crd="$1"
+  local kind="$2"
+  local filter="$3"
+
+  echo "Checking for $kind resources..."
+
+  local json
+  if ! json=$(kubectl get "$crd" --all-namespaces -o json 2>&1); then
+    if grep -q "the server doesn't have a resource type" <<< "$json"; then
+      echo "Resource type $crd not found. Skipping."
+      echo
+      return 0
+    else
+      echo "Error retrieving $kind resources: $json"
+      exit 1
+    fi
+  fi
+
+  local items
+  items=$(jq -r "$filter" <<< "$json")
+
+  if [ -z "$items" ]; then
+    echo "No $kind resources found."
+    echo
+  else
+    print_resource_table "$kind" "$items"
+  fi
+}
+
+print_summary() {
+  echo "===== SUMMARY ====="
+  local total=0
+  for kind in "${!COUNTS[@]}"; do
+    local count=${COUNTS[$kind]}
+    echo "$kind: $count"
+    total=$((total + count))
+  done
+
+  echo "Total resources detected: $total"
+
+  if [ "$RESOURCES_FOUND" = true ]; then
+    echo "Error: RKE related resources were found, please delete the mentioned resources to continue"
+    exit 1
+  else
+    echo "No RKE related resources found."
+  fi
+}
+
+main() {
+  check_prerequisites
+
+  detect_resource "clusters.management.cattle.io" "RKE Management Cluster" \
+    '.items[] | select(.spec.rancherKubernetesEngineConfig != null) | 
+     [.metadata.namespace // "default", .metadata.name, .spec.displayName // ""] | @tsv'
+
+  detect_resource "nodetemplates.management.cattle.io" "NodeTemplate" \
+    '.items[] | [.metadata.namespace // "default", .metadata.name, .spec.displayName // ""] | @tsv'
+
+  detect_resource "clustertemplates.management.cattle.io" "ClusterTemplate" \
+    '.items[] | [.metadata.namespace // "default", .metadata.name, .spec.displayName // ""] | @tsv'
+
+  print_summary
+}
+
+main

--- a/chart/templates/pre-upgrade-hook-cluster-role-binding.yaml
+++ b/chart/templates/pre-upgrade-hook-cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "rancher.fullname" . }}-pre-upgrade
+  labels: {{ include "rancher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "rancher.fullname" . }}-pre-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "rancher.fullname" . }}-pre-upgrade
+    namespace: {{ .Release.Namespace }}

--- a/chart/templates/pre-upgrade-hook-cluster-role.yaml
+++ b/chart/templates/pre-upgrade-hook-cluster-role.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "rancher.fullname" . }}-pre-upgrade
+  labels: {{ include "rancher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["management.cattle.io"]
+    resources:
+      - "clusters"
+      - "nodetemplates"
+      - "clustertemplates"
+    verbs: ["get", "list"]

--- a/chart/templates/pre-upgrade-hook-config-map.yaml
+++ b/chart/templates/pre-upgrade-hook-config-map.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "rancher.fullname" . }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "rancher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  pre-upgrade-hook.sh: |-
+{{ $.Files.Get "scripts/pre-upgrade-hook.sh" | indent 4 }}

--- a/chart/templates/pre-upgrade-hook-job.yaml
+++ b/chart/templates/pre-upgrade-hook-job.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "rancher.fullname" . }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "rancher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: {{ template "rancher.fullname" . }}-pre-upgrade
+      labels: {{ include "rancher.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ template "rancher.fullname" . }}-pre-upgrade
+      restartPolicy: Never
+      containers:
+        - name: {{ template "rancher.name" . }}-pre-upgrade
+          image: "{{ include "system_default_registry" . }}{{ .Values.preUpgrade.image.repository }}:{{ .Values.preUpgrade.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+          command:
+            - /scripts/pre-upgrade-hook.sh
+          volumeMounts:
+            - mountPath: /scripts
+              name: config-volume
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "rancher.fullname" . }}-pre-upgrade
+            defaultMode: 0777

--- a/chart/templates/pre-upgrade-hook-service-account.yaml
+++ b/chart/templates/pre-upgrade-hook-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "rancher.fullname" . }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "rancher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -177,6 +177,11 @@ postDelete:
   # by default, the job will fail if it fail to uninstall any of the apps
   ignoreTimeoutError: false
 
+preUpgrade:
+  image:
+    repository: %PRE_UPGRADE_IMAGE_NAME%
+    tag: %PRE_UPGRADE_IMAGE_TAG%
+
 # Set a bootstrap password. If leave empty, a random password will be generated.
 bootstrapPassword: ""
 

--- a/dev-scripts/prepare-chart
+++ b/dev-scripts/prepare-chart
@@ -32,4 +32,5 @@ echo "Preparing Rancher Chart for release: ${CHART_VERSION}"
 sed_i_wrapper -i -e "s/%VERSION%/${CHART_VERSION}/g" ./chart/Chart.yaml
 sed_i_wrapper -i -e "s/%APP_VERSION%/${APP_VERSION}/g" ./chart/Chart.yaml
 sed_i_wrapper -i -e "s@%POST_DELETE_IMAGE_NAME%@${test_image}@g" ./chart/values.yaml
+sed_i_wrapper -i -e "s@%PRE_UPGRADE_IMAGE_NAME%@${test_image}@g" ./chart/values.yaml
 sed_i_wrapper -i -e "s/%POST_DELETE_IMAGE_TAG%/${APP_VERSION}/g" ./chart/values.yaml

--- a/scripts/chart/build
+++ b/scripts/chart/build
@@ -16,16 +16,18 @@ cp -rf ${1} build/chart/rancher
 sed -i -e "s/%VERSION%/${CHART_VERSION}/g" build/chart/rancher/Chart.yaml
 sed -i -e "s/%APP_VERSION%/${APP_VERSION}/g" build/chart/rancher/Chart.yaml
 
-post_delete_base=$CATTLE_DEFAULT_SHELL_VERSION
-post_delete_image_name=$(echo "${post_delete_base}" | cut -d ":" -f 1) || ""
-post_delete_image_tag=$(echo "${post_delete_base}" | cut -d ":" -f 2) || ""
-if [[ ! ${post_delete_image_name} =~ ^rancher\/.+ ]]; then
-  echo "The image name [$post_delete_image_name] is invalid. Its prefix should be rancher/"
+rancher_shell_base=$CATTLE_DEFAULT_SHELL_VERSION
+rancher_shell_image_name=$(echo "${rancher_shell_base}" | cut -d ":" -f 1) || ""
+rancher_shell_image_tag=$(echo "${rancher_shell_base}" | cut -d ":" -f 2) || ""
+if [[ ! ${rancher_shell_image_name} =~ ^rancher\/.+ ]]; then
+  echo "The image name [$rancher_shell_image_name] is invalid. Its prefix should be rancher/"
   exit 1
 fi
-if [[ ! ${post_delete_image_tag} =~ ^v.+ ]]; then
-  echo "The image tag [$post_delete_image_tag] is invalid. It should start with the letter v"
+if [[ ! ${rancher_shell_image_tag} =~ ^v.+ ]]; then
+  echo "The image tag [$rancher_shell_image_tag] is invalid. It should start with the letter v"
   exit 1
 fi
-sed -i -e "s@%POST_DELETE_IMAGE_NAME%@${post_delete_image_name}@g" build/chart/rancher/values.yaml
-sed -i -e "s/%POST_DELETE_IMAGE_TAG%/${post_delete_image_tag}/g" build/chart/rancher/values.yaml
+sed -i -e "s@%POST_DELETE_IMAGE_NAME%@${rancher_shell_image_name}@g" build/chart/rancher/values.yaml
+sed -i -e "s/%POST_DELETE_IMAGE_TAG%/${rancher_shell_image_tag}/g" build/chart/rancher/values.yaml
+sed -i -e "s@%PRE_UPGRADE_IMAGE_NAME%@${rancher_shell_image_name}@g" build/chart/rancher/values.yaml
+sed -i -e "s/%PRE_UPGRADE_IMAGE_TAG%/${rancher_shell_image_tag}/g" build/chart/rancher/values.yaml


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/50286
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 since rke will be removed from v2.12 a pre upgrade hook in rancher chart needs to be added.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 Added a pre upgrade hook in rancher helm chart which checks for RKE management clusters, Nodetemplates and ClusterTemplates in the local cluster and fails if any of the resources are found.
 
 added restartPolicy Never and backofflimit to 0  so that the pod created by pre-upgrade-hook job persist after the failed upgrade and users can check the logs.
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
following are the script results for a few cases 
1. ran the script on a local kind cluster: **script exit code 0**
```
Checking for RKE Management Cluster resources...
Resource type clusters.management.cattle.io not found. Skipping.

Checking for NodeTemplate resources...
Resource type nodetemplates.management.cattle.io not found. Skipping.

Checking for ClusterTemplate resources...
Resource type clustertemplates.management.cattle.io not found. Skipping.

===== SUMMARY =====
Total resources detected: 0
No RKE related resources found.
```

2. ran the script on a rancher HA server after creation and also when all rke resources are removed. **script exit code 0**
```
Checking for RKE Management Cluster resources...
No RKE Management Cluster resources found.

Checking for NodeTemplate resources...
No NodeTemplate resources found.

Checking for ClusterTemplate resources...
No ClusterTemplate resources found.

===== SUMMARY =====
Total resources detected: 0
No RKE related resources found.
``` 

3. when rke resources are present: **script exit code 1**
```
Checking for RKE Management Cluster resources...
Found 2 RKE Management Cluster resource(s):
NAMESPACE  NAME     DISPLAY NAME         
---------  -------  ---------------------
default    c-n2t27  vardhaman-test       
default    c-vn54v  vardhaman-test-custom

Checking for NodeTemplate resources...
Found 1 NodeTemplate resource(s):
NAMESPACE         NAME      DISPLAY NAME
----------------  --------  ------------
cattle-global-nt  nt-4p6v6  var         

Checking for ClusterTemplate resources...
Found 1 ClusterTemplate resource(s):
NAMESPACE           NAME      DISPLAY NAME
------------------  --------  ------------
cattle-global-data  ct-ssw5c  var         

===== SUMMARY =====
NodeTemplate: 1
ClusterTemplate: 1
RKE Management Cluster: 2
Total resources detected: 4
Error: RKE related resources were found, please delete the mentioned resources to continue
```

4. when network is disconnected. **script exit code 1**
```
Checking for RKE Management Cluster resources...
Error retrieving RKE Management Cluster resources: E0521 16:16:47.206557   24972 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://<Rancher-URL>/k8s/clusters/local/api?timeout=32s\": dial tcp: lookup <Rancher-URL> on 127.0.0.53:53: server misbehaving"
E0521 16:16:47.208648   24972 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://<Rancher-URL>/k8s/clusters/local/api?timeout=32s\": dial tcp: lookup <Rancher-URL> on 127.0.0.53:53: server misbehaving"
E0521 16:16:47.210634   24972 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://<Rancher-URL>/k8s/clusters/local/api?timeout=32s\": dial tcp: lookup <Rancher-URL> on 127.0.0.53:53: server misbehaving"
E0521 16:16:47.212539   24972 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://<Rancher-URL>/k8s/clusters/local/api?timeout=32s\": dial tcp: lookup <Rancher-URL> on 127.0.0.53:53: server misbehaving"
E0521 16:16:47.214450   24972 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://<Rancher-URL>/k8s/clusters/local/api?timeout=32s\": dial tcp: lookup <Rancher-URL> on 127.0.0.53:53: server misbehaving"
Unable to connect to the server: dial tcp: lookup <Rancher-URL> on 127.0.0.53:53: server misbehaving
```

5. built the chart using scripts/chart/build, create a few RKE related resources and tried rancher chart upgrade on rancher HA setup(v2.11.1)...
pre-upgrade hook failed and the pod was persisted so that user can check logs 
upgrade failed with error
```
Error: UPGRADE FAILED: pre-upgrade hooks failed: 1 error occurred:
	* job rancher-pre-upgrade failed: BackoffLimitExceeded

```
![Screenshot from 2025-05-21 16-39-26](https://github.com/user-attachments/assets/f4ad1758-6d82-44eb-822b-0e4db0ebeb2a)



## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_