### PR TITLE
POC gen apidocs

### DIFF
--- a/.github/actions/public-api-docs/generate/action.yaml
+++ b/.github/actions/public-api-docs/generate/action.yaml
@@ -16,7 +16,6 @@ runs:
       run: |
         echo '{"exec-opts": ["native.cgroupdriver=cgroupfs"]}'| sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
-      #TODO: Wait for image server ready
     - uses: actions/setup-go@v5
       with:
         go-version: '${{ steps.env.outputs.GO_VERSION }}'
@@ -42,7 +41,6 @@ runs:
     - name: Install crd-swagger
       shell: bash
       run: |
-        # TODO: Switch to official rancher repository
         go install github.com/tomleb/rancher-crd-swagger@236ff9f29c511116cff4736f11aa81cd12941f73
     - name: Create ARTIFACTS_BASE_DIR
       shell: bash

--- a/.github/actions/public-api-docs/generate/action.yaml
+++ b/.github/actions/public-api-docs/generate/action.yaml
@@ -44,7 +44,11 @@ runs:
       run: |
         # TODO: Switch to official rancher repository
         go install github.com/tomleb/rancher-crd-swagger@236ff9f29c511116cff4736f11aa81cd12941f73
+    - name: Create ARTIFACTS_BASE_DIR
+      shell: bash
+      run: |
+        mkdir -p "$ARTIFACTS_BASE_DIR"
     - name: Generate Rancher Public API docs
       shell: bash
       run: |
-        rancher-crd-swagger -i "${{ steps.load.outputs.image_server_id }}" -f ./public-api.txt -p 9998 -t 9999 -o bin/openapi.json
+        rancher-crd-swagger -i "${{ steps.load.outputs.image_server_id }}" -f ./public-api.txt -p 9998 -t 9999 -o "$ARTIFACTS_BASE_DIR/openapi.json"

--- a/.github/actions/public-api-docs/generate/action.yaml
+++ b/.github/actions/public-api-docs/generate/action.yaml
@@ -1,0 +1,50 @@
+name: "Generate Public API OpenAPI docs"
+description: "Generate Rancher Public API OpenAPI docs"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Environment Variables
+      uses: ./.github/actions/setup-tag-env
+    - id: env
+      name: Setup Dependencies Env Variables
+      uses: ./.github/actions/setup-build-env
+    - name: Update dependencies
+      shell: bash
+      run: sudo apt-get update
+    - name: Configure Docker for cgroupfs
+      shell: bash
+      run: |
+        echo '{"exec-opts": ["native.cgroupdriver=cgroupfs"]}'| sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+      #TODO: Wait for image server ready
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '${{ steps.env.outputs.GO_VERSION }}'
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "${{ env.GOLANG_VERSION }}"
+    - name: Download Docker images artifact
+      uses: actions/download-artifact@v4
+      with:
+        path: "/tmp"
+        merge-multiple: true
+    - name: Load server image
+      shell: bash
+      id: load
+      run: |
+        image_server_id=$(docker load --input /tmp/rancher-linux-amd64.tar 2>&1 | grep "Loaded image" | awk '{print $NF}')
+        if [ -z "$image_server_id" ]; then
+          echo "Error: Failed to load image from tarball!"
+          exit 1
+        fi
+        echo "image_server_id=$image_server_id" >> $GITHUB_OUTPUT
+    - name: Install crd-swagger
+      shell: bash
+      run: |
+        # TODO: Switch to official rancher repository
+        go install github.com/tomleb/rancher-crd-swagger@236ff9f29c511116cff4736f11aa81cd12941f73
+    - name: Generate Rancher Public API docs
+      shell: bash
+      run: |
+        rancher-crd-swagger -i "${{ steps.load.outputs.image_server_id }}" -f ./public-api.txt -p 9998 -t 9999 -o bin/openapi.json

--- a/.github/actions/public-api-docs/publish-gh/action.yml
+++ b/.github/actions/public-api-docs/publish-gh/action.yml
@@ -1,0 +1,18 @@
+name: "Publish Public API docs to GitHub"
+description: "Upload public API docs to a GitHub release"
+runs:
+  using: "composite"
+  steps:
+    - name: Create App Token
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ env.APP_ID }}
+        private-key: ${{ env.PRIVATE_KEY }}
+    - name: Upload artifacts
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      shell: bash
+      run: |
+        set -ex
+        gh release upload -R ${{ github.repository_owner }}/rancher ${{ env.TAG }} "./$ARTIFACTS_BASE_DIR/openapi.json" --clobber

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -67,3 +67,24 @@ jobs:
   provisioning-tests:
     needs: [build-server, build-agent]
     uses: ./.github/workflows/provisioning-tests.yml
