### PR TITLE
add 'which' package to zypper line in publish-provisioning-tests job

### DIFF
--- a/.github/workflows/publish-provisioning-test-results.yaml
+++ b/.github/workflows/publish-provisioning-test-results.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Python Deps
         run: |
           # install python
-          zypper --non-interactive install python311 python311-pip python311-virtualenv
+          zypper --non-interactive install python311 python311-pip python311-virtualenv which
 
           # set python as the default python (essentially just a symlink)
           update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1


### PR DESCRIPTION
Looks like `which` isn't in the bci container by default: https://github.com/rancher/rancher/actions/runs/17141689244/job/48630194488#step:7:71

Just adding that to the container to hopefully get the comment working over here. 