### PR TITLE
Rename ext Token status fields

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -112,9 +112,9 @@ type TokenPrincipal struct {
 // TokenStatus defines the most recently observed status of the Token.
 type TokenStatus struct {
 	// Value is the access key. It is shown only on token creation and not saved.
-	Value string `json:"tokenValue,omitempty"`
+	Value string `json:"value,omitempty"`
 	// Hash is the hash of the Value.
-	Hash string `json:"tokenHash,omitempty"`
+	Hash string `json:"hash,omitempty"`
 	// Current indicates whether the token was used to authenticate the current request.
 	Current bool `json:"current"`
 	// Expired indicates whether the token has exceeded its TTL.

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -585,14 +585,14 @@ func schema_pkg_apis_extcattleio_v1_TokenStatus(ref common.ReferenceCallback) co
 				Description: "TokenStatus defines the most recently observed status of the Token.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"tokenValue": {
+					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Value is the access key. It is shown only on token creation and not saved.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
-					"tokenHash": {
+					"hash": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Hash is the hash of the Value.",
 							Type:        []string{"string"},


### PR DESCRIPTION

## Issue: <!-- link the issue or issues this PR resolves here -->
 
## Problem

Sync the field names to be similar/same to kubeconfig.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_