+  generate-public-api-docs:
+    needs: [build-server]
+    runs-on: runs-on,runner=2cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      ARTIFACTS_BASE_DIR: "bin"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: generate
+        uses: ./.github/actions/public-api-docs/generate
+      - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: "openapi.json"
+          path: "${{ env.ARTIFACTS_BASE_DIR }}/openapi.json"
+          if-no-files-found: error
+          retention-days: 4
+          overwrite: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -67,24 +67,3 @@ jobs:
   provisioning-tests:
     needs: [build-server, build-agent]
     uses: ./.github/workflows/provisioning-tests.yml
-  generate-public-api-docs:
-    needs: [build-server]
-    runs-on: runs-on,runner=2cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
-    permissions:
-      contents: write
-      id-token: write
-    env:
-      ARTIFACTS_BASE_DIR: "bin"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: generate
-        uses: ./.github/actions/public-api-docs/generate
-      - name: Upload public API docs
-        uses: actions/upload-artifact@v4
-        with:
-          name: "openapi.json"
-          path: "${{ env.ARTIFACTS_BASE_DIR }}/openapi.json"
-          if-no-files-found: error
-          retention-days: 4
-          overwrite: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
       - name: generate
         uses: ./.github/actions/public-api-docs/generate
-      - name: Upload image
+      - name: Upload public API docs
         uses: actions/upload-artifact@v4
         with:
           name: "openapi.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,27 @@ jobs:
         with:
           image: "${{ env.IMAGE_INSTALLER }}"
         uses: ./.github/actions/merge-manifests
+  generate-public-api-docs:
+    needs: [build-server]
+    runs-on: runs-on,runner=2cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      ARTIFACTS_BASE_DIR: "bin"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: generate
+        uses: ./.github/actions/public-api-docs/generate
+      - name: Read App Secrets
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY ;
+      - name: publish to gh
+        uses: ./.github/actions/public-api-docs/publish-gh
   create-images-files:
     runs-on: runs-on,runner=2cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
     permissions:

--- a/public-api.txt
+++ b/public-api.txt
@@ -4,4 +4,3 @@ RoleTemplate.management.cattle.io
 ProjectRoleTemplateBinding.management.cattle.io
 ClusterRoleTemplateBinding.management.cattle.io
 Project.management.cattle.io
-Tokens.ext.cattle.io

--- a/public-api.txt
+++ b/public-api.txt
@@ -1,0 +1,7 @@
+GlobalRole.management.cattle.io
+GlobalRoleBinding.management.cattle.io
+RoleTemplate.management.cattle.io
+ProjectRoleTemplateBinding.management.cattle.io
+ClusterRoleTemplateBinding.management.cattle.io
+Project.management.cattle.io
+Tokens.ext.cattle.io

--- a/public-api.txt
+++ b/public-api.txt
@@ -1,3 +1,5 @@
+Kubeconfig.ext.cattle.io
+Token.ext.cattle.io
 GlobalRole.management.cattle.io
 GlobalRoleBinding.management.cattle.io
 RoleTemplate.management.cattle.io


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/50609

Would like to get your thoughts on this approach for the public API OpenAPI docs.

# Context

The Rancher docs has a page listing our public API doc: https://ranchermanager.docs.rancher.com/api/api-reference. This is a per-release doc and the page is generated from an openapi.json file (eg: [openapi/swagger-v2.11.json](https://github.com/rancher/rancher-docs/blob/main/openapi/swagger-v2.11.json), [openapi/swagger-v2.10.json](https://github.com/rancher/rancher-docs/blob/main/openapi/swagger-v2.10.json), etc).

These files are generated using [crd-swagger](https://github.com/rancher/crd-swagger).

The current workflow for updating these docs is the following:
- A new rancher tag is released (can be an -rc, -alpha or the actual release)
- The docs team need to run crd-swagger with the release-specific "resource file" (which lists the APIs part of the Public API)
- The docs team copies the resulting openapi.json file to their docs repo

The resource file needs to be Release-specific (meaning Rancher 2.X might have different APIs than 2.Y). It must also be maintained.


# Proposal

Devs maintain this list of public APIs right in rancher/rancher repository. It will be per branch (per releases) which is what we want.

Docs team no longer need to run the crd-swagger tool. Instead, it will be run on release workflows. We'll add a way to run this manually too via GHA but in a future PR.

**Get openapi.json from release**

```
gh release download -R rancher/rancher <tag> --pattern openapi.json -O openapi.json
```

OR you can also go to the release page and download from there.

WDYT?