### PR TITLE
feat: shared managed cluster list for downstream metric consumer

### DIFF
--- a/pkg/metrics/managedcluster/managed_cluster.go
+++ b/pkg/metrics/managedcluster/managed_cluster.go
@@ -1,0 +1,116 @@
+package managedcluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	controllerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	initMdGathererOnce sync.Once
+	mdGatherer         *mgmtClusterMdGatherer
+)
+
+const (
+	CallbackMetricID = "prom-metrics-managed-cluster"
+	CallbackSccID    = "scc-managed-cluster"
+)
+
+func NewMetadataGatherer(
+	clusterCache controllerv3.ClusterCache,
+	opts GatherOpts,
+) {
+	logrus.Debug("Attempting to initialize metatadata gatherer for managed clusters...")
+	count := 0
+	initMdGathererOnce.Do(func() {
+		mdGatherer = newMetadataGatherer(clusterCache, GatherOpts{
+			CollectInterval: opts.CollectInterval,
+			Ctx:             opts.Ctx,
+		})
+		logrus.Info("Metadata gatherer for managed clusters initialized")
+		count += 1
+		go mdGatherer.Run()
+	})
+
+	if count == 0 {
+		logrus.Warn("Metadata gatherer for managed clusters already initialized")
+	}
+
+}
+
+func RegisterCallback(
+	name string,
+	cb func([]*apiv3.Cluster),
+) error {
+	if mdGatherer == nil {
+		logrus.Errorf("Metadata gatherer is not initialized, cannot register callback %s", name)
+		return fmt.Errorf("metadata gatherer not initialized")
+	}
+	mdGatherer.registerCallback(name, cb)
+	return nil
+}
+
+type mgmtClusterMdGatherer struct {
+	clusterCache controllerv3.ClusterCache
+
+	cbMu *sync.Mutex
+	cbs  map[string]func([]*apiv3.Cluster)
+
+	opts GatherOpts
+}
+
+type GatherOpts struct {
+	CollectInterval time.Duration
+	Ctx             context.Context
+}
+
+func newMetadataGatherer(clusterCache controllerv3.ClusterCache, opts GatherOpts) *mgmtClusterMdGatherer {
+	mg := &mgmtClusterMdGatherer{
+		clusterCache: clusterCache,
+		cbs:          make(map[string]func([]*apiv3.Cluster)),
+		cbMu:         &sync.Mutex{},
+		opts:         opts,
+	}
+	return mg
+}
+
+func (mg *mgmtClusterMdGatherer) registerCallback(name string, cb func([]*apiv3.Cluster)) {
+	logrus.Debugf("Registering callback %s for managed cluster metadata gatherer", name)
+	mg.cbMu.Lock()
+	defer mg.cbMu.Unlock()
+	mg.cbs[name] = cb
+}
+
+func (mg *mgmtClusterMdGatherer) Run() {
+	logrus.Info("Starting managed cluster metadata gatherer...")
+	tDur := mg.opts.CollectInterval
+	if mg.opts.CollectInterval <= 0 {
+		tDur = 60 * time.Second
+	}
+	t := time.NewTicker(tDur)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			clusters, err := mg.clusterCache.List(labels.Everything())
+			if err != nil {
+				continue
+			}
+			mg.cbMu.Lock()
+			for name, cb := range mg.cbs {
+				logrus.Debugf("Calling callback %s for managed cluster metadata gatherer", name)
+				cb(clusters)
+			}
+			mg.cbMu.Unlock()
+		case <-mg.opts.Ctx.Done():
+			logrus.Infof("Stopping metadata gatherer for managed clusters...")
+			return
+		}
+	}
+}

