### PR TITLE
bump kube-api-auth to 2.5.0-rc.1

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -5,7 +5,7 @@ var (
 		AuthSystemImages AuthSystemImages
 	}{
 		AuthSystemImages: AuthSystemImages{
-			KubeAPIAuth: "rancher/kube-api-auth:v0.2.4",
+			KubeAPIAuth: "rancher/kube-api-auth:v0.2.5-rc.1",
 		},
 	}
 )


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#49473
 
## Problem

See #49493 and associated https://github.com/rancher/kube-api-auth/pull/35
 
## Solution

This PR bumps r/r to the kube-api-auth 2.5.0-rc.1 image so that the combination of the above-referenced PR's can be properly tested together.
