### PR TITLE
Fix memleak resumable watch

### DIFF
--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -212,7 +212,12 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to create secret watcher: %w", err)
 	}
-	defer watcher.Stop()
+	defer func() {
+		watcher.Stop()
+		// drain events
+		for range watcher.ResultChan() {
+		}
+	}()
 
 	if err := p.handleCert(); err != nil {
 		logrus.Error(err)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
## Issue: TODO

 
## Problem

In [resumableWatch](https://github.com/rancher/rancher/blob/eec584a0f4602f2cd9964a89e3f256adfe64d938/pkg/watcher/watcher.go#L104), we're not draining the events from [lasso's watcher](https://github.com/rancher/lasso/blob/d9be1e6a051ddf344ab23f18d8ec92f8b1ece3ea/pkg/client/client.go#L347) which means the [goroutine in injectKind is stuck](https://github.com/rancher/lasso/blob/d9be1e6a051ddf344ab23f18d8ec92f8b1ece3ea/pkg/client/client.go#L333-L339) and leaks (and the event channel leaks as well). Kinda mind-bending but basically, the goroutine is stuck specifically on the channel send:

			eventChan <- event

with no consumer (the consumer exits, [calls watcher.Stop()](https://github.com/rancher/rancher/blob/eec584a0f4602f2cd9964a89e3f256adfe64d938/pkg/watcher/watcher.go#L132), and no longer reads the events from eventChan)

It seems we're getting an error event (haven't found what the original error was) and eventually we try a watch again with a resource version that's too old.
 
## Solution

Drain the event, handle RV too old by restarting the watch with `resourceVersion=""`. I'm not sure the exact intent of `OnChange` but it seems that it at least misses the initial LIST (which may or may not be important) and on newer watch we also may miss events due to the way we handle restart of watches now.. I'll sleep on it if we want to do a complete LIST+Watch instead.. I'd rather handle duplicated events (we're used to having handlers idempotent) vs missing critical events.

@joshmeranda I'm also wondering here.. In the case of the cert for imperative API, what happens if the watch receives a error event? Do we end up restarting the watch ever? Or is that watch gone until Rancher restarts?
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_