### PR TITLE
Bump steve to v0.7.9 (#51521) (Steve PR #785).

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.1
 	github.com/rancher/aks-operator v1.12.0
-	github.com/rancher/apiserver v0.7.0
+	github.com/rancher/apiserver v0.7.2
 	github.com/rancher/channelserver v0.7.0
 	github.com/rancher/dynamiclistener v0.7.0
 	github.com/rancher/eks-operator v1.12.0
@@ -140,7 +140,7 @@ require (
 	github.com/rancher/remotedialer v0.5.0-rc.1
 	github.com/rancher/rke v1.8.0-rc.4
 	github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b
-	github.com/rancher/steve v0.7.4
+	github.com/rancher/steve v0.7.9
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd
 	github.com/rancher/wrangler v1.1.2
 	github.com/rancher/wrangler/v3 v3.2.3

--- a/go.sum
+++ b/go.sum
@@ -727,6 +727,7 @@ github.com/rancher/aks-operator v1.12.0 h1:ua3jHCX1AtF2eFx7XBmqeGFEVFwbd9WckRMkR
 github.com/rancher/aks-operator v1.12.0/go.mod h1:tgoEZKKWIwgydqoqAyTKv4jw7nrp4uVgjtSQjbtPH4Q=
 github.com/rancher/apiserver v0.7.0 h1:8N9XQXurELdZ3nfU5WKwgwDcYOoixNfpdpMbLZ4rrnM=
 github.com/rancher/apiserver v0.7.0/go.mod h1:9b/n58YT7S8bMFEyr1v7xzL72qwZKQQJK2Ir6lMT8Yk=
+github.com/rancher/apiserver v0.7.2/go.mod h1:9b/n58YT7S8bMFEyr1v7xzL72qwZKQQJK2Ir6lMT8Yk=
 github.com/rancher/channelserver v0.7.0 h1:ZN5o8aD4mD31uhjEEW2e9yQXa3eOb+4Cp6DcWm7W/Lc=
 github.com/rancher/channelserver v0.7.0/go.mod h1:Mwd7hlMSu9X4FnZKj+0mA5ak8nTyJZtZsVX33G62Gzc=
 github.com/rancher/dynamiclistener v0.7.0 h1:+jyfZ4lVamc1UbKWo8V8dhSPtCgRZYaY8nm7wiHeko4=
@@ -761,6 +762,7 @@ github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b h1:QIC9NNyUroMFIn
 github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/steve v0.7.4 h1:uOpbWxa5fzbiCYETaXUhLdBZeY12Jw2I+JwD0xnDWvU=
 github.com/rancher/steve v0.7.4/go.mod h1:/IH+uMCnW/lE1Syz5jgLc1W6QqpPWv117MBFEL9kg5A=
+github.com/rancher/steve v0.7.9/go.mod h1:O4ZebgmHiR4LnmeM3vIW9VjpzGPLqHmImflmj44G1No=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
This ensures the VAI database is reset after an api-service change.

Related to issue #51521 