### PR TITLE
Remove `clean` from updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -75,9 +75,9 @@ jobs:
           # and K3s versions. This is currently a workaround for the
           # autodiscovery module (to be removed once
           # https://github.com/updatecli/updatecli/issues/6076 is implemented).
-          updatecli apply --clean --values updatecli/values.d/values.yaml   \
-                                  --values updatecli/values.d/versions.yaml \
-                                  --config updatecli/updatecli.d/update-versions-config-yaml/
+          updatecli apply --values updatecli/values.d/values.yaml   \
+                          --values updatecli/values.d/versions.yaml \
+                          --config updatecli/updatecli.d/update-versions-config-yaml/
           # Copy the updated versions.yaml to updatecli's folder.
           cp /tmp/updatecli/github/rancher/rancher/updatecli/values.d/versions.yaml updatecli/values.d/versions.yaml
           # This apply is responsible for updating the dependencies.


### PR DESCRIPTION
After introducing updatecli in https://github.com/rancher/rancher/pull/52175, the first `--clean` from the workflow must be removed, otherwise we cannot copy the updated versions file.