### PR TITLE
Add setting to filter helm versions in head builds

### DIFF
--- a/pkg/catalogv2/content/content_test.go
+++ b/pkg/catalogv2/content/content_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -595,6 +596,73 @@ func TestAirgappedAndBundledIcons(t *testing.T) {
 	}
 
 	deleteDir("../rancher-data")
+}
+
+func TestSkipIndexFiltering(t *testing.T) {
+	tests := []struct {
+		testName               string
+		serverVersion          string
+		skipHelmIndexFiltering bool
+		expected               bool
+	}{
+		{
+			"Should NOT skip if version is release and setting is true",
+			"v2.13.0",
+			true,
+			false,
+		},
+		{
+			"Should NOT skip if version is release and setting is false",
+			"v2.13.0",
+			false,
+			false,
+		},
+		{
+			"Should NOT skip if version is rc and setting is true",
+			"v2.13.0-rc.1",
+			true,
+			false,
+		},
+		{
+			"Should NOT skip if version is rc and setting is false",
+			"v2.13.0-rc.1",
+			false,
+			false,
+		},
+		{
+			"Should skip if version is dev and setting is true",
+			"dev",
+			true,
+			true,
+		},
+		{
+			"Should NOT skip if version is dev and setting is false",
+			"dev",
+			false,
+			false,
+		},
+		{
+			"Should skip if version is head and setting is true",
+			"v2.13.0-head",
+			true,
+			true,
+		},
+		{
+			"Should NOT skip if version is head and setting is false",
+			"v2.13.0-head",
+			false,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			_ = settings.SkipHelmIndexFiltering.Set(strconv.FormatBool(tt.skipHelmIndexFiltering))
+			_ = settings.ServerVersion.Set(tt.serverVersion)
+			result := skipIndexFiltering()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func createDir(dir string) error {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -239,6 +239,9 @@ var (
 	// debug purposes.
 	RKE2ChartDefaultURL = NewSetting("rke2-chart-default-url", "https://git.rancher.io/")
 
+	// SkipHelmIndexFiltering flag that tells Rancher to skip filtering charts in helm index. Only works in -head versions.
+	SkipHelmIndexFiltering = NewSetting("skip-helm-index-filtering", "true")
+
 	// S3BucketCheckTimeout is the timeout for checking if an s3 bucket for etcd backups exists,
 	// in the go duration string format.
 	S3BucketCheckTimeout = NewSetting("s3-bucket-check-timeout", "30s")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -239,7 +239,7 @@ var (
 	// debug purposes.
 	RKE2ChartDefaultURL = NewSetting("rke2-chart-default-url", "https://git.rancher.io/")
 
-	// SkipHelmIndexFiltering flag that tells Rancher to skip filtering charts in helm index. Only works in -head versions.
+	// SkipHelmIndexFiltering flag that tells Rancher to skip filtering charts in helm index. Only works in -head or dev versions.
 	SkipHelmIndexFiltering = NewSetting("skip-helm-index-filtering", "true")
 
 	// S3BucketCheckTimeout is the timeout for checking if an s3 bucket for etcd backups exists,


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49720
 
This aims at keeping the default behavior for head builds as is today, while adding a setting to skip the filtering of the helm index