### PR TITLE
Delete embedded CAPI webhook configurations on startup

### DIFF
--- a/pkg/data/dashboard/add.go
+++ b/pkg/data/dashboard/add.go
@@ -6,11 +6,22 @@ import (
 	"github.com/rancher/rancher/pkg/data/management"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 func EarlyData(ctx context.Context, k8s kubernetes.Interface) error {
 	return addCattleGlobalNamespaces(ctx, k8s)
+}
+
+func EarlyRemove(ctx context.Context, k8s kubernetes.Interface) error {
+	if !features.EmbeddedClusterAPI.Enabled() || features.Turtles.Enabled() {
+		if err := CleanupCAPIWebhookConfigs(ctx, k8s); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func Add(ctx context.Context, wrangler *wrangler.Context, addLocal, removeLocal, embedded bool) error {
@@ -42,4 +53,23 @@ func Add(ctx context.Context, wrangler *wrangler.Context, addLocal, removeLocal,
 	}
 
 	return addUnauthenticatedRoles(wrangler.Apply)
+}
+
+const (
+	CAPIMutatingWebhookName   = "mutating-webhook-configuration"
+	CAPIValidatingWebhookName = "validating-webhook-configuration"
+)
+
+func CleanupCAPIWebhookConfigs(ctx context.Context, k8s kubernetes.Interface) error {
+	err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, CAPIMutatingWebhookName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	err = k8s.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, CAPIValidatingWebhookName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -182,6 +182,11 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 	}
 	features.InitializeFeatures(wranglerContext.Mgmt.Feature(), opts.Features)
 
+	// Remove any resources that are dependent on specific features being enabled
+	if err := dashboarddata.EarlyRemove(ctx, wranglerContext.K8s); err != nil {
+		return nil, err
+	}
+
 	kontainerdriver.RegisterIndexers(wranglerContext)
 	managementauth.RegisterWranglerIndexers(wranglerContext)
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52335
 
## Problem
When Rancher starts up and the `embedded-cluster-api` feature is true, CRDs and webhook configurations will be automatically created. However, Rancher will not clean these resources up if that feature is later disabled, interfering with other webhooks provided by turtles. Related PRs have already addressed blocking the creation of embedded CRDs, but we still need to handle webhook configurations.

## Solution
On startup delete the two webhook configurations. Toggling the embedded-capi feature flag requires a restart, ensuring this logic will run.
 
## Testing
+ Start rancher with embedded capi equal to `true` and turtles equal to `false`
+ Disable the `embedded-capi` feature and enable `turtles`, causing rancher to restart
+ Allow rancher to restart
+ Ensure that the two embedded capi webhook configurations have been removed, and that new ones have been created by turtles.

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_