### PR TITLE
[main] API doc for dynamic schemas

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/machine.go
+++ b/pkg/apis/rke.cattle.io/v1/machine.go
@@ -8,21 +8,55 @@ import (
 )
 
 type RKECommonNodeConfig struct {
-	Labels                    map[string]string `json:"labels,omitempty"`
-	Taints                    []corev1.Taint    `json:"taints,omitempty"`
-	CloudCredentialSecretName string            `json:"cloudCredentialSecretName,omitempty"`
+	// +optional
+	// +nullable
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// +optional
+	// +nullable
+	Taints []corev1.Taint `json:"taints,omitempty"`
+
+	// +optional
+	// +nullable
+	CloudCredentialSecretName string `json:"cloudCredentialSecretName,omitempty"`
 }
 
 type RKEMachineStatus struct {
-	Conditions                []genericcondition.GenericCondition `json:"conditions,omitempty"`
-	JobName                   string                              `json:"jobName,omitempty"`
-	Ready                     bool                                `json:"ready,omitempty"`
-	DriverHash                string                              `json:"driverHash,omitempty"`
-	DriverURL                 string                              `json:"driverUrl,omitempty"`
-	CloudCredentialSecretName string                              `json:"cloudCredentialSecretName,omitempty"`
-	FailureReason             string                              `json:"failureReason,omitempty"`
-	FailureMessage            string                              `json:"failureMessage,omitempty"`
-	Addresses                 []capi.MachineAddress               `json:"addresses,omitempty"`
+	// Conditions is a representation of the machine's current state.
+	// +optional
+	Conditions []genericcondition.GenericCondition `json:"conditions,omitempty"`
+
+	// JobName is the name of the provisioning job of the machine.
+	// +optional
+	JobName string `json:"jobName,omitempty"`
+
+	// Ready indicates whether the provider ID has been set in this machine's spec.
+	// +optional
+	Ready bool `json:"ready,omitempty"`
+
+	// DriverHash is the expected hash of the node driver binary used for provisioning the machine.
+	// +optional
+	DriverHash string `json:"driverHash,omitempty"`
+
+	// DriverURL is the url used to download the node driver binary for provisioning the machine.
+	// +optional
+	DriverURL string `json:"driverUrl,omitempty"`
+
+	// CloudCredentialSecretName is the secret name that was used as a credential to provision the machine.
+	// +optional
+	CloudCredentialSecretName string `json:"cloudCredentialSecretName,omitempty"`
+
+	// FailureReason indicates whether the provisioning job failed on creation or on removal of the machine.
+	// +optional
+	FailureReason string `json:"failureReason,omitempty"`
+
+	// FailureMessage is the container termination message for a provisioning job that failed.
+	// +optional
+	FailureMessage string `json:"failureMessage,omitempty"`
+
+	// Addresses are the machine network addresses. Assigned by the CAPI controller.
+	// +optional
+	Addresses []capi.MachineAddress `json:"addresses,omitempty"`
 }
 
 // +genclient

--- a/pkg/controllers/capr/controllers.go
+++ b/pkg/controllers/capr/controllers.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 )
 
-func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
+func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) error {
 	rkePlanner := planner.New(ctx, clients, planner.InfoFunctions{
 		ImageResolver:           image.ResolveWithControlPlane,
 		ReleaseData:             capr.GetKDMReleaseData,
@@ -34,7 +34,9 @@ func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager 
 		GetBootstrapManifests:   prebootstrap.NewRetriever(clients).GeneratePreBootstrapClusterAgentManifest,
 	})
 	if features.MCM.Enabled() {
-		dynamicschema.Register(ctx, clients)
+		if err := dynamicschema.Register(ctx, clients); err != nil {
+			return err
+		}
 		machineprovision.Register(ctx, clients, kubeconfigManager)
 	}
 	rkecluster.Register(ctx, clients)
@@ -46,4 +48,6 @@ func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager 
 	rkecontrolplane.Register(ctx, clients)
 	managesystemagent.Register(ctx, clients)
 	machinedrain.Register(ctx, clients)
+
+	return nil
 }

