### PR TITLE
Remove ClusterRoles made by RoleTemplates from downstream clusters

### DIFF
--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -82,7 +82,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, cl
 
 	// Only one set of CRTB/PRTB/RoleTemplate controllers should run at a time. Using aggregated cluster roles is currently experimental and only available via feature flags.
 	if features.AggregatedRoleTemplates.Enabled() {
-		roletemplates.Register(ctx, management)
+		roletemplates.Register(ctx, management, clusterManager)
 	} else {
 		management.Management.ClusterRoleTemplateBindings("").AddLifecycle(ctx, ctrbMGMTController, crtb)
 		management.Management.ProjectRoleTemplateBindings("").AddLifecycle(ctx, ptrbMGMTController, prtb)

--- a/pkg/controllers/management/auth/roletemplates/register.go
+++ b/pkg/controllers/management/auth/roletemplates/register.go
@@ -3,18 +3,31 @@ package roletemplates
 import (
 	"context"
 
+	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/types/config"
 )
 
-func Register(ctx context.Context, management *config.ManagementContext) {
-	r := newRoleTemplateHandler(management.Wrangler)
-	management.Wrangler.Mgmt.RoleTemplate().OnChange(ctx, "mgmt-roletemplate-change-handler", r.OnChange)
+const (
+	roleTemplateChangeHandler = "mgmt-roletemplate-change-handler"
+	roleTemplateRemoveHandler = "mgmt-roletemplate-remove-handler"
+
+	crtbChangeHandler = "mgmt-crtb-change-handler"
+	crtbRemoveHandler = "mgmt-crtb-remove-handler"
+
+	prtbChangeHandler = "mgmt-prtb-change-handler"
+	prtbRemoveHandler = "mgmt-prtb-remove-handler"
+)
+
+func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
+	r := newRoleTemplateHandler(management.Wrangler, clusterManager)
+	management.Wrangler.Mgmt.RoleTemplate().OnChange(ctx, roleTemplateChangeHandler, r.OnChange)
+	management.Wrangler.Mgmt.RoleTemplate().OnRemove(ctx, roleTemplateRemoveHandler, r.OnRemove)
 
 	c := newCRTBHandler(management)
-	management.Wrangler.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, "mgmt-crtb-change-handler", c.OnChange)
-	management.Wrangler.Mgmt.ClusterRoleTemplateBinding().OnRemove(ctx, "mgmt-crtb-remove-handler", c.OnRemove)
+	management.Wrangler.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, crtbChangeHandler, c.OnChange)
+	management.Wrangler.Mgmt.ClusterRoleTemplateBinding().OnRemove(ctx, crtbRemoveHandler, c.OnRemove)
 
 	p := newPRTBHandler(management)
-	management.Wrangler.Mgmt.ProjectRoleTemplateBinding().OnChange(ctx, "mgmt-prtb-change-handler", p.OnChange)
-	management.Wrangler.Mgmt.ProjectRoleTemplateBinding().OnRemove(ctx, "mgmt-prtb-remove-handler", p.OnRemove)
+	management.Wrangler.Mgmt.ProjectRoleTemplateBinding().OnChange(ctx, prtbChangeHandler, p.OnChange)
+	management.Wrangler.Mgmt.ProjectRoleTemplateBinding().OnRemove(ctx, prtbRemoveHandler, p.OnRemove)
 }

