### PR TITLE
[main] Follow up to systemDefaultRegistry fixes

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -4,6 +4,9 @@
 {{ end -}}
 {{- include "chart.deprecated" (list .Values.busyboxImage ".Values.busyboxImage" "Use `.Values.auditLog.image.repository` & `.Values.auditLog.image.tag` instead.") -}}
 {{- include "chart.replace" (list .Values.busyboxImagePullPolicy ".Values.busyboxImagePullPolicy" ".Values.auditLog.image.pullPolicy") -}}
+{{- include "chart.deprecated" (list .Values.rancherImage ".Values.rancherImage" "Use `.Values.image.repository` & `.Values.image.registry` instead; if you used image name with Registry included you must split them up.") -}}
+{{- include "chart.replace" (list .Values.rancherImageTag ".Values.rancherImageTag" ".Values.image.tag") -}}
+{{- include "chart.replace" (list .Values.rancherImagePullPolicy ".Values.rancherImagePullPolicy" ".Values.image.pullPolicy") -}}
 
 
 Rancher Server has been {{ $action }}. Rancher may take several minutes to fully initialize.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -2,9 +2,13 @@
 {{ if .Release.IsUpgrade -}}
 {{ $action = "upgraded" -}}
 {{ end -}}
-Rancher Server has been {{ $action }}.
+{{- include "chart.deprecated" (list .Values.busyboxImage ".Values.busyboxImage" "Use `.Values.auditLog.image.repository` & `.Values.auditLog.image.tag` instead.") -}}
+{{- include "chart.replace" (list .Values.busyboxImagePullPolicy ".Values.busyboxImagePullPolicy" ".Values.auditLog.image.pullPolicy") -}}
 
-NOTE: Rancher may take several minutes to fully initialize. Please standby while Certificates are being issued, Containers are started and the Ingress rule comes up.
+
+Rancher Server has been {{ $action }}. Rancher may take several minutes to fully initialize.
+
+Please standby while Certificates are being issued, Containers are started and the Ingress rule comes up.
 
 Check out our docs at https://rancher.com/docs/
 

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -2,11 +2,11 @@
 {{ if .Release.IsUpgrade -}}
 {{ $action = "upgraded" -}}
 {{ end -}}
-{{- include "chart.deprecated" (list .Values.busyboxImage ".Values.busyboxImage" "Use `.Values.auditLog.image.repository` & `.Values.auditLog.image.tag` instead.") -}}
-{{- include "chart.replace" (list .Values.busyboxImagePullPolicy ".Values.busyboxImagePullPolicy" ".Values.auditLog.image.pullPolicy") -}}
-{{- include "chart.deprecated" (list .Values.rancherImage ".Values.rancherImage" "Use `.Values.image.repository` & `.Values.image.registry` instead; if you used image name with Registry included you must split them up.") -}}
-{{- include "chart.replace" (list .Values.rancherImageTag ".Values.rancherImageTag" ".Values.image.tag") -}}
-{{- include "chart.replace" (list .Values.rancherImagePullPolicy ".Values.rancherImagePullPolicy" ".Values.image.pullPolicy") -}}
+{{- include "tpl.chart.deprecated" (list .Values.busyboxImage ".Values.busyboxImage" "Use `.Values.auditLog.image.repository` & `.Values.auditLog.image.tag` instead.") -}}
+{{- include "tpl.chart.replace" (list .Values.busyboxImagePullPolicy ".Values.busyboxImagePullPolicy" ".Values.auditLog.image.pullPolicy") -}}
+{{- include "tpl.chart.deprecated" (list .Values.rancherImage ".Values.rancherImage" "Use `.Values.image.repository` & `.Values.image.registry` instead; if you used image name with Registry included you must split them up.") -}}
+{{- include "tpl.chart.replace" (list .Values.rancherImageTag ".Values.rancherImageTag" ".Values.image.tag") -}}
+{{- include "tpl.chart.replace" (list .Values.rancherImagePullPolicy ".Values.rancherImagePullPolicy" ".Values.image.pullPolicy") -}}
 
 
 Rancher Server has been {{ $action }}. Rancher may take several minutes to fully initialize.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,4 +1,26 @@
 {{/* vim: set filetype=mustache: */}}
