### PR TITLE
Revert "Allow read-only access to CRD definitions for the base and standard Rancher users"

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -98,8 +98,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch").
-		addRule().apiGroups("apiextensions.k8s.io").resources("customresourcedefinitions").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch")
 
 	// TODO user should be dynamically authorized to only see herself
 	// TODO enable when groups are "in". they need to be self-service
@@ -415,8 +414,7 @@ func addUserRules(role *roleBuilder) *roleBuilder {
 		addRule().apiGroups("management.cattle.io").resources("cisbenchmarkversions").verbs("get", "list", "watch").
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
-		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch").
-		addRule().apiGroups("apiextensions.k8s.io").resources("customresourcedefinitions").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch")
 	return role
 }
 


### PR DESCRIPTION
The new Imperative API resource Kubeconfig is no longer ephemeral and implements `rest.Patcher`. Thus it's no longer needed.

Reverts #49318