### PR TITLE
[main] Remove rancher-rke-k8s-versions.txt from artifacts list

### DIFF
--- a/scripts/artifacts-list.sh
+++ b/scripts/artifacts-list.sh
@@ -11,7 +11,6 @@ export ARTIFACTS=(
   "rancher-load-images.sh"
   "rancher-mirror-to-rancher-org.ps1"
   "rancher-mirror-to-rancher-org.sh"
-  "rancher-rke-k8s-versions.txt"
   "rancher-save-images.ps1"
   "rancher-save-images.sh"
   "rancher-windows-images-sources.txt"


### PR DESCRIPTION
We stopped writing to `rancher-rke-k8s-versions.txt` as it included only RKE1 versions so far in [this PR](https://github.com/rancher/rancher/commit/7e4dc583125ee4624f341777f9d44268e425aed8#diff-2623863f3d8249bed94fa69df203ba439413583a04367f68031f176af5187200L99). 