### PR TITLE
[main] Node Driver Public API

### DIFF
--- a/pkg/apis/management.cattle.io/v3/condition.go
+++ b/pkg/apis/management.cattle.io/v3/condition.go
@@ -1,0 +1,59 @@
+package v3
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// Note: This struct is largely a mirror of the upstream 'metav1.Condition' type, with one key difference: The LastUpdateTime field.
+// The 'condition' packages within both norman and wrangler attempt to set this field when updating the condition,
+// and will panic if they are unable to do so (due to their use of reflection). Due to this, as well as the absence of other
+// utility packages for working with conditions in Rancher, simply swapping out this Condition struct with the
+// upstream 'metav1.Condition' struct is not a trivial change and likely needs to be evaluated on a per CRD basis.
+
+type Condition struct {
+	// type of condition in CamelCase or in foo.example.com/CamelCase.
+	// ---
+	// Many .condition.type values are consistent across resources like
+	// Available, but because arbitrary conditions can be useful
+	// (see .node.status.conditions), the ability to deconflict is important.
+	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+	// +kubebuilder:validation:MaxLength=316
+	Type string `json:"type"`
+	// status of the condition, one of True, False, Unknown.
+	// +kubebuilder:validation:Enum=True;False;Unknown
+	Status v1.ConditionStatus `json:"status"`
+	// lastUpdateTime of this condition. This is incremented if the resource
+	// is updated for any reason. This could be when the underlying condition
+	// changed, but may also be updated if other fields are modified
+	// (Message, Reason, etc.).
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
+	LastUpdateTime string `json:"lastUpdateTime,omitempty"`
+	// lastTransitionTime is the last time the condition transitioned from
+	// one status to another. This should be when the underlying condition
+	// changed. If that is not known, then using the time when the API field
+	// changed is acceptable.
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
+	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
+	// reason contains a programmatic identifier indicating the reason for
+	// the condition's last transition. Producers of specific condition types
+	// may define expected values and meanings for this field, and whether
+	// the values are considered a guaranteed API. The value should be
+	// a CamelCase string.
+	// +optional
+	// +kubebuilder:validation:MaxLength=1024
+	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
+	Reason string `json:"reason,omitempty"`
+	// message is a human readable message indicating details
+	// about the transition.
+	// This may be an empty string.
+	// +optional
+	// +kubebuilder:validation:MaxLength=32768
+	Message string `json:"message,omitempty"`
+}

--- a/pkg/apis/management.cattle.io/v3/machine_types.go
+++ b/pkg/apis/management.cattle.io/v3/machine_types.go
@@ -269,28 +269,51 @@ type NodeCommonParams struct {
 }
 
 // +genclient
-// +kubebuilder:skipversion
 // +genclient:nonNamespaced
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Activated",type=string,JSONPath=".spec.active"
+// +kubebuilder:printcolumn:name="Binary URL",type=string,JSONPath=".spec.url"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// NodeDriver represents a Rancher node driver for a specific cloud provider used to provision cluster nodes.
 type NodeDriver struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the Node Driver. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+	// +kubebuilder:validation:XValidation:rule="!has(self.checksum) || (self.checksum.size() in [0, 32, 40, 64, 128])",message="Checksum must be an md5, sha1, sha256, or sha512 digest."
 	Spec NodeDriverSpec `json:"spec"`