--- a/pkg/controllers/capr/dynamicschema/sample/rke-machine.cattle.io_samples.yaml
+++ b/pkg/controllers/capr/dynamicschema/sample/rke-machine.cattle.io_samples.yaml
@@ -1,0 +1,181 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: samples.rke-machine.cattle.io
+spec:
+  group: rke-machine.cattle.io
+  names:
+    kind: Sample
+    listKind: SampleList
+    plural: samples
+    singular: sample
+  scope: Namespaced
+  versions:
+  - name: sample
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              common:
+                description: Generic machine configuration.
+                properties:
+                  cloudCredentialSecretName:
+                    nullable: true
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    nullable: true
+                    type: object
+                  taints:
+                    items:
+                      description: |-
+                        The node this Taint is attached to has the "effect" on
+                        any pod that does not tolerate the Taint.
+                      properties:
+                        effect:
+                          description: |-
+                            Required. The effect of the taint on pods
+                            that do not tolerate the taint.
+                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Required. The taint key to be applied to a
+                            node.
+                          type: string
+                        timeAdded:
+                          description: |-
+                            TimeAdded represents the time at which the taint was added.
+                            It is only written for NoExecute taints.
+                          format: date-time
+                          type: string
+                        value:
+                          description: The taint value corresponding to the taint
+                            key.
+                          type: string
+                      required:
+                      - effect
+                      - key
+                      type: object
+                    nullable: true
+                    type: array
+                type: object
+            required:
+            - common
+            type: object
+          status:
+            description: Observed status of the Machine.
+            properties:
+              addresses:
+                description: Addresses are the machine network addresses. Assigned
+                  by the CAPI controller.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              cloudCredentialSecretName:
+                description: CloudCredentialSecretName is the secret name that was
+                  used as a credential to provision the machine.
+                type: string
+              conditions:
+                description: Conditions is a representation of the machine's current
+                  state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of cluster condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              driverHash:
+                description: DriverHash is the expected hash of the node driver binary
+                  used for provisioning the machine.
+                type: string
+              driverUrl:
+                description: DriverURL is the url used to download the node driver
+                  binary for provisioning the machine.
+                type: string
+              failureMessage:
+                description: FailureMessage is the container termination message for
+                  a provisioning job that failed.
+                type: string
+              failureReason:
+                description: FailureReason indicates whether the provisioning job
+                  failed on creation or on removal of the machine.
+                type: string
+              jobName:
+                description: JobName is the name of the provisioning job of the machine.
+                type: string
+              ready:
+                description: Ready indicates whether the provider ID has been set
+                  in this machine's spec.
+                type: boolean
+            type: object
+        required:
+        - metadata
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true

--- a/pkg/controllers/capr/dynamicschema/sample/sample.go
+++ b/pkg/controllers/capr/dynamicschema/sample/sample.go
@@ -1,0 +1,54 @@
+// +groupName=rke-machine.cattle.io
+package sample
+
+import (
+	_ "embed"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/wrangler/v3/pkg/yaml"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//go:embed rke-machine.cattle.io_samples.yaml
+var sampleBytes []byte
+
+// ---
+// This sample struct is used for generating a CRD for extracting
+// some of the openapi field definitions for static types, so that they can be
+// injected into dynamically generated CRDs. It wouldn't be possible to access their
+// comments for descriptions at run-time by importing their schemas using wrangler.
+//
+// This sample CRD is only read as an embedded file, it is never installed
+// in any cluster.
+//
+// This sample CRD is used to inject static fields in both the dynamically generated
+// InfrastructureMachine and InfrastructureMachineTemplate CRDs, for each infrastructure
+// provider.
+type Sample struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	Spec SampleSpec `json:"spec"`
+
+	// Observed status of the Machine.
+	// ---
+	// The status field is only needed for the InfrastructureMachine CRD.
+	Status rkev1.RKEMachineStatus `json:"status"`
+}
+
+type SampleSpec struct {
+	// Generic machine configuration.
+	Common rkev1.RKECommonNodeConfig `json:"common"`
+}
+
+func GetSampleProps() (*apiextv1.JSONSchemaProps, error) {
+	var sampleCRD apiextv1.CustomResourceDefinition
+
+	err := yaml.Unmarshal(sampleBytes, &sampleCRD)
+	if err != nil {
+		return nil, err
+	}
+
+	return sampleCRD.Spec.Versions[0].Schema.OpenAPIV3Schema, nil
+}

