### PR TITLE
Enhance User-Agent header for Helm repository checks (SURE-10360)

### DIFF
--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/catalogv2/roundtripper"
-	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -188,7 +187,7 @@ func (g *git) httpClientWithCreds() (*http.Client, error) {
 
 	// Wrap the transport with a custom RoundTripper to set the User-Agent header
 	client.Transport = &roundtripper.UserAgent{
-		UserAgent: fmt.Sprintf("%s/%s/%s %s", "go", "rancher", settings.ServerVersion.Get(), "(Git-based Helm Repository)"),
+		UserAgent: roundtripper.BuildUserAgent("go", "(Git-based Helm Repository)"),
 		Next:      client.Transport,
 	}
 
@@ -326,7 +325,7 @@ func (g *git) gitCmd(output io.Writer, args ...string) error {
 	kv := fmt.Sprintf("credential.helper=%s", `/bin/sh -c 'echo "password=$GIT_PASSWORD"'`)
 	cmd := exec.Command("git", append([]string{"-c", kv}, args...)...)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("GIT_PASSWORD=%s", g.password))
-	userAgentValue := fmt.Sprintf("%s/%s/%s %s", "git", "rancher", settings.ServerVersion.Get(), "(Git-based Helm Repository)")
+	userAgentValue := roundtripper.BuildUserAgent("git", "(Git-based Helm Repository)")
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_HTTP_USER_AGENT=%s", userAgentValue))
 
 	stderrBuf := &bytes.Buffer{}

--- a/pkg/catalogv2/http/client.go
+++ b/pkg/catalogv2/http/client.go
@@ -3,7 +3,6 @@ package http
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	"github.com/rancher/rancher/pkg/catalogv2/roundtripper"
-	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -62,7 +60,7 @@ func HelmClient(secret *corev1.Secret, caBundle []byte, insecureSkipTLSVerify bo
 
 	// Wrap the transport with a custom RoundTripper to set the User-Agent header
 	client.Transport = &roundtripper.UserAgent{
-		UserAgent: fmt.Sprintf("%s/%s/%s %s", "go", "rancher", settings.ServerVersion.Get(), "(HTTP-based Helm Repository)"),
+		UserAgent: roundtripper.BuildUserAgent("go", "(HTTP-based Helm Repository)"),
 		Next:      client.Transport,
 	}
 

--- a/pkg/catalogv2/oci/client.go
+++ b/pkg/catalogv2/oci/client.go
@@ -16,7 +16,6 @@ import (
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/catalogv2/oci/capturewindowclient"
 	"github.com/rancher/rancher/pkg/catalogv2/roundtripper"
-	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	helmregistry "helm.sh/helm/v3/pkg/registry"
@@ -227,7 +226,7 @@ func (o *Client) SetAuthClient() error {
 	}
 
 	o.HTTPClient.Transport = &roundtripper.UserAgent{
-		UserAgent: fmt.Sprintf("%s/%s/%s %s", "go", "rancher", settings.ServerVersion.Get(), "(OCI-based Helm Repository)"),
+		UserAgent: roundtripper.BuildUserAgent("go", "(OCI-based Helm Repository)"),
 		Next:      o.HTTPClient.Transport,
 	}
 

--- a/pkg/catalogv2/roundtripper/user_agent_round_trip.go
+++ b/pkg/catalogv2/roundtripper/user_agent_round_trip.go
@@ -1,6 +1,11 @@
 package roundtripper
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/rancher/rancher/pkg/settings"
+)
 
 type UserAgent struct {
 	UserAgent string
@@ -10,4 +15,13 @@ type UserAgent struct {
 func (u *UserAgent) RoundTrip(request *http.Request) (*http.Response, error) {
 	request.Header.Set("User-Agent", u.UserAgent)
 	return u.Next.RoundTrip(request)
+}
+
+// BuildUserAgent constructs a standardized User-Agent string for Helm repository access
+func BuildUserAgent(protocol, context string) string {
+	return fmt.Sprintf("%s/rancher/%s/%s %s",
+		protocol,
+		settings.ServerVersionType.Get(),
+		settings.ServerVersion.Get(),
+		context)
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -102,6 +102,7 @@ var (
 	ServerImage                         = NewSetting("server-image", "rancher/rancher")
 	ServerURL                           = NewSetting("server-url", "")
 	ServerVersion                       = NewSetting("server-version", "dev")
+	ServerVersionType                   = NewSetting("server-version-type", getVersionType())
 	SystemAgentVersion                  = NewSetting("system-agent-version", "")
 	WinsAgentVersion                    = NewSetting("wins-agent-version", "")
 	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
@@ -601,6 +602,14 @@ func getMetadataConfig() string {
 		return ""
 	}
 	return string(ans)
+}
+
+func getVersionType() string {
+	versionType := os.Getenv("RANCHER_VERSION_TYPE")
+	if versionType == "" {
+		return "dev"
+	}
+	return versionType
 }
 
 // GetSettingByID returns a setting that is stored with the given id.

--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -166,7 +166,13 @@ func StartHTTPRepository(c *ClusterRepoTestSuite) *httptest.Server {
 			serverVersion.Value = serverVersion.Default
 		}
 
-		assert.Equal(c.T(), r.Header.Get("User-Agent"), fmt.Sprintf("%s/%s/%s %s", "go", "rancher", serverVersion.Value, "(HTTP-based Helm Repository)"))
+		serverVersionType, err := c.client.Management.Setting.ByID("server-version-type")
+		assert.NoError(c.T(), err)
+		if serverVersionType.Value == "" {
+			serverVersionType.Value = serverVersionType.Default
+		}
+
+		assert.Equal(c.T(), r.Header.Get("User-Agent"), fmt.Sprintf("%s/%s/%s/%s %s", "go", "rancher", serverVersionType.Value, serverVersion.Value, "(HTTP-based Helm Repository)"))
 		http.StripPrefix("/", http.FileServer(http.Dir(repositoryDirectory))).ServeHTTP(w, r)
 	}))
 


### PR DESCRIPTION
Adds the RANCHER_VERSION_TYPE as needed. Defaults to `dev`.

Consolidate the code.

## Issue: https://jira.suse.com/browse/SURE-10360
 
## Problem

The User-Agent should include the version type of the build.
 
## Solution

Add the RANCHER_VERSION_TYPE to the User-Agent string sent. Defaults to `dev`,
unless RANCHER_VERSION_TYPE is explicitly set. Release builds should set this
to `oss`, `prime`, `ovh` etc.
 
## Testing

## Engineering Testing
### Manual Testing

Compile tested.

### Automated Testing
* Test types added/modified:
    * Unit

Unit test adjusted and succeeded.

## QA Testing Considerations

### Regressions Considerations

This is a backend detail and should not affect regressions.

# Outlook

This could be a backport candidate to versions still under maintenance.
