### PR TITLE
[main] Bump wins to `0.5.2-rc.1`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -142,7 +142,7 @@ ENV LINODE_UI_DRIVER_VERSION v0.7.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
 ENV DOCKER_MACHINE_HARVESTER_VERSION v1.0.2
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
-ENV CATTLE_WINS_AGENT_VERSION v0.5.1
+ENV CATTLE_WINS_AGENT_VERSION v0.5.2-rc.1
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -101,7 +101,7 @@ var (
 	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
 	CSIProxyAgentURL                    = NewSetting("csi-proxy-agent-url", "https://acs-mirror.azureedge.net/csi-proxy/%[1]s/binaries/csi-proxy-%[1]s.tar.gz")
 	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://github.com/rancher/system-agent/releases/download/v0.3.13-rc.3/install.sh") // To ensure consistency between SystemAgentInstallScript default value and CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT to utilize the local system-agent-install.sh script when both values are equal.
-	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.5.1/install.ps1")
+	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.5.2-rc.1/install.ps1")
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "") // Defined via environment variable
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")   // Defined via environment variable
 	WinsAgentUpgradeImage               = NewSetting("wins-agent-upgrade-image", "")

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -60,7 +60,7 @@ ENV LINODE_UI_DRIVER_VERSION v0.7.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
 ENV DOCKER_MACHINE_HARVESTER_VERSION v0.6.7
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
-ENV CATTLE_WINS_AGENT_VERSION v0.5.1
+ENV CATTLE_WINS_AGENT_VERSION v0.5.2-rc.1
 ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
 ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50458, https://github.com/rancher/rancher/issues/50500
 
## Problem
Rancher 2.12 needs to support k8s 1.33, so wins and various other dependencies need to be bumped. Additionally, the removal of Windows 2019 GHA runners resulted in changes to how the 2019 wins artifact and SUC image is published. Artifacts produced in this new pipeline need to be tested to ensure no regressions are present

## Solution
bump `rancher-wins` to support 1.33 and to bring in the updated 2019 artifacts 
 
## Testing
Basic windows provisioning on k8s 1.33, including basic testing around upgrades / SUC behavior (agent environment variables) 


## Engineering Testing
### Manual Testing
I provisioned a windows 2019 node and confirmed that the SUC image ran properly 


I also confirmed that the OS version metadata for the 2019 SUC image within dockerhub matches the same minor version as previously released versions of the 2019 SUC image. 

<details>
<summary>
manifest comparison
</summary>


wins 0.5.1

```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 4486,
         "digest": "sha256:33be76b3fc761ea56e1d2e5aa8d49f91f17af178f0267ccdbd0c05ca2921f7ae",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.7249"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 4486,
         "digest": "sha256:0672c2048997b3b1dcafe58ac20266de5a1c14359e5214a83cf5823526be9454",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.3328"
         }
      }
   ]
}
```

wins 0.5.2-rc.1

```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 4486,
         "digest": "sha256:3eb61a59abf384f76864ad4aa5b3c973a082a8f23693c8376b5fdd1c00cf15ae",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.7434"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 4486,
         "digest": "sha256:66015e65879a03a71d9f5c81efa01354735ab338a73804be29bc963a260d5730",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.3807"
         }
      }
   ]
}
```

Note that the minor versions set in `os.version` for both images (`17763`, `20348`) within the list match across both `0.5.1` and `0.5.2-rc.1`. The patch versions differ, but this is expect and based entirely on the GHA runner revision used when releasing the tag.

</details>

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations

### Regressions Considerations
