### PR TITLE
Migrate project scoped secret controllers

### DIFF
--- a/pkg/controllers/managementuser/secret/project_scoped_secrets.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"slices"
 	"strings"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -32,22 +34,29 @@ const (
 	projectScopedSecretLabel = "management.cattle.io/project-scoped-secret"
 	pssCopyAnnotation        = "management.cattle.io/project-scoped-secret-copy"
 )
+const (
+	normanLabel      = "cattle.io/creator"
+	oldPSSAnnotation = "lifecycle.cattle.io/create.secretsController_"
+	oldPSSFinalizer  = "clusterscoped.controller.cattle.io/secretsController_"
+)
 
 type namespaceHandler struct {
-	managementSecretCache wcorev1.SecretCache
-	clusterNamespaceCache wcorev1.NamespaceCache
-	projectCache          mgmtv3.ProjectCache
-	secretClient          wcorev1.SecretClient
-	clusterName           string
+	managementSecretCache  wcorev1.SecretCache
+	managementSecretClient wcorev1.SecretClient
+	clusterNamespaceCache  wcorev1.NamespaceCache
+	projectCache           mgmtv3.ProjectCache
+	secretClient           wcorev1.SecretClient
+	clusterName            string
 }
 
 func RegisterProjectScopedSecretHandler(ctx context.Context, cluster *config.UserContext) {
 	n := &namespaceHandler{
-		secretClient:          cluster.Corew.Secret(),
-		managementSecretCache: cluster.Management.Wrangler.Core.Secret().Cache(),
-		projectCache:          cluster.Management.Wrangler.Mgmt.Project().Cache(),
-		clusterNamespaceCache: cluster.Corew.Namespace().Cache(),
-		clusterName:           cluster.ClusterName,
+		secretClient:           cluster.Corew.Secret(),
+		managementSecretCache:  cluster.Management.Wrangler.Core.Secret().Cache(),
+		managementSecretClient: cluster.Management.Wrangler.Core.Secret(),
+		projectCache:           cluster.Management.Wrangler.Mgmt.Project().Cache(),
+		clusterNamespaceCache:  cluster.Corew.Namespace().Cache(),
+		clusterName:            cluster.ClusterName,
 	}
 	cluster.Corew.Namespace().OnChange(ctx, namespaceChangeHandler, n.OnChange)
 	relatedresource.WatchClusterScoped(ctx, namespaceEnqueuerName, n.secretEnqueueNamespace, cluster.Corew.Namespace(), cluster.Management.Wrangler.Core.Secret())
@@ -58,7 +67,20 @@ func (n *namespaceHandler) OnChange(_ string, namespace *corev1.Namespace) (*cor
 		return nil, nil
 	}
 
-	secrets, err := n.getProjectScopedSecretsFromNamespace(namespace)
+	project, err := n.getProjectFromNamespace(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("error getting project for namespace %s: %w", namespace.Name, err)
+	}
+	if project == nil {
+		return nil, nil
+	}
+
+	// migrate existing project scoped secrets
+	if err := n.migrateExistingProjectScopedSecrets(project); err != nil {
+		return nil, err
+	}
+
+	secrets, err := n.getProjectScopedSecretsFromNamespace(project)
 	if err != nil {
 		return nil, err
 	}
@@ -81,28 +103,49 @@ func (n *namespaceHandler) OnChange(_ string, namespace *corev1.Namespace) (*cor
 	return namespace, n.removeUndesiredProjectScopedSecrets(namespace, desiredSecrets)
 }
 
-// getProjectScopedSecretsFromNamespace gets all project scoped secret from a project namespace.
-func (n *namespaceHandler) getProjectScopedSecretsFromNamespace(namespace *corev1.Namespace) ([]*corev1.Secret, error) {
-	// check if namespace is part of a project
-	projectID, ok := namespace.Annotations[projectIDLabel]
-	if !ok {
-		return nil, nil
-	}
+// migrateExistingProjectScopedSecrets migrates existing project scoped secrets.
+// It removes the following:
+//   - Finalizer "clusterscoped.controller.cattle.io/secretsController_<clusterID>"
+//   - Annotation "lifecycle.cattle.io/create.secretsController_<clusterID>"
+//   - Label "rancher.io/creator"
+//
+// And adds:
+//   - Label "management.cattle.io/project-scoped-secret"
+func (n *namespaceHandler) migrateExistingProjectScopedSecrets(project *v3.Project) error {
+	backingNamespace := project.GetProjectBackingNamespace()
+	clusterName := project.Spec.ClusterName
 
-	clusterName, projectName, found := strings.Cut(projectID, ":")
-	if !found {
-		logrus.Debugf("Namespace %s projectId annotation %s is malformed, should be <cluster name>:<project name>", namespace.Name, namespace.Annotations[projectIDLabel])
-		return nil, nil
-	}
-
-	p, err := n.projectCache.Get(clusterName, projectName)
+	r, err := labels.NewRequirement(normanLabel, selection.Equals, []string{"norman"})
 	if err != nil {
-		return nil, fmt.Errorf("error getting project %s for namespace %s: %w", projectName, namespace.Name, err)
+		return err
+	}
+	secrets, err := n.managementSecretCache.List(backingNamespace, labels.NewSelector().Add(*r))
+	if err != nil {
+		return err
 	}
 
-	backingNamespace := p.GetProjectBackingNamespace()
+	// Remove the norman creator label, secret lifecycle annotation and secret lifecycle finalizer.
+	// The controllers handling those were removed in v2.12 https://github.com/rancher/rancher/pull/49995
+	var errs error
+	for _, s := range secrets {
+		delete(s.Labels, normanLabel)
+		delete(s.Annotations, oldPSSAnnotation+clusterName)
+		if i := slices.Index(s.Finalizers, oldPSSFinalizer+clusterName); i >= 0 {
+			s.Finalizers = slices.Delete(s.Finalizers, i, i+1)
+		}
+		s.Labels[projectScopedSecretLabel] = project.Name
+		_, err := n.managementSecretClient.Update(s)
+		errors.Join(errs, err)
+	}
 
-	r, err := labels.NewRequirement(projectScopedSecretLabel, selection.Equals, []string{projectName})
+	return errs
+}
+
+// getProjectScopedSecretsFromNamespace gets all project scoped secret from a project namespace.
+func (n *namespaceHandler) getProjectScopedSecretsFromNamespace(project *v3.Project) ([]*corev1.Secret, error) {
+	backingNamespace := project.GetProjectBackingNamespace()
+
+	r, err := labels.NewRequirement(projectScopedSecretLabel, selection.Equals, []string{project.Name})
 	if err != nil {
 		return nil, err
 	}
@@ -136,6 +179,22 @@ func (n *namespaceHandler) removeUndesiredProjectScopedSecrets(namespace *corev1
 		errs = errors.Join(errs, n.secretClient.Delete(namespace.Name, secret.Name, &metav1.DeleteOptions{}))
 	}
 	return errs
+}
+
+// getProjectFromNamespace returns the project that a namespace belongs to, if it belongs to one.
+func (n *namespaceHandler) getProjectFromNamespace(namespace *corev1.Namespace) (*v3.Project, error) {
+	// check if namespace is part of a project
+	projectID, ok := namespace.Annotations[projectIDLabel]
+	if !ok {
+		return nil, nil
+	}
+	clusterName, projectName, found := strings.Cut(projectID, ":")
+	if !found {
+		logrus.Debugf("Namespace %s projectId annotation %s is malformed, should be <cluster name>:<project name>", namespace.Name, namespace.Annotations[projectIDLabel])
+		return nil, nil
+	}
+
+	return n.projectCache.Get(clusterName, projectName)
 }
 
 // secretEnqueueNamespace enqueues all the project namespaces of a project scoped secret.

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets_test.go
@@ -11,7 +11,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -189,11 +191,89 @@ func Test_namespaceHandler_getNamespacesFromSecret(t *testing.T) {
 
 func Test_namespaceHandler_getProjectScopedSecretsFromNamespace(t *testing.T) {
 	tests := []struct {
+		name                 string
+		project              *v3.Project
+		setupManagementCache func(*fake.MockCacheInterface[*corev1.Secret])
+		wantSecrets          []*corev1.Secret
+		wantErr              bool
+	}{
+		{
+			name: "successfully retrieve project scoped secrets",
+			project: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: "p-test"},
+				Status:     v3.ProjectStatus{BackingNamespace: "c-abc123-p-test"},
+			},
+			setupManagementCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				expectedSelector, _ := labels.NewRequirement(projectScopedSecretLabel, selection.Equals, []string{"p-test"})
+				f.EXPECT().List("c-abc123-p-test", labels.NewSelector().Add(*expectedSelector)).Return([]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "c-abc123-p-test"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "c-abc123-p-test"}},
+				}, nil)
+			},
+			wantSecrets: []*corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "c-abc123-p-test"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: "c-abc123-p-test"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no secrets found",
+			project: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: "p-test"},
+				Status:     v3.ProjectStatus{BackingNamespace: "c-abc123-p-test"},
+			},
+			setupManagementCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				expectedSelector, _ := labels.NewRequirement(projectScopedSecretLabel, selection.Equals, []string{"p-test"})
+				f.EXPECT().List("c-abc123-p-test", labels.NewSelector().Add(*expectedSelector)).Return([]*corev1.Secret{}, nil)
+			},
+			wantSecrets: []*corev1.Secret{},
+			wantErr:     false,
+		},
+		{
+			name: "error listing secrets from cache",
+			project: &v3.Project{
+				ObjectMeta: metav1.ObjectMeta{Name: "p-test"},
+				Status:     v3.ProjectStatus{BackingNamespace: "c-abc123-p-test"},
+			},
+			setupManagementCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				expectedSelector, _ := labels.NewRequirement(projectScopedSecretLabel, selection.Equals, []string{"p-test"})
+				f.EXPECT().List("c-abc123-p-test", labels.NewSelector().Add(*expectedSelector)).Return(nil, errDefault)
+			},
+			wantSecrets: nil,
+			wantErr:     true,
+		},
+	}
+	ctrl := gomock.NewController(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			managementSecretCacheMock := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			if tt.setupManagementCache != nil {
+				tt.setupManagementCache(managementSecretCacheMock)
+			}
+
+			n := &namespaceHandler{
+				managementSecretCache: managementSecretCacheMock,
+			}
+
+			gotSecrets, err := n.getProjectScopedSecretsFromNamespace(tt.project)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("namespaceHandler.getProjectScopedSecretsFromNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotSecrets, tt.wantSecrets) {
+				t.Errorf("namespaceHandler.getProjectScopedSecretsFromNamespace() gotSecrets = %v, want %v", gotSecrets, tt.wantSecrets)
+			}
+		})
+	}
+}
+
+func Test_namespaceHandler_getProjectFromNamespace(t *testing.T) {
+	tests := []struct {
 		name              string
 		namespace         *corev1.Namespace
 		setupProjectCache func(*fake.MockCacheInterface[*v3.Project])
-		setupSecretCache  func(*fake.MockCacheInterface[*corev1.Secret])
-		want              []*corev1.Secret
+		want              *v3.Project
 		wantErr           bool
 	}{
 		{
@@ -234,7 +314,7 @@ func Test_namespaceHandler_getProjectScopedSecretsFromNamespace(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "error listing secrets",
+			name: "get a project",
 			namespace: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -249,34 +329,11 @@ func Test_namespaceHandler_getProjectScopedSecretsFromNamespace(t *testing.T) {
 					},
 				}, nil)
 			},
-			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
-				f.EXPECT().List("c-abc123-p-abc123", gomock.Any()).Return(nil, errDefault)
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "get list of secrets",
-			namespace: &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						projectIDLabel: "c-abc123:p-abc123",
-					},
+			want: &v3.Project{
+				Status: v3.ProjectStatus{
+					BackingNamespace: "c-abc123-p-abc123",
 				},
 			},
