### PR TITLE
Squash used-limit information for projects without namespaces

### DIFF
--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -150,7 +150,7 @@ func Register(ctx context.Context, workload *config.UserContext) error {
 		ResourceQuotaLister: workload.Corew.ResourceQuota().Cache(),
 		LimitRange:          workload.Corew.LimitRange(),
 		LimitRangeLister:    workload.Corew.LimitRange().Cache(),
-		ProjectLister:       management.Management.Projects(workload.ClusterName).Controller().Lister(),
+		ProjectCache:        management.Wrangler.Mgmt.Project().Cache(),
 	}
 
 	nsLifecycle := newNamespaceLifecycle(r, sync)

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -313,7 +313,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 
 	var namespace string
 	if parts := strings.SplitN(projectID, ":", 2); len(parts) == 2 && len(parts[1]) > 0 {
-		project, err := n.rq.ProjectLister.Get(parts[0], parts[1])
+		project, err := n.rq.ProjectCache.Get(parts[0], parts[1])
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				logrus.Warnf("Namespace %s references project %s in namespace %s which does not exist", ns.Name, parts[1], parts[0])

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_calculate_used.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_calculate_used.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"reflect"
 
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/ref"
 	validate "github.com/rancher/rancher/pkg/resourcequota"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	clientcache "k8s.io/client-go/tools/cache"
@@ -20,10 +22,9 @@ collectController is responsible for calculate the combined limit set on the pro
 and setting this information in the project
 */
 type calculateLimitController struct {
-	projectLister v3.ProjectLister
-	projects      v3.ProjectInterface
-	nsIndexer     clientcache.Indexer
-	clusterName   string
+	projects    wmgmtv3.ProjectClient
+	nsIndexer   clientcache.Indexer
+	clusterName string
 }
 
 func (c *calculateLimitController) calculateResourceQuotaUsed(_ string, ns *corev1.Namespace) (*corev1.Namespace, error) {
@@ -37,7 +38,7 @@ func (c *calculateLimitController) calculateResourceQuotaUsed(_ string, ns *core
 	return nil, c.calculateProjectResourceQuota(projectID)
 }
 
-func (c *calculateLimitController) calculateResourceQuotaUsedProject(key string, p *v3.Project) (runtime.Object, error) {
+func (c *calculateLimitController) calculateResourceQuotaUsedProject(key string, p *apiv3.Project) (runtime.Object, error) {
 	if p == nil || p.DeletionTimestamp != nil {
 		return nil, nil
 	}
@@ -47,7 +48,7 @@ func (c *calculateLimitController) calculateResourceQuotaUsedProject(key string,
 
 func (c *calculateLimitController) calculateProjectResourceQuota(projectID string) error {
 	projectNamespace, projectName := ref.Parse(projectID)
-	project, err := c.projectLister.Get(projectNamespace, projectName)
+	project, err := c.projects.Get(projectNamespace, projectName, metav1.GetOptions{})
 	if err != nil || project.Spec.ResourceQuota == nil {
 		if errors.IsNotFound(err) {
 			// If Rancher is unaware of a project, we should ignore trying to calculate the project resource quota

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/rancher/norman/types/convert"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	validate "github.com/rancher/rancher/pkg/resourcequota"
 	"github.com/rancher/rancher/pkg/utils"
@@ -37,7 +37,7 @@ SyncController takes care of creating Kubernetes resource quota based on the res
 defined in namespace.resourceQuota
 */
 type SyncController struct {
-	ProjectLister       v3.ProjectLister
+	ProjectCache        wmgmtv3.ProjectCache
 	Namespaces          corew.NamespaceClient
 	ResourceQuotas      corew.ResourceQuotaClient
 	ResourceQuotaLister corew.ResourceQuotaCache
@@ -257,7 +257,7 @@ func (c *SyncController) deriveRequestedResourceQuota(ns *corev1.Namespace) (*v3
 		return nil, nil, err
 	}
 
-	defaultQuota, err := getProjectNamespaceDefaultQuota(ns, c.ProjectLister)
+	defaultQuota, err := getProjectNamespaceDefaultQuota(ns, c.ProjectCache)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -319,7 +319,7 @@ func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quot
 	}
 
 	// get project limit
-	projectLimit, projectID, err := getProjectResourceQuotaLimit(ns, c.ProjectLister)
+	projectLimit, projectID, err := getProjectResourceQuotaLimit(ns, c.ProjectCache)
 	if err != nil {
 		return false, ns, nil, err
 	}
@@ -403,7 +403,7 @@ func (c *SyncController) getResourceLimitToUpdate(ns *corev1.Namespace) (*corev1
 	if err != nil {
 		return nil, err
 	}
-	projectLimit, err := getProjectContainerDefaultLimit(ns, c.ProjectLister)
+	projectLimit, err := getProjectContainerDefaultLimit(ns, c.ProjectCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_validate.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_validate.go
@@ -3,8 +3,10 @@ package resourcequota
 import (
 	"fmt"
 
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	corew "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcache "k8s.io/client-go/tools/cache"
@@ -17,9 +19,10 @@ so they get a chance to reconcile the resource quotas
 type reconcileController struct {
 	namespaces corew.NamespaceController
 	nsIndexer  clientcache.Indexer
+	projects   wmgmtv3.ProjectClient
 }
 
-func (r *reconcileController) reconcileNamespaces(key string, p *v3.Project) (runtime.Object, error) {
+func (r *reconcileController) reconcileNamespaces(_ string, p *apiv3.Project) (runtime.Object, error) {
 	if p == nil || p.DeletionTimestamp != nil {
 		return nil, nil
 	}
@@ -27,6 +30,25 @@ func (r *reconcileController) reconcileNamespaces(key string, p *v3.Project) (ru
 	namespaces, err := r.nsIndexer.ByIndex(nsByProjectIndex, projectID)
 	if err != nil {
 		return nil, err
+	}
+
+	// With no namespaces used-limit has to be empty because there is
+	// nothing which can be used without namespaces. Therefore squash
+	// non-empty used-limits, if present.
+	empty := apiv3.ResourceQuotaLimit{}
+	if len(namespaces) == 0 &&
+		p.Spec.ResourceQuota != nil &&
+		p.Spec.ResourceQuota.UsedLimit != empty {
+
+		logrus.Warnf("project %q, clearing bogus used-limit", p.Name)
+
+		newP := p.DeepCopy()
+		newP.Spec.ResourceQuota.UsedLimit = empty
+		_, err := r.projects.Update(newP)
+		if err != nil {
+			logrus.Errorf("project %q, clearing bogus used-limit failed: %q", p.Name, err)
+			return nil, err
+		}
 	}
 
 	for _, n := range namespaces {

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_validate_test.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_validate_test.go
@@ -1,0 +1,169 @@
+package resourcequota
+
+import (
+	"fmt"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wranglerfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestReconcileNamespaces(t *testing.T) {
+	now := metav1.Now()
+
+	testCases := []struct {
+		name        string
+		err         error
+		setup       func(ctrl *gomock.Controller, enqCounter *int) *reconcileController
+		project     *apiv3.Project
+		enqExpected int
+	}{
+		{
+			name:    "nil project",
+			project: nil,
+			setup: func(ctrl *gomock.Controller, enqCounter *int) *reconcileController {
+				return &reconcileController{}
+			},
+			err: nil,
+		},
+		{
+			name: "deleted project",
+			project: &apiv3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+			},
+			setup: func(ctrl *gomock.Controller, enqCounter *int) *reconcileController {
+				return &reconcileController{}
+			},
+			err: nil,
+		},
+		// Unknown how to induce error for `ByIndex` call
+		{
+			name: "project with namespaces",
+			project: &apiv3.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "p-namespace",
+					Name:      "p-name",
+				},
+			},
+			enqExpected: 1,
+			setup: func(ctrl *gomock.Controller, enqCounter *int) *reconcileController {
+				nsMockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				nsMockIndexer.AddIndexers(cache.Indexers{nsByProjectIndex: nsByProjectID})
+				nsMockIndexer.Add(&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "a-namespace",
+						Annotations: map[string]string{
+							projectIDAnnotation: "p-namespace:p-name",
+						},
+					},
+				})
+
+				nsMock := wranglerfake.NewMockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList](ctrl)
+				nsMock.EXPECT().
+					Enqueue(gomock.Any()).
+					DoAndReturn(func (_ string) {
+						*enqCounter = *enqCounter + 1
+				})
+
+				return &reconcileController{
+					namespaces: nsMock,
+					nsIndexer:  nsMockIndexer,
+				}
+			},
+		},
+		{
+			name: "project without namespaces, empty used limit, ok",
+			// no error, no actions on projects nor namespaces
+			project: &apiv3.Project{},
+			setup: func(ctrl *gomock.Controller, enqCounter *int) *reconcileController {
+				nsMockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				nsMockIndexer.AddIndexers(cache.Indexers{nsByProjectIndex: nsByProjectID})
+				return &reconcileController{
+					nsIndexer: nsMockIndexer,
+				}
+			},
+			err: nil,
+		},
+		{
+			name: "project without namespaces, yet non-empty used limit",
+			project: &apiv3.Project{
+				Spec: apiv3.ProjectSpec{
+					ResourceQuota: &apiv3.ProjectResourceQuota{
+						UsedLimit: apiv3.ResourceQuotaLimit{
+							Pods: "2500025",
+						},
+					},
+				},
+			},
+			setup: func(ctrl *gomock.Controller, enqCounter *int) *reconcileController {
+				nsMockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				nsMockIndexer.AddIndexers(cache.Indexers{nsByProjectIndex: nsByProjectID})
+
+				projectMock := wranglerfake.NewMockControllerInterface[*apiv3.Project, *apiv3.ProjectList](ctrl)
+				projectMock.EXPECT().Update(gomock.Any()).Return(nil, nil)
+
+				return &reconcileController{
+					nsIndexer: nsMockIndexer,
+					projects:  projectMock,
+				}
+			},
+		},
+		{
+			name: "project without namespaces, yet non-empty used limit, update error",
+			project: &apiv3.Project{
+				Spec: apiv3.ProjectSpec{
+					ResourceQuota: &apiv3.ProjectResourceQuota{
+						UsedLimit: apiv3.ResourceQuotaLimit{
+							Pods: "2500025",
+						},
+					},
+				},
+			},
+			setup: func(ctrl *gomock.Controller, enqCounter *int) *reconcileController {
+				nsMockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				nsMockIndexer.AddIndexers(cache.Indexers{nsByProjectIndex: nsByProjectID})
+
+				projectMock := wranglerfake.NewMockControllerInterface[*apiv3.Project, *apiv3.ProjectList](ctrl)
+				projectMock.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("some error"))
+
+				return &reconcileController{
+					nsIndexer: nsMockIndexer,
+					projects:  projectMock,
+				}
+			},
+			err: fmt.Errorf("some error"),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			var enqCalled int
+			r := tt.setup(ctrl, &enqCalled)
+
+			_, err := r.reconcileNamespaces("dummy", tt.project)
+
+			if tt.err != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.err, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.enqExpected, enqCalled)
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#49041
 
Associated webhook PR https://github.com/rancher/webhook/pull/1118

## Problem

Users can provide bogus used-limit information because the relevant fields are currently located under `.spec` of projects.
 
## Solution

This change ensures that project changes trigger a removal of used-limit data when a project has no namespaces. Note that setting used-limit to bogus data when namespaces are present already triggers a re-calculation and fix-up through the existing code (enqueue of namespaces forces recalc).

Note however that a bug in the webhook causes the rejection of the original changes, and may do the same for our fix.
This bug has the webhook perform request validation using the old (user-supplied bogus) data, which fails.

Only after the bug in the webhook is fixed should this PR be effective as an additional place performing project cleanup.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_