### PR TITLE
[v2.11] Backport support local replace make quick

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -47,6 +47,68 @@ BUILD_ARGS+=("--build-arg=CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION}")
 BUILD_ARGS+=("--build-arg=RANCHER_TAG=${TAG}")
 BUILD_ARGS+=("--build-arg=RANCHER_REPO=${REPO}")
 
+# because macos doesn't have realpath apparently
+abs_path() {
+  echo "$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
+}
+
+is_safe_local_directive() {
+  while IFS= read -r safe_path; do
+    safe_path="$(abs_path "$safe_path")"
+    if [[ "$1" == "$safe_path"* ]]; then
+      return 0
+    fi
+  done < <(echo "$BUILD_SAFE_DIRS" | tr ':' '\n')
+  return 1
+}
+
+needs_workdir="false"
+
+# add_context adds _some_ support for local replace directives of dependency.
+add_context() {
+  if ! replace=$(grep "$1 =>" go.mod); then
+    return 0
+  fi
+
+  # Detect local replace directive or either form:
+  #             github.com/rancher/steve => /absolute/or/relative/path/to/steve
+  # or
+  #     replace github.com/rancher/steve => /absolute/or/relative/path/to/steve
+  if [ -n "$(echo "$replace" | cut -d= -f2 | cut -d' ' -f3)" ]; then
+    return 0
+  fi
+
+  set +x
+  godep=$(echo "$replace" | cut -d= -f2 | cut -d' ' -f2)
+  path=$(abs_path "$godep")
+  if ! is_safe_local_directive "$path"; then
+    cat <<EOF
+Detected replace directive with path $godep ($path). This directive is not listed under a safe
+prefix path with BUILD_SAFE_DIRS environment variable.
+Path you want to use with replace directive must be under a prefix path set in the BUILD_SAFE_DIRS
+env var. Its value should be a colon-separated (:) list of prefix paths.
+For example, for a path of /home/user/sources/steve, you could set BUILD_SAFE_DIRS=/home/user/sources.
+EOF
+    exit 1
+  fi
+
+  set -x
+  BUILD_ARGS+=("--build-context=$2=$path")
+  BUILD_ARGS+=("--build-arg=$3=$2")
+  BUILD_ARGS+=("--build-arg=$3_PATH=$path")
+  needs_workdir="true"
+}
+
+add_context "github.com/rancher/apiserver" "apiserver-context" "GODEP_APISERVER"
+add_context "github.com/rancher/remotedialer" "remotedialer-context" "GODEP_REMOTEDIALER"
+add_context "github.com/rancher/shepherd" "shepherd-context" "GODEP_SHEPHERD"
+add_context "github.com/rancher/steve" "steve-context" "GODEP_STEVE"
+add_context "github.com/rancher/wrangler/v3" "wrangler-context" "GODEP_WRANGLER"
+
+if [ "$needs_workdir" = "true" ]; then
+  BUILD_ARGS+=("--build-arg=BUILD_WORKDIR=$PWD")
+fi
+
 if [ -z "$TARGET" ] || [ "$TARGET" = "server" ]; then
   # start the builds
   docker buildx build \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,5 +1,18 @@
 ARG ARCH=amd64
 
+ARG BUILD_WORKDIR=/app
+
+ARG GODEP_APISERVER=scratch
+ARG GODEP_APISERVER_PATH
+ARG GODEP_REMOTEDIALER=scratch
+ARG GODEP_REMOTEDIALER_PATH
+ARG GODEP_SHEPHERD=scratch
+ARG GODEP_SHEPHERD_PATH
+ARG GODEP_STEVE=scratch
+ARG GODEP_STEVE_PATH
+ARG GODEP_WRANGLER=scratch
+ARG GODEP_WRANGLER_PATH
+
 ARG CHART_DEFAULT_BRANCH=dev-v2.11
 ARG PARTNER_CHART_DEFAULT_BRANCH=main
 ARG RKE2_CHART_DEFAULT_BRANCH=main
@@ -7,6 +20,12 @@ ARG RKE2_CHART_DEFAULT_BRANCH=main
 ARG CATTLE_KDM_BRANCH=dev-v2.11
 
 ARG VERSION=${VERSION}
+
+FROM --platform=$BUILDPLATFORM ${GODEP_APISERVER} AS godep-apiserver
+FROM --platform=$BUILDPLATFORM ${GODEP_REMOTEDIALER} AS godep-remotedialer
+FROM --platform=$BUILDPLATFORM ${GODEP_SHEPHERD} AS godep-shepherd
+FROM --platform=$BUILDPLATFORM ${GODEP_STEVE} AS godep-steve
+FROM --platform=$BUILDPLATFORM ${GODEP_WRANGLER} AS godep-wrangler
 
 FROM registry.suse.com/bci/bci-micro:15.7 AS final
 RUN : # No-op command to create an explicit layer - this fixes a weird buildkit/buildx bug on macos arm
@@ -315,7 +334,18 @@ RUN ./export-images -k3s-version ${CATTLE_K3S_VERSION} -output /src/k3s-airgap-i
 # dependencies downloaded. Can be used to build both the Rancher server and agent
 # binaries.
 FROM --platform=$BUILDPLATFORM go-builder AS rancher-go-builder
