### PR TITLE
fix: enable psa permissions on downstream clusters

### DIFF
--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -498,6 +498,8 @@ func addManageNSPermission(clusterRole *rbacv1.ClusterRole, projectName string) 
 	return clusterRole
 }
 
+// addUpdatepsaClusterRole returns a ClusterRole with the updatepsa verb enabled.
+// The name of the ClusterRole has the following format: <project_name>-namespaces-psa
 func addUpdatepsaClusterRole(projectName string) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{}
 	crName := "%s-namespaces-psa"

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -498,6 +498,22 @@ func addManageNSPermission(clusterRole *rbacv1.ClusterRole, projectName string) 
 	return clusterRole
 }
 
+func addUpdatepsaClusterRole(projectName string) *rbacv1.ClusterRole {
+	clusterRole := &rbacv1.ClusterRole{}
+	crName := "%s-namespaces-psa"
+	clusterRole.Name = fmt.Sprintf(crName, projectName)
+	clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
+		APIGroups:     []string{management.GroupName},
+		Verbs:         []string{"updatepsa"},
+		Resources:     []string{apisV3.ProjectResourceName},
+		ResourceNames: []string{projectName},
+	})
+	if clusterRole.Annotations == nil {
+		clusterRole.Annotations = map[string]string{}
+	}
+	return clusterRole
+}
+
 func crByNS(obj interface{}) ([]string, error) {
 	cr, ok := obj.(*rbacv1.ClusterRole)
 	if !ok {

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -306,12 +306,12 @@ func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTempla
 		// delete CR and CRB for the given project
 		psaCRName := fmt.Sprintf("%s-namespaces-psa", projectName)
 		err = p.crClient.Delete(psaCRName, &metav1.DeleteOptions{})
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("error deleting clusterrole %v: %w", psaCRName, err)
 		}
 		psaCRBName := fmt.Sprintf("%s-updatepsa", projectName)
 		err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{})
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("error deleting clusterrolebinding %v: %w", psaCRBName, err)
 		}
 	}

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -306,12 +306,12 @@ func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTempla
 		// delete CR and CRB for the given project
 		psaCRName := fmt.Sprintf("%s-namespaces-psa", projectName)
 		err = p.crClient.Delete(psaCRName, &metav1.DeleteOptions{})
-		if !apierrors.IsNotFound(err) {
+		if err != nil {
 			return fmt.Errorf("error deleting clusterrole %v: %w", psaCRName, err)
 		}
 		psaCRBName := fmt.Sprintf("%s-updatepsa", projectName)
 		err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{})
-		if !apierrors.IsNotFound(err) {
+		if err != nil {
 			return fmt.Errorf("error deleting clusterrolebinding %v: %w", psaCRBName, err)
 		}
 	}

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -203,7 +203,7 @@ func (p *prtbLifecycle) ensurePSAPermissions(binding *v3.ProjectRoleTemplateBind
 		if apierrors.IsNotFound(err) {
 			// create ClusterRole if it doesn't exist
 			psaCR, err = p.crClient.Create(psaCRWanted)
-			if err != nil {
+			if err != nil && !apierrors.IsAlreadyExists(err) {
 				return err
 			}
 		} else {
@@ -235,7 +235,7 @@ func (p *prtbLifecycle) ensurePSAPermissions(binding *v3.ProjectRoleTemplateBind
 	psaCRB.Subjects = []rbacv1.Subject{subject}
 
 	_, err = p.crbClient.Create(psaCRB)
-	if err != nil && apierrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/slice"
+	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -22,8 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 )
 
 const owner = "owner-user"
@@ -69,6 +73,8 @@ func newPRTBLifecycle(m *manager, management *config.ManagementContext, nsInform
 		rbClient:   m.workload.RBAC.RoleBindings(""),
 		crbLister:  m.workload.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		crbClient:  m.workload.RBAC.ClusterRoleBindings(""),
+		crClient:   m.workload.RBAC.ClusterRoles(""),
+		crLister:   m.workload.RBAC.ClusterRoles("").Controller().Lister(),
 		prtbClient: management.Management.ProjectRoleTemplateBindings(""),
 	}
 }
@@ -81,6 +87,8 @@ type prtbLifecycle struct {
 	rbClient   typesrbacv1.RoleBindingInterface
 	crbLister  typesrbacv1.ClusterRoleBindingLister
 	crbClient  typesrbacv1.ClusterRoleBindingInterface
+	crClient   typesrbacv1.ClusterRoleInterface
+	crLister   typesrbacv1.ClusterRoleLister
 	prtbClient v3.ProjectRoleTemplateBindingInterface
 }
 
@@ -129,6 +137,10 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 		return err
 	}
 
+	if err := p.ensurePSAPermissions(binding, roles); err != nil {
+		return fmt.Errorf("couldn't ensure psa permissions: %w", err)
+	}
+
 	if err := p.m.ensureRoles(roles); err != nil {
 		return fmt.Errorf("couldn't ensure roles: %w", err)
 	}
@@ -152,6 +164,87 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 	return p.reconcileProjectAccessToGlobalResources(binding, roles)
 }
 
