### PR TITLE
[v2.12] Bump csp-adapter version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 webhookVersion: 107.0.0+up0.8.0-rc.8
 remoteDialerProxyVersion: 106.0.0+up0.4.4
 provisioningCAPIVersion: 107.0.0+up0.8.0
-cspAdapterMinVersion: 106.0.0+up6.0.0-rc1
+cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
 defaultShellVersion: rancher/shell:v0.5.0-rc.4
 fleetVersion: 107.0.0+up0.13.0-alpha.7

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion     = "106.0.0+up6.0.0-rc1"
+	CspAdapterMinVersion     = "107.0.0+up7.0.0-rc.1"
 	DefaultShellVersion      = "rancher/shell:v0.5.0-rc.4"
 	FleetVersion             = "107.0.0+up0.13.0-alpha.7"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"


### PR DESCRIPTION
##Issue: 
rancher/rancher#48796

##Problem:
Create new rancher-csp-adapter chart for 2.12 rancher

##Testing:

scenario 1 (fresh install):

    On an EKS cluster (k8s version 1.33), install locally built rancher with cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.

scenario 2 (upgrade scenario):

    Start with an EKS cluster (k8s version 1.32), install rancher 2.11.2 with csp-adapter 6.0.0
    Upgrade rancher to locally built rancher with cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
    Update charts url repo/branch and upgrade csp-adapter version to 107.0.0+up7.0.0-rc.1
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.