### PR TITLE
Use text/template for generating kubeconfigs

### DIFF
--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -403,7 +403,9 @@ func TestStoreCreate(t *testing.T) {
 			require.Equal(t, namePrefix, obj.GenerateName)
 
 			configMap = obj.DeepCopy()
-			configMap.CreationTimestamp = metav1.Now()
+			loc, err := time.LoadLocation("Europe/London") // This is to ensure we don't use html encoding e.g. "+01:00" -> "&#43;01:00"
+			require.NoError(t, err)
+			configMap.CreationTimestamp = metav1.NewTime(time.Now().In(loc))
 			configMap.Name = names.SimpleNameGenerator.GenerateName(configMap.GenerateName)
 			return configMap, nil
 		}).Times(1)

--- a/pkg/kubeconfig/templates.go
+++ b/pkg/kubeconfig/templates.go
@@ -1,6 +1,6 @@
 package kubeconfig
 
-import "html/template"
+import "text/template"
 
 const (
 	tokenTemplateText = `apiVersion: v1


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/50684
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The pkg/kubeconfig historically uses html/template for generating kubeconfigs.
The new Imperative Kubeconfig API outputs Kubeconfig metadata as comments including the creationTimestamp. If the timezone is `+XX:YY` (e.g. `Europe/Berlin`) the `+` is html-encoded.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Use `text/template` instead.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A