### PR TITLE
[v2.12] Bump Go toolchain to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 replace (
 	github.com/crewjam/saml => github.com/rancher/saml v0.4.14-rancher3

--- a/gotools/controller-gen/go.mod
+++ b/gotools/controller-gen/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/gotools/controller-gen
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 tool sigs.k8s.io/controller-tools/cmd/controller-gen
 

--- a/gotools/mockgen/go.mod
+++ b/gotools/mockgen/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/gotools/mockgen
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 tool go.uber.org/mock/mockgen
 

--- a/hack/airgap/go.mod
+++ b/hack/airgap/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/airgap
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 require (
 	github.com/containers/common v0.60.0

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/pkg/apis
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 replace (
 	k8s.io/api => k8s.io/api v0.33.1

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/rancher/pkg/client
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 replace github.com/rancher/wrangler/v3 => github.com/rancher/wrangler/v3 v3.2.2
 


### PR DESCRIPTION
Bump Go toolchain to 1.24.6

```
docker pull registry.suse.com/bci/golang:1.24
docker inspect registry.suse.com/bci/golang:1.24 | grep GOLANG_VERSION
                "GOLANG_VERSION=1.24.6",
```