### PR TITLE
[release/v2.12] Un-rc csp-adapter v7.0.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 webhookVersion: 107.0.0+up0.8.0-rc.12
 remoteDialerProxyVersion: 106.0.1+up0.5.0
 provisioningCAPIVersion: 107.0.0+up0.8.0
-cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
+cspAdapterMinVersion: 107.0.0+up7.0.0
 defaultShellVersion: rancher/shell:v0.5.0-rc.4
 fleetVersion: 107.0.0+up0.13.0

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion     = "107.0.0+up7.0.0-rc.1"
+	CspAdapterMinVersion     = "107.0.0+up7.0.0"
 	DefaultShellVersion      = "rancher/shell:v0.5.0-rc.4"
 	FleetVersion             = "107.0.0+up0.13.0"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"


### PR DESCRIPTION
##Problem:
Un-rc rancher-csp-adapter chart for 2.12 rancher

##Testing:

scenario 1 (fresh install):

    On an EKS cluster (k8s version 1.33), install locally built rancher with cspAdapterMinVersion: 107.0.0+up7.0.0
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.

scenario 2 (upgrade scenario):

    Start with an EKS cluster k8s version 1.32, upgrade k8s version to 1.33, install rancher 2.11.2 with csp-adapter 6.0.0
    Upgrade rancher to locally built rancher with cspAdapterMinVersion: 107.0.0+up7.0.0
    Update charts url repo/branch and upgrade csp-adapter version to 107.0.0+up7.0.0
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.