-			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
-				f.EXPECT().Get("c-abc123", "p-abc123").Return(&v3.Project{
-					Status: v3.ProjectStatus{
-						BackingNamespace: "c-abc123-p-abc123",
-					},
-				}, nil)
-			},
-			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
-				f.EXPECT().List("c-abc123-p-abc123", gomock.Any()).Return([]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "secret"}},
-				}, nil)
-			},
-			want: []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "secret"}}},
 		},
 	}
 	ctrl := gomock.NewController(t)
@@ -286,15 +343,10 @@ func Test_namespaceHandler_getProjectScopedSecretsFromNamespace(t *testing.T) {
 			if tt.setupProjectCache != nil {
 				tt.setupProjectCache(projectCache)
 			}
-			secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
-			if tt.setupSecretCache != nil {
-				tt.setupSecretCache(secretCache)
-			}
 			n := &namespaceHandler{
-				managementSecretCache: secretCache,
-				projectCache:          projectCache,
+				projectCache: projectCache,
 			}
-			got, err := n.getProjectScopedSecretsFromNamespace(tt.namespace)
+			got, err := n.getProjectFromNamespace(tt.namespace)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("namespaceHandler.getProjectScopedSecretsFromNamespace() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50756
 
## Problem
The original intention was to use a new migration framework to convert existing project scoped secrets to use the new label. Due to time constraints, the migration framework was not implemented for v2.12 release. So we need to introduce a different migration mechanic for those existing secrets.
 
## Solution
Add a new step to the controller that removes a label, finalizer, and annotation from the old controllers and adds a label used by the new controllers.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_