### PR TITLE
fix: creating fleet workspace `fleet-local`

### DIFF
--- a/pkg/controllers/provisioningv2/fleetworkspace/controller.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller.go
@@ -2,6 +2,7 @@ package fleetworkspace
 
 import (
 	"context"
+	"fmt"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -18,9 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var (
-	managed = "provisioning.cattle.io/managed"
-)
+var managed = "provisioning.cattle.io/managed"
 
 type handle struct {
 	workspaceCache mgmtcontrollers.FleetWorkspaceCache
@@ -139,6 +138,9 @@ func (h *handle) onFleetObject(obj runtime.Object) error {
 		})
 		if apierror.IsAlreadyExists(err) {
 			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("creating fleetworkspace: %w", err)
 		}
 	}
 

--- a/pkg/data/dashboard/namespace.go
+++ b/pkg/data/dashboard/namespace.go
@@ -12,6 +12,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	k8sManagedLabel = "app.kubernetes.io/managed-by"
+)
+
 func addCattleGlobalNamespaces(ctx context.Context, k8s kubernetes.Interface) error {
 	if features.Fleet.Enabled() {
 		_, err := k8s.CoreV1().Namespaces().Get(ctx, fleetconst.ClustersLocalNamespace, metav1.GetOptions{})
@@ -19,6 +23,9 @@ func addCattleGlobalNamespaces(ctx context.Context, k8s kubernetes.Interface) er
 			_, err = k8s.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fleetconst.ClustersLocalNamespace,
+					Labels: map[string]string{
+						k8sManagedLabel: "rancher",
+					},
 				},
 			}, metav1.CreateOptions{})
 		}
@@ -31,6 +38,9 @@ func addCattleGlobalNamespaces(ctx context.Context, k8s kubernetes.Interface) er
 		_, err = k8s.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace.System,
+				Labels: map[string]string{
+					k8sManagedLabel: "rancher",
+				},
 			},
 		}, metav1.CreateOptions{})
 	}
@@ -43,6 +53,9 @@ func addCattleGlobalNamespaces(ctx context.Context, k8s kubernetes.Interface) er
 			_, err = k8s.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace.UIPluginNamespace,
+					Labels: map[string]string{
+						k8sManagedLabel: "rancher",
+					},
 				},
 			}, metav1.CreateOptions{})
 		}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52257
 
## Problem

As reported in #52257, Fleet Workspace `fleet-local` fails to create with the following unspecific error:
```
[ERROR] error syncing 'fleet-local/local': handler workspace-backport-cluster: fleetworkspaces.management.cattle.io "fleet-local" not found, requeuing
```

We found this to be related to the logic used for creating the namespace associated with a fleet workspace. In this scenario `fleet-local` is an existing namespace and the fleet workspace is created afterwards. This means that the usual process of creating first a workspace, then the linked namespace is not used here. However, `rancher/webhook` is blocking the creation of the workspace with the following condition:
https://github.com/rancher/webhook/blob/0142fa39cce608c018d272b7094648655c6604fb/pkg/resources/management.cattle.io/v3/fleetworkspace/mutator.go#L110

The `fleet-local` namespace is not labeled as managed by Rancher, which is breaking the above condition. We expect it to contain the label: `"app.kubernetes.io/managed-by": "rancher"`.

**After analyzing this, we don't have a clear explanation why this error has not appeared before.** Any feedback is welcome!

cc: @alexander-demicev @anmazzotti @cpinjani @furkatgofurov7 @valaparthvi  @yiannistri 
 
## Solution

By labeling the namespace `fleet-local` on creation https://github.com/rancher/rancher/blob/f1191d0574c9438ee539d5c730bdf5b6884f6225/pkg/data/dashboard/namespace.go#L17, we can satisfy the webhook's condition and the fleet workspace is created correctly. We extended this change to all of the other namespaces created in `addCattleGlobalNamespaces`.

Additionally, we added a wrapped error that we used for understanding what was the root cause of the issue. We should probably consider wrapping more errors to facilitate debugging and give more nuanced information to developers/support.
 
## Testing

The environment used for testing:
- Kubernetes `v1.32.8` cluster.
- Custom build Rancher image with the state of this PR.

Waited for Rancher to be installed and all fleet workspaces `fleet-default` and `fleet-local` are available.

## Engineering Testing
### Manual Testing

### Automated Testing

## QA Testing Considerations

### Regressions Considerations

