### PR TITLE
Refactor controller to wait for CAPI CRDs

### DIFF
--- a/pkg/api/steve/machine/machine.go
+++ b/pkg/api/steve/machine/machine.go
@@ -12,8 +12,8 @@ import (
 
 func Register(server *steve.Server, clients *wrangler.Context) {
 	sshClient := &sshClient{
-		machines: clients.CAPI.Machine(),
-		secrets:  clients.Core.Secret(),
+		secrets:         clients.Core.Secret(),
+		wranglerContext: clients,
 	}
 
 	server.SchemaFactory.AddTemplate(schema2.Template{

--- a/pkg/api/steve/setup.go
+++ b/pkg/api/steve/setup.go
@@ -19,7 +19,9 @@ func Setup(ctx context.Context, server *steve.Server, config *wrangler.Context) 
 	if err := clusters.Register(ctx, server, config); err != nil {
 		return err
 	}
-	machine.Register(server, config)
+	if config.CAPI != nil {
+		machine.Register(server, config)
+	}
 	navlinks.Register(ctx, server)
 	settings.Register(server)
 	disallow.Register(server)
@@ -27,4 +29,12 @@ func Setup(ctx context.Context, server *steve.Server, config *wrangler.Context) 
 		server,
 		config.HelmOperations,
 		config.CatalogContentManager)
+}
+
+// SetupPostCAPI sets up CAPI dependent components after CAPI CRDs are available
+func SetupPostCAPI(ctx context.Context, server *steve.Server, config *wrangler.Context) error {
+	if config.CAPI != nil {
+		machine.Register(server, config)
+	}
+	return nil
 }


### PR DESCRIPTION
CAPI dependent controllers now wait for CRDs before starting. To support Turtles being installed as a system chart first, we register these controllers after Start(). This may cause a race condition where late registered controllers don’t start automatically.