### PR TITLE
[main] Bump scc-operator to tag & minor bug fixes

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,4 +4,4 @@ provisioningCAPIVersion: 107.0.0+up0.8.0
 cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
 defaultShellVersion: rancher/shell:v0.5.0
 fleetVersion: 107.0.0+up0.13.0
-defaultSccOperatorImage: rancher/scc-operator:main-64fd4c4
+defaultSccOperatorImage: rancher/scc-operator:v0.0.0-alpha.6

--- a/pkg/apis/telemetry.cattle.io/v1/types.go
+++ b/pkg/apis/telemetry.cattle.io/v1/types.go
@@ -59,3 +59,15 @@ func (sr *SecretRequest) HasCondition(matchCond condition.Cond) bool {
 
 	return false
 }
+
+func (sr *SecretRequest) RemoveCondition(matchCond condition.Cond) {
+	newConditions := make([]genericcondition.GenericCondition, 0)
+	for _, cond := range sr.Status.Conditions {
+		if cond.Type == string(matchCond) {
+			continue
+		}
+		newConditions = append(newConditions, cond)
+	}
+
+	sr.Status.Conditions = newConditions
+}

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion     = "107.0.0+up7.0.0-rc.1"
-	DefaultSccOperatorImage  = "rancher/scc-operator:main-64fd4c4"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.0.0-alpha.6"
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "107.0.0+up0.13.0"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"

--- a/pkg/scc/deployer/params/params.go
+++ b/pkg/scc/deployer/params/params.go
@@ -129,6 +129,8 @@ func (p *SCCOperatorParams) PrepareDeployment() *appsv1.Deployment {
 		scale = 0
 	}
 
+	// TODO: We should support the "extra tolerations" feature users are asking for
+	// ref: https://github.com/rancher/rancher/issues/48541
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: consts.DefaultSCCNamespace,
@@ -151,6 +153,7 @@ func (p *SCCOperatorParams) PrepareDeployment() *appsv1.Deployment {
 }
 
 func (p *SCCOperatorParams) preparePodSpec() corev1.PodSpec {
+	// TODO: should pass in some relevant ENVs to the container
 	return corev1.PodSpec{
 		ServiceAccountName: consts.ServiceAccountName,
 		Containers: []corev1.Container{

--- a/pkg/scc/scc.go
+++ b/pkg/scc/scc.go
@@ -32,8 +32,6 @@ func StartDeployer(ctx context.Context, wContext *wrangler.Context) error {
 		return fmt.Errorf("cannot start scc-operator deployer, failed to ensure dependencies: %w", err)
 	}
 
-	// TODO: maybe namespace controller scoped for the SCC namespace - or webhook?
-
 	controllers.RegisterDeployer(
 		ctx,
 		operatorLogger,

--- a/pkg/telemetry/controllers/secretrequest/secretrequest.go
+++ b/pkg/telemetry/controllers/secretrequest/secretrequest.go
@@ -120,6 +120,7 @@ func (h *handler) OnSecretRequestChange(key string, incomingObj *v1.SecretReques
 	preparedObj := incomingObj.DeepCopy()
 	v1.ResourceConditionDone.True(preparedObj)
 	v1.ResourceConditionProgressing.False(preparedObj)
+	preparedObj.RemoveCondition(v1.ResourceConditionFailure)
 	timeNow := metav1.Now()
 	preparedObj.Status.LastSyncTS = &timeNow
 	updated, updateErr := h.secretRequests.UpdateStatus(preparedObj)

--- a/pkg/telemetry/exporter.go
+++ b/pkg/telemetry/exporter.go
@@ -265,7 +265,7 @@ func (s *secretTelemetryExporter) createOrUpdate(data []byte) error {
 		return nil
 	}
 
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 


### PR DESCRIPTION
Bug fixes include:

- Updating related condition when SyncNow used
- Remove Failure condition on SecretRequest when it works successfully (if failure set)
- remove redundant logic check