### PR TITLE
fix: adding safe validation for ipv6 host

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/cavalidator"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/logserver"
+	"github.com/rancher/rancher/pkg/utils"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/v3/pkg/signals"
 	"github.com/sirupsen/logrus"
@@ -280,7 +281,11 @@ func run(ctx context.Context) error {
 	}()
 
 	for {
-		wsURL := fmt.Sprintf("wss://%s/v3/connect", serverURL.Host)
+		safeHost := serverURL.Host
+		if utils.IsPlainIPV6(safeHost) {
+			safeHost = fmt.Sprintf("[%s]", safeHost)
+		}
+		wsURL := fmt.Sprintf("wss://%s/v3/connect", safeHost)
 		if !isConnect() {
 			wsURL += "/register"
 		}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42722
 
## Problem
The formatting performed for websocket URL is not ipv6 compatible.
 
## Solution
Added a check to determine the peer IP belongs to which family, and wrap the IP is [] square brackets if belongs to ipv6.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_