### PR TITLE
Fix impersonation in HA mode

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -234,7 +234,10 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 			return err
 		}
 	} else {
-		clusterController.RegisterCaches(rec.cluster)
+		if err := clusterController.RegisterFollower(rec.cluster); err != nil {
+			transaction.Rollback()
+			return err
+		}
 	}
 
 	done := make(chan error, 1)

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -48,7 +48,8 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 		})()
 	})
 
-	RegisterCaches(cluster)
+	registerCaches(cluster)
+
 	// early request an impersonator for initializing it
 	if _, err := impersonation.ForCluster(cluster); err != nil {
 		return fmt.Errorf("unable to create impersonator for cluster %q: %w", cluster.ClusterName, err)
@@ -94,8 +95,18 @@ func registerProvV2(ctx context.Context, cluster *config.UserContext, capi *wran
 	machinerole.Register(ctx, cluster)
 }
 
-// RegisterCaches initializes caches early in the initialization process to have them available as soon as possible (instead of on demand when Lister/Cache or Controller are called)
-func RegisterCaches(cluster *config.UserContext) {
+func RegisterFollower(cluster *config.UserContext) error {
+	registerCaches(cluster)
+
+	// early request an impersonator for initializing it
+	if _, err := impersonation.ForCluster(cluster); err != nil {
+		return fmt.Errorf("unable to create impersonator for cluster %q: %w", cluster.ClusterName, err)
+	}
+	return nil
+}
+
+// registerCaches initializes caches early in the initialization process to have them available as soon as possible (instead of on demand when Lister/Cache or Controller are called)
+func registerCaches(cluster *config.UserContext) {
 	cluster.Core.Namespaces("").Controller()
 	cluster.RBACw.ClusterRoleBinding().Informer()
 	cluster.RBACw.ClusterRole().Informer()


### PR DESCRIPTION
## Issue: #52234

Follow-up of #52222, fixing a regression that prevented using the k8s proxy for clusters not "owned" by that particular pod (replica running user controllers for that downstream).
 
## Problem

The new impersonator is not correctly initialized when a Rancher replica acts as a follower, and not the owner of a downstream cluster (all clusters get load-balanced across all available replicas). I still believe there may be a bug or race-condition in the logic that registers extra replicas, but this can be investigated separately, as this PR ensures the initialization sequence is fixed.
 
## Solution

Early register an impersonator, ensuring the dedicated cache factory is already registered before `UserContext.Start()` is called.
 
## Testing

## Engineering Testing
### Manual Testing
Manually deployed both affected version and the one with a fix:

* Before the changes:
```
❯ for pod in $(k -n cattle-system get po -o name -l app=rancher | cut -d/ -f2); do echo "=======$pod" ; k -n cattle-system exec -ti $pod -- curl -Ssf -k -H 'Authorization: Bearer <REDACTED>' https://localhost:443/k8s/clusters/c-m-psdnqksk && echo OK || echo ; done
=======rancher-6ff7cdd458-jwmqp
curl: (22) The requested URL returned error: 500
command terminated with exit code 22

=======rancher-6ff7cdd458-m9f9n
OK
=======rancher-6ff7cdd458-nllcn
curl: (22) The requested URL returned error: 500
command terminated with exit code 22
```

* After:
```
❯ for pod in $(k -n cattle-system get po -o name -l app=rancher | cut -d/ -f2); do echo "=======$pod" ; k -n cattle-system exec -ti $pod -- curl -Ssf -k -H 'Authorization: Bearer <REDACTED>' https://localhost:443/k8s/clusters/c-m-psdnqksk && echo OK || echo ; done
=======rancher-6ff7cdd458-9bg8n
OK
=======rancher-6ff7cdd458-fwqgc
OK
=======rancher-6ff7cdd458-xtc6s
OK
```