### PR TITLE
Adjust CRD to match RFD docs

### DIFF
--- a/pkg/apis/scc.cattle.io/v1/types.go
+++ b/pkg/apis/scc.cattle.io/v1/types.go
@@ -78,9 +78,9 @@ func (rs *RegistrationSpec) WithoutSyncNow() *RegistrationSpec {
 type RegistrationRequest struct {
 	RegistrationCodeSecretRef *corev1.SecretReference `json:"registrationCodeSecretRef,omitempty"`
 	// +optional
-	RegistrationUrl *string `json:"registrationUrl,omitempty"`
+	RegistrationAPIUrl *string `json:"registrationAPIUrl,omitempty"`
 	// +optional
-	ServerCertificateSecretRef *corev1.SecretReference `json:"serverCertficateSecretRef,omitempty"`
+	RegistrationAPICertificateSecretRef *corev1.SecretReference `json:"registrationAPICertificateSecretRef,omitempty"`
 }
 
 type RegistrationStatus struct {
@@ -113,8 +113,6 @@ type SystemActivationState struct {
 	Activated bool `json:"activated"`
 	// +optional
 	LastValidatedTS *metav1.Time `json:"lastValidatedTS"`
-	// +optional
-	Certificate *string `json:"certificate,omitempty"`
 	// +optional
 	SystemUrl *string `json:"systemUrl,omitempty"`
 }

--- a/pkg/apis/scc.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/scc.cattle.io/v1/zz_generated_deepcopy.go
@@ -96,13 +96,13 @@ func (in *RegistrationRequest) DeepCopyInto(out *RegistrationRequest) {
 		*out = new(corev1.SecretReference)
 		**out = **in
 	}
-	if in.RegistrationUrl != nil {
-		in, out := &in.RegistrationUrl, &out.RegistrationUrl
+	if in.RegistrationAPIUrl != nil {
+		in, out := &in.RegistrationAPIUrl, &out.RegistrationAPIUrl
 		*out = new(string)
 		**out = **in
 	}
-	if in.ServerCertificateSecretRef != nil {
-		in, out := &in.ServerCertificateSecretRef, &out.ServerCertificateSecretRef
+	if in.RegistrationAPICertificateSecretRef != nil {
+		in, out := &in.RegistrationAPICertificateSecretRef, &out.RegistrationAPICertificateSecretRef
 		*out = new(corev1.SecretReference)
 		**out = **in
 	}
@@ -206,11 +206,6 @@ func (in *SystemActivationState) DeepCopyInto(out *SystemActivationState) {
 	if in.LastValidatedTS != nil {
 		in, out := &in.LastValidatedTS, &out.LastValidatedTS
 		*out = (*in).DeepCopy()
-	}
-	if in.Certificate != nil {
-		in, out := &in.Certificate, &out.Certificate
-		*out = new(string)
-		**out = **in
 	}
 	if in.SystemUrl != nil {
 		in, out := &in.SystemUrl, &out.SystemUrl

--- a/pkg/crds/yaml/generated/scc.cattle.io_registrations.yaml
+++ b/pkg/crds/yaml/generated/scc.cattle.io_registrations.yaml
@@ -75,7 +75,7 @@ spec:
                 x-kubernetes-map-type: atomic
               registrationRequest:
                 properties:
-                  registrationCodeSecretRef:
+                  registrationAPICertificateSecretRef:
                     description: |-
                       SecretReference represents a Secret Reference. It has enough information to retrieve secret
                       in any namespace
@@ -90,9 +90,9 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
-                  registrationUrl:
+                  registrationAPIUrl:
                     type: string
-                  serverCertficateSecretRef:
+                  registrationCodeSecretRef:
                     description: |-
                       SecretReference represents a Secret Reference. It has enough information to retrieve secret
                       in any namespace
@@ -120,8 +120,6 @@ spec:
                   activated:
                     default: false
                     type: boolean
-                  certificate:
-                    type: string
                   lastValidatedTS:
                     format: date-time
                     type: string

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -871,13 +871,13 @@ func schema_pkg_apis_scccattleio_v1_RegistrationRequest(ref common.ReferenceCall
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},
-					"registrationUrl": {
+					"registrationAPIUrl": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
 						},
 					},
-					"serverCertficateSecretRef": {
+					"registrationAPICertificateSecretRef": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},
@@ -1020,12 +1020,6 @@ func schema_pkg_apis_scccattleio_v1_SystemActivationState(ref common.ReferenceCa
 					"lastValidatedTS": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
-						},
-					},
-					"certificate": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
 						},
 					},
 					"systemUrl": {

--- a/pkg/scc/controllers/online.go
+++ b/pkg/scc/controllers/online.go
@@ -79,7 +79,7 @@ func (s sccOnlineMode) Register(registrationObj *v1.Registration) (suseconnect.R
 	//	b. BAYG/RMT/etc based Registration and will not use a code
 	registrationCode := suseconnect.FetchSccRegistrationCodeFrom(s.secrets, registrationObj.Spec.RegistrationRequest.RegistrationCodeSecretRef)
 
-	regUrl := registrationObj.Spec.RegistrationRequest.RegistrationUrl
+	regUrl := registrationObj.Spec.RegistrationRequest.RegistrationAPIUrl
 
 	// Initiate connection to SCC & verify reg code is for Rancher
 	sccConnection := suseconnect.OnlineRancherConnection(s.sccCredentials.SccCredentials(), s.systemInfoExporter, *regUrl)
@@ -198,7 +198,7 @@ func (s sccOnlineMode) Activate(registrationObj *v1.Registration) error {
 	}
 
 	registrationCode := suseconnect.FetchSccRegistrationCodeFrom(s.secrets, registrationObj.Spec.RegistrationRequest.RegistrationCodeSecretRef)
-	registrationUrl := registrationObj.Spec.RegistrationRequest.RegistrationUrl
+	registrationUrl := registrationObj.Spec.RegistrationRequest.RegistrationAPIUrl
 	sccConnection := suseconnect.OnlineRancherConnection(s.sccCredentials.SccCredentials(), s.systemInfoExporter, *registrationUrl)
 
 	metaData, product, err := sccConnection.Activate(registrationCode)
@@ -220,7 +220,7 @@ func (s sccOnlineMode) PrepareActivatedForKeepalive(registrationObj *v1.Registra
 	if credentialsErr != nil {
 		return nil, fmt.Errorf("cannot load scc credentials: %w", credentialsErr)
 	}
-	regUrl := registrationObj.Spec.RegistrationRequest.RegistrationUrl
+	regUrl := registrationObj.Spec.RegistrationRequest.RegistrationAPIUrl
 	sccConnection := suseconnect.OnlineRancherConnection(s.sccCredentials.SccCredentials(), s.systemInfoExporter, *regUrl)
 
 	activations, err := sccConnection.ActivationStatus()
@@ -269,7 +269,7 @@ func (s sccOnlineMode) Keepalive(registrationObj *v1.Registration) error {
 	}
 
 	regCode := suseconnect.FetchSccRegistrationCodeFrom(s.secrets, registrationObj.Spec.RegistrationRequest.RegistrationCodeSecretRef)
-	regUrl := registrationObj.Spec.RegistrationRequest.RegistrationUrl
+	regUrl := registrationObj.Spec.RegistrationRequest.RegistrationAPIUrl
 	sccConnection := suseconnect.OnlineRancherConnection(s.sccCredentials.SccCredentials(), s.systemInfoExporter, *regUrl)
 
 	metaData, product, err := sccConnection.Activate(regCode)
@@ -320,7 +320,7 @@ func (s sccOnlineMode) ReconcileKeepaliveError(registration *v1.Registration, ke
 
 func (s sccOnlineMode) Deregister() error {
 	_ = s.sccCredentials.Refresh()
-	regUrl := s.registration.Spec.RegistrationRequest.RegistrationUrl
+	regUrl := s.registration.Spec.RegistrationRequest.RegistrationAPIUrl
 	sccConnection := suseconnect.OnlineRancherConnection(s.sccCredentials.SccCredentials(), s.systemInfoExporter, *regUrl)
 	// TODO : this causes deletion to fail if the credentials are invalid. I think we
 	// need to do a best effort check to see if it was ever registered before

--- a/pkg/scc/controllers/resources.go
+++ b/pkg/scc/controllers/resources.go
@@ -235,7 +235,7 @@ func paramsToRegSpec(params RegistrationParams) v1.RegistrationSpec {
 
 	// check if params has regUrl and use, otherwise check if devmode and when true use staging Scc url
 	if params.regUrl != "" {
-		regSpec.RegistrationRequest.RegistrationUrl = &params.regUrl
+		regSpec.RegistrationRequest.RegistrationAPIUrl = &params.regUrl
 	}
 
 	return regSpec


### PR DESCRIPTION
Per title this syncs up the CRD fields to match recent discussions around the RFD doc and SCC library. (Helps to ensure we use common names on both rancher and SCC side)