### PR TITLE
[release/v2.12] Cachesync timeout

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -159,6 +159,10 @@ spec:
         - name: AGGREGATION_REGISTRATION_TIMEOUT
           value: {{ .Values.aggregationRegistrationTimeout }}
 {{- end }}
+{{- if .Values.cacheSyncTimeout }}
+        - name: CACHE_SYNC_TIMEOUT
+          value: {{ .Values.cacheSyncTimeout }}
+{{- end }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -698,3 +698,20 @@ tests:
           limits:
             cpu: 500m
             memory: 500Mi
+- it: should set the CACHE_SYNC_TIMEOUT when provided
+  set:
+    cacheSyncTimeout: 10m
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env
+      value:
+        - name: CATTLE_NAMESPACE
+          value: NAMESPACE
+        - name: CATTLE_PEER_SERVICE
+          value: RELEASE-NAME-rancher
+        - name: IMPERATIVE_API_DIRECT
+          value: "true"
+        - name: IMPERATIVE_API_APP_SELECTOR
+          value: RELEASE-NAME-rancher
+        - name: CACHE_SYNC_TIMEOUT
+          value: 10m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,6 +40,9 @@ auditLog:
     # options: Always, Never, IfNotPresent
     pullPolicy: "IfNotPresent"
 
+# Timeout for rancher controllers to complete a cache sync. Larger clusters may need to increase this value.
+# cacheSyncTimeout: 5m
+
 # As of Rancher v2.5.0 this flag is deprecated and must be set to 'true' in order for Rancher to start
 addLocal: "true"
 

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -218,7 +218,7 @@ func (w *Context) checkGVK(ctx context.Context, gvk schema.GroupVersionKind) err
 	}
 
 	if !enabled {
-		return fmt.Errorf("crd '%s' has not served versions")
+		return fmt.Errorf("crd '%s' has no served versions", gvk.String())
 	}
 
 	return nil

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"time"
 
 	fleetv1alpha1api "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/lasso/pkg/controller"

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -115,7 +115,7 @@ func init() {
 	utilruntime.Must(AddToScheme(Scheme))
 	utilruntime.Must(schemes.AddToScheme(Scheme))
 
-	if timeout := os.Getenv(cacheSyncTimeoutEnvVar); timeout == "" {
+	if timeout := os.Getenv(cacheSyncTimeoutEnvVar); timeout != "" {
 		var err error
 		if cacheSyncTimeout, err = time.ParseDuration(timeout); err != nil {
 			logrus.Fatalf("env var '%s' is not a valid duration: %s", cacheSyncTimeoutEnvVar, timeout)

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -198,7 +198,15 @@ func (w *Context) StartWithTransaction(ctx context.Context, f func(context.Conte
 		return err
 	}
 
-	w.ControllerFactory.SharedCacheFactory().WaitForCacheSync(ctx)
+	timeoutCtx, _ := context.WithTimeout(ctx, time.Minute*5)
+	gvks := w.ControllerFactory.SharedCacheFactory().WaitForCacheSync(timeoutCtx)
+
+	for gvk, isSynced := range gvks {
+		if !isSynced {
+			logrus.Warnf("cache for '%s' did not sync", gvk.String())
+		}
+	}
+
 	transaction.Commit()
 	return w.Start(ctx)
 }

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 
 	fleetv1alpha1api "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -103,12 +104,27 @@ var (
 	}
 	AddToScheme = localSchemeBuilder.AddToScheme
 	Scheme      = runtime.NewScheme()
+
+	cacheSyncTimeoutEnvVar = "CACHE_SYNC_TIMEOUT"
+	cacheSyncTimeout       time.Duration
 )
 
 func init() {
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
 	utilruntime.Must(AddToScheme(Scheme))
 	utilruntime.Must(schemes.AddToScheme(Scheme))
+
+	switch timeout := os.Getenv(cacheSyncTimeoutEnvVar); timeout {
+	case "":
+		cacheSyncTimeout = time.Minute * 5
+
+	default:
+		var err error
+		cacheSyncTimeout, err = time.ParseDuration(timeout)
+		if err != nil {
+			logrus.Fatalf("env var '%s' is not a valid duration: %s", cacheSyncTimeoutEnvVar, timeout)
+		}
+	}
 }
 
 type Context struct {
@@ -198,7 +214,7 @@ func (w *Context) StartWithTransaction(ctx context.Context, f func(context.Conte
 		return err
 	}
 
-	timeoutCtx, _ := context.WithTimeout(ctx, time.Minute*5)
+	timeoutCtx, _ := context.WithTimeout(ctx, cacheSyncTimeout)
 	gvks := w.ControllerFactory.SharedCacheFactory().WaitForCacheSync(timeoutCtx)
 
 	for gvk, isSynced := range gvks {

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -201,6 +201,29 @@ func (w *Context) OnLeader(f func(ctx context.Context) error) {
 	w.leadership.OnLeader(f)
 }
 
+func (w *Context) checkGVK(ctx context.Context, gvk schema.GroupVersionKind) error {
+	logrus.Warnf("cache for '%s' did not sync", gvk.String())
+	crd, err := w.CRD.CustomResourceDefinition().Get(gvk.GroupKind().String(), metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get crd for gvk: %s", err)
+
+	}
+
+	var enabled bool
+	for _, v := range crd.Spec.Versions {
+		if v.Served {
+			enabled = true
+			break
+		}
+	}
+
+	if !enabled {
+		return fmt.Errorf("crd '%s' has not served versions")
+	}
+
+	return nil
+}
+
 func (w *Context) StartWithTransaction(ctx context.Context, f func(context.Context) error) (err error) {
 	transaction := controller.NewHandlerTransaction(ctx)
 	if err := f(transaction); err != nil {
@@ -219,7 +242,9 @@ func (w *Context) StartWithTransaction(ctx context.Context, f func(context.Conte
 
 	for gvk, isSynced := range gvks {
 		if !isSynced {
-			logrus.Warnf("cache for '%s' did not sync", gvk.String())
+			if err := w.checkGVK(ctx, gvk); err != nil {
+				logrus.Errorf("found issues for gvk '%s': %s", gvk.String(), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/51754
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When syncing controller caches in `WaitForCacheSync` it is possible to block in some cases (ex CRD has not served versions) and prevent controllers from starting.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add timeout to the `context.Context` which defaults to `5m`, but can be changed by the `CACHE_SYNC_TIMEOUT` evnvar to prevent blocking all controllers indefinitely.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Created CRD with no served versions and observed rancher warn of unsycnhed caches with information about no served versions.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_