### PR TITLE
Remove caValidatorDedicatedCache from UserOnlyContext

### DIFF
--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -51,7 +51,9 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 
 	registerImpersonationCaches(cluster)
 
-	cavalidator.Register(ctx, cluster)
+	if err := cavalidator.Register(ctx, cluster); err != nil {
+		return err
+	}
 
 	// register controller for API
 	cluster.APIAggregation.APIServices("").Controller()

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -317,9 +317,6 @@ func (w *UserContext) UserOnlyContext() *UserOnlyContext {
 		BatchV1:     w.BatchV1,
 		Cluster:     w.Cluster,
 		Storage:     w.Storage,
-
-		caValidatorControllerFactory: w.caValidatorControllerFactory,
-		CAValidatorSecret:            w.CAValidatorSecret,
 	}
 }
 
@@ -341,9 +338,6 @@ type UserOnlyContext struct {
 	Networking      knetworkingv1.Interface
 	Cluster         clusterv3.Interface
 	Storage         storagev1.Interface
-
-	caValidatorControllerFactory controller.SharedControllerFactory
-	CAValidatorSecret            wcorev1.SecretController
 }
 
 func newManagementContext(c *ScaledContext) (*ManagementContext, error) {
@@ -543,23 +537,6 @@ func NewUserOnlyContext(config *wrangler.Context) (*UserOnlyContext, error) {
 		AddSchemas(managementSchema.Schemas).
 		AddSchemas(clusterSchema.Schemas).
 		AddSchemas(projectSchema.Schemas)
-
-	clientFactory, err := client.NewSharedClientFactory(enableProtobuf(&context.RESTConfig), &client.SharedClientFactoryOptions{
-		Scheme: wrangler.Scheme,
-	})
-	if err != nil {
-		return nil, err
-	}
-	caValidatorControllerFactory := newCAValidatorControllerFactory(clientFactory)
-	context.caValidatorControllerFactory = caValidatorControllerFactory
-	caValidatorOpts := &generic.FactoryOptions{
-		SharedControllerFactory: caValidatorControllerFactory,
-	}
-	caValidatorCorew, err := core.NewFactoryFromConfigWithOptions(&context.RESTConfig, caValidatorOpts)
-	if err != nil {
-		return nil, err
-	}
-	context.CAValidatorSecret = caValidatorCorew.Core().V1().Secret()
 
 	return context, err
 }


### PR DESCRIPTION
## Issue: #52234

Follow-up of #51375 

## Problem
`UserContext` was polluted to include fields only needed for the `cavalidator` controller. This wan ad-hoc solution for a problem, but should reworked for a cleaner implementation.
 
## Solution
Add a new method to register non-default controller factories, then start them together with the rest of controllers.
Then, move the creation and configuration of the dedicated cache factory to the downstream controller implementation and make it use the new registration interface.
