### PR TITLE
Fix go vet

### DIFF
--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -112,7 +112,7 @@ func TestTokenEndpoint(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fakeTokenName,
 			CreationTimestamp: metav1.Time{
-				time.Unix(10, 0),
+				Time: time.Unix(10, 0),
 			},
 		},
 		UserID:       fakeUserID,


### PR DESCRIPTION
## Problem
go vet shows the following error:

```
pkg/oidc/provider/token_test.go:114:23: k8s.io/apimachinery/pkg/apis/meta/v1.Time struct literal uses unkeyed fields
```
 
## Solution
Add key to time struct when initializing it. 
 
