### PR TITLE
[v2.13] Bump csp-adapter version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ webhookVersion: 108.0.0+up0.9.0-rc.8
 remoteDialerProxyVersion: 106.0.2+up0.6.0-rc.4
 provisioningCAPIVersion: 107.0.0+up0.8.0
 turtlesVersion: 108.0.0+up0.25.0-rc.2
-cspAdapterMinVersion: 107.0.0+up7.0.0-rc.1
+cspAdapterMinVersion: 108.0.0+up8.0.0-rc.1
 defaultShellVersion: rancher/shell:v0.5.0
 fleetVersion: 108.0.0+up0.14.0-alpha.4
 defaultSccOperatorImage: rancher/scc-operator:head

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion     = "107.0.0+up7.0.0-rc.1"
+	CspAdapterMinVersion     = "108.0.0+up8.0.0-rc.1"
 	DefaultSccOperatorImage  = "rancher/scc-operator:head"
 	DefaultShellVersion      = "rancher/shell:v0.5.0"
 	FleetVersion             = "108.0.0+up0.14.0-alpha.4"


### PR DESCRIPTION
##Issue: 
rancher/rancher#52012

##Problem:
Create new rancher-csp-adapter chart for 2.13 rancher

##Testing:

scenario 1 (fresh install):

    On an EKS cluster (k8s version 1.34), install locally built rancher with cspAdapterMinVersion: 108.0.0+up8.0.0-rc.1
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.

scenario 2 (upgrade scenario):

    Start with an EKS cluster (k8s version 1.33), install rancher 2.12.2 with csp-adapter 7.0.0
    Upgrade rancher to locally built rancher with cspAdapterMinVersion: 108.0.0+up8.0.0-rc.1
    Update charts url repo/branch and upgrade csp-adapter version to 108.0.0+up8.0.0-rc.1
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.
