### PR TITLE
[51878] Add migration to remove stale finalizer for node-controller

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -44,6 +44,7 @@ const (
 	migrateSystemAgentVarDirToDataDirectory    = "migratesystemagentvardirtodatadirectory"
 	migrateImportedClusterManagedFields        = "migrateimportedclustermanagedfields"
 	rkeCleanupMigration                        = "rkecleanupmigration"
+	managementNodeCleanupMigration             = "managementnodecleanupmigration"
 	rancherVersionKey                          = "rancherVersion"
 	projectsCreatedKey                         = "projectsCreated"
 	namespacesAssignedKey                      = "namespacesAssigned"
@@ -53,6 +54,7 @@ const (
 	systemAgentVarDirMigratedKey               = "systemAgentVarDirMigrated"
 	importedClusterManagedFieldsMigratedKey    = "importedClusterManagedFieldsMigrated"
 	rkeCleanupCompletedKey                     = "rkecleanupcompleted"
+	managementCleanupCompletedKey              = "managementcleanupcompleted"
 )
 
 var (
@@ -95,7 +97,15 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		return err
 	}
 
-	return rkeResourcesCleanup(wranglerContext)
+	if err := rkeResourcesCleanup(wranglerContext); err != nil {
+		return err
+	}
+
+	if err := managementNodeCleanup(wranglerContext); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func getConfigMap(configMapController controllerv1.ConfigMapController, configMapName string) (*v1.ConfigMap, error) {
@@ -693,5 +703,43 @@ func rkeResourcesCleanup(w *wrangler.Context) error {
 	}
 
 	cm.Data[rkeCleanupCompletedKey] = "true"
+	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
+}
+
+func managementNodeCleanup(w *wrangler.Context) error {
+	cm, err := getConfigMap(w.Core.ConfigMap(), managementNodeCleanupMigration)
+	if err != nil || cm == nil {
+		return err
+	}
+
+	// Check if this migration has already run.
+	if cm.Data[managementCleanupCompletedKey] == "true" {
+		return nil
+	}
+
+	nodes, err := w.Mgmt.Node().List("", metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes.Items {
+		for i, f := range node.Finalizers {
+			if f != "controller.cattle.io/node-controller" {
+				continue
+			}
+
+			node = *node.DeepCopy()
+			node.Finalizers = append(node.Finalizers[:i], node.Finalizers[i+1:]...)
+
+			_, err = w.Mgmt.Node().Update(&node)
+			if err != nil {
+				return err
+			}
+
+			break
+		}
+	}
+
+	cm.Data[managementCleanupCompletedKey] = "true"
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #51878
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Clusters provisioned before v2.12.0 will fail to cleanup resources. `node.management.cattle.io/v3` objects have a stale finalizer that is no longer added or removed, so any node object which had the finalizer added will not be cleaned up, preventing the node objects and namespaces it lives in from being properly deleted.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Add a migration to delete these resources.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

:+1: 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, finalizers removed, `node.management.cattle.io` deleted, namespaces deleted..