### PR TITLE
[RoleTemplate Aggregation] When binding to promoted rules, use aggregated cluster role

### DIFF
--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler.go
@@ -407,7 +407,7 @@ func (p *prtbHandler) ensureOnlyDesiredClusterRoleBindingsExists(crbs []*rbacv1.
 
 // doesRoleTemplateHavePromotedRules checks if the PRTB's RoleTemplate has a ClusterRole for promoted rules.
 func (p *prtbHandler) doesRoleTemplateHavePromotedRules(rt *v3.RoleTemplate) (bool, error) {
-	_, err := p.crClient.Get(rbac.PromotedClusterRoleNameFor(rt.Name), metav1.GetOptions{})
+	_, err := p.crClient.Get(rbac.AggregatedClusterRoleNameFor(rbac.PromotedClusterRoleNameFor(rt.Name)), metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
 	}

--- a/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/prtb_handler_test.go
@@ -30,7 +30,7 @@ var (
 	defaultRT = v3.RoleTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-rt"},
 	}
-	promotedCRName = "test-rt-promoted"
+	promotedCRName = "test-rt-promoted-aggregator"
 	errDefault     = fmt.Errorf("error")
 	errNotFound    = apierrors.NewNotFound(schema.GroupResource{}, "error")
 )


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49389
 
## Background
Promoted rules are cluster wide rules that are granted by project roletemplates. It's a set list of resources that are considered "exceptional" since they go beyond the project boundary.

## Problem
When binding to a project roletemplate was created that inherited another project roletemplate with promoted rules, the user wouldn't get any of the inherited promoted rules.
 
## Solution
The issue was that the logic for promoted rule binding was to bind to the cluster role, not the aggregated cluster role. Therefore it would bind to any promoted rules that existed for the top level roletemplate, but fail to add any inherited promoted rules.

Very simple fix is to just use the right name of the promoted rule. The logic for setting the subject of the binding actually had the right check, but the logic for checking in general was failing.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Using the reproduction steps from the issue, you can see that a user has all the correct permissions and all the right bindings are created.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: Updated the unit test to use the proper name.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_