### PR TITLE
Don't install CAPI CRDs and webhooks when Turtles is enabled

### DIFF
--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -12,7 +12,7 @@ func RequiredCRDs() []string {
 		if features.RKE2.Enabled() {
 			requiredCRDS = append(requiredCRDS, RKE2CRDs()...)
 		}
-		if features.EmbeddedClusterAPI.Enabled() {
+		if features.EmbeddedClusterAPI.Enabled() && !features.Turtles.Enabled() {
 			requiredCRDS = append(requiredCRDS, CAPICRDs()...)
 		}
 		if features.Fleet.Enabled() {

--- a/pkg/crds/provisioningv2/crds.go
+++ b/pkg/crds/provisioningv2/crds.go
@@ -33,7 +33,7 @@ func List() (result []crd.CRD) {
 	if features.RKE2.Enabled() {
 		result = append(result, rke2()...)
 	}
-	if features.EmbeddedClusterAPI.Enabled() {
+	if features.EmbeddedClusterAPI.Enabled() && !features.Turtles.Enabled() {
 		result = append(result, capi()...)
 	}
 	return
@@ -115,7 +115,7 @@ func rke2() []crd.CRD {
 }
 
 func Webhooks() []runtime.Object {
-	if features.EmbeddedClusterAPI.Enabled() {
+	if features.EmbeddedClusterAPI.Enabled() && !features.Turtles.Enabled() {
 		return capiWebhooks()
 	}
 	return nil


### PR DESCRIPTION
This PR handles a corner case when users enable both Turtles and embedded CAPI features, we can't prevent this mistake from happening. Turtles wins in this case and gets installed.
 
Related issue https://github.com/rancher/turtles/issues/1828