### PR TITLE
Fix rbac for v2prov

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/cluster_types.go
+++ b/pkg/apis/provisioning.cattle.io/v1/cluster_types.go
@@ -500,6 +500,7 @@ type ClusterStatus struct {
 // +genclient
 // +kubebuilder:resource:path=clusters,scope=Namespaced,categories=provisioning
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels={"auth.cattle.io/cluster-indexed=true"}
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=".spec.kubernetesVersion"
 // +kubebuilder:printcolumn:name="Cluster Name",type=string,JSONPath=".status.clusterName"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"

--- a/pkg/apis/rke.cattle.io/v1/rkecontrolplane_types.go
+++ b/pkg/apis/rke.cattle.io/v1/rkecontrolplane_types.go
@@ -154,7 +154,7 @@ type RKEControlPlaneStatus struct {
 // +genclient
 // +kubebuilder:resource:path=rkecontrolplanes,shortName=rcp,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
-// +kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1"
+// +kubebuilder:metadata:labels={"cluster.x-k8s.io/v1beta1=v1","auth.cattle.io/cluster-indexed=true"}
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
 // +kubebuilder:printcolumn:name="Initialized",type=string,JSONPath=".status.initialized",description="This denotes whether or not the control plane is initialized"
 // +kubebuilder:printcolumn:name="API Server Available",type=boolean,JSONPath=".status.ready",description="RKEControlPlane API Server is ready to receive requests"

--- a/pkg/crds/yaml/generated/provisioning.cattle.io_clusters.yaml
+++ b/pkg/crds/yaml/generated/provisioning.cattle.io_clusters.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    auth.cattle.io/cluster-indexed: "true"
   name: clusters.provisioning.cattle.io
 spec:
   group: provisioning.cattle.io

--- a/pkg/crds/yaml/generated/rke.cattle.io_rkecontrolplanes.yaml
+++ b/pkg/crds/yaml/generated/rke.cattle.io_rkecontrolplanes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
   labels:
+    auth.cattle.io/cluster-indexed: "true"
     cluster.x-k8s.io/v1beta1: v1
   name: rkecontrolplanes.rke.cattle.io
 spec:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #51095
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

RBAC was all messed up because I forgot to add the `"auth.cattle.io/cluster-indexed=true"` label to the provisioning cluster and controlplane CRDs.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add it back

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Tested manually, clusters no longer hang on creation and the `crt-<CLUSTER_NAME>-cluster-admin` and `crt-<CLUSTER_NAME>-cluster-owner` roles show the provisioning cluster object and controlplane object.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
Just make sure to test with the expected standard users/create cluster role.