### PR TITLE
Add manage-oidc-clients builtin GlobalRole

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -72,7 +72,10 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("clustertemplaterevisions").verbs("create")
 	rb.addRole("View Rancher Metrics", "view-rancher-metrics").
 		addRule().apiGroups("management.cattle.io").resources("ranchermetrics").verbs("get")
-
+	if features.OIDCProvider.Enabled() {
+		rb.addRole("Manage OIDC Clients", "manage-oidc-clients").
+			addRule().apiGroups("management.cattle.io").resources("oidcclients").verbs("get", "list", "patch", "create", "update", "watch", "delete", "deletecollection")
+	}
 	rb.addRole("Admin", "admin").
 		addRule().apiGroups("*").resources("*").verbs("*").
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48317
 
This PR adds a built-in `GlobalRole` to manage `OIDCClient` resources.