+// ensurePSAPermissions creates the necessary ClusterRole and ClusterRoleBinding
+// to give the 'updatepsa' permission to the project.
+func (p *prtbLifecycle) ensurePSAPermissions(binding *v3.ProjectRoleTemplateBinding, roles map[string]*v3.RoleTemplate) error {
+	// extract project name from the format "cluster-name:project-name"
+	_, projectName, found := strings.Cut(binding.ProjectName, ":")
+	if !found {
+		return fmt.Errorf("invalid project name format")
+	}
+
+	// create AttributesRecord to test if roles allow the updatepsa operation
+	psaRec := authorizer.AttributesRecord{
+		Verb:            "updatepsa",
+		APIGroup:        management.GroupName,
+		Resource:        v32.ProjectResourceName,
+		Name:            binding.ProjectName,
+		ResourceRequest: true,
+	}
+
+	// check if any of the RoleTemplates grant updatepsa permission
+	hasUpdatePSAPermission := false
+	for _, role := range roles {
+		if rbac.RulesAllow(psaRec, role.Rules...) {
+			hasUpdatePSAPermission = true
+		}
+	}
+
+	// only create RBAC resources if user has updatepsa permission
+	if !hasUpdatePSAPermission {
+		return nil
+	}
+
+	// ensure ClusterRole exists with correct updatepsa rules
+	psaCRName := fmt.Sprintf("%s-namespaces-psa", projectName)
+	psaCRWanted := addUpdatepsaClusterRole(projectName)
+	psaCR, err := p.crLister.Get("", psaCRName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// create ClusterRole if it doesn't exist
+			psaCR, err = p.crClient.Create(psaCRWanted)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	// verify existing ClusterRole has the correct updatepsa rules
+	if !reflect.DeepEqual(psaCR.Rules, psaCRWanted.Rules) {
+		return fmt.Errorf("%s rules do not grant required updatepsa permissions", psaCRName)
+	}
+
+	// create ClusterRoleBinding to bind the ClusterRole to the user/group
+	psaCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-updatepsa", projectName),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     psaCRName,
+		},
+	}
+
+	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
+	if err != nil {
+		return err
+	}
+	psaCRB.Subjects = []rbacv1.Subject{subject}
+
+	_, err = p.crbClient.Create(psaCRB)
+	if err != nil && apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+// ensurePRTBDelete cleans up all RBAC resources (RoleBindings, ServiceAccount, etc)
+// associated with a ProjectRoleTemplateBinding when it's deleted.
+// This ensures proper cleanup and prevents orphaned permissions.
 func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding) error {
 	// Get namespaces belonging to project
 	namespaces, err := p.nsIndexer.ByIndex(namespace.NsByProjectIndex, binding.ProjectName)
@@ -176,11 +269,54 @@ func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding)
 		}
 	}
 
