### PR TITLE
Add trigger_ci file for CI testing

### DIFF
--- a/.github/workflows/ci-testing-create-pr.yml
+++ b/.github/workflows/ci-testing-create-pr.yml
@@ -76,7 +76,9 @@ jobs:
 
       - name: Create and push empty commit
         run: |
-          git commit --allow-empty -m "Empty commit"
+          touch trigger_ci
+          git add trigger_ci
+          git commit -m "Add trigger_ci file for CI testing"
           git push origin ${{ steps.branch-setup.outputs.branch }}
 
       - name: Create draft PR


### PR DESCRIPTION
to workaround the [paths-ignore](https://github.com/rancher/rancher/blob/main/.github/workflows/pull-request.yml#L3-L8) of the build pull request action.

[Successful test run](https://github.com/rancher/rancher/pull/51710)