--- a/pkg/controllers/managementuser/rbac/roletemplates/register.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/register.go
@@ -23,7 +23,6 @@ const (
 	prtbByUsernameIndex = "auth.management.cattle.io/prtb-by-username"
 
 	roleTemplateChangeHandler = "cluster-roletemplate-change-handler"
-	roleTemplateRemoveHandler = "cluster-roletemplate-remove-handler"
 )
 
 func RegisterIndexers(wranglerContext *wrangler.Context) {
@@ -44,7 +43,6 @@ func Register(ctx context.Context, workload *config.UserContext) {
 
 	rth := newRoleTemplateHandler(workload)
 	management.Wrangler.Mgmt.RoleTemplate().OnChange(ctx, roleTemplateChangeHandler, rth.OnChange)
-	management.Wrangler.Mgmt.RoleTemplate().OnRemove(ctx, roleTemplateRemoveHandler, rth.OnRemove)
 }
 
 // TODO(wrangler/v4): revert to use OnRemove when it supports options (https://github.com/rancher/wrangler/pull/472).

--- a/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
@@ -1,8 +1,6 @@
 package roletemplates
 
 import (
-	"errors"
-
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -11,12 +9,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	clusterRoleOwnerAnnotation = "authz.cluster.cattle.io/clusterrole-owner"
-	aggregationLabel           = "management.cattle.io/aggregates"
 	projectContext             = "project"
 )
 
@@ -63,12 +59,14 @@ func (rth *roleTemplateHandler) OnChange(_ string, rt *v3.RoleTemplate) (*v3.Rol
 // clusterRolesForRoleTemplate builds and returns all needed Cluster Roles for the RoleTemplate using the given rules.
 func (rth *roleTemplateHandler) clusterRolesForRoleTemplate(rt *v3.RoleTemplate) ([]*rbacv1.ClusterRole, error) {
 	res := []*rbacv1.ClusterRole{}
+	// We extract the promoted rules from the RoleTemplate, so we don't want to modify the original object
+	rtCopy := rt.DeepCopy()
 
-	if rt.Context == projectContext {
+	if rtCopy.Context == projectContext {
 		// ClusterRoles for promoted rules
 		var promotedClusterRoles []*rbacv1.ClusterRole
 		var err error
-		promotedClusterRoles, rt.Rules, err = rth.buildPromotedClusterRoles(rt)
+		promotedClusterRoles, rtCopy.Rules, err = rth.buildPromotedClusterRoles(rtCopy)
 		if err != nil {
 			return nil, err
 		}
@@ -77,40 +75,12 @@ func (rth *roleTemplateHandler) clusterRolesForRoleTemplate(rt *v3.RoleTemplate)
 	}
 
 	// If the RoleTemplate refers to an external cluster role, don't modify/create it. Instead we will aggregate it.
-	if !rt.External {
-		res = append(res, rbac.BuildClusterRole(rbac.ClusterRoleNameFor(rt.Name), rt.Name, rt.Rules))
+	if !rtCopy.External {
+		res = append(res, rbac.BuildClusterRole(rbac.ClusterRoleNameFor(rtCopy.Name), rtCopy.Name, rtCopy.Rules))
 	}
-	res = append(res, rbac.BuildAggregatingClusterRole(rt, rbac.ClusterRoleNameFor))
+	res = append(res, rbac.BuildAggregatingClusterRole(rtCopy, rbac.ClusterRoleNameFor))
 
 	return res, nil
-}
-
-// OnRemove deletes all ClusterRoles created by the RoleTemplate
-func (rth *roleTemplateHandler) OnRemove(_ string, rt *v3.RoleTemplate) (*v3.RoleTemplate, error) {
-	var returnedErrors error
-
-	crName := rbac.ClusterRoleNameFor(rt.Name)
-	acrName := rbac.AggregatedClusterRoleNameFor(crName)
-
-	returnedErrors = rth.removeLabelFromExternalRole(rt)
-
-	// if the cluster role is external don't delete the external cluster role
-	if !rt.External {
-		returnedErrors = rbac.DeleteResource(crName, rth.crController)
-	}
-
-	returnedErrors = errors.Join(returnedErrors, rbac.DeleteResource(acrName, rth.crController))
-
-	if rt.Context == projectContext {
-		promotedCRName := rbac.PromotedClusterRoleNameFor(crName)
-		promotedACRName := rbac.AggregatedClusterRoleNameFor(promotedCRName)
-		returnedErrors = errors.Join(returnedErrors,
-			rbac.DeleteResource(promotedCRName, rth.crController),
-			rbac.DeleteResource(promotedACRName, rth.crController),
-		)
-	}
-
-	return nil, returnedErrors
 }
 
 // buildPromotedClusterRoles looks for promoted rules in a project role template and creates required promoted cluster roles.
@@ -202,7 +172,7 @@ func (rth *roleTemplateHandler) addLabelToExternalRole(rt *v3.RoleTemplate) erro
 		return nil
 	}
 
-	externalRole, err := rth.crController.Get(rt.Name, v1.GetOptions{})
+	externalRole, err := rth.crController.Get(rt.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -214,34 +184,8 @@ func (rth *roleTemplateHandler) addLabelToExternalRole(rt *v3.RoleTemplate) erro
 		externalRole.Labels = map[string]string{}
 	}
 
-	if val, ok := externalRole.Labels[aggregationLabel]; !ok || val != rbac.ClusterRoleNameFor(rt.Name) {
-		externalRole.Labels[aggregationLabel] = rbac.ClusterRoleNameFor(rt.Name)
-		if _, err := rth.crController.Update(externalRole); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// removeLabelFromExternalRole removes the aggregation label from the external role.
-// It is a no-op if the RoleTemplate does not have an external role.
-func (rth *roleTemplateHandler) removeLabelFromExternalRole(rt *v3.RoleTemplate) error {
-	if !rt.External {
-		return nil
-	}
-
-	externalRole, err := rth.crController.Get(rt.Name, v1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	if externalRole.Labels == nil {
-		return nil
-	}
-
-	if _, ok := externalRole.Labels[aggregationLabel]; ok {
-		delete(externalRole.Labels, aggregationLabel)
+	if val, ok := externalRole.Labels[rbac.AggregationLabel]; !ok || val != rbac.ClusterRoleNameFor(rt.Name) {
+		externalRole.Labels[rbac.AggregationLabel] = rbac.ClusterRoleNameFor(rt.Name)
 		if _, err := rth.crController.Update(externalRole); err != nil {
 			return err
 		}

--- a/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -243,12 +244,17 @@ func Test_clusterRolesForRoleTemplate(t *testing.T) {
 			rth := &roleTemplateHandler{
 				crController: crController,
 			}
+			roleTemplateCopy := tt.rt.DeepCopy()
 			got, err := rth.clusterRolesForRoleTemplate(tt.rt)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
 			tt.verify(t, got)
+
+			// Ensure the rules have not been modified within clusterRolesForRoleTemplate even though it extracts promoted rules.
+			// Otherwise, when the controller runs for a different downstream cluster, it won't have the promoted rules.
+			assert.Equal(t, tt.rt.Rules, roleTemplateCopy.Rules)
 		})
 	}
 }
@@ -569,13 +575,8 @@ var (
 	clusterRoleWithAggregationLabel = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				aggregationLabel: "test-rt",
+				rbac.AggregationLabel: "test-rt",
 			},
-		},
-	}
-	clusterRoleWithNoAggregationLabel = rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{},
 		},
 	}
 )
