### PR TITLE
[RoleTemplate Aggregation] Check the right management plane cluster role for inheritance

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/crtb_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler.go
@@ -179,7 +179,7 @@ func (c *crtbHandler) getDesiredClusterRoleBindings(crtb *v3.ClusterRoleTemplate
 	desiredCRBs := map[string]*rbacv1.ClusterRoleBinding{}
 	// Check if there is a project management role to bind to
 	projectMagementRoleName := rbac.ProjectManagementPlaneClusterRoleNameFor(crtb.RoleTemplateName)
-	cr, err := c.crController.Get(projectMagementRoleName, metav1.GetOptions{})
+	cr, err := c.crController.Get(rbac.AggregatedClusterRoleNameFor(projectMagementRoleName), metav1.GetOptions{})
 	if err == nil && cr != nil {
 		crb, err := rbac.BuildAggregatingClusterRoleBindingFromRTB(crtb, projectMagementRoleName)
 		if err != nil {
@@ -192,7 +192,7 @@ func (c *crtbHandler) getDesiredClusterRoleBindings(crtb *v3.ClusterRoleTemplate
 
 	// Check if there is a cluster management role to bind to
 	clusterManagementRoleName := rbac.ClusterManagementPlaneClusterRoleNameFor(crtb.RoleTemplateName)
-	cr, err = c.crController.Get(clusterManagementRoleName, metav1.GetOptions{})
+	cr, err = c.crController.Get(rbac.AggregatedClusterRoleNameFor(clusterManagementRoleName), metav1.GetOptions{})
 	if err == nil && cr != nil {
 		crb, err := rbac.BuildAggregatingClusterRoleBindingFromRTB(crtb, clusterManagementRoleName)
 		if err != nil {

--- a/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
@@ -294,6 +294,11 @@ func Test_crtbHandler_reconcileMembershipBindings(t *testing.T) {
 	}
 }
 
+const (
+	projectMGMT = "test-rt-project-mgmt-aggregator"
+	clusterMGMT = "test-rt-cluster-mgmt-aggregator"
+)
+
 func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -306,7 +311,7 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 			name: "error getting project management plane role",
 			crtb: defaultCRTB.DeepCopy(),
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, errDefault)
+				m.EXPECT().Get(projectMGMT, metav1.GetOptions{}).Return(nil, errDefault)
 			},
 			wantErr: true,
 		},
@@ -314,8 +319,8 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 			name: "error getting cluster management plane role",
 			crtb: defaultCRTB.DeepCopy(),
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, errNotFound)
-				m.EXPECT().Get("test-rt-cluster-mgmt", metav1.GetOptions{}).Return(nil, errDefault)
+				m.EXPECT().Get(projectMGMT, metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get(clusterMGMT, metav1.GetOptions{}).Return(nil, errDefault)
 			},
 			wantErr: true,
 		},
@@ -323,8 +328,8 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 			name: "no cluster or project management plane role",
 			crtb: defaultCRTB.DeepCopy(),
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, errNotFound)
-				m.EXPECT().Get("test-rt-cluster-mgmt", metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get(projectMGMT, metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get(clusterMGMT, metav1.GetOptions{}).Return(nil, errNotFound)
 			},
 			want: map[string]*rbacv1.ClusterRoleBinding{},
 		},
