### PR TITLE
Don't modify machineDeploymentLabels in spec

### DIFF
--- a/pkg/controllers/provisioningv2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/template.go
@@ -336,13 +336,10 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 			infraRef = *machinePool.NodeConfig
 		}
 
-		if machinePool.MachineOS == "" {
-			machinePool.MachineOS = capr.DefaultMachineOS
+		machineOS := machinePool.MachineOS
+		if machineOS == "" {
+			machineOS = capr.DefaultMachineOS
 		}
-		if machinePool.MachineDeploymentLabels == nil {
-			machinePool.MachineDeploymentLabels = make(map[string]string)
-		}
-		machinePool.MachineDeploymentLabels[capr.CattleOSLabel] = machinePool.MachineOS
 
 		machineDeploymentLabels := map[string]string{}
 		for k, v := range machinePool.Labels {
@@ -351,6 +348,8 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 		for k, v := range machinePool.MachineDeploymentLabels {
 			machineDeploymentLabels[k] = v
 		}
+
+		machineDeploymentLabels[capr.CattleOSLabel] = machineOS
 
 		machineSpecAnnotations := map[string]string{}
 		// Ignore drain if DrainBeforeDelete is unset
@@ -426,11 +425,7 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 			machineDeployment.Spec.Template.Labels[capr.WorkerRoleLabel] = "true"
 		}
 
-		if len(machinePool.MachineOS) > 0 {
-			machineDeployment.Spec.Template.Labels[capr.CattleOSLabel] = machinePool.MachineOS
-		} else {
-			machineDeployment.Spec.Template.Labels[capr.CattleOSLabel] = capr.DefaultMachineOS
-		}
+		machineDeployment.Spec.Template.Labels[capr.CattleOSLabel] = machineOS
 
 		if len(machinePool.Labels) > 0 {
 			for k, v := range machinePool.Labels {


### PR DESCRIPTION
## Issue: [<!-- link the issue or issues this PR resolves here -->](https://github.com/rancher/rancher/issues/51259)
 
## Problem
Whenever a user specifies values `machineDeploymentLabels` for a machine pool in the provisioning cluster spec, a Rancher controller populates the `cattle.io/os` label not only in the generated `MachineDeployment` object but also in the cluster spec itself.

Rancher should set this label in the `MachineDeployment` object but not modify the cluster spec.

This effect is only sometimes visible because the controller that does this doesn't explicitly update the cluster object: this change to the spec only has an effect if for another reason a subsequent handler in the controller chain updates the cluster object on the api server. It also only happens if the field has any other values: the `cattle.io/os` label is never set in the spec if `machineDeploymentLabels`  was unset.

For additional context into why this was likely unintended, see the issue description.
 
## Solution
Don't alter the machine pool spec in the controller, use a local variable.
 
## Testing

## Engineering Testing
### Manual Testing
Provisioned a cluster on Rancher without this PR with one of the pools with `machineDeploymentLabels` set to a test label. Nudged the cluster to have it modify the spec with the `cattle.io/os` label. Removed this label. Upgraded Rancher with this PR. Nudged the cluster again and verified the `cattle.io/os` label wasn't being set in the cluster spec. Checked that the actual `MachineDeployment` had the `cattle.io/os` label.

Provisioned a vpshere cluster with a windows worker pool to check it worked OK, since windows provisioning is affected by the `machineOS` field (related to the label). Added a deployment label and checked the os label was still correctly set in the deployment object.

### Automated Testing
None.

## QA Testing Considerations
TODO
 
### Regressions Considerations
It's unlikely that there should be regressions: clusters that don't define `machineDeploymentLabels` aren't affected by this issue and have been working OK. The behavior of adding `cattle.io/os` to the `MachineDeployment` itself is preserved.