### PR TITLE
Remove the ext featureflags

### DIFF
--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -260,15 +260,13 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 		return nil, fmt.Errorf("failed to install stores: %w", err)
 	}
 
-	if features.ExtTokens.Enabled() {
-		// deferred ext controller setup ...
-		logrus.Debug("[deferred-ext/run] DEFER - cluster auth token - register ext token indexers")
-		wranglerContext.DeferredEXTAPIRegistration.DeferFunc(func(extContext *wrangler.EXTAPIContext) {
-			if err := clusterauthtoken.RegisterExtIndexers(extContext.Client); err != nil {
-				logrus.Fatalf("Unexpected error while adding ext indexers: %v", err)
-			}
-		})
-	}
+	// deferred ext controller setup ...
+	logrus.Debug("[deferred-ext/run] DEFER - cluster auth token - register ext token indexers")
+	wranglerContext.DeferredEXTAPIRegistration.DeferFunc(func(extContext *wrangler.EXTAPIContext) {
+		if err := clusterauthtoken.RegisterExtIndexers(extContext.Client); err != nil {
+			logrus.Fatalf("Unexpected error while adding ext indexers: %v", err)
+		}
+	})
 
 	return extensionAPIServer, nil
 }

--- a/pkg/ext/stores/install.go
+++ b/pkg/ext/stores/install.go
@@ -36,18 +36,14 @@ func InstallStores(
 	}
 	logrus.Infof("Successfully installed useractivity store")
 
-	if features.ExtTokens.Enabled() {
-		if err := server.Install(
-			tokens.PluralName,
-			tokens.GVK,
-			tokens.NewFromWrangler(wranglerContext, server.GetAuthorizer()),
-		); err != nil {
-			return fmt.Errorf("unable to install %s store: %w", tokens.SingularName, err)
-		}
-		logrus.Infof("Successfully installed token store")
-	} else {
-		logrus.Infof("Feature ext-tokens is disabled")
+	if err := server.Install(
+		tokens.PluralName,
+		tokens.GVK,
+		tokens.NewFromWrangler(wranglerContext, server.GetAuthorizer()),
+	); err != nil {
+		return fmt.Errorf("unable to install %s store: %w", tokens.SingularName, err)
 	}
+	logrus.Infof("Successfully installed token store")
 
 	userManager, err := common.NewUserManagerNoBindings(wranglerContext)
 	if err != nil {

--- a/pkg/ext/stores/install.go
+++ b/pkg/ext/stores/install.go
@@ -49,23 +49,19 @@ func InstallStores(
 		logrus.Infof("Feature ext-tokens is disabled")
 	}
 
-	if features.ExtKubeconfigs.Enabled() {
-		userManager, err := common.NewUserManagerNoBindings(wranglerContext)
-		if err != nil {
-			return fmt.Errorf("error getting user manager: %w", err)
-		}
-
-		if err := server.Install(
-			extv1.KubeconfigResourceName,
-			extv1.SchemeGroupVersion.WithKind(kubeconfig.Kind),
-			kubeconfig.New(features.MCM.Enabled(), wranglerContext, server.GetAuthorizer(), userManager),
-		); err != nil {
-			return fmt.Errorf("unable to install kubeconfig store: %w", err)
-		}
-		logrus.Infof("Successfully installed kubeconfig store")
-	} else {
-		logrus.Infof("Feature ext-kubeconfigs is disabled")
+	userManager, err := common.NewUserManagerNoBindings(wranglerContext)
+	if err != nil {
+		return fmt.Errorf("error getting user manager: %w", err)
 	}
+
+	if err := server.Install(
+		extv1.KubeconfigResourceName,
+		extv1.SchemeGroupVersion.WithKind(kubeconfig.Kind),
+		kubeconfig.New(features.MCM.Enabled(), wranglerContext, server.GetAuthorizer(), userManager),
+	); err != nil {
+		return fmt.Errorf("unable to install kubeconfig store: %w", err)
+	}
+	logrus.Infof("Successfully installed kubeconfig store")
 
 	err = server.Install(
 		extv1.PasswordChangeRequestResourceName,

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -176,12 +176,6 @@ var (
 		isPrime(),
 		false,
 		true)
-	ExtKubeconfigs = newFeature(
-		"ext-kubeconfigs",
-		"Enable Imperative API resource kubeconfigs.ext.cattle.io.",
-		true,
-		false,
-		true)
 	ExtTokens = newFeature(
 		"ext-tokens",
 		"Enable Imperative API resource tokens.ext.cattle.io.",

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -176,12 +176,6 @@ var (
 		isPrime(),
 		false,
 		true)
-	ExtTokens = newFeature(
-		"ext-tokens",
-		"Enable Imperative API resource tokens.ext.cattle.io.",
-		true,
-		false,
-		true)
 	RancherSCCRegistrationExtension = newFeature(
 		"rancher-scc-registration-extension",
 		"Enable Rancher's SCC registration extension to register the system(s) for customer support",

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rancher/rancher/pkg/catalogv2/helmop"
 	"github.com/rancher/rancher/pkg/catalogv2/system"
 	"github.com/rancher/rancher/pkg/controllers"
-	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io"
 	catalogcontrollers "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/generated/controllers/fleet.cattle.io"
@@ -366,9 +365,7 @@ func NewPrimaryContext(ctx context.Context, clientConfig clientcmd.ClientConfig,
 	}
 
 	wCtx.DeferredCAPIRegistration.Manage(ctx)
-	if features.ExtTokens.Enabled() {
-		wCtx.DeferredEXTAPIRegistration.Manage(ctx)
-	}
+	wCtx.DeferredEXTAPIRegistration.Manage(ctx)
 	return wCtx, nil
 }
 


### PR DESCRIPTION
## Issue: 

#51218
 
## Problem

Starting with 2.13 the UI will manage ext kubeconfigs. Instead of having to support both states of the feature flag in the UI it is requested to remove the feature flag and assume that ext support is always active.

## Solution

Both ext feature flags are removed.
 
## Testing
## Engineering Testing
### Manual Testing
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_