### PR TITLE
[main] Ensure all `r/r` chart images use systemDefaultRegistry value

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
       {{- toYaml .Values.extraTolerations | nindent 8 }}
       {{- end }}
       containers:
-      - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
+      - image: {{ printf "%s%s" (include "system_default_registry" .) .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}
         name: {{ template "rancher.name" . }}
         ports:
@@ -230,7 +230,7 @@ spec:
 {{- if eq .Values.auditLog.destination "sidecar" }}
   {{- if .Values.auditLog.enabled }}
       # Make audit logs available for Rancher log collector tools.
-      - image: {{ include "auditLog_image" . }}
+      - image: {{ printf "%s%s" (include "system_default_registry" .) (include "auditLog_image" .) }}
         imagePullPolicy: {{ default .Values.auditLog.image.pullPolicy .Values.busyboxImagePullPolicy }}
         name: {{ template "rancher.name" . }}-audit-log
         command: ["tail"]

--- a/chart/templates/post-delete-hook-job.yaml
+++ b/chart/templates/post-delete-hook-job.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: {{ template "rancher.name" . }}-post-delete
-          image: "{{ include "system_default_registry" . }}{{ .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
+          image: "{{ printf "%s%s" (include "system_default_registry" .) .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0

--- a/chart/templates/pre-upgrade-hook-job.yaml
+++ b/chart/templates/pre-upgrade-hook-job.yaml
@@ -19,7 +19,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ template "rancher.name" . }}-pre-upgrade
-          image: "{{ include "system_default_registry" . }}{{ .Values.preUpgrade.image.repository }}:{{ .Values.preUpgrade.image.tag }}"
+          image: "{{ printf "%s%s" (include "system_default_registry" .) .Values.preUpgrade.image.repository }}:{{ .Values.preUpgrade.image.tag }}"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0

--- a/chart/tests/images_test.yaml
+++ b/chart/tests/images_test.yaml
@@ -1,0 +1,42 @@
+suite: Test Chart Images
+tests:
+  - it: "should correctly set image for deployment.yaml"
+    templates:
+      - deployment.yaml
+    set:
+      systemDefaultRegistry: "registry.company.com"
+      rancherImageTag: "v1.0.0-testing"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.company.com/rancher/rancher:v1.0.0-testing"
+  - it: "should correctly set image for pre-upgrade-hook-job.yaml"
+    templates:
+      - pre-upgrade-hook-job.yaml
+    set:
+      systemDefaultRegistry: "registry.company.com"
+      preUpgrade:
+        image:
+          tag: "v1.0.0-testing"
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.company.com/rancher/shell:v1.0.0-testing"
+  - it: "should correctly set image for post-delete-hook-job.yaml"
+    templates:
+      - post-delete-hook-job.yaml
+    set:
+      systemDefaultRegistry: "registry.company.com"
+      postDelete:
+        image:
+          tag: "v1.0.0-testing"
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.company.com/rancher/shell:v1.0.0-testing"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -121,7 +121,8 @@ privateCA: false
 # comma separated list of domains or ip addresses that will not use the proxy
 noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
 
-# Override rancher image location for Air Gap installs
+# Override the name of the Rancher image to pull.
+# To override the registry location use systemDefaultRegistry instead.
 rancherImage: rancher/rancher
 # rancher/rancher image tag. https://hub.docker.com/r/rancher/rancher/tags/
 # Defaults to .Chart.appVersion
@@ -151,6 +152,7 @@ resources: {}
 # - external
 tls: ingress
 
+# Set a custom image registry mirror to pull Rancher images from; useful in air-gapped environments.
 systemDefaultRegistry: ""
 
 # Set to use the packaged system charts

--- a/dev-scripts/prepare-chart
+++ b/dev-scripts/prepare-chart
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+file="$(git rev-parse --show-toplevel)/build.yaml"
+DEFAULT_SHELL_IMAGE=$(grep -m1 'defaultShellVersion' "$file" | cut -d ' ' -f2)
+rancher_shell_image_name=$(echo "${DEFAULT_SHELL_IMAGE}" | cut -d ":" -f 1) || ""
+rancher_shell_image_tag=$(echo "${DEFAULT_SHELL_IMAGE}" | cut -d ":" -f 2) || ""
+
 function is_gnu_sed(){
   sed --version >/dev/null 2>&1
 }
@@ -57,10 +62,10 @@ echo "Preparing Rancher Chart for release: ${CHART_VERSION}"
 
 sed_i_wrapper -i -e "s/%VERSION%/${CHART_VERSION}/g" ./chart/Chart.yaml
 sed_i_wrapper -i -e "s/%APP_VERSION%/${APP_VERSION}/g" ./chart/Chart.yaml
-sed_i_wrapper -i -e "s@%POST_DELETE_IMAGE_NAME%@${test_image}@g" ./chart/values.yaml
-sed_i_wrapper -i -e "s/%POST_DELETE_IMAGE_TAG%/${APP_VERSION}/g" ./chart/values.yaml
-sed_i_wrapper -i -e "s@%PRE_UPGRADE_IMAGE_NAME%@${test_image}@g" ./chart/values.yaml
-sed_i_wrapper -i -e "s/%PRE_UPGRADE_IMAGE_TAG%/${APP_VERSION}/g" ./chart/values.yaml
+sed_i_wrapper -i -e "s@%POST_DELETE_IMAGE_NAME%@${rancher_shell_image_name}@g" ./chart/values.yaml
+sed_i_wrapper -i -e "s/%POST_DELETE_IMAGE_TAG%/${rancher_shell_image_tag}/g" ./chart/values.yaml
+sed_i_wrapper -i -e "s@%PRE_UPGRADE_IMAGE_NAME%@${rancher_shell_image_name}@g" ./chart/values.yaml
+sed_i_wrapper -i -e "s/%PRE_UPGRADE_IMAGE_TAG%/${rancher_shell_image_tag}/g" ./chart/values.yaml
 
 if [[ $REPO != "rancher" ]]; then
   sed_i_wrapper -i -e "s#rancherImage: rancher/rancher#rancherImage: ${test_image}#g" ./chart/values.yaml


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/52108
 
## Problem
Rancher chart values not acting as expected with system default registry.
 
## Solution
Fix missing chart logic (and follow up in `rancher-prime` too).
 
## Testing
N/A

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manual testing with `helm template` commands


### Automated Testing
Add more helm-unittest to cover this use case.

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_