### PR TITLE
Push images only when explicitly asked by dev

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -114,7 +114,7 @@ if [ -z "$TARGET" ] || [ "$TARGET" = "server" ]; then
     --target server \
     --file ./package/Dockerfile .
 
-  if [ "$REPO" != "rancher" ]; then
+  if [ "$PUSH" = "true" ]; then
     docker push "${REPO}"/rancher:"${TAG}" &
   fi
 fi
@@ -127,7 +127,7 @@ if [ -z "$TARGET" ] || [ "$TARGET" = "agent" ]; then
     --target agent \
     --file ./package/Dockerfile .
 
-    if [ "$REPO" != "rancher" ]; then
+    if [ "$PUSH" = "true" ]; then
       docker push "${REPO}"/rancher-agent:"${TAG}" &
     fi
 fi


### PR DESCRIPTION
# Issue 

The command I use is usually:

```
$ make quick REPO=tlebreux TAG=<some tag>
```

so it always triggers the push even though I sometimes just want to test changes locally first, then push. 

# Solution

Use an explicit env var to trigger the image push. So now this works:

```
make quick PUSH=true
# OR
PUSH=true make quick
# OR
export PUSH=true
make quick
```

My workflow also works:

```
# Build image
$ make quick REPO=tlebreux TAG=<some tag>

# Local testing
....

# Basically only push the image since the code hasn't changed, everything is cached.
$ make quick REPO=tlebreux TAG=<some tag> PUSH=true
```