### PR TITLE
fix user deletion when disabling cognito

### DIFF
--- a/pkg/auth/api/secrets/fields.go
+++ b/pkg/auth/api/secrets/fields.go
@@ -22,6 +22,7 @@ var (
 		client.OIDCConfigType:            {client.OIDCConfigFieldPrivateKey, client.OIDCConfigFieldClientSecret},
 		client.KeyCloakOIDCConfigType:    {client.KeyCloakOIDCConfigFieldPrivateKey, client.KeyCloakOIDCConfigFieldClientSecret},
 		client.GenericOIDCConfigType:     {client.GenericOIDCConfigFieldPrivateKey, client.GenericOIDCConfigFieldClientSecret},
+		client.CognitoConfigType:         {client.CognitoConfigFieldPrivateKey, client.CognitoConfigFieldClientSecret},
 	}
 	// SubTypeToFields associates an Auth Config type with a nested map of secret names related to the config.
 	SubTypeToFields = map[string]map[string][]string{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48512
 
## Problem
Users are not deleted when disabling amazon cognito. The following error is displayed in the logs:
```
2025/07/15 10:09:05 [ERROR] error syncing 'cognito': handler mgmt-auth-config-controller: error cleaning up resources associated with a disabled auth provider cognito: cannot delete auth provider cognitoConfig because it's unknown to Rancher, requeuing
```
The problem is a missing entry in the [TypeToFields](https://github.com/rancher/rancher/blob/main/pkg/auth/api/secrets/fields.go#L10) map. The error is returned [here](https://github.com/rancher/rancher/blob/main/pkg/auth/api/secrets/cleanup.go#L24).
 
## Solution
Add Cognito type to `TypeToFields` 
