### PR TITLE
[WIP] Add backup label to provisioning secrets

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -92,6 +92,9 @@ const (
 	MachineTemplateClonedFromKindAnn         = "rke.cattle.io/cloned-from-kind"
 	MachineTemplateClonedFromNameAnn         = "rke.cattle.io/cloned-from-name"
 
+	// Label added to secrets to make sure they are included in backups when created in a namespace other than fleet-default
+	BackupLabel = "resources.cattle.io/backup"
+
 	CattleOSLabel    = "cattle.io/os"
 	DefaultMachineOS = "linux"
 	WindowsMachineOS = "windows"

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -1182,6 +1182,9 @@ func (p *Planner) ensureRKEStateSecret(controlPlane *rkev1.RKEControlPlane, newC
 						UID:        controlPlane.UID,
 					},
 				},
+				Labels: map[string]string{
+					capr.BackupLabel: "true",
+				},
 			},
 			Data: map[string][]byte{
 				"serverToken": []byte(serverToken),

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -391,6 +391,7 @@ func getLabelsAndAnnotationsForPlanSecret(bootstrap *rkev1.RKEBootstrap, machine
 	labels := make(map[string]string, len(bootstrap.Labels)+2)
 	labels[capr.MachineNameLabel] = machine.Name
 	labels[capr.ClusterNameLabel] = bootstrap.Spec.ClusterName
+	labels[capr.BackupLabel] = "true"
 	for k, v := range bootstrap.Labels {
 		labels[k] = v
 	}

--- a/pkg/controllers/capr/machineprovision/template.go
+++ b/pkg/controllers/capr/machineprovision/template.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/rancher/rancher/pkg/capr"
 	name2 "github.com/rancher/wrangler/v3/pkg/name"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,9 @@ func objects(ready bool, args driverArgs) []runtime.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      args.StateSecretName,
 			Namespace: args.MachineNamespace,
+			Labels: map[string]string{
+				capr.BackupLabel: "true",
+			},
 		},
 		Type: "rke.cattle.io/machine-state",
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/backup-restore-operator/issues/663
 
## Problem

Users often choose to create their provisioning clusters via GitOps in namespaces other than `fleet-default`.
This leads to problems with backup and restores using [BRO](https://github.com/rancher/backup-restore-operator) as the operator doesn't look for these Secrets in other namespaces. 

There's two reasons why we chose that design:
- Searching all namespaces makes Backups significantly slower, to the fewer of those queries we have, the better.
- Avoid including unrelated secrets that may have a name matching the backup rules.
 
## Solution

With that in mind, the ideal solution in our (the O&B team's) mind is to have each team, (in this case, provisioning) control which Secrets should be included in the Backups by labeling them with `"resources.cattle.io/backup": true`.

This PR is a first effort in that direction and needs thorough review and possibly improvements by the Provisioning team which has expertise on this scenario.  
 
## Testing

Testing this PR consists of:
- Deploying a downstream cluster in a namespace other than `fleet-default`
- Creating a Backup
- Perform an in-place restore, making sure the Cluster still works
- Perform a migration, making sure the resulting cluster still works

My PR is possibly non-exhaustive as it looks like BRO includes [several Provisioning secrets](https://github.com/rancher/backup-restore-operator/blob/main/charts/rancher-backup/files/sensitive-resourceset-contents/provisioningv2.yaml) into backups other than the ones we're labeling with this PR