### PR TITLE
renaming due comment

### DIFF
--- a/pkg/controllers/capr/machineprovision/controller.go
+++ b/pkg/controllers/capr/machineprovision/controller.go
@@ -642,10 +642,10 @@ func (h *handler) OnChange(obj runtime.Object) (runtime.Object, error) {
 
 func parseDeleteOnFailureAfterSetting(infra *infraObject) time.Duration {
 
-	deleteInfraTimeSetting := settings.DeleteInfraMachineOnFailureAfter.Get()
+	deleteInfraTimeSetting := settings.DeleteMachineOnFailureAfter.Get()
 	deleteOnFailureAfter, err := time.ParseDuration(deleteInfraTimeSetting)
 	if err != nil {
-		logrus.Warnf("[machineprovision] %s/%s: error parsing the '%s' setting: %v: %v, returning 0", infra.meta.GetNamespace(), infra.meta.GetName(), settings.DeleteInfraMachineOnFailureAfter.Name, deleteInfraTimeSetting, err)
+		logrus.Warnf("[machineprovision] %s/%s: error parsing the '%s' setting: %v: %v, returning 0", infra.meta.GetNamespace(), infra.meta.GetName(), settings.DeleteMachineOnFailureAfter.Name, deleteInfraTimeSetting, err)
 		return 0
 	}
 

--- a/pkg/controllers/capr/machineprovision/controller_test.go
+++ b/pkg/controllers/capr/machineprovision/controller_test.go
@@ -379,7 +379,7 @@ func TestOnChange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			settings.DeleteInfraMachineOnFailureAfter.Set(tc.setting)
+			settings.DeleteMachineOnFailureAfter.Set(tc.setting)
 
 			dynamicControllerFake := dynamicControllerFake{}
 			h.dynamic = &dynamicControllerFake

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -177,9 +177,9 @@ var (
 	// An empty string or a zero value means the feature is disabled.
 	DeleteInactiveUserAfter = NewSetting("delete-inactive-user-after", "")
 
-	// DeleteInfraMachineOnFailureAfter is the duration after which a machine job that failed to provision a machine will be deleted.
+	// DeleteMachineOnFailureAfter is the duration after which a machine job that failed to provision a machine will be deleted.
 	// The value should be expressed in valid time.Duration units. See https://pkg.go.dev/time#ParseDuration
-	DeleteInfraMachineOnFailureAfter = NewSetting("delete-infra-machine-on-failure-after", "0s")
+	DeleteMachineOnFailureAfter = NewSetting("delete-machine-on-failure-after", "0s")
 
 	// UserRetentionDryRun determines if the user retention process should actually disable and delete users.
 	// Valid values are "true" and "false". An empty string means "false".


### PR DESCRIPTION
## Issue: 
Just renaming the setting name from `delete-infra-machine-on-failure-after` to `delete-machine-on-failure-after` due to a review comment.

https://github.com/rancher/rancher/pull/51323#pullrequestreview-3122076029
 
## Problem
The name can be confusing for usage, as it does not delays the **infraMachine**, but the **machineJob** instead.
 
## Solution
Changed the name.
 