### PR TITLE
Expose OIDCClient to Steve

### DIFF
--- a/pkg/api/steve/disallow/disallow.go
+++ b/pkg/api/steve/disallow/disallow.go
@@ -20,6 +20,7 @@ var (
 		"podsecurityadmissionconfigurationtemplates": true,
 		"projects":                                   true,
 		"projectroletemplatebindings":                true,
+		"oidcclients":                                true,
 	}
 	allowPost = map[string]bool{
 		"settings": true,


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48317
 
## Problem
`OIDCClients` can't be updated using Steve. All resources all blocked from Steve unless they are explicitly allowed. This is because we don't want to bypass the Norman validation for resources that have not been migrated to the public api yet.
 
## Solution
Add `OIDCClient` to the Steve allow list. 
