### PR TITLE
Add namespace `cattle-tokens` to system project

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -55,6 +55,7 @@ var (
 		"calico-apiserver",
 		"cattle-elemental-system",
 		"cattle-local-user-passwords",
+		"cattle-tokens",
 	}
 
 	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:head")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#51228 

## Problem

The namespace `cattle-token` is the backing store for the data of ext token and ext kubeconfig.
This namespace should belong to the system project.
 
## Solution

Added the namespace to the set of namespaces for the system project.
