### PR TITLE
[main] Bump SCC Operator image

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,4 +4,4 @@ provisioningCAPIVersion: 107.0.0+up0.8.0
 cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
 defaultShellVersion: rancher/shell:v0.5.0
 fleetVersion: 107.0.0+up0.13.0
-defaultSccOperatorImage: rancher/scc-operator:v0.0.0-alpha.6
+defaultSccOperatorImage: rancher/scc-operator:head

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion     = "107.0.0+up7.0.0-rc.1"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.0.0-alpha.6"
+	DefaultSccOperatorImage  = "rancher/scc-operator:head"
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "107.0.0+up0.13.0"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"


### PR DESCRIPTION
The SCC Operator is able to support many versions of Rancher with a single release line. This is because it has very minimal dependencies on `r/r` core components - only accessing anything we need via `dynamicClient` or other means. This ensures that as long as the core Telemetry service exists in Rancher, then that version of Rancher can use the SCC Operator.

For Rancher's `main` branch, the `head` rolling tag will be used. This ensures it always uses the most recent changes to the SCC Operator w/o us needing to make superfluous PRs to bump alpha tags during regular development.

The `release/v*` branches will always use tagged images - and more importantly they likely should all be bumped in unison using the same tags. At least this is the logic we are using until or unless something causes necessary breaking changes to require multiple release lines for the SCC Operator.

---

During and near the Rancher Minor release cycles we will treat `main` like the other `release/v*` branches. Meaning that it will get the same Alpha/Beta/RC/Release tags. And then after `main` is branched for a new release we will revert it back to using the `head` tag.