### PR TITLE
[2.13] Add AWS dual-stack (IPv4 and IPv6) endpoints

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -144,6 +144,8 @@ func addMachineDrivers(management *config.ManagementContext) error {
 			"iam.amazonaws.com",
 			"iam.us-gov.amazonaws.com",
 			"iam.%.amazonaws.com.cn",
+			// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_dual-stack_endpoint_support.html
+			"iam.global.api.aws",
 			// https://docs.aws.amazon.com/general/latest/gr/ec2-service.html
 			"ec2.%.amazonaws.com",
 			"ec2.%.amazonaws.com.cn",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/50616

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
We could not create AWS credentials when Rnacher is installed in an IPv6-supported environment. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Fixes need to go to both the backend and the UI:
- UI should send requests to the dual-stack endpoint: `ec2.region.api.aws`
- The backend should whitelist the above endpoint to proxy the request. 
 
This PR is to implement the backend fixes. 


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


To prove the backend fix works, we need to do the following on an existing Rancher setup:
- First, we need to edit the settings.management.cattle.io `whitelist-domain` to allow the `ec2.%.api.aws` domain. 
- Then, we need to attempt to create a new AWS node-driver cluster -> choose to create a new credential, and  get the cURL of the request that UI sends from Chrome's network tab
- Finally, we need to modify the url to use the `api.aws` domain and execute the command in the terminal

As a result, we will see the request succeed with the expected response.


### Automated Testing

N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
QA should be able to create AWS credentials.


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 
n/a 

Existing / newly added automated tests that provide evidence there are no regressions:

n/a 