### PR TITLE
[backport v2.12] 47898 bug onleaderordie 

### DIFF
--- a/pkg/controllers/nodedriver/nodedriver.go
+++ b/pkg/controllers/nodedriver/nodedriver.go
@@ -15,7 +15,7 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 	wrangler.Mgmt.NodeDriver().OnChange(ctx, "custom-node-driver-handler", onChange)
 
 	// when this pod becomes the leader, do not run the onChange code
-	wrangler.OnLeader(func(ctx context.Context) error {
+	wrangler.OnLeaderOrDie("nodedriver-register", func(ctx context.Context) error {
 		leader.Store(true)
 		return nil
 	})

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -183,7 +183,7 @@ func (m *mcm) Start(ctx context.Context) error {
 		}
 	}
 
-	m.wranglerContext.OnLeader(func(ctx context.Context) error {
+	m.wranglerContext.OnLeaderOrDie("multiclustermanager-start", func(ctx context.Context) error {
 		err := m.wranglerContext.StartWithTransaction(ctx, func(ctx context.Context) error {
 			var (
 				err error

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -331,7 +331,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 	auditLogMiddleware := audit.NewAuditLogMiddleware(auditLogWriter)
 	aggregationMiddleware := aggregation.NewMiddleware(ctx, wranglerContext.Mgmt.APIService(), wranglerContext.TunnelServer)
 
-	wranglerContext.OnLeader(func(ctx context.Context) error {
+	wranglerContext.OnLeaderOrDie("rancher-new", func(ctx context.Context) error {
 		serviceaccounttoken.StartServiceAccountSecretCleaner(
 			ctx,
 			wranglerContext.Core.Secret().Cache(),
@@ -429,10 +429,11 @@ func (r *Rancher) Start(ctx context.Context) error {
 		}
 	}
 
-	r.Wrangler.OnLeader(func(ctx context.Context) error {
+	r.Wrangler.OnLeaderOrDie("rancher-start::dashboarddata", func(ctx context.Context) error {
 		if err := dashboarddata.Add(ctx, r.Wrangler, localClusterEnabled(r.opts), r.opts.AddLocal == "false", r.opts.Embedded); err != nil {
 			return err
 		}
+
 		if err := r.Wrangler.StartWithTransaction(ctx, func(ctx context.Context) error {
 			return dashboard.Register(ctx, r.Wrangler, r.opts.Embedded, r.opts.ClusterRegistry)
 		}); err != nil {
@@ -443,7 +444,7 @@ func (r *Rancher) Start(ctx context.Context) error {
 	})
 
 	if !features.MCMAgent.Enabled() && features.RancherSCCRegistrationExtension.Enabled() {
-		r.Wrangler.OnLeader(func(ctx context.Context) error {
+		r.Wrangler.OnLeaderOrDie("rancher-start::RancherSCCRegistration", func(ctx context.Context) error {
 			// TODO: pull this out of here if/when other features depend on the SecretRequest controllers
 			if err := telemetrycontrollers.RegisterControllers(ctx, r.Wrangler, r.telemetryManager); err != nil {
 				return err
@@ -458,7 +459,7 @@ func (r *Rancher) Start(ctx context.Context) error {
 		return err
 	}
 
-	r.Wrangler.OnLeader(r.authServer.OnLeader)
+	r.Wrangler.OnLeaderOrDie("rancher-start::authServer", r.authServer.OnLeader)
 
 	r.auditLog.Start(ctx)
 

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -181,6 +181,16 @@ type MultiClusterManager interface {
 	K8sClient(clusterName string) (kubernetes.Interface, error)
 }
 
+// OnLeaderOrDie this function will be called when leadership is acquired or die if failed. Eg:
+// Name convention: "file_name-function" or "file_name-function::additional_context".
+// if OnLeaderOrDie is called more than once by the same origin, add an additional context to the name
+// (eg, "rancher-start::dashboarddata")
+// if OnLeaderOrDie is called only once inform the origin
+// (eg,"nodedriver-register")
+func (w *Context) OnLeaderOrDie(name string, f func(ctx context.Context) error) {
+	w.leadership.OnLeaderOrDie(name, f)
+}
+
 func (w *Context) OnLeader(f func(ctx context.Context) error) {
 	w.leadership.OnLeader(f)
 }
@@ -423,7 +433,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 	}
 
 	leadership := leader.NewManager("", "cattle-controllers", k8s)
-	leadership.OnLeader(func(ctx context.Context) error {
+	leadership.OnLeaderOrDie("wrangler-newContext", func(ctx context.Context) error {
 		if peerManager != nil {
 			peerManager.Leader()
 		}


### PR DESCRIPTION
PR main: https://github.com/rancher/rancher/pull/51582
This is a backport issue for https://github.com/rancher/rancher/issues/47898, automatically created via [GitHub Actions workflow](https://github.com/rancher/rancher/actions/runs/16942184490) initiated by @tomleb

Original issue body:

We hit an issue when starting up Rancher, where the functions executed by the OnLeader handler were not idempotent and caused a panic.

https://github.com/rancher/wrangler/blob/master/pkg/leader/manager.go#L47-L59

Given that we have no guarantees that the handlers are idempotent we should drop the retry mechanism, this would allow error