### PR TITLE
Enforce RKE1 Resource Pre-Upgrade Validation in Rancher Manager

### DIFF
--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/rancher/pkg/api/steve/aggregation"
 	"github.com/rancher/rancher/pkg/api/steve/proxy"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/auth"
 	"github.com/rancher/rancher/pkg/auth/audit"
 	"github.com/rancher/rancher/pkg/auth/requests"
@@ -635,7 +634,7 @@ func validateRKE1Resources(wranglerContext *wrangler.Context) error {
 		return nil
 	}
 
-	return fmt.Errorf("Rancher v2.12 no longer supports RKE1.\nDetected RKE1-related resources (listed below).\nPlease migrate these clusters to RKE2 or K3s, or delete the related resources.\nMore info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s/\n - %s", strings.Join(resources, "\n - "))
+	return fmt.Errorf("Rancher v2.12 no longer supports RKE1. Detected RKE1-related resources (listed below).\nPlease migrate these clusters to RKE2 or K3s, or delete the related resources. More info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s/\n - %s", strings.Join(resources, "\n - "))
 }
 
 // checkForRKE1Resources scans for deprecated RKE1 (Rancher Kubernetes Engine v1) resources in the Rancher management context.
@@ -669,7 +668,7 @@ func checkForRKE1Resources(wranglerContext *wrangler.Context) ([]string, error) 
 	}
 
 	for _, obj := range nodeTemplates.Items {
-		found = append(found, fmt.Sprintf("NodeTemplate: name=%s, displayName=%s, namespace=%s", obj.Name, obj.Spec.DisplayName, obj.Namespace))
+		found = append(found, fmt.Sprintf("NodeTemplate: name=%s, displayName=%s", obj.Name, obj.Spec.DisplayName))
 	}
 
 	// ClusterTemplates in the global namespace
@@ -682,23 +681,7 @@ func checkForRKE1Resources(wranglerContext *wrangler.Context) ([]string, error) 
 	}
 
 	for _, obj := range clusterTemplates.Items {
-		found = append(found, fmt.Sprintf("ClusterTemplate: name=%s, displayName=%s, namespace=%s", obj.Name, obj.Spec.DisplayName, obj.Namespace))
-	}
-
-	// Check for associated v1 provisioning clusters
-	provisioningClusters, err := wranglerContext.Provisioning.Cluster().List("", metav1.ListOptions{})
-
-	if err != nil {
-		if k8serror.IsNotFound(err) {
-			// No provisioning cluster CRD installed, treat as no resources
-			provisioningClusters = &provisioningv1.ClusterList{}
-		} else {
-			return nil, fmt.Errorf("error checking provisioning clusters: %w", err)
-		}
-	}
-
-	for _, provisioningCluster := range provisioningClusters.Items {
-		found = append(found, fmt.Sprintf("ProvisioningCluster: name=%s", provisioningCluster.Name))
+		found = append(found, fmt.Sprintf("ClusterTemplate: name=%s, displayName=%s", obj.Name, obj.Spec.DisplayName))
 	}
 
 	return found, nil

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -634,7 +634,7 @@ func validateRKE1Resources(wranglerContext *wrangler.Context) error {
 		return nil
 	}
 
-	return fmt.Errorf("Rancher v2.12 no longer supports RKE1. Detected RKE1-related resources (listed below).\nPlease migrate these clusters to RKE2 or K3s, or delete the related resources. More info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s/\n - %s", strings.Join(resources, "\n - "))
+	return fmt.Errorf("Rancher v2.12+ does not support RKE1. Detected RKE1-related resources (listed below).\nPlease migrate these clusters to RKE2 or K3s, or delete the related resources. More info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s/\n - %s", strings.Join(resources, "\n - "))
 }
 
 // checkForRKE1Resources scans for deprecated RKE1 (Rancher Kubernetes Engine v1) resources in the Rancher management context.


### PR DESCRIPTION
## Issue
https://github.com/rancher/rancher/issues/50286

## Problem
With the deprecation and removal of RKE in Rancher v2.12, it's necessary to ensure that existing installations don't inadvertently upgrade without first removing RKE-related resources. Currently, there's no enforcement mechanism in place to block such upgrades, which could lead to failures or inconsistent states.

## Solution
**Key Changes**
- Validation logic added at startup to detect the presence of RKE1 resources:
      1. Cluster templates referencing RKE1
      2. Node templates used by RKE1 clusters
      3. Existing RKE1 clusters
- If any RKE1-related resource is detected, Rancher fails fast with a clear error message.

**_This ensures: No unsupported RKE1 workloads are managed in Rancher v2.12+. Admins are forced to clean up or migrate before upgrading_**

**How to Upgrade Safely**
1. Before upgrading to v2.12.0+:
    - Delete all RKE1 downstream clusters, node templates, and cluster templates referencing RKE1.
2. Once the environment is RKE1-free:
    - Proceed with upgrading to Rancher v2.12+ with the validation PR.
    - Rancher will start cleanly and block any new RKE1 cluster creation attempts.

## Validation PR Testing Summary
This PR introduces validation logic to prevent Rancher from managing RKE1 resources starting in v2.12.0 and later. To verify its behavior, we conducted the following tests using Rancher v2.11.1 and a custom image with the validation script.

**Test Workflow**
**1. Initial Setup in Rancher v2.11.1**

Created a downstream RKE1 cluster using:
- Node Template
- Cluster Template

Verified successful provisioning.

![Screenshot from 2025-05-23 10-50-40](https://github.com/user-attachments/assets/13582436-183f-455d-a416-41b2684bb118)

**2. Upgrade to Custom Image with Validation Logic**

- Upgraded the container image to the custom Rancher build with the validation script.
- On startup, Rancher failed to list/manage existing RKE1 resources, as expected due to the validation logic.


![Screenshot from 2025-05-23 10-54-50](https://github.com/user-attachments/assets/00b2645d-65ba-4181-811e-eb0fb7291b78)

**3. Revert and Cleanup in v2.11.1**
- Rolled back to Rancher v2.11.1 using the same volume.
- Deleted all downstream RKE1 clusters and related resources.

![Screenshot from 2025-05-23 10-59-06](https://github.com/user-attachments/assets/68afe212-be6d-4a93-9c0e-097e16444686)

**4. Retest with Clean Volume**
- Created a new volume from the cleaned state.
- Launched the custom Rancher image again.
- Rancher started successfully with no RKE1 resources present.

![Screenshot from 2025-05-23 11-04-09](https://github.com/user-attachments/assets/8a0f285f-b594-4a02-a314-607afd62aee8)
