### PR TITLE
[main] EtcdSnapshot Public API

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/etcdsnapshot_types.go
+++ b/pkg/apis/rke.cattle.io/v1/etcdsnapshot_types.go
@@ -2,28 +2,38 @@ package v1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// ETCDSnapshotS3 defines S3 snapshot configuration for ETCD backups.
 type ETCDSnapshotS3 struct {
 	// Endpoint is the S3 endpoint used for snapshot operations.
+	// If this field is not explicitly set, the 'defaultEndpoint' value from the referenced CloudCredential will be used.
 	// +nullable
 	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
 
 	// EndpointCA is the CA certificate for validating the S3 endpoint.
+	// This can be either a file path (e.g., "/etc/ssl/certs/my-ca.crt")
+	// or the CA certificate content, in base64-encoded or plain PEM format.
+	// If this field is not explicitly set, the 'defaultEndpointCA' value from the referenced CloudCredential will be used.
 	// +nullable
 	// +optional
 	EndpointCA string `json:"endpointCA,omitempty"`
 
-	// SkipSSLVerify is a flag used to ignore certificate validation errors
-	// when using the configured endpoint.
+	// SkipSSLVerify defines whether TLS certificate verification is disabled.
+	// If this field is not explicitly set, the 'defaultSkipSSLVerify' value
+	// from the referenced CloudCredential will be used.
 	// +optional
 	SkipSSLVerify bool `json:"skipSSLVerify,omitempty"`
 
 	// Bucket is the name of the S3 bucket used for snapshot operations.
+	// If this field is not explicitly set, the 'defaultBucket' value from the referenced CloudCredential will be used.
+	// An empty bucket name will cause a 'failed to initialize S3 client: s3 bucket name was not set' error.
+	// +kubebuilder:validation:MaxLength=63
 	// +nullable
 	// +optional
 	Bucket string `json:"bucket,omitempty"`
 
-	// Region is the S3 region used for snapshot operations.
+	// Region is the S3 region used for snapshot operations. (e.g., "us-east-1").
+	// If this field is not explicitly set, the 'defaultRegion' value from the referenced CloudCredential will be used.
 	// +nullable
 	// +optional
 	Region string `json:"region,omitempty"`
@@ -39,44 +49,96 @@ type ETCDSnapshotS3 struct {
 	// - defaultSkipSSLVerify
 	// - defaultBucket
 	// - defaultFolder
+	// Fields set directly in this spec (`ETCDSnapshotS3`) take precedence over the corresponding
+	// values from the CloudCredential secret. This field must be in the format of "namespace:name".
 	// +nullable
 	// +optional
 	CloudCredentialName string `json:"cloudCredentialName,omitempty"`
 
 	// Folder is the name of the S3 folder used for snapshot operations.
+	// If this field is not explicitly set, the folder from the referenced CloudCredential will be used.
 	// +nullable
 	// +optional
 	Folder string `json:"folder,omitempty"`
 }
 
 // +genclient
-// +kubebuilder:skipversion
+// +kubebuilder:resource:path=etcdsnapshots,scope=Namespaced
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// ETCDSnapshot is the top-level resource representing a snapshot operation.
 type ETCDSnapshot struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ETCDSnapshotSpec   `json:"spec,omitempty"`
-	SnapshotFile      ETCDSnapshotFile   `json:"snapshotFile,omitempty"`
-	Status            ETCDSnapshotStatus `json:"status"`
+
+	// Spec defines the desired state of the ETCDSnapshot.
+	// +optional
+	Spec ETCDSnapshotSpec `json:"spec,omitempty"`
+
+	// SnapshotFile holds metadata about the snapshot file produced by this snapshot operation.
+	// +optional
+	SnapshotFile ETCDSnapshotFile `json:"snapshotFile,omitempty"`
+
+	// Status contains information about the current state of the snapshot operation.
+	// +optional
+	Status ETCDSnapshotStatus `json:"status,omitempty"`
 }
 
+// ETCDSnapshotSpec defines the desired state of a snapshot.
 type ETCDSnapshotSpec struct {
+	// ClusterName is the name of the cluster (cluster.provisioning.cattle.io) for which this snapshot was taken.
+	// +optional
 	ClusterName string `json:"clusterName,omitempty"`
 }
 
