### PR TITLE
[main] Add backup label to provisioning secrets (#51029)

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -92,6 +92,9 @@ const (
 	MachineTemplateClonedFromKindAnn         = "rke.cattle.io/cloned-from-kind"
 	MachineTemplateClonedFromNameAnn         = "rke.cattle.io/cloned-from-name"
 
+	// Label added to secrets to make sure they are included in backups when created in a namespace other than fleet-default
+	BackupLabel = "resources.cattle.io/backup"
+
 	CattleOSLabel    = "cattle.io/os"
 	DefaultMachineOS = "linux"
 	WindowsMachineOS = "windows"

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -1193,6 +1193,9 @@ func (p *Planner) ensureRKEStateSecret(controlPlane *rkev1.RKEControlPlane, newC
 						UID:        controlPlane.UID,
 					},
 				},
+				Labels: map[string]string{
+					capr.BackupLabel: "true",
+				},
 			},
 			Data: map[string][]byte{
 				"serverToken": []byte(serverToken),

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -391,6 +391,7 @@ func getLabelsAndAnnotationsForPlanSecret(bootstrap *rkev1.RKEBootstrap, machine
 	labels := make(map[string]string, len(bootstrap.Labels)+2)
 	labels[capr.MachineNameLabel] = machine.Name
 	labels[capr.ClusterNameLabel] = bootstrap.Spec.ClusterName
+	labels[capr.BackupLabel] = "true"
 	for k, v := range bootstrap.Labels {
 		labels[k] = v
 	}

--- a/pkg/controllers/capr/machineprovision/args.go
+++ b/pkg/controllers/capr/machineprovision/args.go
@@ -96,6 +96,9 @@ func (h *handler) getArgsEnvAndStatus(infra *infraObject, args map[string]any, d
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      wranglername.SafeConcatName(infra.meta.GetName(), "machine", "driver", "secret"),
 			Namespace: infra.meta.GetNamespace(),
+			Labels: map[string]string{
+				capr.BackupLabel: "true",
+			},
 		},
 		Data: getWhitelistedEnvVars(),
 	}

--- a/pkg/controllers/capr/machineprovision/template.go
+++ b/pkg/controllers/capr/machineprovision/template.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/rancher/rancher/pkg/capr"
 	name2 "github.com/rancher/wrangler/v3/pkg/name"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,9 @@ func objects(ready bool, args driverArgs) []runtime.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      args.StateSecretName,
 			Namespace: args.MachineNamespace,
+			Labels: map[string]string{
+				capr.BackupLabel: "true",
+			},
 		},
 		Type: "rke.cattle.io/machine-state",
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/backup-restore-operator/issues/663
 
A backport of: https://github.com/rancher/rancher/pull/51029
(for @jbiers as she is away)