### PR TITLE
[CI] Add publish-provisioning-test-results GitHub Action

### DIFF
--- a/.github/workflows/publish-provisioning-test-results.yaml
+++ b/.github/workflows/publish-provisioning-test-results.yaml
@@ -8,13 +8,22 @@ permissions: {}
 
 jobs:
   publish-provisioning-test-results:
-    runs-on: runs-on,runner=4cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
+    container: registry.suse.com/bci/bci-base:15.7
     if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
     permissions:
       checks: write
       pull-requests: write
       actions: read
     steps:
+      - name: Install Python Deps
+        run: |
+          # install python
+          zypper --non-interactive install python311 python311-pip python311-virtualenv
+
+          # set python as the default python (essentially just a symlink)
+          update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+
       - name: mkdir test-results
         run: mkdir -p /tmp/test-results
 


### PR DESCRIPTION
Adjacent to https://github.com/rancher/rancher/pull/51047, this can go in before/after it. But the actual test-results won't be published until this is merged. If this one is merged first however the results will start being published with #51047 

This is what actually does the comment back on the PR following a PR Workflow run.

Essentially this action gets called after the `Build Pull Request` workflow completes, then:
- Downloads the XML results (converted during provisioning-tests)
- Downloads the Event File (information regarding the PR push event)
- Comments back on the PR with some slightly detailed info on the tests, example [here](https://github.com/rancher/kontainer-driver-metadata/pull/1643#issuecomment-3161876282)
