### PR TITLE
[OIDC] use JSONPatchType when updating an OIDCClient status

### DIFF
--- a/pkg/controllers/management/oidcprovider/controller_test.go
+++ b/pkg/controllers/management/oidcprovider/controller_test.go
@@ -105,19 +105,23 @@ func TestOnChange(t *testing.T) {
 				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.MergePatchType, patchBytes, "status").Return(oidcClient, nil)
 
 				// update status with client secret
-				patchData = map[string]interface{}{
-					"status": v3.OIDCClientStatus{
-						ClientID: fakeClientId,
-						ClientSecrets: map[string]v3.OIDCClientSecretStatus{
-							secretKeyPrefix + "1": {
-								CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
-								LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
+				patchOp := []map[string]interface{}{
+					{
+						"op":   "add",
+						"path": "/status",
+						"value": v3.OIDCClientStatus{
+							ClientID: fakeClientId,
+							ClientSecrets: map[string]v3.OIDCClientSecretStatus{
+								secretKeyPrefix + "1": {
+									CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
+									LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
+								},
 							},
 						},
 					},
 				}
-				patchBytes, _ = json.Marshal(patchData)
-				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.MergePatchType, patchBytes, "status").Return(oidcClient, nil)
+				patchBytes, _ = json.Marshal(patchOp)
+				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.JSONPatchType, patchBytes, "status").Return(oidcClient, nil)
 			},
 		},
 		"clientID and clientSecret are not created for an existing OIDCClient": {
@@ -207,23 +211,26 @@ func TestOnChange(t *testing.T) {
 				p.oidcClient.EXPECT().Update(client).Return(client, nil)
 
 				// update status with client secret
-				patchData := map[string]interface{}{
-					"status": v3.OIDCClientStatus{
-						ClientID: fakeClientId,
-						ClientSecrets: map[string]v3.OIDCClientSecretStatus{
-							secretKeyPrefix + "1": {
-								LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
-							},
-							secretKeyPrefix + "2": {
-								CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
-								LastFiveCharacters: fakeClientSecret2[len(fakeClientSecret2)-5:],
+				patchOp := []map[string]interface{}{
+					{
+						"op":   "add",
+						"path": "/status",
+						"value": v3.OIDCClientStatus{
+							ClientID: fakeClientId,
+							ClientSecrets: map[string]v3.OIDCClientSecretStatus{
+								secretKeyPrefix + "1": {
+									LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
+								},
+								secretKeyPrefix + "2": {
+									CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
+									LastFiveCharacters: fakeClientSecret2[len(fakeClientSecret2)-5:],
+								},
 							},
 						},
 					},
 				}
-
-				patchBytes, _ := json.Marshal(patchData)
-				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.MergePatchType, patchBytes, "status").Return(oidcClient, nil)
+				patchBytes, _ := json.Marshal(patchOp)
+				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.JSONPatchType, patchBytes, "status").Return(oidcClient, nil)
 			},
 		},
 		"client secret is regenerated with annotation": {
@@ -295,19 +302,23 @@ func TestOnChange(t *testing.T) {
 				p.oidcClient.EXPECT().Update(client).Return(client, nil)
 
 				// update status with client secret
-				patchData := map[string]interface{}{
-					"status": v3.OIDCClientStatus{
-						ClientID: fakeClientId,
-						ClientSecrets: map[string]v3.OIDCClientSecretStatus{
-							secretKeyPrefix + "1": {
-								CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
-								LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
+				patchOp := []map[string]interface{}{
+					{
+						"op":   "add",
+						"path": "/status",
+						"value": v3.OIDCClientStatus{
+							ClientID: fakeClientId,
+							ClientSecrets: map[string]v3.OIDCClientSecretStatus{
+								secretKeyPrefix + "1": {
+									CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
+									LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
+								},
 							},
 						},
 					},
 				}
-				patchBytes, _ := json.Marshal(patchData)
-				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.MergePatchType, patchBytes, "status").Return(oidcClient, nil)
+				patchBytes, _ := json.Marshal(patchOp)
+				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.JSONPatchType, patchBytes, "status").Return(oidcClient, nil)
 			},
 		},
 		"client secret is removed with annotation": {
@@ -381,20 +392,23 @@ func TestOnChange(t *testing.T) {
 				p.oidcClient.EXPECT().Update(client).Return(client, nil)
 
 				// update status with client secret
-				patchData := map[string]interface{}{
-					"status": v3.OIDCClientStatus{
-						ClientID: fakeClientId,
-						ClientSecrets: map[string]v3.OIDCClientSecretStatus{
-							secretKeyPrefix + "2": {
-								CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
-								LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
+				patchOp := []map[string]interface{}{
+					{
+						"op":   "add",
+						"path": "/status",
+						"value": v3.OIDCClientStatus{
+							ClientID: fakeClientId,
+							ClientSecrets: map[string]v3.OIDCClientSecretStatus{
+								secretKeyPrefix + "2": {
+									CreatedAt:          fmt.Sprintf("%d", fakeNow.Unix()),
+									LastFiveCharacters: fakeClientSecret[len(fakeClientSecret)-5:],
+								},
 							},
 						},
 					},
 				}
-
-				patchBytes, _ := json.Marshal(patchData)
-				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.MergePatchType, patchBytes, "status").Return(oidcClient, nil)
+				patchBytes, _ := json.Marshal(patchOp)
+				p.oidcClient.EXPECT().Patch(fakeOIDCClientName, types.JSONPatchType, patchBytes, "status").Return(oidcClient, nil)
 			},
 		},
 		"secret is deleted when clientID status patch fails": {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48317
 
## Problem
Current implementation using `MergePatchType` does not delete client secrets from the status when they are removed.
 
## Solution
Use `JSONPatchType` to replace the status since we are already recalculating the status.
This PR also initializes the map in `Data` if it is [empty](https://github.com/rancher/rancher/commit/c79af623d058931029bbc5d808657618036c49e7). This is a problem when creating a new client secret after all client secrets were previously deleted.