### PR TITLE
[main] Node Driver API Followup

### DIFF
--- a/pkg/apis/management.cattle.io/v3/machine_types.go
+++ b/pkg/apis/management.cattle.io/v3/machine_types.go
@@ -279,14 +279,14 @@ type NodeCommonParams struct {
 type NodeDriver struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object’s metadata. More info:
-	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the Node Driver. More info:
-	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +kubebuilder:validation:XValidation:rule="!has(self.checksum) || (self.checksum.size() in [0, 32, 40, 64, 128])",message="Checksum must be an md5, sha1, sha256, or sha512 digest."
 	Spec NodeDriverSpec `json:"spec"`
 	// Most recent observed status of the Node Driver. More info:
-	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Status NodeDriverStatus `json:"status,omitempty"`
 }

--- a/pkg/crds/yaml/generated/management.cattle.io_nodedrivers.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_nodedrivers.yaml
@@ -47,7 +47,7 @@ spec:
           spec:
             description: |-
               Specification of the desired behavior of the Node Driver. More info:
-              https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+              https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
               active:
                 description: Active specifies if the driver can be used to provision
@@ -111,7 +111,7 @@ spec:
           status:
             description: |-
               Most recent observed status of the Node Driver. More info:
-              https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+              https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
               appliedChecksum:
                 description: |-


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49400
 
## Problem
The links included in the current Node Driver struct, and now the `kubectl explain` output, are dead. 

## Solution
Update the links to the correct upstream documentation urls
 
## Testing
Ran `kubectl explain` and confirm that the description is updated. 

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_