### PR TITLE
Pass through error events when watching ext tokens 

### DIFF
--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1068,7 +1068,7 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 					return
 				}
 
-				var token *ext.Token
+				var obj runtime.Object
 				switch event.Type {
 				case watch.Bookmark:
 					secret, ok := event.Object.(*corev1.Secret)
@@ -1077,19 +1077,11 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 						continue
 					}
 
-					token = &ext.Token{
+					obj = &ext.Token{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: secret.ResourceVersion,
 						},
 					}
-				case watch.Error:
-					status, ok := event.Object.(*metav1.Status)
-					if ok {
-						logrus.Warnf("tokens: watch: received error event: %s", status.String())
-					} else {
-						logrus.Warnf("tokens: watch: received error event: %s", event.Object.GetObjectKind().GroupVersionKind().String())
-					}
-					continue
 				case watch.Added, watch.Modified, watch.Deleted:
 					secret, ok := event.Object.(*corev1.Secret)
 					if !ok {
@@ -1097,7 +1089,7 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 						continue
 					}
 
-					token, err = fromSecret(secret)
+					token, err := fromSecret(secret)
 					if err != nil {
 						logrus.Errorf("tokens: watch: error converting secret '%s' to token: %s", secret.Name, err)
 						continue
@@ -1108,16 +1100,16 @@ func (t *Store) watch(ctx context.Context, options *metav1.ListOptions) (watch.I
 					// ListOptionMerge above) takes care of only
 					// asking for owned tokens
 					token.Status.Current = token.Name == authTokenID
-				default:
-					logrus.Warnf("tokens: watch: received and ignored unknown event: '%s'", event.Type)
-					continue
+					obj = token
+				default: // watch.Error
+					obj = event.Object
 				}
 
 				// push to consumer, and terminate ourselves if
 				// the consumer terminated on us
 				if pushed := consumer.addEvent(watch.Event{
 					Type:   event.Type,
-					Object: token,
+					Object: obj,
 				}); !pushed {
 					return
 				}


### PR DESCRIPTION
## Issue: 
 
#51830
Related to SURE-10638
See PR #51824 for the analogous ext kubeconfig work.

## Problem

When watching ext kubeconfig resources the error events are discarded and corresponding log messages produced, which prevents consumers from receiving essential error events like expired resource versions.
```
token: watch: received error event: &Status{ListMeta:ListMeta{SelfLink:,ResourceVersion:,Continue:,RemainingItemCount:nil,},Status:Failure,Message:The resourceVersion for the provided watch is too old.,Reason:Expired,Details:nil,Code:410,}
```
 
## Solution

Pass through error events from the backing watcher.
 
## Testing
## Engineering Testing
### Manual Testing
### Automated Testing

* Test types added/modified:
    * Unit

## QA Testing Considerations
 
### Regressions Considerations

N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A
