### PR TITLE
updatecli: Add workflow to bump Wins and System Agent

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -75,15 +75,15 @@ jobs:
           # and K3s versions. This is currently a workaround for the
           # autodiscovery module (to be removed once
           # https://github.com/updatecli/updatecli/issues/6076 is implemented).
-          updatecli apply --values updatecli/values.d/values.yaml   \
-                          --values updatecli/values.d/versions.yaml \
-                          --config updatecli/updatecli.d/update-versions-config-yaml/
-          # Copy the updated versions.yaml to updatecli's folder.
-          cp /tmp/updatecli/github/rancher/rancher/updatecli/values.d/versions.yaml updatecli/values.d/versions.yaml
-          # This apply is responsible for updating the dependencies.
-          updatecli apply --clean --values updatecli/values.d/values.yaml   \
-                                  --values updatecli/values.d/versions.yaml \
-                                  --config updatecli/updatecli.d/update-k8s-k3s/
+          #updatecli apply --values updatecli/values.d/values.yaml   \
+          #                --values updatecli/values.d/versions.yaml \
+          #                --config updatecli/updatecli.d/update-versions-config-yaml/
+          ## Copy the updated versions.yaml to updatecli's folder.
+          #cp /tmp/updatecli/github/rancher/rancher/updatecli/values.d/versions.yaml updatecli/values.d/versions.yaml
+          ## This apply is responsible for updating the dependencies.
+          #updatecli apply --clean --values updatecli/values.d/values.yaml   \
+          #                        --values updatecli/values.d/versions.yaml \
+          #                        --config updatecli/updatecli.d/update-k8s-k3s/
           updatecli apply --clean --values updatecli/values.d/values.yaml \
                                   --values updatecli/values.d/versions.yaml \
                                   --config updatecli/updatecli.d/update-wins-system-agent/

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -84,3 +84,6 @@ jobs:
           updatecli apply --clean --values updatecli/values.d/values.yaml   \
                                   --values updatecli/values.d/versions.yaml \
                                   --config updatecli/updatecli.d/update-k8s-k3s/
+          updatecli apply --clean --values updatecli/values.d/values.yaml \
+                                  --values updatecli/values.d/versions.yaml \
+                                  --config updatecli/updatecli.d/update-wins-system-agent/