+
+{{ define "chart.deprecated" -}}
+{{ $val := index . 0 -}}
+{{ $name := index . 1 -}}
+{{ $msg := "" -}}
+{{ if ge (len .) 3 -}}
+  {{ $msg = index . 2 -}}
+{{ end -}}
+{{ if $val -}}
+{{ printf "[WARNING] Deprecated: %s is deprecated and will be removed in a future release.%s\n" $name $msg | indent 0 }}
+{{ end -}}
+{{ end -}}
+
+{{ define "chart.replace" -}}
+{{ $val := index . 0 -}}
+{{ $old := index . 1 -}}
+{{ $new := index . 2 -}}
+{{ if $val -}}
+{{ printf "[WARNING] Deprecated: %s is deprecated. Please use %s instead.\n" $old $new | indent 0 }}
+{{ end -}}
+{{ end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{/* vim: set filetype=mustache: */}}
 
-{{ define "chart.deprecated" -}}
+{{ define "tpl.chart.deprecated" -}}
 {{ $val := index . 0 -}}
 {{ $name := index . 1 -}}
 {{ $msg := "" -}}
@@ -12,7 +12,7 @@
 {{ end -}}
 {{ end -}}
 
-{{ define "chart.replace" -}}
+{{ define "tpl.chart.replace" -}}
 {{ $val := index . 0 -}}
 {{ $old := index . 1 -}}
 {{ $new := index . 2 -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -50,6 +50,48 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Prepare the Rancher Image value w/ new fields as opt-in for now.
+*/}}
+{{ define "rancher.image" -}}
+{{ if .Values.rancherImage -}}
+{{ .Values.rancherImage -}}
+{{ else -}}
+{{ $reg := default "" (default .Values.systemDefaultRegistry .Values.image.registry) -}}
+{{ if eq "" $reg -}}
+{{ include "rancher.imageRepo" . -}}
+{{ else -}}
+{{ if hasSuffix "/" $reg -}}
+{{ printf "%s%s" $reg (include "rancher.imageRepo" .) -}}
+{{ else -}}
+{{ printf "%s/%s" $reg (include "rancher.imageRepo" .) -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{/*
+Prepare the Rancher Image repo value w/ new fields as opt-in for now.
+*/}}
+{{ define "rancher.imageRepo" -}}
+{{ default "rancher/rancher" .Values.image.repository -}}
+{{ end -}}
+
+
+{{/*
+Prepare the Rancher Image Tag value w/ new fields as opt-in for now.
+*/}}
+{{ define "rancher.imageTag" -}}
+{{ default .Chart.AppVersion (default .Values.image.tag (default "" .Values.rancherImageTag)) -}}
+{{ end -}}
+
+{{/*
+Prepare the Rancher Image Pull Policy value w/ new fields as opt-in for now.
+*/}}
+{{ define "rancher.imagePullPolicy" -}}
+{{ default "IfNotPresent" (default .Values.image.pullPolicy (default "" .Values.rancherImagePullPolicy)) -}}
+{{ end -}}
+
+{{/*
 Render Values in configurationSnippet
 */}}
 {{- define "configurationSnippet" -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,5 +1,10 @@
 {{/* vim: set filetype=mustache: */}}
 
+{{- define "tpl.url.ensureTrailingSlash" -}}
+{{- $url := . | trimSuffix "/" -}}
+{{- printf "%s/" $url -}}
+{{- end -}}
+
 {{ define "tpl.chart.deprecated" -}}
 {{ $val := index . 0 -}}
 {{ $name := index . 1 -}}
@@ -162,10 +167,8 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 
 {{- define "system_default_registry" -}}
 {{- if .Values.systemDefaultRegistry -}}
-  {{- if hasSuffix "/" .Values.systemDefaultRegistry -}}
-    {{- printf "%s" .Values.systemDefaultRegistry -}}
-  {{- else -}}
-    {{- printf "%s/" .Values.systemDefaultRegistry -}}
+{{- include "tpl.url.ensureTrailingSlash" .Values.systemDefaultRegistry -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -170,6 +170,16 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 {{- include "tpl.url.ensureTrailingSlash" .Values.systemDefaultRegistry -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "defaultOrOverrideRegistry" -}}
+{{- $rootContext := index . 0 -}}
+{{- $inputRegistry := index . 1 | default "" -}}
+{{- if $inputRegistry -}}
+
+{{- $systemDefault := include "system_default_registry" $rootContext | default "" -}}
+
+{{- coalesce (include "tpl.url.ensureTrailingSlash" $inputRegistry) $systemDefault "" -}}
+
 {{- end -}}
 {{- end -}}
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -230,7 +230,7 @@ spec:
 {{- if eq .Values.auditLog.destination "sidecar" }}
   {{- if .Values.auditLog.enabled }}
       # Make audit logs available for Rancher log collector tools.
-      - image: {{ printf "%s%s" (include "system_default_registry" .) (include "auditLog_image" .) }}
+      - image: {{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . .Values.auditLog.image.registry)) (include "auditLog_image" .) }}
         imagePullPolicy: {{ default .Values.auditLog.image.pullPolicy .Values.busyboxImagePullPolicy }}
         name: {{ template "rancher.name" . }}-audit-log
         command: ["tail"]

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -230,7 +230,7 @@ spec:
 {{- if eq .Values.auditLog.destination "sidecar" }}
   {{- if .Values.auditLog.enabled }}
       # Make audit logs available for Rancher log collector tools.
-      - image: {{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . .Values.auditLog.image.registry)) (include "auditLog_image" .) }}
+      - image: "{{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . (default "" .Values.auditLog.image.registry))) (include "auditLog.image" .) }}"
         imagePullPolicy: {{ default .Values.auditLog.image.pullPolicy .Values.busyboxImagePullPolicy }}
         name: {{ template "rancher.name" . }}-audit-log
         command: ["tail"]

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -71,8 +71,8 @@ spec:
       {{- toYaml .Values.extraTolerations | nindent 8 }}
       {{- end }}
       containers:
-      - image: {{ printf "%s%s" (include "system_default_registry" .) .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
-        imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}
+      - image: "{{ template "rancher.image" . }}:{{ template "rancher.imageTag" . }}"
+        imagePullPolicy: {{ include "rancher.imagePullPolicy" . }}
         name: {{ template "rancher.name" . }}
         ports:
         - containerPort: 80

--- a/chart/templates/post-delete-hook-job.yaml
+++ b/chart/templates/post-delete-hook-job.yaml
@@ -20,8 +20,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: {{ template "rancher.name" . }}-post-delete
-          image: "{{ printf "%s%s" (include "system_default_registry" .) .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          image: "{{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . .Values.postDelete.image.registry)) .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.postDelete.pullPolicy }}
           securityContext:
             runAsUser: 0
           command:

--- a/chart/templates/pre-upgrade-hook-job.yaml
+++ b/chart/templates/pre-upgrade-hook-job.yaml
@@ -19,8 +19,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ template "rancher.name" . }}-pre-upgrade
-          image: "{{ printf "%s%s" (include "system_default_registry" .) .Values.preUpgrade.image.repository }}:{{ .Values.preUpgrade.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          image: "{{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . .Values.preUpgrade.image.registry)) .Values.preUpgrade.image.repository }}:{{ .Values.preUpgrade.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.preUpgrade.pullPolicy }}
           securityContext:
             runAsUser: 0
           command:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -46,7 +46,7 @@
       "description": "The default rancher ingress configuration",
       "properties": {
         "servicePort": {
-          "type": "number",
+          "type": "integer",
           "enum": [443, 80]
         }
       }
