### PR TITLE
Increase updatecli workflow timeout

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    timeout-minutes: 600
+    timeout-minutes: 120
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 600
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout


### PR DESCRIPTION
Had to increase the timeout due to the amount of Go dependencies being updated. As we add more workflows, will make sure to check what we can parallelize and then reduce it again if needed.