### PR TITLE
Use a dedicated ClusterRole for projects

### DIFF
--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
@@ -266,7 +266,7 @@ func (p *prtbHandler) buildNamespaceBindings(prtb *v3.ProjectRoleTemplateBinding
 	}
 
 	// check if any of the aggregated CR grant updatepsa permission
-	psaCRName := fmt.Sprintf("%s-namespaces-psa", projectName)
+	psaCRName := projectName + "-namespaces-psa"
 	psaRec := authorizer.AttributesRecord{
 		Verb:            updatePSAVerb,
 		APIGroup:        management.GroupName,

--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
@@ -290,7 +290,6 @@ func (p *prtbHandler) buildNamespaceBindings(prtb *v3.ProjectRoleTemplateBinding
 			return nil, err
 		}
 
-		// here we prepare the CRB to give updatepsa permission to the user.
 		namespacePSACRB, err := rbac.BuildClusterRoleBindingFromRTB(prtb, psaCR.Name)
 		if err != nil {
 			return nil, err

--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
@@ -276,7 +276,7 @@ func (p *prtbHandler) buildNamespaceBindings(prtb *v3.ProjectRoleTemplateBinding
 	}
 	if rbacAuth.RulesAllow(psaRec, cr.Rules...) {
 		// if rules allow user to use updatepsa,
-		// then we create the CR dedicated for the project.
+		// then we create a dedicated ClusterRole for the project.
 		psaCR := rbac.BuildClusterRole(psaCRName, prtb.RoleTemplateName, []rbacv1.PolicyRule{
 			{
 				APIGroups:     []string{management.GroupName},

--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler_test.go
@@ -423,13 +423,13 @@ var (
 	}
 	crbPSA = rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "crb-apzwokaidy",
+			Name:   "crb-or6ne64g56",
 			Labels: map[string]string{"authz.cluster.cattle.io/prtb-owner": "test-prtb"},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "namespaces-psa",
+			Name:     "p-xyz789-namespaces-psa",
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -511,6 +511,7 @@ func Test_prtbHandler_buildNamespaceBindings(t *testing.T) {
 						},
 					},
 				}, nil)
+				m.EXPECT().Create(gomock.All()).Return(&rbacv1.ClusterRole{}, nil)
 			},
 			want: []*rbacv1.ClusterRoleBinding{crbPSA.DeepCopy()},
 		},
@@ -527,6 +528,7 @@ func Test_prtbHandler_buildNamespaceBindings(t *testing.T) {
 						},
 					},
 				}, nil)
+				m.EXPECT().Create(gomock.All()).Return(&rbacv1.ClusterRole{}, nil)
 			},
 			want: []*rbacv1.ClusterRoleBinding{crbCreateNS.DeepCopy(), crbEdit.DeepCopy(), crbPSA.DeepCopy()},
 		},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50778
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
This fix allow the user to not use a pre-defined RoleTemplate to allow access to `updatepsa` for users.

## Solution
Instead of using the aggregated CR generated from the applied RoleTemplate, I'm creating a dedicated CR in order to better manage the flow of granting access to the `Project` resource.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_