### PR TITLE
[OIDC provider] Fix oidc client secret last used

### DIFF
--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -41,6 +41,12 @@ type signingKeyGetter interface {
 	GetPublicKey(kid string) (*rsa.PublicKey, error)
 }
 
+type jsonPatch struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value"`
+}
+
 type tokenHandler struct {
 	tokenCache          wrangmgmtv3.TokenCache
 	tokenClient         wrangmgmtv3.TokenClient
@@ -406,21 +412,13 @@ func (h *tokenHandler) updateClientSecretUsedTimeStamp(oidcClient *v3.OIDCClient
 	var patch []byte
 	var err error
 	if oidcClient.Annotations != nil {
-		patch, err = json.Marshal([]struct {
-			Op    string `json:"op"`
-			Path  string `json:"path"`
-			Value any    `json:"value"`
-		}{{
+		patch, err = json.Marshal([]jsonPatch{{
 			Op:    "add",
 			Path:  "/metadata/annotations/cattle.io.oidc-client-secret-used-" + clientSecretID,
 			Value: fmt.Sprintf("%d", h.now().Unix()),
 		}})
 	} else {
-		patch, err = json.Marshal([]struct {
-			Op    string `json:"op"`
-			Path  string `json:"path"`
-			Value any    `json:"value"`
-		}{{
+		patch, err = json.Marshal([]jsonPatch{{
 			Op:   "add",
 			Path: "/metadata/annotations",
 			Value: map[string]string{
@@ -441,21 +439,13 @@ func (h *tokenHandler) addOIDCClientIDToRancherToken(oidcClientName string, ranc
 	var patch []byte
 	var err error
 	if rancherToken.Labels != nil {
-		patch, err = json.Marshal([]struct {
-			Op    string `json:"op"`
-			Path  string `json:"path"`
-			Value any    `json:"value"`
-		}{{
+		patch, err = json.Marshal([]jsonPatch{{
 			Op:    "add",
 			Path:  "/metadata/labels/cattle.io.oidc-client-" + oidcClientName,
 			Value: "true",
 		}})
 	} else {
-		patch, err = json.Marshal([]struct {
-			Op    string `json:"op"`
-			Path  string `json:"path"`
-			Value any    `json:"value"`
-		}{{
+		patch, err = json.Marshal([]jsonPatch{{
 			Op:   "add",
 			Path: "/metadata/labels",
 			Value: map[string]string{

--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -178,7 +178,7 @@ func (h *tokenHandler) createTokenFromCode(r *http.Request) (TokenResponse, *oid
 		if clientSecret == string(cs) {
 			clientSecretFound = true
 			if err := h.updateClientSecretUsedTimeStamp(oidcClient, key); err != nil {
-				logrus.Errorf("[OIDC provider] failed to add OIDC Client ID to Rancher token: %v", err)
+				logrus.Errorf("[OIDC provider] failed to update client secret used timestamp: %v", err)
 			}
 			break
 		}
@@ -392,7 +392,7 @@ func (h *tokenHandler) createTokenResponse(rancherToken *v3.Token, oidcClient *v
 		}
 		resp.RefreshToken = refreshTokenString
 
-		if err := h.addOIDCClientIDToRancherToken(oidcClient.Name, rancherToken.Name); err != nil {
+		if err := h.addOIDCClientIDToRancherToken(oidcClient.Name, rancherToken); err != nil {
 			return TokenResponse{}, oidcerror.New(oidcerror.ServerError, fmt.Sprintf("failed to add OIDC Client ID to Rancher token: %v", err))
 		}
 	}
@@ -403,15 +403,31 @@ func (h *tokenHandler) createTokenResponse(rancherToken *v3.Token, oidcClient *v
 }
 
 func (h *tokenHandler) updateClientSecretUsedTimeStamp(oidcClient *v3.OIDCClient, clientSecretID string) interface{} {
-	patch, err := json.Marshal([]struct {
-		Op    string `json:"op"`
-		Path  string `json:"path"`
-		Value any    `json:"value"`
-	}{{
-		Op:    "add",
-		Path:  "/metadata/annotations/cattle.io.oidc-client-secret-used-" + clientSecretID,
-		Value: fmt.Sprintf("%d", h.now().Unix()),
-	}})
+	var patch []byte
+	var err error
+	if oidcClient.Annotations != nil {
+		patch, err = json.Marshal([]struct {
+			Op    string `json:"op"`
+			Path  string `json:"path"`
+			Value any    `json:"value"`
+		}{{
+			Op:    "add",
+			Path:  "/metadata/annotations/cattle.io.oidc-client-secret-used-" + clientSecretID,
+			Value: fmt.Sprintf("%d", h.now().Unix()),
+		}})
+	} else {
+		patch, err = json.Marshal([]struct {
+			Op    string `json:"op"`
+			Path  string `json:"path"`
+			Value any    `json:"value"`
+		}{{
+			Op:   "add",
+			Path: "/metadata/annotations",
+			Value: map[string]string{
+				"cattle.io.oidc-client-secret-used-" + clientSecretID: fmt.Sprintf("%d", h.now().Unix()),
+			},
+		}})
+	}
 	if err != nil {
 		return err
 	}
@@ -421,20 +437,36 @@ func (h *tokenHandler) updateClientSecretUsedTimeStamp(oidcClient *v3.OIDCClient
 	return err
 }
 
-func (h *tokenHandler) addOIDCClientIDToRancherToken(oidcClientName string, rancherTokenName string) error {
-	patch, err := json.Marshal([]struct {
-		Op    string `json:"op"`
-		Path  string `json:"path"`
-		Value any    `json:"value"`
-	}{{
-		Op:    "add",
-		Path:  "/metadata/labels/cattle.io.oidc-client-" + oidcClientName,
-		Value: "true",
-	}})
+func (h *tokenHandler) addOIDCClientIDToRancherToken(oidcClientName string, rancherToken *v3.Token) error {
+	var patch []byte
+	var err error
+	if rancherToken.Labels != nil {
+		patch, err = json.Marshal([]struct {
+			Op    string `json:"op"`
+			Path  string `json:"path"`
+			Value any    `json:"value"`
+		}{{
+			Op:    "add",
+			Path:  "/metadata/labels/cattle.io.oidc-client-" + oidcClientName,
+			Value: "true",
+		}})
+	} else {
+		patch, err = json.Marshal([]struct {
+			Op    string `json:"op"`
+			Path  string `json:"path"`
+			Value any    `json:"value"`
+		}{{
+			Op:   "add",
+			Path: "/metadata/labels",
+			Value: map[string]string{
+				"cattle.io.oidc-client-" + oidcClientName: "true",
+			},
+		}})
+	}
 	if err != nil {
 		return err
 	}
-	_, err = h.tokenClient.Patch(rancherTokenName, types.JSONPatchType, patch)
+	_, err = h.tokenClient.Patch(rancherToken.Name, types.JSONPatchType, patch)
 
 	return err
 }

--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -178,7 +178,7 @@ func (h *tokenHandler) createTokenFromCode(r *http.Request) (TokenResponse, *oid
 		if clientSecret == string(cs) {
 			clientSecretFound = true
 			if err := h.updateClientSecretUsedTimeStamp(oidcClient, key); err != nil {
-				logrus.Errorf("[OIDC provider] failed to update client secret used timestamp: %v", err)
+				logrus.Errorf("[OIDC provider] failed to update client secret's used timestamp: %v", err)
 			}
 			break
 		}

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -162,18 +162,22 @@ func TestTokenEndpoint(t *testing.T) {
 		Path  string `json:"path"`
 		Value any    `json:"value"`
 	}{{
-		Op:    "add",
-		Path:  "/metadata/annotations/cattle.io.oidc-client-secret-used-" + fakeClientSecretID,
-		Value: fmt.Sprintf("%d", fakeTime().Unix()),
+		Op:   "add",
+		Path: "/metadata/annotations",
+		Value: map[string]string{
+			"cattle.io.oidc-client-secret-used-" + fakeClientSecretID: fmt.Sprintf("%d", fakeTime().Unix()),
+		},
 	}})
 	tokenPatch, _ := json.Marshal([]struct {
 		Op    string `json:"op"`
 		Path  string `json:"path"`
 		Value any    `json:"value"`
 	}{{
-		Op:    "add",
-		Path:  "/metadata/labels/cattle.io.oidc-client-" + fakeClientName,
-		Value: "true",
+		Op:   "add",
+		Path: "/metadata/labels",
+		Value: map[string]string{
+			"cattle.io.oidc-client-" + fakeClientName: "true",
+		},
 	}})
 	tests := map[string]struct {
 		req                    func() *http.Request


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48317
 
## Problem
Patch to update the OIDC client secret last used timestamp fails when the `OIDCClient` annotations is `nil`. This is an issue when creating `OIDCClients` from the UI as no annotations are created. This issue is not reproducible when using `kubectl apply` as it adds an annotation.
 
## Solution
Check if annotation is `nil` to create the relevant patch for updating the client secret last used timestamp. Do the same when doing a patch to add the OIDC client to a token.
 