### PR TITLE
[main] block rancher until kube apiserver connects

### DIFF
--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	extstores "github.com/rancher/rancher/pkg/ext/stores"
@@ -36,6 +37,9 @@ const (
 type Options struct {
 	// AppSelector is the expected value for the "app" label on the rancher service.
 	AppSelector string
+
+	// KubeAggregatorReadyChan is the channel to close once the extension server receives a request from the kube API.
+	KubeAggregatorReadyChan chan struct{}
 }
 
 func DefaultOptions() Options {
@@ -226,6 +230,8 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 
 	authenticator := steveext.NewUnionAuthenticator(authenticators...)
 
+	var once sync.Once
+
 	aslAuthorizer := steveext.NewAccessSetAuthorizer(wranglerContext.ASL)
 	codecs := serializer.NewCodecFactory(scheme)
 	extOpts := steveext.ExtensionAPIServerOptions{
@@ -243,6 +249,12 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		},
 		Authenticator: authenticator,
 		Authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			if a.GetUser().GetName() == "system:aggregator" {
+				once.Do(func() {
+					close(opts.KubeAggregatorReadyChan)
+				})
+			}
+
 			if a.IsResourceRequest() {
 				return aslAuthorizer.Authorize(ctx, a)
 			}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -95,6 +95,8 @@ type Rancher struct {
 	auditLog   *audit.LogWriter
 	authServer *auth.Server
 	opts       *Options
+
+	kubeAggregationReadyChan chan struct{}
 }
 
 func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options) (*Rancher, error) {
@@ -202,7 +204,10 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, ext.DefaultOptions())
+	extensionOpts := ext.DefaultOptions()
+	extensionOpts.KubeAggregatorReadyChan = make(chan struct{})
+
+	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, extensionOpts)
 	if err != nil {
 		return nil, fmt.Errorf("extension api server: %w", err)
 	}
@@ -270,11 +275,12 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 			additionalAPI,
 			requests.NewRequireAuthenticatedFilter("/v1/", "/v1/management.cattle.io.setting"),
 		}.Handler(steve),
-		Wrangler:   wranglerContext,
-		Steve:      steve,
-		auditLog:   auditLogWriter,
-		authServer: authServer,
-		opts:       opts,
+		Wrangler:                 wranglerContext,
+		Steve:                    steve,
+		auditLog:                 auditLogWriter,
+		authServer:               authServer,
+		opts:                     opts,
+		kubeAggregationReadyChan: extensionOpts.KubeAggregatorReadyChan,
 	}, nil
 }
 
@@ -332,6 +338,14 @@ func (r *Rancher) ListenAndServe(ctx context.Context) error {
 
 	r.startAggregation(ctx)
 	go r.Steve.StartAggregation(ctx)
+
+	select {
+	case <-r.kubeAggregationReadyChan:
+		logrus.Info("Kube-APIServer connected to imperative api")
+	case <-time.After(time.Minute * 2):
+		logrus.Fatal("Kube-APIServer did not contact the rancher imperative api in time")
+	}
+
 	if err := tls.ListenAndServe(ctx, r.Wrangler.RESTConfig,
 		r.Auth(r.Handler),
 		r.opts.BindHost,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/50399
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If a user attempts to install rancher on a system that is not configured for extension APIs, the kube-apiserver will not know to contact the rancher imperative-api and there will be no clear indication that the system is not working as expected.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Block rancher start up until the imperative-api receives a request from the kube-apisever.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_