### PR TITLE
Stop 'make quick' from returning to the command-line prematurely.

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -68,3 +68,5 @@ if [ -z $TARGET ] || [ $TARGET = "agent" ]; then
       docker push "${REPO}"/rancher-agent:"${TAG}" &
     fi
 fi
+
+wait


### PR DESCRIPTION
It makes sense that this script runs `docker push` in the background, but it should wait on all background
processes before exiting.