-	// Most recent observed status of the cluster. More info:
+	// Most recent observed status of the Node Driver. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
-	Status NodeDriverStatus `json:"status"`
+	// +optional
+	Status NodeDriverStatus `json:"status,omitempty"`
 }
 
 type NodeDriverStatus struct {
-	Conditions                  []Condition `json:"conditions"`
-	AppliedURL                  string      `json:"appliedURL"`
-	AppliedChecksum             string      `json:"appliedChecksum"`
-	AppliedDockerMachineVersion string      `json:"appliedDockerMachineVersion"`
+	// Conditions is a representation of the current state of the driver,
+	// this includes its installation status (Downloaded, Installed), as well
+	// as its current state (Active, Inactive). Information related to
+	// errors encountered while transitioning to one of these states will be
+	// populated in the Message and Reason fields.
+	// +optional
+	Conditions []Condition `json:"conditions,omitempty"`
+	// AppliedURL is the url last used to download the driver.
+	// +optional
+	AppliedURL string `json:"appliedURL,omitempty"`
+	// AppliedChecksum is the last known checksum of the driver. This is used
+	// to determine when a Driver needs to be redownloaded from its URL.
+	// +optional
+	AppliedChecksum string `json:"appliedChecksum,omitempty"`
+	// AppliedDockerMachineVersion specifies the last docker machine version
+	// (a.k.a rancher-machine) which provides this driver. When this version
+	// is incremented, Rancher will query the rancher-machine driver to
+	// obtain its arguments and update the automatically generated schema
+	// and associated machine config object. This field is only specified for
+	// drivers bundled within Rancher via rancher-machine.
+	// +optional
+	AppliedDockerMachineVersion string `json:"appliedDockerMachineVersion,omitempty"`
 }
 
 var (
@@ -300,34 +323,47 @@ var (
 	NodeDriverConditionInactive   condition.Cond = "Inactive"
 )
 
-type Condition struct {
-	// Type of cluster condition.
-	Type string `json:"type"`
-	// Status of the condition, one of True, False, Unknown.
-	Status v1.ConditionStatus `json:"status"`
-	// The last time this condition was updated.
-	LastUpdateTime string `json:"lastUpdateTime,omitempty"`
-	// Last time the condition transitioned from one status to another.
-	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
-	// The reason for the condition's last transition.
-	Reason string `json:"reason,omitempty"`
-	// Human-readable message indicating details about last transition
-	Message string `json:"message,omitempty"`
-}
-
 type NodeDriverSpec struct {
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
-	URL         string `json:"url" norman:"required"`
-	ExternalID  string `json:"externalId"`
-	Builtin     bool   `json:"builtin"`
-	Active      bool   `json:"active"`
-	// If AddCloudCredential is true, then the cloud credential schema is created
-	// regardless of whether the node driver is active.
-	AddCloudCredential bool     `json:"addCloudCredential"`
-	Checksum           string   `json:"checksum"`
-	UIURL              string   `json:"uiUrl"`
-	WhitelistDomains   []string `json:"whitelistDomains,omitempty"`
+	// DisplayName specifies the publicly visible name of the driver shown in the Rancher UI.
+	// +kubebuilder:validation:MaxLength=57
+	// +optional
+	DisplayName string `json:"displayName,omitempty"`
+	// Description provides a short explanation of what the driver does.
+	// +optional
+	Description string `json:"description,omitempty"`
+	// URL defines the location of the driver binary that will
+	// be downloaded when the driver is enabled. This can either be
+	// an absolute url to a remote resource, or a reference to localhost.
+	// +required
+	URL string `json:"url" norman:"required"`
+	// ExternalID is not currently used.
+	// +optional
+	ExternalID string `json:"externalId,omitempty"`
+	// Builtin specifies if a driver is built into Rancher via rancher-machine.
+	// +optional
+	Builtin bool `json:"builtin,omitempty"`
+	// Active specifies if the driver can be used to provision clusters.
+	// +required
+	Active bool `json:"active"`
+	// AddCloudCredential determines if an associated cloud credential
+	// dynamic schema should be created for this driver even if it is not
+	// enabled.
+	// +optional
+	AddCloudCredential bool `json:"addCloudCredential,omitempty"`
+	// Checksum is used to represent the expected content of the driver
+	// binary. When this value changes, the driver binary will be
+	// redownloaded from its URL.
+	// +kubebuilder:validation:Pattern="^$|^[a-fA-F0-9]{32,128}$"
+	// +kubebuilder:validation:MaxLength=128
+	// +optional
+	Checksum string `json:"checksum,omitempty"`
+	// UIURL is the url to load for a customized Add Nodes screen for this driver.
+	// +optional
+	UIURL string `json:"uiUrl,omitempty"`
+	// WhitelistDomains is a list of domains which will be automatically
+	// white-listed by Rancher to allow for the driver to be downloaded.
+	// +optional
+	WhitelistDomains []string `json:"whitelistDomains,omitempty"`
 }
 
 type PublicEndpoint struct {

--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -231,7 +231,7 @@ var MigratedResources = map[string]bool{
 	"managedcharts.management.cattle.io":                              false,
 	"monitormetrics.management.cattle.io":                             false,
 	"navlinks.ui.cattle.io":                                           false,
-	"nodedrivers.management.cattle.io":                                false,
+	"nodedrivers.management.cattle.io":                                true,
 	"nodepools.management.cattle.io":                                  false,
 	"nodes.management.cattle.io":                                      false,
 	"nodetemplates.management.cattle.io":                              false,

--- a/pkg/crds/yaml/generated/management.cattle.io_nodedrivers.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_nodedrivers.yaml
@@ -1,0 +1,198 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: nodedrivers.management.cattle.io
+spec:
+  group: management.cattle.io
+  names:
+    kind: NodeDriver
+    listKind: NodeDriverList
+    plural: nodedrivers
+    singular: nodedriver
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.active
+      name: Activated
+      type: string
+    - jsonPath: .spec.url
+      name: Binary URL
+      type: string
+    name: v3
+    schema:
+      openAPIV3Schema:
+        description: NodeDriver represents a Rancher node driver for a specific cloud
+          provider used to provision cluster nodes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the Node Driver. More info:
+              https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+            properties:
+              active:
+                description: Active specifies if the driver can be used to provision
+                  clusters.
+                type: boolean
+              addCloudCredential:
+                description: |-
+                  AddCloudCredential determines if an associated cloud credential
+                  dynamic schema should be created for this driver even if it is not
+                  enabled.
+                type: boolean
+              builtin:
+                description: Builtin specifies if a driver is built into Rancher via
+                  rancher-machine.
+                type: boolean
+              checksum:
+                description: |-
+                  Checksum is used to represent the expected content of the driver
+                  binary. When this value changes, the driver binary will be
+                  redownloaded from its URL.
+                maxLength: 128
+                pattern: ^$|^[a-fA-F0-9]{32,128}$
+                type: string
+              description:
+                description: Description provides a short explanation of what the
+                  driver does.
+                type: string
+              displayName:
+                description: DisplayName specifies the publicly visible name of the
+                  driver shown in the Rancher UI.
+                maxLength: 57
+                type: string
+              externalId:
+                description: ExternalID is not currently used.
+                type: string
+              uiUrl:
+                description: UIURL is the url to load for a customized Add Nodes screen
+                  for this driver.
+                type: string
+              url:
+                description: |-
+                  URL defines the location of the driver binary that will
+                  be downloaded when the driver is enabled. This can either be
+                  an absolute url to a remote resource, or a reference to localhost.
+                type: string
+              whitelistDomains:
+                description: |-
+                  WhitelistDomains is a list of domains which will be automatically
+                  white-listed by Rancher to allow for the driver to be downloaded.
+                items:
+                  type: string
+                type: array
+            required:
+            - active
+            - url
+            type: object
+            x-kubernetes-validations:
+            - message: Checksum must be an md5, sha1, sha256, or sha512 digest.
+              rule: '!has(self.checksum) || (self.checksum.size() in [0, 32, 40, 64,
+                128])'
+          status:
+            description: |-
+              Most recent observed status of the Node Driver. More info:
+              https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+            properties:
+              appliedChecksum:
+                description: |-
+                  AppliedChecksum is the last known checksum of the driver. This is used
+                  to determine when a Driver needs to be redownloaded from its URL.
+                type: string
+              appliedDockerMachineVersion:
+                description: |-
+                  AppliedDockerMachineVersion specifies the last docker machine version
+                  (a.k.a rancher-machine) which provides this driver. When this version
+                  is incremented, Rancher will query the rancher-machine driver to
+                  obtain its arguments and update the automatically generated schema
+                  and associated machine config object. This field is only specified for
+                  drivers bundled within Rancher via rancher-machine.
+                type: string
+              appliedURL:
+                description: AppliedURL is the url last used to download the driver.
+                type: string
+              conditions:
+                description: |-
+                  Conditions is a representation of the current state of the driver,
+                  this includes its installation status (Downloaded, Installed), as well
+                  as its current state (Active, Inactive). Information related to
+                  errors encountered while transitioning to one of these states will be
+                  populated in the Message and Reason fields.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from
+                        one status to another. This should be when the underlying condition
+                        changed. If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        lastUpdateTime of this condition. This is incremented if the resource
+                        is updated for any reason. This could be when the underlying condition
+                        changed, but may also be updated if other fields are modified
+                        (Message, Reason, etc.).
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details
+                        about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for
+                        the condition's last transition. Producers of specific condition types
+                        may define expected values and meanings for this field, and whether
+                        the values are considered a guaranteed API. The value should be
+                        a CamelCase string.
+                      maxLength: 1024
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}


### PR DESCRIPTION
## Problem: https://github.com/rancher/rancher/issues/49400

`kubectl explain` does not describe the various fields included in the Node Driver CRD. This makes it more difficult to work with the CRD directly from the CLI. 
 
## Solution

Add kube builder annotations to the struct and ensure each field has a useful description. I could not find a case where the `externalID` field was used within Rancher or the UI, so I marked that field as unused. If a reviewer knows if this field is still in use by Rancher, let me know and I will update the description accordingly. 
 
## Testing

After making these changes I confirmed I was able to provision a cluster via the Rancher UI. I also confirmed that changing various properties of an existing node driver (activating / deactivating, updating names and urls) via `kubectl` worked as expected and were properly reflected in the Rancher UI. 

`kubectl explain` now includes a short description of each field, and `kubectl get` shows if the driver is active and the URL the binary is downloaded from.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Existing / newly added automated tests that provide evidence there are no regressions:
