### PR TITLE
Prevent unnecessary updates to promoted clusterroles

### DIFF
--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -357,7 +357,8 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 	desiredResourceNames := sets.New(baseRule.ResourceNames...)
 
 	// if the currentVerbs and the currentResourceNames matches the desired state we can return
-	if currentVerbs.Equal(newVerbs) && currentResourceNames.Equal(desiredResourceNames) {
+	// if the number of verbs desired is 0, we don't need to check ResourceNames because we don't want any rule
+	if currentVerbs.Equal(newVerbs) && (newVerbs.Len() == 0 || currentResourceNames.Equal(desiredResourceNames)) {
 		return roleName, nil
 	}
 

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -555,6 +555,36 @@ func Test_manager_reconcileRoleForProjectAccessToGlobalResource(t *testing.T) {
 			clusterRolesMockUpdateErr: errors.New("something bad happened"),
 			wantErr:                   true,
 		},
+		{
+			name: "baserule with resourcenames and no newverbs does not update clusterrole",
+			args: args{
+				rtName:   "myrole",
+				resource: "clusters",
+				newVerbs: sets.New[string](),
+				baseRule: rbacv1.PolicyRule{
+					APIGroups:     []string{"management.cattle.io"},
+					ResourceNames: []string{"local"},
+				},
+			},
+			crListerMockGetResult: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myrole-promoted",
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"storage.k8s.io"},
+						Resources: []string{"storageclasses"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{"", "core"},
+						Resources: []string{"persistentvolumes"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+			want: "myrole-promoted",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/rancher/norman/types/slice"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/controllers/managementuser/rbac/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplate_handler.go
@@ -67,6 +67,8 @@ func (c *rtSync) sync(key string, obj *v3.RoleTemplate) (runtime.Object, error) 
 	return obj, err
 }
 
+// syncRT ensures that all the Roles and RoleBindings needed for PRTBs and CRTBs to give RoleTemplate access exist.
+// For PRTBs there is special handling to provide access to global resources, which are referred to as Promoted Rules.
 func (c *rtSync) syncRT(template *v3.RoleTemplate, prtbs []any, crtbs []any) error {
 	roleTemplates := map[string]*v3.RoleTemplate{}
 	if err := c.m.gatherRoles(template, roleTemplates, 0); err != nil {


### PR DESCRIPTION
## Issue: https://jira.suse.com/browse/SURE-10194
 https://github.com/rancher/rancher/issues/50534
## Problem

Project RoleTemplates can give access to non-namespaced resources, which we refer to as "promoted rules". Full list can be found here https://github.com/rancher/rancher/blob/a54be8cc6e3ccf16a61b253d4f98f4345ec3052c/pkg/controllers/managementuser/rbac/prtb_handler.go#L34

When a Project RoleTemplate has these, we create a ClusterRole that contains all the promoted rules. Then, any time the RoleTemplate is updated, there is a check to ensure that the ClusterRole has the correct verbs. The problem that users were noticing was that they would be seeing logs of `[INFO] Updating clusterRole admin-promoted for project access to global resource.` over and over. In systems with thousands of users and PRTBs, this could flood the logs with thousands of messages.

The problem was that as we search through the RoleTemplate for each promote rule, the equality check to avoid updating the ClusterRole was as follows:
1. The required verbs from the RoleTemplate == the existing verbs from the ClusterRole
2. The `ResourceNames` in the `BaseRule` (from the promoted rules map) == the existing `ResourceNames` from the ClusterRole

However, when we encountered a `BaseRule` with a `ResourceName` (namely `clusters`), and the promoted ClusterRole should not have a rule for that `BaseRule`, we would fail the check because the `BaseRule` has 1 `ResourceName`, and the ClusterRole has 0. So we would go on to update the ClusterRole.

This happens EVERY time a PRTB or RoleTemplate gets updated and every 10 hours. So each time it will just update the ClusterRole with the exact same information.
 
## Solution

I added an additional part to the early exit check. I check that the verbs between current and desired match, and then if the number of verbs is 0 or that the `ResourceNames` match. That way, if we have a situation where the `ResourceNames` don't match, but there are shouldn't be a Rule for that `Resource` anyway, it exits.

While I was investigating this code, I also found an area of improvement. The code within this block https://github.com/rancher/rancher/blob/a54be8cc6e3ccf16a61b253d4f98f4345ec3052c/pkg/controllers/managementuser/rbac/roletemplate_handler.go#L81

is a duplicate of what goes on within `ensureGlobalResourcesRolesForPRTB` shortly after https://github.com/rancher/rancher/blob/a54be8cc6e3ccf16a61b253d4f98f4345ec3052c/pkg/controllers/managementuser/rbac/roletemplate_handler.go#L103

https://github.com/rancher/rancher/blob/a54be8cc6e3ccf16a61b253d4f98f4345ec3052c/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go#L136

`usedInProjects` is true if the slice `prtbs` is greater than 0, but then immediately after we do the same work because we're looping through the slice. It would probably be more efficient to do this once, but each PRTB needs to create a list of the clusterroles to bind to, so I just took the simplest route.
 
## Testing

## Engineering Testing
### Manual Testing

To test this, you can pretty easily create a RoleTemplate that causes the update log message to happen.

1. Create a Project RoleTemplate with the following rule Verb: `*` Resource: `persistentvolumes`
2. Create a user
3. Create a project
4. In the UI, go to Project Membership and add your new user to the project with your custom RoleTemplate
5. Either through the UI or through kubectl, edit the yaml of the custom RoleTemplate
    - I usually just add and remove an annotation
6. The logs will show `[INFO] Updating clusterRole <your_rt>-promoted for project access to global resource.` every time

After this PR, that is no longer the case.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Added a unit test to cover the 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_