### PR TITLE
49324 the api extension service from remotedialer proxy is never used

### DIFF
--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -53,7 +53,7 @@ const (
 	// The main kube-apiserver will connect to that port (through a tunnel).
 	Port              = 6666
 	APIServiceName    = "v1.ext.cattle.io"
-	TargetServiceName = "imperative-api-extension"
+	TargetServiceName = "api-extension"
 	Namespace         = "cattle-system"
 )
 
@@ -191,9 +191,9 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 
 	additionalSniProviders = append(additionalSniProviders, sniProvider)
 
-	if err := CreateOrUpdateService(wranglerContext.Core.Service(), opts.AppSelector); err != nil {
-		return nil, fmt.Errorf("failed to create or update APIService: %w", err)
-	}
+	//if err := CreateOrUpdateService(wranglerContext.Core.Service(), opts.AppSelector); err != nil {
+	//	return nil, fmt.Errorf("failed to create or update APIService: %w", err)
+	//}
 
 	defaultAuthenticator, err := steveext.NewDefaultAuthenticator(wranglerContext.K8s)
 	if err != nil {

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -77,7 +77,7 @@ func CreateOrUpdateAPIService(apiservice wranglerapiregistrationv1.APIServiceCon
 		},
 	}
 
-	current, err := apiservice.Get(APIServiceName, metav1.GetOptions{})
+	_, err := apiservice.Get(APIServiceName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		if _, err := apiservice.Create(desired); err != nil {
 			return err
@@ -85,6 +85,11 @@ func CreateOrUpdateAPIService(apiservice wranglerapiregistrationv1.APIServiceCon
 	} else if err != nil {
 		return err
 	} else {
+		//getting it again with newest version
+		current, err := apiservice.Get(APIServiceName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 		current.Spec = desired.Spec
 
 		if _, err := apiservice.Update(current); err != nil {


### PR DESCRIPTION
## Issue: #49324
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
This PR addresses unnecessary complexity and potential confusion related to the `api-extension `and `imperative-api-extension `Services within the cattle-system namespace. Previously, the `api-extension` Service was always deployed but never utilized, as the apiservice for ext.cattle.io consistently pointed to `imperative-api-extension`, regardless of the remotedialer-proxy (RDP) deployment status. This created redundant resources and obscured the actual service handling.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This change formalizes `api-extension` as the sole service for ext.cattle.io and eliminates any redundant or legacy service creation logic. The core problem this PR solves is ensuring that the `api-extension` service is correctly managed and the apiservice for ext.cattle.io always points to it, without any remnants of `imperative-api-extension` logic or unused service creations.

- Confirms `api-extension `as the single, authoritative Service for ext.cattle.io.
- Removes any potential redundant creation logic for a separate `api-extension `Service within the `NewExtensionAPIServer` function, ensuring it's managed correctly as the primary service.
- Eliminates any reference or creation of the now-defunct `imperative-api-extension` Service.
- Ensures the apiservice for ext.cattle.io consistently and exclusively points to the `api-extension` Service.
- Simplifies the overall architecture of API extension handling by removing unnecessary complexity and historical artifacts.


 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Fresh Rancher Installation:
- Perform a clean Rancher installation (both with and without remotedialer-proxy if its deployment influences `api-extension's `behavior, though the primary goal here is` api-extension` as sole service).
- Verify that only the `api-extension` Service exists in the cattle-system namespace.
- Confirm that `imperative-api-extension` Service is not created.
- Ensure the apiservice for ext.cattle.io correctly points to the `api-extension` Service.
- Validate all core Rancher functionalities that rely on ext.cattle.io (e.g., shell access to downstream clusters, cluster provisioning, UI interactions with extensions) are fully operational.


### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_