### PR TITLE
fix: add create secrets permissions in fleet-default namespace

### DIFF
--- a/pkg/data/management/rolebuilder.go
+++ b/pkg/data/management/rolebuilder.go
@@ -98,6 +98,10 @@ func (rb *roleBuilder) addNamespacedRule(namespace string) *namespacedRuleBuilde
 	return n
 }
 
+func (r *ruleBuilder) addNamespacedRule(namespace string) *namespacedRuleBuilder {
+	return r.rb.addNamespacedRule(namespace)
+}
+
 func (rb *roleBuilder) setRoleTemplateNames(names ...string) *roleBuilder {
 	rb.roleTemplateNames = names
 	return rb


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50528
 
For information about the PR please refer to this old PR:
https://github.com/rancher/rancher/pull/49604

This was re-opened after a chat with the security team where we agreed with that there are no security concerns with this solution.