### PR TITLE
[v2.11] Make cavalidator handler use a single-object watch

### DIFF
--- a/pkg/controllers/managementuser/cavalidator/cavalidator_test.go
+++ b/pkg/controllers/managementuser/cavalidator/cavalidator_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
+	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -112,16 +112,15 @@ func TestCAValidator_clusterConditionManipulation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockClusterLister := &fakes.ClusterListerMock{}
+			ctrl := gomock.NewController(t)
+			mockClusterLister := fake.NewMockNonNamespacedCacheInterface[*mgmtv3.Cluster](ctrl)
 			if tt.args.secret != nil && tt.args.secret.Name == "stv-aggregation" && tt.args.secret.Namespace == namespace.System {
-				mockClusterLister.GetFunc = func(namespace, name string) (*mgmtv3.Cluster, error) {
-					return tt.args.cluster, nil
-				}
+				mockClusterLister.EXPECT().Get(tt.args.cluster.Name).Return(tt.args.cluster, nil)
 			}
 
-			mockCluster := &fakes.ClusterInterfaceMock{}
+			mockCluster := fake.NewMockNonNamespacedClientInterface[*mgmtv3.Cluster, *mgmtv3.ClusterList](ctrl)
 			if tt.args.conditionSet {
-				mockCluster.UpdateFunc = func(cluster *mgmtv3.Cluster) (*mgmtv3.Cluster, error) {
+				mockCluster.EXPECT().UpdateStatus(gomock.Any()).DoAndReturn(func(cluster *mgmtv3.Cluster) (*mgmtv3.Cluster, error) {
 					if tt.args.conditionSet {
 						require.Len(t, cluster.Status.Conditions, 1)
 						require.Equal(t, string(CertificateAuthorityValid), string(cluster.Status.Conditions[0].Type), "incorrect condition set")
@@ -130,20 +129,18 @@ func TestCAValidator_clusterConditionManipulation(t *testing.T) {
 						require.Len(t, cluster.Status.Conditions, 0)
 					}
 					return cluster, nil
-
-				}
+				})
 			}
 
 			cav := &CertificateAuthorityValidator{
-				clusterName:   tt.args.cluster.Name,
-				clusterLister: mockClusterLister,
-				clusters:      mockCluster,
+				clusterName:  tt.args.cluster.Name,
+				clusterCache: mockClusterLister,
+				clusters:     mockCluster,
 			}
 
-			a := assert.New(t)
-
-			_, err := cav.onStvAggregationSecret(tt.args.secret.Name, tt.args.secret)
-			a.NoError(err)
+			secret := tt.args.secret
+			_, err := cav.onStvAggregationSecret(secret.Namespace+"/"+secret.Name, secret)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -48,9 +48,9 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 
 		machinerole.Register(ctx, cluster)
 	}
-	cavalidator.Register(ctx, cluster)
-
 	registerImpersonationCaches(cluster)