@@ -57,10 +57,9 @@
     "properties": {
       "service": {
         "properties": {
-          "disableHTTP": {
-            "const": true
-          }
-        }
+          "disableHTTP": { "const": true }
+        },
+        "required": ["disableHTTP"]
       }
     }
   },
@@ -69,10 +68,10 @@
       "ingress": {
         "properties": {
           "servicePort": {
-            "const": 443,
-            "errorMessage": "ingress.servicePort must be 443 when service.disableHTTP is true."
+            "enum": [443]
           }
-        }
+        },
+        "required": ["servicePort"]
       }
     }
   }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1,5 +1,8 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:rancher:schema:rancher-chart:v1",
+  "title": "Rancher Chart Values",
+  "type": "object",
   "properties": {
     "agentTLSMode": {
       "type": ["string", "null"],
@@ -24,16 +27,6 @@
           "description": "auditLog.enabled must be a boolean"
         }
       }
-    },
-    "busyboxImage": {
-      "type": "string",
-      "description": "[DEPRECATED] This value is deprecated, use `auditLog.image.repository` & `auditLog.image.tag` instead.",
-      "deprecated": true
-    },
-    "busyboxImagePullPolicy": {
-      "type": "string",
-      "description": "[DEPRECATED] This value is deprecated, use `auditLog.image.pullPolicy` instead.",
-      "deprecated": true
     },
     "service": {
       "type": "object",
@@ -60,8 +53,6 @@
     }
   },
   "required": [],
