### PR TITLE
Bump remotedialer-proxy charts to 106.0.1+up0.5.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 webhookVersion: 108.0.0+up0.9.0-rc.4
-remoteDialerProxyVersion: 106.0.1+up0.5.0-rc.1
+remoteDialerProxyVersion: 106.0.1+up0.5.0
 provisioningCAPIVersion: 107.0.0+up0.8.0
 cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
 defaultShellVersion: rancher/shell:v0.5.0

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -8,6 +8,6 @@ const (
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "107.0.0+up0.13.0"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"
-	RemoteDialerProxyVersion = "106.0.1+up0.5.0-rc.1"
+	RemoteDialerProxyVersion = "106.0.1+up0.5.0"
 	WebhookVersion           = "108.0.0+up0.9.0-rc.4"
 )


### PR DESCRIPTION
It needs to be bumped anyway, but bumping because the RC no longer exist in charts due to https://github.com/rancher/charts/pull/6102