+// ETCDSnapshotFile holds metadata about a snapshot file.
 type ETCDSnapshotFile struct {
-	Name      string          `json:"name,omitempty"`
-	NodeName  string          `json:"nodeName,omitempty"`
-	Location  string          `json:"location,omitempty"`
-	Metadata  string          `json:"metadata,omitempty"`
-	CreatedAt *metav1.Time    `json:"createdAt,omitempty"`
-	Size      int64           `json:"size,omitempty"`
-	S3        *ETCDSnapshotS3 `json:"s3,omitempty"`
-	Status    string          `json:"status,omitempty"`
-	Message   string          `json:"message,omitempty"`
+	// Name is the full snapshot name. It consists of the cluster name prefix,
+	// followed by the base snapshot identifier and ends with an optional storage suffix (e.g. "s3").
+	// The typical format is:
+	//   <cluster>-etcd-snapshot-<cluster>-<nodepool>-<uniqueid>-<timestamp>[-<storage-type>]
+	// The base snapshot identifier follows:
+	//   etcd-snapshot-<cluster>-<nodepool>-<uniqueid>-<timestamp>
+	// +optional
+	Name string `json:"name,omitempty"`
+
+	// NodeName is the name of the downstream node where the snapshot was created.
+	// +optional
+	NodeName string `json:"nodeName,omitempty"`
+
+	// Location is the absolute file:// or s3:// URI address of the snapshot.
+	// +optional
+	Location string `json:"location,omitempty"`
+
+	// Metadata contains a base64-encoded, gzipped snapshot of the cluster spec at the time the snapshot was taken.
+	// +optional
+	Metadata string `json:"metadata,omitempty"`
+
+	// CreatedAt is the timestamp when the snapshot was created.
+	// +optional
+	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+
+	// Size is the size of the snapshot file in bytes.
+	// +optional
+	Size int64 `json:"size,omitempty"`
+
+	// S3 holds metadata about the S3 destination if the snapshot is stored remotely. If nil, the snapshot
+	// is assumed to be stored locally and associated with the owning CAPI machine.
+	// +optional
+	S3 *ETCDSnapshotS3 `json:"s3,omitempty"`
+
+	// Status represents the current state of the snapshot, such as "successful" or "failed".
+	// +optional
+	Status string `json:"status,omitempty"`
+
+	// Message is a string detailing the encountered error during snapshot creation if specified.
+	// +optional
+	Message string `json:"message,omitempty"`
 }
 
+// ETCDSnapshotStatus describes the observed state of the snapshot.
 type ETCDSnapshotStatus struct {
+	// This field is currently unused but retained for backward compatibility or future use.
 	Missing bool `json:"missing"`
 }

--- a/pkg/apis/rke.cattle.io/v1/rkecontrolplane_types.go
+++ b/pkg/apis/rke.cattle.io/v1/rkecontrolplane_types.go
@@ -59,7 +59,7 @@ type RKEControlPlaneSpec struct {
 	// +required
 	ManagementClusterName string `json:"managementClusterName,omitempty"`
 
-	// UnamanagedConfig indicates whether the configuration files for this
+	// UnmanagedConfig indicates whether the configuration files for this
 	// cluster are managed by Rancher or externally.
 	UnmanagedConfig bool `json:"unmanagedConfig,omitempty"`
 }

