### PR TITLE
[v2.11] Bump Go to 1.24

### DIFF
--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -10,7 +10,7 @@ on:
 env:
   GOARCH: amd64
   CGO_ENABLED: 0
-  SETUP_GO_VERSION: '1.22.*'
+  SETUP_GO_VERSION: '1.24.*'
 
 jobs:
   run-tests:

--- a/.github/workflows/verify-generated-code-changes.yml
+++ b/.github/workflows/verify-generated-code-changes.yml
@@ -11,7 +11,7 @@ env:
   MAIN_BRANCH: origin/master
   GOARCH: amd64
   CGO_ENABLED: 0
-  SETUP_GO_VERSION: '1.23.*'
+  SETUP_GO_VERSION: '1.24.*'
 
 jobs:
   check-changes:

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,4 +1,4 @@
-FROM library/golang:1.23
+FROM library/golang:1.24
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG DAPPER_HOST_ARCH

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rancher
 
-go 1.23.4
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.5
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.27 // for compatibilty with docker 20.10.x

--- a/hack/airgap/go.mod
+++ b/hack/airgap/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rancher/airgap
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.5
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.7.27 // CVE-2024-40635

--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -523,7 +523,7 @@ func validateEKSNodegroups(spec *v32.ClusterSpec) error {
 	for _, ng := range nodegroups {
 		name := aws.StringValue(ng.NodegroupName)
 		if name == "" {
-			return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("nodegroupName cannot be an empty"))
+			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodegroupName cannot be an empty")
 		}
 
 		version := ng.Version
@@ -537,7 +537,7 @@ func validateEKSNodegroups(spec *v32.ClusterSpec) error {
 	}
 
 	if len(errors) != 0 {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf(strings.Join(errors, ";")))
+		return httperror.NewAPIError(httperror.InvalidBodyContent, strings.Join(errors, ";"))
 	}
 	return nil
 }
@@ -691,11 +691,11 @@ func validateGKENodePools(spec *v32.ClusterSpec) error {
 	}
 
 	if !hasRequiredLinuxPool {
-		errors = append(errors, fmt.Sprintf("at least 1 Linux node pool is required"))
+		errors = append(errors, "at least 1 Linux node pool is required")
 	}
 
 	if len(errors) != 0 {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf(strings.Join(errors, ";")))
+		return httperror.NewAPIError(httperror.InvalidBodyContent, strings.Join(errors, ";"))
 	}
 	return nil
 }

