### PR TITLE
feat: Add cattle-kubewarden-system to system namespaces

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -53,6 +53,7 @@ var (
 		"cattle-csp-adapter-system",
 		"calico-apiserver",
 		"cattle-elemental-system",
+		"cattle-kubewarden-system",
 	}
 
 	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:head")


### PR DESCRIPTION



## Issue:  Part of https://github.com/rancher/kubewarden/issues/7

 
## Problem

The default kubewarden namespace of installations performed via the Kubewarden UI extension, `cattle-kubewarden-system` is not included as system namespace. This is needed to be able to backup Kubewarden resources installed via the Kubewarden UI.
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add   `cattle-kubewarden-system`  as system namespace.

Kubewarden can already run under [PSA restricted](https://docs.kubewarden.io/howtos/security-hardening#pod-security-admission), hence there is no need to add it as an exception.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
This was manually tested as part of testing upcoming rancher-backup operator additions for Kubewarden.


### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None - Reason: lack of framework capable of testing a deployment with Rancher + Kubewarden UI extension + Backup Operator. This is ongoing work as part of https://github.com/rancher/kubewarden/issues/7, and will be tested and maintained on the Kubewarden / Kubewarden UI side.
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
 Fresh installation of Rancher + Kubewarden UI extension + Backup operator, then perform backup and restore following the process in https://github.com/kubewarden/docs/pull/632.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
None. There was no problem so far having kubewarden under the `cattle-kubewarden-system` namespace either.

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_