### PR TITLE
[main] change autoscaler kubeconfig to use server-url rather than internal-server-url setting

### DIFF
--- a/pkg/controllers/capr/autoscaler/util.go
+++ b/pkg/controllers/capr/autoscaler/util.go
@@ -56,7 +56,7 @@ func ownerReference(cluster *capi.Cluster) []metav1.OwnerReference {
 // generateKubeconfig generates a kubeconfig YAML string using the provided token and server URL settings.
 func generateKubeconfig(token string) ([]byte, error) {
 	// Update the kubeconfig data with new token
-	serverURL, cacert := settings.InternalServerURL.Get(), settings.CACerts.Get()
+	serverURL, cacert := settings.ServerURL.Get(), settings.CACerts.Get()
 
 	data, err := clientcmd.Write(clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{


### PR DESCRIPTION
this is a followup to #52243 - it was found during QA that if the `internal-server-url` differs from the `server-url` a non-working kubeconfig was generated. 

Example from my setup:
```bash
$> k get setting | grep server-url
internal-server-url                           https://foo.cp-dev.rancher.space
server-url                                    https://foo.cp-dev.rancher.space
```

Example from a qa-setup:
```bash
$> k get setting | grep server-url
internal-server-url                           https://192.168.123.5:8443
server-url                                    https://foo.cp-dev.rancher.space
```

by using the `server-url` setting which always seems to be publicly accessible - this should make the autoscaler work even if the settings differ.

RFE: https://github.com/rancher/rancher/issues/49680