### PR TITLE
Add feature flag that enables ext Kubeconfigs

### DIFF
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -176,6 +176,12 @@ var (
 		isPrime(),
 		false,
 		true)
+	ExtKubeconfigs = newFeature(
+		"ext-kubeconfigs",
+		"Enable Imperative API resource kubeconfigs.ext.cattle.io.",
+		true,
+		false,
+		true)
 )
 
 type Feature struct {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/50683
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Given that Imperative API is in its infancy we'd like to have a feature flag (for one or two minor versions of Rancher) that can be used to disable Kubeconfigs resource store in case we encounter issues with it.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add feature flag that enables Imperative Kubeconfigs resource store.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A