### PR TITLE
Ensure ext.Token namespace exists on Rancher start

### DIFF
--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -560,7 +560,7 @@ func TestRefreshAttributes(t *testing.T) {
 						return nil, nil
 					},
 				}),
-				extTokenStore: exttokens.NewSystem(nil, secrets, users, nil,
+				extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil,
 					exttokens.NewTimeHandler(),
 					exttokens.NewHashHandler(),
 					exttokens.NewAuthHandler()),

--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -760,7 +760,7 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 			return nil, nil
 		}).AnyTimes()
 
-	store := exttokenstore.NewSystem(nil, secrets, users, nil, nil, nil, nil)
+	store := exttokenstore.NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 
 	authenticator := tokenAuthenticator{
 		ctx:                 context.Background(),
@@ -859,7 +859,7 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 			AnyTimes()
 		newSecrets.EXPECT().Patch("cattle-tokens", token.Name, k8stypes.JSONPatchType, gomock.Any()).
 			Return(nil, fmt.Errorf("some error")).Times(1)
-		authenticator.extTokenStore = exttokenstore.NewSystem(nil, newSecrets, users, nil, nil, nil, nil)
+		authenticator.extTokenStore = exttokenstore.NewSystem(nil, nil, newSecrets, users, nil, nil, nil, nil)
 
 		tokenSecret.Data["last-used-at"] = []byte(now.
 			Add(-time.Second).
@@ -1006,7 +1006,7 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 			Get("cattle-tokens", token.Name).
 			Return(nil, apierrors.NewNotFound(schema.GroupResource{}, token.Name)).
 			Times(1)
-		authenticator.extTokenStore = exttokenstore.NewSystem(nil, newSecrets, users, nil, nil, nil, nil)
+		authenticator.extTokenStore = exttokenstore.NewSystem(nil, nil, newSecrets, users, nil, nil, nil, nil)
 
 		userRefresher.reset()
 
@@ -1028,7 +1028,7 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 			Get("cattle-tokens", token.Name).
 			Return(nil, fmt.Errorf("some error")).
 			Times(1)
-		authenticator.extTokenStore = exttokenstore.NewSystem(nil, newSecrets, users, nil, nil, nil, nil)
+		authenticator.extTokenStore = exttokenstore.NewSystem(nil, nil, newSecrets, users, nil, nil, nil, nil)
 
 		userRefresher.reset()
 

--- a/pkg/auth/requests/impersonate_test.go
+++ b/pkg/auth/requests/impersonate_test.go
@@ -165,7 +165,7 @@ func TestAuthenticateImpersonation(t *testing.T) {
 				secrets.EXPECT().Cache().Return(nil)
 				users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 				users.EXPECT().Cache().Return(nil)
-				store := exttokenstore.NewSystem(nil, secrets, users, cache, nil, nil, nil)
+				store := exttokenstore.NewSystem(nil, nil, secrets, users, cache, nil, nil, nil)
 				return store
 			},
 			wantUserInfo: &user.DefaultInfo{
@@ -237,7 +237,7 @@ func TestAuthenticateImpersonation(t *testing.T) {
 							exttokenstore.FieldUID:            []byte("2905498-kafld-lkad"),
 						},
 					}, nil)
-				store := exttokenstore.NewSystem(nil, secrets, users, cache, nil, nil, nil)
+				store := exttokenstore.NewSystem(nil, nil, secrets, users, cache, nil, nil, nil)
 				return store
 			},
 			wantUserInfo: &user.DefaultInfo{
@@ -380,7 +380,7 @@ func TestAuthenticateImpersonation(t *testing.T) {
 				users.EXPECT().Cache().Return(nil)
 				secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
 				secrets.EXPECT().Cache().Return(nil)
-				store := exttokenstore.NewSystem(nil, secrets, users, cache, nil, nil, nil)
+				store := exttokenstore.NewSystem(nil, nil, secrets, users, cache, nil, nil, nil)
 				return store
 			},
 			wantErr: "request token user does not match impersonation user",
@@ -441,7 +441,7 @@ func TestAuthenticateImpersonation(t *testing.T) {
 					}, nil)
 				users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 				users.EXPECT().Cache().Return(nil)
