### PR TITLE
Fix rbac

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -49,6 +49,7 @@ type handler struct {
 	crdCache                             apiextcontrollers.CustomResourceDefinitionCache
 	dynamic                              *dynamic.Controller
 	resources                            map[schema.GroupVersionKind]resourceMatch
+	knownResources                       map[schema.GroupVersionKind]bool
 	resourcesList                        []resourceMatch
 	resourcesLock                        sync.RWMutex
 	apply                                apply.Apply
@@ -88,6 +89,7 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 			clients.Mgmt.ClusterRoleTemplateBinding(),
 			clients.RBAC.RoleBinding()),
 		resources:              map[schema.GroupVersionKind]resourceMatch{},
+		knownResources:         map[schema.GroupVersionKind]bool{},
 		provisioningClusterGVK: clusterGVK,
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/51589
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Some recent changes in steve (https://github.com/rancher/steve/pull/778/files) have resulted in locks being added when rebuilding the dbs, which is also the same lock held by the OnChangeCRD handler in steve. Since handlers for a given key are processed sequentially, the OnCRD handler within rancher (https://github.com/rancher/rancher/blob/main/pkg/controllers/management/authprovisioningv2/role.go#L107) has to wait for the steve handler to complete, and depending on the state of things it may take a considerable amount of time (Tom and I noticed that occasionally it did not reproduce, although much easier to reproduce with breakpoints enabled). If the handler cannot process with the 500ms refresh period for lasso's dynamic controller, the gvkMatcher function will fail the indexer check, and as it is not recomputed, will fail to add an indexer for the type. This only affects CRDs that do not exists on startup: i.e. only the machine, machinetemplate, and configs generated at runtime from node drivers. Subsequent restarts of rancher should fix the indexer problem.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Lazy evaluate crds when using the gvkMatcher function.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested Manually