--- a/pkg/api/norman/customization/oci/handler.go
+++ b/pkg/api/norman/customization/oci/handler.go
@@ -191,14 +191,14 @@ func (handler *handler) extractCreds(req *http.Request, creds *Credentials) (int
 		// Get credentials from body
 		raw, err := ioutil.ReadAll(req.Body)
 		if err != nil {
-			logrus.Debugf("[oci-handler] cannot read request body: " + err.Error())
-			return httperror.InvalidBodyContent.Status, fmt.Errorf("cannot read request body: " + err.Error())
+			logrus.Debugf("[oci-handler] cannot read request body: %s", err)
+			return httperror.InvalidBodyContent.Status, fmt.Errorf("cannot read request body: %w", err)
 		}
 
 		err = json.Unmarshal(raw, &creds)
 		if err != nil {
-			logrus.Debugf("[oci-handler] cannot parse request body: " + err.Error())
-			return httperror.InvalidBodyContent.Status, fmt.Errorf("cannot parse request body: " + err.Error())
+			logrus.Debugf("[oci-handler] cannot parse request body: %s", err)
+			return httperror.InvalidBodyContent.Status, fmt.Errorf("cannot parse request body: %w", err)
 		}
 	} else {
 		return httperror.Unauthorized.Status, fmt.Errorf("cannot access OCI API without credentials to authenticate")

--- a/pkg/api/norman/customization/yaml/link.go
+++ b/pkg/api/norman/customization/yaml/link.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -47,7 +48,7 @@ func (s *yamlLinkHandler) LinkHandler(apiContext *types.APIContext, next types.R
 
 	schema := apiContext.Schemas.Schema(apiContext.Version, apiContext.Type)
 	if schema == nil {
-		return fmt.Errorf("failed to find schema " + apiContext.Type)
+		return errors.New("failed to find schema " + apiContext.Type)
 	}
 
 	data, err := schema.Store.ByID(apiContext, schema, apiContext.ID)

--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -352,7 +352,7 @@ func (r *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 		if secret != nil {
 			err = r.secretMigrator.UpdateSecretOwnerReference(secret, owner)
 			if err != nil {
-				logrus.Errorf(errMsg)
+				logrus.Error(errMsg)
 			}
 		}
 	}
@@ -914,7 +914,7 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		if secret != nil {
 			err = r.secretMigrator.UpdateSecretOwnerReference(secret, owner)
 			if err != nil {
-				logrus.Errorf(errMsg)
+				logrus.Error(errMsg)
 			}
 		}
 	}

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rancher/pkg/apis
 
-go 1.23.4
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.5
 
 replace (
 	k8s.io/api => k8s.io/api v0.32.2

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -118,7 +118,7 @@ func InitializeSamlServiceProvider(configToSet *v32.SamlConfig, name string) err
 
 		cert, err = x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return fmt.Errorf("SAML: failed to parse DER encoded public key: " + err.Error())
+			return fmt.Errorf("SAML: failed to parse DER encoded public key: %w", err)
 		}
 	}
 

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -189,7 +189,7 @@ func (p *Planner) setMachineConditionStatus(clusterPlan *plan.Plan, machineNames
 			if capr.Reconciled.GetMessage(machine) == msg {
 				continue
 			}
-			conditions.MarkUnknown(machine, capi.ConditionType(capr.Reconciled), "Waiting", msg)
+			conditions.MarkUnknown(machine, capi.ConditionType(capr.Reconciled), "Waiting", "%s", msg)
 		} else if !capr.Reconciled.IsTrue(machine) {
 			// Since there is no status message, then the condition should be set to true.
 			conditions.MarkTrue(machine, capi.ConditionType(capr.Reconciled))

--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -292,7 +293,7 @@ func (m *Manager) install(namespace, name, minVersion, exactVersion string, valu
 	chart, err := index.Get(name, v)
 	if err != nil {
 		// The helm library is using github.com/pkg/errors which is deprecated
-		return fmt.Errorf(err.Error())
+		return errors.New(err.Error())
 	}
 	// Because of the behavior of `index.Get`, we need this check.
 	if v != latestVersionMatcher && chart.Version != v {

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rancher/pkg/client
 
-go 1.23.4
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.5
 
 require (
 	github.com/rancher/norman v0.5.2

--- a/pkg/controllers/capr/plansecret/plansecret.go
+++ b/pkg/controllers/capr/plansecret/plansecret.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"time"
+
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/capr/planner"
@@ -201,7 +202,7 @@ func (h *handler) reconcileMachinePlanAppliedCondition(secret *corev1.Secret, pl
 			!conditions.IsFalse(machine, condition) ||
 			conditions.GetReason(machine, condition) != "Error") {
 		logrus.Debugf("[plansecret] machine %s/%s: marking PlanApplied as false", machine.Namespace, machine.Name)
-		conditions.MarkFalse(machine, condition, "Error", capi.ConditionSeverityError, planAppliedErr.Error())
+		conditions.MarkFalse(machine, condition, "Error", capi.ConditionSeverityError, "%s", planAppliedErr.Error())
 		needsUpdate = true
 	} else if planAppliedErr == nil && !conditions.IsTrue(machine, condition) {
 		logrus.Debugf("[plansecret] machine %s/%s: marking PlanApplied as true", machine.Namespace, machine.Name)

--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -3,6 +3,7 @@ package eks
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	stderrors "errors"
 	"fmt"
 	"net"
@@ -32,7 +33,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -113,7 +114,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 	// get EKS Cluster Config, if it does not exist, create it
 	eksClusterConfigDynamic, err := e.DynamicClient.Namespace(namespace.GlobalNamespace).Get(context.TODO(), cluster.Name, v1.GetOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return cluster, err
 		}
 
@@ -193,7 +194,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 		}
 
 		if apimgmtv3.ClusterConditionUpdated.IsFalse(cluster) && strings.HasPrefix(apimgmtv3.ClusterConditionUpdated.GetMessage(cluster), "[Syncing error") {
-			return cluster, fmt.Errorf(apimgmtv3.ClusterConditionUpdated.GetMessage(cluster))
+			return cluster, errors.New(apimgmtv3.ClusterConditionUpdated.GetMessage(cluster))
 		}
 
 		// EKS cluster must have at least one node to run cluster agent. The best way to verify

--- a/pkg/controllers/managementuser/nodesyncer/cordonfieldssyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/cordonfieldssyncer.go
@@ -169,7 +169,7 @@ func (d *nodeDrain) drain(ctx context.Context, obj *v32.Node, nodeName string, c
 			if err != nil {
 				if ctx.Err() == context.Canceled {
 					stopped = true
-					logrus.Infof(fmt.Sprintf("Stopped draining %s in %s", nodeName, obj.Namespace))
+					logrus.Infof("Stopped draining %s in %s", nodeName, obj.Namespace)
 					return nodeObj, nil
 				}
 				errMsg := filterErrorMsg(msg, nodeName)
@@ -182,8 +182,8 @@ func (d *nodeDrain) drain(ctx context.Context, obj *v32.Node, nodeName string, c
 			ignore, timeoutErr := ignoreErr(err.Error())
 			if ignore {
 				if timeoutErr {
-					err = fmt.Errorf(fmt.Sprintf("Drain failed: drain did not complete within %vs",
-						obj.Spec.NodeDrainInput.Timeout))
+					err = fmt.Errorf("Drain failed: drain did not complete within %vs",
+						obj.Spec.NodeDrainInput.Timeout)
 				} else {
 					// log before ignoring
 					logrus.Errorf("nodeDrain: kubectl error ignore draining node [%s] in cluster [%s]: %v", nodeName,

--- a/pkg/kontainer-engine/service/service.go
+++ b/pkg/kontainer-engine/service/service.go
@@ -468,20 +468,20 @@ func (r *RunningDriver) Start() (string, error) {
 
 // portOnly attempts to return port fragment of address
 func portOnly(address string) (string, error) {
-	portParseErr := fmt.Errorf("failed to parse port from address [%s]", address)
+	portParseErrPrefix := fmt.Errorf("failed to parse port from address [%s]", address)
 
 	_, port, err := net.SplitHostPort(address)
 	if err != nil {
-		return "", errors.Wrap(err, portParseErr.Error())
+		return "", fmt.Errorf("%s: %w", portParseErrPrefix, err)
 	}
 
 	portNum, err := strconv.Atoi(port)
 	if err != nil {
-		return "", portParseErr
+		return "", fmt.Errorf("%s: %w", portParseErrPrefix, err)
 	}
 
 	if portNum < 1 || portNum > 65535 {
-		return "", errors.Wrap(fmt.Errorf(fmt.Sprintf("invalid port [%s], port range is between 1 and 65535", port)), portParseErr.Error())
+		return "", fmt.Errorf("%s: invalid port [%s], port range is between 1 and 65535", portParseErrPrefix, port)
 	}
 
 	return port, nil

--- a/pkg/rkeworker/docker.go
+++ b/pkg/rkeworker/docker.go
@@ -2,6 +2,7 @@ package rkeworker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -413,7 +414,7 @@ func waitContainerExit(rootCtx context.Context, dockerCli *client.Client, contai
 			if result.Error != nil {
 				statusC <- containerWaitingStatus{
 					code:  125,
-					cause: fmt.Errorf(result.Error.Message),
+					cause: errors.New(result.Error.Message),
 				}
 			} else {
 				statusC <- containerWaitingStatus{

--- a/tests/v2/codecoverage/Dockerfile.buildcodecoverage
+++ b/tests/v2/codecoverage/Dockerfile.buildcodecoverage
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 # Configure Go
 ENV GOPATH /root/go

--- a/tests/v2/codecoverage/Dockerfile.codecoverage
+++ b/tests/v2/codecoverage/Dockerfile.codecoverage
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 # Configure Go
 ENV GOPATH /root/go

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -229,7 +229,7 @@ ENV ETCD_UNSUPPORTED_ARCH=${ETCD_UNSUPPORTED_ARCH}
 
 
 # Enable exporting of the k3s images as part of the build process.
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS images
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.24 AS images
 
 ENV CATTLE_K3S_VERSION=v1.32.1+k3s1
 
@@ -244,7 +244,7 @@ RUN go build -tags k3s_export -o export-images ./...
 RUN ./export-images -k3s-version ${CATTLE_K3S_VERSION} -output /src/k3s-airgap-images.tar
 
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.24 AS build
 ARG VERSION=dev
 ARG COMMIT
 ARG RKE_VERSION

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -5,7 +5,7 @@ ARG RANCHER_IMAGE=${REGISTRY}/${RANCHER_REPO}/rancher:${RANCHER_TAG}
 ARG ARCH
 ARG VERSION=dev
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.24 AS build
 ARG VERSION=${VERSION}
 ARG CGO_ENABLED=0
 ARG TAGS="k8s"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

v2.11 is currently built with Go 1.23. Go 1.25 is about to be released and main + v2.12 were built with Go 1.24 for a while now.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Start building v2.11 with Go 1.24.
It also allows us to use go tool for v2.11, v2.12, and main.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A