### PR TITLE
Don't double encode ACE cluster's CACert when generating a kubeconfig

### DIFF
--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -424,7 +425,7 @@ func (s *Store) Create(
 		return ref, nil
 	}
 
-	caCert := kconfig.FormatCert(settings.CACerts.Get())
+	caCert := kconfig.FormatCertString(base64.StdEncoding.EncodeToString([]byte(settings.CACerts.Get())))
 	data := kconfig.KubeConfig{
 		Meta: kconfig.Meta{
 			Name:              kubeConfigID,
@@ -570,7 +571,7 @@ func (s *Store) Create(
 				data.Clusters = append(data.Clusters, kconfig.Cluster{
 					Name:   fqdnName,
 					Server: "https://" + authEndpoint.FQDN,
-					Cert:   kconfig.FormatCert(authEndpoint.CACerts),
+					Cert:   kconfig.FormatCertString(base64.StdEncoding.EncodeToString([]byte(authEndpoint.CACerts))),
 				})
 				data.Contexts = append(data.Contexts, kconfig.Context{
 					Name:    fqdnName,
@@ -599,7 +600,7 @@ func (s *Store) Create(
 				return apierrors.NewInternalError(fmt.Errorf("error listing nodes for cluster %s: %w", cluster.Name, err))
 			}
 
-			clusterCerts := kconfig.FormatCert(cluster.Status.CACert)
+			clusterCerts := kconfig.FormatCertString(cluster.Status.CACert) // Already base64 encoded.
 			var isCurrentContextSet bool
 			for _, node := range nodes {
 				if !node.Spec.ControlPlane {

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -73,7 +73,7 @@ type KubeConfig struct {
 	CurrentContext string
 }
 
-func formatCertString(certData string) string {
+func FormatCertString(certData string) string {
 	buf := &bytes.Buffer{}
 	if len(certData) > firstLen {
 		buf.WriteString(certData[:firstLen])
@@ -96,15 +96,7 @@ func caCertString() string {
 		return ""
 	}
 	certData = base64.StdEncoding.EncodeToString([]byte(certData))
-	return formatCertString(certData)
-}
-
-func FormatCert(data string) string {
-	if data == "" {
-		return ""
-	}
-
-	return formatCertString(base64.StdEncoding.EncodeToString([]byte(data)))
+	return FormatCertString(certData)
 }
 
 func getDefaultNode(clusterName, clusterID, host string) kubeNode {
@@ -150,7 +142,7 @@ func ForClusterTokenBased(cluster *clientv3.Cluster, nodes []*normanv3.Node, clu
 		clusterNode := kubeNode{
 			ClusterName: clusterName + "-fqdn",
 			Server:      "https://" + cluster.LocalClusterAuthEndpoint.FQDN,
-			Cert:        formatCertString(fqdnCACerts),
+			Cert:        FormatCertString(fqdnCACerts),
 			User:        clusterName,
 		}
 		nodesForConfig = append(nodesForConfig, clusterNode)
@@ -161,7 +153,7 @@ func ForClusterTokenBased(cluster *clientv3.Cluster, nodes []*normanv3.Node, clu
 				clusterNode := kubeNode{
 					ClusterName: nodeName,
 					Server:      "https://" + node.GetEndpointNodeIP(n) + ":6443",
-					Cert:        formatCertString(cluster.CACert),
+					Cert:        FormatCertString(cluster.CACert),
 					User:        clusterName,
 				}
 				nodesForConfig = append(nodesForConfig, clusterNode)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/50855
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Cluster's CACert is already base64 encoded which was leading to double encoding when generating a kubeconfig for an ACE cluster.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Don't base64 encode Cluster's CACert. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A