### PR TITLE
[v2.11] Backport Fix #50499 prevent index out of range panic when `after` is empty

### DIFF
--- a/pkg/catalogv2/oci/oci.go
+++ b/pkg/catalogv2/oci/oci.go
@@ -177,7 +177,7 @@ func GenerateIndex(ociClient *Client, URL string, credentialSecret *corev1.Secre
 
 			// Work on all repositories if the user has not provided any repository or
 			// work on the oci repositories that match with the userProvidedRepository
-			if after, found := strings.CutPrefix(repository, ociClient.repository); found && (ociClient.repository == "" || after[0] == '/') {
+			if after, found := strings.CutPrefix(repository, ociClient.repository); found && (ociClient.repository == "" || after == "" || strings.HasPrefix(after, "/")) {
 				ociClient.repository = repository
 				orasRepository, err := ociClient.GetOrasRepository()
 				if err != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

#50895 
Original Issue: #50499 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Rancher pods go into a CrashLoopBackoff when an OCI repo after an upgrade from 2.11.1 to 2.11.2

```log
panic: runtime error: index out of range [0] with length 0 [recovered]                                                           panic: runtime error: index out of range [0] with length 0                                                                                                                                
```

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

after[0] needs to evaluated only after we check that it is not empty and it is safe to do so, as suggested in the original issue #50499  

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

K3S version: 1.30.13-k3s1

1. Installed Rancher
2. Created an OCI repo with (oci://code.forgejo.org/forgejo-helm/forgejo)
3. Created an OCI repo using zot and added to Repositories
4. Kept under observation for a couple of hours
5. No crashes observed

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_