--- a/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
+++ b/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
@@ -1,0 +1,121 @@
+name: '{{ .wins_system_agent.manifest }}'
+pipelineid: '{{ .wins_system_agent.pipelineid }}'
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repo }}'
+      branch: '{{ .scm.branch }}'
+      user: '{{ .scm.user }}'
+      email: '{{ .scm.email }}'
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+      commitusingapi: {{ .scm.commitusingapi }}
+      commitmessage:
+        squash: {{ .scm.commitmessage.squash }}
+        type: '{{ .wins_system_agent.commitmessage.type }}'
+        scope: '{{ .wins_system_agent.commitmessage.scope }}'
+        title: 'Bump versions of Wins and System Agent'
+        body: 'Bump versions of Wins to {{ source "wins-release" }} and System Agent to {{ source "system-agent-release" }}.'
+
+actions:
+  rancher-pr:
+    kind: github/pullrequest
+    scmid: 'default'
+    spec:
+      labels:
+        - 'dependencies'
+      reviewers:
+        - 'rancher/rancher-team-2-hostbusters-dev'
+      mergemethod: '{{ .scm.mergemethod }}'
+      title: '[{{ .scm.branch }}] Bump Wins to {{ source "wins-release" }} and System Agent to {{ source "system-agent-release" }}.'
+      description: 'Bump patch versions of Wins to {{ source "wins-release" }} and System Agent to {{ source "system-agent-release" }}.'
+
+sources:
+  wins-release:
+    name: 'Get latest upstream Wins version'
+    kind: githubrelease
+    spec:
+      owner: '{{ .repos.wins.owner }}'
+      repository: '{{ .repos.wins.repo }}'
+      key: tagname
+      typefilter:
+        latest: true
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+
+  system-agent-release:
+    name: 'Get latest upstream System Agent version'
+    kind: githubrelease
+    spec:
+      owner: '{{ .repos.system_agent.owner }}'
+      repository: '{{ .repos.system_agent.repo }}'
+      key: tagname
+      typefilter:
+        latest: true
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+
+conditions:
+  check-dockerfile-wins-version:
+    name: 'Check if ENV CATTLE_WINS_AGENT_VERSION is set in Dockerfile'
+    kind: file
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      files:
+        - 'package/Dockerfile'
+      matchpattern: '(?:ENV|ARG)[\s\t]+CATTLE_WINS_AGENT_VERSION[=\s]\S+'
+
+  check-dockerfile-system-agent-version:
+    name: 'Check if ENV CATTLE_SYSTEM_AGENT_VERSION is set in Dockerfile'
+    kind: file
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      files:
+        - 'package/Dockerfile'
+      matchpattern: '(?:ENV|ARG)[\s\t]+CATTLE_SYSTEM_AGENT_VERSION[=\s]\S+'
+
+targets:
+  update-dockerfile-wins-release:
+    name: 'Update ENV CATTLE_WINS_AGENT_VERSION to {{ source "wins-release" }} in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'wins-release'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_WINS_AGENT_VERSION[=\s]\S+'
+      replacepattern: '$1 CATTLE_WINS_AGENT_VERSION={{ source "wins-release" }}'
+
+  update-dockerfile-system-agent-release:
+    name: 'Update ENV CATTLE_SYSTEM_AGENT_VERSION to {{ source "system-agent-release" }} in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'system-agent-release'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_SYSTEM_AGENT_VERSION[=\s]\S+'
+      replacepattern: '$1 CATTLE_SYSTEM_AGENT_VERSION={{ source "system-agent-release" }}'
+
+  update-pkg-settings-wins-release:
+    name: 'Update Wins to {{ source "wins-release" }} in pkg/settings/setting.go'
+    kind: file
+    scmid: 'default'
+    sourceid: 'wins-release'
+    spec:
+      file: 'pkg/settings/setting.go'
+      matchpattern: 'https://raw.githubusercontent.com/rancher/wins/v\S+/install.ps1'
+      replacepattern: 'https://raw.githubusercontent.com/rancher/wins/{{ source "wins-release" }}/install.ps1'
+
+  update-pkg-settings-system-agent-release:
+    name: 'Update System Agent to {{ source "system-agent-release" }} in pkg/settings/setting.go'
+    kind: file
+    scmid: 'default'
+    sourceid: 'system-agent-release'
+    spec:
+      file: 'pkg/settings/setting.go'
+      matchpattern: 'https://github.com/rancher/system-agent/releases/download/v\S+/install.sh'
+      replacepattern: 'https://github.com/rancher/system-agent/releases/download/{{ source "system-agent-release" }}/install.sh'

--- a/updatecli/values.d/values.yaml
+++ b/updatecli/values.d/values.yaml
@@ -25,6 +25,12 @@ repos:
   k8s:
     owner: 'kubernetes'
     repo: 'kubernetes'
+  system_agent:
+    owner: 'rancher'
+    repo: 'system-agent'
+  wins:
+    owner: 'rancher'
+    repo: 'wins'
 
 k8s_k3s:
   manifest: 'Update K8s and K3s patch versions'
@@ -32,3 +38,10 @@ k8s_k3s:
   commitmessage:
     type: 'deps'
     scope: 'k8s and k3s'
+
+wins_system_agent:
+  manifest: 'Update Wins and System Agent patch versions'
+  pipelineid: 'update-wins-system-agent-version'
+  commitmessage:
+    type: 'deps'
+    scope: 'wins and system-agent'


### PR DESCRIPTION
This PR does:

1. Add a updatecli workflow to bump Wins and System Agent versions. An example PR is https://github.com/macedogm/fork-rancher/pull/81.
2. Temporarily disable the workflow that bumps K8s and K3s. Will re-enable once Rancher moves to K8s 1.34.