### PR TITLE
(backport of #50482) fix: add create secrets permissions in fleet-default namespace

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -41,20 +41,22 @@ var (
 func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) (string, error) {
 	rb := newRoleBuilder()
 
-	rb.addRole("Create Clusters", "clusters-create").
-		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
+	clusterCreateRole := rb.addRole("Create Clusters", "clusters-create")
+	clusterCreateRole.addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("*").
-		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("cisconfigs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("cisbenchmarkversions").verbs("get", "list", "watch").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
 		addRule().apiGroups("rke.cattle.io").resources("etcdsnapshots").verbs("get", "list", "watch")
+
+	clusterCreateRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create").
+		addNamespacedRule("fleet-default").addRule().apiGroups("").resources("secrets").verbs("create")
 
 	rb.addRole("Manage Node Drivers", "nodedrivers-manage").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("*")
@@ -115,6 +117,9 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	userRole.
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("get", "list", "watch")
+
+	userRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create").
+		addNamespacedRule("fleet-default").addRule().apiGroups("").resources("secrets").verbs("create")
 
 	userRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create")
 

--- a/pkg/data/management/rolebuilder.go
+++ b/pkg/data/management/rolebuilder.go
@@ -98,6 +98,10 @@ func (rb *roleBuilder) addNamespacedRule(namespace string) *namespacedRuleBuilde
 	return n
 }
 
+func (r *ruleBuilder) addNamespacedRule(namespace string) *namespacedRuleBuilder {
+	return r.rb.addNamespacedRule(namespace)
+}
+
 func (rb *roleBuilder) setRoleTemplateNames(names ...string) *roleBuilder {
 	rb.roleTemplateNames = names
 	return rb


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50528
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Backport of https://github.com/rancher/rancher/pull/50482 to `release/v2.9`
Differently from https://github.com/rancher/rancher/pull/50482, I removed permissions for `ext.cattle.io` (`useractivities` and `tokens`) which were not present on this release.