### PR TITLE
Return id in the login response

### DIFF
--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -366,6 +366,7 @@ func (h *loginHandler) login(w http.ResponseWriter, r *http.Request, input login
 		"expiresAt": token.ExpiresAt,
 		// The following fields are included for backwards compatibility
 		// with existing v3 clients e.g. the Rancher terraform provider.
+		"id":       token.Name,
 		"baseType": "token",
 		"type":     "token",
 	}

--- a/tests/integration/suite/test_tokens.py
+++ b/tests/integration/suite/test_tokens.py
@@ -75,6 +75,8 @@ def test_kubeconfig_token_ttl(admin_mc, user_mc):
     kubeconfig_token = login()
     assert kubeconfig_token["token"] != ""
     assert kubeconfig_token["expiresAt"] != ""
+    assert kubeconfig_token["id"] != ""
+    assert kubeconfig_token["token"].startswith(kubeconfig_token["id"])
     assert kubeconfig_token["type"] == "token"
     assert kubeconfig_token["baseType"] == "token"
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Existing v3 clients e.g. terraform provider depend on the presence of the `id` field in the login endpoint response, which the new login handler was not returning.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Include the `id` field for backwards compatibility.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Existing / newly added automated tests that provide evidence there are no regressions: