### PR TITLE
Add feature flag that enables ext Tokens

### DIFF
--- a/pkg/ext/stores/install.go
+++ b/pkg/ext/stores/install.go
@@ -33,19 +33,23 @@ func InstallStores(
 	}
 	logrus.Infof("Successfully installed useractivity store")
 
-	tokenStore := tokens.NewFromWrangler(wranglerContext, server.GetAuthorizer())
-	if err := tokenStore.EnsureNamespace(); err != nil {
-		return fmt.Errorf("error ensuring token namespace: %w", err)
-	}
+	if features.ExtTokens.Enabled() {
+		tokenStore := tokens.NewFromWrangler(wranglerContext, server.GetAuthorizer())
+		if err := tokenStore.EnsureNamespace(); err != nil {
+			return fmt.Errorf("error ensuring token namespace: %w", err)
+		}
 
-	if err := server.Install(
-		tokens.PluralName,
-		tokens.GVK,
-		tokenStore,
-	); err != nil {
-		return fmt.Errorf("unable to install %s store: %w", tokens.SingularName, err)
+		if err := server.Install(
+			tokens.PluralName,
+			tokens.GVK,
+			tokenStore,
+		); err != nil {
+			return fmt.Errorf("unable to install %s store: %w", tokens.SingularName, err)
+		}
+		logrus.Infof("Successfully installed token store")
+	} else {
+		logrus.Infof("Feature ext-tokens is disabled")
 	}
-	logrus.Infof("Successfully installed token store")
 
 	if features.ExtKubeconfigs.Enabled() {
 		userManager, err := common.NewUserManagerNoBindings(wranglerContext)

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -182,6 +182,12 @@ var (
 		true,
 		false,
 		true)
+	ExtTokens = newFeature(
+		"ext-tokens",
+		"Enable Imperative API resource tokens.ext.cattle.io.",
+		true,
+		false,
+		true)
 )
 
 type Feature struct {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Given that Imperative API is in its infancy we'd like to have a feature flag (for one or two minor versions of Rancher) that can be used to disable Tokens resource store in case we encounter issues with it.
 
## Solution
Add feature flag that enables Imperative Kubeconfigs resource store.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_