### PR TITLE
[51879] Add migration to remove stale finalizer for node-controller

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -74,6 +74,9 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		if err := forceSystemNamespaceAssignment(wranglerContext.Core.ConfigMap(), wranglerContext.Mgmt.Project()); err != nil {
 			return err
 		}
+		if err := managementNodeCleanup(wranglerContext); err != nil {
+			return err
+		}
 	}
 
 	if err := migrateImportedClusterFields(wranglerContext); err != nil {
@@ -99,10 +102,6 @@ func runRKE2Migrations(wranglerContext *wrangler.CAPIContext) error {
 		if err := migrateMachinePoolsDynamicSchemaLabel(wranglerContext); err != nil {
 			return err
 		}
-	}
-
-	if err := managementNodeCleanup(wranglerContext); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
Forwardport of #51877 

## Issue: <!-- link the issue or issues this PR resolves here --> #51879
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Clusters provisioned before v2.12.0 will fail to cleanup resources. `node.management.cattle.io/v3` objects have a stale finalizer that is no longer added or removed, so any node object which had the finalizer added will not be cleaned up, preventing the node objects and namespaces it lives in from being properly deleted.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Add a migration to delete these resources.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

:+1: 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, finalizers removed, `node.management.cattle.io` deleted, namespaces deleted..