### PR TITLE
Bump steve to v0.7.4 to move default sorting from `namespace+name` to `id`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/rancher/remotedialer v0.5.0-rc.1
 	github.com/rancher/rke v1.8.0-rc.4
 	github.com/rancher/shepherd v0.0.0-20250411212007-f3f2fd268849
-	github.com/rancher/steve v0.7.3
+	github.com/rancher/steve v0.7.4
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd
 	github.com/rancher/tests/actions v0.0.0-20250505204226-5b136337f7c5
 	github.com/rancher/wrangler v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -678,8 +678,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20250411212007-f3f2fd268849 h1:hxa/Y0LRTx8BzMPxirT9Yg3IZg2YXus7+smLLn5n9tw=
 github.com/rancher/shepherd v0.0.0-20250411212007-f3f2fd268849/go.mod h1:IVVaLrIQ1/1Fk7KTrkhpKFlgaqhh3uv27CokmEhXHJc=
-github.com/rancher/steve v0.7.3 h1:IIvkRRpxCQUMiHgjlqhQr65us7sFMXLfRNYZVJYCsso=
-github.com/rancher/steve v0.7.3/go.mod h1:/IH+uMCnW/lE1Syz5jgLc1W6QqpPWv117MBFEL9kg5A=
+github.com/rancher/steve v0.7.4 h1:uOpbWxa5fzbiCYETaXUhLdBZeY12Jw2I+JwD0xnDWvU=
+github.com/rancher/steve v0.7.4/go.mod h1:/IH+uMCnW/lE1Syz5jgLc1W6QqpPWv117MBFEL9kg5A=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/tests/actions v0.0.0-20250505204226-5b136337f7c5 h1:iatxRcqkupXLGISfU5zRA37po3YO7Pqq/Ao7bIqFsu4=


### PR DESCRIPTION
Related to #50999 