### PR TITLE
enhance the logic for setting node-ip and node-external-ip

### DIFF
--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -1,0 +1,236 @@
+package planner
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/data/management"
+	"github.com/rancher/wrangler/v3/pkg/data/convert"
+)
+
+func TestUpdateConfigWithAddresses(t *testing.T) {
+	tests := []struct {
+		name                    string
+		initialConfig           map[string]interface{}
+		info                    *machineNetworkInfo
+		expectedNodeIPs         []string
+		expectedNodeExternalIPs []string
+	}{
+		{
+			name: "AWS dual-stack node",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.5"},
+				ExternalAddresses: []string{"1.2.3.4"},
+				IPv6Address:       "2001:db8::1",
+				DriverName:        management.Amazonec2driver,
+			},
+			expectedNodeIPs:         []string{"10.0.0.5", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
+		},
+		{
+			name: "AWS IPv4-only node",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.5"},
+				ExternalAddresses: []string{"1.2.3.4"},
+				DriverName:        management.Amazonec2driver,
+			},
+			expectedNodeIPs:         []string{"10.0.0.5"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
+		},
+		{
+			name: "AWS IPv6-only node",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				IPv6Address: "2001:db8::1",
+				DriverName:  management.Amazonec2driver,
+			},
+			expectedNodeIPs:         []string{"2001:db8::1"},
+			expectedNodeExternalIPs: []string{},
+		},
+		{
+			name: "DigitalOcean IPv4-only with internal IP",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.1.2.3"},
+				ExternalAddresses: []string{"203.0.113.1"},
+				DriverName:        management.DigitalOceandriver,
+			},
+			expectedNodeIPs:         []string{"10.1.2.3"},
+			expectedNodeExternalIPs: []string{"203.0.113.1"},
+		},
+		{
+			name: "DigitalOcean driver IPv4-only with no internal IP",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{"203.0.113.1"},
+				DriverName:        management.DigitalOceandriver,
+			},
+			expectedNodeIPs:         []string{"203.0.113.1"},
+			expectedNodeExternalIPs: []string{},
+		},
+		{
+			name: "DigitalOcean driver dual-stack with internal IP",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.1.2.3"},
+				ExternalAddresses: []string{"203.0.113.1"},
+				IPv6Address:       "2001:db8::1",
+				DriverName:        management.DigitalOceandriver,
+			},
+			expectedNodeIPs:         []string{"10.1.2.3", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"203.0.113.1"},
+		},
+		{
+			name: "Pod driver skips node-ip assignment",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.10.10.5"},
+				ExternalAddresses: []string{"172.16.1.5"},
+				DriverName:        management.PodDriver,
+			},
+			expectedNodeIPs:         []string{},
+			expectedNodeExternalIPs: []string{},
+		},
+		{
+			name: "Cloud provider set disables external IP assignment",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "aws",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.7"},
+				ExternalAddresses: []string{"203.0.113.5"},
+				IPv6Address:       "2001:db8::7",
+				DriverName:        "amazonec2",
+			},
+			expectedNodeIPs:         []string{"10.0.0.7", "2001:db8::7"},
+			expectedNodeExternalIPs: []string{},
+		},
+		{
+			name: "Multiple internal and external IPs",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.5", "10.0.0.6"},
+				ExternalAddresses: []string{"1.2.3.4", "1.2.3.5"},
+				IPv6Address:       "2001:db8::1",
+			},
+			expectedNodeIPs:         []string{"10.0.0.5", "10.0.0.6", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"1.2.3.4", "1.2.3.5"},
+		},
+		{
+			name: "Multiple internal IPs, one is IPv6",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"2001:db8::2", "10.0.0.6"},
+				ExternalAddresses: []string{"1.2.3.4"},
+			},
+			expectedNodeIPs:         []string{"2001:db8::2", "10.0.0.6"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
+		},
+		{
+			name: "Multiple internal IPs, no IPv4",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"2001:db8::2", "2001:db8::3"},
+				ExternalAddresses: []string{"1.2.3.4"},
+			},
+			expectedNodeIPs:         []string{"2001:db8::2", "2001:db8::3"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
+		},
+		{
+			name: "Duplicated internal and external IPs",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"2001:db8::2", "10.0.0.6"},
+				ExternalAddresses: []string{"2001:db8::2", "10.0.0.6"},
+			},
+			expectedNodeIPs:         []string{"2001:db8::2", "10.0.0.6"},
+			expectedNodeExternalIPs: []string{},
+		},
+		{
+			name: "Duplicated internal and external and IPv6",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"1.2.3.4", "1.2.3.5", "1.2.3.7"},
+				ExternalAddresses: []string{"1.2.3.4", "1.2.3.5", "1.2.3.6"},
+				IPv6Address:       "2001:db8::1",
+			},
+			expectedNodeIPs:         []string{"1.2.3.4", "1.2.3.5", "1.2.3.7", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"1.2.3.6"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := make(map[string]interface{}, len(tt.initialConfig))
+			for k, v := range tt.initialConfig {
+				config[k] = v
+			}
+			updateConfigWithAddresses(config, tt.info)
+
+			gotIPs := convert.ToStringSlice(config["node-ip"])
+			if len(tt.expectedNodeIPs) > 0 {
+				if !reflect.DeepEqual(gotIPs, tt.expectedNodeIPs) {
+					t.Errorf("node-ip mismatch:\n  got  %v\n  want %v", gotIPs, tt.expectedNodeIPs)
+				}
+			} else {
+				if len(gotIPs) > 0 {
+					t.Errorf("unexpected node-ip: %v", gotIPs)
+				}
+			}
+
+			gotExternal := convert.ToStringSlice(config["node-external-ip"])
+			if len(tt.expectedNodeExternalIPs) > 0 {
+				if !reflect.DeepEqual(gotExternal, tt.expectedNodeExternalIPs) {
+					t.Errorf("node-external-ip mismatch:\n  got  %v\n  want %v", gotExternal, tt.expectedNodeExternalIPs)
+				}
+			} else {
+				if len(gotExternal) > 0 {
+					t.Errorf("unexpected node-external-ip: %v", gotExternal)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
- https://github.com/rancher/rancher/issues/52225
- https://github.com/rancher/rancher/issues/52226


## Problem
 
There are multiple issues with the current logic for configuring node-ip and node-external-ip in the RKE2/K3s configuration:

- The system does not support comma-separated IPs in the node registration command for custom node clusters. This enhancement is required to support dual-stack clusters, where nodes may have multiple public and/or private addresses.
- Duplicate Internal and External IPs appear under the Node’s status because the same address is sometimes assigned to both node-ip and node-external-ip.
- advertise-address and tls-san are being set unnecessarily. When node-ip and node-external-ip are configured correctly, RKE2/K3s can automatically determine the appropriate advertise-address and tls-san values.

## Solution
 
The following improvements have been implemented:

- Refactored the existing logic into separate functions to improve readability and facilitate unit testing.
- Added unit tests for the logic that configures node-ip and node-external-ip.
- Added support for parsing comma-separated IPs in the node registration command.
- Corrected logic to ensure node-ip and node-external-ip are assigned properly, preventing duplicate values.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


The change has been validated in a local development environment and works as expected.

### Automated Testing

Unit tests have been added for the updateConfigWithAddresses function.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
Steps can be found in the GH issues. 


### Regressions Considerations
 

Cluster provisioning, including IPv4-only, dual-stack, and IPv6-only configurations, should work as expected.

 