### PR TITLE
[v2.12.1] Slightly change the formatting of user agent

### DIFF
--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -188,7 +188,7 @@ func (g *git) httpClientWithCreds() (*http.Client, error) {
 
 	// Wrap the transport with a custom RoundTripper to set the User-Agent header
 	client.Transport = &roundtripper.UserAgent{
-		UserAgent: fmt.Sprintf("%s/%s %s", "go-rancher", settings.ServerVersion.Get(), "(Git-based Helm Repository)"),
+		UserAgent: fmt.Sprintf("%s/%s/%s %s", "go", "rancher", settings.ServerVersion.Get(), "(Git-based Helm Repository)"),
 		Next:      client.Transport,
 	}
 
@@ -326,7 +326,7 @@ func (g *git) gitCmd(output io.Writer, args ...string) error {
 	kv := fmt.Sprintf("credential.helper=%s", `/bin/sh -c 'echo "password=$GIT_PASSWORD"'`)
 	cmd := exec.Command("git", append([]string{"-c", kv}, args...)...)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("GIT_PASSWORD=%s", g.password))
-	userAgentValue := fmt.Sprintf("%s/%s %s", "git-rancher", settings.ServerVersion.Get(), "(Git-based Helm Repository)")
+	userAgentValue := fmt.Sprintf("%s/%s/%s %s", "git", "rancher", settings.ServerVersion.Get(), "(Git-based Helm Repository)")
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_HTTP_USER_AGENT=%s", userAgentValue))
 
 	stderrBuf := &bytes.Buffer{}

--- a/pkg/catalogv2/http/client.go
+++ b/pkg/catalogv2/http/client.go
@@ -62,7 +62,7 @@ func HelmClient(secret *corev1.Secret, caBundle []byte, insecureSkipTLSVerify bo
 
 	// Wrap the transport with a custom RoundTripper to set the User-Agent header
 	client.Transport = &roundtripper.UserAgent{
-		UserAgent: fmt.Sprintf("%s/%s %s", "go-rancher", settings.ServerVersion.Get(), "(HTTP-based Helm Repository)"),
+		UserAgent: fmt.Sprintf("%s/%s/%s %s", "go", "rancher", settings.ServerVersion.Get(), "(HTTP-based Helm Repository)"),
 		Next:      client.Transport,
 	}
 

--- a/pkg/catalogv2/oci/client.go
+++ b/pkg/catalogv2/oci/client.go
@@ -227,7 +227,7 @@ func (o *Client) SetAuthClient() error {
 	}
 
 	o.HTTPClient.Transport = &roundtripper.UserAgent{
-		UserAgent: fmt.Sprintf("%s/%s %s", "go-rancher", settings.ServerVersion.Get(), "(OCI-based Helm Repository)"),
+		UserAgent: fmt.Sprintf("%s/%s/%s %s", "go", "rancher", settings.ServerVersion.Get(), "(OCI-based Helm Repository)"),
 		Next:      o.HTTPClient.Transport,
 	}
 

--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -166,7 +166,7 @@ func StartHTTPRepository(c *ClusterRepoTestSuite) *httptest.Server {
 			serverVersion.Value = serverVersion.Default
 		}
 
-		assert.Equal(c.T(), r.Header.Get("User-Agent"), fmt.Sprintf("%s/%s %s", "go-rancher", serverVersion.Value, "(HTTP-based Helm Repository)"))
+		assert.Equal(c.T(), r.Header.Get("User-Agent"), fmt.Sprintf("%s/%s/%s %s", "go", "rancher", serverVersion.Value, "(HTTP-based Helm Repository)"))
 		http.StripPrefix("/", http.FileServer(http.Dir(repositoryDirectory))).ServeHTTP(w, r)
 	}))
 
@@ -187,7 +187,8 @@ func StartRegistry(c *ClusterRepoTestSuite) (*httptest.Server, error) {
 	// Optionally, you can customize the handler here if needed
 	// e.g., add middleware, logging, etc.
 	customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Contains(c.T(), r.Header["User-Agent"][0], "go-rancher")
+		assert.Contains(c.T(), r.Header["User-Agent"][0], "go")
+		assert.Contains(c.T(), r.Header["User-Agent"][0], "rancher")
 		assert.Contains(c.T(), r.Header["User-Agent"][0], "(OCI-based Helm Repository)")
 		handler.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
Issue : https://github.com/rancher/rancher/issues/49109

### Summary 

- This is required since some version control implementations such as Azure DevOps repos implement checking of useragent to see if it starts with "git/" or not ?
- If we don't follow the format of `git/` for `user-agent` header, Azure will redirect to interactive URL login and disregard the PAT token we provided through env variable. 

### QA Testing 

- [ ] Recheck bitbucket testing that is already done here https://github.com/rancher/rancher/issues/48388#issuecomment-2667975945
- [ ] Get access Azure landing zone and try adding https://rohits-org@dev.azure.com/rohits-org/test/_git/test. Please ping me for username/password.
