### PR TITLE
Bump Rancher CLI to v2.12.0-rc.1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -247,7 +247,7 @@ RUN mkdir -p /var/lib/rancher/k3s/agent/images/ && \
 
 ENV CATTLE_UI_VERSION 2.12.0-alpha7
 ENV CATTLE_DASHBOARD_UI_VERSION v2.12.0-alpha7
-ENV CATTLE_CLI_VERSION v2.11.0-rc.1
+ENV CATTLE_CLI_VERSION v2.12.0-rc.1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -176,7 +176,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.9.0
 ENV CATTLE_DASHBOARD_UI_VERSION v2.9.0
-ENV CATTLE_CLI_VERSION v2.11.0-rc.1
+ENV CATTLE_CLI_VERSION v2.12.0-rc.1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=


### PR DESCRIPTION
In the anticipation of v2.12.0 release set Rancher CLI to [v2.12.0-rc.1](https://github.com/rancher/cli/releases/tag/v2.12.0-rc.1).