### PR TITLE
Fast-track Steve startup if the aggregation API was previously proven to work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/rancher/remotedialer v0.4.5-rc.3
 	github.com/rancher/rke v1.8.0-rc.4
 	github.com/rancher/shepherd v0.0.0-20250411212007-f3f2fd268849
-	github.com/rancher/steve v0.6.19
+	github.com/rancher/steve v0.6.20
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250306000150-b1a9781accab
 	github.com/rancher/tests/actions v0.0.0-20250505204226-5b136337f7c5
 	github.com/rancher/wrangler v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -717,8 +717,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20250411212007-f3f2fd268849 h1:hxa/Y0LRTx8BzMPxirT9Yg3IZg2YXus7+smLLn5n9tw=
 github.com/rancher/shepherd v0.0.0-20250411212007-f3f2fd268849/go.mod h1:IVVaLrIQ1/1Fk7KTrkhpKFlgaqhh3uv27CokmEhXHJc=
-github.com/rancher/steve v0.6.19 h1:YQcAm/53K0+Fa4LwWDd3gA/VnNWJj/21WgVKWEwqCO0=
-github.com/rancher/steve v0.6.19/go.mod h1:gl+vSbpkBwhHBXAmb0Z/QbWlHE5Lrkhzk8uACxH+j5o=
+github.com/rancher/steve v0.6.20 h1:KCUtfRN13mBnGLfy2wx67pUs0kzING90MlKFZqCoXw4=
+github.com/rancher/steve v0.6.20/go.mod h1:gl+vSbpkBwhHBXAmb0Z/QbWlHE5Lrkhzk8uACxH+j5o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250306000150-b1a9781accab h1:Ttxt14bAImsWyFrtQZ314GW2DeExrYRNoAb+u9V3RiA=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250306000150-b1a9781accab/go.mod h1:9gzmXntv/s0sEDBERi/fS58PRt5HFUfZr7niDGsDbAA=
 github.com/rancher/tests/actions v0.0.0-20250505204226-5b136337f7c5 h1:iatxRcqkupXLGISfU5zRA37po3YO7Pqq/Ao7bIqFsu4=

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -419,27 +419,27 @@ func (r *Rancher) ListenAndServe(ctx context.Context) error {
 func (r *Rancher) checkAPIAggregationOrDie() {
 	logrus.Infof("Waiting for %s imperative API to be ready", r.aggregationRegistrationTimeout)
 
-	ctx, cancel := context.WithTimeout(context.Background(), r.aggregationRegistrationTimeout)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), r.aggregationRegistrationTimeout)
 	defer cancel()
 
 	apiserviceClient := r.Wrangler.API.APIService()
 	waitingForAPIService := !r.Steve.SkipWaitForExtensionAPIServer
 	for {
+		// Case 1: Successful - ExtensionServer was contacted by the Kube API, causing the channel to be closed.
+		// Case 2: Successful - ExtensionServer in a different replica was contacted by the Kube API, and that updated the APIService object annotation.
+		//         Only valid if Steve was configured to wait. Otherwise, it would short-circuit here directly here
+		// Case 3: Fatal - the Kube API didn't contact the Extension Server within the configured timeout, interpreted as API Aggregation not being supported in the cluster
 		select {
-		// Case 1: ExtensionServer was contacted by the Kube API,
 		case <-r.kubeAggregationReadyChan:
 			logrus.Info("kube-apiserver connected to imperative api")
 			ext.SetAggregationCheck(apiserviceClient, true)
 			return
-		// Case 2: ExtensionServer in a different replica was contacted by the Kube API
-		//         Only valid if Steve was configured to wait. Otherwise, it would short-circuit here directly here
 		case <-time.After(5 * time.Second):
 			if waitingForAPIService && ext.AggregationPreCheck(apiserviceClient) {
 				logrus.Info("kube-apiserver connected to imperative api")
 				return
 			}
-		// Case 3: the Kube API didn't contact the Extension Server within the configured timeout, interpreted as API Aggregation not being supported in the cluster
-		case <-ctx.Done():
+		case <-ctxTimeout.Done():
 			ext.SetAggregationCheck(apiserviceClient, false)
 			logrus.Fatal("kube-apiserver did not contact the rancher imperative api in time, please ensure k8s is configured to support api extension")
 		}


### PR DESCRIPTION
## Issue: #50399

Relates to #50661
### Depends on
- [x] https://github.com/rancher/steve/pull/694 (needs to be merged and released)
 
## Problem

The new Imperative API is now enabled by default for Rancher 2.12. This means there is now a hard requirement for API Aggregation to be supported in the upstream cluster. The only reliable way we currently have for verifying that is to make Rancher run and become available for Kubernetes to contact it, after which we'll unblock Steve from working as normal (hence unblocking the UI usage).

This could introduce a delay in the startup process, affecting the user and development/testing experience.
 
## Solution

Minimize the impact of the new check by implementing some sort of memory:
 - Whenever the Aggregation API is proven to first work, the corresponding `apiservice` resource will be annotated.
 - Subsequent Rancher starts can now check the `apiservice` resource for the annotation presence, and directly start serving Steve normally.
   - As a protection against the feature being disabled on an already running cluster, or backup+restored to a new cluster with this support, the mentioned check will be kept running "in background mode", revoking any previous successful checks if the condition is not met in time.

In practice, Steve will only be temporarily blocked during the first Rancher installation.
 
## Testing

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_