### PR TITLE
[v2.10] Temporary fix for windows 2019 agent CI build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,10 +70,14 @@ jobs:
     strategy:
       matrix:
         os: [windows]
-        version: [2019, 2022]
-    runs-on: ${{ matrix.os }}-${{ matrix.version }}
+        version:
+        - version: 2019
+          go_tag: 1.23.9-windowsservercore-1809
+        - version: 2022
+          go_tag: '1.23'
+    runs-on: ${{ matrix.os }}-${{ matrix.version.version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Build Windows Agent Image
-      run: docker build -t ${{ env.IMAGE_AGENT }}:${{ env.TAG }} --build-arg VERSION=${{ env.COMMIT }} --build-arg SERVERCORE_VERSION=ltsc${{ matrix.version }} -f package/windows/Dockerfile.agent .
+      run: docker build -t ${{ env.IMAGE_AGENT }}:${{ env.TAG }} --build-arg VERSION=${{ env.COMMIT }} --build-arg SERVERCORE_VERSION=ltsc${{ matrix.version.version }} --build-arg GO_TAG=${{ matrix.version.go_tag }} -f package/windows/Dockerfile.agent .

--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -1,8 +1,9 @@
 ARG SERVERCORE_VERSION
 ARG ARCH=amd64
 ARG VERSION=dev
+ARG GO_TAG
 
-FROM library/golang:1.23 as build
+FROM library/golang:${GO_TAG} as build
 
 WORKDIR C:/app
 COPY . .


### PR DESCRIPTION
The go docker image with tag 1.23 no longer has windows server 2019 as one of its platforms. This is a temporary fix to allow the agent to be built. It still uses the current latest go 1.23 version as that is still available for windows server 2019, but it has to be specified manually since it's no longer part of the multi-platform image 1.23.