### PR TITLE
Allow the namespace CRB to be reused by PRTBs

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/common.go
+++ b/pkg/controllers/management/auth/roletemplates/common.go
@@ -23,7 +23,6 @@ const (
 const (
 	// Statuses
 	clusterRoleTemplateBindingDelete = "ClusterRoleTemplateBindingDelete"
-	labelsReconciled                 = "LabelsReconciled"
 	removeClusterRoleBindings        = "RemoveClusterRoleBindings"
 	reconcileSubject                 = "ReconcileSubject"
 	reconcileMembershipBindings      = "ReconcileMembershipBindings"
@@ -44,7 +43,6 @@ const (
 	failedToGetRoleTemplate                 = "FailedToGetRoleTemplate"
 	failedToGetUser                         = "FailedToGetUser"
 	failedToListExistingClusterRoleBindings = "FailedToGetExistingClusterRoleBindings"
-	failedToDeleteClusterMembershipBinding  = "FailedToDeleteClusterMembershipBindings"
 )
 
 // createOrUpdateClusterMembershipBinding ensures that the user specified by a CRTB or PRTB has membership to the cluster referenced by the CRTB or PRTB.
@@ -278,7 +276,7 @@ func getRTBLabel(obj metav1.Object) string {
 // The only intentionally created RoleBindings are created by auth provisioning v2 to provide access to the fleet cluster.
 // The creation of those is handled in pkg/controllers/management/authprovisioningv2.
 func removeAuthV2Permissions(obj metav1.Object, rbController crbacv1.RoleBindingController) error {
-	listOptions := metav1.ListOptions{LabelSelector: rbac.GetRTBOwnerLabel(obj)}
+	listOptions := metav1.ListOptions{LabelSelector: rbac.GetAuthV2OwnerLabel(obj)}
 
 	roleBindings, err := rbController.List(fleet.ClustersDefaultNamespace, listOptions)
 	if err != nil {

--- a/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/mock/gomock"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type reducedCondition struct {
@@ -444,12 +443,12 @@ func TestUpdateStatus(t *testing.T) {
 
 	crtbSubjectExist := &v3.ClusterRoleTemplateBinding{
 		Status: v3.ClusterRoleTemplateBindingStatus{
-			LocalConditions: []v1.Condition{
+			LocalConditions: []metav1.Condition{
 				{
 					Type:   subjectExists,
-					Status: v1.ConditionTrue,
+					Status: metav1.ConditionTrue,
 					Reason: subjectExists,
-					LastTransitionTime: v1.Time{
+					LastTransitionTime: metav1.Time{
 						Time: mockTime,
 					},
 				},
@@ -459,20 +458,20 @@ func TestUpdateStatus(t *testing.T) {
 	}
 	crtbSubjectAndBindingExist := &v3.ClusterRoleTemplateBinding{
 		Status: v3.ClusterRoleTemplateBindingStatus{
-			LocalConditions: []v1.Condition{
+			LocalConditions: []metav1.Condition{
 				{
 					Type:   subjectExists,
-					Status: v1.ConditionTrue,
+					Status: metav1.ConditionTrue,
 					Reason: subjectExists,
-					LastTransitionTime: v1.Time{
+					LastTransitionTime: metav1.Time{
 						Time: mockTime,
 					},
 				},
 				{
 					Type:   bindingsExists,
-					Status: v1.ConditionTrue,
+					Status: metav1.ConditionTrue,
 					Reason: bindingsExists,
-					LastTransitionTime: v1.Time{
+					LastTransitionTime: metav1.Time{
 						Time: mockTime,
 					},
 				},
@@ -482,12 +481,12 @@ func TestUpdateStatus(t *testing.T) {
 	}
 	crtbSubjectError := &v3.ClusterRoleTemplateBinding{
 		Status: v3.ClusterRoleTemplateBindingStatus{
-			LocalConditions: []v1.Condition{
+			LocalConditions: []metav1.Condition{
 				{
 					Type:   subjectExists,
-					Status: v1.ConditionFalse,
+					Status: metav1.ConditionFalse,
 					Reason: failedToCreateUser,
-					LastTransitionTime: v1.Time{
+					LastTransitionTime: metav1.Time{
 						Time: mockTime,
 					},
 				},
@@ -509,7 +508,7 @@ func TestUpdateStatus(t *testing.T) {
 	tests := map[string]struct {
 		crtb            *v3.ClusterRoleTemplateBinding
 		crtbClient      func(*v3.ClusterRoleTemplateBinding) mgmtv3.ClusterRoleTemplateBindingController
-		localConditions []v1.Condition
+		localConditions []metav1.Condition
 		wantErr         error
 	}{
 		"status updated": {
@@ -518,12 +517,12 @@ func TestUpdateStatus(t *testing.T) {
 				mock := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 				mock.EXPECT().UpdateStatus(&v3.ClusterRoleTemplateBinding{
 					Status: v3.ClusterRoleTemplateBindingStatus{
-						LocalConditions: []v1.Condition{
+						LocalConditions: []metav1.Condition{
 							{
 								Type:   subjectExists,
-								Status: v1.ConditionTrue,
+								Status: metav1.ConditionTrue,
 								Reason: subjectExists,
-								LastTransitionTime: v1.Time{
+								LastTransitionTime: metav1.Time{
 									Time: mockTime,
 								},
 							},
@@ -550,12 +549,12 @@ func TestUpdateStatus(t *testing.T) {
 				mock := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 				mock.EXPECT().UpdateStatus(&v3.ClusterRoleTemplateBinding{
 					Status: v3.ClusterRoleTemplateBindingStatus{
-						LocalConditions: []v1.Condition{
+						LocalConditions: []metav1.Condition{
 							{
 								Type:   subjectExists,
-								Status: v1.ConditionTrue,
+								Status: metav1.ConditionTrue,
 								Reason: subjectExists,
-								LastTransitionTime: v1.Time{
+								LastTransitionTime: metav1.Time{
 									Time: mockTime,
 								},
 							},
@@ -577,12 +576,12 @@ func TestUpdateStatus(t *testing.T) {
 				mock := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 				mock.EXPECT().UpdateStatus(&v3.ClusterRoleTemplateBinding{
 					Status: v3.ClusterRoleTemplateBindingStatus{
-						LocalConditions: []v1.Condition{
+						LocalConditions: []metav1.Condition{
 							{
 								Type:   subjectExists,
-								Status: v1.ConditionFalse,
+								Status: metav1.ConditionFalse,
 								Reason: failedToCreateUser,
-								LastTransitionTime: v1.Time{
+								LastTransitionTime: metav1.Time{
 									Time: mockTime,
 								},
 							},

--- a/pkg/controllers/managementuser/rbac/roletemplates/crtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/crtb_handler_test.go
@@ -20,7 +20,7 @@ type reducedCondition struct {
 }
 
 var (
-	defaultListOption = metav1.ListOptions{LabelSelector: "authz.cluster.cattle.io/crtb-owner=test-crtb"}
+	defaultListOption = metav1.ListOptions{LabelSelector: "authz.cluster.cattle.io/crtb-owner-test-crtb"}
 	defaultCRTB       = v3.ClusterRoleTemplateBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-crtb",
@@ -31,7 +31,7 @@ var (
 	defaultCRB = rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "crb-mggi3adyhn",
-			Labels: map[string]string{"authz.cluster.cattle.io/crtb-owner": "test-crtb"},
+			Labels: map[string]string{"authz.cluster.cattle.io/crtb-owner-test-crtb": "true"},
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "ClusterRole",
@@ -50,7 +50,7 @@ var (
 	externalCRB = rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "crb-panishv6ga",
-			Labels: map[string]string{"authz.cluster.cattle.io/crtb-owner": "test-crtb"},
+			Labels: map[string]string{"authz.cluster.cattle.io/crtb-owner-test-crtb": "true"},
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "ClusterRole",

--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -21,11 +22,9 @@ import (
 )
 
 const (
-	prtbOwnerLabel      = "authz.cluster.cattle.io/prtb-owner"
 	projectIDAnnotation = "field.cattle.io/projectId"
 	namespaceReadOnly   = "namespaces-readonly"
 	namespaceEdit       = "namespaces-edit"
-	namespacePSA        = "namespaces-psa"
 	namespacesCreate    = "create-ns"
 	updatePSAVerb       = "updatepsa"
 )
@@ -72,11 +71,15 @@ func (p *prtbHandler) OnChange(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 
 	// Handle cluster role bindings for special permissions.
 	if err := p.reconcileClusterRoleBindings(prtb); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reconciling ClusterRoleBindings for ProjectRoleTemplateBinding %s:%w", prtb.Name, err)
+	}
+
+	if err := p.reconcileNamespaceBindings(prtb); err != nil {
+		return nil, fmt.Errorf("error reconciling Namespace RoleBindings for ProjectRoleTemplateBinding %s:%w", prtb.Name, err)
 	}
 
 	if err := p.reconcileBindings(prtb); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reconciling RoleBindings for ProjectRoleTemplateBinding %s:%w", prtb.Name, err)
 	}
 
 	// Ensure a service account impersonator exists on the cluster.
@@ -129,7 +132,7 @@ func (p *prtbHandler) reconcileBindings(prtb *v3.ProjectRoleTemplateBinding) err
 		rb := &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      rbac.NameForRoleBinding(namespace.Name, roleRef, subject),
-				Labels:    map[string]string{rbac.PrtbOwnerLabel: prtb.Name},
+				Labels:    map[string]string{rbac.GetPRTBOwnerLabel(prtb.Name): "true"},
 				Namespace: namespace.Name,
 			},
 			RoleRef:  roleRef,
@@ -155,12 +158,13 @@ func (p *prtbHandler) OnRemove(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 		return nil, err
 	}
 
-	lo := metav1.ListOptions{LabelSelector: rbac.GetPRTBOwnerLabel(prtb.Name)}
+	prtbOwnerLabel := rbac.GetPRTBOwnerLabel(prtb.Name)
+	listOptions := metav1.ListOptions{LabelSelector: prtbOwnerLabel}
 
 	var returnError error
 	// Remove all role bindings.
 	for _, n := range namespaces.Items {
-		rbs, err := p.rbClient.List(n.Name, lo)
+		rbs, err := p.rbClient.List(n.Name, listOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -173,11 +177,29 @@ func (p *prtbHandler) OnRemove(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 	}
 
 	// Remove all cluster role bindings.
-	crbs, err := p.crbClient.List(lo)
+	crbs, err := p.crbClient.List(listOptions)
 	if err != nil {
 		return nil, err
 	}
 	for _, crb := range crbs.Items {
+		// Check if the CRB is owned by another PRTB
+		// This can happen if the CRB is reused like the namespace access CRB
+		crbOwnedByAnotherPRTB := false
+		delete(crb.Labels, prtbOwnerLabel)
+		for label := range crb.Labels {
+			if strings.HasPrefix(label, rbac.PrtbOwnerLabel) {
+				crbOwnedByAnotherPRTB = true
+				break
+			}
+		}
+		// In the case where it is shared, only update the CRB with the ownership label removed
+		if crbOwnedByAnotherPRTB {
+			_, err = p.crbClient.Update(&crb)
+			returnError = errors.Join(returnError, err)
+			continue
+		}
+
+		// If there are no other owners, delete the CRB
 		err = p.crbClient.Delete(crb.Name, &metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			returnError = errors.Join(returnError, err)
@@ -232,11 +254,47 @@ func (p *prtbHandler) reconcileClusterRoleBindings(prtb *v3.ProjectRoleTemplateB
 	return p.ensureOnlyDesiredClusterRoleBindingsExists(crbs, rbac.GetPRTBOwnerLabel(prtb.Name))
 }
 
+// reconcileNamespaceBindings ensures that the PRTB has created ClusterRoleBindings to the ClusterRoles responsible
+// for providing access to each of the namespaces within the project.
+func (p *prtbHandler) reconcileNamespaceBindings(prtb *v3.ProjectRoleTemplateBinding) error {
+	namespaceBindings, err := p.buildNamespaceBindings(prtb)
+	if err != nil {
+		return err
+	}
+
+	var returnedErr error
+	for _, namespaceBinding := range namespaceBindings {
+		existingCRB, err := p.crbClient.Get(namespaceBinding.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			_, err = p.crbClient.Create(namespaceBinding)
+			returnedErr = errors.Join(returnedErr, err)
+			continue
+		} else if err != nil {
+			returnedErr = errors.Join(returnedErr, err)
+			continue
+		}
+
+		if existingCRB.Labels == nil {
+			existingCRB.Labels = map[string]string{}
+		}
+
+		// The binding already exists. Make sure it references this PRTB
+		if _, ok := existingCRB.Labels[rbac.GetPRTBOwnerLabel(prtb.Name)]; !ok {
+			existingCRB.Labels[rbac.GetPRTBOwnerLabel(prtb.Name)] = "true"
+			_, err := p.crbClient.Update(existingCRB)
+			returnedErr = errors.Join(returnedErr, err)
+
+		}
+	}
+
+	return returnedErr
+}
+
 // buildNamespaceBindings builds the Cluster Role Bindings used to provide access to the project's namespaces.
 func (p *prtbHandler) buildNamespaceBindings(prtb *v3.ProjectRoleTemplateBinding) ([]*rbacv1.ClusterRoleBinding, error) {
 	cr, err := p.crClient.Get(rbac.AggregatedClusterRoleNameFor(prtb.RoleTemplateName), metav1.GetOptions{})
 	// With no CR the namespace bindings can't be created
-	if apierrors.IsNotFound(err) || cr == nil {
+	if apierrors.IsNotFound(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -339,7 +397,8 @@ func (p *prtbHandler) ensureOnlyDesiredClusterRoleBindingsExists(crbs []*rbacv1.
 
 	// Any remaining ClusterRoleBindings in the desiredCRBs get created.
 	for _, crb := range desiredCRBs {
-		if _, err := p.crbClient.Create(crb); err != nil {
+		// It's possible the CRB was already created, so ignore AlreadyExists errors
+		if _, err := p.crbClient.Create(crb); err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49265
 
## Problem
This resolves a few things, but the most important is as follows:

When you create a PRTB, part of the logic is providing the user access to the namespaces within the project. To do that, a ClusterRoleBinding is created pointing to a ClusterRole called `<project-name>-namespaces-readonly` A user can be given access to that ClusterRole by multiple PRTBs. Instead of creating a new CRB each time, we instead re-use the same CRB.

The issue came about when a PRTB was deleted. It would remove the CRB even if other PRTBs were relying on it, which would remove access to the project namespaces.

The issue linked may seem unrelated, but it was failing to provide namespaced permissions within a project because it was encountering an error when handling the shared CRB, so it never attempted to complete the RoleBindings.
 
## Solution
To solve the problem, I re-used a solution I had for membership bindings which exist in the management cluster. Basically, instead of using a label of the form `authz.cluster.cattle.io/prtb-owner: <prtb.Name>` to indicate a CRB belongs to the PRTB, I made it `authz.cluster.cattle.io/prtb-owner-<prtb-name>: true`. That way I can have multiple owner labels on the same CRB, and then when I add or remove a PRTB, the label is added or removed. If there are no ownership labels left, the CRB is deleted.
 
## Testing
## Engineering Testing
### Manual Testing
Tested it pretty thoroughly manually. The original issue is resolved, and I made sure that adding and removing PRTBs to the same user provided the right access. So removing a PRTB while another exists doesn't remove namespace access.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Improved the general test coverage of the RoleTemplate Aggregation PRTB controllers

## QA Testing Considerations
This could have been causing other problems within the RoleTemplate aggregation. Need to do some more digging if any open issues might be resolved.
 
### Regressions Considerations
This is specifically related to PRTB namespace access, but some of the code is shared with CRTBs and cluster access. Worthwhile to test both sets of regression tests.

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_