### PR TITLE
[main] Add updatecli automation to bump K8s and K3s

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,86 @@
+name: "updatecli"
+
+on:
+  schedule:
+    # Runs daily at 12:00 UTC.
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install updatecli
+        uses: updatecli/updatecli-action@57aa8966d4d775cb1420b90c270ba97a4b5abe47 # v2.93.0
+
+      - name: Install Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Delete leftover updatecli branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list \
+            --search "is:closed is:pr head:updatecli_" \
+            --json headRefName \
+            --jq ".[].headRefName" | sort -u > closed_prs_branches.txt
+          gh pr list \
+            --search "is:open is:pr head:updatecli_" \
+            --json headRefName \
+            --jq ".[].headRefName" | sort -u > open_prs_branches.txt
+          for branch in $(comm -23 closed_prs_branches.txt open_prs_branches.txt); do
+            if (git ls-remote --exit-code --heads origin "${branch}"); then
+              echo "Deleting leftover updatecli branch - ${branch}";
+              git push origin --delete "${branch}";
+            fi
+          done
+
+      - name: Get App secrets
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          # We use Renovate's App token, because it has the same permissions
+          # needed and serve the same purpose.
+          secrets: |
+            secret/data/github/org/rancher/github/renovate-rancher appId      | APP_ID ;
+            secret/data/github/org/rancher/github/renovate-rancher privateKey | PRIVATE_KEY
+
+      - name: Create App token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: app-token
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+
+      - name: Apply updatecli
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Never use '--debug' or 'manifest show' options, because they will
+          # leak the GH token.
+          #
+          # We run a first apply to update versions.yaml with the needed K8s
+          # and K3s versions. This is currently a workaround for the
+          # autodiscovery module (to be removed once
+          # https://github.com/updatecli/updatecli/issues/6076 is implemented).
+          updatecli apply --clean --values updatecli/values.d/values.yaml   \
+                                  --values updatecli/values.d/versions.yaml \
+                                  --config updatecli/updatecli.d/update-versions-config-yaml/
+          # Copy the updated versions.yaml to updatecli's folder.
+          cp /tmp/updatecli/github/rancher/rancher/updatecli/values.d/versions.yaml updatecli/values.d/versions.yaml
+          # This apply is responsible for updating the dependencies.
+          updatecli apply --clean --values updatecli/values.d/values.yaml   \
+                                  --values updatecli/values.d/versions.yaml \
+                                  --config updatecli/updatecli.d/update-k8s-k3s/

--- a/updatecli/README.md
+++ b/updatecli/README.md
@@ -43,7 +43,7 @@ its main purpose.
 
 Local testing of manifests require:
 
