### PR TITLE
manage-user can't update password for other users

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -37,7 +37,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	rb := newRoleBuilder()
 
 	clusterCreateRole := rb.addRole("Create Clusters", "clusters-create")
-		clusterCreateRole.addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
+	clusterCreateRole.addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
@@ -46,7 +46,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
 		addRule().apiGroups("rke.cattle.io").resources("etcdsnapshots").verbs("get", "list", "watch")
-	
+
 	clusterCreateRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create").
 		addNamespacedRule("fleet-default").addRule().apiGroups("").resources("secrets").verbs("create")
 
@@ -55,7 +55,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	rb.addRole("Manage Cluster Drivers", "kontainerdrivers-manage").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("*")
 	rb.addRole("Manage Users", "users-manage").
-		addNamespacedRule(pbkdf2.LocalUserPasswordsNamespace).addRule().apiGroups("").resources("secrets").verbs("create").
+		addNamespacedRule(pbkdf2.LocalUserPasswordsNamespace).addRule().apiGroups("").resources("secrets").verbs("create", "update").
 		addRule().apiGroups("ext.cattle.io").resources("groupmembershiprefreshrequests").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("users", "globalrolebindings").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("globalroles").verbs("get", "list", "watch")


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52111
 
## Problem

"Manage Users" role cannot update password via `PasswordChangeRequest`
 
## Solution
Grant "Manage Users" role update secrets in the `cattle-local-user-passwords` namespace. This will allow to change any password for any user. That's the current behavior and it is documented (see danger box [here](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions#combining-built-in-globalroles)).