### PR TITLE
[backport 2.12] Don't ignore errors when retrieving authentication token ID

### DIFF
--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -448,9 +448,12 @@ func (t *Store) Update(
 		return nil, false, apierrors.NewNotFound(GVR.GroupResource(), oldToken.Name)
 	}
 
-	sessionID := t.auth.SessionID(ctx)
+	authTokenID, err := t.auth.SessionID(ctx)
+	if err != nil {
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
+	}
 
-	resultToken, err := t.SystemStore.update(sessionID, false, oldToken, newToken, options)
+	resultToken, err := t.SystemStore.update(authTokenID, false, oldToken, newToken, options)
 
 	return resultToken, false, err
 }
@@ -497,10 +500,18 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 		return nil, apierrors.NewBadRequest("operation references a disabled user")
 	}
 
+	authTokenID, err := t.auth.SessionID(ctx)
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
+	}
+	if authTokenID == "" {
+		return nil, apierrors.NewForbidden(GVR.GroupResource(), "", fmt.Errorf("missing authentication token ID"))
+	}
+
 	// Get token of the request and use its principal as ours. Any attempt
 	// by the user to set their own information for the principal is
 	// discarded and written over. No checks are made, no errors are thrown.
-	requestToken, err := t.Fetch(t.auth.SessionID(ctx))
+	requestToken, err := t.Fetch(authTokenID)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
@@ -621,8 +632,13 @@ func (t *Store) get(ctx context.Context, name string, options *metav1.GetOptions
 		return nil, err
 	}
 
+	authTokenID, err := t.auth.SessionID(ctx)
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
+	}
+
 	// note: have to get token first before we can check for a user mismatch
-	token, err := t.SystemStore.Get(name, t.auth.SessionID(ctx), options)
+	token, err := t.SystemStore.Get(name, authTokenID, options)
 	if err != nil {
 		return nil, err
 	}
@@ -637,7 +653,7 @@ func (t *Store) get(ctx context.Context, name string, options *metav1.GetOptions
 	return token, nil
 }
 
-func (t *SystemStore) Get(name, sessionID string, options *metav1.GetOptions) (*ext.Token, error) {
+func (t *SystemStore) Get(name, authTokenID string, options *metav1.GetOptions) (*ext.Token, error) {
 	// Core token retrieval from backing secrets
 	// We try to go through the fast cache as much as we can.
 	var err error
@@ -659,7 +675,7 @@ func (t *SystemStore) Get(name, sessionID string, options *metav1.GetOptions) (*
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to extract token %s: %w", name, err))
 	}
 
-	token.Status.Current = token.Name == sessionID
+	token.Status.Current = token.Name == authTokenID
 	token.Status.Value = ""
 	return token, nil
 }
@@ -671,7 +687,12 @@ func (t *Store) list(ctx context.Context, options *metav1.ListOptions) (*ext.Tok
 		return nil, err
 	}
 
-	return t.SystemStore.list(fullAccess, userInfo.GetName(), t.auth.SessionID(ctx), options)
+	authTokenID, err := t.auth.SessionID(ctx)
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
+	}
+
+	return t.SystemStore.list(fullAccess, userInfo.GetName(), authTokenID, options)
 }
 
 // ListForUser returns the set of token owned by the named user. It is an
@@ -702,7 +723,7 @@ func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
 	}, nil
 }
 
-func (t *SystemStore) list(fullAccess bool, userName, sessionID string, options *metav1.ListOptions) (*ext.TokenList, error) {
+func (t *SystemStore) list(fullAccess bool, userName, authTokenID string, options *metav1.ListOptions) (*ext.TokenList, error) {
 	// Non-system requests always filter the tokens down to those of the current user.
 	// Merge our own selection request (user match!) into the caller's demands
 	localOptions, err := ListOptionMerge(fullAccess, userName, options)
@@ -728,7 +749,7 @@ func (t *SystemStore) list(fullAccess bool, userName, sessionID string, options 
 		}
 
 		// Filtering for users is done already, see above where the options are set up and/or merged.
-		token.Status.Current = token.Name == sessionID
+		token.Status.Current = token.Name == authTokenID
 		tokens = append(tokens, *token)
 	}
 
@@ -746,7 +767,7 @@ func (t *SystemStore) Update(oldToken, token *ext.Token, options *metav1.UpdateO
 	return t.update("", true, oldToken, token, options)
 }
 
-func (t *SystemStore) update(sessionID string, fullPermission bool, oldToken, token *ext.Token,
+func (t *SystemStore) update(authTokenID string, fullPermission bool, oldToken, token *ext.Token,
 	options *metav1.UpdateOptions) (*ext.Token, error) {
 	// check if the user does not wish to actually change anything
 	dryRun := options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll
@@ -815,7 +836,7 @@ func (t *SystemStore) update(sessionID string, fullPermission bool, oldToken, to
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to regenerate token: %w", err))
 	}
 
-	newToken.Status.Current = newToken.Name == sessionID
+	newToken.Status.Current = newToken.Name == authTokenID
 	newToken.Status.Value = ""
 	return newToken, nil
 }
@@ -925,7 +946,10 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 		return nil, apierrors.NewInternalError(fmt.Errorf("tokens: watch: error starting watch: %w", err))
 	}
 
-	sessionID := t.auth.SessionID(ctx)
+	authTokenID, err := t.auth.SessionID(ctx)
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting the authentication token: %w", err))
+	}
 
 	// watch the backend secrets for changes and transform their events into
 	// the appropriate token events.
@@ -985,7 +1009,7 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 					// user is not required. The watch filter (see
 					// ListOptionMerge above) takes care of only
 					// asking for owned tokens
