### PR TITLE
Prevent drain when config change in a single node cluster

### DIFF
--- a/pkg/capr/planner/filter.go
+++ b/pkg/capr/planner/filter.go
@@ -31,13 +31,13 @@ func filterConfigData(config map[string]interface{}, controlPlane *rkev1.RKECont
 	return nil
 }
 
-var removeForDraining = []string{"server"}
+var removeForDraining = []string{"server", "cluster-init"}
 
 func filterDrainData(config map[string]any) map[string]any {
 	filtered := map[string]any{}
 	maps.Copy(filtered, config)
 	for _, key := range removeForDraining {
-		delete(config, key)
+		delete(filtered, key)
 	}
 	return filtered
 }

--- a/pkg/capr/planner/filter_test.go
+++ b/pkg/capr/planner/filter_test.go
@@ -1,0 +1,69 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterDrainData(t *testing.T) {
+	t.Run("when input is nil should return an empty non-nil map", func(t *testing.T) {
+		got := filterDrainData(nil)
+		assert.Equal(t, make(map[string]any), got)
+	})
+
+	t.Run("when top-level server exists should remove only that key and keep others and nested", func(t *testing.T) {
+		nested := map[string]any{"server": "nested-should-stay", "foo": "bar"}
+		in := map[string]any{
+			"server": "https://1.2.3.4:9345",
+			"foo":    42,
+			"nested": nested,
+		}
+		expected := map[string]any{
+			"foo":    42,
+			"nested": nested,
+		}
+
+		out := filterDrainData(in)
+
+		assert.Equal(t, expected, out)
+	})
+
+	t.Run("when top-level cluster-init exists should remove only that key and keep others and nested", func(t *testing.T) {
+		nested := map[string]any{"cluster-init": true, "foo": "bar"}
+		in := map[string]any{
+			"cluster-init": true,
+			"foo":          42,
+			"nested":       nested,
+		}
+		expected := map[string]any{
+			"foo":    42,
+			"nested": nested,
+		}
+		out := filterDrainData(in)
+
+		assert.Equal(t, expected, out)
+	})
+
+	t.Run("when top-level cluster-init and server exists should remove only those keys and keep others", func(t *testing.T) {
+		in := map[string]any{
+			"cluster-init": true,
+			"server":       "https://1.2.3.4:9345",
+			"foo":          42,
+		}
+		expected := map[string]any{
+			"foo": 42,
+		}
+
+		out := filterDrainData(in)
+
+		assert.Equal(t, expected, out)
+	})
+
+	t.Run("when no \"server\" or \"cluster-init\" key exists should return an identical map", func(t *testing.T) {
+		in := map[string]any{"foo": "bar", "baz": 1}
+		out := filterDrainData(in)
+
+		assert.Equal(t, out, in)
+	})
+}

--- a/tests/v2prov/tests/machineprovisioning/machine_test.go
+++ b/tests/v2prov/tests/machineprovisioning/machine_test.go
@@ -704,7 +704,7 @@ func Test_Provisioning_Single_Node_All_Roles_Drain(t *testing.T) {
 	c, err = cluster.WaitForCreate(clients, c)
 	require.NoError(t, err)
 
-	// Validate we started with exactly one Machine and capture its template hash
+	// Validate that exactly one Machine and capture its template hash
 	machines, err := cluster.Machines(clients, c)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(machines.Items), "expected exactly one machine initially")
@@ -713,7 +713,7 @@ func Test_Provisioning_Single_Node_All_Roles_Drain(t *testing.T) {
 	oldHash := old.Labels["machine-template-hash"]
 	require.NotEmpty(t, oldHash, "old machine missing template-hash label")
 
-	// Create a fresh machine config we can mutate.
+	// Create a fresh machine config that can be mutated.
 	newCfgRef, err := nodeconfig.NewPodConfig(clients, c.Namespace)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Issue: [#48752](https://github.com/rancher/rancher/issues/48752)

## Problem

When **drain-on-config** is enabled, triggering a node rollout (e.g., changing node size) causes the cluster to get stuck in **Updating**:

* A replacement node is provisioned.
* The new node stalls at **“waiting for uncordon to finish”**, and the old node remains **Deleting**.
* This reproduces on both **RKE2** and **K3s**.

1. **RKE2 path** — `filterDrainData` returned the **unfiltered** map by mistake. Transient/ephemeral fields that should be ignored for drain comparisons still influenced the computed machine template.

2. **K3s path** — even after fixing the return value, the ignore set didn’t include the **K3s-only** `cluster-init` key. That ephemeral bootstrap flag kept re-introducing a diff, leading to the same stuck behavior.

## Solution

1. **Return the correct (filtered) map** from `filterDrainData`.
   This makes the ignore list actually effective during drain-on-config comparisons.

2. **Extend the ignore list** (`removeForDraining`) with **`cluster-init`** (K3s-only).
   We already ignore **`server`** for RKE2; adding `cluster-init` prevents ephemeral K3s bootstrap state from triggering fake template diffs.

3. **Add an integration (v2prov) test** that exercises a controlled machine-template change and validates a single, successful drain/rollout and convergence back to Ready.

## Testing

## Engineering Testing

### Manual Testing

* **Baseline (without this PR)**

  * Provisioned **K3s** and **RKE2** single-node clusters (cp+etcd+worker) with **drain-on-config enabled** for control plane and workers.
  * Triggered a rollout by changing the node size.
  * **Observed (bug):** cluster stuck in **Updating**; new node stuck **“waiting for uncordon to finish”**; old node stuck **Deleting**.

* **With this PR**

  * Repeated the scenario above for both **K3s** and **RKE2**.
  * **Observed (fixed):** a **single** rollout occurs; new node reaches **Ready**, old node is deleted, and the cluster returns to **Ready** without getting stuck.

### Automated Testing

* **Integration (v2prov Framework)**
  Added `Test_Provisioning_Single_Node_All_Roles_Drain`, which:

  * Provisions a single-node cluster with drain-on-config enabled.
  * Triggers a controlled machine-template change (via a no-op tweak to the PodConfig `userdata`).
  * Verifies the expected drain/rollout sequence:

    * Machines go **1 → 2 → 1**,
    * the new node has a new `machine-template-hash` and reaches **Ready=True**,
    * the old node enters **Deleting** and is removed,
    * the cluster returns to **Ready**.

* **Unit/Validation**
  - Added a unit test for filterDrainData to ensure:
  	- the ignore list is applied (including server for RKE2 and cluster-init for K3s), and
  	- the function returns the filtered map (not the original), preventing ephemeral fields from affecting drain comparisons.

## QA Testing Considerations

1. **RKE2 & K3s – drain-on-config happy path**

   * Create a single-node cluster with drain-on-config enabled (workers and control plane).
   * Trigger a rollout (e.g., change node size or another real machine template field).
   * **Expect:** exactly one rollout, new node **Ready**, old node deleted, cluster returns to **Ready**.

2. **No spurious drain from ephemeral state**

   * After the cluster settles, allow another reconcile without changing real template inputs.
   * **Expect:** no additional rollout (i.e., ephemeral bootstrap differences like `server` for RKE2 and `cluster-init` for K3s do **not** trigger drains).

3. **Optional multi-pool smoke**

   * In a multi-pool cluster, alter one pool’s template; confirm only that pool rolls.

## Regressions Considerations

This PR changes `filterDrainData` from a no-op (it had been returning the original map in all cases) to actually removing keys specified in `removeForDraining` (and now also cluster-init for k3s). Because callers may have unintentionally relied on the previously unfiltered content during drain/upgrade, we should sanity-check for knock-on effects where the rendered machine plan differs during drain.