### PR TITLE
Return a bearer token when creating a tokens.ext.cattle.io

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -143,6 +143,8 @@ type TokenStatus struct {
 	// LastActivitySeen is the timestamp of the last time user activity
 	// (mouse movement, interaction, ...) was reported for the token.
 	LastActivitySeen *metav1.Time `json:"lastActivitySeen,omitempty"`
+	// Fully formed bearer token that is ready to use in the Authorization header to authenticate to Rancher.
+	BearerToken string `json:"bearerToken,omitempty"`
 }
 
 // Implement the TokenAccessor interface

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -22,14 +22,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 var (
-	// enabledUser
 	enabledUser = &v3.User{
-		Enabled: pointer.Bool(true),
+		Enabled: ptr.To(true),
 	}
 	// use for disabled tokens
 
@@ -98,7 +97,7 @@ var (
 			UserID:        properUser,
 			Description:   "",
 			TTL:           4000,
-			Enabled:       pointer.Bool(false),
+			Enabled:       ptr.To(false),
 			Kind:          "session",
 			UserPrincipal: properPrincipal,
 		},
@@ -194,7 +193,7 @@ func init() {
 	properTokenCurrent.Status.Current = true
 }
 
-func Test_ttlGreater(t *testing.T) {
+func TestTTLGreater(t *testing.T) {
 
 	tests := []struct {
 		name string
@@ -242,7 +241,7 @@ func Test_ttlGreater(t *testing.T) {
 	}
 }
 
-func Test_Store_New(t *testing.T) {
+func TestStoreNew(t *testing.T) {
 	t.Parallel()
 
 	store := &Store{}
@@ -251,7 +250,7 @@ func Test_Store_New(t *testing.T) {
 	assert.IsType(t, &ext.Token{}, obj)
 }
 
-func Test_Store_NewList(t *testing.T) {
+func TestStoreNewList(t *testing.T) {
 	store := &Store{}
 	obj := store.NewList()
 	require.NotNil(t, obj)
@@ -261,17 +260,17 @@ func Test_Store_NewList(t *testing.T) {
 	assert.Nil(t, list.Items)
 }
 
-func Test_Store_GetSingularName(t *testing.T) {
+func TestStoreGetSingularName(t *testing.T) {
 	store := &Store{}
 	assert.Equal(t, SingularName, store.GetSingularName())
 }
 
-func Test_Store_NamespaceScoped(t *testing.T) {
+func TestStoreNamespaceScoped(t *testing.T) {
 	store := &Store{}
 	assert.False(t, store.NamespaceScoped())
 }
 
-func Test_Store_GroupVersionKind(t *testing.T) {
+func TestStoreGroupVersionKind(t *testing.T) {
 	store := &Store{}
 	assert.Equal(t, GVK, store.GroupVersionKind(ext.SchemeGroupVersion))
 }
@@ -282,14 +281,13 @@ func TestStoreDeleteCollection(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	t.Run("admin deletes a user's tokens with a label", func(t *testing.T) {
-
 		var deleteValidationCalledTimes int
 		deleteValidation := func(ctx context.Context, obj runtime.Object) error {
 			deleteValidationCalledTimes++
 			return nil
 		}
 		deleteOptions := &metav1.DeleteOptions{
-			GracePeriodSeconds: pointer.Int64(60),
+			GracePeriodSeconds: ptr.To(int64(60)),
 		}
 		listOptions := &metainternalversion.ListOptions{
 			LabelSelector: labels.Set{
@@ -342,7 +340,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 	})
 }
 
-func Test_Store_Delete(t *testing.T) {
+func TestStoreDelete(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Delete
 	// Here we test the actions and checks done before delegation to the
 	// embedded system store
@@ -479,7 +477,7 @@ func Test_Store_Delete(t *testing.T) {
 	})
 }
 
-func Test_Store_Get(t *testing.T) {
+func TestStoreGet(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Get
 	// Here we only test the permission checks done after delegation to the
 	// embedded system store
@@ -605,7 +603,7 @@ func Test_Store_Get(t *testing.T) {
 
 		fieldToken := properTokenCurrent.DeepCopy()
 		fieldToken.ObjectMeta.ManagedFields = []metav1.ManagedFieldsEntry{
-			metav1.ManagedFieldsEntry{
+			{
 				Manager:    "token",
 				Operation:  "something",
 				Time:       &now,
@@ -633,12 +631,11 @@ func Test_Store_Get(t *testing.T) {
 	})
 }
 
-func Test_Store_Watch(t *testing.T) {
-	// This test suite is a bit special, as it is not table driven like all other suites coming
-	// after it.  This is done because we need stronger control about the environment the
-	// various store calls are in, i.e. the channels involved, the context, and the goroutine
-	// internal to `Watch`.
-
+// This test suite is a bit special, as it is not table driven like all other suites coming
+// after it.  This is done because we need stronger control about the environment the
+// various store calls are in, i.e. the channels involved, the context, and the goroutine
+// internal to `Watch`.
+func TestStoreWatch(t *testing.T) {
 	t.Run("backend watch creation error fails early", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
@@ -991,7 +988,7 @@ func Test_Store_Watch(t *testing.T) {
 	})
 }
 
-func Test_Store_Create(t *testing.T) {
+func TestStoreCreate(t *testing.T) {
 	tests := []struct {
 		name       string                // test name
 		err        error                 // expected op result, error
@@ -1082,7 +1079,7 @@ func Test_Store_Create(t *testing.T) {
 
 				users.EXPECT().Get("world").
 					Return(&v3.User{
-						Enabled: pointer.Bool(false),
+						Enabled: ptr.To(false),
 					}, nil)
 			},
 		},
@@ -1196,7 +1193,7 @@ func Test_Store_Create(t *testing.T) {
 					Return(&v3.User{
 						DisplayName: "worldwide",
 						Username:    "wide",
-						Enabled:     pointer.Bool(true),
+						Enabled:     ptr.To(true),
 					}, nil)
 
 				// Fake value and hash
@@ -1245,7 +1242,7 @@ func Test_Store_Create(t *testing.T) {
 					Return(&v3.User{
 						DisplayName: "worldwide",
 						Username:    "wide",
-						Enabled:     pointer.Bool(true),
+						Enabled:     ptr.To(true),
 					}, nil)
 
 				// Fake value and hash
@@ -1294,7 +1291,7 @@ func Test_Store_Create(t *testing.T) {
 					Return(&v3.User{
 						DisplayName: "worldwide",
 						Username:    "wide",
-						Enabled:     pointer.Bool(true),
+						Enabled:     ptr.To(true),
 					}, nil)
 
 				// Fake value and hash
@@ -1351,7 +1348,7 @@ func Test_Store_Create(t *testing.T) {
 					Return(&v3.User{
 						DisplayName: "worldwide",
 						Username:    "wide",
-						Enabled:     pointer.Bool(true),
+						Enabled:     ptr.To(true),
 					}, nil)
 
 				// Fake value and hash -- See rtok below
@@ -1369,6 +1366,7 @@ func Test_Store_Create(t *testing.T) {
 				copy := properToken.DeepCopy()
 				copy.Status.Hash = ""
 				copy.Status.Value = "94084kdlafj43"
+				copy.Status.BearerToken = fmt.Sprintf("ext/%s:%s", copy.Name, copy.Status.Value)
 				return copy
 			}(),
 		},
@@ -1412,7 +1410,7 @@ func Test_Store_Create(t *testing.T) {
 	}
 }
 
-func Test_SystemStore_List(t *testing.T) {
+func TestSystemStoreList(t *testing.T) {
 	tests := []struct {
 		name       string              // test name
 		user       string              // user making request
@@ -1457,7 +1455,7 @@ func Test_SystemStore_List(t *testing.T) {
 				ListMeta: metav1.ListMeta{
 					ResourceVersion:    "1",
 					Continue:           "true",
-					RemainingItemCount: pointer.Int64(2),
+					RemainingItemCount: ptr.To(int64(2)),
 				},
 				Items: []ext.Token{
 					properToken,
@@ -1470,7 +1468,7 @@ func Test_SystemStore_List(t *testing.T) {
 						ListMeta: metav1.ListMeta{
 							ResourceVersion:    "1",
 							Continue:           "true",
-							RemainingItemCount: pointer.Int64(2),
+							RemainingItemCount: ptr.To(int64(2)),
 						},
 						Items: []corev1.Secret{
 							properSecret,
@@ -1572,7 +1570,7 @@ func Test_SystemStore_List(t *testing.T) {
 	}
 }
 
-func Test_SystemStore_Delete(t *testing.T) {
+func TestSystemStoreDelete(t *testing.T) {
 	tests := []struct {
 		name       string                // test name
 		token      string                // name of token to delete
@@ -1642,7 +1640,7 @@ func Test_SystemStore_Delete(t *testing.T) {
 	}
 }
 
-func Test_SystemStore_UpdateLastUsedAt(t *testing.T) {
+func TestSystemStoreUpdateLastUsedAt(t *testing.T) {
 	t.Run("patch last-used-at, ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
@@ -1695,7 +1693,7 @@ func Test_SystemStore_UpdateLastUsedAt(t *testing.T) {
 	})
 }
 
-func Test_SystemStore_UpdateLastActivitySeen(t *testing.T) {
+func TestSystemStoreUpdateLastActivitySeen(t *testing.T) {
 	t.Run("patch last-activity-seen, ok", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
@@ -1748,7 +1746,7 @@ func Test_SystemStore_UpdateLastActivitySeen(t *testing.T) {
 	})
 }
 
-func Test_SystemStore_Update(t *testing.T) {
+func TestSystemStoreUpdate(t *testing.T) {
 	tests := []struct {
 		name       string                // test name
 		fullPerm   bool                  // permission level: full or not
@@ -2065,7 +2063,7 @@ func Test_SystemStore_Update(t *testing.T) {
 	}
 }
 
-func Test_SystemStore_Get(t *testing.T) {
+func TestSystemStoreGet(t *testing.T) {
 	tests := []struct {
 		name       string             // test name
 		tokname    string             // name of token to retrieve
@@ -2249,7 +2247,7 @@ func Test_SystemStore_Get(t *testing.T) {
 					UserID:        properUser,
 					Description:   "",
 					TTL:           4000,
-					Enabled:       pointer.Bool(false),
+					Enabled:       ptr.To(false),
 					Kind:          "session",
 					UserPrincipal: properPrincipal,
 				},
@@ -2291,10 +2289,6 @@ func Test_SystemStore_Get(t *testing.T) {
 	}
 }
 
-// helpers
-
-// implementation of the k8s user info interface for mocking
-
 type mockUser struct {
 	name string
 }
@@ -2314,8 +2308,6 @@ func (u *mockUser) GetGroups() []string {
 func (u *mockUser) GetExtra() map[string][]string {
 	return map[string][]string{}
 }
-
-// implementation of the k8s watch interface for mocking
 
 func NewWatcherFor(e ...watch.Event) *mockWatch {
 	ch := make(chan watch.Event, len(e))
@@ -2339,5 +2331,4 @@ func (w *mockWatch) ResultChan() <-chan watch.Event {
 	return w.ch
 }
 
-func (w *mockWatch) Stop() {
-}
+func (w *mockWatch) Stop() {}

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -1097,6 +1097,13 @@ func schema_pkg_apis_extcattleio_v1_TokenStatus(ref common.ReferenceCallback) co
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"bearerToken": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Fully formed bearer token that is ready to use in the Authorization header to authenticate to Rancher.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"current", "expired", "expiresAt", "lastUpdateTime"},
 			},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

#51630
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The end user needs to know/remember how to form the bearer token given the token id, secret key and ext prefix.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Return the fully formed bearer token as a status field when the new token is created.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A