### PR TITLE
[main] Update post-delete-hook-cluster-role with cronjob

### DIFF
--- a/chart/templates/post-delete-hook-cluster-role.yaml
+++ b/chart/templates/post-delete-hook-cluster-role.yaml
@@ -13,7 +13,7 @@ rules:
     resources: [ "deployments" ]
     verbs: [ "get", "list", "delete" ]
   - apiGroups: [ "batch" ]
-    resources: [ "jobs" ]
+    resources: [ "jobs", "cronjobs" ]
     verbs: [ "get", "list", "watch", "delete", "create" ]
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources: [ "clusterroles", "clusterrolebindings", "roles", "rolebindings" ]


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/51478
SURE-10826
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Fleet team added a cronjob resource to clean up gitrepo bundles using a cronjob in PR https://github.com/rancher/fleet/pull/2910 

Rancher chart's post-delete-hook cluster role does not have the access to delete cronjobs since the addition of this resource in the fleet helm chart. https://github.com/rancher/rancher/blob/main/chart/templates/post-delete-hook-cluster-role.yaml#L15-L17

When uninstalling Rancher helm chart you get this error.
```bash
leap:~ # helm uninstall rancher -n cattle-system
helm uninstall rancher -n cattle-system
Error: uninstallation completed with 1 error(s): 1 error occurred:
        * job rancher-post-delete failed: BackoffLimitExceeded 
```
The post-delete job logs
```bash
Uninstalling Rancher resources in the following namespaces: cattle-fleet-system cattle-system rancher-operator-system
--- Deleting the app [fleet] in the namespace [cattle-fleet-system]
Error: failed to delete release: fleet
--- Skip the app [fleet-crd] in the namespace [cattle-fleet-system]
Removing Rancher bootstrap secret in the following namespace: cattle-system
------ Summary ------
Failed to uninstall the following apps: fleet 
```
The cronjob resource does not get deleted causing the error.
```bash
leap:~ # kubectl get cronjobs -n cattle-fleet-system
NAMESPACE             NAME                                 SCHEDULE    TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cattle-fleet-system   fleet-cleanup-gitrepo-jobs           @daily      <none>     False     0        <none>          6h48m
```
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added the cronjob resource to the batch jobs to allow deletion of the fleet helm release without error.
```bash
   - apiGroups: [ "batch" ]
-    resources: [ "jobs" ]
+    resources: [ "jobs", "cronjobs" ]
     verbs: [ "get", "list", "watch", "delete", "create" ]
```
Using the scripts in this repo, built a test chart, then upgraded Rancher release. Ran helm uninstall with no errors.
```bash
:~ helm_v3 upgrade -i rancher ./build/chart/rancher -n cattle-system -f values.yaml
NOTES:
Rancher Server has been installed. Rancher may take several minutes to fully initialize.
Please standby while Certificates are being issued, Containers are started and the Ingress rule comes up.
Check out our docs at https://rancher.com/docs/
... #shortned for brevity
Happy Containering!

:~ helm_v3 uninstall rancher -n cattle-system
release "rancher" uninstalled

:~ kubectl get job -n cattle-system
NAME                  STATUS     COMPLETIONS   DURATION   AGE
rancher-post-delete   Complete   1/1           39s        44s
```
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

1. Create VM or use baremetal server with a supported OS for Rancher/RKE2 (Ubuntu 24.04/Leap 15.6 tested)
2. Deploy rke2 using install script with default values
```bash
curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.31.12+rke2r1 sh - 
```
3. Install Rancher `v2.11.2`
```bash
helm upgrade --install rancher rancher-stable/rancher -n cattle-system --create-namespace --version v2.11.2 -f values.yaml

# values.yaml used
cat values.yaml
hostname: "rancher-test.infra"
useBundledSystemChart: true
global:
  cattle:
    psp:
      enabled: false
replicas: 1
agent-tls-mode: system-store
bootstrapPassword: redacted
privateCA: false
```
4. Uninstall rancher using helm
```bash
helm uninstall rancher -n cattle-system 
```
5. Grab post-delete-hook job logs to determine fleet helm release fails to uninstall
```bash
leap:~ # kubectl get po -n cattle-system
NAME                                         READY   STATUS    RESTARTS      AGE
rancher-post-delete-gnmb6                    0/1     Error     2 (24s ago)   25s
system-upgrade-controller-5fb67f585d-fbn28   1/1     Running   0             69m
leap:~ # kubectl logs rancher-post-delete-gnmb6 -n cattle-system
Uninstalling Rancher resources in the following namespaces: cattle-fleet-system cattle-system rancher-operator-system
--- Deleting the app [fleet] in the namespace [cattle-fleet-system]
Error: failed to delete release: fleet
--- Skip the app [fleet-crd] in the namespace [cattle-fleet-system]
Removing Rancher bootstrap secret in the following namespace: cattle-system
------ Summary ------
Failed to uninstall the following apps: fleet
```

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally built Rancher chart with PR change. Deployed it with helm and ran the uninstall to confirm no errors present. No errors on uninstall.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->

* "None" - Reason: Chart unit tests don't test for hardcoded cluster role configuration.

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Test reproduction on newer versions of Rancher 2.12, 2.13.
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
No regressions that I can see in the helm chart as this change is permission additive.
Existing / newly added automated tests that provide evidence there are no regressions:
None as the helm chart unit tests do not test for non template cluster role resource.