### PR TITLE
[CI] add pipefail + upload plain text version of test results

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -87,18 +87,22 @@ jobs:
           V2PROV_TEST_DIST: "${{ matrix.V2PROV_TEST_DIST }}"
           CATTLE_FEATURES: "${{ matrix.CATTLE_FEATURES }}"
           CATTLE_AGENT_IMAGE: "${{ env.IMAGE_AGENT}}:${{ env.TAG }}"
-      - name: Rename Test Output
+      - name: Rename JSON test output & generate plain text version for debugging
         id: test_output
         run: |
-          export TESTSUITE="$(echo '${{ matrix.V2PROV_TEST_RUN_REGEX }}' | tr -d '()|^.*$')"
+          export TESTSUITE="$(echo '${{ matrix.V2PROV_TEST_RUN_REGEX }}' | sed 's/Test//' | tr -d '()|_^.*$')"
           echo "suite=${TESTSUITE}" >> $GITHUB_OUTPUT
           # need sudo due to this being created in the dapper container
           sudo mv ./build/out.json /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.json
-      - name: Upload JSON Test Results
+
+          cat /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.json | \
+            sed '/^go:/d' | \
+            jq -sr '.[] | .Output' > /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.txt
+      - name: Upload JSON and Plain Text Test Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: "JSON Results ${{ matrix.V2PROV_TEST_DIST }} ${{ steps.test_output.outputs.suite }}"
-          path: "/tmp/report-${{ matrix.V2PROV_TEST_DIST }}-${{ steps.test_output.outputs.suite }}.json"
+          name: "Test Results ${{ matrix.V2PROV_TEST_DIST }} ${{ steps.test_output.outputs.suite }}"
+          path: "/tmp/report-${{ matrix.V2PROV_TEST_DIST }}-${{ steps.test_output.outputs.suite }}.*"
 
   convert-to-xml:
     needs: [provisioning_tests]

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 if ./scripts/only-ui-bumps.sh; then
     exit 0
 fi


### PR DESCRIPTION
Fixing a couple issues - notably when a provisioning-test fails it is still marked green due to tee exiting with status code 0, a common bash pitfall which is fixed with the pipefail option.

The second part is this is a bit difficult to troubleshoot without some jq-foo if you want the logs. So adding a separate artifact upload which runs that jq-magic for us in order to store the plaintext test results themselves as artifacts. 