### PR TITLE
[2.12] ensure the SUC app to be always installed on node-driver/custom RKE2/K3s clusters

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -298,7 +298,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				}
 				var versionManagementEnabled bool
 				if features.MCMAgent.Enabled() {
-					// For the imported or node-driver RKE2/K3s cluster,
+					// For the imported or node-driver/custom RKE2/K3s cluster,
 					// cluster agent checks the ManagedSystemUpgradeController feature in the cluster
 					versionManagementEnabled = features.ManagedSystemUpgradeController.Enabled()
 				}
@@ -341,7 +341,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 
 				var versionManagementEnabled bool
 				if features.MCMAgent.Enabled() {
-					// For the imported or node-driver RKE2/K3s cluster,
+					// For the imported or node-driver/custom RKE2/K3s cluster,
 					// cluster agent checks the ManagedSystemUpgradeController feature in the cluster
 					versionManagementEnabled = features.ManagedSystemUpgradeController.Enabled()
 				}

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -299,7 +299,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				var versionManagementEnabled bool
 				if features.MCMAgent.Enabled() {
 					// For the imported or node-driver RKE2/K3s cluster,
-					// cluster agent checks the ManagedSystemUpgradeController feature in the imported cluster
+					// cluster agent checks the ManagedSystemUpgradeController feature in the cluster
 					versionManagementEnabled = features.ManagedSystemUpgradeController.Enabled()
 				}
 				if features.MCM.Enabled() {
@@ -341,8 +341,8 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 
 				var versionManagementEnabled bool
 				if features.MCMAgent.Enabled() {
-					// For the imported RKE2/K3s cluster,
-					// cluster agent checks the ManagedSystemUpgradeController feature in the imported cluster
+					// For the imported or node-driver RKE2/K3s cluster,
+					// cluster agent checks the ManagedSystemUpgradeController feature in the cluster
 					versionManagementEnabled = features.ManagedSystemUpgradeController.Enabled()
 				}
 				if features.MCM.Enabled() {

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -255,11 +255,12 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 	enableMSUC := false
 	if cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 || cluster.Status.Driver == apimgmtv3.ClusterDriverK3s {
 		// the case of imported RKE2/K3s cluster
-		enableMSUC = importedclusterversionmanagement.Enabled(cluster)
+		enableMSUC = importedclusterversionmanagement.Enabled(cluster) && features.ManagedSystemUpgradeController.Enabled()
 	}
 	if cluster.Status.Driver == apimgmtv3.ClusterDriverImported &&
 		(cluster.Status.Provider == apimgmtv3.ClusterDriverRke2 || cluster.Status.Provider == apimgmtv3.ClusterDriverK3s) {
 		// the case of node-driver RKE2/K3s cluster
+		// The SUC app must be installed in order for Rancher to upgrade the cluster’s Kubernetes version.
 		enableMSUC = true
 	}
 	return map[string]bool{
@@ -271,7 +272,7 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 		features.EmbeddedClusterAPI.Name():             false,
 		features.UISQLCache.Name():                     features.UISQLCache.Enabled(),
 		features.ProvisioningPreBootstrap.Name():       capr.PreBootstrap(cluster),
-		features.ManagedSystemUpgradeController.Name(): features.ManagedSystemUpgradeController.Enabled() && enableMSUC,
+		features.ManagedSystemUpgradeController.Name(): enableMSUC,
 	}
 }
 

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -259,7 +259,7 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 	}
 	if cluster.Status.Driver == apimgmtv3.ClusterDriverImported &&
 		(cluster.Status.Provider == apimgmtv3.ClusterDriverRke2 || cluster.Status.Provider == apimgmtv3.ClusterDriverK3s) {
-		// the case of node-driver RKE2/K3s cluster
+		// the case of node-driver/custom RKE2/K3s cluster
 		// The SUC app must be installed in order for Rancher to upgrade the cluster’s Kubernetes version.
 		enableMSUC = true
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/51051

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
 
The `system-upgrade-controller` app is required on downstream node-driver RKE2/K3s clusters for Rancher to perform Kubernetes version upgrades.

However, if the `managed-system-upgrade-controller` feature flag is disabled, the SUC app will not be installed on these clusters. This flag is intended for internal use to control SUC app management in imported clusters, not node-driver clusters, where the app should always be installed.



## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This occurs because, starting with Rancher 2.12.0, the installation of the `system-upgrade-controller` app in node-driver clusters is managed by the cluster agent. Therefore, we need to update the logic that determines whether the `managed-system-upgrade-controller` feature should be enabled in the cattle-cluster-agent for the target node-driver RKE2/K3s cluster.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
 
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


The fix is validated by using the images built from the PR. 
 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
When Rancher is installed with the `managed-system-upgrade-controller` feature disabled:

- Confirm that the SUC app is installed on the node-driver clusters
- Confirm that the SUC app is NOT installed on the imported clusters


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 
Same as the above 

 