### PR TITLE
[release/v2.12] Rollback the SCC Operator image

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,4 +4,4 @@ provisioningCAPIVersion: 107.0.0+up0.8.0
 cspAdapterMinVersion: 107.0.0+up7.0.0
 defaultShellVersion: rancher/shell:v0.5.0
 fleetVersion: 107.0.2+up0.13.2
-defaultSccOperatorImage: rancher/scc-operator:v0.2.1-alpha.2
+defaultSccOperatorImage: rancher/scc-operator:v0.1.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	CspAdapterMinVersion     = "107.0.0+up7.0.0"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.2.1-alpha.2"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.1.2"
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "107.0.2+up0.13.2"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"


### PR DESCRIPTION
Per title - this PR rolls back the non-stable SCC Operator tag back to the previous stable tag.

This is an alternative to: https://github.com/rancher/rancher/pull/52078