### PR TITLE
[v2.9] Fix rke upgrade controller

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -157,7 +157,8 @@ func (h *handler) deployK3sBasedUpgradeController(cluster *mgmtv3.Cluster) error
 	case cluster.Status.Driver == mgmtv3.ClusterDriverRke2:
 		appName = Rke2AppName
 	}
-	app, err := appLister.Get(systemProjectName, appName)
+	systemProjectBackingNamespace := systemProject.Status.BackingNamespace
+	app, err := appLister.Get(systemProjectBackingNamespace, appName)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -166,7 +167,7 @@ func (h *handler) deployK3sBasedUpgradeController(cluster *mgmtv3.Cluster) error
 		desiredApp := &prjv3.App{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      appName,
-				Namespace: systemProjectName,
+				Namespace: systemProjectBackingNamespace,
 				Annotations: map[string]string{
 					"field.cattle.io/creatorId": creator.Name,
 				},

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -157,7 +157,7 @@ func (h *handler) deployK3sBasedUpgradeController(cluster *mgmtv3.Cluster) error
 	case cluster.Status.Driver == mgmtv3.ClusterDriverRke2:
 		appName = Rke2AppName
 	}
-	systemProjectBackingNamespace := systemProject.Status.BackingNamespace
+	systemProjectBackingNamespace := systemProject.GetProjectBackingNamespace()
 	app, err := appLister.Get(systemProjectBackingNamespace, appName)
 	if err != nil {
 		if !errors.IsNotFound(err) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50372
 
## Problem
https://github.com/rancher/rancher/pull/49859 introduced project backing namespaces which is the namespace that contains project related resources. I missed a reference to the project namespace in the k3s upgrade controller.
 
## Solution
Use the backing namespace instead of the project name for the namespace.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_