### PR TITLE
[release/v2.12] Fix OIDC test failures

### DIFF
--- a/tests/controllers/oidc/oidc_provider_test.go
+++ b/tests/controllers/oidc/oidc_provider_test.go
@@ -239,7 +239,7 @@ func (s *OIDCProviderSuite) TestOIDCAuthorizationCodeFlow() {
 		clientID = oidcClient.Status.ClientID
 		assert.NotEmpty(c, clientID)
 		secret, err := s.wranglerContext.Core.Secret().Get(clientSecretsNamespace, clientID, metav1.GetOptions{})
-		assert.NoError(s.T(), err)
+		assert.NoError(c, err)
 		clientSecret = string(secret.Data["client-secret-1"])
 		assert.NotEmpty(c, clientSecret)
 	}, duration, tick)


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/52141

This test keeps failing for me on my steve bump PR here: https://github.com/rancher/rancher/actions/runs/18105171812/job/51528059145?pr=52135:

```
 === RUN   TestOIDCProviderSuite/TestOIDCAuthorizationCodeFlow
I0929 19:34:49.078877   33553 warnings.go:110] "Warning: unknown field \"userPrincipal.metadata\""
    oidc_provider_test.go:242: 
        	Error Trace:	/home/runner/work/rancher/rancher/tests/controllers/oidc/oidc_provider_test.go:242
        	            				/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/runtime/asm_amd64.s:1700
        	Error:      	Received unexpected error:
        	            	resource name may not be empty
        	Test:       	TestOIDCProviderSuite/TestOIDCAuthorizationCodeFlow
time="2025-09-29T19:34:50Z" level=info msg="Shutting down management.cattle.io/v3, Kind=OIDCClient workers"
--- FAIL: TestOIDCProviderSuite (6.47s)
    --- FAIL: TestOIDCProviderSuite/TestOIDCAuthorizationCodeFlow (1.05s)
```

Previously, that line using `s.T()` will fail the "EventuallyWithT" instead of having it retry.