### PR TITLE
[v2.9] Use project backing namespace to list apps in k3sbased upgrade handler

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -157,7 +157,9 @@ func (h *handler) deployK3sBasedUpgradeController(cluster *mgmtv3.Cluster) error
 	case cluster.Status.Driver == mgmtv3.ClusterDriverRke2:
 		appName = Rke2AppName
 	}
-	app, err := appLister.Get(systemProjectName, appName)
+
+	systemProjectBackingNamespace := systemProject.GetProjectBackingNamespace()
+	app, err := appLister.Get(systemProjectBackingNamespace, appName)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -166,7 +168,7 @@ func (h *handler) deployK3sBasedUpgradeController(cluster *mgmtv3.Cluster) error
 		desiredApp := &prjv3.App{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      appName,
-				Namespace: systemProjectName,
+				Namespace: systemProjectBackingNamespace,
 				Annotations: map[string]string{
 					"field.cattle.io/creatorId": creator.Name,
 				},

--- a/pkg/controllers/managementuserlegacy/helm/controller.go
+++ b/pkg/controllers/managementuserlegacy/helm/controller.go
@@ -135,9 +135,8 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 		return obj, nil
 	}
 	// always refresh app to avoid updating app twice
-	_, projectName := ref.Parse(obj.Spec.ProjectName)
 	var err error
-	obj, err = l.AppsLister.Get(projectName, obj.Name)
+	obj, err = l.AppsLister.Get(obj.Namespace, obj.Name)
 	if err != nil {
 		return obj, err
 	}
@@ -150,7 +149,7 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 	}
 
 	obj = newObj.(*v3.App)
-	appRevisionClient := l.AppRevisionGetter.AppRevisions(projectName)
+	appRevisionClient := l.AppRevisionGetter.AppRevisions(obj.Namespace)
 	if obj.Spec.AppRevisionName != "" {
 		currentRevision, err := appRevisionClient.Get(obj.Spec.AppRevisionName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

#50372
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

- #49859 introduced project backing namespaces which is the namespace that contains project related resources. I missed a reference to the project namespace in the k3s upgrade controller.
- helm controller tries to infer the app namespace from the project name instead of using App's Namespace.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Use the backing namespace instead of the project name for the namespace.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A