### PR TITLE
[release/v2.12] Cert rotator err

### DIFF
--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -235,7 +235,10 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 				logrus.Error(err)
 			}
 		case event, ok := <-watcher.ResultChan():
-			if !ok || event.Type == watch.Error {
+			if !ok {
+				logrus.Errorf("watcher channel closed")
+				return nil
+			} else if event.Type == watch.Error {
 				switch obj := event.Object.(type) {
 				case *metav1.Status:
 					logrus.Errorf("watcher channel closed: %s", obj.Message)
@@ -244,10 +247,10 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 				}
 
 				return nil
-			}
-
-			if err := p.handleCertEvent(event); err != nil {
-				logrus.Error(err)
+			} else {
+				if err := p.handleCertEvent(event); err != nil {
+					logrus.Error(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/51722

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/51690
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When logging an error in the watcher event the wrong error value is referenced. This results in always logging a `nil` error.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Reference the `event.Object` when logging the error.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_