### PR TITLE
[release/v2.12] Bump SCC operator image to v0.1.0-alpha.2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,4 +4,4 @@ provisioningCAPIVersion: 107.0.0+up0.8.0
 cspAdapterMinVersion: 107.0.0+up7.0.0
 defaultShellVersion: rancher/shell:v0.5.0
 fleetVersion: 107.0.1+up0.13.1-rc.4
-defaultSccOperatorImage: rancher/scc-operator:v0.1.0-alpha.1
+defaultSccOperatorImage: rancher/scc-operator:v0.1.0-alpha.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion     = "107.0.0+up7.0.0"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.1.0-alpha.1"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.1.0-alpha.2"
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "107.0.1+up0.13.1-rc.4"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"


### PR DESCRIPTION
From SCC Operator changelog, this covers:

- [main] Dereference string pointers in logger by @jbiers in https://github.com/rancher/scc-operator/pull/19
- Bump to newest SCC library by @mallardduck in https://github.com/rancher/scc-operator/pull/20

The second commit is the important one that is required before release. It will ensure we are in sync with the SCC offline workflows.