### PR TITLE
fix oci_repo rancher panic

### DIFF
--- a/pkg/catalogv2/oci/oci.go
+++ b/pkg/catalogv2/oci/oci.go
@@ -177,7 +177,7 @@ func GenerateIndex(ociClient *Client, URL string, credentialSecret *corev1.Secre
 
 			// Work on all repositories if the user has not provided any repository or
 			// work on the oci repositories that match with the userProvidedRepository
-			if after, found := strings.CutPrefix(repository, ociClient.repository); found && (ociClient.repository == "" || after[0] == '/') {
+			if after, found := strings.CutPrefix(repository, ociClient.repository); found && (ociClient.repository == "" || len(after) > 0 && after[0] == '/') {
 				ociClient.repository = repository
 				orasRepository, err := ociClient.GetOrasRepository()
 				if err != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
[#50499
](https://github.com/rancher/rancher/issues/50499)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Rancher deployment is stuck in CrashLoopBackoff after upgrade from 2.11.1 to 2.11.2

This is the log from the rancher pod:
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

[after[0] ](https://github.com/rancher/rancher/blob/main/pkg/catalogv2/oci/oci.go#L180)was accessed on an empty string

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 after[0] is only accessed if len(after) > 0.
don't accidentally evaluate a mixed condition (found && (ociClient.repository == "" || after[0] == '/'))
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
- create a OCI repo with below URL 
-  "url": "oci://code.forgejo.org/forgejo-helm/forgejo"

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Yes, tested manually and seems working fine...

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_