--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -227,7 +227,7 @@ var MigratedResources = map[string]bool{
 	"custommachines.rke.cattle.io":                                    true,
 	"dockercredentials.project.cattle.io":                             false,
 	"dynamicschemas.management.cattle.io":                             true,
-	"etcdsnapshots.rke.cattle.io":                                     false,
+	"etcdsnapshots.rke.cattle.io":                                     true,
 	"extensionconfigs.runtime.cluster.x-k8s.io":                       false,
 	"features.management.cattle.io":                                   false,
 	"fleetworkspaces.management.cattle.io":                            false,

--- a/pkg/crds/yaml/generated/provisioning.cattle.io_clusters.yaml
+++ b/pkg/crds/yaml/generated/provisioning.cattle.io_clusters.yaml
@@ -2405,8 +2405,11 @@ spec:
                         nullable: true
                         properties:
                           bucket:
-                            description: Bucket is the name of the S3 bucket used
-                              for snapshot operations.
+                            description: |-
+                              Bucket is the name of the S3 bucket used for snapshot operations.
+                              If this field is not explicitly set, the 'defaultBucket' value from the referenced CloudCredential will be used.
+                              An empty bucket name will cause a 'failed to initialize S3 client: s3 bucket name was not set' error.
+                            maxLength: 63
                             nullable: true
                             type: string
                           cloudCredentialName:
@@ -2422,32 +2425,41 @@ spec:
                               - defaultSkipSSLVerify
                               - defaultBucket
                               - defaultFolder
+                              Fields set directly in this spec (`ETCDSnapshotS3`) take precedence over the corresponding
+                              values from the CloudCredential secret. This field must be in the format of "namespace:name".
                             nullable: true
                             type: string
                           endpoint:
-                            description: Endpoint is the S3 endpoint used for snapshot
-                              operations.
+                            description: |-
+                              Endpoint is the S3 endpoint used for snapshot operations.
+                              If this field is not explicitly set, the 'defaultEndpoint' value from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           endpointCA:
-                            description: EndpointCA is the CA certificate for validating
-                              the S3 endpoint.
+                            description: |-
+                              EndpointCA is the CA certificate for validating the S3 endpoint.
+                              This can be either a file path (e.g., "/etc/ssl/certs/my-ca.crt")
+                              or the CA certificate content, in base64-encoded or plain PEM format.
+                              If this field is not explicitly set, the 'defaultEndpointCA' value from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           folder:
-                            description: Folder is the name of the S3 folder used
-                              for snapshot operations.
+                            description: |-
+                              Folder is the name of the S3 folder used for snapshot operations.
+                              If this field is not explicitly set, the folder from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           region:
-                            description: Region is the S3 region used for snapshot
-                              operations.
+                            description: |-
+                              Region is the S3 region used for snapshot operations. (e.g., "us-east-1").
+                              If this field is not explicitly set, the 'defaultRegion' value from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           skipSSLVerify:
                             description: |-
-                              SkipSSLVerify is a flag used to ignore certificate validation errors
-                              when using the configured endpoint.
+                              SkipSSLVerify defines whether TLS certificate verification is disabled.
+                              If this field is not explicitly set, the 'defaultSkipSSLVerify' value
+                              from the referenced CloudCredential will be used.
                             type: boolean
                         type: object
                       snapshotRetention:

--- a/pkg/crds/yaml/generated/rke.cattle.io_etcdsnapshots.yaml
+++ b/pkg/crds/yaml/generated/rke.cattle.io_etcdsnapshots.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: etcdsnapshots.rke.cattle.io
+spec:
+  group: rke.cattle.io
+  names:
+    kind: ETCDSnapshot
+    listKind: ETCDSnapshotList
+    plural: etcdsnapshots
+    singular: etcdsnapshot
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ETCDSnapshot is the top-level resource representing a snapshot
+          operation.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          snapshotFile:
+            description: SnapshotFile holds metadata about the snapshot file produced
+              by this snapshot operation.
+            properties:
+              createdAt:
+                description: CreatedAt is the timestamp when the snapshot was created.
+                format: date-time
+                type: string
+              location:
+                description: Location is the absolute file:// or s3:// URI address
+                  of the snapshot.
+                type: string
+              message:
+                description: Message is a string detailing the encountered error during
+                  snapshot creation if specified.
+                type: string
+              metadata:
+                description: Metadata contains a base64-encoded, gzipped snapshot
+                  of the cluster spec at the time the snapshot was taken.
+                type: string
+              name:
+                description: |-
+                  Name is the full snapshot name. It consists of the cluster name prefix,
+                  followed by the base snapshot identifier and ends with an optional storage suffix (e.g. "s3").
+                  The typical format is:
+                    <cluster>-etcd-snapshot-<cluster>-<nodepool>-<uniqueid>-<timestamp>[-<storage-type>]
+                  The base snapshot identifier follows:
+                    etcd-snapshot-<cluster>-<nodepool>-<uniqueid>-<timestamp>
+                type: string
+              nodeName:
+                description: NodeName is the name of the downstream node where the
+                  snapshot was created.
+                type: string
+              s3:
+                description: |-
+                  S3 holds metadata about the S3 destination if the snapshot is stored remotely. If nil, the snapshot
+                  is assumed to be stored locally and associated with the owning CAPI machine.
+                properties:
+                  bucket:
+                    description: |-
+                      Bucket is the name of the S3 bucket used for snapshot operations.
+                      If this field is not explicitly set, the 'defaultBucket' value from the referenced CloudCredential will be used.
+                      An empty bucket name will cause a 'failed to initialize S3 client: s3 bucket name was not set' error.
+                    maxLength: 63
+                    nullable: true
+                    type: string
+                  cloudCredentialName:
+                    description: |-
+                      CloudCredentialName is the name of the secret containing the
+                      credentials used to access the S3 bucket.
+                      The secret is expected to have the following keys:
+                      - accessKey [required]
+                      - secretKey [required]
+                      - defaultRegion
+                      - defaultEndpoint
+                      - defaultEndpointCA
+                      - defaultSkipSSLVerify
+                      - defaultBucket
+                      - defaultFolder
+                      Fields set directly in this spec (`ETCDSnapshotS3`) take precedence over the corresponding
+                      values from the CloudCredential secret. This field must be in the format of "namespace:name".
+                    nullable: true
+                    type: string
+                  endpoint:
+                    description: |-
+                      Endpoint is the S3 endpoint used for snapshot operations.
+                      If this field is not explicitly set, the 'defaultEndpoint' value from the referenced CloudCredential will be used.
+                    nullable: true
+                    type: string
+                  endpointCA:
+                    description: |-
+                      EndpointCA is the CA certificate for validating the S3 endpoint.
+                      This can be either a file path (e.g., "/etc/ssl/certs/my-ca.crt")
+                      or the CA certificate content, in base64-encoded or plain PEM format.
+                      If this field is not explicitly set, the 'defaultEndpointCA' value from the referenced CloudCredential will be used.
+                    nullable: true
+                    type: string
+                  folder:
+                    description: |-
+                      Folder is the name of the S3 folder used for snapshot operations.
+                      If this field is not explicitly set, the folder from the referenced CloudCredential will be used.
+                    nullable: true
+                    type: string
+                  region:
+                    description: |-
+                      Region is the S3 region used for snapshot operations. (e.g., "us-east-1").
+                      If this field is not explicitly set, the 'defaultRegion' value from the referenced CloudCredential will be used.
+                    nullable: true
+                    type: string
+                  skipSSLVerify:
+                    description: |-
+                      SkipSSLVerify defines whether TLS certificate verification is disabled.
+                      If this field is not explicitly set, the 'defaultSkipSSLVerify' value
+                      from the referenced CloudCredential will be used.
+                    type: boolean
+                type: object
+              size:
+                description: Size is the size of the snapshot file in bytes.
+                format: int64
+                type: integer
+              status:
+                description: Status represents the current state of the snapshot,
+                  such as "successful" or "failed".
+                type: string
+            type: object
+          spec:
+            description: Spec defines the desired state of the ETCDSnapshot.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the cluster (cluster.provisioning.cattle.io)
+                  for which this snapshot was taken.
+                type: string
+            type: object
+          status:
+            description: Status contains information about the current state of the
+              snapshot operation.
+            properties:
+              missing:
+                description: This field is currently unused but retained for backward
+                  compatibility or future use.
+                type: boolean
+            required:
+            - missing
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/crds/yaml/generated/rke.cattle.io_rkecontrolplanes.yaml
+++ b/pkg/crds/yaml/generated/rke.cattle.io_rkecontrolplanes.yaml
@@ -146,8 +146,11 @@ spec:
                     nullable: true
                     properties:
                       bucket:
-                        description: Bucket is the name of the S3 bucket used for
-                          snapshot operations.
+                        description: |-
+                          Bucket is the name of the S3 bucket used for snapshot operations.
+                          If this field is not explicitly set, the 'defaultBucket' value from the referenced CloudCredential will be used.
+                          An empty bucket name will cause a 'failed to initialize S3 client: s3 bucket name was not set' error.
+                        maxLength: 63
                         nullable: true
                         type: string
                       cloudCredentialName:
@@ -163,31 +166,41 @@ spec:
                           - defaultSkipSSLVerify
                           - defaultBucket
                           - defaultFolder
+                          Fields set directly in this spec (`ETCDSnapshotS3`) take precedence over the corresponding
+                          values from the CloudCredential secret. This field must be in the format of "namespace:name".
                         nullable: true
                         type: string
                       endpoint:
-                        description: Endpoint is the S3 endpoint used for snapshot
-                          operations.
+                        description: |-
+                          Endpoint is the S3 endpoint used for snapshot operations.
+                          If this field is not explicitly set, the 'defaultEndpoint' value from the referenced CloudCredential will be used.
                         nullable: true
                         type: string
                       endpointCA:
-                        description: EndpointCA is the CA certificate for validating
-                          the S3 endpoint.
+                        description: |-
+                          EndpointCA is the CA certificate for validating the S3 endpoint.
+                          This can be either a file path (e.g., "/etc/ssl/certs/my-ca.crt")
+                          or the CA certificate content, in base64-encoded or plain PEM format.
+                          If this field is not explicitly set, the 'defaultEndpointCA' value from the referenced CloudCredential will be used.
                         nullable: true
                         type: string
                       folder:
-                        description: Folder is the name of the S3 folder used for
-                          snapshot operations.
+                        description: |-
+                          Folder is the name of the S3 folder used for snapshot operations.
+                          If this field is not explicitly set, the folder from the referenced CloudCredential will be used.
                         nullable: true
                         type: string
                       region:
-                        description: Region is the S3 region used for snapshot operations.
+                        description: |-
+                          Region is the S3 region used for snapshot operations. (e.g., "us-east-1").
+                          If this field is not explicitly set, the 'defaultRegion' value from the referenced CloudCredential will be used.
                         nullable: true
                         type: string
                       skipSSLVerify:
                         description: |-
-                          SkipSSLVerify is a flag used to ignore certificate validation errors
-                          when using the configured endpoint.
+                          SkipSSLVerify defines whether TLS certificate verification is disabled.
+                          If this field is not explicitly set, the 'defaultSkipSSLVerify' value
+                          from the referenced CloudCredential will be used.
                         type: boolean
                     type: object
                   snapshotRetention:
@@ -687,7 +700,7 @@ spec:
                 type: object
               unmanagedConfig:
                 description: |-
-                  UnamanagedConfig indicates whether the configuration files for this
+                  UnmanagedConfig indicates whether the configuration files for this
                   cluster are managed by Rancher or externally.
                 type: boolean
               upgradeStrategy:
@@ -1005,8 +1018,11 @@ spec:
                         nullable: true
                         properties:
                           bucket:
-                            description: Bucket is the name of the S3 bucket used
-                              for snapshot operations.
+                            description: |-
+                              Bucket is the name of the S3 bucket used for snapshot operations.
+                              If this field is not explicitly set, the 'defaultBucket' value from the referenced CloudCredential will be used.
+                              An empty bucket name will cause a 'failed to initialize S3 client: s3 bucket name was not set' error.
+                            maxLength: 63
                             nullable: true
                             type: string
                           cloudCredentialName:
@@ -1022,32 +1038,41 @@ spec:
                               - defaultSkipSSLVerify
                               - defaultBucket
                               - defaultFolder
+                              Fields set directly in this spec (`ETCDSnapshotS3`) take precedence over the corresponding
+                              values from the CloudCredential secret. This field must be in the format of "namespace:name".
                             nullable: true
                             type: string
                           endpoint:
-                            description: Endpoint is the S3 endpoint used for snapshot
-                              operations.
+                            description: |-
+                              Endpoint is the S3 endpoint used for snapshot operations.
+                              If this field is not explicitly set, the 'defaultEndpoint' value from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           endpointCA:
-                            description: EndpointCA is the CA certificate for validating
-                              the S3 endpoint.
+                            description: |-
+                              EndpointCA is the CA certificate for validating the S3 endpoint.
+                              This can be either a file path (e.g., "/etc/ssl/certs/my-ca.crt")
+                              or the CA certificate content, in base64-encoded or plain PEM format.
+                              If this field is not explicitly set, the 'defaultEndpointCA' value from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           folder:
-                            description: Folder is the name of the S3 folder used
-                              for snapshot operations.
+                            description: |-
+                              Folder is the name of the S3 folder used for snapshot operations.
+                              If this field is not explicitly set, the folder from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           region:
-                            description: Region is the S3 region used for snapshot
-                              operations.
+                            description: |-
+                              Region is the S3 region used for snapshot operations. (e.g., "us-east-1").
+                              If this field is not explicitly set, the 'defaultRegion' value from the referenced CloudCredential will be used.
                             nullable: true
                             type: string
                           skipSSLVerify:
                             description: |-
-                              SkipSSLVerify is a flag used to ignore certificate validation errors
-                              when using the configured endpoint.
+                              SkipSSLVerify defines whether TLS certificate verification is disabled.
+                              If this field is not explicitly set, the 'defaultSkipSSLVerify' value
+                              from the referenced CloudCredential will be used.
                             type: boolean
                         type: object
                       snapshotRetention:
@@ -1549,7 +1574,7 @@ spec:
                     type: object
                   unmanagedConfig:
                     description: |-
-                      UnamanagedConfig indicates whether the configuration files for this
+                      UnmanagedConfig indicates whether the configuration files for this
                       cluster are managed by Rancher or externally.
                     type: boolean
                   upgradeStrategy:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/50231
 
## Problem
`kubectl explain etcdsnapshots.rke.cattle.io` does not have meaningful output.

## Solution
Add comments and kube builder markers to improve kubectl explain output. 
 
## Testing
Tested output of `kubectl explain etcdsnapshot.snapshotFile`, `kubectl explain kubectl explain etcdsnapshots.snapshotFile.s3` and  `kubectl get crd etcdsnapshots.rke.cattle.io -o yaml`. 

Created a downstream cluster and confirmed etcd snapshots continue to work for local and s3.

## Engineering Testing
### Manual Testing
Explained above 