### PR TITLE
Restore make quick's ability to produce debuggable images

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -11,6 +11,7 @@ TAG="${TAG:-$(grep -m1 ' TAG:' .github/workflows/pull-request.yml | sed -e 's/^[
 OS="${OS:-linux}"
 ARCH="${ARCH:-amd64}"
 REPO="${REPO:-rancher}"
+DEBUG=${DEBUG:-false}
 CATTLE_K3S_VERSION=$(grep -m1 'ENV CATTLE_K3S_VERSION=' package/Dockerfile | cut -d '=' -f2)
 CATTLE_KDM_BRANCH=$(grep -m1 'ARG CATTLE_KDM_BRANCH=' package/Dockerfile | cut -d '=' -f2)
 CATTLE_RANCHER_WEBHOOK_VERSION=$(grep -m1 'webhookVersion' build.yaml | cut -d ' ' -f2)
@@ -43,6 +44,12 @@ BUILD_ARGS+=("--build-arg=CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION}")
 BUILD_ARGS+=("--build-arg=CATTLE_HELM_VERSION=${CATTLE_HELM_VERSION}")
 BUILD_ARGS+=("--build-arg=RANCHER_TAG=${TAG}")
 BUILD_ARGS+=("--build-arg=RANCHER_REPO=${REPO}")
+if [ "$DEBUG" = true ]; then
+  # Remove -s (strip symbols)
+  BUILD_ARGS+=("--build-arg=LINKFLAGS=-extldflags -static")
+  # Disable compiler optimizations
+  BUILD_ARGS+=("--build-arg=EXTRAFLAGS=-gcflags=all=-N -l")
+fi
 
 # because macos doesn't have realpath apparently
 abs_path() {

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -363,11 +363,12 @@ ARG COMMIT
 ARG TAGS="k8s"
 ARG LINKFLAGS="-extldflags -static -s"
 ARG LDFLAGS="-X github.com/rancher/rancher/pkg/version.Version=${VERSION} -X github.com/rancher/rancher/pkg/version.GitCommit=${COMMIT} ${LINKFLAGS}"
+ARG EXTRAFLAGS=""
 ARG TARGETOS
 ARG TARGETARCH
 COPY pkg/ pkg/
 COPY main.go ./
-RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o /app/rancher
+RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" "${EXTRAFLAGS}" -o /app/rancher
 
 # Output just the server binary
 FROM scratch AS server-binary
@@ -379,11 +380,12 @@ ARG VERSION
 ARG TAGS="k8s"
 ARG LINKFLAGS="-extldflags -static -s"
 ARG LDFLAGS="-X main.VERSION=${VERSION} $LINKFLAGS"
+ARG EXTRAFLAGS=""
 ARG TARGETOS
 ARG TARGETARCH
 COPY cmd/ cmd/
 COPY pkg/ pkg/
-RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o /app/agent ./cmd/agent
+RUN --mount=type=cache,target=/root/.cache,id=rancher GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${TAGS}" -ldflags "${LDFLAGS}" "${EXTRAFLAGS}" -o /app/agent ./cmd/agent
 
 
 FROM base AS server


### PR DESCRIPTION
## Problem

Developers might need to attach a debugger to a live instance of Rancher.

In order to do that, the executable needs to be built without stripping symbols (linker flags `-s` and `-w` must be absent) and disabling some compiler optimizations (build flag `-gcflags='all=-N -l'` must be present).

`make quick` and the `Dockerfile` used to support this, and it is leveraged by `delve-debugger`:

https://github.com/rancherlabs/delve-debugger/tree/master

Specifically:

https://github.com/rancherlabs/delve-debugger/blob/master/docs/guides/README-rancher.md

This was recently broken by changes to Dockerfile.
 
## Solution

This patch adds an optional argument to Dockerfile and changes `make quick` to provide the correct flags if DEBUG is set at compile time.
 
## Testing

Manually tested.