### PR TITLE
Drop Parallel from Settings tests for Quantities

### DIFF
--- a/pkg/settings/setting_test.go
+++ b/pkg/settings/setting_test.go
@@ -150,7 +150,6 @@ func TestGetMachineProvisionImagePullPolicy(t *testing.T) {
 }
 
 func TestGetInt(t *testing.T) {
-	t.Parallel()
 	fakeIntSetting := NewSetting("int", "1")
 	fakeStringSetting := NewSetting("string", "one")
 
@@ -172,7 +171,6 @@ func TestGetInt(t *testing.T) {
 }
 
 func TestGetQuantityAsInt64(t *testing.T) {
-	t.Parallel()
 	fakeLimitSetting := NewSetting("limit", "1Mi")
 
 	val, err := fakeLimitSetting.GetQuantityAsInt64(1000)


### PR DESCRIPTION


## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Tests can fail due to concurrent access to a `Setting()` value.
 
## Solution
This drops the t.Parallel() call from these tests.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_