-1. The updatecli binary that can be download from
+1. The updatecli binary that can be downloaded from
 [updatecli/updatecli#releases]. Test only with the latest stable version.
    1. Always run locally with the command `diff`, that will show the changes
 without actually applying them.

--- a/updatecli/README.md
+++ b/updatecli/README.md
@@ -1,0 +1,70 @@
+# updatecli automation
+
+The Rancher project uses [updatecli] to automate and orchestrate security
+related updates and versions bumps.
+
+## Tool
+
+We use updatecli for this automation, instead of Dependabot or Renovate,
+because of its extensibility and multiple plugins resources that allow greater
+flexibility when automating sequences of conditional update steps.
+
+For detailed information on how to use updatecli, please consult its
+[documentation].
+
+## Scheduled workflow
+
+The automation runs as a GitHub Actions scheduled workflow once per day. Manual
+execution of the pipelines can be [triggered] when needed.
+
+## Project organization
+
+A manifest or pipeline consists of three stages: `sources`, `conditions` and
+`targets`, that define how to apply the update strategy.
+
+When adding a new manifest, please follow the example structure defined below.
+
+```
+updatecli/
+├── README.md
+├── scripts                                # For auxiliary scripts if needed
+├── updatecli.d                            # For the update related workflows
+│   ├── update-k8s-k3s                     # Each workflow should have its own subdirectory
+│   └── update-versions-config-yaml        # Another workflow in its own directory
+└── values.d                               # For variable related configuration files
+    ├── values.yaml                        # Configuration values
+    └── versions.yaml                      # Configuration versions
+```
+
+The manifest files must be placed inside a directory path named accordingly to
+its main purpose.
+
+## Local testing
+
+Local testing of manifests require:
+
+1. The updatecli binary that can be download from
+[updatecli/updatecli#releases]. Test only with the latest stable version.
+   1. Always run locally with the command `diff`, that will show the changes
+without actually applying them.
+1. A GitHub personal fine-grained token.
+   1. For obvious security reasons and to avoid leaking your GH PAT, export it
+as a local environment variable.
+
+```shell
+export UPDATECLI_GITHUB_TOKEN="your GH token"
+updatecli diff --clean --values updatecli/values.d/values.yaml --values <other values files> --config updatecli/updatecli.d/<your workflow> 
+```
+
+## Contributing
+
+Before contributing, please follow the guidelines provided in this README and
+make sure to test locally your changes, and against your own fork, before
+opening a PR.
+
+
+<!-- Links -->
+[updatecli]: https://github.com/updatecli/updatecli
+[documentation]: https://www.updatecli.io/docs/prologue/introduction/
+[triggered]: https://github.com/rancher/rancher/actions/workflows/updatecli.yml
+[updatecli/updatecli#releases]: https://github.com/updatecli/updatecli/releases

--- a/updatecli/updatecli.d/update-k8s-k3s/_scm.yaml
+++ b/updatecli/updatecli.d/update-k8s-k3s/_scm.yaml
@@ -1,0 +1,32 @@
+# This is a partial file (prefixed with _) that allows to reuse the scm and
+# action configurations.
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repo }}'
+      branch: '{{ .scm.branch }}'
+      user: '{{ .scm.user }}'
+      email: '{{ .scm.email }}'
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+      commitusingapi: {{ .scm.commitusingapi }}
+      commitmessage:
+        squash: {{ .scm.commitmessage.squash }}
+        type: '{{ .k8s_k3s.commitmessage.type }}'
+        scope: '{{ .k8s_k3s.commitmessage.scope }}'
+        title: 'Bump patch versions of K8s and K3s'
+        body: 'Bump patch versions of K8s to {{ .k8s.main }} and K3s to {{ .k3s.release }}.'
+
+actions:
+  rancher-pr:
+    kind: github/pullrequest
+    scmid: 'default'
+    spec:
+      labels:
+        - 'dependencies'
+      mergemethod: '{{ .scm.mergemethod }}'
+      title: '[{{ .scm.branch }}] Bump K8s to `{{ .k8s.main }}` and K3s to `{{ .k3s.release }}`'
+      description: 'Bump patch versions of K8s to `{{ .k8s.main }}` and K3s to `{{ .k3s.release }}`.'

--- a/updatecli/updatecli.d/update-k8s-k3s/_scm.yaml
+++ b/updatecli/updatecli.d/update-k8s-k3s/_scm.yaml
@@ -27,6 +27,9 @@ actions:
     spec:
       labels:
         - 'dependencies'
+      reviewers:
+        - 'rancher/infracloud-team'
+        - 'rancher/rancher-team-2-hostbusters-dev'
       mergemethod: '{{ .scm.mergemethod }}'
       title: '[{{ .scm.branch }}] Bump K8s to `{{ .k8s.main }}` and K3s to `{{ .k3s.release }}`'
       description: 'Bump patch versions of K8s to `{{ .k8s.main }}` and K3s to `{{ .k3s.release }}`.'

--- a/updatecli/updatecli.d/update-k8s-k3s/autodiscovery-k8s-deps.yaml
+++ b/updatecli/updatecli.d/update-k8s-k3s/autodiscovery-k8s-deps.yaml
@@ -1,0 +1,23 @@
+name: '{{ .k8s_k3s.manifest }}'
+pipelineid: '{{ .k8s_k3s.pipelineid }}'
+
+autodiscovery:
+  scmid: 'default'
+  actionid: 'rancher-pr'
+  groupby: all
+  crawlers:
+    golang:
+      versionfilter:
+        kind: semver
+        pattern: '{{ .k8s.deps }}'
+      only:
+        - modules:
+            '^k8s\.io\/.*': ''
+      ignore:
+        - modules:
+            '^k8s\.io\/client-go': ''
+            '^k8s\.io\/kubernetes': ''
+            '^k8s\.io\/kube-openapi': ''
+            '^k8s\.io\/legacy-cloud-providers': ''
+            '^k8s\.io\/helm': ''
+            '^k8s\.io\/utils': ''

--- a/updatecli/updatecli.d/update-k8s-k3s/autodiscovery-k8s.yaml
+++ b/updatecli/updatecli.d/update-k8s-k3s/autodiscovery-k8s.yaml
@@ -1,0 +1,15 @@
+name: '{{ .k8s_k3s.manifest }}'
+pipelineid: '{{ .k8s_k3s.pipelineid }}'
+
+autodiscovery:
+  scmid: 'default'
+  actionid: 'rancher-pr'
+  groupby: all
+  crawlers:
+    golang:
+      versionfilter:
+        kind: semver
+        pattern: '{{ .k8s.main }}'
+      only:
+        - modules:
+            'k8s.io/kubernetes': ''

--- a/updatecli/updatecli.d/update-k8s-k3s/update-k3s.yaml
+++ b/updatecli/updatecli.d/update-k8s-k3s/update-k3s.yaml
@@ -1,0 +1,48 @@
+name: '{{ .k8s_k3s.manifest }}'
+pipelineid: update-k8s-k3s-versions
+
+conditions:
+  check-dockerfile-k3s-cattle-version:
+    name: 'Check if ENV CATTLE_K3S_VERSION is set in Dockerfiles'
+    kind: file
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      files:
+        - 'Dockerfile.dapper'
+        - 'package/Dockerfile'
+      matchpattern: 'ENV[\s\t]+CATTLE_K3S_VERSION[=\s]\S+'
+
+  check-dockerfile-k3s-image:
+    name: 'Check if rancher/k3s image is set in Dockerfiles'
+    kind: file
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      files:
+        - 'Dockerfile.dapper'
+        - 'package/Dockerfile'
+      matchpattern: 'COPY[\s\t]+--from=rancher/k3s:\S+'
+
+targets:
+  update-dockerfile-k3s-cattle-version:
+    name: 'Update ENV CATTLE_K3S_VERSION to {{ .k3s.release }} in Dockerfiles'
+    kind: file
+    scmid: 'default'
+    spec:
+      files:
+        - 'Dockerfile.dapper'
+        - 'package/Dockerfile'
+      matchpattern: 'ENV[\s\t]+CATTLE_K3S_VERSION[=\s]+\S+'
+      replacepattern: 'ENV CATTLE_K3S_VERSION={{ .k3s.release }}'
+
+  update-dockerfile-k3s-image-version:
+    name: 'Update rancher/k3s image to {{ .k3s.image }} in Dockerfiles'
+    kind: file
+    scmid: 'default'
+    spec:
+      files:
+        - 'Dockerfile.dapper'
+        - 'package/Dockerfile'
+      matchpattern: 'COPY[\s\t]+--from=rancher/k3s:\S+'
+      replacepattern: 'COPY --from=rancher/k3s:{{ .k3s.image }}'

--- a/updatecli/updatecli.d/update-versions-config-yaml/_scm.yaml
+++ b/updatecli/updatecli.d/update-versions-config-yaml/_scm.yaml
@@ -1,0 +1,32 @@
+# This is a partial file (prefixed with _) that allows to reuse the scm and
+# action configurations.
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repo }}'
+      branch: '{{ .scm.branch }}'
+      user: '{{ .scm.user }}'
+      email: '{{ .scm.email }}'
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+      commitusingapi: {{ .scm.commitusingapi }}
+      commitmessage:
+        squash: {{ .scm.commitmessage.squash }}
+        type: '{{ .k8s_k3s.commitmessage.type }}'
+        scope: '{{ .k8s_k3s.commitmessage.scope }}'
+        title: 'Bump patch versions of K8s and K3s'
+        body: 'Bump patch versions of K8s to {{ .k8s.main }} and K3s to {{ .k3s.release }}.'
+
+actions:
+  rancher-pr:
+    kind: github/pullrequest
+    scmid: 'default'
+    spec:
+      labels:
+        - 'dependencies'
+      mergemethod: '{{ .scm.mergemethod }}'
+      title: '[{{ .scm.branch }}] Bump K8s to `{{ .k8s.main }}` and K3s to `{{ .k3s.release }}`'
+      description: 'Bump patch versions of K8s to `{{ .k8s.main }}` and K3s to `{{ .k3s.release }}`.'

