### PR TITLE
[Post 2.12] Properly support uid preconditions for ext token deletion

### DIFF
--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -659,6 +659,9 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "token-v2rcx",
 			CreationTimestamp: metav1.NewTime(now),
+			Labels: map[string]string{
+				exttokenstore.UserIDLabel: userID,
+			},
 		},
 		Spec: ext.TokenSpec{
 			UserID:  userID,
@@ -682,6 +685,10 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "token-v2rcx",
 			CreationTimestamp: metav1.NewTime(now),
+			Labels: map[string]string{
+				exttokenstore.UserIDLabel:     userID,
+				exttokenstore.SecretKindLabel: exttokenstore.SecretKindLabelValue,
+			},
 		},
 		Data: map[string][]byte{
 			exttokenstore.FieldEnabled:        []byte("true"),

--- a/pkg/auth/requests/impersonate_test.go
+++ b/pkg/auth/requests/impersonate_test.go
@@ -224,6 +224,10 @@ func TestAuthenticateImpersonation(t *testing.T) {
 					Return(&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "kubeconfig-u-user5zfww",
+							Labels: map[string]string{
+								exttokenstore.UserIDLabel:     "impUser",
+								exttokenstore.SecretKindLabel: exttokenstore.SecretKindLabelValue,
+							},
 						},
 						Data: map[string][]byte{
 							exttokenstore.FieldUserID: []byte("impUser"),
@@ -426,6 +430,10 @@ func TestAuthenticateImpersonation(t *testing.T) {
 					Return(&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "kubeconfig-u-user5zfww",
+							Labels: map[string]string{
+								exttokenstore.UserIDLabel:     "someoneelse",
+								exttokenstore.SecretKindLabel: exttokenstore.SecretKindLabelValue,
+							},
 						},
 						Data: map[string][]byte{
 							exttokenstore.FieldUserID: []byte("someoneelse"),

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -274,7 +274,6 @@ func (t *Store) Create(
 }
 
 // DeleteCollection implements [rest.CollectionDeleter]
-// Calls on deleteCore.
 func (t *Store) DeleteCollection(
 	ctx context.Context,
 	deleteValidation rest.ValidateObjectFunc,
@@ -327,8 +326,7 @@ func (t *Store) DeleteCollection(
 	return list, nil
 }
 
-// Delete implements [rest.GracefulDeleter], the interface to support the
-// `delete` verb. Calls on `deleteCore`.
+// Delete implements [rest.GracefulDeleter], the interface to support the `delete` verb.
 func (t *Store) Delete(
 	ctx context.Context,
 	name string,
@@ -356,9 +354,7 @@ func (t *Store) Delete(
 	return t.deleteCore(ctx, secret, deleteValidation, options)
 }
 
-// deleteCore is invoked by Delete and DeleteCollection, after access checks,
-// with the backing secret of the token to delete. After conversion and further
-// checks it delegates to the system store.
+// deleteCore performs the common parts of token deletion.
 func (t *Store) deleteCore(
 	ctx context.Context,
 	secret *corev1.Secret,

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -379,6 +379,16 @@ func (t *Store) deleteCore(
 		}
 	}
 
+	// If an UID precondition exists and matches the tokens's UID, then we
+	// have to replace it with the corresponding secrets's UID.
+	if options != nil &&
+		options.Preconditions != nil &&
+		options.Preconditions.UID != nil &&
+		*options.Preconditions.UID == token.UID {
+
+		options.Preconditions.UID = &secret.UID
+	}
+
 	// and now actually delete
 	if err := t.SystemStore.Delete(token.Name, options); err != nil {
 		return nil, false, err

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -311,14 +311,12 @@ func TestStoreDeleteCollection(t *testing.T) {
 				assert.Equal(t, deleteOptions, options)
 				return nil
 			}).Times(1)
-		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
-		secretClient.EXPECT().Cache().Return(scache)
+		secretClient.EXPECT().Cache().Return(nil)
 		userClient := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Cache().Return(nil)
 		auth := NewMockauthHandler(ctrl)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(&mockUser{name: properUser}, false, true, nil).
-			Times(2)
+			Return(&mockUser{name: properUser}, false, true, nil)
 
 		store := New(nil, nil, nil, secretClient, userClient, nil, nil, nil, auth)
 
@@ -344,17 +342,14 @@ func Test_Store_Delete(t *testing.T) {
 	t.Run("failed to get secret, arbitrary error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
-		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "laber"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Cache().Return(scache)
-		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+		secrets.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
 			Return(nil, someerror)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
@@ -368,17 +363,14 @@ func Test_Store_Delete(t *testing.T) {
 	t.Run("failed to get secret, not found", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
-		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "laber"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Cache().Return(scache)
-		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+		secrets.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
 			Return(nil, apierrors.NewNotFound(GVR.GroupResource(), "bogus"))
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
@@ -409,17 +401,14 @@ func Test_Store_Delete(t *testing.T) {
 	t.Run("not owned, no permission, not found", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
-		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdl/ksjlkds"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Cache().Return(scache)
-		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+		secrets.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
 			Return(&properSecret, nil)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
@@ -432,17 +421,14 @@ func Test_Store_Delete(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
-		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
-		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(&mockUser{name: properUser}, false, true, nil).Times(2)
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), "delete").
+			Return(&mockUser{name: properUser}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Cache().Return(scache)
-		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+		secrets.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
 			Return(&properSecret, nil)
 		secrets.EXPECT().
 			Delete("cattle-tokens", "bogus", gomock.Any()).

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -48,6 +48,7 @@ var (
 				UserIDLabel:     properUser,
 				SecretKindLabel: SecretKindLabelValue,
 			},
+			UID: "bombastic",
 		},
 		Data: map[string][]byte{
 			FieldDescription:    []byte(""),
@@ -115,6 +116,11 @@ var (
 	dummyToken = ext.Token{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "bogus",
+			Labels: map[string]string{
+				UserIDLabel:     properUser,
+				SecretKindLabel: SecretKindLabelValue,
+			},
+			UID: "bombastic",
 		},
 	}
 
@@ -436,6 +442,36 @@ func Test_Store_Delete(t *testing.T) {
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
 		_, ok, err := store.Delete(context.TODO(), "bogus", nil, &metav1.DeleteOptions{})
+
+		assert.True(t, ok)
+		assert.Nil(t, err)
+	})
+
+	t.Run("ok with uid precondition", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+		auth := NewMockauthHandler(ctrl)
+
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), "delete").
+			Return(&mockUser{name: properUser}, false, true, nil)
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
+			Return(&properSecret, nil)
+		secrets.EXPECT().
+			Delete("cattle-tokens", "bogus", gomock.Any()).
+			DoAndReturn(func(namespace, name string, options *metav1.DeleteOptions) error {
+				// verify that the delete option data was properly translated
+				assert.Equal(t, options.Preconditions, metav1.NewUIDPreconditions("bombastic"))
+				return nil
+			})
+
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, auth)
+		_, ok, err := store.Delete(context.TODO(), "bogus", nil,
+			&metav1.DeleteOptions{
+				Preconditions: metav1.NewUIDPreconditions("2905498-kafld-lkad"),
+			})
 
 		assert.True(t, ok)
 		assert.Nil(t, err)

--- a/pkg/ext/stores/useractivity/store_test.go
+++ b/pkg/ext/stores/useractivity/store_test.go
@@ -137,6 +137,10 @@ func TestStoreCreate(t *testing.T) {
 				eSecret := corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "token-12345",
+						Labels: map[string]string{
+							exttokenstore.UserIDLabel:     "admin",
+							exttokenstore.SecretKindLabel: exttokenstore.SecretKindLabelValue,
+						},
 					},
 					Data: map[string][]byte{
 						exttokenstore.FieldDescription:    []byte(""),
@@ -451,6 +455,10 @@ func TestStoreGet(t *testing.T) {
 				eSecret := corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "token-12345",
+						Labels: map[string]string{
+							exttokenstore.UserIDLabel:     "admin",
+							exttokenstore.SecretKindLabel: exttokenstore.SecretKindLabelValue,
+						},
 					},
 					Data: map[string][]byte{
 						exttokenstore.FieldDescription:      []byte(""),


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#51113

## Problem

The ext token store mishandles deletion with uid preconditions.
 
## Solution

Translate the token uid found in the incoming precondition into the uid of the backing secret and use that in the precondition handed to the backend.
 
## Testing

Additional unit test.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_