### PR TITLE
chore(deps): Update rancher/shepherd to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.5.1-rc.1
 	github.com/rancher/rke v1.8.0-rc.4
-	github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b
+	github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70
 	github.com/rancher/steve v0.7.16
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd
 	github.com/rancher/wrangler v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -760,8 +760,8 @@ github.com/rancher/rke v1.8.0-rc.4 h1:jowVyaF3LsJonC7vNsAwWf3MONHAtEFUD/j3UzNSE5
 github.com/rancher/rke v1.8.0-rc.4/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
 github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHRkGaJ5v0=
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
-github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b h1:QIC9NNyUroMFInTwPYaJM27eb8xihHHOnamykw/TOMc=
-github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70 h1:XouRIvo2zm8Y/hi2LZJPKZj2LuEaTmxf3M7L650Ly+I=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/steve v0.7.16 h1:eSd4T++ZUQo0UOWCaMm2YrEsf1WgW2NFDY2ZyPBq/yw=
 github.com/rancher/steve v0.7.16/go.mod h1:78+b2lm6TSLcqvXzK7cph20zgMHQlUOXV33iy8bQ9YE=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=


### PR DESCRIPTION
This PR updates the `rancher/shepherd` dependency to the latest version.

Automated pull request created by the `create-rancher-pr` workflow in `rancher/shepherd`.

Source Author: @igomez06