### PR TITLE
[release/v2.12] Retry telemetry-controller project fetching

### DIFF
--- a/pkg/telemetry/controllers/controllers.go
+++ b/pkg/telemetry/controllers/controllers.go
@@ -3,31 +3,53 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	mgmgv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/telemetry"
 	"github.com/rancher/rancher/pkg/telemetry/controllers/secretrequest"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/sirupsen/logrus"
 )
 
-func RegisterControllers(ctx context.Context, wContext *wrangler.Context, telemetrManager telemetry.TelemetryExporterManager) error {
-	// TODO(dan): we could do k8s RBAC bindings here instead of this
-	projects, err := wContext.Mgmt.Project().List("local", v1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to register telemetry controllers: %w", err)
-	}
+var SystemProjectBackoff = wait.Backoff{
+	Steps:    10,
+	Duration: 15 * time.Second,
+	Factor:   2.0,
+	Jitter:   0.1,
+}
 
+func RegisterControllers(ctx context.Context, wContext *wrangler.Context, telemetryManager telemetry.TelemetryExporterManager) error {
+	// TODO(dan): we could do k8s RBAC bindings here instead of this
 	var systemProject *mgmgv3.Project
-	for _, project := range projects.Items {
-		if project.Spec.DisplayName != "System" {
-			continue
+
+	if initErr := retry.OnError(SystemProjectBackoff, func(err error) bool {
+		logrus.Errorf("failed to register telemetry controller, will retry: %v", err)
+		return true
+	}, func() error {
+		projects, err := wContext.Mgmt.Project().List("local", v1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to list projects: %v", err)
 		}
-		systemProject = &project
-	}
-	if systemProject == nil {
-		return fmt.Errorf("no system project found")
+
+		for _, project := range projects.Items {
+			if project.Spec.DisplayName != "System" {
+				continue
+			}
+			systemProject = &project
+		}
+
+		if systemProject == nil {
+			return fmt.Errorf("no system project found")
+		}
+
+		return nil
+	}); initErr != nil {
+		return initErr
 	}
 
 	secretrequest.Register(
@@ -37,7 +59,7 @@ func RegisterControllers(ctx context.Context, wContext *wrangler.Context, teleme
 		systemProject,
 		wContext.Core.Namespace(),
 		wContext.Core.Secret(),
-		telemetrManager,
+		telemetryManager,
 	)
 
 	return nil


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/51836

## Problem
After the _OnLeader_ function was replaced for _OnLeaderOrDie_ in [this PR](https://github.com/rancher/rancher/pull/51777), the telemetry-controller started crashing on Rancher startup. This PR should fix the issue.