### PR TITLE
ext token userid filter label changed to match new kubeconfig work

### DIFF
--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	TokenNamespace       = "cattle-tokens"
-	UserIDLabel          = "authn.management.cattle.io/token-userId"
+	UserIDLabel          = "cattle.io/user-id"
 	KindLabel            = "authn.management.cattle.io/kind"
 	IsLogin              = "session"
 	SecretKindLabel      = "cattle.io/kind"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#50473 

## Problem

kubeconfig and ext token are inconsistent in the label with which to filter by user id.

## Solution

modified ext token store to use the same label as kubeconfigs: `cattle.io/user-id`.
 
## Testing
## Engineering Testing
### Manual Testing

unit tests pass after the change.

### Automated Testing

The ext token test plan requires updates to all test cases referencing the old label.

Summary: _TODO_

## QA Testing Considerations

Filtering by user id requires re-testing.
 
### Regressions Considerations
