### PR TITLE
[backport v2.12] Add namespace `cattle-tokens` to system project

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -56,6 +56,7 @@ var (
 		"cattle-elemental-system",
 		"cattle-scc-system",
 		"cattle-telemetry-system",
+		"cattle-tokens",
 	}
 
 	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:head")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#51230 

This PR is a backport of PR #51242.
 
## Problem

The namespace `cattle-token` is the backing store for the data of ext token and ext kubeconfig.
These namespaces should belong to the system project.
 
## Solution

Added the namespace to the set of namespaces for the system project.
