### PR TITLE
Ext controllers

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -178,6 +178,27 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 	return []*chart.Definition{
 		{
 			ReleaseNamespace:    namespace.System,
+			ChartName:           chart.RemoteDialerProxyChartName,
+			ExactVersionSetting: settings.RemoteDialerProxyVersion,
+			Values: func() map[string]interface{} {
+				values := map[string]interface{}{}
+				// add priority class value
+				h.setPriorityClass(values, chart.RemoteDialerProxyChartName)
+				return values
+			},
+			Enabled: func() bool {
+				// do not deploy RDP in downstream cluster
+				if features.MCMAgent.Enabled() {
+					return false
+				}
+
+				return features.ImperativeApiExtension.Enabled() && ext.RDPEnabled()
+			},
+			Uninstall:       !features.ImperativeApiExtension.Enabled(),
+			RemoveNamespace: false,
+		},
+		{
+			ReleaseNamespace:    namespace.System,
 			ChartName:           chart.WebhookChartName,
 			ExactVersionSetting: settings.RancherWebhookVersion,
 			Values: func() map[string]interface{} {
@@ -319,27 +340,6 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 					toUninstall, !versionManagementEnabled, noManagedPlan)
 				return toUninstall
 			}(),
-		},
-		{
-			ReleaseNamespace:    namespace.System,
-			ChartName:           chart.RemoteDialerProxyChartName,
-			ExactVersionSetting: settings.RemoteDialerProxyVersion,
-			Values: func() map[string]interface{} {
-				values := map[string]interface{}{}
-				// add priority class value
-				h.setPriorityClass(values, chart.RemoteDialerProxyChartName)
-				return values
-			},
-			Enabled: func() bool {
-				// do not deploy RDP in downstream cluster
-				if features.MCMAgent.Enabled() {
-					return false
-				}
-
-				return features.ImperativeApiExtension.Enabled() && ext.RDPEnabled()
-			},
-			Uninstall:       !features.ImperativeApiExtension.Enabled(),
-			RemoveNamespace: false,
 		},
 	}
 }

--- a/pkg/controllers/management/controller.go
+++ b/pkg/controllers/management/controller.go
@@ -2,7 +2,9 @@ package management
 
 import (
 	"context"
+	"fmt"
 
+	extv1 "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/management/agentupgrade"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
@@ -31,6 +33,10 @@ import (
 )
 
 func Register(ctx context.Context, management *config.ManagementContext, manager *clustermanager.Manager, wrangler *wrangler.Context) {
+	wrangler.Ext.Token().OnChange(ctx, "test-ext", func(key string, token *extv1.Token) (*extv1.Token, error) {
+		fmt.Println("HITHERE HELLO!!")
+		return nil, nil
+	})
 	// auth handlers need to run early to create namespaces that back clusters and projects
 	// also, these handlers are purely in the mgmt plane, so they are lightweight compared to those that interact with machines and clusters
 	auth.RegisterEarly(ctx, management, manager)

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	extstores "github.com/rancher/rancher/pkg/ext/stores"
@@ -36,6 +37,9 @@ const (
 type Options struct {
 	// AppSelector is the expected value for the "app" label on the rancher service.
 	AppSelector string
+
+	// KubeAggregatorReadyChan is the channel to close once the extension server receives a request from the kube API.
+	KubeAggregatorReadyChan chan struct{}
 }
 
 func DefaultOptions() Options {
@@ -226,6 +230,8 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 
 	authenticator := steveext.NewUnionAuthenticator(authenticators...)
 
+	var once sync.Once
+
 	aslAuthorizer := steveext.NewAccessSetAuthorizer(wranglerContext.ASL)
 	codecs := serializer.NewCodecFactory(scheme)
 	extOpts := steveext.ExtensionAPIServerOptions{
@@ -243,6 +249,12 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		},
 		Authenticator: authenticator,
 		Authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			if a.GetUser().GetName() == "system:aggregator" {
+				once.Do(func() {
+					close(opts.KubeAggregatorReadyChan)
+				})
+			}
+
 			if a.IsResourceRequest() {
 				return aslAuthorizer.Authorize(ctx, a)
 			}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -95,6 +95,8 @@ type Rancher struct {
 	auditLog   *audit.LogWriter
 	authServer *auth.Server
 	opts       *Options
+
+	kubeAggregationReadyChan chan struct{}
 }
 
 func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options) (*Rancher, error) {
@@ -202,7 +204,10 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, ext.DefaultOptions())
+	extensionOpts := ext.DefaultOptions()
+	extensionOpts.KubeAggregatorReadyChan = make(chan struct{})
+
+	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, extensionOpts)
 	if err != nil {
 		return nil, fmt.Errorf("extension api server: %w", err)
 	}
@@ -270,11 +275,12 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 			additionalAPI,
 			requests.NewRequireAuthenticatedFilter("/v1/", "/v1/management.cattle.io.setting"),
 		}.Handler(steve),
-		Wrangler:   wranglerContext,
-		Steve:      steve,
-		auditLog:   auditLogWriter,
-		authServer: authServer,
-		opts:       opts,
+		Wrangler:                 wranglerContext,
+		Steve:                    steve,
+		auditLog:                 auditLogWriter,
+		authServer:               authServer,
+		opts:                     opts,
+		kubeAggregationReadyChan: extensionOpts.KubeAggregatorReadyChan,
 	}, nil
 }
 