+
+	cavalidator.Register(ctx, cluster)
 
 	// register controller for API
 	cluster.APIAggregation.APIServices("").Controller()

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,161 @@
+package watcher
+
+import (
+	"context"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	defaultRetryPeriod = 5 * time.Second
+)
+
+type watchOptions struct {
+	handlerName   string
+	namespace     string
+	fieldSelector fields.Selector
+	retryPeriod   time.Duration
+	watchTimeout  *int64
+}
+
+func (o watchOptions) getLogger() logrus.FieldLogger {
+	if o.handlerName != "" {
+		return logrus.WithField("handler", o.handlerName)
+	}
+	return logrus.StandardLogger()
+}
+
+func loadWatchOptions(opts ...WatchOption) watchOptions {
+	options := watchOptions{
+		fieldSelector: fields.Everything(),
+		retryPeriod:   defaultRetryPeriod,
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+	return options
+}
+
+// WatchOption allows configuring how watches are performed
+type WatchOption func(*watchOptions)
+
+// WithHandlerName configures the handler name, used for logging
+func WithHandlerName(name string) WatchOption {
+	return func(o *watchOptions) {
+		o.handlerName = name
+	}
+}
+
+// WithNamespace allows watching resources in a single namespace
+func WithNamespace(namespace string) WatchOption {
+	return func(o *watchOptions) {
+		o.namespace = namespace
+	}
+}
+
+// WithFieldSelector will configure a field selector during Watch. E.g. setting "metadata.name=some-name" allows watching a specific resource
+func WithFieldSelector(m map[string]string) WatchOption {
+	return func(o *watchOptions) {
+		o.fieldSelector = fields.SelectorFromSet(m)
+	}
+}
+
+// WithRetryPeriod will set a retry period between failed watch attempts
+func WithRetryPeriod(retryPeriod time.Duration) WatchOption {
+	return func(o *watchOptions) {
+		o.retryPeriod = retryPeriod
+	}
+}
+
+// WithWatchTimeout will set a timeout for the every Watch operation
+func WithWatchTimeout(watchTimeout time.Duration) WatchOption {
+	return func(o *watchOptions) {
+		if watchTimeout >= time.Second {
+			seconds := int64(watchTimeout.Seconds())
+			o.watchTimeout = &seconds
+		}
+	}
+}
+
+type watchCallback[T generic.RuntimeMetaObject] func(T, watch.EventType)
+
+// OnChange configures a handler to be executed based on a dedicated watcher, not involving informers or existing caches
+// Despite accepting a generic.ObjectHandler, and unlike wrangler/lasso controllers, error-handling must be implemented on the handler directly
+func OnChange[T generic.RuntimeMetaObject, TList runtime.Object](client generic.ClientInterface[T, TList], ctx context.Context, name string, handler generic.ObjectHandler[T], opts ...WatchOption) {
+	opts = append(opts, WithHandlerName(name))
+	options := loadWatchOptions(opts...)
+	logger := options.getLogger()
+	callback := func(obj T, _ watch.EventType) {
+		key := objKey(obj)
+		if _, err := handler(key, obj); err != nil {
+			logger.Errorf("couldn't process %q object: %v", key, err)
+		}
+	}
+	go resumableWatch(ctx, client, callback, opts...)
+}
+
+// resumableWatch creates a watcher from client based on the provided watchOptions, then execute the callback with every event received. It is context-aware and will resume watching in case it is interrupted before the context is canceled
+func resumableWatch[T generic.RuntimeMetaObject, TList runtime.Object](ctx context.Context, client generic.ClientInterface[T, TList], callback watchCallback[T], opts ...WatchOption) {
+	options := loadWatchOptions(opts...)
+	logger := options.getLogger()
+
+	var watcher watch.Interface
+	var lastSeen string
+	for {
+		if watcher == nil {
+			var err error
+			watcher, err = client.Watch(options.namespace, metav1.ListOptions{
+				FieldSelector:   options.fieldSelector.String(),
+				TimeoutSeconds:  options.watchTimeout,
+				ResourceVersion: lastSeen, // if empty, it will produce an "Added" event with the initial state of the resources
+			})
+			if err != nil {
+				logger.WithError(err).Warnf("creating watch")
+				time.Sleep(options.retryPeriod)
+				continue
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			watcher.Stop()
+			return
+		case event, ok := <-watcher.ResultChan():
+			// Special case for watcher closed by the producer, e.g., due to an error or timeout
+			if !ok || event.Type == watch.Error {
+				watcher.Stop()
+				watcher = nil
+				continue
+			}
+
+			switch event.Type {
+			case watch.Added, watch.Modified, watch.Deleted:
+				obj, ok := event.Object.(T)
+				if !ok {
+					logger.Warnf("unexpected type %T, skipping...", event.Object)
+					continue
+				}
+				lastSeen = obj.GetResourceVersion()
+
+				callback(obj, event.Type)
+			}
+		}
+	}
+}
+
+func objKey(obj metav1.Object) string {
+	if obj == nil {
+		return ""
+	}
+	ns, name := obj.GetNamespace(), obj.GetName()
+	if ns == "" {
+		return name
+	}
+	return ns + "/" + name
+}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,153 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// TestResumableWatch_EventsHandled verifies that the callback is invoked for ADDED, MODIFIED, and DELETED events.
+func TestResumableWatch_EventsHandled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	watcher := watch.NewFake()
+	mockClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+	mockClient.EXPECT().Watch(gomock.Any(), gomock.Any()).Return(watcher, nil)
+
+	// This slice will store the events processed by the callback
+	var processedEvents []watch.EventType
+	callback := func(obj *corev1.ConfigMap, eventType watch.EventType) {
+		processedEvents = append(processedEvents, eventType)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go resumableWatch[*corev1.ConfigMap, *corev1.ConfigMapList](ctx, mockClient, callback)
+
+	// Send events to the watcher
+	obj := &corev1.ConfigMap{}
+	watcher.Add(obj)
+	watcher.Modify(obj)
+	watcher.Delete(obj)
+
+	// Give the goroutine time to process events
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	assert.Equal(t, []watch.EventType{watch.Added, watch.Modified, watch.Deleted}, processedEvents)
+}
+
+// TestResumableWatch_ContextCanceled ensures the watch loop terminates when the context is canceled.
+func TestResumableWatch_ContextCanceled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	watcher := watch.NewFake()
+	mockClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+	mockClient.EXPECT().Watch(gomock.Any(), gomock.Any()).Return(watcher, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		resumableWatch[*corev1.ConfigMap, *corev1.ConfigMapList](ctx, mockClient, nil)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Errorf("Watcher was not closed within the specified timeout")
+	case <-done:
+		assert.True(t, watcher.IsStopped())
+	}
+}
+
+// TestResumableWatch_RetryAfterError tests if the function retries when watch creation fails.
+func TestResumableWatch_RetryAfterError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	watcher := watch.NewFake()
+	mockClient := fake.NewMockClientInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	var attempts int
+	mockClient.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(func(string, metav1.ListOptions) (watch.Interface, error) {
+		attempts++
+		// Return an error on the first attempt to watch
+		if attempts <= 1 {
+			return nil, fmt.Errorf("can't watch this!")
+		}
+		return watcher, nil
+	}).Times(2) // expect to be called twice
+
+	var callbackCalled bool
+	callback := func(obj *corev1.Secret, eventType watch.EventType) {
+		callbackCalled = true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go resumableWatch[*corev1.Secret, *corev1.SecretList](ctx, mockClient, callback,
+		// Use a very short retry period for the test
+		WithRetryPeriod(10*time.Millisecond))
+
+	watcher.Add(&corev1.Secret{})
+
+	// Give it time to fail, retry, and process the event
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 2, attempts, "Expected two watch attempts")
+	assert.True(t, callbackCalled, "Callback should have been called after successful retry")
+}
+
+// TestResumableWatch_ResumesAfterErrorEvent verifies that the watch is re-established after an interruption.
+func TestResumableWatch_ResumesAfterErrorEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	watcher := watch.NewFake()
+	mockClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+	var doneFirstWatch bool
+	mockClient.EXPECT().Watch(gomock.Any(), gomock.Cond(func(opts metav1.ListOptions) bool {
+		// Verify that resumed watches provide a resource version
+		return !doneFirstWatch || opts.ResourceVersion == "1"
+	})).DoAndReturn(func(string, metav1.ListOptions) (watch.Interface, error) {
+		doneFirstWatch = true
+		watcher.Reset()
+		return watcher, nil
+	}).Times(2)
+
+	var eventsProcessed int
+	callback := func(obj *corev1.ConfigMap, eventType watch.EventType) {
+		eventsProcessed++
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go resumableWatch[*corev1.ConfigMap, *corev1.ConfigMapList](ctx, mockClient, callback)
+	for !doneFirstWatch {
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "1",
+		},
+	}
+	watcher.Add(cm)
+	watcher.Error(nil)
+
+	// Wait for events to be processed and watch resumed (first try is immediate)
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, eventsProcessed, "Expected one watch event")
+
+	cm.ResourceVersion = "2"
+	watcher.Modify(cm)
+
+	// Verify the watcher keeps working and processing events after the interruption
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 2, eventsProcessed, "Expected one watch event")
+}


### PR DESCRIPTION
## Issue: #50996 

Backports #50937