### PR TITLE
add env CATTLE_HELM_VERSION

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -15,6 +15,9 @@ outputs:
   HELM_VERSION: 
     description: "HELM_VERSION from package/Dockerfile.installer"
     value: ${{ steps.vars.outputs.HELM_VERSION }}
+  CATTLE_HELM_VERSION: 
+    description: "CATTLE_HELM_VERSION from package/Dockerfile"
+    value: ${{ steps.vars.outputs.CATTLE_HELM_VERSION }}
   GO_VERSION: 
     description: "GO_VERSION from package/Dockerfile"
     value: ${{ steps.vars.outputs.GO_VERSION }}
@@ -54,6 +57,7 @@ runs:
         CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=$CATTLE_RANCHER_PROVISIONING_CAPI_VERSION
         CATTLE_CSP_ADAPTER_MIN_VERSION=$CATTLE_CSP_ADAPTER_MIN_VERSION
         CATTLE_FLEET_VERSION=$CATTLE_FLEET_VERSION
+        CATTLE_HELM_VERSION=$(grep -m1 'ENV CATTLE_HELM_VERSION=' package/Dockerfile | cut -d '=' -f2)
 
         if [[ -z "$CATTLE_KDM_BRANCH" ]]; then
           echo "CATTLE_KDM_BRANCH not found"
@@ -65,6 +69,10 @@ runs:
         fi
         if [[ -z "$HELM_VERSION" ]]; then
           echo "HELM_VERSION not found"
+          exit 1
+        fi
+        if [[ -z "$CATTLE_HELM_VERSION" ]]; then
+          echo "CATTLE_HELM_VERSION not found"
           exit 1
         fi
         if [[ -z "$GO_VERSION" ]]; then
@@ -106,4 +114,5 @@ runs:
         echo "CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=$CATTLE_RANCHER_PROVISIONING_CAPI_VERSION" >> $GITHUB_OUTPUT
         echo "CATTLE_CSP_ADAPTER_MIN_VERSION=$CATTLE_CSP_ADAPTER_MIN_VERSION" >> $GITHUB_OUTPUT 
         echo "CATTLE_FLEET_VERSION=$CATTLE_FLEET_VERSION" >> $GITHUB_OUTPUT 
+        echo "CATTLE_HELM_VERSION=$CATTLE_HELM_VERSION" >> $GITHUB_OUTPUT
 

--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -18,6 +18,7 @@ CATTLE_REMOTEDIALER_PROXY_VERSION=$(grep -m1 'remoteDialerProxyVersion' build.ya
 CATTLE_CSP_ADAPTER_MIN_VERSION=$(grep -m1 'cspAdapterMinVersion' build.yaml | cut -d ' ' -f2)
 CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=$(grep -m1 'provisioningCAPIVersion' build.yaml | cut -d ' ' -f2)
 CATTLE_FLEET_VERSION=$(grep -m1 'fleetVersion' build.yaml | cut -d ' ' -f2)
+CATTLE_HELM_VERSION=$(grep -m1 'ENV CATTLE_HELM_VERSION=' package/Dockerfile | cut -d '=' -f2)
 
 # download airgap images and export it to a tarball
 curl -Lf https://github.com/rancher/k3s/releases/download/"${CATTLE_K3S_VERSION}"/k3s-images.txt -o ./k3s-images.txt
@@ -39,6 +40,7 @@ BUILD_ARGS+=("--build-arg=CATTLE_REMOTEDIALER_PROXY_VERSION=${CATTLE_REMOTEDIALE
 BUILD_ARGS+=("--build-arg=CATTLE_RANCHER_PROVISIONING_CAPI_VERSION=${CATTLE_RANCHER_PROVISIONING_CAPI_VERSION}")
 BUILD_ARGS+=("--build-arg=CATTLE_CSP_ADAPTER_MIN_VERSION=${CATTLE_CSP_ADAPTER_MIN_VERSION}")
 BUILD_ARGS+=("--build-arg=CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION}")
+BUILD_ARGS+=("--build-arg=CATTLE_HELM_VERSION=${CATTLE_HELM_VERSION}")
 BUILD_ARGS+=("--build-arg=RANCHER_TAG=${TAG}")
 BUILD_ARGS+=("--build-arg=RANCHER_REPO=${REPO}")
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -157,6 +157,8 @@ ENV CATTLE_MACHINE_PROVISION_IMAGE=rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION=v3.5.21
 ENV DOCKER_MACHINE_LINODE_VERSION=v0.1.15
 ENV LINODE_UI_DRIVER_VERSION=v0.7.0
+# For displaying Helm version in the UI only.
+ENV CATTLE_HELM_VERSION=v3.18.3-rancher1
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
 ENV DOCKER_MACHINE_HARVESTER_VERSION=v1.0.2
 ENV CATTLE_KDM_BRANCH=${CATTLE_KDM_BRANCH}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/46536
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The CATTLE_HELM_VERSION variable — this was completely [removed](https://github.com/rancher/rancher/pull/47661/commits/356f6c38e9c0a4f5dc111c3c1d193862fe70e585#diff-c55d1ee74f32cd4b9eeeceaec981a180f52e761acb158a5b0b0e088c7725c9caL60) from the backend starting with Rancher v2.11. Since then, Helm version is fetched from the dev environment. However, in upgraded clusters, it still seems to fall back to the old CATTLE_HELM_VERSION value, leading to inconsistencies.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
reintroduce CATTLE_HELM_VERSION
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
<img width="941" height="533" alt="image" src="https://github.com/user-attachments/assets/6d0a1644-0640-469e-9712-f7e97c23efcf" />


### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_