### PR TITLE
[main] PodDisruptionBudget & PriorityClass for Fleet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -369,7 +369,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/gomega v1.38.2 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
+
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -53,7 +54,8 @@ const (
 	fleetWorkspaceNameAnn     = "provisioning.cattle.io/fleet-workspace-name"
 	externallyManagedAnn      = "provisioning.cattle.io/externally-managed"
 
-	manageSchedulingDefaultsAnn = "provisioning.cattle.io/enable-scheduling-customization"
+	manageSchedulingDefaultsAnn      = "provisioning.cattle.io/enable-scheduling-customization"
+	manageFleetSchedulingDefaultsAnn = "provisioning.cattle.io/enable-fleet-scheduling-customization"
 )
 
 var (
@@ -305,6 +307,24 @@ func (h *handler) generateProvisioningClusterFromLegacyCluster(cluster *v3.Clust
 		}
 	}
 
+	if cluster.Spec.FleetAgentDeploymentCustomization != nil && cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization != nil {
+		provCluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization = &v1.AgentSchedulingCustomization{}
+
+		if cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget != nil {
+			provCluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget = &v1.PodDisruptionBudgetSpec{
+				MinAvailable:   cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget.MinAvailable,
+				MaxUnavailable: cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget.MaxUnavailable,
+			}
+		}
+
+		if cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass != nil {
+			provCluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass = &v1.PriorityClassSpec{
+				Value:            cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass.Value,
+				PreemptionPolicy: cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass.PreemptionPolicy,
+			}
+		}
+	}
+
 	return []runtime.Object{
 		provCluster,
 	}, status, nil
@@ -497,6 +517,24 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 			spec.ClusterAgentDeploymentCustomization.SchedulingCustomization.PriorityClass = &v3.PriorityClassSpec{
 				Value:            cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization.PriorityClass.Value,
 				PreemptionPolicy: cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization.PriorityClass.PreemptionPolicy,
+			}
+		}
+	}
+
+	if cluster.Spec.FleetAgentDeploymentCustomization != nil && cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization != nil {
+		spec.FleetAgentDeploymentCustomization.SchedulingCustomization = &v3.AgentSchedulingCustomization{}
+
+		if cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget != nil {
+			spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget = &v3.PodDisruptionBudgetSpec{
+				MaxUnavailable: cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget.MaxUnavailable,
+				MinAvailable:   cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PodDisruptionBudget.MinAvailable,
+			}
+		}
+
+		if cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass != nil {
+			spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass = &v3.PriorityClassSpec{
+				Value:            cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass.Value,
+				PreemptionPolicy: cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization.PriorityClass.PreemptionPolicy,
 			}
 		}
 	}

--- a/pkg/controllers/provisioningv2/cluster/scheduling_customization.go
+++ b/pkg/controllers/provisioningv2/cluster/scheduling_customization.go
@@ -11,11 +11,12 @@ import (
 	"github.com/rancher/rancher/pkg/settings"
 )
 
