### PR TITLE
[main] add namespaced rbac rule for machinetemplate so autoscaler can scale MachineDeployment from zero

### DIFF
--- a/pkg/controllers/capr/autoscaler/rbac_test.go
+++ b/pkg/controllers/capr/autoscaler/rbac_test.go
@@ -176,6 +176,16 @@ func (s *autoscalerSuite) TestEnsureGlobalRole_RoleAlreadyExists() {
 				Name:      "md-1",
 				Namespace: "default",
 			},
+			Spec: capi.MachineDeploymentSpec{
+				Template: capi.MachineTemplateSpec{
+					Spec: capi.MachineSpec{
+						InfrastructureRef: corev1.ObjectReference{
+							Kind:       "TestMachineTemplate",
+							APIVersion: "testing-rke.cattle.com/v1",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -221,6 +231,11 @@ func (s *autoscalerSuite) TestEnsureGlobalRole_RoleAlreadyExists() {
 				Resources:     []string{"machines"},
 				Verbs:         []string{"get", "update", "patch"},
 				ResourceNames: []string{"machine-1"},
+			},
+			{
+				APIGroups: []string{"testing-rke.cattle.com"},
+				Resources: []string{"testmachinetemplates"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds another rule to the autoscaler globalrole for a cluster - it turns out when you want to scale from zero [special RBAC rules](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/clusterapi#rbac-changes-for-scaling-from-zero) are required that I had missed in my initial implemention.

The nice thing is that the `InfrastructureRef` on the CAPI MachineDeployment object already has the info we need - so we just yoink that and do some string manipulation to make it into an RBAC rule.

Tests have been updated to account for this as well as the string manipulation on the kind/apiversion.

RFE: https://github.com/rancher/rancher/issues/49680