-				store := exttokenstore.NewSystem(nil, secrets, users, cache, nil, nil, nil)
+				store := exttokenstore.NewSystem(nil, nil, secrets, users, cache, nil, nil, nil)
 				return store
 			},
 			wantErr: "request token user does not match impersonation user",
@@ -477,7 +477,7 @@ func TestAuthenticateImpersonation(t *testing.T) {
 				users.EXPECT().Cache().Return(nil)
 				secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
 				secrets.EXPECT().Cache().Return(nil)
-				store := exttokenstore.NewSystem(nil, secrets, users, cache, nil, nil, nil)
+				store := exttokenstore.NewSystem(nil, nil, secrets, users, cache, nil, nil, nil)
 				return store
 			},
 			wantErr: "multiple requesttokenid values",
@@ -610,7 +610,7 @@ func TestAuthenticateImpersonation(t *testing.T) {
 				scache.EXPECT().
 					Get("cattle-tokens", "kubeconfig-u-user5zfww").
 					Return(nil, errors.New("unexpected error"))
-				store := exttokenstore.NewSystem(nil, secrets, users, cache, nil, nil, nil)
+				store := exttokenstore.NewSystem(nil, nil, secrets, users, cache, nil, nil, nil)
 				return store
 			},
 			wantErr: "error getting request token",

