### PR TITLE
Fix route initialization for SAML auth providers

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -189,6 +189,8 @@ func InitializeSamlServiceProvider(configToSet *apiv3.SamlConfig, name string) e
 
 	SamlProviders[name] = provider
 
+	log.Debugf("SAML [InitializeSamlServiceProvider]: Set /v1-saml handlers for %s on root %p", name, root)
+
 	switch name {
 	case PingName:
 		root.Get("PingACS").HandlerFunc(provider.ServeHTTP)
@@ -217,12 +219,20 @@ func InitializeSamlServiceProvider(configToSet *apiv3.SamlConfig, name string) e
 		root.Get("ShibbolethMetadata").HandlerFunc(provider.ServeHTTP)
 	}
 
-	appliedVersion = configToSet.ResourceVersion
+	log.Debugf("SAML [InitializeSamlServiceProvider]: /v1-saml handlers for %s on root %p active", name, root)
 
+	appliedVersion = configToSet.ResourceVersion
 	return nil
 }
 
 func AuthHandler() http.Handler {
+	log.Debugf("SAML [AuthHandler]: Setting up /v1-saml routes, mux is %p", root)
+
+	if root != nil {
+		log.Debugf("SAML [AuthHandler]: /v1-saml routes are already set, mux is %p", root)
+		return root
+	}
+
 	root = mux.NewRouter()
 
 	root.Methods("POST").Path("/v1-saml/ping/saml/acs").Name("PingACS")
@@ -250,6 +260,7 @@ func AuthHandler() http.Handler {
 	root.Methods("GET").Path("/v1-saml/shibboleth/saml/slo").Name("ShibbolethSLOGet")
 	root.Methods("GET").Path("/v1-saml/shibboleth/saml/metadata").Name("ShibbolethMetadata")
 
+	log.Debugf("SAML [AuthHandler]: /v1-saml routes made, mux is %p", root)
 	return root
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Ref hotfix https://github.com/rancher/rancher/pull/52271
 
## Problem

The internal SAML dispatcher singleton is no such. On each initialization call a new structure is delivered.
Internally only the last delivered structure is remembered and fully initialized with actual handlers.
When a partially initialized dispatcher is actually used it causes 404 on all SAML requests.
 
## Solution

The code was modified to ensure that the structure is a singleton to the callers as well.
All calls after the first simply return the already created structure.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_