### PR TITLE
refactor rancher components script

### DIFF
--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -9,22 +9,23 @@ cd $(dirname $0)/..
 mkdir -p bin
 
 COMPONENTSFILE=./bin/rancher-components.txt
+K8SVERSIONSFILE=./bin/rancher-rke-k8s-versions.txt
 
 echo "# Images with -rc" >$COMPONENTSFILE
 
-printf '%s\n' "$(grep -h "\-rc|\-alpha" ./bin/rancher-images.txt ./bin/rancher-windows-images.txt | awk -F: '{ print $1,$2 }')" | sort -u >>$COMPONENTSFILE
+grep -h -e '-rc' -e '-alpha' ./bin/rancher-images.txt ./bin/rancher-windows-images.txt | sort -u >>$COMPONENTSFILE
+echo "" >>$COMPONENTSFILE
 
 echo "# Components with -rc" >>$COMPONENTSFILE
 
-printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$|MIN_VERSION" | grep CATTLE | sed 's/CATTLE_//g' | sed 's/=/ /g' | awk '{ print $2,$3 }' | sort | grep "\-rc|\-alpha")" >>$COMPONENTSFILE
-
-printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./" | egrep -v "\/pkg\/apis|\/pkg\/client|^module" | grep -v "=>" | awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)' | sort | grep "\-rc|\-alpha")" >>$COMPONENTSFILE
+grep -e '^ENV CATTLE_.*_VERSION.*' package/Dockerfile | grep -E -v 'http|\$|MIN_VERSION' | grep -e '-rc' -e '-alpha' | sed 's/ENV CATTLE_//g' | sort >>$COMPONENTSFILE
+grep -e "rancher/" go.mod | grep -v -e '\./' -e '/pkg/apis' -e '/pkg/client' -e '^module' -e '=>' | grep -e '-rc' -e '-alpha' | cut -d '/' -f3 | awk '$1 = toupper($1)' | sort >>$COMPONENTSFILE
+echo "" >>$COMPONENTSFILE
 
 echo "# Min version components with -rc" >>$COMPONENTSFILE
 
-printf '%s\n' "$(grep "_MIN_VERSION" ./package/Dockerfile | grep ENV | grep CATTLE | sed 's/CATTLE_//g' | sed 's/=/ /g' | awk '{ print $2,$3 }' | sort | grep "\-rc|\-alpha")" >>$COMPONENTSFILE
-
-K8SVERSIONSFILE=./bin/rancher-rke-k8s-versions.txt
+grep -e '^ENV CATTLE_.*_MIN_VERSION.*' package/Dockerfile | grep -e '-rc' -e '-alpha' | sed 's/ENV CATTLE_//g' | sort >>$COMPONENTSFILE
+echo "" >>$COMPONENTSFILE
 
 if [[ -f "$K8SVERSIONSFILE" ]]; then
   echo "# RKE Kubernetes versions" >>$COMPONENTSFILE


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The `create-components-file.sh` script is not properly finding -rc and -alpha images because some expressions were invalid
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Refactor the script to use updated expressions that work with the latest grep version available
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
File generated with the refactored script in `v2.11.3`
```
# Images with -rc
rancher/rke2-cloud-provider:v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101

# Components with -rc

# Min version components with -rc

# Chart/KDM sources
* CHART_DEFAULT_BRANCH: release-v2.11 (`scripts/package-env`)
* CHART_DEFAULT_BRANCH: release-v2.11 (`package/Dockerfile`)
* CATTLE_KDM_BRANCH: release-v2.11 (`package/Dockerfile`)
* CATTLE_KDM_BRANCH: release-v2.11 (`Dockerfile.dapper`)
* KDMBranch: release-v2.11 (`pkg/settings/setting.go`)
* ChartDefaultBranch: release-v2.11 (`pkg/settings/setting.go`)
```
Original `v2.11.3` file:
```
# Images with -rc

# Components with -rc


# Min version components with -rc

# Chart/KDM sources
* CHART_DEFAULT_BRANCH: release-v2.11 (`scripts/package-env`)
* CHART_DEFAULT_BRANCH: release-v2.11 (`package/Dockerfile`)
* CATTLE_KDM_BRANCH: release-v2.11 (`package/Dockerfile`)
* CATTLE_KDM_BRANCH: release-v2.11 (`Dockerfile.dapper`)
* KDMBranch: release-v2.11 (`pkg/settings/setting.go`)
* ChartDefaultBranch: release-v2.11 (`pkg/settings/setting.go`)
```

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_