### PR TITLE
[main][scc] Fix offline cert error Unwrap panic

### DIFF
--- a/pkg/scc/systeminfo/offline/offline.go
+++ b/pkg/scc/systeminfo/offline/offline.go
@@ -15,6 +15,7 @@ func offlineValidatorContextLogger() log.StructuredLogger {
 	return logBuilder.ToLogger()
 }
 
+// offlineCertError represents an issue encountered with offline certs; either a base error or wrapped error
 type offlineCertError struct {
 	Operation  string
 	Details    string
@@ -33,6 +34,12 @@ func (e *offlineCertError) Error() string {
 }
 
 func (e *offlineCertError) Unwrap() error {
+	// If e.WrappedErr is nil, it means this offlineCertError is
+	// the "base" or "original" error and doesn't wrap anything.
+	// In this case, return nil as per the errors.Unwrap contract.
+	if e.WrappedErr == nil {
+		return nil
+	}
 	return *e.WrappedErr
 }
 


### PR DESCRIPTION
## Problem

Offline Cert validation causes panic instead of an error.

```
│ rancher-cbcccfcfd-gnglk github.com/rancher/rancher/pkg/scc/systeminfo/offline.(*offlineCertError).Unwrap(0x108a0230?)           │
│ rancher-cbcccfcfd-gnglk     /app/pkg/scc/systeminfo/offline/offline.go:36 +0x4                                                  │
│ rancher-cbcccfcfd-gnglk errors.is({0xb294fc0?, 0xc007268320?}, {0xb294b60, 0x10898360}, 0x1)  
```

 
## Solution
Fix the `Unwrap` contract by returning nil if not a wrapped error.

