### PR TITLE
Add new annotation to track which project scoped secrets are copies

### DIFF
--- a/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
@@ -346,10 +346,18 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret1",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret2",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 					},
 				}, nil)
@@ -382,10 +390,18 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret1",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret2",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 					},
 				}, nil)
@@ -402,10 +418,18 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret1",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret2",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 					},
 				}, nil)
@@ -425,10 +449,18 @@ func Test_namespaceHandler_removeUndesiredProjectScopedSecrets(t *testing.T) {
 				f.EXPECT().List("ns1", metav1.ListOptions{LabelSelector: projectScopedSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret1",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "ns1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        "secret2",
+								Namespace:   "ns1",
+								Annotations: map[string]string{pssCopyAnnotation: "true"},
+							},
 						},
 					},
 				}, nil)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50622
 
## Problem
When restarting Rancher, the Project Scoped Secret controller would delete the original project scoped secret.
 
## Solution
Added a new annotation to track which secrets are copies. Then the controller checks for that annotation and only modifies/deletes those.
 
## Testing
## Engineering Testing
### Manual Testing
Followed the steps in the issue. On restart the original project scoped secret is no longer removed.

### Automated Testing
* Test types added/modified:
    * Unit
Summary: Added checks for the annotation in the unit tests.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_