### PR TITLE
Make sure Kubeconfigs work when MCM is disabled

### DIFF
--- a/pkg/ext/stores/install.go
+++ b/pkg/ext/stores/install.go
@@ -55,7 +55,7 @@ func InstallStores(
 		if err := server.Install(
 			extv1.KubeconfigResourceName,
 			extv1.SchemeGroupVersion.WithKind(kubeconfig.Kind),
-			kubeconfig.New(wranglerContext, server.GetAuthorizer(), userManager),
+			kubeconfig.New(features.MCM.Enabled(), wranglerContext, server.GetAuthorizer(), userManager),
 		); err != nil {
 			return fmt.Errorf("unable to install kubeconfig store: %w", err)
 		}

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -420,6 +420,7 @@ func TestStoreCreate(t *testing.T) {
 		userManager := &fakeUserManager{} // Subtest specific instance.
 
 		store := &Store{
+			mcmEnabled:          true,
 			authorizer:          authorizer,
 			nsCache:             nsCache,
 			configMapClient:     configMapClient,
@@ -556,6 +557,7 @@ func TestStoreCreate(t *testing.T) {
 		userManager := &fakeUserManager{} // Subtest specific instance.
 
 		store := &Store{
+			mcmEnabled:          true,
 			authorizer:          commonAuthorizer,
 			nsCache:             nsCache,
 			configMapClient:     configMapClient,
@@ -642,6 +644,7 @@ func TestStoreCreate(t *testing.T) {
 		userManager := &fakeUserManager{} // Subtest specific instance.
 
 		store := &Store{
+			mcmEnabled:          true,
 			authorizer:          commonAuthorizer,
 			userCache:           userCache,
 			tokenCache:          tokenCache,
@@ -759,6 +762,7 @@ func TestStoreCreate(t *testing.T) {
 		userManager := &fakeUserManager{} // Subtest specific instance.
 
 		store := &Store{
+			mcmEnabled:          true,
 			authorizer:          authorizer,
 			nsCache:             nsCache,
 			configMapClient:     configMapClient,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/50865
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The Imperative resource Kubeconfigs makes use of nodes.managements.cattle.io for listing control plane nodes for an ACE-enabled cluster. When the MCM is not enabled this CRD is not available.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Make sure nodes are not being used when the MCM is disabled.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A