### PR TITLE
Ensure that managementNodeCleanup on run when MCM is enabled

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -101,8 +101,10 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		return err
 	}
 
-	if err := managementNodeCleanup(wranglerContext); err != nil {
-		return err
+	if features.MCM.Enabled() {
+		if err := managementNodeCleanup(wranglerContext); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/51952

Note: This part of the nodes CRD bug for Harvester only applies to 2.12 no `main` yet.
 
## Problem
`managementNodeCleanup` within migrations requires Node CRDs which require MCM enabled. This breaks things when MCM is disabled.
 
## Solution
Make this part of migrations conditional like `forceSystemNamespaceAssignment` is conditional.
 
## Testing
Same as what's explained here: https://github.com/rancher/rancher/issues/51931#issuecomment-3307530128

## QA Testing Considerations
TBH - I am unsure who's QA should validate. ORBS QA has already done this once for my previous fix, however this original code being modified is more Hostbusters area.
 
### Regressions Considerations
As mentioned `main` doesn't have this code so doesn't have this bug on Harvester (but they are updating to 2.12 not 2.13) - so when https://github.com/rancher/rancher/issues/51879 is worked on this fix should be included there.