### PR TITLE
Pass through error events when watching ext kubeconfigs

### DIFF
--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -1687,18 +1687,14 @@ func TestStoreWatch(t *testing.T) {
 		assert.Equal(t, statusIn.Reason, statusOut.Reason)
 		assert.Equal(t, statusIn.Code, statusOut.Code)
 
-		// Unknown error with a nil object, which should not produce an event.
+		// Not a Status error.
 		configMapWatcher.add(watch.Event{
 			Type: watch.Error,
 		})
 
-		select {
-		case event, ok = <-watcher.ResultChan():
-			if ok {
-				require.FailNow(t, "unexpected event: %v", event)
-			}
-		default:
-		}
+		event = <-watcher.ResultChan()
+		require.Equal(t, watch.Error, event.Type)
+		require.Nil(t, event.Object)
 
 		// Add another bookmark after an error event.
 		configMapWatcher.add(watch.Event{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

#51830

Related to SURE-10638
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When watching ext kubeconfig resources the error events are discarded and corresponding log messages produced, which prevents consumers from receiving essential error events like expired resource versions.

```
kubeconfig: watch: received error event: &Status{ListMeta:ListMeta{SelfLink:,ResourceVersion:,Continue:,RemainingItemCount:nil,},Status:Failure,Message:The resourceVersion for the provided watch is too old.,Reason:Expired,Details:nil,Code:410,}
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Pass through error events from the backing watcher.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A