### PR TITLE
[main] Early rdp

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -178,6 +178,27 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 	return []*chart.Definition{
 		{
 			ReleaseNamespace:    namespace.System,
+			ChartName:           chart.RemoteDialerProxyChartName,
+			ExactVersionSetting: settings.RemoteDialerProxyVersion,
+			Values: func() map[string]interface{} {
+				values := map[string]interface{}{}
+				// add priority class value
+				h.setPriorityClass(values, chart.RemoteDialerProxyChartName)
+				return values
+			},
+			Enabled: func() bool {
+				// do not deploy RDP in downstream cluster
+				if features.MCMAgent.Enabled() {
+					return false
+				}
+
+				return features.ImperativeApiExtension.Enabled() && ext.RDPEnabled()
+			},
+			Uninstall:       !features.ImperativeApiExtension.Enabled(),
+			RemoveNamespace: false,
+		},
+		{
+			ReleaseNamespace:    namespace.System,
 			ChartName:           chart.WebhookChartName,
 			ExactVersionSetting: settings.RancherWebhookVersion,
 			Values: func() map[string]interface{} {
@@ -319,27 +340,6 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 					toUninstall, !versionManagementEnabled, noManagedPlan)
 				return toUninstall
 			}(),
-		},
-		{
-			ReleaseNamespace:    namespace.System,
-			ChartName:           chart.RemoteDialerProxyChartName,
-			ExactVersionSetting: settings.RemoteDialerProxyVersion,
-			Values: func() map[string]interface{} {
-				values := map[string]interface{}{}
-				// add priority class value
-				h.setPriorityClass(values, chart.RemoteDialerProxyChartName)
-				return values
-			},
-			Enabled: func() bool {
-				// do not deploy RDP in downstream cluster
-				if features.MCMAgent.Enabled() {
-					return false
-				}
-
-				return features.ImperativeApiExtension.Enabled() && ext.RDPEnabled()
-			},
-			Uninstall:       !features.ImperativeApiExtension.Enabled(),
-			RemoveNamespace: false,
 		},
 	}
 }

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -105,6 +105,15 @@ echo "Waiting for K3s kubeconfig to be generated"
   --exit-command "dump_rancher_logs" `# Dump logs to find out why K3s did not start` \
   "stat /etc/rancher/k3s/k3s.yaml &>/dev/null"
 
+echo "Waiting up to 5 minutes for the api-extension deployment"
+./scripts/retry \
+  --timeout 300 `# Time out after 300 seconds (5 min)` \
+  --sleep 2 `# Sleep for 2 seconds in between attempts` \
+  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
+  --message "api-extension was not available after {{elapsed}} seconds" `# Print this progress message` \
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why api-extension did not start` \
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/api-extension &>/dev/null"
+
 echo "Waiting up to 5 minutes for rancher-webhook deployment"
 ./scripts/retry \
   --timeout 300 `# Time out after 300 seconds (5 min)` \
@@ -122,15 +131,6 @@ echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
   --message "rancher-provisioning-capi was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why capi-controller-manager did not start` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-provisioning-capi-system deploy/capi-controller-manager  &>/dev/null"
-
-echo "Waiting up to 5 minutes for the api-extension deployment"
-./scripts/retry \
-  --timeout 300 `# Time out after 300 seconds (5 min)` \
-  --sleep 2 `# Sleep for 2 seconds in between attempts` \
-  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
-  --message "api-extension was not available after {{elapsed}} seconds" `# Print this progress message` \
-  --exit-command "dump_rancher_logs" `# Dump logs to find out why api-extension did not start` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/api-extension &>/dev/null"
 
 
 echo Running integrationsetup

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -204,6 +204,16 @@ trap cleanup exit
 echo "Waiting for Rancher to be healthy"
 ./scripts/retry --sleep 2 --timeout 300 "curl -sf -o /dev/null http://localhost:8080/ping"
 
+# The remotedialer-proxy is pulled in by the api-extension deployment
+echo "Waiting up to 5 minutes for the api-extension deployment"
+./scripts/retry \
+  --timeout 300 `# Time out after 300 seconds (5 min)` \
+  --sleep 2 `# Sleep for 2 seconds in between attempts` \
+  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
+  --message "api-extension was not available after {{elapsed}} seconds" `# Print this progress message` \
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why api-extension did not start` \
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/api-extension &>/dev/null"
+
 echo "Waiting up to 5 minutes for rancher-webhook deployment"
 ./scripts/retry \
   --timeout 300 `# Time out after 300 seconds (5 min)` \
@@ -221,16 +231,6 @@ echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
   --message "rancher-provisioning-capi was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why capi-controller-manager did not start` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-provisioning-capi-system deploy/capi-controller-manager &>/dev/null"
-
-# The remotedialer-proxy is pulled in by the api-extension deployment
-echo "Waiting up to 5 minutes for the api-extension deployment"
-./scripts/retry \
-  --timeout 300 `# Time out after 300 seconds (5 min)` \
-  --sleep 2 `# Sleep for 2 seconds in between attempts` \
-  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
-  --message "api-extension was not available after {{elapsed}} seconds" `# Print this progress message` \
-  --exit-command "dump_rancher_logs" `# Dump logs to find out why api-extension did not start` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/api-extension &>/dev/null"
 
 # only push the image if we're not using the default image:tag
 if [ "${CATTLE_AGENT_IMAGE}" != "rancher/rancher-agent:head" ]; then

--- a/scripts/test
+++ b/scripts/test
@@ -145,6 +145,15 @@ trap cleanup exit
 echo "Waiting for Rancher to be healthy"
 ./scripts/retry --sleep 2 "curl -sf -o /dev/null http://localhost:8080/ping"
 
+# The remotedialer-proxy is pulled in by the api-extension deployment
+echo "Waiting up to 5 minutes for the api-extension deployment"
+./scripts/retry \
+  --timeout 300 `# Time out after 300 seconds (5 min)` \
+  --sleep 2 `# Sleep for 2 seconds in between attempts` \
+  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
+  --message "remotedialer-proxy was not available after {{elapsed}} seconds" `# Print this progress message` \
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/api-extension &>/dev/null"
+
 echo "Waiting up to 5 minutes for rancher-webhook deployment"
 ./scripts/retry \
   --timeout 300 `# Time out after 300 seconds (5 min)` \
@@ -160,15 +169,6 @@ echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-provisioning-capi was not available after {{elapsed}} seconds" `# Print this progress message` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-provisioning-capi-system deploy/capi-controller-manager &>/dev/null"
-
-# The remotedialer-proxy is pulled in by the api-extension deployment
-echo "Waiting up to 5 minutes for the api-extension deployment"
-./scripts/retry \
-  --timeout 300 `# Time out after 300 seconds (5 min)` \
-  --sleep 2 `# Sleep for 2 seconds in between attempts` \
-  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
-  --message "remotedialer-proxy was not available after {{elapsed}} seconds" `# Print this progress message` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/api-extension &>/dev/null"
 
 #kill $TPID
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/50398
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The `remotedialer-proxy` chart does not become "up" until late in the rancher start up process. This will make it difficult to determine if the underlying k8s distribution is configured to support the aggregated API layer and ultimately hinder progress on https://github.com/rancher/rancher/issues/50399.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Move the chart installation earlier in the startup process.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_