--- a/updatecli/updatecli.d/update-versions-config-yaml/update-versions-config.yaml
+++ b/updatecli/updatecli.d/update-versions-config-yaml/update-versions-config.yaml
@@ -1,0 +1,102 @@
+name: '{{ .k8s_k3s.manifest }}'
+pipelineid: '{{ .k8s_k3s.pipelineid }}'
+
+sources:
+  rancher-go-mod-k8s:
+    name: 'Get K8s version in go.mod'
+    kind: golang/gomod
+    scmid: 'default'
+    spec:
+      module: 'k8s.io/kubernetes'
+    transformers:
+      - find: 'v\d+\.\d+'
+
+  k8s-release:
+    name: 'Get latest upstream K8s version for {{ source "rancher-go-mod-k8s" }} patch version'
+    kind: githubrelease
+    spec:
+      owner: '{{ .repos.k8s.owner }}'
+      repository: '{{ .repos.k8s.repo }}'
+      key: tagname
+      typefilter:
+        release: true
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+      versionfilter:
+        kind: semver
+        pattern: '~{{ source "rancher-go-mod-k8s" }}'
+
+  k3s-release:
+    name: 'Check if K3s {{ source "k8s-release" }} release is available'
+    kind: githubrelease
+    spec:
+      owner: '{{ .repos.k3s.owner }}'
+      repository: '{{ .repos.k3s.repo }}'
+      key: tagname
+      typefilter:
+        release: true
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+      versionfilter:
+        kind: regex
+        pattern: '{{ source "k8s-release" }}'
+    transformers:
+      - replacer:
+          from: '+'
+          to: '-'
+
+conditions:
+  check-upstream-k3s-image-tag:
+    name: 'Check if K3s image for {{ source "k3s-release" }} release is available'
+    kind: dockerimage
+    sourceid: 'k3s-release'
+    spec:
+      image: 'rancher/k3s'
+      tag: '{{ source "k3s-release" }}'
+
+targets:
+  update-k8s-main:
+    name: 'Update K8s main config version'
+    kind: yaml
+    scmid: 'default'
+    sourceid: k8s-release
+    spec:
+      file: '{{ .config.versions }}'
+      key: '$.k8s.main'
+
+  update-k8s-deps:
+    name: 'Update K8s dep config version'
+    kind: yaml
+    scmid: 'default'
+    sourceid: k8s-release
+    spec:
+      file: '{{ .config.versions }}'
+      key: '$.k8s.deps'
+    transformers:
+      - trimprefix: 'v'
+      - findsubmatch:
+          pattern: '\d+(.\d+.\d+)'
+          captureindex: 1
+      - addprefix: 'v0'
+
+  update-k3s-release:
+    name: 'Update K3s release config version'
+    kind: yaml
+    scmid: 'default'
+    sourceid: k3s-release
+    spec:
+      file: '{{ .config.versions }}'
+      key: '$.k3s.release'
+    transformers:
+      - replacer:
+          from: '-'
+          to: '+'
+
+  update-k3s-image:
+    name: 'Update K3s image config version'
+    kind: yaml
+    scmid: 'default'
+    sourceid: k3s-release
+    spec:
+      file: '{{ .config.versions }}'
+      key: '$.k3s.image'

