### PR TITLE
[RoleTemplate Aggregation] Add PRTB and CRTB enqueuers for changed RoleTemplates

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/register_test.go
+++ b/pkg/controllers/management/auth/roletemplates/register_test.go
@@ -130,13 +130,6 @@ func Test_roletemplateEnqueueCRTBs(t *testing.T) {
 			want:    nil,
 			wantErr: false,
 		},
-		{
-			name:    "invalid object type",
-			obj:     &v3.Cluster{},
-			caches:  caches{},
-			want:    nil,
-			wantErr: false,
-		},
 	}
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {
@@ -151,7 +144,7 @@ func Test_roletemplateEnqueueCRTBs(t *testing.T) {
 				r.crtbCache = tt.caches.crtbCache(ctrl)
 			}
 
-			got, err := r.roletemplateEnqueueCRTBs("", "", tt.obj)
+			got, err := r.roletemplateEnqueueCRTBs("", "rt-1", tt.obj)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -262,13 +255,6 @@ func Test_roletemplateEnqueuePRTBs(t *testing.T) {
 			want:    nil,
 			wantErr: false,
 		},
-		{
-			name:    "invalid object type",
-			obj:     &v3.Cluster{},
-			caches:  caches{},
-			want:    nil,
-			wantErr: false,
-		},
 	}
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {
@@ -286,7 +272,7 @@ func Test_roletemplateEnqueuePRTBs(t *testing.T) {
 				r.prtbCache = tt.caches.prtbCache(ctrl)
 			}
 
-			got, err := r.roletemplateEnqueuePRTBs("", "", tt.obj)
+			got, err := r.roletemplateEnqueuePRTBs("", "rt-1", tt.obj)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/49320
 
## Problem
When a RoleTemplate is changed, it's possible the new version will add/remove new cluster roles. In that case, the CRTB and PRTB controllers need to run to add the appropriate bindings. Currently there is no such mechanism so these changes don't occur and the changes may not get reflected in the permissions.
 
## Solution
Added an enqueuer for both CRTBs and PRTBs to trigger whenever a RoleTemplate they reference is changed.
 
## Testing

## Engineering Testing
### Manual Testing
The repro steps in the issue are good for CRTBs, but I also tried it with PRTBs (using secrets instead of projects as the changing rule) and it worked as well.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: Added unit tests to cover the new enqueue functions

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_