### PR TITLE
Add cattle-local-user-passwords namespace to the system project

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -54,6 +54,7 @@ var (
 		"cattle-csp-adapter-system",
 		"calico-apiserver",
 		"cattle-elemental-system",
+		"cattle-local-user-passwords",
 	}
 
 	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:head")


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher-security/issues/1261
 
`cattle-local-user-passwords` holds the secrets that store passwords for local users. This namespace should belong to the system project.
