### PR TITLE
Fix error handling in namespace project cluster role update

### DIFF
--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -496,8 +496,7 @@ func (n *nsLifecycle) reconcileNamespaceProjectClusterRole(ns *v1.Namespace) err
 					})
 				}
 
-				_, err = roleCli.Update(cr)
-				if err != nil {
+				if _, err := roleCli.Update(cr); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
This pull request makes a minor change to the error handling logic in the `reconcileNamespaceProjectClusterRole` function. The update ensures that errors from the `roleCli.Update(cr)` call are properly checked and returned, improving reliability in error propagation.

#52290