### PR TITLE
fix kubectl explain users

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -102,26 +102,47 @@ func (t *Token) GetExpiresAt() string {
 }
 
 // +genclient
-// +kubebuilder:skipversion
 // +genclient:nonNamespaced
+// +kubebuilder:resource:scope=Cluster
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// User represents a user in Rancher
 type User struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// DisplayName is the user friendly name shown in the UI
+	// +optional
 	DisplayName string `json:"displayName,omitempty"`
+	// Description provides a brief summary about the user
+	// +optional
 	Description string `json:"description"`
-	Username    string `json:"username,omitempty"`
-	// Deprecated. Password are stored in secrets in the cattle-local-user-passwords namespace.
-	Password           string   `json:"password,omitempty" norman:"writeOnly,noupdate"`
-	MustChangePassword bool     `json:"mustChangePassword,omitempty"`
-	PrincipalIDs       []string `json:"principalIds,omitempty" norman:"type=array[reference[principal]]"`
-	// Deprecated. Me is an old field only used in the norman API.
-	Me      bool       `json:"me,omitempty" norman:"nocreate,noupdate"`
-	Enabled *bool      `json:"enabled,omitempty" norman:"default=true"`
-	Spec    UserSpec   `json:"spec,omitempty"`
-	Status  UserStatus `json:"status"`
+	// Username is the unique login identifier for the user
+	// +optional
+	Username string `json:"username,omitempty"`
+	// Deprecated. Password are stored in secrets in the cattle-local-user-passwords namespace
+	// +optional
+	Password string `json:"password,omitempty" norman:"writeOnly,noupdate"`
+	// MustChangePassword is a flag that, if true, forces the user to change their
+	// password upon their next login.
+	// +optional
+	MustChangePassword bool `json:"mustChangePassword,omitempty"`
+	// PrincipalIDs lists the authentication provider identities (e.g. GitHub, Keycloak or Active Directory)
+	// that are associated with this user account.
+	// +optional
+	PrincipalIDs []string `json:"principalIds,omitempty" norman:"type=array[reference[principal]]"`
+	// Deprecated. Me is an old field only used in the norman API
+	// +optional
+	Me bool `json:"me,omitempty" norman:"nocreate,noupdate"`
+	// Enabled indicates whether the user account is active
+	// +optional
+	Enabled *bool `json:"enabled,omitempty" norman:"default=true"`
+	// Spec holds the desired state and configuration for the user
+	// +optional
+	Spec UserSpec `json:"spec,omitempty"`
+	// Status contains the most recent observed state of the user
+	// +optional
+	Status UserStatus `json:"status"`
 }
 
 // IsSystem returns true if the user is a system user.
@@ -141,6 +162,7 @@ func (u *User) IsDefaultAdmin() bool {
 }
 
 type UserStatus struct {
+	// +optional
 	Conditions []UserCondition `json:"conditions"`
 }
 

--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -277,7 +277,7 @@ var MigratedResources = map[string]bool{
 	"templateversions.management.cattle.io":                           false,
 	"tokens.management.cattle.io":                                     false,
 	"userattributes.management.cattle.io":                             false,
-	"users.management.cattle.io":                                      false,
+	"users.management.cattle.io":                                      true,
 	"uiplugins.catalog.cattle.io":                                     true,
 	"workloads.project.cattle.io":                                     false,
 }

--- a/pkg/crds/yaml/generated/management.cattle.io_users.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_users.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: users.management.cattle.io
+spec:
+  group: management.cattle.io
+  names:
+    kind: User
+    listKind: UserList
+    plural: users
+    singular: user
+  scope: Cluster
+  versions:
+  - name: v3
+    schema:
+      openAPIV3Schema:
+        description: User represents a user in Rancher
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          description:
+            description: Description provides a brief summary about the user
+            type: string
+          displayName:
+            description: DisplayName is the user friendly name shown in the UI
+            type: string
+          enabled:
+            description: Enabled indicates whether the user account is active
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          me:
+            description: Deprecated. Me is an old field only used in the norman API
+            type: boolean
+          metadata:
+            type: object
+          mustChangePassword:
+            description: |-
+              MustChangePassword is a flag that, if true, forces the user to change their
+              password upon their next login.
+            type: boolean
+          password:
+            description: Deprecated. Password are stored in secrets in the cattle-local-user-passwords
+              namespace
+            type: string
+          principalIds:
+            description: |-
+              PrincipalIDs lists the authentication provider identities (e.g. GitHub, Keycloak or Active Directory)
+              that are associated with this user account.
+            items:
+              type: string
+            type: array
+          spec:
+            description: Spec holds the desired state and configuration for the user
+            type: object
+          status:
+            description: Status contains the most recent observed state of the user
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of user condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+          username:
+            description: Username is the unique login identifier for the user
+            type: string
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52107

### Problem
kubectl explain does not show any information for users

### Solution
Set the user resource as migrated to the Public API, so kubebuilder is used to generate the crd yaml. Comments added to all fields, so they are displayed in kubectl explain