### PR TITLE
Add `make quick-binary-server` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ quick-agent:
 quick-server:
 	@$(MAKE) quick TARGET="server"
 
+quick-binary-server:
+	@$(MAKE) quick TARGET="binary-server"
+
 $(DEV_TARGETS):
 	./dev-scripts/$@
 
-.PHONY: $(TARGETS) $(DEV_TARGETS) quick-agent quick-server
+.PHONY: $(TARGETS) $(DEV_TARGETS) quick-agent quick-server quick-binary-server

--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -105,6 +105,15 @@ if [ "$needs_workdir" = "true" ]; then
   BUILD_ARGS+=("--build-arg=BUILD_WORKDIR=$PWD")
 fi
 
+if [ "$TARGET" = "binary-server" ]; then
+  docker buildx build \
+    "${BUILD_ARGS[@]}" \
+    --output=type=local,dest=$PWD \
+    --platform="${OS}/${ARCH}" \
+    --target server-binary \
+    --file ./package/Dockerfile .
+fi
+
 if [ -z "$TARGET" ] || [ "$TARGET" = "server" ]; then
   # start the builds
   docker buildx build \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -367,6 +367,10 @@ COPY pkg/ pkg/
 COPY main.go ./
 RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o /app/rancher
 
+# Output just the server binary
+FROM scratch AS server-binary
+COPY --from=server-build /app/rancher /bin/rancher
+
 
 FROM --platform=$BUILDPLATFORM rancher-go-builder AS agent-build
 ARG VERSION


### PR DESCRIPTION
# TL;DR

We'll be able to build the binary like `make build` by running `make quick-binary-server`. It's going to be fast, re-use caches for images and support local Go replace directive.

# Context

Currently building Rancher can be done in many ways:
- build the image with `make quick` (or `make quick-server` or `make quick-agent`)
- build the go binary with `make build` (or `make build-server` or `make build-agent`) (uses Dapper)
- running your own go build script

I usually use `make build` because I want to build an image. This works fine and is quick because it mounts volumes for `GOCACHE` and `GOMODCACHE`. It has one limitation though: it doesn't support local Go replace directive. So if I want to build Rancher with a `steve` local to my machine, I must edit `Dockerfile.dapper` to add a volume OR push the steve code, update the gomod, etc. It's painful.

# Solution

Let's just re-use our build step from our Dockerfile to build the binary.

Benefits (some only for linux):
- `dev-scripts/quick` already supports local Go replace directive
- Our `package/Dockerfile` is now optimized with `GOCACHE` and `GOMODCACHE` support. We no longer duplicate the cache (one for building the images, one for make build).
- Building the image after building the binary is much faster, because Docker caches that layer. The reverse is also true, building the binary after building the image is super quick.
- One less thing we need Dapper for

We can therefore build _just_ the binary using our current dockerfile (with minimal modification).

## How does it work

Docker support building a target and outputting the resulting content to disk. So we simply:
1. Build the rancher binary
2. Create a `scratch` target
3. Copy the binary to the scratch target
4. Let docker output this to disk

## `make build-server` vs `make quick-binary-server`

I don't expect much regression or improvement to build speed here. Both builds are done in docker, both use Go caches. Example: Making a code change (with cache already warmed up)

```
# make build-server
real    0m24.150s
user    0m1.898s
sys     0m0.894s

# make quick-binary-server
real    0m24.796s
user    0m1.930s
sys     0m0.846s
```