### PR TITLE
[2.11] fix lke checksum

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -103,7 +103,7 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	if err := creator.addCustomDriver(
 		"linodekubernetesengine",
 		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.13/kontainer-engine-driver-lke-linux-amd64",
-		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		"b17337edeb3b3d4d4f007836e0f9dd946e51eb5cf0945f51f6d48e74123883b5",
 		"",
 		false,
 		"api.linode.com",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #51201
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Checksum was `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`, which is a sha256sum of zero bytes.