--- a/pkg/controllers/management/auth/user_test.go
+++ b/pkg/controllers/management/auth/user_test.go
@@ -389,7 +389,7 @@ func TestUpdated(t *testing.T) {
 
 			timer := exttokens.NewMocktimeHandler(ctrl)
 
-			store := exttokens.NewSystem(nil, secrets, users, nil, timer, nil, nil)
+			store := exttokens.NewSystem(nil, nil, secrets, users, nil, timer, nil, nil)
 			ul.extTokenStore = store
 
 			tt.mockSetup(secrets, scache, timer)

--- a/pkg/ext/stores/install.go
+++ b/pkg/ext/stores/install.go
@@ -32,12 +32,16 @@ func InstallStores(
 	}
 	logrus.Infof("Successfully installed useractivity store")
 
-	err = server.Install(
+	tokenStore := tokens.NewFromWrangler(wranglerContext, server.GetAuthorizer())
+	if err := tokenStore.EnsureNamespace(); err != nil {
+		return fmt.Errorf("error ensuring token namespace: %w", err)
+	}
+
+	if err := server.Install(
 		tokens.PluralName,
 		tokens.GVK,
-		tokens.NewFromWrangler(wranglerContext, server.GetAuthorizer()),
-	)
-	if err != nil {
+		tokenStore,
+	); err != nil {
 		return fmt.Errorf("unable to install %s store: %w", tokens.SingularName, err)
 	}
 	logrus.Infof("Successfully installed token store")

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -214,6 +214,41 @@ func Test_ttlGreater(t *testing.T) {
 	}
 }
 
+func Test_Store_New(t *testing.T) {
+	t.Parallel()
+
+	store := &Store{}
+	obj := store.New()
+	require.NotNil(t, obj)
+	assert.IsType(t, &ext.Token{}, obj)
+}
+
+func Test_Store_NewList(t *testing.T) {
+	store := &Store{}
+	obj := store.NewList()
+	require.NotNil(t, obj)
+	require.IsType(t, &ext.TokenList{}, obj)
+
+	list := obj.(*ext.TokenList)
+	assert.Nil(t, list.Items)
+}
+
+func Test_Store_GetSingularName(t *testing.T) {
+	store := &Store{}
+	assert.Equal(t, SingularName, store.GetSingularName())
+}
+
+func Test_Store_NamespaceScoped(t *testing.T) {
+	store := &Store{}
+	assert.False(t, store.NamespaceScoped())
+}
+
+func Test_Store_GroupVersionKind(t *testing.T) {
+	store := &Store{}
+	assert.Equal(t, GVK, store.GroupVersionKind(ext.SchemeGroupVersion))
+}
+
+
 func Test_Store_Delete(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Delete
 	// Here we test the actions and checks done before delegation to the

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -234,7 +234,7 @@ func Test_Store_Delete(t *testing.T) {
 			Get("cattle-tokens", "bogus").
 			Return(nil, someerror)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		_, ok, err := store.Delete(context.TODO(), "bogus", nil, &metav1.DeleteOptions{})
 
 		assert.False(t, ok)
@@ -258,7 +258,7 @@ func Test_Store_Delete(t *testing.T) {
 			Get("cattle-tokens", "bogus").
 			Return(nil, apierrors.NewNotFound(GVR.GroupResource(), "bogus"))
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		_, ok, err := store.Delete(context.TODO(), "bogus", nil, &metav1.DeleteOptions{})
 
 		assert.False(t, ok)
@@ -276,7 +276,7 @@ func Test_Store_Delete(t *testing.T) {
 			Return(&mockUser{name: ""}, false, false, apierrors.NewInternalError(invalidContext))
 		secrets.EXPECT().Cache().Return(nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		_, ok, err := store.Delete(context.TODO(), "bogus", nil, &metav1.DeleteOptions{})
 
 		assert.False(t, ok)
@@ -299,7 +299,7 @@ func Test_Store_Delete(t *testing.T) {
 			Get("cattle-tokens", "bogus").
 			Return(&properSecret, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		_, ok, err := store.Delete(context.TODO(), "bogus", nil, &metav1.DeleteOptions{})
 
 		assert.False(t, ok)
@@ -325,7 +325,7 @@ func Test_Store_Delete(t *testing.T) {
 			Delete("cattle-tokens", "bogus", gomock.Any()).
 			Return(nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		_, ok, err := store.Delete(context.TODO(), "bogus", nil, &metav1.DeleteOptions{})
 
 		assert.True(t, ok)
@@ -353,7 +353,7 @@ func Test_Store_Get(t *testing.T) {
 			Get("cattle-tokens", "bogus").
 			Return(&properSecret, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		tok, err := store.Get(context.TODO(), "bogus", &metav1.GetOptions{})
 
 		assert.Equal(t, bogusNotFoundError, err)
@@ -376,7 +376,7 @@ func Test_Store_Get(t *testing.T) {
 			Get("cattle-tokens", "bogus").
 			Return(&properSecret, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		tok, err := store.Get(context.TODO(), "bogus", &metav1.GetOptions{})
 
 		assert.Nil(t, err)
@@ -399,7 +399,7 @@ func Test_Store_Get(t *testing.T) {
 			Get("cattle-tokens", "bogus").
 			Return(&properSecret, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		tok, err := store.Get(context.TODO(), "bogus", &metav1.GetOptions{})
 
 		assert.Nil(t, err)
@@ -430,7 +430,7 @@ func Test_Store_Watch(t *testing.T) {
 		todo, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(todo, &metav1.ListOptions{})
 		assert.Error(t, err)
 		assert.Nil(t, consumer)
@@ -453,7 +453,7 @@ func Test_Store_Watch(t *testing.T) {
 
 		todo, cancel := context.WithCancel(context.TODO())
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(todo, &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -486,7 +486,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -519,7 +519,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -552,7 +552,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -587,7 +587,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdl/ksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -620,7 +620,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -658,7 +658,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -696,7 +696,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -729,7 +729,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -762,7 +762,7 @@ func Test_Store_Watch(t *testing.T) {
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
-		store := New(nil, nil, secrets, users, nil, nil, nil, auth)
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		consumer, err := store.watch(context.TODO(), &metav1.ListOptions{})
 		assert.Nil(t, err)
 
@@ -824,28 +824,6 @@ func Test_Store_Create(t *testing.T) {
 					Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 			},
 		},
-		{
-			name: "namespace creation error",
-			err:  someerror,
-			tok:  &ext.Token{},
-			opts: &metav1.CreateOptions{},
-			storeSetup: func( // configure store backend clients
-				space *fake.MockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList],
-				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
-				scache *fake.MockCacheInterface[*corev1.Secret],
-				users *fake.MockNonNamespacedCacheInterface[*v3.User],
-				token *fake.MockNonNamespacedCacheInterface[*v3.Token],
-				timer *MocktimeHandler,
-				hasher *MockhashHandler,
-				auth *MockauthHandler) {
-
-				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&mockUser{name: "world"}, false, true, nil)
-
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, someerror)
-			},
-		},
 		// token generation and hash errors -- no mocking -- unable to induce and test
 		{
 			name: "user retrieval error",
@@ -868,9 +846,6 @@ func Test_Store_Create(t *testing.T) {
 
 				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mockUser{name: "world"}, false, true, nil)
-
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
 
 				users.EXPECT().Get("world").
 					Return(nil, someerror)
@@ -897,9 +872,6 @@ func Test_Store_Create(t *testing.T) {
 
 				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&mockUser{name: "world"}, false, true, nil)
-
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
 
 				users.EXPECT().Get("world").
 					Return(&v3.User{
@@ -937,9 +909,6 @@ func Test_Store_Create(t *testing.T) {
 				scache.EXPECT().Get("cattle-tokens", "session-token").
 					Return(nil, someerror)
 
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
-
 				users.EXPECT().Get("world").
 					Return(enabledUser, nil)
 			},
@@ -974,9 +943,6 @@ func Test_Store_Create(t *testing.T) {
 					UserPrincipal: v3.Principal{
 						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
 					}}, nil)
-
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
 
 				users.EXPECT().Get("world").
 					Return(enabledUser, nil)
@@ -1015,9 +981,6 @@ func Test_Store_Create(t *testing.T) {
 					UserPrincipal: v3.Principal{
 						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
 					}}, nil)
-
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
 
 				users.EXPECT().Get("world").
 					Return(&v3.User{
@@ -1067,9 +1030,6 @@ func Test_Store_Create(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
 					}}, nil)
 
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
-
 				users.EXPECT().Get("world").
 					Return(&v3.User{
 						DisplayName: "worldwide",
@@ -1117,9 +1077,6 @@ func Test_Store_Create(t *testing.T) {
 					UserPrincipal: v3.Principal{
 						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
 					}}, nil)
-
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
 
 				users.EXPECT().Get("world").
 					Return(&v3.User{
@@ -1177,9 +1134,6 @@ func Test_Store_Create(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
 					}}, nil)
 
-				space.EXPECT().Create(gomock.Any()).
-					Return(nil, nil)
-
 				users.EXPECT().Get("world").
 					Return(&v3.User{
 						DisplayName: "worldwide",
@@ -1212,7 +1166,6 @@ func Test_Store_Create(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			// assemble and configure a store from mock clients ...
-			space := fake.NewMockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList](ctrl)
 			scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
 			ucache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
 			tcache := fake.NewMockNonNamespacedCacheInterface[*v3.Token](ctrl)
@@ -1226,8 +1179,8 @@ func Test_Store_Create(t *testing.T) {
 			secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
 			secrets.EXPECT().Cache().Return(scache)
 
-			store := New(nil, space, secrets, users, tcache, timer, hasher, auth)
-			test.storeSetup(space, secrets, scache, ucache, tcache, timer, hasher, auth)
+			store := New(nil, nil, nil, secrets, users, tcache, timer, hasher, auth)
+			test.storeSetup(nil, secrets, scache, ucache, tcache, timer, hasher, auth)
 
 			// perform test and validate results
 			tok, err := store.create(context.TODO(), test.tok, test.opts)
@@ -1386,7 +1339,7 @@ func Test_SystemStore_List(t *testing.T) {
 			users.EXPECT().Cache().Return(nil)
 			secrets.EXPECT().Cache().Return(nil)
 
-			store := NewSystem(nil, secrets, users, nil, nil, nil, nil)
+			store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 			test.storeSetup(secrets)
 
 			// perform test and validate results
@@ -1458,7 +1411,7 @@ func Test_SystemStore_Delete(t *testing.T) {
 			users.EXPECT().Cache().Return(nil)
 			secrets.EXPECT().Cache().Return(nil)
 
-			store := NewSystem(nil, secrets, users, nil, nil, nil, nil)
+			store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 			test.storeSetup(secrets)
 
 			// perform test and validate results
@@ -1483,7 +1436,7 @@ func Test_SystemStore_UpdateLastUsedAt(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		store := NewSystem(nil, secrets, users, nil, nil, nil, nil)
+		store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 
 		var patchData []byte
 		secrets.EXPECT().Patch("cattle-tokens", "atoken", types.JSONPatchType, gomock.Any()).
@@ -1513,7 +1466,7 @@ func Test_SystemStore_UpdateLastUsedAt(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		store := NewSystem(nil, secrets, users, nil, nil, nil, nil)
+		store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 
 		secrets.EXPECT().Patch("cattle-tokens", "atoken", types.JSONPatchType, gomock.Any()).
 			Return(nil, fmt.Errorf("some error")).
@@ -1536,7 +1489,7 @@ func Test_SystemStore_UpdateLastActivitySeen(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		store := NewSystem(nil, secrets, users, nil, nil, nil, nil)
+		store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 
 		var patchData []byte
 		secrets.EXPECT().Patch("cattle-tokens", "atoken", types.JSONPatchType, gomock.Any()).
@@ -1566,7 +1519,7 @@ func Test_SystemStore_UpdateLastActivitySeen(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
 
-		store := NewSystem(nil, secrets, users, nil, nil, nil, nil)
+		store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 
 		secrets.EXPECT().Patch("cattle-tokens", "atoken", types.JSONPatchType, gomock.Any()).
 			Return(nil, fmt.Errorf("some error")).
@@ -1859,7 +1812,7 @@ func Test_SystemStore_Update(t *testing.T) {
 			hasher := NewMockhashHandler(ctrl)
 			auth := NewMockauthHandler(ctrl)
 
-			store := NewSystem(nil, secrets, users, nil, timer, hasher, auth)
+			store := NewSystem(nil, nil, secrets, users, nil, timer, hasher, auth)
 			if test.storeSetup != nil {
 				test.storeSetup(secrets, scache, timer, hasher, auth)
 			}
@@ -2095,7 +2048,7 @@ func Test_SystemStore_Get(t *testing.T) {
 			users.EXPECT().Cache().Return(nil)
 			secrets.EXPECT().Cache().Return(scache)
 
-			store := NewSystem(nil, secrets, users, nil, nil, nil, nil)
+			store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil)
 			test.storeSetup(scache)
 
 			// perform test and validate results

--- a/pkg/ext/stores/useractivity/store_test.go
+++ b/pkg/ext/stores/useractivity/store_test.go
@@ -328,9 +328,11 @@ func TestStoreCreate(t *testing.T) {
 			secrets = wranglerfake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
 			scache = wranglerfake.NewMockCacheInterface[*corev1.Secret](ctrl)
 			users = wranglerfake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+
 			users.EXPECT().Cache().Return(nil)
 			secrets.EXPECT().Cache().Return(scache)
-			store = exttokenstore.NewSystem(nil, secrets, users, mockTokenCacheFake, nil, nil, nil)
+
+			store = exttokenstore.NewSystem(nil, nil, secrets, users, mockTokenCacheFake, nil, nil, nil)
 
 			uas := &Store{
 				tokens:        mockTokenControllerFake,
@@ -531,10 +533,10 @@ func TestStoreGet(t *testing.T) {
 		secrets = wranglerfake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
 		scache = wranglerfake.NewMockCacheInterface[*corev1.Secret](ctrl)
 		users = wranglerfake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
-
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
-		store = exttokenstore.NewSystem(nil, secrets, users, mockTokenCacheFake, nil, nil, nil)
+
+		store = exttokenstore.NewSystem(nil, nil, secrets, users, mockTokenCacheFake, nil, nil, nil)
 
 		uas := &Store{
 			tokens:        mockTokenControllerFake,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
 
## Problem

kubeconfig and token stores used different places and methods in the code to initialize the namespace for their backing store.
 
## Solution

Reworked token store to match kubeconfig. Updated unit tests. Added unrelated unit tests.
 
## Testing
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_