### PR TITLE
Fix providerrefresh daemon

### DIFF
--- a/pkg/auth/providerrefresh/daemon.go
+++ b/pkg/auth/providerrefresh/daemon.go
@@ -24,13 +24,14 @@ func StartRefreshDaemon(scaledContext *config.ScaledContext, mgmtContext *config
 	refreshCronTime := settings.AuthUserInfoResyncCron.Get()
 	maxAge := settings.AuthUserInfoMaxAgeSeconds.Get()
 	ref = &refresher{
-		tokenLister:         mgmtContext.Management.Tokens("").Controller().Lister(),
-		tokens:              mgmtContext.Management.Tokens(""),
-		userLister:          mgmtContext.Management.Users("").Controller().Lister(),
-		tokenMGR:            tokens.NewManager(scaledContext.Wrangler),
-		userAttributes:      mgmtContext.Management.UserAttributes(""),
-		userAttributeLister: mgmtContext.Management.UserAttributes("").Controller().Lister(),
-		extTokenStore:       extTokenStore,
+		tokenLister:               mgmtContext.Management.Tokens("").Controller().Lister(),
+		tokens:                    mgmtContext.Management.Tokens(""),
+		userLister:                mgmtContext.Management.Users("").Controller().Lister(),
+		tokenMGR:                  tokens.NewManager(scaledContext.Wrangler),
+		userAttributes:            mgmtContext.Management.UserAttributes(""),
+		userAttributeLister:       mgmtContext.Management.UserAttributes("").Controller().Lister(),
+		extTokenStore:             extTokenStore,
+		ensureAndGetUserAttribute: scaledContext.UserManager.EnsureAndGetUserAttribute,
 	}
 
 	UpdateRefreshMaxAge(maxAge)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

On daemon start the `refresher` instance was created without initializing the `ensureAndGetUserAttribute` member, leading to a panic.
Caused by #51284
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Properly initialize the `refresher` instance.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions: N/A