-  "title": "Rancher Chart Values",
-  "type": "object",
   "if": {
     "properties": {
       "service": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -121,13 +121,23 @@ privateCA: false
 # comma separated list of domains or ip addresses that will not use the proxy
 noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
 
+# Rancher image configuration
+image:
+  # Optional: Image-specific registry override
+  # registry: ""
+  repository: rancher/rancher
+  # Defaults to .Chart.appVersion
+  # rancher/rancher image tag. https://hub.docker.com/r/rancher/rancher/tags/
+  tag: ""
+  pullPolicy: IfNotPresent
+
+## Deprecation Notice: `rancherImage`, `rancherImageTag`,  and `rancherImagePullPolicy` are deprecated - use `image.*` fields instead.
 # Override the name of the Rancher image to pull.
 # To override the registry location use systemDefaultRegistry instead.
-rancherImage: rancher/rancher
+# rancherImage: ""
 # rancher/rancher image tag. https://hub.docker.com/r/rancher/rancher/tags/
 # Defaults to .Chart.appVersion
 # rancherImageTag: v2.0.7
-
 # Override imagePullPolicy for rancher server images
 # options: Always, Never, IfNotPresent
 # Defaults to IfNotPresent

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -194,8 +194,13 @@ customLogos:
 postDelete:
   enabled: true
   image:
+    # Optional: Image-specific registry override
+    # registry: ""
     repository: %POST_DELETE_IMAGE_NAME%
     tag: %POST_DELETE_IMAGE_TAG%
+    # Optional: Image-specific pullPolicy Override
+    # options: Always, Never, IfNotPresent
+    # pullPolicy: "Always"
   namespaceList:
     - cattle-fleet-system
     - cattle-system
@@ -207,8 +212,12 @@ postDelete:
 
 preUpgrade:
   image:
+    # Optional: Image-specific registry override
+    # registry: ""
     repository: %PRE_UPGRADE_IMAGE_NAME%
     tag: %PRE_UPGRADE_IMAGE_TAG%
+    # Optional: Image-specific pull policy override
+    # pullPolicy: "Always"
 
 # Set a bootstrap password. If leave empty, a random password will be generated.
 bootstrapPassword: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -34,9 +34,11 @@ auditLog:
   # Image for collecting rancher audit logs.
   # Important: update pkg/image/export/resolve.go when this default image is changed, so that it's reflected accordingly in rancher-images.txt generated for air-gapped setups.
   image:
+    # Optional: Image-specific registry override
+    # registry: ""
     repository: "rancher/mirrored-bci-micro"
     tag: 15.6.24.2
-    # Override imagePullPolicy image
+    # Optional: Image-specific pullPolicy Override
     # options: Always, Never, IfNotPresent
     pullPolicy: "IfNotPresent"
 

--- a/scripts/chart/build
+++ b/scripts/chart/build
@@ -31,8 +31,3 @@ sed -i -e "s@%POST_DELETE_IMAGE_NAME%@${rancher_shell_image_name}@g" build/chart
 sed -i -e "s/%POST_DELETE_IMAGE_TAG%/${rancher_shell_image_tag}/g" build/chart/rancher/values.yaml
 sed -i -e "s@%PRE_UPGRADE_IMAGE_NAME%@${rancher_shell_image_name}@g" build/chart/rancher/values.yaml
 sed -i -e "s/%PRE_UPGRADE_IMAGE_TAG%/${rancher_shell_image_tag}/g" build/chart/rancher/values.yaml
-
-if [[ -v REGISTRY ]]; then
-  sed -i -e "s|systemDefaultRegistry: .*|systemDefaultRegistry: ${REGISTRY}|g" build/chart/rancher/values.yaml
-  sed -i -e 's/^\(|[[:space:]]*`systemDefaultRegistry`[[:space:]]*|\)[[:space:]]*"[^"]*"/\1"'"${REGISTRY}"'"/g' build/chart/rancher/README.md
-fi

--- a/scripts/chart/build
+++ b/scripts/chart/build
@@ -33,5 +33,6 @@ sed -i -e "s@%PRE_UPGRADE_IMAGE_NAME%@${rancher_shell_image_name}@g" build/chart
 sed -i -e "s/%PRE_UPGRADE_IMAGE_TAG%/${rancher_shell_image_tag}/g" build/chart/rancher/values.yaml
 
 if [[ -v REGISTRY ]]; then
-  sed -i -e "s/rancherImage:\ rancher\/rancher/rancherImage:\ $REGISTRY\/rancher\/rancher/" build/chart/rancher/values.yaml
+  sed -i -e "s|systemDefaultRegistry: .*|systemDefaultRegistry: ${REGISTRY}|g" build/chart/rancher/values.yaml
+  sed -i -e 's/^\(|[[:space:]]*`systemDefaultRegistry`[[:space:]]*|\)[[:space:]]*"[^"]*"/\1"'"${REGISTRY}"'"/g' build/chart/rancher/README.md
 fi


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/52128
Build Error: https://github.com/rancher/rancher/actions/runs/18036563542/job/51328120261#step:6:637

## Problem
TL;DR: Helm unit tests fail after my fix because we customize the chart to have `docker.io` on the `rancherImage`. After the fix, this causes the image to be incorrect in Helm unit tests that validate overriding the `systemDefaultRegistry`.

```
				-registry.company.com/rancher/rancher:v1.0.0-testing
				+registry.company.com/docker.io/rancher/rancher:v1.0.0-testing
```

Note: `registry.company.com` is the helm unit test local customization - `docker.io` comes from `rancherImage`.

A logical fix might be changing the build script to match the change made to `rancher/rancher-prime`. Unfortunately, after adjusting the build script to customize `systemDefaultRegistry` this cause more helm unit tests errors. Because now all tests expecting `""` as that value have the value set.

This is really a second issue ultimately - as helm unit tests are written with the expectation of the default `values.yaml` file and part of the build process is modifying those values.
 
## Solution

### Fix the remaining chart bugs
Fully commit to setting up a new - more standardized - way to manage the images. Create lots of helm helpers/functions to make the old system still work so the "full fix" is opt-in. The gist being that all Rancher images are in the top level `images` field.

### Fix the Deprecations in JSONschema being ineffective
Added new helpers to generate deprecation warnings into `NOTES.txt`. Before this no obvious indication that a deprecated field/value was used is given. After this change users should see:

```
NOTES:
[WARNING] Deprecated: .Values.busyboxImage is deprecated and will be removed in a future release.Use `.Values.auditLog.image.repository` & `.Values.auditLog.image.tag` instead.

[WARNING] Deprecated: .Values.busyboxImagePullPolicy is deprecated. Please use .Values.auditLog.image.pullPolicy instead.

Rancher Server has been installed
```