-// updateV1SchedulingCustomization looks for the provisioning.cattle.io/enable-scheduling-customization annotation on the v1.Cluster
-// and if found populates the spec.ClusterAgentDeploymentCustomization.SchedulingCustomization field with the default values set in the
-// global settings. If the cluster-agent-scheduling-customization feature is disabled, the cluster will be returned unchanged.
-// The provisioning.cattle.io/enable-scheduling-customization annotation can be set to 'true' or 'false', which will add or remove
-// the scheduling customization field as needed.
+// updateV1SchedulingCustomization looks for the provisioning.cattle.io/enable-{fleet-}scheduling-customization
+// annotation on the v1.Cluster and if found populates the
+// spec.{Cluster,Fleet}AgentDeploymentCustomization.SchedulingCustomization fields with the default values set in the
+// global settings. If the cluster-agent-scheduling-customization feature is disabled, the cluster will be returned
+// unchanged. The provisioning.cattle.io/enable-{fleet-}scheduling-customization annotation can be set to 'true' or
+// 'false', which will add or remove the scheduling customization field as needed.
 func (h *handler) updateV1SchedulingCustomization(_ string, cluster *v1.Cluster) (*v1.Cluster, error) {
 	if cluster == nil {
 		return nil, nil
@@ -25,61 +26,28 @@ func (h *handler) updateV1SchedulingCustomization(_ string, cluster *v1.Cluster)
 		return cluster, nil
 	}
 
-	value, ok := cluster.ObjectMeta.Annotations[manageSchedulingDefaultsAnn]
-	if !ok {
-		return cluster, nil
-	}
-
-	lowerVal := strings.ToLower(value)
-	if lowerVal != "true" && lowerVal != "false" {
-		return cluster, nil
-	}
-
-	cluster = cluster.DeepCopy()
-	if lowerVal == "false" {
-		delete(cluster.ObjectMeta.Annotations, manageSchedulingDefaultsAnn)
-		if cluster.Spec.ClusterAgentDeploymentCustomization == nil {
-			return h.clusters.Update(cluster)
-		}
-		cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization = nil
-		return h.clusters.Update(cluster)
-	}
-
-	// annotation was added to a cluster that already has the fields set, we should not override the existing values.
-	if cluster.Spec.ClusterAgentDeploymentCustomization != nil && cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization != nil {
-		delete(cluster.ObjectMeta.Annotations, manageSchedulingDefaultsAnn)
-		return h.clusters.Update(cluster)
-	}
-
-	defaultPC, defaultPDB, err := getDefaultSchedulingCustomization[v1.PriorityClassSpec, v1.PodDisruptionBudgetSpec]()
+	cluster, err := h.updateV1AgentSchedulingCustomization(cluster)
 	if err != nil {
-		return cluster, fmt.Errorf("failed to get default scheduling customization: %w", err)
-	}
-	if defaultPDB != nil || defaultPC != nil {
-		if cluster.Spec.ClusterAgentDeploymentCustomization == nil {
-			cluster.Spec.ClusterAgentDeploymentCustomization = &v1.AgentDeploymentCustomization{}
-		}
-		cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization = &v1.AgentSchedulingCustomization{
-			PodDisruptionBudget: defaultPDB,
-			PriorityClass:       defaultPC,
-		}
+		return nil, err
 	}
 
-	delete(cluster.ObjectMeta.Annotations, manageSchedulingDefaultsAnn)
-	return h.clusters.Update(cluster)
+	cluster, err = h.updateV1FleetAgentSchedulingCustomization(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
 }
 
-// updateV1SchedulingCustomization looks for the provisioning.cattle.io/enable-scheduling-customization annotation on the v3.Cluster
-// and if found populates the spec.ClusterAgentDeploymentCustomization.SchedulingCustomization field with the default values set in the
-// global settings. If the cluster-agent-scheduling-customization feature is disabled, the cluster will be returned unchanged.
-// The provisioning.cattle.io/enable-scheduling-customization annotation can be set to 'true' or 'false', which will add or remove
-// the scheduling customization field as needed. updateV3SchedulingCustomization is intended to handle KEv2 and legacy clusters specifically.
+// updateV3SchedulingCustomization looks for the provisioning.cattle.io/enable-{fleet-}scheduling-customization
+// annotation on the v3.Cluster and if found populates the
+// spec.{Cluster,Fleet}AgentDeploymentCustomization.SchedulingCustomization fields with the default values set in the
+// global settings. If the cluster-agent-scheduling-customization feature is disabled, the cluster will be returned
+// unchanged. The provisioning.cattle.io/enable-{fleet-}scheduling-customization annotation can be set to 'true' or
+// 'false', which will add or remove the scheduling customization field as needed. updateV3SchedulingCustomization is
+// intended to handle KEv2 and legacy clusters specifically.
 func (h *handler) updateV3SchedulingCustomization(_ string, cluster *v3.Cluster) (*v3.Cluster, error) {
 	if cluster == nil {
-		return nil, nil
-	}
-
-	if !h.isLegacyCluster(cluster) {
 		return nil, nil
 	}
 
@@ -87,7 +55,60 @@ func (h *handler) updateV3SchedulingCustomization(_ string, cluster *v3.Cluster)
 		return cluster, nil
 	}
 
-	value, ok := cluster.ObjectMeta.Annotations[manageSchedulingDefaultsAnn]
+	cluster, err := h.updateV3AgentSchedulingCustomization(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err = h.updateV3FleetAgentSchedulingCustomization(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+// updateV1AgentSchedulingCustomization looks for the provisioning.cattle.io/enable-scheduling-customization annotation
+// on the v1.Cluster and if found populates the spec.ClusterAgentDeploymentCustomization.SchedulingCustomization fields
+// with the default values set in the global settings. The provisioning.cattle.io/enable-scheduling-customization
+// annotation can be set to 'true' or 'false', which will add or remove the scheduling customization field as needed.
+func (h *handler) updateV1AgentSchedulingCustomization(cluster *v1.Cluster) (*v1.Cluster, error) {
+	return h.updateV1SchedulingCustomizationForAgent(cluster, clusterAgent)
+}
+
+// updateV1FleetAgentSchedulingCustomization looks for the provisioning.cattle.io/enable-fleet-scheduling-customization
+// annotation on the v1.Cluster and if found populates the spec.FleetAgentDeploymentCustomization.SchedulingCustomization fields
+// with the default values set in the global settings. The provisioning.cattle.io/enable-fleet-scheduling-customization
+// annotation can be set to 'true' or 'false', which will add or remove the scheduling customization field as needed.
+func (h *handler) updateV1FleetAgentSchedulingCustomization(cluster *v1.Cluster) (*v1.Cluster, error) {
+	return h.updateV1SchedulingCustomizationForAgent(cluster, fleetAgent)
+}
+
+type agentType int
+
+const (
+	clusterAgent agentType = iota
+	fleetAgent
+)
+
+func (h *handler) updateV1SchedulingCustomizationForAgent(cluster *v1.Cluster, agent agentType) (*v1.Cluster, error) {
+	var annotation string
+	var pcSetting, pdbSetting settings.Setting
+
+	switch agent {
+	case clusterAgent:
+		annotation = manageSchedulingDefaultsAnn
+		pcSetting = settings.ClusterAgentDefaultPriorityClass
+		pdbSetting = settings.ClusterAgentDefaultPodDisruptionBudget
+	case fleetAgent:
+		annotation = manageFleetSchedulingDefaultsAnn
+		pcSetting = settings.FleetAgentDefaultPriorityClass
+		pdbSetting = settings.FleetAgentDefaultPodDisruptionBudget
+	default:
+		return nil, fmt.Errorf("unknown agent type: %v", agent)
+	}
+
+	value, ok := cluster.Annotations[annotation]
 	if !ok {
 		return cluster, nil
 	}
@@ -98,41 +119,174 @@ func (h *handler) updateV3SchedulingCustomization(_ string, cluster *v3.Cluster)
 	}
 
 	cluster = cluster.DeepCopy()
+
+	var adc *v1.AgentDeploymentCustomization
+	switch agent {
+	case clusterAgent:
+		adc = cluster.Spec.ClusterAgentDeploymentCustomization
+	case fleetAgent:
+		adc = cluster.Spec.FleetAgentDeploymentCustomization
+	default:
+		return nil, fmt.Errorf("unknown agent type during adc assignment: %v", agent)
+	}
+
 	if lowerVal == "false" {
-		delete(cluster.ObjectMeta.Annotations, manageSchedulingDefaultsAnn)
-		if cluster.Spec.ClusterAgentDeploymentCustomization == nil {
-			return h.mgmtClusters.Update(cluster)
+		delete(cluster.Annotations, annotation)
+
+		if adc != nil {
+			adc.SchedulingCustomization = nil
 		}
-		cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization = nil
-		return h.mgmtClusters.Update(cluster)
+
+		return h.clusters.Update(cluster)
 	}
 
 	// annotation was added to a cluster that already has the fields set, we should not override the existing values.
-	if cluster.Spec.ClusterAgentDeploymentCustomization != nil && cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization != nil {
-		delete(cluster.ObjectMeta.Annotations, manageSchedulingDefaultsAnn)
-		return h.mgmtClusters.Update(cluster)
+	if adc != nil && adc.SchedulingCustomization != nil {
+		delete(cluster.Annotations, annotation)
+		return h.clusters.Update(cluster)
 	}
 
-	defaultPC, defaultPDB, err := getDefaultSchedulingCustomization[v3.PriorityClassSpec, v3.PodDisruptionBudgetSpec]()
+	defaultPC, defaultPDB, err := getDefaultSchedulingCustomization[v1.PriorityClassSpec, v1.PodDisruptionBudgetSpec](
+		pcSetting,
+		pdbSetting,
+	)
 	if err != nil {
 		return cluster, fmt.Errorf("failed to get default scheduling customization: %w", err)
 	}
 	if defaultPDB != nil || defaultPC != nil {
-		if cluster.Spec.ClusterAgentDeploymentCustomization == nil {
-			cluster.Spec.ClusterAgentDeploymentCustomization = &v3.AgentDeploymentCustomization{}
+		if adc == nil {
+			adc = &v1.AgentDeploymentCustomization{}
+			switch agent {
+			case clusterAgent:
+				cluster.Spec.ClusterAgentDeploymentCustomization = adc
+			case fleetAgent:
+				cluster.Spec.FleetAgentDeploymentCustomization = adc
+			default:
+				return nil, fmt.Errorf("unknown agent type during adc assignment: %v", agent)
+			}
 		}
-		cluster.Spec.ClusterAgentDeploymentCustomization.SchedulingCustomization = &v3.AgentSchedulingCustomization{
+		adc.SchedulingCustomization = &v1.AgentSchedulingCustomization{
 			PodDisruptionBudget: defaultPDB,
 			PriorityClass:       defaultPC,
 		}
 	}
 
-	delete(cluster.ObjectMeta.Annotations, manageSchedulingDefaultsAnn)
+	delete(cluster.Annotations, annotation)
+	return h.clusters.Update(cluster)
+}
+
+// updateV3AgentSchedulingCustomization looks for the provisioning.cattle.io/enable-scheduling-customization annotation
+// on the v3.Cluster and if found populates the spec.ClusterAgentDeploymentCustomization.SchedulingCustomization fields
+// with the default values set in the global settings. The provisioning.cattle.io/enable-scheduling-customization
+// annotation can be set to 'true' or 'false', which will add or remove the scheduling customization field as needed.
+// updateV3AgentSchedulingCustomization is intended to handle KEv2 and legacy clusters specifically.
+func (h *handler) updateV3AgentSchedulingCustomization(cluster *v3.Cluster) (*v3.Cluster, error) {
+	return h.updateV3SchedulingCustomizationForAgent(cluster, clusterAgent)
+}
+
+// updateV3FleetAgentSchedulingCustomization looks for the provisioning.cattle.io/enable-fleet-scheduling-customization
+// annotation on the v3.Cluster and if found populates the
+// spec.FleetAgentDeploymentCustomization.SchedulingCustomization fields with the default values set in the global
+// settings. The provisioning.cattle.io/enable-fleet-scheduling-customization annotation can be set to 'true' or
+// 'false', which will add or remove the scheduling customization field as needed.
+// updateV3FleetAgentSchedulingCustomization is intended to handle KEv2 and legacy clusters specifically.
+func (h *handler) updateV3FleetAgentSchedulingCustomization(cluster *v3.Cluster) (*v3.Cluster, error) {
+	return h.updateV3SchedulingCustomizationForAgent(cluster, fleetAgent)
+}
+
+func (h *handler) updateV3SchedulingCustomizationForAgent(cluster *v3.Cluster, agent agentType) (*v3.Cluster, error) {
+	if cluster == nil {
+		return nil, nil
+	}
+	if !h.isLegacyCluster(cluster) {
+		return nil, nil
+	}
+
+	var annotation string
+	var pcSetting, pdbSetting settings.Setting
+
+	switch agent {
+	case clusterAgent:
+		annotation = manageSchedulingDefaultsAnn
+		pcSetting = settings.ClusterAgentDefaultPriorityClass
+		pdbSetting = settings.ClusterAgentDefaultPodDisruptionBudget
+	case fleetAgent:
+		annotation = manageFleetSchedulingDefaultsAnn
+		pcSetting = settings.FleetAgentDefaultPriorityClass
+		pdbSetting = settings.FleetAgentDefaultPodDisruptionBudget
+	default:
+		return nil, fmt.Errorf("unknown agent type: %v", agent)
+	}
+
+	value, ok := cluster.Annotations[annotation]
+	if !ok {
+		return cluster, nil
+	}
+
+	lowerVal := strings.ToLower(value)
+	if lowerVal != "true" && lowerVal != "false" {
+		return cluster, nil
+	}
+
+	cluster = cluster.DeepCopy()
+
+	var adc *v3.AgentDeploymentCustomization
+	switch agent {
+	case clusterAgent:
+		adc = cluster.Spec.ClusterAgentDeploymentCustomization
+	case fleetAgent:
+		adc = cluster.Spec.FleetAgentDeploymentCustomization
+	default:
+		return nil, fmt.Errorf("unknown agent type during adc assignment: %v", agent)
+	}
+
+	if lowerVal == "false" {
+		delete(cluster.Annotations, annotation)
+
+		if adc != nil {
+			adc.SchedulingCustomization = nil
+		}
+
+		return h.mgmtClusters.Update(cluster)
+	}
+
+	// annotation was added to a cluster that already has the fields set, we should not override the existing values.
+	if adc != nil && adc.SchedulingCustomization != nil {
+		delete(cluster.Annotations, annotation)
+		return h.mgmtClusters.Update(cluster)
+	}
+
+	defaultPC, defaultPDB, err := getDefaultSchedulingCustomization[v3.PriorityClassSpec, v3.PodDisruptionBudgetSpec](
+		pcSetting,
+		pdbSetting,
+	)
+	if err != nil {
+		return cluster, fmt.Errorf("failed to get default scheduling customization: %w", err)
+	}
+	if defaultPDB != nil || defaultPC != nil {
+		if adc == nil {
+			adc = &v3.AgentDeploymentCustomization{}
+			switch agent {
+			case clusterAgent:
+				cluster.Spec.ClusterAgentDeploymentCustomization = adc
+			case fleetAgent:
+				cluster.Spec.FleetAgentDeploymentCustomization = adc
+			}
+		}
+		adc.SchedulingCustomization = &v3.AgentSchedulingCustomization{
+			PodDisruptionBudget: defaultPDB,
+			PriorityClass:       defaultPC,
+		}
+	}
+
+	delete(cluster.ObjectMeta.Annotations, annotation)
 	return h.mgmtClusters.Update(cluster)
 }
 
-func getDefaultSchedulingCustomization[T v1.PriorityClassSpec | v3.PriorityClassSpec, TT v1.PodDisruptionBudgetSpec | v3.PodDisruptionBudgetSpec]() (*T, *TT, error) {
-	defaultPC := settings.ClusterAgentDefaultPriorityClass.Get()
+func getDefaultSchedulingCustomization[T v1.PriorityClassSpec | v3.PriorityClassSpec, TT v1.PodDisruptionBudgetSpec | v3.PodDisruptionBudgetSpec](
+	defaultPriorityClassSetting, defaultPodDisruptionClassSetting settings.Setting,
+) (*T, *TT, error) {
+	defaultPC := defaultPriorityClassSetting.Get()
 	pc := new(T)
 	if defaultPC != "" {
 		err := json.Unmarshal([]byte(defaultPC), &pc)
@@ -143,7 +297,7 @@ func getDefaultSchedulingCustomization[T v1.PriorityClassSpec | v3.PriorityClass
 		pc = nil
 	}
 
-	defaultPdb := settings.ClusterAgentDefaultPodDisruptionBudget.Get()
+	defaultPdb := defaultPodDisruptionClassSetting.Get()
 	pdb := new(TT)
 	if defaultPdb != "" {
 		err := json.Unmarshal([]byte(defaultPdb), &pdb)

--- a/pkg/controllers/provisioningv2/cluster/scheduling_customization_test.go
+++ b/pkg/controllers/provisioningv2/cluster/scheduling_customization_test.go
@@ -1,0 +1,764 @@
+package cluster
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/pmezard/go-difflib/difflib"
+	"go.uber.org/mock/gomock"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/features"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+)
+
+var (
+	PreemptLowerPriority = corev1.PreemptLowerPriority
+)
+
+func Test_updateV1AgentSchedulingCustomization(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         v1.Cluster
+		expectedErr     bool
+		expectedCluster v1.Cluster
+	}{
+		{
+			name:            "empty cluster missed annotation, no change expected",
+			cluster:         v1.Cluster{},
+			expectedCluster: v1.Cluster{},
+		},
+		{
+			name: "has annotation but no customization, expecting removal of annotation and addition of defaults",
+			cluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						manageSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v1.ClusterSpec{},
+			},
+			expectedCluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v1.ClusterSpec{
+					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+						SchedulingCustomization: &v1.AgentSchedulingCustomization{
+							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
+								MaxUnavailable: "0",
+								MinAvailable:   "1",
+							},
+							PriorityClass: &v1.PriorityClassSpec{
+								PreemptionPolicy: &PreemptLowerPriority,
+								Value:            1000000000,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "has annotation and customization, expecting removal of annotation and no changes to customization",
+			cluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						manageSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v1.ClusterSpec{
+					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+						SchedulingCustomization: &v1.AgentSchedulingCustomization{
+							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
+								MaxUnavailable: "50%",
+							},
+						},
+					},
+				},
+			},
+			expectedCluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v1.ClusterSpec{
+					ClusterAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+						SchedulingCustomization: &v1.AgentSchedulingCustomization{
+							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
+								MaxUnavailable: "50%",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			clusters := fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](mockCtrl)
+			clusters.EXPECT().Update(gomock.Any()).DoAndReturn(func(cluster *v1.Cluster) (*v1.Cluster, error) {
+				return cluster, nil
+			}).AnyTimes()
+
+			h := handler{
+				clusters: clusters,
+			}
+
+			features.ClusterAgentSchedulingCustomization.Set(true)
+
+			outputCluster, err := h.updateV1AgentSchedulingCustomization(&tt.cluster)
+
+			if tt.expectedErr && err == nil {
+				t.Fatalf("expected error but got none")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Fatalf("did not expect error but got: %v", err)
+			}
+
+			if !reflect.DeepEqual(outputCluster, &tt.expectedCluster) {
+				out, err := yaml.Marshal(outputCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal input cluster: %v", err)
+				}
+				expected, err := yaml.Marshal(tt.expectedCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal output cluster: %v", err)
+				}
+				diff := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(string(out)),
+					B:        difflib.SplitLines(string(expected)),
+					FromFile: "actual",
+					ToFile:   "expected",
+					Context:  3,
+				}
+				text, err := difflib.GetUnifiedDiffString(diff)
+				if err != nil {
+					t.Fatalf("failed to get diff string: %v", err)
+				}
+				if text != "" {
+					t.Fatalf("resulting cluster differs from the expected cluster\n%s", text)
+				}
+			}
+		})
+	}
+}
+
+func Test_updateV1FleetAgentSchedulingCustomization(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         v1.Cluster
+		expectedErr     bool
+		expectedCluster v1.Cluster
+	}{
+		{
+			name:            "empty cluster missed annotation, no change expected",
+			cluster:         v1.Cluster{},
+			expectedCluster: v1.Cluster{},
+		},
+		{
+			name: "has annotation but no customization, expecting removal of annotation and addition of defaults",
+			cluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						manageFleetSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v1.ClusterSpec{},
+			},
+			expectedCluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v1.ClusterSpec{
+					FleetAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+						SchedulingCustomization: &v1.AgentSchedulingCustomization{
+							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
+								MaxUnavailable: "0",
+								MinAvailable:   "1",
+							},
+							PriorityClass: &v1.PriorityClassSpec{
+								PreemptionPolicy: &PreemptLowerPriority,
+								Value:            999999999,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "has annotation and customization, expecting removal of annotation and no changes to customization",
+			cluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						manageFleetSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v1.ClusterSpec{
+					FleetAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+						SchedulingCustomization: &v1.AgentSchedulingCustomization{
+							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
+								MaxUnavailable: "50%",
+							},
+						},
+					},
+				},
+			},
+			expectedCluster: v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v1.ClusterSpec{
+					FleetAgentDeploymentCustomization: &v1.AgentDeploymentCustomization{
+						SchedulingCustomization: &v1.AgentSchedulingCustomization{
+							PodDisruptionBudget: &v1.PodDisruptionBudgetSpec{
+								MaxUnavailable: "50%",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			clusters := fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](mockCtrl)
+			clusters.EXPECT().Update(gomock.Any()).DoAndReturn(func(cluster *v1.Cluster) (*v1.Cluster, error) {
+				return cluster, nil
+			}).AnyTimes()
+
+			h := handler{
+				clusters: clusters,
+			}
+
+			features.ClusterAgentSchedulingCustomization.Set(true)
+
+			outputCluster, err := h.updateV1FleetAgentSchedulingCustomization(&tt.cluster)
+
+			if tt.expectedErr && err == nil {
+				t.Fatalf("expected error but got none")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Fatalf("did not expect error but got: %v", err)
+			}
+
+			if !reflect.DeepEqual(outputCluster, &tt.expectedCluster) {
+				out, err := yaml.Marshal(outputCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal input cluster: %v", err)
+				}
+				expected, err := yaml.Marshal(tt.expectedCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal output cluster: %v", err)
+				}
+
+				diff := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(string(out)),
+					B:        difflib.SplitLines(string(expected)),
+					FromFile: "actual",
+					ToFile:   "expected",
+					Context:  3,
+				}
+				text, err := difflib.GetUnifiedDiffString(diff)
+				if err != nil {
+					t.Fatalf("failed to get diff string: %v", err)
+				}
+				if text != "" {
+					fmt.Printf("Diff:\n%s\n", text)
+					t.Fatalf("resulting cluster differs from the expected cluster\n%s", text)
+				}
+			}
+		})
+	}
+}
+
+func Test_updateV3AgentSchedulingCustomization(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         v3.Cluster
+		expectedErr     bool
+		expectedCluster *v3.Cluster
+	}{
+		{
+			name: "local (legacy) cluster with annotation but no customization, expecting removal of annotation and addition of defaults",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+					Annotations: map[string]string{
+						manageSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{},
+			},
+			expectedCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "0",
+									MinAvailable:   "1",
+								},
+								PriorityClass: &v3.PriorityClassSpec{
+									PreemptionPolicy: &PreemptLowerPriority,
+									Value:            1000000000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "c-cluster (legacy) cluster with annotation but no customization, expecting removal of annotation and addition of defaults",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-abcde",
+					Annotations: map[string]string{
+						manageSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{},
+			},
+			expectedCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-abcde",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "0",
+									MinAvailable:   "1",
+								},
+								PriorityClass: &v3.PriorityClassSpec{
+									PreemptionPolicy: &PreemptLowerPriority,
+									Value:            1000000000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "non-legacy cluster, no changes",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+					Annotations: map[string]string{
+						manageSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{},
+			},
+			expectedCluster: nil,
+		},
+		{
+			name: "has annotation and customization, expecting removal of annotation and no changes to customization",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+					Annotations: map[string]string{
+						manageSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "50%",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "50%",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			clusters := fake.NewMockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList](mockCtrl)
+			if tt.expectedCluster != nil {
+				clusters.EXPECT().Update(gomock.Any()).DoAndReturn(func(cluster *v3.Cluster) (*v3.Cluster, error) {
+					return cluster, nil
+				}).AnyTimes()
+			}
+
+			h := handler{
+				mgmtClusters: clusters,
+			}
+
+			features.ClusterAgentSchedulingCustomization.Set(true)
+
+			outputCluster, err := h.updateV3AgentSchedulingCustomization(&tt.cluster)
+
+			if tt.expectedErr && err == nil {
+				t.Fatalf("expected error but got none")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Fatalf("did not expect error but got: %v", err)
+			}
+
+			if tt.expectedCluster == nil {
+				if outputCluster != nil {
+					t.Fatalf("expected nil cluster but got: %v", outputCluster)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(outputCluster, tt.expectedCluster) {
+				out, err := yaml.Marshal(outputCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal input cluster: %v", err)
+				}
+				expected, err := yaml.Marshal(tt.expectedCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal output cluster: %v", err)
+				}
+
+				diff := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(string(out)),
+					B:        difflib.SplitLines(string(expected)),
+					FromFile: "actual",
+					ToFile:   "expected",
+					Context:  3,
+				}
+				text, err := difflib.GetUnifiedDiffString(diff)
+				if err != nil {
+					t.Fatalf("failed to get diff string: %v", err)
+				}
+				if text != "" {
+					t.Fatalf("resulting cluster differs from the expected cluster\n%s", text)
+				}
+			}
+		})
+	}
+}
+
+func Test_updateV3FleetAgentSchedulingCustomization(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         v3.Cluster
+		expectedErr     bool
+		expectedCluster *v3.Cluster
+	}{
+		{
+			name: "local (legacy) cluster with annotation but no customization, expecting removal of annotation and addition of defaults",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+					Annotations: map[string]string{
+						manageFleetSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{},
+			},
+			expectedCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						FleetAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "0",
+									MinAvailable:   "1",
+								},
+								PriorityClass: &v3.PriorityClassSpec{
+									PreemptionPolicy: &PreemptLowerPriority,
+									Value:            999999999,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "c-cluster (legacy) cluster with annotation but no customization, expecting removal of annotation and addition of defaults",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-abcde",
+					Annotations: map[string]string{
+						manageFleetSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{},
+			},
+			expectedCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-abcde",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						FleetAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "0",
+									MinAvailable:   "1",
+								},
+								PriorityClass: &v3.PriorityClassSpec{
+									PreemptionPolicy: &PreemptLowerPriority,
+									Value:            999999999,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "non-legacy cluster, no changes",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+					Annotations: map[string]string{
+						manageFleetSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{},
+			},
+			expectedCluster: nil,
+		},
+		{
+			name: "has annotation and customization, expecting removal of annotation and no changes to customization",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+					Annotations: map[string]string{
+						manageFleetSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						FleetAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "50%",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						FleetAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "50%",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			clusters := fake.NewMockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList](mockCtrl)
+			if tt.expectedCluster != nil {
+				clusters.EXPECT().Update(gomock.Any()).DoAndReturn(func(cluster *v3.Cluster) (*v3.Cluster, error) {
+					return cluster, nil
+				}).AnyTimes()
+			}
+
+			h := handler{
+				mgmtClusters: clusters,
+			}
+
+			features.ClusterAgentSchedulingCustomization.Set(true)
+
+			outputCluster, err := h.updateV3FleetAgentSchedulingCustomization(&tt.cluster)
+
+			if tt.expectedErr && err == nil {
+				t.Fatalf("expected error but got none")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Fatalf("did not expect error but got: %v", err)
+			}
+
+			if tt.expectedCluster == nil {
+				if outputCluster != nil {
+					t.Fatalf("expected nil cluster but got: %v", outputCluster)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(outputCluster, tt.expectedCluster) {
+				out, err := yaml.Marshal(outputCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal input cluster: %v", err)
+				}
+				expected, err := yaml.Marshal(tt.expectedCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal output cluster: %v", err)
+				}
+
+				diff := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(string(out)),
+					B:        difflib.SplitLines(string(expected)),
+					FromFile: "actual",
+					ToFile:   "expected",
+					Context:  3,
+				}
+				text, err := difflib.GetUnifiedDiffString(diff)
+				if err != nil {
+					t.Fatalf("failed to get diff string: %v", err)
+				}
+				if text != "" {
+					t.Fatalf("resulting cluster differs from the expected cluster\n%s", text)
+				}
+			}
+		})
+	}
+}
+
+func Test_updateV3SchedulingCustomization(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         v3.Cluster
+		expectedErr     bool
+		expectedCluster *v3.Cluster
+	}{
+		{
+			name: "has both annotations and no customizations, expecting both customizations to be added",
+			cluster: v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+					Annotations: map[string]string{
+						manageSchedulingDefaultsAnn:      "true",
+						manageFleetSchedulingDefaultsAnn: "true",
+					},
+				},
+				Spec: v3.ClusterSpec{},
+			},
+			expectedCluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "local",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "0",
+									MinAvailable:   "1",
+								},
+								PriorityClass: &v3.PriorityClassSpec{
+									PreemptionPolicy: &PreemptLowerPriority,
+									Value:            1000000000,
+								},
+							},
+						},
+						FleetAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							SchedulingCustomization: &v3.AgentSchedulingCustomization{
+								PodDisruptionBudget: &v3.PodDisruptionBudgetSpec{
+									MaxUnavailable: "0",
+									MinAvailable:   "1",
+								},
+								PriorityClass: &v3.PriorityClassSpec{
+									PreemptionPolicy: &PreemptLowerPriority,
+									Value:            999999999,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			clusters := fake.NewMockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList](mockCtrl)
+			if tt.expectedCluster != nil {
+				clusters.EXPECT().Update(gomock.Any()).DoAndReturn(func(cluster *v3.Cluster) (*v3.Cluster, error) {
+					return cluster, nil
+				}).AnyTimes()
+			}
+
+			h := handler{
+				mgmtClusters: clusters,
+			}
+
+			features.ClusterAgentSchedulingCustomization.Set(true)
+
+			outputCluster, err := h.updateV3SchedulingCustomization(tt.name, &tt.cluster)
+
+			if tt.expectedErr && err == nil {
+				t.Fatalf("expected error but got none")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Fatalf("did not expect error but got: %v", err)
+			}
+
+			if tt.expectedCluster == nil {
+				if outputCluster != nil {
+					t.Fatalf("expected nil cluster but got: %v", outputCluster)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(outputCluster, tt.expectedCluster) {
+				out, err := yaml.Marshal(outputCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal input cluster: %v", err)
+				}
+				expected, err := yaml.Marshal(tt.expectedCluster)
+				if err != nil {
+					t.Fatalf("failed to marshal output cluster: %v", err)
+				}
+
+				diff := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(string(out)),
+					B:        difflib.SplitLines(string(expected)),
+					FromFile: "actual",
+					ToFile:   "expected",
+					Context:  3,
+				}
+				text, err := difflib.GetUnifiedDiffString(diff)
+				if err != nil {
+					t.Fatalf("failed to get diff string: %v", err)
+				}
+				if text != "" {
+					t.Fatalf("resulting cluster differs from the expected cluster\n%s", text)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	mgmtcluster "github.com/rancher/rancher/pkg/cluster"
@@ -21,11 +20,13 @@ import (
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/taints"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/sirupsen/logrus"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/yaml"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -250,6 +251,21 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 	// sort tolerations for consistent ordering to avoid unnecessary updates
 	sortTolerations(tolerations)
 
+	schedulingCustomization := &fleet.AgentSchedulingCustomization{}
+	if cluster.Spec.FleetAgentDeploymentCustomization != nil && cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization != nil {
+		sc := cluster.Spec.FleetAgentDeploymentCustomization.SchedulingCustomization
+		if sc.PodDisruptionBudget != nil {
+			schedulingCustomization.PodDisruptionBudget = &fleet.PodDisruptionBudgetSpec{}
+			schedulingCustomization.PodDisruptionBudget.MaxUnavailable = sc.PodDisruptionBudget.MaxUnavailable
+			schedulingCustomization.PodDisruptionBudget.MinAvailable = sc.PodDisruptionBudget.MinAvailable
+		}
+		if sc.PriorityClass != nil {
+			schedulingCustomization.PriorityClass = &fleet.PriorityClassSpec{}
+			schedulingCustomization.PriorityClass.PreemptionPolicy = sc.PriorityClass.PreemptionPolicy
+			schedulingCustomization.PriorityClass.Value = sc.PriorityClass.Value
+		}
+	}
+
 	return append(objs, &fleet.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cluster.Name,
@@ -258,14 +274,15 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 			Annotations: annotations,
 		},
 		Spec: fleet.ClusterSpec{
-			KubeConfigSecret:          clientSecret,
-			KubeConfigSecretNamespace: cluster.Namespace,
-			AgentEnvVars:              mgmtCluster.Spec.AgentEnvVars,
-			AgentNamespace:            agentNamespace,
-			PrivateRepoURL:            h.getPrivateRepoURL(cluster, mgmtCluster),
-			AgentTolerations:          tolerations,
-			AgentAffinity:             agentAffinity,
-			AgentResources:            mgmtcluster.GetFleetAgentResourceRequirements(mgmtCluster),
+			KubeConfigSecret:             clientSecret,
+			KubeConfigSecretNamespace:    cluster.Namespace,
+			AgentEnvVars:                 mgmtCluster.Spec.AgentEnvVars,
+			AgentNamespace:               agentNamespace,
+			PrivateRepoURL:               h.getPrivateRepoURL(cluster, mgmtCluster),
+			AgentTolerations:             tolerations,
+			AgentAffinity:                agentAffinity,
+			AgentResources:               mgmtcluster.GetFleetAgentResourceRequirements(mgmtCluster),
+			AgentSchedulingCustomization: schedulingCustomization,
 		},
 	}), status, nil
 }

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -9,6 +9,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	managementv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -160,7 +161,7 @@ var (
 		true).lockOnInstall()
 	ClusterAgentSchedulingCustomization = newFeature(
 		"cluster-agent-scheduling-customization",
-		"Enables the automatic deployment of Pod Disruption Budgets and Priority Classes when deploying the cattle-cluster-agent. Disabling this feature will not impact existing clusters.",
+		"Enables the automatic deployment of Pod Disruption Budgets and Priority Classes when deploying the cattle-cluster-agent and fleet agent. Disabling this feature will not impact existing clusters.",
 		false,
 		true,
 		true)

--- a/pkg/settings/agent_customization.go
+++ b/pkg/settings/agent_customization.go
@@ -115,7 +115,17 @@ const (
     "value": 1000000000
 }`
 
+	FleetAgentPriorityClass = `{
+    "preemptionPolicy": "PreemptLowerPriority",
+    "value":  999999999
+}`
+
 	ClusterAgentPodDisruptionBudget = `{
+	"minAvailable": "1",
+	"maxUnavailable": "0"
+}`
+
+	FleetAgentPodDisruptionBudget = `{
 	"minAvailable": "1",
 	"maxUnavailable": "0"
 }`

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -147,6 +147,8 @@ var (
 
 	ClusterAgentDefaultPriorityClass       = NewSetting("cluster-agent-default-priority-class", ClusterAgentPriorityClass)
 	ClusterAgentDefaultPodDisruptionBudget = NewSetting("cluster-agent-default-pod-disruption-budget", ClusterAgentPodDisruptionBudget)
+	FleetAgentDefaultPriorityClass         = NewSetting("fleet-agent-default-priority-class", FleetAgentPriorityClass)
+	FleetAgentDefaultPodDisruptionBudget   = NewSetting("fleet-agent-default-pod-disruption-budget", FleetAgentPodDisruptionBudget)
 
 	Rke2DefaultVersion = NewSetting("rke2-default-version", "")
 	K3sDefaultVersion  = NewSetting("k3s-default-version", "")


### PR DESCRIPTION
## Issue #52535 and #52437

## Problem

Currently, there are some situations where the fleet agent can be evicted from a downstream cluster. This could be due to node pressure or the scheduler favoring of higher priority workloads. This prevents users from deploying to the cluster via Fleet (with and without the Rancher UI).

## Solution

Implement a new feature which will automatically create a Priority Class and Pod Disruption Budget in the downstream cluster when deploying the fleet agent. The Priority Class will assign the second highest user configurable priority value of 1 billion minus 1 on the fleet agent, and allow for the preemption of lower priority pods. The Pod Disruption Budget will ensure that there is at least 1 replica of the agent running at any time by default.

This feature is disabled by default, but once enabled, allows users to configure the schedulingCustomization field added to the existing FleetAgentDeploymentCustomization field in v3.Cluster and v1.Cluster objects. Any changes to this new field will automatically update the fleet cluster resource and therefore update the PC and PDB in the downstream cluster and redeploy the fleet agent. Two new global settings are introduced which provide the default PC and PDB configuration. It should be noted that updating these global settings will not update existing clusters.

Additionally, controllers for handling a new annotation (provisioning.cattle.io/enable-scheduling-customization) have been previously added in the initial implementation. Setting this annotation to `true` or `false` will automatically update the schedulingCustomization field using the global defaults. This can be set on both v1.Cluster and v3.Cluster objects.

This backend work supports all cluster types. Additionally, the associated UI implementation may not target all cluster types initially). While this feature is disabled by default for 2.11, it will eventually be enabled by default in a later release.

## Testing

For Node Driver Provisioned and Custom Clusters:

- Enable the `cluster-agent-scheduling-customization` feature flag in global settings of the Rancher UI
- Provision a cluster with one or more nodes or import an existing cluster
- Manually edit the v1.Cluster object in either the UI or by using kubectl
- Add the `fleetAgentDeploymentCustomization` and `schedulingCustomization` fields as required, and populate both the `priorityClass` and `podDisruptionBudget` fields with valid values
- Update the cluster and monitor the fleet-agent deployment to ensure a new replica is deployed
Once updated
- confirm that the PDB has been created on the downstream cluster(s) `kubectl get poddisruptionbudgets.policy -n cattle-fleet-system fleet-agent-pod-disruption-budget -o yaml`
- confirm that the PC has been created on the downstream cluster(s) `kubectl get priorityclasses.scheduling.k8s.io fleet-agent-priority-class -o yaml`
- confirm that the fleet-agent has been redeployed and is marked with the correct priority value in its spec `kubectl get pod -n cattle-fleet-system -l app=fleet-agent -o yaml`
- Test permutations of both the PC and PDB, and repeat the above steps to ensure that the objects and agent are updated appropriately.

For Imported or KEv2 clusters, you can repeat the above steps with the only caveat being that you must modify the v3.Cluster when adding the schedulingCustomization fields instead of the v1.Cluster.

## Webhook

Additional logic will be added to the webhook to ensure that users are not able to configure these fields incorrectly (e.g. setting an invalid priority value, or configuring both minAvailable and maxUnavailable on the PDB).

## References

Issue #52535

Partly implemented through the initial implementation in Rancher and an implementation in Fleet, which the Rancher implementation did not require.

https://github.com/rancher/rancher/issues/48995
https://github.com/rancher/fleet/issues/4118