### PR TITLE
[RoleTemplate Aggregation] Add a mechanism for removing management plane cluster roles when they shouldn't exist

### DIFF
--- a/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	clusterRoleOwnerAnnotation = "authz.cluster.cattle.io/clusterrole-owner"
-	projectContext             = "project"
+	projectContext = "project"
 )
 
 func newRoleTemplateHandler(uc *config.UserContext) *roleTemplateHandler {

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -443,12 +443,12 @@ func TestAreClusterRolesSame(t *testing.T) {
 				current: &rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"otherannotation":          "foobar",
-							clusterRoleOwnerAnnotation: "owner",
+							"otherannotation": "foobar",
 						},
 						Labels: map[string]string{
-							"otherlabel":     "foobar",
-							AggregationLabel: "AggregationLabel",
+							"otherlabel":          "foobar",
+							AggregationLabel:      "AggregationLabel",
+							ClusterRoleOwnerLabel: "owner",
 						},
 					},
 					AggregationRule: &rbacv1.AggregationRule{
@@ -459,8 +459,10 @@ func TestAreClusterRolesSame(t *testing.T) {
 				},
 				modified: &rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{clusterRoleOwnerAnnotation: "owner"},
-						Labels:      map[string]string{AggregationLabel: "AggregationLabel"},
+						Labels: map[string]string{
+							AggregationLabel:      "AggregationLabel",
+							ClusterRoleOwnerLabel: "owner",
+						},
 					},
 					AggregationRule: &rbacv1.AggregationRule{
 						ClusterRoleSelectors: []metav1.LabelSelector{
@@ -532,8 +534,10 @@ func TestAreClusterRolesSame(t *testing.T) {
 				},
 				modified: &rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{clusterRoleOwnerAnnotation: "owner"},
-						Labels:      map[string]string{AggregationLabel: "AggregationLabel"},
+						Labels: map[string]string{
+							AggregationLabel:      "AggregationLabel",
+							ClusterRoleOwnerLabel: "owner",
+						},
 					},
 					AggregationRule: &rbacv1.AggregationRule{
 						ClusterRoleSelectors: []metav1.LabelSelector{
@@ -546,11 +550,11 @@ func TestAreClusterRolesSame(t *testing.T) {
 			wantUpdated: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"otherannotation":          "foobar",
-						clusterRoleOwnerAnnotation: "owner",
+						"otherannotation": "foobar",
 					},
 					Labels: map[string]string{
-						AggregationLabel: "AggregationLabel",
+						AggregationLabel:      "AggregationLabel",
+						ClusterRoleOwnerLabel: "owner",
 					},
 				},
 				AggregationRule: &rbacv1.AggregationRule{
@@ -592,9 +596,7 @@ func TestBuildAggregatingClusterRole(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-rt-transform-aggregator",
 					Labels: map[string]string{
-						"management.cattle.io/aggregates": "test-rt-transform-aggregator",
-					},
-					Annotations: map[string]string{
+						"management.cattle.io/aggregates":           "test-rt-transform-aggregator",
 						"authz.cluster.cattle.io/clusterrole-owner": "test-rt",
 					},
 				},
@@ -619,9 +621,7 @@ func TestBuildAggregatingClusterRole(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-rt-transform-aggregator",
 					Labels: map[string]string{
-						"management.cattle.io/aggregates": "test-rt-transform-aggregator",
-					},
-					Annotations: map[string]string{
+						"management.cattle.io/aggregates":           "test-rt-transform-aggregator",
 						"authz.cluster.cattle.io/clusterrole-owner": "test-rt",
 					},
 				},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49353
 
## Problem
When a RoleTemplate has management plane rules, 2 special ClusterRoles are created in the management cluster to provide those special rules. The problem is that if you then edit the RoleTemplate to not have those management plane rules, the ClusterRoles were not getting deleted. That left users still bound to them.
 
## Solution
Similar to other aggregation controllers, we instead do a check for existing ClusterRoles and remove any that aren't in the list of desired ClusterRoles. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
I tested this by making Project RoleTemplates and Cluster RoleTemplates with management plane rules and then editing the rules.
- Removing the management plane rules removes the permissions
- Adding the rules back re-adds the permissions
- Works with inheritance as well, tried with parent and child RoleTemplates

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Added several tests to increase the coverage. I also tried to make the code a little more readable by creating shared clusterrole and roletemplate variables.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_