### PR TITLE
Generalized Deferred Registration

### DIFF
--- a/pkg/api/steve/machine/machine.go
+++ b/pkg/api/steve/machine/machine.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Register(server *steve.Server, clients *wrangler.Context) {
-	clients.DeferredCAPIRegistration.DeferFunc(func(clients *wrangler.Context) {
+	clients.DeferredCAPIRegistration.DeferFunc(func(clients *wrangler.CAPIContext) {
 		sshClient := &sshClient{
 			machines: clients.CAPI.Machine(),
 			secrets:  clients.Core.Secret(),

--- a/pkg/capr/configserver/server.go
+++ b/pkg/capr/configserver/server.go
@@ -92,7 +92,7 @@ func New(clients *wrangler.Context) *RKE2ConfigServer {
 }
 
 func (r *RKE2ConfigServer) DeferCAPIResources(clients *wrangler.Context) {
-	clients.DeferredCAPIRegistration.DeferFunc(func(clients *wrangler.Context) {
+	clients.DeferredCAPIRegistration.DeferFunc(func(clients *wrangler.CAPIContext) {
 		r.machineCache = clients.CAPI.Machine().Cache()
 		r.machines = clients.CAPI.Machine()
 		r.capiAvailable = true

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -146,7 +146,7 @@ type InfoFunctions struct {
 	GetBootstrapManifests   func(plane *rkev1.RKEControlPlane) ([]plan.File, error)
 }
 
-func New(ctx context.Context, clients *wrangler.Context, functions InfoFunctions) *Planner {
+func New(ctx context.Context, clients *wrangler.CAPIContext, functions InfoFunctions) *Planner {
 	clients.Mgmt.ClusterRegistrationToken().Cache().AddIndexer(ClusterRegToken, func(obj *v3.ClusterRegistrationToken) ([]string, error) {
 		return []string{obj.Spec.ClusterName}, nil
 	})

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -57,7 +57,7 @@ type handler struct {
 	k8s                 kubernetes.Interface
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		serviceAccountCache: clients.Core.ServiceAccount().Cache(),
 		secretCache:         clients.Core.Secret().Cache(),

--- a/pkg/controllers/capr/controllers.go
+++ b/pkg/controllers/capr/controllers.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 )
 
-func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) error {
+func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) error {
 	rkePlanner := planner.New(ctx, clients, planner.InfoFunctions{
 		ImageResolver:           image.ResolveWithControlPlane,
 		ReleaseData:             capr.GetKDMReleaseData,

--- a/pkg/controllers/capr/dynamicschema/dynamicschema.go
+++ b/pkg/controllers/capr/dynamicschema/dynamicschema.go
@@ -34,7 +34,7 @@ type handler struct {
 	sampleProps       *apiextv1.JSONSchemaProps
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) error {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) error {
 	sampleProps, err := sample.GetSampleProps()
 	if err != nil {
 		return err

--- a/pkg/controllers/capr/machinedrain/machinedrain.go
+++ b/pkg/controllers/capr/machinedrain/machinedrain.go
@@ -30,7 +30,7 @@ type handler struct {
 	secretCache  corecontrollers.SecretCache
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		ctx:          ctx,
 		machineCache: clients.CAPI.Machine().Cache(),

--- a/pkg/controllers/capr/machinenodelookup/controller.go
+++ b/pkg/controllers/capr/machinenodelookup/controller.go
@@ -45,7 +45,7 @@ type handler struct {
 	dynamic             *dynamic.Controller
 }
 
-func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) {
 	h := &handler{
 		rancherClusterCache: clients.Provisioning.Cluster().Cache(),
 		machines:            clients.CAPI.Machine(),

--- a/pkg/controllers/capr/machineprovision/controller.go
+++ b/pkg/controllers/capr/machineprovision/controller.go
@@ -101,7 +101,7 @@ type handler struct {
 	kubeconfigManager   *kubeconfig.Manager
 }
 
-func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) {
 	h := &handler{
 		ctx: ctx,
 		apply: clients.Apply.WithCacheTypes(clients.Core.Secret(),

--- a/pkg/controllers/capr/machineprovision/controller.go
+++ b/pkg/controllers/capr/machineprovision/controller.go
@@ -330,7 +330,7 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 			return obj, err
 		}
 		logrus.Debugf("[machineprovision] create job for %s not finished, job was found and the error was not nil and was not an isnotfound", key)
-		// OnChange handler will not run when the infra machine is being deleted, we have to reconcile here in order to
+		// WaitForClient handler will not run when the infra machine is being deleted, we have to reconcile here in order to
 		// finish the create job, since it has to have completed successfully or never ran for the delete job to run
 		state, _, err := h.run(infra, true)
 		if err != nil {

--- a/pkg/controllers/capr/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagent.go
@@ -82,7 +82,7 @@ type handler struct {
 	secrets                   corev1controllers.SecretController
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		clusterRegistrationTokens: clients.Mgmt.ClusterRegistrationToken().Cache(),
 		bundles:                   clients.Fleet.Bundle(),

--- a/pkg/controllers/capr/planner/controller.go
+++ b/pkg/controllers/capr/planner/controller.go
@@ -33,7 +33,7 @@ type handler struct {
 	controlPlanes v1.RKEControlPlaneController
 }
 
-func Register(ctx context.Context, clients *wrangler.Context, planner *caprplanner.Planner) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext, planner *caprplanner.Planner) {
 	h := handler{
 		planner:       planner,
 		controlPlanes: clients.RKE.RKEControlPlane(),

--- a/pkg/controllers/capr/planner/controller.go
+++ b/pkg/controllers/capr/planner/controller.go
@@ -89,7 +89,7 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext, planner *caprp
 }
 
 func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
-	logrus.Debugf("[planner] rkecluster %s/%s: handler OnChange called", cp.Namespace, cp.Name)
+	logrus.Debugf("[planner] rkecluster %s/%s: handler WaitForClient called", cp.Namespace, cp.Name)
 	if !cp.DeletionTimestamp.IsZero() {
 		return status, nil
 	}

--- a/pkg/controllers/capr/plansecret/plansecret.go
+++ b/pkg/controllers/capr/plansecret/plansecret.go
@@ -30,7 +30,7 @@ type handler struct {
 	rkeControlPlaneCache rkev1controllers.RKEControlPlaneCache
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := handler{
 		secrets:              clients.Core.Secret(),
 		machinesCache:        clients.CAPI.Machine().Cache(),

--- a/pkg/controllers/capr/rkecluster/controller.go
+++ b/pkg/controllers/capr/rkecluster/controller.go
@@ -23,7 +23,7 @@ type handler struct {
 	capiClusterCache capicontrollers.ClusterCache
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := handler{
 		rkeCluster:       clients.RKE.RKECluster(),
 		capiClusterCache: clients.CAPI.Cluster().Cache(),

--- a/pkg/controllers/capr/rkecontrolplane/controlplane.go
+++ b/pkg/controllers/capr/rkecontrolplane/controlplane.go
@@ -24,7 +24,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		clusterCache:              clients.Mgmt.Cluster().Cache(),
 		provClusterCache:          clients.Provisioning.Cluster().Cache(),

--- a/pkg/controllers/capr/unmanaged/controller.go
+++ b/pkg/controllers/capr/unmanaged/controller.go
@@ -36,7 +36,7 @@ import (
 
 const UnmanagedMachineKind = "CustomMachine"
 
-func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) {
 	h := handler{
 		kubeconfigManager: kubeconfigManager,
 		unmanagedMachine:  clients.RKE.CustomMachine(),

--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -69,7 +69,7 @@ func Register(ctx context.Context, clients *wrangler.Context, embedded bool, reg
 		clusterindex.Register(ctx, clients)
 		cluster.EarlyRegister(ctx, clients, kubeconfigManager)
 		// defer registration of controllers which have CAPI clients or use CAPI caches
-		clients.DeferredCAPIRegistration.DeferRegistration(func(ctx context.Context, clients *wrangler.Context) error {
+		clients.DeferredCAPIRegistration.DeferRegistration(func(ctx context.Context, clients *wrangler.CAPIContext) error {
 			provisioningv2.Register(ctx, clients, kubeconfigManager)
 			if features.RKE2.Enabled() {
 				if err := capr.Register(ctx, clients, kubeconfigManager); err != nil {

--- a/pkg/controllers/management/auth/roletemplates/roletemplate_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/roletemplate_handler_test.go
@@ -543,7 +543,7 @@ func Test_OnChange(t *testing.T) {
 			_, err := r.OnChange("", tt.rt)
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("roleTemplateHandler.OnChange() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("roleTemplateHandler.WaitForClient() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rancher/rancher/pkg/systemaccount"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/types/config/systemtokens"
+	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -80,7 +81,7 @@ type nodeDrain struct {
 
 type canChangeValuePolicy func(key string) bool
 
-func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
+func Register(ctx context.Context, cluster *config.UserContext, capi *wrangler.CAPIContext, kubeConfigGetter common.KubeConfigGetter) {
 	m := &nodesSyncer{
 		clusterNamespace:     cluster.ClusterName,
 		machines:             cluster.Management.Management.Nodes(cluster.ClusterName),
@@ -90,7 +91,7 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 		clusterLister:        cluster.Management.Management.Clusters("").Controller().Lister(),
 		secretLister:         cluster.Management.Core.Secrets("").Controller().Lister(),
 		provClusterCache:     cluster.Management.Wrangler.Provisioning.Cluster().Cache(),
-		capiClusterCache:     cluster.Management.Wrangler.CAPI.Cluster().Cache(),
+		capiClusterCache:     capi.CAPI.Cluster().Cache(),
 		rkeControlPlaneCache: cluster.Management.Wrangler.RKE.RKEControlPlane().Cache(),
 	}
 

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -116,7 +116,7 @@ func EarlyRegister(ctx context.Context, clients *wrangler.Context, kubeconfigMan
 
 func Register(
 	ctx context.Context,
-	clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
+	clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) {
 	h := handler{
 		mgmtClusterCache:      clients.Mgmt.Cluster().Cache(),
 		mgmtClusters:          clients.Mgmt.Cluster(),

--- a/pkg/controllers/provisioningv2/controllers.go
+++ b/pkg/controllers/provisioningv2/controllers.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 )
 
-func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) {
 	cluster.Register(ctx, clients, kubeconfigManager)
 	if features.MCM.Enabled() {
 		secret.Register(ctx, clients)

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -65,7 +65,7 @@ type handler struct {
 // the fleetcluster operates on both provisioning and management clusters in Rancher, by way of transformation logic
 // in the provisioningcluster rke2 controller (a clusters.provisioning.cattle.io/v1 object is generated for every
 // corresponding clusters.management.cattle.io/v3 object, if one does not already exist, and vice-versa)
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		clientConfig:      clients.ClientConfig,
 		clusters:          clients.Mgmt.Cluster(),

--- a/pkg/controllers/provisioningv2/fleetworkspace/controller.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller.go
@@ -28,7 +28,7 @@ type handle struct {
 	workspaces     mgmtcontrollers.FleetWorkspaceClient
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handle{
 		workspaceCache: clients.Mgmt.FleetWorkspace().Cache(),
 		workspaces:     clients.Mgmt.FleetWorkspace(),

--- a/pkg/controllers/provisioningv2/harvestercleanup/controller.go
+++ b/pkg/controllers/provisioningv2/harvestercleanup/controller.go
@@ -35,7 +35,7 @@ type handler struct {
 	secretCache  corecontrollers.SecretCache
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := handler{
 		capiClusters: clients.CAPI.Cluster().Cache(),
 		clusterCache: clients.Provisioning.Cluster().Cache(),

--- a/pkg/controllers/provisioningv2/machineconfigcleanup/controller.go
+++ b/pkg/controllers/provisioningv2/machineconfigcleanup/controller.go
@@ -24,7 +24,7 @@ type handler struct {
 	apply                     apply.Apply
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		apply: clients.Apply.WithCacheTypes(
 			clients.Batch.Job(),

--- a/pkg/controllers/provisioningv2/managedchart/managedchart.go
+++ b/pkg/controllers/provisioningv2/managedchart/managedchart.go
@@ -30,7 +30,7 @@ const (
 	chartByRepo = "chartByRepo"
 )
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		charts: content.NewManager(
 			clients.K8s.Discovery(),

--- a/pkg/controllers/provisioningv2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/controller.go
@@ -52,7 +52,7 @@ type handler struct {
 	capiMachineCache  capicontrollers.MachineCache
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := handler{
 		dynamic:           clients.Dynamic,
 		secretCache:       clients.Core.Secret().Cache(),

--- a/pkg/controllers/provisioningv2/provisioninglog/provisioninglog.go
+++ b/pkg/controllers/provisioningv2/provisioninglog/provisioninglog.go
@@ -27,7 +27,7 @@ var (
 	clusterRegexp = regexp.MustCompile("^c-m-[a-z0-9]{8}$")
 )
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
 		configMapsCache: clients.Core.ConfigMap().Cache(),
 		configMaps:      clients.Core.ConfigMap(),

--- a/pkg/controllers/provisioningv2/secret/secret.go
+++ b/pkg/controllers/provisioningv2/secret/secret.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := handler{
 		roles:             clients.RBAC.Role(),
 		rolesCache:        clients.RBAC.Role().Cache(),

--- a/pkg/provisioningv2/prebootstrap/resolve.go
+++ b/pkg/provisioningv2/prebootstrap/resolve.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewRetriever(clients *wrangler.Context) *Retriever {
+func NewRetriever(clients *wrangler.CAPIContext) *Retriever {
 	return &Retriever{
 		mgmtClusterCache:              clients.Mgmt.Cluster().Cache(),
 		clusterRegistrationTokenCache: clients.Mgmt.ClusterRegistrationToken().Cache(),

--- a/pkg/provisioningv2/systeminfo/systeminfo.go
+++ b/pkg/provisioningv2/systeminfo/systeminfo.go
@@ -15,7 +15,7 @@ type Retriever struct {
 }
 
 // NewRetriever returns a new instance of the systeminfo.Retriever
-func NewRetriever(clients *wrangler.Context) *Retriever {
+func NewRetriever(clients *wrangler.CAPIContext) *Retriever {
 	if clients == nil {
 		return nil
 	}

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -81,7 +81,7 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 	return rkeResourcesCleanup(wranglerContext)
 }
 
-func runRKE2Migrations(wranglerContext *wrangler.Context) error {
+func runRKE2Migrations(wranglerContext *wrangler.CAPIContext) error {
 	if features.RKE2.Enabled() {
 		// must migrate system agent data directory first, since update requests will be rejected by webhook if
 		// "CATTLE_AGENT_VAR_DIR" is set within AgentEnvVars.
@@ -263,7 +263,7 @@ func applyProjectConditionForNamespaceAssignment(label string, condition conditi
 	return nil
 }
 
-func migrateCAPIMachineLabelsAndAnnotationsToPlanSecret(w *wrangler.Context) error {
+func migrateCAPIMachineLabelsAndAnnotationsToPlanSecret(w *wrangler.CAPIContext) error {
 	cm, err := getConfigMap(w.Core.ConfigMap(), migrateFromMachineToPlanSecret)
 	if err != nil || cm == nil {
 		return err
@@ -406,7 +406,7 @@ func migrateCAPIMachineLabelsAndAnnotationsToPlanSecret(w *wrangler.Context) err
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
 }
 
-func migrateEncryptionKeyRotationLeader(w *wrangler.Context) error {
+func migrateEncryptionKeyRotationLeader(w *wrangler.CAPIContext) error {
 	cm, err := getConfigMap(w.Core.ConfigMap(), migrateEncryptionKeyRotationLeaderToStatus)
 	if err != nil || cm == nil {
 		return err
@@ -456,7 +456,7 @@ func migrateEncryptionKeyRotationLeader(w *wrangler.Context) error {
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
 }
 
-func migrateMachinePoolsDynamicSchemaLabel(w *wrangler.Context) error {
+func migrateMachinePoolsDynamicSchemaLabel(w *wrangler.CAPIContext) error {
 	cm, err := getConfigMap(w.Core.ConfigMap(), migrateDynamicSchemaToMachinePools)
 	if err != nil || cm == nil {
 		return err
@@ -529,7 +529,7 @@ func migrateMachinePoolsDynamicSchemaLabel(w *wrangler.Context) error {
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
 }
 
-func migrateSystemAgentDataDirectory(w *wrangler.Context) error {
+func migrateSystemAgentDataDirectory(w *wrangler.CAPIContext) error {
 	cm, err := getConfigMap(w.Core.ConfigMap(), migrateSystemAgentVarDirToDataDirectory)
 	if err != nil || cm == nil {
 		return err

--- a/pkg/wrangler/capi.go
+++ b/pkg/wrangler/capi.go
@@ -2,11 +2,10 @@ package wrangler
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"sync/atomic"
 
 	capi "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io"
+	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
 	wapiextv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/sirupsen/logrus"
@@ -14,19 +13,35 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-// manageDeferredCAPIContext polls for the availability of CAPI CRDs and registers deferred controllers
-// and executes deferred functions once they are available. Once CAPI CRDs are found, this function will
-// not continue polling. Individual registration calls can be made once polling is complete by directly using
-// the DeferredCAPIRegistration struct.
-func (w *Context) manageDeferredCAPIContext(ctx context.Context) {
-	logrus.Info("[deferred-capi - manageDeferredCAPIContext] Starting to monitor CAPI CRD availability")
+// CAPIContext is a scoped context which wraps the larger Wrangler context.
+// It includes CAPI clients and factories which are initialized after CAPI
+// CRDs are detected.
+type CAPIContext struct {
+	*Context
+	CAPI        capicontrollers.Interface
+	CAPIFactory *capi.Factory
+}
+
+// DeferredCAPIInitializer implements the DeferredInitializer interface
+// and monitors CRDs until all expected CAPI resources have been created.
+type DeferredCAPIInitializer struct {
+	*BaseInitializer[*CAPIContext]
+}
+
+func NewCAPIInitializer() *DeferredCAPIInitializer {
+	return &DeferredCAPIInitializer{
+		BaseInitializer: NewBaseInitializer[*CAPIContext](),
+	}
+}
+
+func (d *DeferredCAPIInitializer) OnChange(ctx context.Context, c *Context) {
 	var done atomic.Bool
-	w.CRD.CustomResourceDefinition().OnChange(ctx, "capi-deferred-registration", func(key string, crd *apiextv1.CustomResourceDefinition) (*apiextv1.CustomResourceDefinition, error) {
+	c.CRD.CustomResourceDefinition().OnChange(ctx, "capi-deferred-registration", func(key string, crd *apiextv1.CustomResourceDefinition) (*apiextv1.CustomResourceDefinition, error) {
 		if done.Load() {
 			return crd, nil
 		}
 
-		if !capiCRDsReady(w.CRD.CustomResourceDefinition().Cache()) {
+		if !capiCRDsReady(c.CRD.CustomResourceDefinition().Cache()) {
 			return crd, nil
 		}
 
@@ -34,30 +49,21 @@ func (w *Context) manageDeferredCAPIContext(ctx context.Context) {
 			return crd, nil
 		}
 
-		logrus.Info("[deferred-capi - manageDeferredCAPIContext] initializing CAPI factory")
+		logrus.Info("[deferred-capi - OnChange] initializing CAPI factory")
 		opts := &generic.FactoryOptions{
-			SharedControllerFactory: w.ControllerFactory,
+			SharedControllerFactory: c.ControllerFactory,
 		}
 
-		capi, err := capi.NewFactoryFromConfigWithOptions(w.RESTConfig, opts)
+		capi, err := capi.NewFactoryFromConfigWithOptions(c.RESTConfig, opts)
 		if err != nil {
 			logrus.Fatalf("Encountered unexpected error while creating capi factory: %v", err)
 		}
-		w.DeferredCAPIRegistration.mutex.Lock()
-		defer w.DeferredCAPIRegistration.mutex.Unlock()
 
-		w.capiMutex.Lock()
-		defer w.capiMutex.Unlock()
-
-		w.capi = capi
-		w.CAPI = capi.Cluster().V1beta1()
-
-		go func() {
-			err = w.DeferredCAPIRegistration.run(ctx)
-			if err != nil {
-				logrus.Fatalf("failed to run loop during deferred capi registration: %v", err)
-			}
-		}()
+		d.SetClientContext(&CAPIContext{
+			Context:     c,
+			CAPIFactory: capi,
+			CAPI:        capi.Cluster().V1beta1(),
+		})
 
 		return crd, nil
 	})
@@ -105,72 +111,4 @@ func capiCRDsReady(crdCache wapiextv1.CustomResourceDefinitionCache) bool {
 	}
 
 	return allCRDsReady
-}
-
-type DeferredCAPIRegistration struct {
-	mutex sync.Mutex
-
-	clients           *Context
-	registrationFuncs chan func(ctx context.Context, clients *Context) error
-	funcs             chan func(clients *Context)
-}
-
-func newDeferredCAPIRegistration(clients *Context) *DeferredCAPIRegistration {
-	return &DeferredCAPIRegistration{
-		clients:           clients,
-		registrationFuncs: make(chan func(ctx context.Context, clients *Context) error, 100),
-		funcs:             make(chan func(clients *Context), 100),
-	}
-}
-
-func (d *DeferredCAPIRegistration) run(ctx context.Context) error {
-	for {
-		select {
-		case f := <-d.registrationFuncs:
-			if err := d.clients.StartFactoryWithTransaction(ctx, func(ctx context.Context) error {
-				if err := f(ctx, d.clients); err != nil {
-					return fmt.Errorf("failed to invoke reg func: %w", err)
-				}
-				return nil
-			}); err != nil {
-				return err
-			}
-		case f := <-d.funcs:
-			f(d.clients)
-		case <-ctx.Done():
-			return nil
-		}
-	}
-}
-
-// DeferFunc enqueues a function to be executed once the CAPI CRDs are available by adding it to the function pool.
-// Calls to DeferFunc are processed in the order they are made. Calls to DeferFunc made after the CAPI CRDs are
-// available will execute immediately.
-func (d *DeferredCAPIRegistration) DeferFunc(f func(clients *Context)) {
-	logrus.Debug("[deferred-capi - DeferFunc] Adding function to pool")
-	d.funcs <- f
-}
-
-// DeferFuncWithError creates a new go routine which invokes f once the DeferredCAPIRegistration wait group completes.
-// It returns an error channel to indicate if f encountered any errors during execution.
-func (d *DeferredCAPIRegistration) DeferFuncWithError(f func(wrangler *Context) error) chan error {
-	errChan := make(chan error, 1)
-	d.funcs <- func(clients *Context) {
-		defer close(errChan)
-
-		if err := f(clients); err != nil {
-			errChan <- err
-		}
-	}
-	return errChan
-}
-
-// DeferRegistration enqueues a function to be executed once the CAPI CRDs are available by adding it to the registration function pool.
-// The functions passed to DeferRegistration are expected to register one or more event handlers which rely on CAPI clients.
-// Functions which must be deferred, but do not register event handlers, should be passed to DeferFunc instead.
-// Calls to DeferRegistration are processed in the order they are made. Calls to DeferRegistration made after the CAPI CRDs are
-// available will execute immediately, and the controller factory will be immediately started.
-func (d *DeferredCAPIRegistration) DeferRegistration(register func(ctx context.Context, clients *Context) error) {
-	logrus.Debug("[deferred-capi - DeferRegistration] Adding registration function to pool")
-	d.registrationFuncs <- register
 }

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -560,7 +560,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		telemetry:    telemetry,
 	}
 
-	wContext.DeferredCAPIRegistration = NewDeferredRegistration[*CAPIContext, *DeferredCAPIInitializer](wContext, NewCAPIInitializer(), "deferred-capi")
+	wContext.DeferredCAPIRegistration = NewDeferredRegistration[*CAPIContext, *DeferredCAPIInitializer](wContext, NewCAPIInitializer(wContext), "deferred-capi")
 
 	return wContext, nil
 }

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -560,7 +560,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		telemetry:    telemetry,
 	}
 
-	wContext.DeferredCAPIRegistration = NewDeferredRegistration[*CAPIContext, *DeferredCAPIInitializer](wContext, NewCAPIInitializer())
+	wContext.DeferredCAPIRegistration = NewDeferredRegistration[*CAPIContext, *DeferredCAPIInitializer](wContext, NewCAPIInitializer(), "deferred-capi")
 
 	return wContext, nil
 }

--- a/pkg/wrangler/defer.go
+++ b/pkg/wrangler/defer.go
@@ -1,0 +1,140 @@
+package wrangler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DeferredInitializer describes how a specific client context (T) will be initialized during startup.
+type DeferredInitializer[T any] interface {
+	// OnChange is used to monitor a condition that must be satisfied before the initialization of
+	// the deferred client context. This is typically an event handler watching a k8s resource.
+	OnChange(context.Context, *Context)
+
+	// GetClientContext returns the client context (T) after it has been initialized.
+	GetClientContext(ctx context.Context) (T, error)
+}
+
+func NewBaseInitializer[T any]() *BaseInitializer[T] {
+	return &BaseInitializer[T]{
+		clientCreated: make(chan struct{}),
+	}
+}
+
+// BaseInitializer sets and gets client contexts. This is a utility struct that should
+// be embedded within more specific initializers which implement OnChange.
+type BaseInitializer[T any] struct {
+	clientContext T
+	once          sync.Once
+	clientCreated chan struct{}
+}
+
+func (b *BaseInitializer[T]) SetClientContext(clientContext T) {
+	b.once.Do(func() {
+		b.clientContext = clientContext
+		close(b.clientCreated)
+	})
+}
+
+func (b *BaseInitializer[T]) GetClientContext(ctx context.Context) (T, error) {
+	select {
+	case <-b.clientCreated:
+		return b.clientContext, nil
+	case <-ctx.Done():
+		return b.clientContext, ctx.Err()
+	}
+}
+
+// DeferredRegistration provides a generic way to defer the execution of functions or registration of
+// event handlers within the primary wrangler context. I represents an implementation of DeferredInitializer,
+// and is used to identify when the deferred functions can be executed. T represents a scoped client
+// context which will be passed to all deferred functions. This context is expected to hold the
+// relevant clients, factories, and other resources which can only be accessed after initialization of I is complete.
+type DeferredRegistration[T any, I DeferredInitializer[T]] struct {
+	clientContext     T
+	clientInitializer I
+
+	clients           *Context
+	registrationFuncs chan func(ctx context.Context, clients T) error
+	funcs             chan func(clients T)
+}
+
+func NewDeferredRegistration[T any, I DeferredInitializer[T]](clients *Context, init I) *DeferredRegistration[T, I] {
+	return &DeferredRegistration[T, I]{
+		clientInitializer: init,
+		clients:           clients,
+		registrationFuncs: make(chan func(ctx context.Context, clients T) error, 100),
+		funcs:             make(chan func(clients T), 100),
+	}
+}
+
+func (d *DeferredRegistration[T, I]) Manage(ctx context.Context) {
+	go func() {
+		d.clientInitializer.OnChange(ctx, d.clients)
+
+		var err error
+		d.clientContext, err = d.clientInitializer.GetClientContext(ctx)
+		if err != nil {
+			logrus.Fatalf("failed to get client context while managing deferred registration: %v", err)
+		}
+
+		if err = d.run(ctx); err != nil {
+			logrus.Fatalf("failed to manage deferred registration: %v", err)
+		}
+	}()
+}
+
+func (d *DeferredRegistration[T, I]) run(ctx context.Context) error {
+	for {
+		select {
+		case f := <-d.registrationFuncs:
+			if err := d.clients.StartFactoryWithTransaction(ctx, func(ctx context.Context) error {
+				if err := f(ctx, d.clientContext); err != nil {
+					return fmt.Errorf("failed to invoke registration func: %w", err)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		case f := <-d.funcs:
+			f(d.clientContext)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+// DeferFunc enqueues a function to be executed once the client context has been initialized by adding it to the function pool.
+// Calls to DeferFunc are processed in the order they are made. Calls to DeferFunc made after the client context has initialized
+// will execute immediately.
+func (d *DeferredRegistration[T, I]) DeferFunc(f func(clients T)) {
+	logrus.Debug("[DeferFunc] Adding function to pool")
+	d.funcs <- f
+}
+
+// DeferFuncWithError creates a new go routine which invokes f once the DeferredInitializer creates the client context.
+// It returns an error channel to indicate if f encountered any errors during execution.
+func (d *DeferredRegistration[T, I]) DeferFuncWithError(f func(wrangler T) error) chan error {
+	errChan := make(chan error, 1)
+	d.funcs <- func(clients T) {
+		defer close(errChan)
+
+		if err := f(clients); err != nil {
+			errChan <- err
+		}
+	}
+	return errChan
+}
+
+// DeferRegistration enqueues a function to be executed once the client context has been initialized by adding it to the registration function pool.
+// The functions passed to DeferRegistration are expected to register one or more event handlers which rely on deferred clients.
+// Functions which must be deferred, but do not register event handlers, should be passed to DeferFunc instead.
+// Calls to DeferRegistration are processed in the order they are made. Calls to DeferRegistration made after the client context has
+// initialized will execute immediately, and the controller factory will be immediately started.
+func (d *DeferredRegistration[T, I]) DeferRegistration(register func(ctx context.Context, clients T) error) {
+	logrus.Debug("[DeferRegistration] Adding registration function to pool")
+	d.registrationFuncs <- register
+}

--- a/tests/controllers/common/common.go
+++ b/tests/controllers/common/common.go
@@ -34,6 +34,15 @@ func StartNormanControllers(ctx context.Context, t *testing.T, m *config.Managem
 	}
 }
 
+func StartWranglerControllers(ctx context.Context, t *testing.T, w *wrangler.Context, gvk ...schema.GroupVersionKind) {
+	for _, g := range gvk {
+		c, err := w.ControllerFactory.ForKind(g)
+		assert.NoError(t, err)
+		err = c.Start(ctx, 1)
+		assert.NoError(t, err)
+	}
+}
+
 func StartWranglerCaches(ctx context.Context, t *testing.T, w *wrangler.Context, gvk ...schema.GroupVersionKind) {
 	for _, g := range gvk {
 		err := w.ControllerFactory.SharedCacheFactory().StartGVK(ctx, g)

--- a/tests/controllers/deferRegistration/defer_test.go
+++ b/tests/controllers/deferRegistration/defer_test.go
@@ -119,7 +119,7 @@ func (d *DeferredRegistrationSuite) TestDeferFunc() {
 		assert.NoError(d.T(), clients.Core.Namespace().Delete(otherNS, &metav1.DeleteOptions{}))
 	}()
 
-	testDefer := wrangler.NewDeferredRegistration[*testDeferContext, *testDeferInitializer](clients, newTestDeferInitializer())
+	testDefer := wrangler.NewDeferredRegistration[*testDeferContext, *testDeferInitializer](clients, newTestDeferInitializer(), "test-deferred")
 	testDefer.Manage(d.T().Context())
 
 	// need to start the factory after the deferred initializer's
@@ -175,7 +175,7 @@ func (d *DeferredRegistrationSuite) TestDeferFuncWithError() {
 		assert.NoError(d.T(), clients.Core.Namespace().Delete(otherNS, &metav1.DeleteOptions{}))
 	}()
 
-	testDefer := wrangler.NewDeferredRegistration[*testDeferContext, *testDeferInitializer](clients, newTestDeferInitializer())
+	testDefer := wrangler.NewDeferredRegistration[*testDeferContext, *testDeferInitializer](clients, newTestDeferInitializer(), "test-deferred")
 	testDefer.Manage(d.T().Context())
 
 	// need to start the factory after the deferred initializer's

--- a/tests/controllers/deferRegistration/defer_test.go
+++ b/tests/controllers/deferRegistration/defer_test.go
@@ -1,0 +1,250 @@
+package deferRegistration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/rancher/tests/controllers/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// Note: it is not currently possible to test the DeferRegistration function directly.
+// This is because it will attempt to start the provided wrangler context factory,
+// which references CRDs that do not exist in this test. The only difference between
+// DeferFunc and DeferRegistration is the additional call to the wrangler factory,
+// so only testing DeferFunc will cover the core behavior of defer.go that we're
+// interested in.
+
+type DeferredRegistrationSuite struct {
+	suite.Suite
+
+	testEnv *envtest.Environment
+	rest    *rest.Config
+}
+
+func (d *DeferredRegistrationSuite) SetupSuite() {
+	d.testEnv = &envtest.Environment{}
+
+	restCfg, err := d.testEnv.Start()
+	assert.NoError(d.T(), err)
+	assert.NotNil(d.T(), restCfg)
+	if err != nil {
+		d.T().Fatal(err)
+		return
+	}
+
+	d.rest = restCfg
+}
+
+func (d *DeferredRegistrationSuite) TearDownSuite() {
+	err := d.testEnv.Stop()
+	assert.NoError(d.T(), err)
+}
+
+func (d *DeferredRegistrationSuite) createClients(ctx context.Context) *wrangler.Context {
+	wranglerContext, err := wrangler.NewContext(ctx, nil, d.rest)
+	assert.NoError(d.T(), err)
+	if err != nil {
+		d.T().Fatal(err)
+	}
+	return wranglerContext
+}
+
+func (d *DeferredRegistrationSuite) startClients(w *wrangler.Context) {
+	namespaceGVK := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "namespace",
+	}
+
+	common.StartWranglerControllers(d.T().Context(), d.T(), w, namespaceGVK)
+	common.StartWranglerCaches(d.T().Context(), d.T(), w, namespaceGVK)
+}
+
+func Test_DeferFunc(t *testing.T) {
+	suite.Run(t, new(DeferredRegistrationSuite))
+}
+
+const (
+	triggerNamespace = "trigger"
+)
+
+func newTestNamespaces(test string) (string, string) {
+	return triggerNamespace + test, "someothernamespace" + test
+}
+
+type testDeferContext struct {
+	desiredNamespace string
+}
+
+type testDeferInitializer struct {
+	*wrangler.BaseInitializer[*testDeferContext]
+}
+
+func (t testDeferInitializer) OnChange(ctx context.Context, client *wrangler.Context) {
+	client.Core.Namespace().OnChange(ctx, "deferred-namespace-test", func(_ string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+		if strings.Contains(namespace.Name, triggerNamespace) && namespace.ObjectMeta.DeletionTimestamp == nil {
+			t.SetClientContext(&testDeferContext{
+				desiredNamespace: namespace.ObjectMeta.Name,
+			})
+		}
+		return namespace, nil
+	})
+}
+
+func newTestDeferInitializer() *testDeferInitializer {
+	return &testDeferInitializer{
+		BaseInitializer: wrangler.NewBaseInitializer[*testDeferContext](),
+	}
+}
+
+func (d *DeferredRegistrationSuite) TestDeferFunc() {
+	testCtx, testCtxCancel := context.WithCancel(d.T().Context())
+	defer testCtxCancel()
+
+	clients := d.createClients(testCtx)
+	triggerNS, otherNS := newTestNamespaces("testdeferfunc")
+	defer func() {
+		assert.NoError(d.T(), clients.Core.Namespace().Delete(triggerNS, &metav1.DeleteOptions{}))
+		assert.NoError(d.T(), clients.Core.Namespace().Delete(otherNS, &metav1.DeleteOptions{}))
+	}()
+
+	testDefer := wrangler.NewDeferredRegistration[*testDeferContext, *testDeferInitializer](clients, newTestDeferInitializer())
+	testDefer.Manage(d.T().Context())
+
+	// need to start the factory after the deferred initializer's
+	// onChange handler has been registered in order for it to be picked up
+	d.startClients(clients)
+
+	// queue up some deferred functions
+	count := 0
+	testDefer.DeferFunc(func(clients *testDeferContext) {
+		assert.Equal(d.T(), triggerNS, clients.desiredNamespace)
+		count++
+	})
+	testDefer.DeferFunc(func(clients *testDeferContext) {
+		assert.Equal(d.T(), triggerNS, clients.desiredNamespace)
+		count++
+	})
+	testDefer.DeferFunc(func(clients *testDeferContext) {
+		assert.Equal(d.T(), triggerNS, clients.desiredNamespace)
+		count++
+	})
+
+	// ensure unrelated namespace creation does not trigger functions
+	_, err := clients.Core.Namespace().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: otherNS,
+		},
+	})
+	assert.NoError(d.T(), err)
+	time.Sleep(time.Millisecond * 100)
+	assert.Equal(d.T(), 0, count)
+
+	// trigger execution of deferred functions
+	_, err = clients.Core.Namespace().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: triggerNS,
+		},
+	})
+	assert.NoError(d.T(), err)
+
+	// wait a bit to allow deferred functions to execute
+	time.Sleep(time.Millisecond * 100)
+	assert.Equal(d.T(), 3, count)
+}
+
+func (d *DeferredRegistrationSuite) TestDeferFuncWithError() {
+	testCtx, testCtxCancel := context.WithCancel(d.T().Context())
+	defer testCtxCancel()
+
+	clients := d.createClients(testCtx)
+	triggerNS, otherNS := newTestNamespaces("testdeferwitherror")
+	defer func() {
+		assert.NoError(d.T(), clients.Core.Namespace().Delete(triggerNS, &metav1.DeleteOptions{}))
+		assert.NoError(d.T(), clients.Core.Namespace().Delete(otherNS, &metav1.DeleteOptions{}))
+	}()
+
+	testDefer := wrangler.NewDeferredRegistration[*testDeferContext, *testDeferInitializer](clients, newTestDeferInitializer())
+	testDefer.Manage(d.T().Context())
+
+	// need to start the factory after the deferred initializer's
+	// onChange handler has been registered in order for it to be picked up
+	d.startClients(clients)
+
+	// queue up some deferred functions
+	count := 0
+	errCount := 0
+	err1 := testDefer.DeferFuncWithError(func(clients *testDeferContext) error {
+		assert.Equal(d.T(), triggerNS, clients.desiredNamespace)
+		count++
+		return nil
+	})
+
+	err2 := testDefer.DeferFuncWithError(func(clients *testDeferContext) error {
+		assert.Equal(d.T(), triggerNS, clients.desiredNamespace)
+		errCount++
+		return fmt.Errorf("fake error")
+	})
+
+	err3 := testDefer.DeferFuncWithError(func(clients *testDeferContext) error {
+		assert.Equal(d.T(), triggerNS, clients.desiredNamespace)
+		count++
+		return nil
+	})
+
+	// ensure unrelated namespace creation does not trigger functions
+	_, err := clients.Core.Namespace().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: otherNS,
+		},
+	})
+	assert.NoError(d.T(), err)
+	time.Sleep(time.Millisecond * 100)
+	assert.Equal(d.T(), 0, count)
+	assert.Equal(d.T(), 0, errCount)
+
+	// trigger execution of deferred functions
+	_, err = clients.Core.Namespace().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: triggerNS,
+		},
+	})
+	assert.NoError(d.T(), err)
+
+	errOut1, timedOut := getFromChanOrTimeout(err1)
+	assert.False(d.T(), timedOut)
+	assert.NoError(d.T(), errOut1)
+
+	errOut2, timedOut := getFromChanOrTimeout(err2)
+	assert.False(d.T(), timedOut)
+	assert.Error(d.T(), errOut2)
+
+	errOut3, timedOut := getFromChanOrTimeout(err3)
+	assert.False(d.T(), timedOut)
+	assert.NoError(d.T(), errOut3)
+
+	assert.Equal(d.T(), 2, count)
+	assert.Equal(d.T(), 1, errCount)
+}
+
+func getFromChanOrTimeout(errs chan error) (error, bool) {
+	timeout := time.NewTicker(time.Second * 10)
+	defer timeout.Stop()
+	select {
+	case <-timeout.C:
+		return nil, true
+	case err := <-errs:
+		return err, false
+	}
+}


### PR DESCRIPTION
## Issues: 
https://github.com/rancher/rancher/issues/51134

## Problem
The logic for registering deferred CAPI controllers can be improved in two ways

1. The general process of deferring functions and registrations is not really specific to CAPI. This approach can be used for any resource which is not initialized during the primary startup sequence of Rancher.
2. The larger wrangler context still exposes the CAPI clients and factories, even though they may not always be available. We need to make sure that non-deferred functions cannot access these clients or factories, as there is no safe way to know if they are initialized yet. 
 
## Solution

+ Generalize the logic for executing deferred functions so that it can be utilized for other resources more easily. Resource specific initializers and client contexts can be defined to indicate when deferred functions can be executed and what resources can be used by the deferred functions. 

+ Introduce a CAPI specific initializer and client context. The client context is passed to all deferred functions and registrations, and contains the CAPI clients and factory. The existing CAPI clients and factory have been removed from the larger wrangler context, preventing non-deferred functions from using them.



## Testing

+ Ensure CI reliably passes
+ Deploy Rancher with the `embedded-capi` feature disabled
+ Start rancher and login to the UI 
+ Manually deploy the turtles chart, wait for the CAPI CRDs to be created
+ Provision a downstream cluster
+ Perform day 2 ops 
+ scale the cluster up and down

+ Perform the above steps again, but with the `embedded-capi` feature enabled, and without manually installing the turtles chart

## Engineering Testing
### Manual Testing

I've ran the prov v2 tests locally for machine provisioning and etcd snapshots. I've tested day 2 ops manually on Digital Ocean and did not observe any errors. I simulated the install of CAPI resources via turtles by disabling the embedding CAPI feature and manually installing the turtles chart after logging into Rancher. 

### Automated Testing
* Test types added/modified:
    * Integration (Go Framework)

Summary: Two new controller integration tests have been added. These tests show how deferred functions can be used to execution functions when a specific namespace is created

## QA Testing Considerations
This change should be tested using both the current way of installing CAPI CRDs (`embedded-capi` set to true), as well as when manually installing turtles after Rancher has already started 
 
### Regressions Considerations