-					token.Status.Current = token.Name == sessionID
+					token.Status.Current = token.Name == authTokenID
 				default:
 					logrus.Warnf("tokens: watch: received and ignored unknown event: '%s'", event.Type)
 					continue
@@ -1111,7 +1135,7 @@ func (t *SystemStore) Fetch(tokenID string) (accessor.TokenAccessor, error) {
 		return ext, nil
 	}
 
-	return nil, fmt.Errorf("unable to fetch unknown token %s", tokenID)
+	return nil, fmt.Errorf("unable to fetch unknown token %q", tokenID)
 }
 
 // timeHandler is a helper interface hiding the details of timestamp generation from
@@ -1131,7 +1155,7 @@ type hashHandler interface {
 // information (user name, principal id, auth provider) from the store. This
 // makes these operations mockable for store testing.
 type authHandler interface {
-	SessionID(ctx context.Context) string
+	SessionID(ctx context.Context) (string, error)
 	UserName(ctx context.Context, store *SystemStore, verb string) (user.Info, bool, bool, error)
 }
 
@@ -1227,9 +1251,8 @@ func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore, verb stri
 // I.e. in case of error the result is simply the empty string. Which means that
 // for requests with broken token information no returned token will be marked
 // as current, as a kube resource cannot have the empty string as its name.
-func (tp *tokenAuth) SessionID(ctx context.Context) string {
-	tokenID, _ := SessionID(ctx)
-	return tokenID
+func (tp *tokenAuth) SessionID(ctx context.Context) (string, error) {
+	return SessionID(ctx)
 }
 
 // SessionID hides the details of extracting the name of the authenticated token
@@ -1244,17 +1267,15 @@ func SessionID(ctx context.Context) (string, error) {
 	//   - multiple query attempts instead
 	userInfo, ok := request.UserFrom(ctx)
 	if !ok {
-		return "", fmt.Errorf("context has no provider/principal data")
+		return "", fmt.Errorf("context has no principal data")
 	}
 
 	extras := userInfo.GetExtra()
-	if extras == nil {
-		return "", fmt.Errorf("context has no provider/principal data")
-	}
-
 	tokenIDs := extras[common.ExtraRequestTokenID]
 	if len(tokenIDs) != 1 {
-		return "", fmt.Errorf("context has no provider/principal data")
+		// log only because we get internal requests (watch setup) without token id
+		logrus.Debugf("context principal extras has no unique request token id: %d", len(tokenIDs))
+		return "", nil
 	}
 
 	tokenID := tokenIDs[0]

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -259,7 +259,7 @@ func Test_Store_Delete(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "laber"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -283,7 +283,7 @@ func Test_Store_Delete(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "laber"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -324,7 +324,7 @@ func Test_Store_Delete(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdl/ksjlkds"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -347,7 +347,7 @@ func Test_Store_Delete(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil).Times(2)
 		users.EXPECT().Cache().Return(nil)
@@ -378,7 +378,7 @@ func Test_Store_Get(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdl/ksjlkds"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -401,7 +401,7 @@ func Test_Store_Get(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -424,7 +424,7 @@ func Test_Store_Get(t *testing.T) {
 		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 		auth := NewMockauthHandler(ctrl)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("bogus")
+		auth.EXPECT().SessionID(gomock.Any()).Return("bogus", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
@@ -483,7 +483,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -516,7 +516,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -552,7 +552,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -587,7 +587,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -621,7 +621,7 @@ func Test_Store_Watch(t *testing.T) {
 			LabelSelector: UserIDLabel + "=lkajdl/ksjlkds",
 		}).Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdl/ksjlkds"}, false, true, nil)
 
@@ -652,7 +652,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -682,7 +682,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("bogus")
+		auth.EXPECT().SessionID(gomock.Any()).Return("bogus", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -716,7 +716,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -751,7 +751,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -782,7 +782,7 @@ func Test_Store_Watch(t *testing.T) {
 		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
 			Return(watcher, nil)
 
-		auth.EXPECT().SessionID(gomock.Any()).Return("")
+		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&mockUser{name: "lkajdlksjlkds"}, false, true, nil)
 
@@ -893,7 +893,7 @@ func Test_Store_Create(t *testing.T) {
 		},
 		{
 			name: "provider/principal retrieval error",
-			err:  apierrors.NewInternalError(fmt.Errorf("unable to fetch unknown token session-token")),
+			err:  apierrors.NewInternalError(fmt.Errorf("unable to fetch unknown token \"session-token\"")),
 			tok: &ext.Token{
 				Spec: ext.TokenSpec{
 					UserID: "world",
@@ -915,7 +915,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// fail fetch of session token, v3 and ext
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").
 					Return(nil, someerror)
 				scache.EXPECT().Get("cattle-tokens", "session-token").
@@ -949,7 +949,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -987,7 +987,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -1035,7 +1035,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -1083,7 +1083,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{
@@ -1139,7 +1139,7 @@ func Test_Store_Create(t *testing.T) {
 
 				// session token fetch for user principal
 				auth.EXPECT().SessionID(gomock.Any()).
-					Return("session-token")
+					Return("session-token", nil)
 				token.EXPECT().Get("session-token").Return(&v3.Token{
 					AuthProvider: "local",
 					UserPrincipal: v3.Principal{

--- a/pkg/ext/stores/tokens/zz_token_fakes.go
+++ b/pkg/ext/stores/tokens/zz_token_fakes.go
@@ -117,11 +117,12 @@ func (m *MockauthHandler) EXPECT() *MockauthHandlerMockRecorder {
 }
 
 // SessionID mocks base method.
-func (m *MockauthHandler) SessionID(ctx context.Context) string {
+func (m *MockauthHandler) SessionID(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SessionID", ctx)
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SessionID indicates an expected call of SessionID.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Issue #51364 . This PR is a backport of #49916 for ticket #51332 
 