### PR TITLE
Users Public API: Update secret when resetting admin password

### DIFF
--- a/pkg/auth/providers/local/pbkdf2/pbkdf2.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2.go
@@ -146,6 +146,9 @@ func (p *Pbkdf2) VerifyPassword(user *v3.User, password string) error {
 		return fmt.Errorf("failed to get password secret: %w", err)
 	}
 	if apierrors.IsNotFound(err) {
+		if user.Password == "" {
+			return fmt.Errorf("failed to get password")
+		}
 		// This will only be reached if migration failed. This code will be removed in 2.14
 		logrus.Warn("Using old password field. Check if User migration failed!")
 		if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
@@ -607,6 +607,24 @@ func TestVerifyPassword(t *testing.T) {
 				return fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
 			},
 		},
+		"can't use legacy password if password is empty": {
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fakeUserID,
+				},
+			},
+			password: "",
+			mockSecretCache: func() *fake.MockCacheInterface[*v1.Secret] {
+				mock := fake.NewMockCacheInterface[*v1.Secret](ctlr)
+				mock.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+				return mock
+			},
+			mockSecretClient: func() *fake.MockClientInterface[*v1.Secret, *v1.SecretList] {
+				return fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
+			},
+			expectErrorMessage: "failed to get password",
+		},
 		"valid bcrypt password is migrated": {
 			user: &v3.User{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher-security/issues/1261
 
## Problem
Reset admin password is not working. It returns an error because it tries to create a secret that already exists.
 
## Solution
Update the secret that contains the password. 
Additionally, this PR also checks that the password is not empty when using the legacy password field in User,