--- a/updatecli/updatecli.d/update-versions-config-yaml/update-versions-config.yaml
+++ b/updatecli/updatecli.d/update-versions-config-yaml/update-versions-config.yaml
@@ -3,7 +3,7 @@ pipelineid: '{{ .k8s_k3s.pipelineid }}'
 
 sources:
   rancher-go-mod-k8s:
-    name: 'Get K8s version in go.mod'
+    name: 'Get K8s <major>.<minor> version in go.mod'
     kind: golang/gomod
     scmid: 'default'
     spec:
@@ -12,7 +12,7 @@ sources:
       - find: 'v\d+\.\d+'
 
   k8s-release:
-    name: 'Get latest upstream K8s version for {{ source "rancher-go-mod-k8s" }} patch version'
+    name: 'Get latest upstream K8s patch version for {{ source "rancher-go-mod-k8s" }}'
     kind: githubrelease
     spec:
       owner: '{{ .repos.k8s.owner }}'

--- a/updatecli/values.d/values.yaml
+++ b/updatecli/values.d/values.yaml
@@ -1,0 +1,34 @@
+config:
+  versions: 'updatecli/values.d/versions.yaml'
+
+scm:
+  user: 'github-actions[bot]'
+  email: '41898282+github-actions[bot]@users.noreply.github.com'
+  username: 'UPDATECLI_GITHUB_ACTOR'
+  token: 'UPDATECLI_GITHUB_TOKEN'
+  owner: 'rancher'
+  repo: 'rancher'
+  branch: 'main'
+  # This option allows for the commits to be signed (verified). However, the
+  # GraphQL API doesn't allow the commits to be squashed. For the moment we
+  # prefer to squash them in order to reduce the noise given the amount of
+  # commits that are done for the updates.
+  commitusingapi: false
+  commitmessage:
+    squash: true
+  mergemethod: 'squash'
+
+repos:
+  k3s:
+    owner: 'k3s-io'
+    repo: 'k3s'
+  k8s:
+    owner: 'kubernetes'
+    repo: 'kubernetes'
+
+k8s_k3s:
+  manifest: 'Update K8s and K3s patch versions'
+  pipelineid: 'update-k8s-k3s-versions'
+  commitmessage:
+    type: 'deps'
+    scope: 'k8s and k3s'

--- a/updatecli/values.d/versions.yaml
+++ b/updatecli/values.d/versions.yaml
@@ -1,0 +1,6 @@
+k8s:
+  main: v1.33.4
+  deps: v0.33.4
+k3s:
+  release: v1.33.1+k3s1
+  image: v1.33.1-k3s1


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52125
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Closes https://github.com/rancher/rancher/issues/52125

This PR adds an initial updatecli automation to keep in sync:

1. The patch version of K8s with the most recent patch version available upstream; and
2. To also sync the K3s version to the corresponding K8s patch version.

The GHA workflows re-uses our Renovate's App token, in order to avoid having to create another GH App given that both have the same purpose. If needed, we can request a dedicated app later, which isn't a blocker for this PR.

This can serve as the basis for more updatecli automation.

An example PR done against my fork is https://github.com/macedogm/fork-rancher/pull/61. The only commit add is https://github.com/macedogm/fork-rancher/pull/61/commits/19fc8a53388fa7ce745534310590e91230d84494. The other commits are leftovers from changes that I had to do against the main branch for the local test, please disregard them.