### PR TITLE
[2.11] 50849 etcd snapshot invalid resource version

### DIFF
--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate_test.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate_test.go
@@ -565,6 +565,19 @@ func TestOnDownstreamChange(t *testing.T) {
 	_, err = h.OnDownstreamChange("", snapshot)
 	assert.NoError(t, err, "It should update the snapshot if one exists but could not be found by the indexer")
 
+	// No matching snapshots but does not exist upstream
+
+	etcdSnapshotCache.EXPECT().GetByIndex(cluster2.ByETCDSnapshotName, "test-namespace/test-cluster/test-snapshot-downstream").Return([]*rkev1.ETCDSnapshot{}, nil).Times(1)
+
+	etcdSnapshotController.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *rkev1.ETCDSnapshot) (*rkev1.ETCDSnapshot, error) {
+		assert.Equal(t, "", s.ResourceVersion)
+		s.ResourceVersion = "1"
+		return s, nil
+	})
+
+	_, err = h.OnDownstreamChange("", snapshot)
+	assert.NoError(t, err, "It should create the snapshot if one does not exist")
+
 	// delete multiple snapshots
 
 	toDelete := []*rkev1.ETCDSnapshot{

--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate_test.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate_test.go
@@ -551,7 +551,16 @@ func TestOnDownstreamChange(t *testing.T) {
 	etcdSnapshotCache.EXPECT().GetByIndex(cluster2.ByETCDSnapshotName, "test-namespace/test-cluster/test-snapshot-downstream").Return([]*rkev1.ETCDSnapshot{}, nil).Times(1)
 
 	etcdSnapshotController.EXPECT().Create(gomock.Any()).Return(nil, apierrors.NewAlreadyExists(schema.GroupResource{}, "error")).Times(1)
-	etcdSnapshotController.EXPECT().Update(gomock.Any()).Return(nil, nil).Times(1)
+
+	existingSnapshot := upstreamSnapshot.DeepCopy()
+	existingSnapshot.ResourceVersion = "1"
+
+	etcdSnapshotCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(existingSnapshot, nil).Times(1)
+	etcdSnapshotController.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *rkev1.ETCDSnapshot) (*rkev1.ETCDSnapshot, error) {
+		assert.Equal(t, "1", s.ResourceVersion)
+		s.ResourceVersion = "2"
+		return s, nil
+	})
 
 	_, err = h.OnDownstreamChange("", snapshot)
 	assert.NoError(t, err, "It should update the snapshot if one exists but could not be found by the indexer")


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/50889

## Issue: <!-- link the issue or issues this PR resolves here --> #50849 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If an etcdsnapshot already exists but doesn't match the indexer criteria, it will fail to be updated with the following message:
```
[ERROR] error syncing 's3-etcd-snapshot-...': handler snapshotbackpopulate: etcdsnapshots.rke.cattle.io "...-etcd-snapshot-..." is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update, requeuing
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

If the etcdsnapshot object already exists, fetch the existing one before updating.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Updated existing unit tests to confirm the snapshot is updated.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

**NOTE**: when testing, the snapshot will only be reconciled when the downstream snapshot is changed. This will happen automatically after some time (when the object is reenqueued within rancher), but can be forced by restarting Rancher or editing the corresponding downstream etcdsnapshotfile object. **This behavior is expected, because if the snapshot cannot be correlated, there is no way to determine which downstream snapshot object relates to it without enqueueing all of them.**