### PR TITLE
feat: add initial delay for startup prob so it can be passed in value…

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -166,6 +166,9 @@ spec:
           httpGet:
             path: /healthz
             port: 80
+          {{- with .Values.startupProbe.initialDelaySeconds}}
+          initialDelaySeconds: {{ . }}
+          {{- end }}
           timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}


### PR DESCRIPTION
Problem
In large Rancher instances, the startupProbe may fail during initialization due to the absence of an initialDelaySeconds configuration. This value is not currently exposed in the values.yaml, nor is it referenced in the chart template, so it can't be overriden during installation.

Solution
Expose startupProbe.initialDelaySeconds in the Rancher deployment template. This allows users to optionally specify the delay through the values.yaml or via the --set flag during helm install or helm upgrade.

Testing
Rendered the chart using helm template with and without setting startupProbe.initialDelaySeconds in the values.yaml.

Verified that the rendered YAML includes the field only when the value is set, ensuring backward compatibility.