### PR TITLE
Register cluster generating handlers earlier on initial startup

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -112,31 +112,6 @@ func EarlyRegister(ctx context.Context, clients *wrangler.Context, kubeconfigMan
 		"provisioning-cluster-create",
 		h.generateProvisioningClusterFromLegacyCluster,
 		nil)
-}
-
-func Register(
-	ctx context.Context,
-	clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) {
-	h := handler{
-		mgmtClusterCache:      clients.Mgmt.Cluster().Cache(),
-		mgmtClusters:          clients.Mgmt.Cluster(),
-		clusterTokenCache:     clients.Mgmt.ClusterRegistrationToken().Cache(),
-		clusterTokens:         clients.Mgmt.ClusterRegistrationToken(),
-		featureCache:          clients.Mgmt.Feature().Cache(),
-		featureClient:         clients.Mgmt.Feature(),
-		clusters:              clients.Provisioning.Cluster(),
-		clusterCache:          clients.Provisioning.Cluster().Cache(),
-		rkeControlPlanes:      clients.RKE.RKEControlPlane(),
-		rkeControlPlanesCache: clients.RKE.RKEControlPlane().Cache(),
-		secretCache:           clients.Core.Secret().Cache(),
-		capiClustersCache:     clients.CAPI.Cluster().Cache(),
-		capiClusters:          clients.CAPI.Cluster(),
-		capiMachinesCache:     clients.CAPI.Machine().Cache(),
-		kubeconfigManager:     kubeconfigManager,
-		apply: clients.Apply.WithCacheTypes(
-			clients.Provisioning.Cluster(),
-			clients.Mgmt.Cluster()),
-	}
 
 	clusterCreateApply := clients.Apply.WithCacheTypes(clients.Mgmt.Cluster(),
 		clients.Mgmt.ClusterRegistrationToken(),
@@ -170,6 +145,33 @@ func Register(
 
 	relatedresource.Watch(ctx, "cluster-watch", h.clusterWatch,
 		clients.Provisioning.Cluster(), clients.Mgmt.Cluster())
+}
+
+func Register(
+	ctx context.Context,
+	clients *wrangler.CAPIContext, kubeconfigManager *kubeconfig.Manager) {
+	h := handler{
+		mgmtClusterCache:      clients.Mgmt.Cluster().Cache(),
+		mgmtClusters:          clients.Mgmt.Cluster(),
+		clusterTokenCache:     clients.Mgmt.ClusterRegistrationToken().Cache(),
+		clusterTokens:         clients.Mgmt.ClusterRegistrationToken(),
+		featureCache:          clients.Mgmt.Feature().Cache(),
+		featureClient:         clients.Mgmt.Feature(),
+		clusters:              clients.Provisioning.Cluster(),
+		clusterCache:          clients.Provisioning.Cluster().Cache(),
+		rkeControlPlanes:      clients.RKE.RKEControlPlane(),
+		rkeControlPlanesCache: clients.RKE.RKEControlPlane().Cache(),
+		secretCache:           clients.Core.Secret().Cache(),
+
+		capiClustersCache: clients.CAPI.Cluster().Cache(),
+		capiClusters:      clients.CAPI.Cluster(),
+		capiMachinesCache: clients.CAPI.Machine().Cache(),
+
+		kubeconfigManager: kubeconfigManager,
+		apply: clients.Apply.WithCacheTypes(
+			clients.Provisioning.Cluster(),
+			clients.Mgmt.Cluster()),
+	}
 
 	clients.Mgmt.Cluster().OnRemove(ctx, "mgmt-cluster-remove", h.OnMgmtClusterRemove)
 	clients.Provisioning.Cluster().OnRemove(ctx, "provisioning-cluster-remove", h.OnClusterRemove)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52441

## Problem
As a part of https://github.com/rancher/rancher/issues/51134 several controllers were delayed in their registration until CAPI CRDs were established. This has had an unintended impact on how the local v3 and v1 clusters are created when rancher is deployed with the `MMC` feature disabled. In this configuration, the local v1 cluster will not have its status properly populated. 
 
## Solution
Register the generating handlers for v3 and v1 clusters before CAPI CRDs are available, as they do not strictly need CAPI caches or clients. Only defer the registration of handlers which explicitly need CAPI caches and clients. These handlers will be reevaluated in the future to determine if the CAPI caches/clients are actually needed or the logic related to cluster cleanup be implemented in a more appropriate / cleaner way. 
 
## Testing

+ Start Rancher with the MMC feature disabled
+ Wait for the Rancher UI to become available and login
+ Run `kubectl get clusters.provisioning.cattle.io local -n fleet-local -o yaml`, and ensure that the status is populated
	+ Specifically ensure that the `clusterName` field has a valid value 
	+ If you're running in a docker container, you'll first need to exec into the pod (`docker exec -it rancher sh`) 
+ Create a new instance of Rancher with the MMC feature enabled (the default value)
+ Provision a downstream cluster on any provider
+ Ensure that the cluster provisions successfully and becomes available 

## Engineering Testing
### Manual Testing

I've done the above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: None

## QA Testing Considerations

Upgrade scenarios
 
### Regressions Considerations
None that I can think of 


Existing / newly added automated tests that provide evidence there are no regressions:

N/A as we do not have automated testing which focuses specifically on Rancher startup 