### PR TITLE
2.11.6 hotfix 3e07 - guard against multi setup of saml http dispatcher

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -96,6 +96,7 @@ func newAPIManagement(ctx context.Context, scaledContext *config.ScaledContext) 
 	}
 
 	saml := saml.AuthHandler()
+	logrus.Debugf("SAML [newAPIManagement]: mux root %p", saml)
 
 	root := mux.NewRouter()
 	root.UseEncodedPath()
@@ -109,6 +110,9 @@ func newAPIManagement(ctx context.Context, scaledContext *config.ScaledContext) 
 	limitingHandler := utils.APIBodyLimitingHandler(apiLimit)
 	root.PathPrefix("/v3-public").Handler(limitingHandler(publicAPI))
 	root.PathPrefix("/v1-saml").Handler(limitingHandler(saml))
+
+	logrus.Debugf("SAML [newAPIManagement]: mux root %p now set", saml)
+
 	root.NotFoundHandler = privateAPI
 
 	return func(next http.Handler) http.Handler {

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -97,7 +97,12 @@ func router(ctx context.Context, localClusterEnabled bool, tunnelAuthorizer *mcm
 	unauthed.Handle("/rancherversion", version.NewVersionHandler())
 	unauthed.PathPrefix("/v1-{prefix}-release/channel").Handler(channelserver)
 	unauthed.PathPrefix("/v1-{prefix}-release/release").Handler(channelserver)
-	unauthed.PathPrefix("/v1-saml").Handler(saml.AuthHandler())
+
+	samlMux := saml.AuthHandler()
+	logrus.Debugf("SAML [newMCM]: mux root %p", samlMux)
+	unauthed.PathPrefix("/v1-saml").Handler(samlMux)
+	logrus.Debugf("SAML [newMCM]: mux root %p now set", samlMux)
+
 	unauthed.PathPrefix("/v3-public").Handler(publicAPI)
 
 	// Authenticated routes


### PR DESCRIPTION
prevent saml auth handler setup from initializing multiple dispatchers when used multiple times.
simply return the singleton when it exists.
do not leave partially initialized dispatchers behind.