### PR TITLE
[backport v2.12] drop parallel test quantities

### DIFF
--- a/pkg/settings/setting_test.go
+++ b/pkg/settings/setting_test.go
@@ -150,7 +150,6 @@ func TestGetMachineProvisionImagePullPolicy(t *testing.T) {
 }
 
 func TestGetInt(t *testing.T) {
-	t.Parallel()
 	fakeIntSetting := NewSetting("int", "1")
 	fakeStringSetting := NewSetting("string", "one")
 
@@ -172,7 +171,6 @@ func TestGetInt(t *testing.T) {
 }
 
 func TestGetQuantityAsInt64(t *testing.T) {
-	t.Parallel()
 	fakeLimitSetting := NewSetting("limit", "1Mi")
 
 	val, err := fakeLimitSetting.GetQuantityAsInt64(1000)


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/51782