### PR TITLE
[main] autoscaler bugfixes pertaining to size 0 machinedeployments not being rendered + globalrole conflict errors

### DIFF
--- a/pkg/controllers/provisioningv2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/template.go
@@ -297,9 +297,6 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 
 	machinePoolNames := map[string]bool{}
 	for _, machinePool := range cluster.Spec.RKEConfig.MachinePools {
-		if machinePool.Quantity != nil && *machinePool.Quantity == 0 {
-			continue
-		}
 		if machinePool.Name == "" || machinePool.NodeConfig == nil || machinePool.NodeConfig.Name == "" || machinePool.NodeConfig.Kind == "" {
 			return nil, fmt.Errorf("invalid machinePool [%s] missing name or valid config", machinePool.Name)
 		}


### PR DESCRIPTION
this PR fixes two things:
- noticed a lot of conflict update errors on update when the globalrole was being modified (it's also being modified by the globalRole controller so this lines up)
- size 0 machinedeployments not showing up due to not being rendered by the v2prov controllers. 

RFE: https://github.com/rancher/rancher/issues/49680