@@ -627,7 +628,7 @@ func Test_addLabelToExternalRole(t *testing.T) {
 			getFunc: func() (*rbacv1.ClusterRole, error) {
 				return &rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{aggregationLabel: "wrong-rt"},
+						Labels: map[string]string{rbac.AggregationLabel: "wrong-rt"},
 					},
 				}, nil
 			},
@@ -652,8 +653,8 @@ func Test_addLabelToExternalRole(t *testing.T) {
 			updatedCR: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						aggregationLabel: "test-rt",
-						"other-label":    "value",
+						rbac.AggregationLabel: "test-rt",
+						"other-label":         "value",
 					},
 				},
 			},
@@ -688,105 +689,6 @@ func Test_addLabelToExternalRole(t *testing.T) {
 			}
 			if err := rth.addLabelToExternalRole(tt.rt); (err != nil) != tt.wantErr {
 				t.Errorf("roleTemplateHandler.addLabelToExternalRole() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func Test_removeLabelFromExternalRole(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name       string
-		rt         *v3.RoleTemplate
-		getFunc    func() (*rbacv1.ClusterRole, error)
-		updateFunc func() (*rbacv1.ClusterRole, error)
-		updatedCR  *rbacv1.ClusterRole
-		wantErr    bool
-	}{
-		{
-			name: "no op if there is no external role",
-			rt: &v3.RoleTemplate{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-rt"},
-				External:   false,
-			},
-		},
-		{
-			name:    "error getting external role",
-			rt:      externalRoleTemplate.DeepCopy(),
-			getFunc: func() (*rbacv1.ClusterRole, error) { return nil, fmt.Errorf("error") },
-			wantErr: true,
-		},
-		{
-			name: "external role has no label",
-			rt:   externalRoleTemplate.DeepCopy(),
-			getFunc: func() (*rbacv1.ClusterRole, error) {
-				return clusterRoleWithNoAggregationLabel.DeepCopy(), nil
-			},
-		},
-		{
-			name: "external role has nil label map",
-			rt:   externalRoleTemplate.DeepCopy(),
-			getFunc: func() (*rbacv1.ClusterRole, error) {
-				return &rbacv1.ClusterRole{}, nil
-			},
-		},
-		{
-			name: "external role has label removed",
-			rt:   externalRoleTemplate.DeepCopy(),
-			getFunc: func() (*rbacv1.ClusterRole, error) {
-				return clusterRoleWithAggregationLabel.DeepCopy(), nil
-			},
-			updateFunc: func() (*rbacv1.ClusterRole, error) { return nil, nil },
-			updatedCR:  clusterRoleWithNoAggregationLabel.DeepCopy(),
-		},
-		{
-			name: "external role has label removed but keeps other labels",
-			rt:   externalRoleTemplate.DeepCopy(),
-			getFunc: func() (*rbacv1.ClusterRole, error) {
-				return &rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							aggregationLabel: "test-rt",
-							"other-label":    "value",
-						},
-					},
-				}, nil
-			},
-			updateFunc: func() (*rbacv1.ClusterRole, error) { return nil, nil },
-			updatedCR: &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"other-label": "value"},
-				},
-			},
-		},
-		{
-			name: "error updating cluster role",
-			rt:   externalRoleTemplate.DeepCopy(),
-			getFunc: func() (*rbacv1.ClusterRole, error) {
-				return clusterRoleWithAggregationLabel.DeepCopy(), nil
-			},
-			updateFunc: func() (*rbacv1.ClusterRole, error) { return nil, fmt.Errorf("error") },
-			updatedCR:  clusterRoleWithNoAggregationLabel.DeepCopy(),
-			wantErr:    true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			ctrl := gomock.NewController(t)
-			crController := fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
-			if tt.getFunc != nil {
-				crController.EXPECT().Get(tt.rt.Name, gomock.Any()).Return(tt.getFunc())
-			}
-			if tt.updateFunc != nil {
-				crController.EXPECT().Update(tt.updatedCR).Return(tt.updateFunc())
-			}
-
-			rth := &roleTemplateHandler{
-				crController: crController,
-			}
-			if err := rth.removeLabelFromExternalRole(tt.rt); (err != nil) != tt.wantErr {
-				t.Errorf("roleTemplateHandler.removeLabelFromExternalRole() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -41,7 +41,7 @@ const (
 	RestrictedAdminCRBForClusters     = "restricted-admin-crb-clusters"
 	CrtbOwnerLabel                    = "authz.cluster.cattle.io/crtb-owner"
 	PrtbOwnerLabel                    = "authz.cluster.cattle.io/prtb-owner"
-	aggregationLabel                  = "management.cattle.io/aggregates"
+	AggregationLabel                  = "management.cattle.io/aggregates"
 	clusterRoleOwnerAnnotation        = "authz.cluster.cattle.io/clusterrole-owner"
 	aggregatorSuffix                  = "aggregator"
 	promotedSuffix                    = "promoted"
@@ -421,9 +421,9 @@ func AreClusterRolesSame(currentCR, wantedCR *rbacv1.ClusterRole) (bool, *rbacv1
 		same = false
 		metav1.SetMetaDataAnnotation(&currentCR.ObjectMeta, clusterRoleOwnerAnnotation, want)
 	}
-	if got, want := currentCR.Labels[aggregationLabel], wantedCR.Labels[aggregationLabel]; got != want {
+	if got, want := currentCR.Labels[AggregationLabel], wantedCR.Labels[AggregationLabel]; got != want {
 		same = false
-		metav1.SetMetaDataLabel(&currentCR.ObjectMeta, aggregationLabel, want)
+		metav1.SetMetaDataLabel(&currentCR.ObjectMeta, AggregationLabel, want)
 	}
 	return same, currentCR
 }
@@ -446,7 +446,7 @@ func BuildClusterRole(name, ownerName string, rules []rbacv1.PolicyRule) *rbacv1
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Labels:      map[string]string{aggregationLabel: name},
+			Labels:      map[string]string{AggregationLabel: name},
 			Annotations: map[string]string{clusterRoleOwnerAnnotation: ownerName},
 		},
 		Rules: rules,
@@ -461,12 +461,12 @@ func BuildAggregatingClusterRole(rt *v3.RoleTemplate, nameTransformer func(strin
 	ownerName := rt.Name
 
 	// aggregate our own cluster role
-	roleTemplateLabels := []metav1.LabelSelector{{MatchLabels: map[string]string{aggregationLabel: crName}}}
+	roleTemplateLabels := []metav1.LabelSelector{{MatchLabels: map[string]string{AggregationLabel: crName}}}
 
 	// aggregate every inherited role template
 	for _, roleTemplateName := range rt.RoleTemplateNames {
 		labelSelector := metav1.LabelSelector{
-			MatchLabels: map[string]string{aggregationLabel: AggregatedClusterRoleNameFor(nameTransformer(roleTemplateName))},
+			MatchLabels: map[string]string{AggregationLabel: AggregatedClusterRoleNameFor(nameTransformer(roleTemplateName))},
 		}
 		roleTemplateLabels = append(roleTemplateLabels, labelSelector)
 	}
@@ -477,7 +477,7 @@ func BuildAggregatingClusterRole(rt *v3.RoleTemplate, nameTransformer func(strin
 			Name: aggregatingCRName,
 			// Label so other cluster roles can aggregate this one
 			Labels: map[string]string{
-				aggregationLabel: aggregatingCRName,
+				AggregationLabel: aggregatingCRName,
 			},
 			// Annotation to identify which role template owns the cluster role
 			Annotations: map[string]string{clusterRoleOwnerAnnotation: ownerName},

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -493,7 +493,7 @@ func TestAreClusterRolesSame(t *testing.T) {
 						},
 						Labels: map[string]string{
 							"otherlabel":     "foobar",
-							aggregationLabel: "aggregationlabel",
+							AggregationLabel: "AggregationLabel",
 						},
 					},
 					AggregationRule: &rbacv1.AggregationRule{
@@ -505,7 +505,7 @@ func TestAreClusterRolesSame(t *testing.T) {
 				modified: &rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{clusterRoleOwnerAnnotation: "owner"},
-						Labels:      map[string]string{aggregationLabel: "aggregationlabel"},
+						Labels:      map[string]string{AggregationLabel: "AggregationLabel"},
 					},
 					AggregationRule: &rbacv1.AggregationRule{
 						ClusterRoleSelectors: []metav1.LabelSelector{
@@ -578,7 +578,7 @@ func TestAreClusterRolesSame(t *testing.T) {
 				modified: &rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{clusterRoleOwnerAnnotation: "owner"},
-						Labels:      map[string]string{aggregationLabel: "aggregationlabel"},
+						Labels:      map[string]string{AggregationLabel: "AggregationLabel"},
 					},
 					AggregationRule: &rbacv1.AggregationRule{
 						ClusterRoleSelectors: []metav1.LabelSelector{
@@ -595,7 +595,7 @@ func TestAreClusterRolesSame(t *testing.T) {
 						clusterRoleOwnerAnnotation: "owner",
 					},
 					Labels: map[string]string{
-						aggregationLabel: "aggregationlabel",
+						AggregationLabel: "AggregationLabel",
 					},
 				},
 				AggregationRule: &rbacv1.AggregationRule{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49262
 
## Problem

With the Aggregated ClusterRoles feature enabled, when a RoleTemplate is created, it creates 2 ClusterRoles in each cluster. One named after the RoleTemplate and another that aggregates the first ClusterRole. The problem is that when the RoleTemplate was deleted, it removed the ClusterRoles on the management cluster, but not the downstream clusters.

Another issue I noticed while fixing this was the promoted ClusterRoles weren't being created properly in downstream clusters. For project role templates, certain resources are considered "promoted" and we need to create a separate ClusterRole.
 
## Solution
The issue was that I had registered multiple `OnRemove` handlers, 1 per cluster per RoleTemplate. They all rely on the same finalizer, so what was happening was that the first `OnRemove` handler would run (usually the management cluster), remove the finalizer because it completed the `OnRemove` function and then the RoleTemplate would be cleaned up by k8s. That would prevent any future finalizer from running. To solve this, I instead moved to a single `OnRemove` handler that goes through each cluster using the `clusterManager`. This is how the previous implementation of RoleTemplates worked to remove RBAC resources.

For the promoted cluster role issue, the issue was that the `extractPromotedRules` worked as intended, removing the promoted rules from the RoleTemplate's rules, but then we were updating the original RoleTemplate's rules with the promoted rules free version. Then any handlers run after the initial one (on the management cluster) would not see any promoted rules. To solve that, we can instead just use a copy of the RoleTemplate.
 
## Testing

## Engineering Testing
### Manual Testing
Did the manual testing of creating a project RoleTemplate with promoted rules and ensuring each cluster got 4 ClusterRoles. 1 normal, 1 normal aggregator, 1 promoted and 1 promoted aggregator. Then when I delete the RoleTemplate, it removes the ClusterRoles.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: I mostly just moved the existing `OnRemove` functionality out from the per cluster controllers (`managementuser/rbac`) to the management cluster controllers (`management/auth`). I also added a check to ensure the rules of the RoleTemplate are kept the same by the controller.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_