--- a/pkg/metrics/managedcluster/managed_cluster_test.go
+++ b/pkg/metrics/managedcluster/managed_cluster_test.go
@@ -1,0 +1,253 @@
+package managedcluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	controllerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGlobalMetadataGatherer(t *testing.T) {
+	// Reset globals before each test run
+	mdGatherer = nil
+	initMdGathererOnce = sync.Once{}
+	testMu := &sync.Mutex{}
+
+	err := RegisterCallback(
+		CallbackMetricID,
+		func(_ []*apiv3.Cluster) {},
+	)
+	assert.Error(t, err, "should error when registering a callback before initialization")
+
+	gomockCtrl := gomock.NewController(t)
+	mockClusterCache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Cluster](gomockCtrl)
+	mockClusterCache.EXPECT().List(gomock.Any()).Return([]*apiv3.Cluster{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cluster",
+			},
+			Spec: apiv3.ClusterSpec{
+				DisplayName: "Test Cluster",
+			},
+		},
+	}, nil).AnyTimes()
+
+	NewMetadataGatherer(
+		mockClusterCache,
+		GatherOpts{
+			CollectInterval: 1 * time.Millisecond,
+			Ctx:             t.Context(),
+		},
+	)
+	assert.NotNil(t, mdGatherer, "global gatherer should not be nil after initialization")
+
+	inMap := map[string]*apiv3.Cluster{}
+	RegisterCallback(
+		CallbackMetricID,
+		func(clusters []*apiv3.Cluster) {
+			testMu.Lock()
+			defer testMu.Unlock()
+			for _, cluster := range clusters {
+				inMap[cluster.Name] = cluster
+			}
+
+		},
+	)
+
+	assert.Eventually(t, func() bool {
+		testMu.Lock()
+		defer testMu.Unlock()
+		return assert.ObjectsAreEqual(inMap, map[string]*apiv3.Cluster{
+			"test-cluster": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: apiv3.ClusterSpec{
+					DisplayName: "Test Cluster",
+				},
+			},
+		})
+	}, 50*time.Millisecond, 1*time.Millisecond)
+
+	inMap2 := map[string]*apiv3.Cluster{}
+	RegisterCallback(
+		CallbackSccID,
+		func(clusters []*apiv3.Cluster) {
+			testMu.Lock()
+			defer testMu.Unlock()
+			for _, cluster := range clusters {
+				inMap2["hello-"+cluster.Name] = cluster
+			}
+		},
+	)
+
+	assert.Eventually(t, func() bool {
+		testMu.Lock()
+		defer testMu.Unlock()
+		return assert.ObjectsAreEqual(inMap2, map[string]*apiv3.Cluster{
+			"hello-test-cluster": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: apiv3.ClusterSpec{
+					DisplayName: "Test Cluster",
+				},
+			},
+		})
+	}, 50*time.Millisecond, 1*time.Millisecond)
+	testMu.Lock()
+	defer testMu.Unlock()
+	assert.False(t, assert.ObjectsAreEqual(inMap, inMap2), "the two maps should not be equal, as they are modified by different callbacks")
+}
+
+type tc struct {
+	opts         GatherOpts
+	clusterCache controllerv3.ClusterCache
+
+	expectedMap map[string]*apiv3.Cluster
+	registerCbs map[string]func(map[string]*apiv3.Cluster) func([]*apiv3.Cluster)
+	inputMap    map[string]*apiv3.Cluster
+}
+
+func newTestcase(
+	opts GatherOpts,
+	clusterCache controllerv3.ClusterCache,
+	expectedMap map[string]*apiv3.Cluster,
+	registerCbs map[string]func(map[string]*apiv3.Cluster) func([]*apiv3.Cluster),
+) tc {
+	return tc{
+		opts:         opts,
+		clusterCache: clusterCache,
+		expectedMap:  expectedMap,
+		registerCbs:  registerCbs,
+		inputMap:     map[string]*apiv3.Cluster{},
+	}
+}
+
+func TestMetadataGathererInstance(t *testing.T) {
+	testMu := &sync.Mutex{}
+	ctx, ca := context.WithCancel(t.Context())
+	defer ca()
+	gomockCtrl := gomock.NewController(t)
+
+	mockClusterCache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Cluster](gomockCtrl)
+	mockClusterCache.EXPECT().List(gomock.Any()).Return([]*apiv3.Cluster{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cluster",
+			},
+			Spec: apiv3.ClusterSpec{
+				DisplayName: "Test Cluster",
+			},
+		},
+	}, nil).AnyTimes()
+
+	tcs := []tc{
+		newTestcase(
+			GatherOpts{
+				Ctx:             ctx,
+				CollectInterval: 1 * time.Millisecond,
+			},
+			mockClusterCache,
+			map[string]*apiv3.Cluster{
+				"test-cluster": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+					},
+					Spec: apiv3.ClusterSpec{
+						DisplayName: "Test Cluster",
+					},
+				},
+			},
+			map[string]func(map[string]*apiv3.Cluster) func([]*apiv3.Cluster){
+				"cb": func(in map[string]*apiv3.Cluster) func([]*apiv3.Cluster) {
+					return func(clusters []*apiv3.Cluster) {
+						testMu.Lock()
+						defer testMu.Unlock()
+						for _, cluster := range clusters {
+							in[cluster.Name] = cluster
+						}
+					}
+				},
+			},
+		),
+		newTestcase(
+			GatherOpts{
+				Ctx:             ctx,
+				CollectInterval: 1 * time.Millisecond,
+			},
+			mockClusterCache,
+			map[string]*apiv3.Cluster{
+				"cb1-test-cluster": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+					},
+					Spec: apiv3.ClusterSpec{
+						DisplayName: "Test Cluster",
+					},
+				},
+				"cb2-test-cluster": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+					},
+					Spec: apiv3.ClusterSpec{
+						DisplayName: "Test Cluster",
+					},
+				},
+			},
+			map[string]func(map[string]*apiv3.Cluster) func([]*apiv3.Cluster){
+				"cb": func(in map[string]*apiv3.Cluster) func([]*apiv3.Cluster) {
+					return func(clusters []*apiv3.Cluster) {
+						testMu.Lock()
+						defer testMu.Unlock()
+						for _, cluster := range clusters {
+							in["cb1-"+cluster.Name] = cluster
+						}
+					}
+				},
+				"cb2": func(in map[string]*apiv3.Cluster) func([]*apiv3.Cluster) {
+					return func(clusters []*apiv3.Cluster) {
+						testMu.Lock()
+						defer testMu.Unlock()
+						for _, cluster := range clusters {
+							in["cb2-"+cluster.Name] = cluster
+						}
+					}
+				},
+			},
+		),
+	}
+
+	for _, tc := range tcs {
+		mg := newMetadataGatherer(
+			tc.clusterCache,
+			tc.opts,
+		)
+		ret := map[string]*apiv3.Cluster{}
+
+		for name, cb := range tc.registerCbs {
+			mg.registerCallback(name, cb(tc.inputMap))
+		}
+
+		assert.Len(t, ret, 0, "No clusters should be collected before the first tick")
+
+		go mg.Run()
+		assert.Eventually(t, func() bool {
+			testMu.Lock()
+			defer testMu.Unlock()
+			return assert.ObjectsAreEqual(tc.inputMap, tc.expectedMap)
+		},
+			50*time.Millisecond,
+			1*time.Millisecond,
+			"callbacks did not modify the input map as expected",
+		)
+	}
+
+}


### PR DESCRIPTION
## Issue: 
 
 Related issue : https://github.com/rancher/rancher/issues/50467
 
## Problem

Both SCC controllers and prometheus metric registries need to poll the v3.ClusterCache to send/expose metrics to their respective backends. 

## Solution
This constructs a single poller of the ClusterCache that other packages can register callbacks to the slice collected.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

* Test types added/modified:
    * Unit : covers registering generic callbacks to the slices collected by a v3.ClusterCache for managed clusters

## QA Testing Considerations

N/A. Follow up PRs will have features to test for QA.
 
### Regressions Considerations

N/A. This package is not currently imported by other packages.