--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -66,7 +66,9 @@ func Register(ctx context.Context, wrangler *wrangler.Context, embedded bool, re
 		clusterindex.Register(ctx, wrangler)
 		provisioningv2.Register(ctx, wrangler, kubeconfigManager)
 		if features.RKE2.Enabled() {
-			capr.Register(ctx, wrangler, kubeconfigManager)
+			if err := capr.Register(ctx, wrangler, kubeconfigManager); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/scripts/build-crds
+++ b/scripts/build-crds
@@ -8,3 +8,6 @@ controller-gen crd:generateEmbeddedObjectMeta=true,allowDangerousTypes=false pat
 
 # remove empty CRD that is generated from our use of // +kubebuilder:skipversion
 rm -f ./pkg/crds/yaml/generated/_.yaml
+
+# Generate the sample CRD used for documenting dynamic objects in rke-machine.cattle.io (machines and machinetemplates).
+controller-gen crd paths=./pkg/controllers/capr/dynamicschema/sample output:crd:dir=./pkg/controllers/capr/dynamicschema/sample


### PR DESCRIPTION
Document API for dynamic schemas.

## Issue: https://github.com/rancher/rancher/issues/49402
 
## Problem
Dynamic schemas for node drivers have missing descriptions.

## Solution
Add descriptions for each dynamic schema as it is generated in the dynamic schema controller.

Each node driver generates three schemas: the configuration schema, the CAPI infrastructure machine schema, and the CAPI infrastructure machine template schema.

For instance, the digital ocean driver results in the three following `schemas`:
- `digitaloceanconfigs.rke-machine-config.cattle.io`
- `digitaloceanmachines.rke-machine.cattle.io`
- `digitaloceanmachinetemplates.rke-machine.cattle.io`

Each schema includes the flags used to call the node driver. The descriptions for those flags come from the node driver flag descriptions, and were already working.

All the other properties in the schemas are now also described.

The machine and template schemas also import schemas from various types, e.g. `RKECommonNodeConfig`. Because these were imported at runtime, their comments weren't available to fill in the descriptions. To handle this, this PR generates a sample CRD from these types and injects the corresponding definitions in the final schemas. This sample CRD is never installed in a cluster, it's just read as an embedded file.

The first commit adds the machinery to read the sample CRD. The second commit adds the descriptions.

Fields in `spec` were modified with `+nullable` and `+optional`, to match the existing schemas. Some types are imported from other packages and could not be changed, which causes some differences in schema validation. Fields in `spec` are were not set to nullable as before, because they are usually only set by the rancher and capi controllers. These are detailed below.

Note that to get field descriptions at a given depth, `kubectl explain` has to be called with the corresponding field, e.g. only `kubectl explain obj.spec` will give details for the fields in`spec`.
 
## Testing

## Engineering Testing
### Manual Testing
- Ran rancher locally, inspected various descriptions with `kubectl explain`.
- Ran rancher without the PR, activated all pre-installed node drivers. Downloaded CRDs for all of them. Ran rancher again with the changes, downloaded CRDs again. Filtered out fields that were expected to be changed (e.g. `resourceVersion`), including the tighter validations in imported types described below and the descriptions. Diffed results to check that there were no other differences.
- Provisioned a DO cluster (which uses all of the dynamic schemas for DO), and checked that it came up OK.
- Changed `sample.go` without re-generating the yaml and checked that the CI [fails](https://github.com/rancher/rancher/pull/50741/checks).

## QA Testing Considerations
TODO
 
### Regressions Considerations
Possible regressions would only happen because of the tighter validations. These are unlikely to happen since these fields are usually populated by rancher, so if e.g. a field was set to `null` in the cluster config, it would eventually marshalled/unmarshalled into an empty string in the dynamic schemas.

## Changes in schema validation:

`<Infrastructure>Machine` (e.g. `DigitaloceanMachine`):

- Label values in `spec.common.labels` are no longer `nullable`.
- Taint fields `effect` and `key` in `spec.common.taints`  are now `required`.
- Taint fields in `spec.common.taints` are no longer `nullable` (`effect`, `key`, `value`, `timeAdded`).
- Taint field `timeAdded` is now required to be in the `date-time` [format](https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-7.3.1).
- Fields in `status.addresses` now match the validations from the upstream capi `MachineAddress` type:
  -  Fields are no longer nullable, are required, and `type` must match one of the enum values.
- Fields in `status` are no longer nullable. 
- All of the condition fields in the `status.conditions` array are no longer `nullable`, fields `status` and `type` are both `required`.

`<InfrastructureMachine>Template` (e.g. `DigitaloceanMachineTemplate`):

Same as the corresponding `Machine` crd for `spec.template.spec.common.taints` and `spec.template.spec.common.labels`.

