### PR TITLE
[v2.11] Fix dereference of the empty displayname

### DIFF
--- a/pkg/auth/providers/azure/clients/group_cache.go
+++ b/pkg/auth/providers/azure/clients/group_cache.go
@@ -12,9 +12,13 @@ import (
 // GroupCache is an in-memory cache of group principals.
 var GroupCache *lru.Cache
 
+type userPrincipalsClient interface {
+	GetGroup(id string) (v3.Principal, error)
+}
+
 // UserGroupsToPrincipals attempts to convert a value representing a collection of groups to a slice of principal values.
 // It also stores group values in an in-memory cache for faster subsequent access.
-func UserGroupsToPrincipals(azureClient AzureClient, groupNames []string) ([]v3.Principal, error) {
+func UserGroupsToPrincipals(azureClient userPrincipalsClient, groupNames []string) ([]v3.Principal, error) {
 	var tasksManager errgroup.Group
 	groupPrincipals := make([]v3.Principal, len(groupNames))
 

--- a/pkg/auth/providers/azure/clients/group_cache_test.go
+++ b/pkg/auth/providers/azure/clients/group_cache_test.go
@@ -1,0 +1,69 @@
+package clients
+
+import (
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestUserGroupsToPrincipals(t *testing.T) {
+	setupTestCache(t)
+	testGUID := "0f8fad5b-d9cb-469f-a165-70867728950e"
+
+	fc := &fakePrincipalsClient{
+		groups: map[string]fakeGroup{
+			testGUID: fakeGroup{id: ptr.To(testGUID)},
+		},
+	}
+	principals, err := UserGroupsToPrincipals(fc, []string{testGUID})
+	require.NoError(t, err)
+
+	want := []v3.Principal{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "azuread_group://0f8fad5b-d9cb-469f-a165-70867728950e",
+			},
+			PrincipalType: "group",
+			MemberOf:      true,
+			Provider:      "azuread",
+		},
+	}
+	assert.Equal(t, want, principals)
+}
+
+type fakePrincipalsClient struct {
+	groups map[string]fakeGroup
+}
+
+func (f *fakePrincipalsClient) GetGroup(id string) (v3.Principal, error) {
+	return groupToPrincipal(f.groups[id]), nil
+}
+
+type fakeGroup struct {
+	id          *string
+	displayName *string
+}
+
+func (f fakeGroup) GetId() *string {
+	return f.id
+}
+
+func (f fakeGroup) GetDisplayName() *string {
+	return f.displayName
+}
+
+func setupTestCache(t *testing.T) {
+	t.Helper()
+	oldGroupCache := GroupCache
+	t.Cleanup(func() {
+		GroupCache = oldGroupCache
+	})
+	gc, err := lru.New(10)
+	require.NoError(t, err)
+	GroupCache = gc
+}

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -27,6 +27,7 @@ import (
 	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -334,19 +335,24 @@ func userToPrincipal(user models.Userable) v3.Principal {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: Name + "_user://" + *user.GetId(),
 		},
-		DisplayName:   *user.GetDisplayName(),
-		LoginName:     *user.GetUserPrincipalName(),
+		DisplayName:   ptr.Deref(user.GetDisplayName(), ""),
+		LoginName:     ptr.Deref(user.GetUserPrincipalName(), ""),
 		PrincipalType: "user",
 		Provider:      Name,
 	}
 }
 
-func groupToPrincipal(group models.Groupable) v3.Principal {
+type groupObject interface {
+	GetId() *string
+	GetDisplayName() *string
+}
+
+func groupToPrincipal(group groupObject) v3.Principal {
 	return v3.Principal{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: Name + "_group://" + *group.GetId(),
 		},
-		DisplayName:   *group.GetDisplayName(),
+		DisplayName:   ptr.Deref(group.GetDisplayName(), ""),
 		PrincipalType: "group",
 		Provider:      Name,
 	}

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -330,7 +330,17 @@ func (c AzureMSGraphClient) MarshalTokenJSON() (string, error) {
 	return string(b), err
 }
 
-func userToPrincipal(user models.Userable) v3.Principal {
+type azureObject interface {
+	GetId() *string
+	GetDisplayName() *string
+}
+
+type azureUserObject interface {
+	azureObject
+	GetUserPrincipalName() *string
+}
+
+func userToPrincipal(user azureUserObject) v3.Principal {
 	return v3.Principal{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: Name + "_user://" + *user.GetId(),
@@ -342,12 +352,7 @@ func userToPrincipal(user models.Userable) v3.Principal {
 	}
 }
 
-type groupObject interface {
-	GetId() *string
-	GetDisplayName() *string
-}
-
-func groupToPrincipal(group groupObject) v3.Principal {
+func groupToPrincipal(group azureObject) v3.Principal {
 	return v3.Principal{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: Name + "_group://" + *group.GetId(),


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/51194
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
User and Group objects returned from the Azure Graph queries _may not_ include some fields that we assume are populated.

This can lead to a panic when these fields are not populated.
 
## Solution
This uses the ptr.Deref function to return an empty string when necessary (the value is nil).
 
## Testing
Tests are added.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_