### PR TITLE
Add cleaner for unused user tokens.

### DIFF
--- a/pkg/auth/cleanup/cleanup.go
+++ b/pkg/auth/cleanup/cleanup.go
@@ -4,18 +4,45 @@ import (
 	"errors"
 
 	"github.com/rancher/rancher/pkg/auth/api/secrets"
+	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 )
 
 var cleanupProviders = []string{"genericoidc", "cognito"}
 
+const cleanedUpSecretsAnnotation = "auth.cattle.io/unused-secrets-cleaned"
+
 // CleanupUnusedSecretTokens removes tokens from the cattle-system namespace that have
 // been removed from the PerUserCacheProviders.
-func CleanupUnusedSecretTokens(secretsInterface wcorev1.SecretController) (cleanupErr error) {
+//
+// The AuthConfig is annotated to indicate that the secrets have been cleaned.
+func CleanupUnusedSecretTokens(secretsInterface wcorev1.SecretController, authConfigs v3.AuthConfigController) (cleanupErr error) {
 	for _, name := range cleanupProviders {
+		authConfig, err := authConfigs.Cache().Get(name)
+		if err != nil {
+			logrus.Errorf("getting AuthConfig %s: %s", name, err)
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+
+		if val := authConfig.Annotations[cleanedUpSecretsAnnotation]; val == "true" {
+			continue
+		}
+
 		logrus.Infof("Cleaning unused tokens from provider %s", name)
 		if err := secrets.CleanupOAuthTokens(secretsInterface, name); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+
+		authConfig = authConfig.DeepCopy()
+		if authConfig.Annotations == nil {
+			authConfig.Annotations = map[string]string{}
+		}
+
+		authConfig.Annotations[cleanedUpSecretsAnnotation] = "true"
+		if _, err := authConfigs.Update(authConfig); err != nil {
 			cleanupErr = errors.Join(cleanupErr, err)
 		}
 	}

--- a/pkg/auth/cleanup/cleanup_test.go
+++ b/pkg/auth/cleanup/cleanup_test.go
@@ -1,17 +1,22 @@
 package cleanup
 
 import (
+	"errors"
 	"testing"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	wranglerfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCleanupUnusedSecretTokens(t *testing.T) {
-	var secretStore = map[string]*v1.Secret{
+	secretStore := map[string]*v1.Secret{
 		"cattle-system:test-secret-1": {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-secret-1",
@@ -33,9 +38,13 @@ func TestCleanupUnusedSecretTokens(t *testing.T) {
 			},
 		},
 	}
-
+	authConfigStore := map[string]storedAuthConfig{
+		"genericoidc": {authConfig: &v3.AuthConfig{ObjectMeta: metav1.ObjectMeta{Name: "genericoidc"}}, updated: true},
+		"cognito":     {authConfig: &v3.AuthConfig{ObjectMeta: metav1.ObjectMeta{Name: "cognito"}}, updated: true},
+	}
 	ctrl := gomock.NewController(t)
-	err := CleanupUnusedSecretTokens(getSecretControllerMock(ctrl, secretStore))
+
+	err := CleanupUnusedSecretTokens(getSecretControllerMock(ctrl, secretStore), getAuthConfigControllerMock(ctrl, authConfigStore))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,4 +52,124 @@ func TestCleanupUnusedSecretTokens(t *testing.T) {
 	if len(secretStore) != 0 {
 		t.Errorf("failed to delete secrets: %#v", secretStore)
 	}
+
+	for _, provider := range cleanupProviders {
+		if ann := authConfigStore[provider].authConfig.Annotations; ann[cleanedUpSecretsAnnotation] != "true" {
+			t.Errorf("didn't update the annotations: %#v", ann)
+		}
+	}
+}
+
+func TestCleanupUnusedSecretTokensHandlesErrors(t *testing.T) {
+	secretStore := map[string]*v1.Secret{
+		"cattle-system:test-secret-1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret-1",
+				Namespace: tokens.SecretNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"genericoidc": []byte("my user token"),
+			},
+		},
+	}
+	authConfigStore := map[string]storedAuthConfig{
+		"cognito":     {authConfig: &v3.AuthConfig{ObjectMeta: metav1.ObjectMeta{Name: "cognito"}}, updated: false, err: errors.New("test error")},
+		"genericoidc": {authConfig: &v3.AuthConfig{ObjectMeta: metav1.ObjectMeta{Name: "genericoidc"}}, updated: true},
+	}
+	ctrl := gomock.NewController(t)
+
+	err := CleanupUnusedSecretTokens(getSecretControllerMock(ctrl, secretStore), getAuthConfigControllerMock(ctrl, authConfigStore))
+	if msg := err.Error(); msg != "test error" {
+		t.Fatalf("got error %v", err)
+	}
+
+	if len(secretStore) != 0 {
+		t.Errorf("failed to delete secrets: %#v", secretStore)
+	}
+
+	for _, provider := range cleanupProviders {
+		// Only the non-erroring configs should be updated
+		if authConfigStore[provider].err == nil {
+			if ann := authConfigStore[provider].authConfig.Annotations; ann[cleanedUpSecretsAnnotation] != "true" {
+				t.Errorf("didn't update the annotations: %#v", ann)
+			}
+		}
+	}
+}
+
+func TestCleanupUnusedSecretTokensAlreadyAnnotated(t *testing.T) {
+	secretStore := map[string]*v1.Secret{
+		"cattle-system:test-secret-1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret-1",
+				Namespace: tokens.SecretNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"genericoidc": []byte("my user token"),
+			},
+		},
+	}
+	authConfigStore := map[string]storedAuthConfig{
+		"genericoidc": {
+			authConfig: &v3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "genericoidc",
+					Annotations: map[string]string{cleanedUpSecretsAnnotation: "true"},
+				},
+			},
+			updated: false,
+		},
+		"cognito": {authConfig: &v3.AuthConfig{ObjectMeta: metav1.ObjectMeta{Name: "cognito"}}, updated: true},
+	}
+	ctrl := gomock.NewController(t)
+
+	err := CleanupUnusedSecretTokens(getSecretControllerMock(ctrl, secretStore), getAuthConfigControllerMock(ctrl, authConfigStore))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if l := len(secretStore); l != 1 {
+		t.Errorf("secrets were incorrectly deleted - remaining secrets = %d", l)
+	}
+
+	for _, provider := range cleanupProviders {
+		if ann := authConfigStore[provider].authConfig.Annotations; ann[cleanedUpSecretsAnnotation] != "true" {
+			t.Errorf("didn't update the annotations: %#v", ann)
+		}
+	}
+}
+
+type storedAuthConfig struct {
+	authConfig *v3.AuthConfig
+	updated    bool
+	err        error
+}
+
+func getAuthConfigControllerMock(ctrl *gomock.Controller, store map[string]storedAuthConfig) mgmtv3.AuthConfigController {
+	authConfigs := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.AuthConfig, *v3.AuthConfigList](ctrl)
+	authConfigsCache := fake.NewMockNonNamespacedCacheInterface[*v3.AuthConfig](ctrl)
+	authConfigs.EXPECT().Cache().Return(authConfigsCache).Times(2)
+
+	for _, v := range store {
+		authConfigsCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(name string) (*v3.AuthConfig, error) {
+			stored := store[name]
+			if stored.err != nil {
+				return nil, stored.err
+			}
+			return stored.authConfig, nil
+		})
+
+		if v.updated {
+			authConfigs.EXPECT().Update(gomock.Any()).DoAndReturn(func(ac *v3.AuthConfig) (*v3.AuthConfig, error) {
+				stored := store[ac.GetName()]
+				stored.authConfig = ac
+				store[ac.GetName()] = stored
+				return ac, nil
+			})
+		}
+	}
+
+	return authConfigs
 }

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -352,6 +352,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 	wranglerContext.OnLeader(func(context.Context) error {
 		return cleanup.CleanupUnusedSecretTokens(
 			wranglerContext.Core.Secret(),
+			wranglerContext.Mgmt.AuthConfig(),
 		)
 	})
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52136
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
We no longer store tokens for genericoidc and cognito, this will ensure that these tokens are removed.
 
## Solution
This triggers a cleanup of existing secrets using the standard OAuth Secret cleaner mechanism for the two removed providers.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Startup and checked that on upgrade the secrets are removed.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_