### PR TITLE
add new pushprox image name

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -238,6 +238,7 @@ var OriginMap = map[string]string{
 	"prom-prometheus":                                         "https://github.com/prometheus/prometheus",
 	"prometheus-auth":                                         "https://github.com/rancher/prometheus-auth",
 	"prometheus-federator":                                    "https://github.com/rancher/prometheus-federator",
+	"pushprox":                                                "https://github.com/rancher/PushProx",
 	"pushprox-client":                                         "https://github.com/rancher/PushProx",
 	"pushprox-proxy":                                          "https://github.com/rancher/PushProx",
 	"rancher":                                                 "https://github.com/rancher/rancher",


### PR DESCRIPTION
Backport of: https://github.com/rancher/rancher/pull/50117

Now that we've backported the updated chart to 2.10 the origins in 2.10 need to match.