@@ -332,6 +338,14 @@ func (r *Rancher) ListenAndServe(ctx context.Context) error {
 
 	r.startAggregation(ctx)
 	go r.Steve.StartAggregation(ctx)
+
+	select {
+	case <-r.kubeAggregationReadyChan:
+		logrus.Info("Kube-APIServer connected to imperative api")
+	case <-time.After(time.Minute * 2):
+		logrus.Fatal("Kube-APIServer did not contact the rancher imperative api in time")
+	}
+
 	if err := tls.ListenAndServe(ctx, r.Wrangler.RESTConfig,
 		r.Auth(r.Handler),
 		r.opts.BindHost,

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -339,6 +339,7 @@ func (r *Rancher) ListenAndServe(ctx context.Context) error {
 	r.startAggregation(ctx)
 	go r.Steve.StartAggregation(ctx)
 
+	logrus.Info("Wainting for imperative api to be ready")
 	select {
 	case <-r.kubeAggregationReadyChan:
 		logrus.Info("Kube-APIServer connected to imperative api")


### PR DESCRIPTION
@andreas-kupries This is an example of getting controllers to run for `ext.cattle.io`. I cherry-picked commits from https://github.com/rancher/rancher/pull/50417 and https://github.com/rancher/rancher/pull/50405 since they're expected to be merged soon (related to imperative api).

One issue with this PR is that it modifies the `Accept` header for the REST client used to reach ALL resources. This is not acceptable (ah, no pun intended) imo, but it proves that we don't need the loopback client.

If you want to be unblocked, you can keep creating a separate controller factory (with just `application/json` Accept header) but the rest can stay as is (no need for loopback client).

---

For future reference, the issue with the current controller factory `Accept` header is that it lists support for protobuf, so the server does content negotiation. The server also supports protobuf.. but our types don't have any way to decode/encode protobuf. So the server tries to encode the list of tokens, and hits the following error:


```
W0526 14:10:00.901609    8471 reflector.go:569] pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/reflector.go:251: failed to list *v1.Token: object *v1.TokenList does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message                                                        
E0526 14:10:00.901674    8471 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/reflector.go:251: Failed to watch *v1.Token: failed to list *v1.Token: object *v1.TokenList does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message" logger="UnhandledError"                         
```

We could fix this by supporting protobuf and add protobuf field tags on Go structs.. But that requires some changes to wrangler codegen. Not ideal.

We could also disable protobuf on the server (extension apiserver) but I haven't found how to do that yet. This way, we'd need a single controller factory. Need to dig deeper here.