-WORKDIR /app
+ARG BUILD_WORKDIR
+WORKDIR ${BUILD_WORKDIR}
+ARG GODEP_APISERVER_PATH
+COPY --from=godep-apiserver / ${GODEP_APISERVER_PATH}
+ARG GODEP_REMOTEDIALER_PATH
+COPY --from=godep-remotedialer / ${GODEP_REMOTEDIALER_PATH}
+ARG GODEP_SHEPHERD_PATH
+COPY --from=godep-shepherd / ${GODEP_SHEPHERD_PATH}
+ARG GODEP_STEVE_PATH
+COPY --from=godep-steve / ${GODEP_STEVE_PATH}
+ARG GODEP_WRANGLER_PATH
+COPY --from=godep-wrangler / ${GODEP_WRANGLER_PATH}
 # Only invalidate cache if go.mod/go.sum changes.
 COPY go.mod go.sum ./
 COPY pkg/apis/go.mod pkg/apis/go.sum pkg/apis/
@@ -337,7 +367,7 @@ ARG TARGETOS
 ARG TARGETARCH
 COPY pkg/ pkg/
 COPY main.go ./
-RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o rancher
+RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o /app/rancher
 
 
 FROM --platform=$BUILDPLATFORM rancher-go-builder AS agent-build
@@ -349,7 +379,7 @@ ARG TARGETOS
 ARG TARGETARCH
 COPY cmd/ cmd/
 COPY pkg/ pkg/
-RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o agent ./cmd/agent
+RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o /app/agent ./cmd/agent
 
 
 FROM base AS server


### PR DESCRIPTION
This is a backport of https://github.com/rancher/rancher/pull/50091

# Issue

Currently, it's pretty annoying to build images with local changes in some dependencies.

**Scenario**: You're working on changes in Steve, you want to build a Rancher image to test those changes.

To be able to do this, **for every code change** you need to:
1. Commit your changes in Steve
2. Push your changes in Steve to your fork
3. Get the latest commit of that fork (`git show`)
4. Update Rancher's `go.mod` to point to that commit (can be done with `go mod edit -replace=github.com/rancher/steve=<fork>@<commit> && go mod tidy`
5. Run `make quick`

Pretty tedious, we should make it easier for at least common scenarios..

With local build, we can simply point to a local directory (eg: `go mod edit -replace=github.com/rancher/steve=../steve && go mod tidy`) once, and then new changes don't require changes to `go.mod` anymore. We can't currently do that with `make quick` because the build only includes the rancher/rancher build context (codebase). 

# Solution

See the Explanation section below for details. The gist of it is `make quick` will look at the main `go.mod` to automatically detect local replace directives for a hardcoded list of dependencies we expect to want to often change. The script will then add the appropriate `--build-context` and `--build-arg` parameters to the docker buildx build command to make it "just work".

# Explanation

The PR is better reviewed commit per commit, so I'm describing the changes here in the same order.

**Remove duplicated build-args**

This change really just simplifies / centralizes the params added to the docker build commands. Unused args aren't an issue here, no point in having a separate list for both and duplicate entries.

**Make Rancher server and agent workdir configurable**

By default, we still build the binaries in the `/app` directory. No changes here for default builds (and no changes for release builds). However, to properly support replace directive with relative & absolute paths, we must be able to change this build directory to be the same (isolated, obviously) as the host's build directory.

This way, if I build Rancher in `/home/tlebreux/sources/SUSE/rancher`, then the Rancher context (and the WORKDIR) will be moved to `/home/tlebreux/sources/SUSE/rancher`.

**Add multiple build contexts**


Docker supports multiple build context with the `--build-context <context id>=<path/on/local/machine>`. This can be used with `COPY --from=..` to add the contexts with need. 

Here's a simplified example:

```dockerfile
# Defaults to the "scratch" image which is empty
ARG GODEP_STEVE=scratch
ARG GODEP_STEVE_PATH

# Build an intermediate image for the Steve dependency. It's empty by default but based on the value of "GODEP_STEVE"
# can refer to a build context id.
# --platform=$BUILDPLATFORM because the code is platform agnostic
FROM --platform=$BUILDPLATFORM ${GODEP_STEVE} as godep-steve

# Our intermediate go builder image used to build go binaries for Rancher
FROM --platform=$BUILDPLATFORM go-builder AS rancher-go-builder
# Copy either the custom steve context OR the scratch image (empty)
COPY --from=godep-steve / ${GODEP_STEVE_PATH}
...
# Will build the binary, go.mod containing a steve replace with ../steve will point to /app/steve, so it will just work
RUN go build .
```

You can then do a regular build:

```
docker buildx build -t rancher:latest .
```

or you can build with a custom steve context:

```
docker buildx build --build-arg=GODEP_STEVE=steve-context-id --build-context=steve-context-id=../steve
```

# Results

You can now do (once):

```sh
go mod edit -replace=github.com/rancher/steve=../steve
go mod tidy
```

and now you can build it, make changes to steve, etc (infinitely):

```sh
make quick
```

# Limitations

**Hardcoded list of dependencies**

As can be seen from the PR, the list of dependencies that this would _just work_ needs to be hardcoded and added to the rancher go builder explicitely. This is because each dependency might be found anywhere on the machine so we can't just point to one big directory and use this. Also, if we were to point to a single directory (say `/home/user/SUSE`) this directory might be big (logs files, etc) and would need to be sent to the builder. That's slow.

So instead, each dependency we want to replace is added explicitely and we only copy that dependency to the builder if it has a local replace directive.

**Only support `go.mod` at the root of rancher/rancher**

Honestly, the reason for this limitation is simply that I do not have a use case for making it work for go.mod in pkg/apis and pkg/clients, but it doesn't mean it can't be done. Maybe in another PR if someone needs it?


**Solved**

- ~Currently only supports relative directory in the same parent dir. Eg: `../steve` will work but `../../steve` won't.~ (This is now fixed)
- ~The name of the directory is hardcoded which means `../steve-security` in go.mod won't work.~ (This is now fixed)


---

cc: @ericpromislow because you've recently asked about being able to do this..