+	if err := p.ensurePSAPermissionsDelete(binding); err != nil {
+		return fmt.Errorf("error deleting psa RBAC resources: %w", err)
+	}
+
 	if err := p.m.deleteServiceAccountImpersonator(binding.UserName); err != nil {
 		return fmt.Errorf("error deleting service account impersonator: %w", err)
 	}
 
 	return p.reconcileProjectAccessToGlobalResourcesForDelete(binding)
+}
+
+// ensurePSAPermissionsDelete removes the ClusterRole and ClusterRoleBinding
+// that were created to grant 'updatepsa' permissions when a ProjectRoleTemplateBinding
+// is deleted. This function only performs cleanup if the binding's RoleTemplate
+// actually granted updatepsa permissions, ensuring proper cleanup of PSA-related
+// RBAC resources without affecting unrelated bindings.
+func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTemplateBinding) error {
+	psaRec := authorizer.AttributesRecord{
+		Verb:            "updatepsa",
+		APIGroup:        management.GroupName,
+		Resource:        v32.ProjectResourceName,
+		Name:            binding.ProjectName,
+		ResourceRequest: true,
+	}
+	_, projectName, found := strings.Cut(binding.ProjectName, ":")
+	if !found {
+		return fmt.Errorf("invalid project name format")
+	}
+	prtbRoleTemplate, err := p.rtLister.Get("", binding.RoleTemplateName)
+	if err != nil {
+		return err
+	}
+
+	if rbac.RulesAllow(psaRec, prtbRoleTemplate.Rules...) {
+		// delete CR and CRB for the given project
+		psaCRName := fmt.Sprintf("%s-namespaces-psa", projectName)
+		err = p.crClient.Delete(psaCRName, &metav1.DeleteOptions{})
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error deleting clusterrole %v: %w", psaCRName, err)
+		}
+		psaCRBName := fmt.Sprintf("%s-updatepsa", projectName)
+		err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{})
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error deleting clusterrolebinding %v: %w", psaCRBName, err)
+		}
+	}
+
+	return nil
 }
 
 func (p *prtbLifecycle) reconcileProjectAccessToGlobalResources(binding *v3.ProjectRoleTemplateBinding, rts map[string]*v3.RoleTemplate) error {

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -213,7 +213,8 @@ func (p *prtbLifecycle) ensurePSAPermissions(binding *v3.ProjectRoleTemplateBind
 
 	// verify existing ClusterRole has the correct updatepsa rules
 	if !reflect.DeepEqual(psaCR.Rules, psaCRWanted.Rules) {
-		return fmt.Errorf("%s rules do not grant required updatepsa permissions", psaCRName)
+		// if the CR have been modified, restore it
+		psaCR = addUpdatepsaClusterRole(projectName)
 	}
 
 	// create ClusterRoleBinding to bind the ClusterRole to the user/group

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -215,6 +215,10 @@ func (p *prtbLifecycle) ensurePSAPermissions(binding *v3.ProjectRoleTemplateBind
 	if !reflect.DeepEqual(psaCR.Rules, psaCRWanted.Rules) {
 		// if the CR have been modified, restore it
 		psaCR = addUpdatepsaClusterRole(projectName)
+		_, err = p.crClient.Update(psaCR)
+		if err != nil {
+			return err
+		}
 	}
 
 	// create ClusterRoleBinding to bind the ClusterRole to the user/group
@@ -333,14 +337,13 @@ func (p *prtbLifecycle) isClusterRoleUsed(clusterRoleName string) bool {
 		return false
 	}
 
-	var usingBindings []string
 	for _, binding := range bindings.Items {
 		if binding.RoleRef.Kind == "ClusterRole" && binding.RoleRef.Name == clusterRoleName {
-			usingBindings = append(usingBindings, binding.Name)
+			return true
 		}
 	}
 
-	return len(usingBindings) > 0
+	return false
 }
 
 func (p *prtbLifecycle) reconcileProjectAccessToGlobalResources(binding *v3.ProjectRoleTemplateBinding, rts map[string]*v3.RoleTemplate) error {

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -913,7 +913,7 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "unable to delete CR (locked by other CRB)",
+			name: "delete only CRB (CR locked by other CRBs)",
 			mockSetup: func() {
 				p.rtLister = &rancherv3fakes.RoleTemplateListerMock{
 					GetFunc: func(namespace, name string) (*apisV3.RoleTemplate, error) {

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	typesrbacv1fakes "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -633,18 +632,10 @@ func Test_manager_reconcileRoleForProjectAccessToGlobalResource(t *testing.T) {
 }
 
 func Test_ensurePSAPermissions(t *testing.T) {
-	type fields struct {
-		crbClient typesrbacv1.ClusterRoleBindingInterface
-		crClient  typesrbacv1.ClusterRoleInterface
-		crLister  typesrbacv1.ClusterRoleLister
-	}
 	type args struct {
 		binding *v3.ProjectRoleTemplateBinding
 		roles   map[string]*v3.RoleTemplate
 	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	p := &prtbLifecycle{}
 

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -831,7 +831,7 @@ func Test_ensurePSAPermissions(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -646,7 +646,6 @@ func Test_ensurePSAPermissions(t *testing.T) {
 		args      args
 		wantErr   bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "create psa rbac resources without errors",
 			mockSetup: func() {
@@ -807,7 +806,6 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 		args      args
 		wantErr   bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "clean up psa rbac resources",
 			mockSetup: func() {

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -6,7 +6,10 @@ import (
 	"io"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
+	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	typesrbacv1fakes "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +17,9 @@ import (
 	"go.uber.org/mock/gomock"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -622,6 +627,176 @@ func Test_manager_reconcileRoleForProjectAccessToGlobalResource(t *testing.T) {
 				if tc.clusterRolesMockUpdateErr == nil {
 					assert.Equal(t, tc.clusterRolesMockUpdateResult, results[0].In1)
 				}
+			}
+		})
+	}
+}
+
+func Test_ensurePSAPermissions(t *testing.T) {
+	type fields struct {
+		crbClient typesrbacv1.ClusterRoleBindingInterface
+		crClient  typesrbacv1.ClusterRoleInterface
+		crLister  typesrbacv1.ClusterRoleLister
+	}
+	type args struct {
+		binding *v3.ProjectRoleTemplateBinding
+		roles   map[string]*v3.RoleTemplate
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p := &prtbLifecycle{}
+
+	tests := []struct {
+		name      string
+		mockSetup func()
+		args      args
+		wantErr   bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "create psa rbac resources without errors",
+			mockSetup: func() {
+				p.crLister = &typesrbacv1fakes.ClusterRoleListerMock{
+					GetFunc: func(namespace, name string) (*v1.ClusterRole, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+					},
+				}
+				p.crClient = &typesrbacv1fakes.ClusterRoleInterfaceMock{
+					CreateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+						return &v1.ClusterRole{
+							Rules: []rbacv1.PolicyRule{
+								{
+									APIGroups:     []string{management.GroupName},
+									Verbs:         []string{"updatepsa"},
+									Resources:     []string{apisV3.ProjectResourceName},
+									ResourceNames: []string{"p-example"},
+								},
+							},
+						}, nil
+					},
+				}
+				p.crbClient = &typesrbacv1fakes.ClusterRoleBindingInterfaceMock{
+					CreateFunc: func(in1 *v1.ClusterRoleBinding) (*v1.ClusterRoleBinding, error) {
+						return &v1.ClusterRoleBinding{}, nil
+					},
+				}
+			},
+			args: args{
+				binding: &apisV3.ProjectRoleTemplateBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "prtb-example",
+					},
+					UserName:    "u-test1",
+					ProjectName: "c-abc:p-example",
+				},
+				roles: map[string]*v3.RoleTemplate{
+					"role_template_0": &apisV3.RoleTemplate{
+						Rules: []v1.PolicyRule{
+							{
+								APIGroups: []string{management.GroupName},
+								Verbs:     []string{"updatepsa"},
+								Resources: []string{apisV3.ProjectResourceName},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unable to create CRB",
+			mockSetup: func() {
+				p.crLister = &typesrbacv1fakes.ClusterRoleListerMock{
+					GetFunc: func(namespace, name string) (*v1.ClusterRole, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+					},
+				}
+				p.crClient = &typesrbacv1fakes.ClusterRoleInterfaceMock{
+					CreateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+						return &v1.ClusterRole{
+							Rules: []rbacv1.PolicyRule{
+								{
+									APIGroups:     []string{management.GroupName},
+									Verbs:         []string{"updatepsa"},
+									Resources:     []string{apisV3.ProjectResourceName},
+									ResourceNames: []string{"p-example"},
+								},
+							},
+						}, nil
+					},
+				}
+				p.crbClient = &typesrbacv1fakes.ClusterRoleBindingInterfaceMock{
+					CreateFunc: func(in1 *v1.ClusterRoleBinding) (*v1.ClusterRoleBinding, error) {
+						return nil, fmt.Errorf("error")
+					},
+				}
+			},
+			args: args{
+				binding: &apisV3.ProjectRoleTemplateBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "prtb-example",
+					},
+					UserName:    "u-test1",
+					ProjectName: "c-abc:p-example",
+				},
+				roles: map[string]*v3.RoleTemplate{
+					"role_template_0": &apisV3.RoleTemplate{
+						Rules: []v1.PolicyRule{
+							{
+								APIGroups: []string{management.GroupName},
+								Verbs:     []string{"updatepsa"},
+								Resources: []string{apisV3.ProjectResourceName},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unable to create CR",
+			mockSetup: func() {
+				p.crLister = &typesrbacv1fakes.ClusterRoleListerMock{
+					GetFunc: func(namespace, name string) (*v1.ClusterRole, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+					},
+				}
+				p.crClient = &typesrbacv1fakes.ClusterRoleInterfaceMock{
+					CreateFunc: func(in1 *v1.ClusterRole) (*v1.ClusterRole, error) {
+						return nil, fmt.Errorf("error")
+					},
+				}
+			},
+			args: args{
+				binding: &apisV3.ProjectRoleTemplateBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "prtb-example",
+					},
+					UserName:    "u-test1",
+					ProjectName: "c-abc:p-example",
+				},
+				roles: map[string]*v3.RoleTemplate{
+					"role_template_0": &apisV3.RoleTemplate{
+						Rules: []v1.PolicyRule{
+							{
+								APIGroups: []string{management.GroupName},
+								Verbs:     []string{"updatepsa"},
+								Resources: []string{apisV3.ProjectResourceName},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.mockSetup()
+			if err := p.ensurePSAPermissions(tt.args.binding, tt.args.roles); (err != nil) != tt.wantErr {
+				t.Errorf("prtbLifecycle.ensurePSAPermissions() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48721
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
During QA tests session @Priyashetty17 reported a failing test when using `updatepsa` permissions on a downstream cluster: https://github.com/rancher/rancher/issues/48721#issuecomment-2899052383
The user is unable to create a namespace with PSA labels within a project (having `updatepsa` permissions).

## Solution
This PR allow the user to create namespaces with PSA labels within projects in downstream clusters.
The problem was due to the use of the wrong package (`pkg/controllers/management/auth` instead of `pkg/controllers/managementuser/rbac` which allow to watch resources on both local and downstream cluster).

The following code creates a `ClusterRole` and a `ClusterRoleBinding` to allow the `updatepsa` verb on the user permissions.
The `ClusterRole` has this name: `<project_name>-namespaces-psa`
The `ClusterRoleBinding` has this name: `<project_name>-updatepsa`
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_