@@ -332,8 +337,8 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 			name: "found project management plane role",
 			crtb: defaultCRTB.DeepCopy(),
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
-				m.EXPECT().Get("test-rt-cluster-mgmt", metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get(projectMGMT, metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
+				m.EXPECT().Get(clusterMGMT, metav1.GetOptions{}).Return(nil, errNotFound)
 			},
 			want: map[string]*rbacv1.ClusterRoleBinding{
 				"crb-5x2rfzlbvz": {
@@ -344,7 +349,7 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: "rbac.authorization.k8s.io",
 						Kind:     "ClusterRole",
-						Name:     "test-rt-project-mgmt-aggregator",
+						Name:     projectMGMT,
 					},
 					Subjects: defaultCRB.Subjects,
 				},
@@ -354,8 +359,8 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 			name: "found cluster management plane role",
 			crtb: defaultCRTB.DeepCopy(),
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, errNotFound)
-				m.EXPECT().Get("test-rt-cluster-mgmt", metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
+				m.EXPECT().Get(projectMGMT, metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get(clusterMGMT, metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
 			},
 			want: map[string]*rbacv1.ClusterRoleBinding{
 				"crb-meemnnklov": {
@@ -366,7 +371,7 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: "rbac.authorization.k8s.io",
 						Kind:     "ClusterRole",
-						Name:     "test-rt-cluster-mgmt-aggregator",
+						Name:     clusterMGMT,
 					},
 					Subjects: defaultCRB.Subjects,
 				},
@@ -376,8 +381,8 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 			name: "found both project and cluster management plane role",
 			crtb: defaultCRTB.DeepCopy(),
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
-				m.EXPECT().Get("test-rt-cluster-mgmt", metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
+				m.EXPECT().Get(projectMGMT, metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
+				m.EXPECT().Get(clusterMGMT, metav1.GetOptions{}).Return(&rbacv1.ClusterRole{}, nil)
 			},
 			want: map[string]*rbacv1.ClusterRoleBinding{
 				"crb-meemnnklov": {
@@ -388,7 +393,7 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: "rbac.authorization.k8s.io",
 						Kind:     "ClusterRole",
-						Name:     "test-rt-cluster-mgmt-aggregator",
+						Name:     clusterMGMT,
 					},
 					Subjects: defaultCRB.Subjects,
 				},
@@ -400,7 +405,7 @@ func Test_crtbHandler_getDesiredClusterRoleBindings(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: "rbac.authorization.k8s.io",
 						Kind:     "ClusterRole",
-						Name:     "test-rt-project-mgmt-aggregator",
+						Name:     projectMGMT,
 					},
 					Subjects: defaultCRB.Subjects,
 				},

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler.go
@@ -133,7 +133,7 @@ func (p *prtbHandler) reconcileBindings(prtb *v3.ProjectRoleTemplateBinding) err
 	projectManagementRoleName := rbac.ProjectManagementPlaneClusterRoleNameFor(prtb.RoleTemplateName)
 
 	// If there is no project management plane role, no need to create a binding for it
-	_, err := p.crController.Get(projectManagementRoleName, metav1.GetOptions{})
+	_, err := p.crController.Get(rbac.AggregatedClusterRoleNameFor(projectManagementRoleName), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
@@ -212,7 +212,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "error getting cluster role",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, fmt.Errorf("error"))
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, fmt.Errorf("error"))
 			},
 			prtb: &v3.ProjectRoleTemplateBinding{
 				RoleTemplateName: "test-rt",
@@ -222,7 +222,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "no error when cluster role doesn't exist",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, errNotFound)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, errNotFound)
 			},
 			prtb: &v3.ProjectRoleTemplateBinding{
 				RoleTemplateName: "test-rt",
@@ -232,7 +232,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "error building clusterrolebinding",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			prtb: &v3.ProjectRoleTemplateBinding{
 				RoleTemplateName: "test-rt",
@@ -242,7 +242,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "error listing clusterrolebindings",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]) {
 				m.EXPECT().List(metav1.ListOptions{LabelSelector: ownerLabel}).Return(nil, errDefault)
@@ -257,7 +257,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "error listing clusterrolebindings",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]) {
 				m.EXPECT().List(metav1.ListOptions{LabelSelector: ownerLabel}).Return(nil, errDefault)
@@ -272,7 +272,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "error deleting unwanted clusterrolebindings",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]) {
 				m.EXPECT().List(metav1.ListOptions{LabelSelector: ownerLabel}).Return(&rbacv1.ClusterRoleBindingList{
@@ -294,7 +294,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "CRB already exists",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]) {
 				m.EXPECT().List(metav1.ListOptions{LabelSelector: ownerLabel}).Return(&rbacv1.ClusterRoleBindingList{
@@ -310,7 +310,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "CRB already exists with extra bad CRBs",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]) {
 				m.EXPECT().List(metav1.ListOptions{LabelSelector: ownerLabel}).Return(&rbacv1.ClusterRoleBindingList{
@@ -332,7 +332,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "CRB needs to be created",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]) {
 				m.EXPECT().List(metav1.ListOptions{LabelSelector: ownerLabel}).Return(&rbacv1.ClusterRoleBindingList{
@@ -349,7 +349,7 @@ func Test_reconcileBindings(t *testing.T) {
 		{
 			name: "error creating CRB",
 			setupCRController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]) {
-				m.EXPECT().Get("test-rt-project-mgmt", metav1.GetOptions{}).Return(nil, nil)
+				m.EXPECT().Get("test-rt-project-mgmt-aggregator", metav1.GetOptions{}).Return(nil, nil)
 			},
 			setupCRBController: func(m *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]) {
 				m.EXPECT().List(metav1.ListOptions{LabelSelector: ownerLabel}).Return(&rbacv1.ClusterRoleBindingList{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49224
 
## Problem
Very similar to https://github.com/rancher/rancher/pull/52140 where the check for inherited special rules is checking the base cluster role and not the aggregation cluster role.

In this case, the binding wasn't happening for management plane rules, which are resources that can be given via project or cluster roletemplate that exist within the management cluster.
 
## Solution
Check for the aggregation cluster roles instead of the base cluster role. It was already attempting to bind to the right clusterrole, but the check was incorrect.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Ran the tests from the issue as well as testing project roletemplates too

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: Fixed the unit tests

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_