### PR TITLE
[release/v2.12] Don't restart Rancher on feature flag default change

### DIFF
--- a/pkg/controllers/dashboardapi/feature/feature_handler_test.go
+++ b/pkg/controllers/dashboardapi/feature/feature_handler_test.go
@@ -3,8 +3,8 @@ package feature
 import (
 	"testing"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/features"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,14 +20,26 @@ func TestReconcileFeatures(t *testing.T) {
 	}
 
 	feature := features.GetFeatureByName(mockFeature.Name)
+	assert.False(feature.Enabled())
+
+	newVal, needsRestart := ReconcileFeatures(&mockFeature)
+	assert.Nil(newVal)
+	assert.False(needsRestart)
 	assert.Equal(false, feature.Enabled())
 
-	err := ReconcileFeatures(&mockFeature, false)
-	assert.Nil(err)
+	mockFeatureWithTrueValue := mockFeature.DeepCopy()
+	trueVal := true
+	mockFeatureWithTrueValue.Spec.Value = &trueVal
+	newVal, needsRestart = ReconcileFeatures(mockFeatureWithTrueValue)
+	assert.True(*newVal)
+	assert.True(needsRestart)
 	assert.Equal(false, feature.Enabled())
 
-	err = ReconcileFeatures(&mockFeature, true)
-	assert.Error(err)
+	mockFeatureWithTrueLockedValue := mockFeature.DeepCopy()
+	mockFeatureWithTrueLockedValue.Status.LockedValue = &trueVal
+	newVal, needsRestart = ReconcileFeatures(mockFeatureWithTrueLockedValue)
+	assert.True(*newVal)
+	assert.True(needsRestart)
 	assert.Equal(false, feature.Enabled())
 
 	// testing a dynamic feature
@@ -35,16 +47,25 @@ func TestReconcileFeatures(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "istio-virtual-service-ui",
 		},
+		Spec: v3.FeatureSpec{
+			Value: &trueVal,
+		},
 	}
 
 	feature = features.GetFeatureByName(mockFeature.Name)
 	assert.Equal(true, feature.Enabled())
 
-	err = ReconcileFeatures(&mockFeature, true)
-	assert.Nil(err)
+	newVal, needsRestart = ReconcileFeatures(&mockFeature)
+	assert.True(*newVal)
+	assert.False(needsRestart)
 	assert.Equal(true, feature.Enabled())
 
-	err = ReconcileFeatures(&mockFeature, false)
-	assert.Nil(err)
+	falseValue := false
+	mockFeatureWithFalseValue := mockFeature.DeepCopy()
+	mockFeatureWithFalseValue.Spec.Value = &falseValue
+	newVal, needsRestart = ReconcileFeatures(mockFeatureWithFalseValue)
+	assert.False(*newVal)
+	assert.False(needsRestart)
 	assert.Equal(false, feature.Enabled())
+
 }

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -211,7 +211,7 @@ type Feature struct {
 	description string
 	// val is the effective value- it is equal to default until explicitly changed.
 	// The order of precedence is lockedValue > value > default
-	val bool
+	val *bool
 	// default value of feature
 	def bool
 	// if a feature is not dynamic, then rancher must be restarted when the value is changed
@@ -293,20 +293,15 @@ func InitializeFeatures(featuresClient managementv3.FeatureClient, featureArgs s
 				continue
 			}
 
-			if newFeatureState.Status.LockedValue != nil {
-				f.Set(*newFeatureState.Status.LockedValue)
-				continue
+			newVal := newFeatureState.Status.LockedValue
+			if newVal == nil {
+				newVal = featureState.Spec.Value
 			}
-
-			if featureState.Spec.Value == nil {
-				continue
+			if newVal == nil {
+				f.Unset()
+			} else {
+				f.Set(*newVal)
 			}
-
-			if *featureState.Spec.Value == f.val {
-				continue
-			}
-
-			f.Set(*featureState.Spec.Value)
 		}
 	}
 }
@@ -363,7 +358,6 @@ func applyArgumentDefaults(featureArgs string) error {
 	// only want to apply defaults once all args have been parsed and validated
 	for k, v := range applyFeatureDefaults {
 		features[k].def = v
-		features[k].val = v
 	}
 
 	return nil
@@ -371,24 +365,54 @@ func applyArgumentDefaults(featureArgs string) error {
 
 // Enabled returns whether the feature is enabled
 func (f *Feature) Enabled() bool {
-	return f.val
+	if f.val != nil {
+		return *f.val
+	}
+	return f.def
 }
 
-// Disable will disable a feature such that regardless of the user's choice it will always be false
-func (f *Feature) Disable() {
-	f.val = false
-	f.def = false
-	delete(features, f.name)
+// RequireRestarts determines whether a Rancher restart is necessary. This is
+// the case when (1) the feature is non-dynamic and (2) when the value (.spec.value or .status.lockedValue)
+// was changed by a user.
+//
+// Rancher does not require restart when only the default value changes because
+// this only happens during an upgrade.
+func RequireRestarts(f *Feature, obj *v3.Feature) bool {
+	if f.Dynamic() {
+		return false
+	}
+
+	val := obj.Status.LockedValue
+	if val == nil {
+		val = obj.Spec.Value
+	}
+
+	if val == nil {
+		// val was already nil, so no changes here
+		if f.val == nil {
+			return false
+		}
+
+		// we're unsetting val, let's check if the previous value was
+		// the same as the default
+		return *f.val != f.def
+	}
+
+	return *val != f.Enabled()
 }
 
 // Dynamic returns whether the feature is dynamic. Rancher must be restarted when
-// a non-dynamic feature's effective value is changed.
+// a non-dynamic feature's value is changed (excluding a default value change)
 func (f *Feature) Dynamic() bool {
 	return f.dynamic
 }
 
 func (f *Feature) Set(val bool) {
-	f.val = val
+	f.val = &val
+}
+
+func (f *Feature) Unset() {
+	f.val = nil
 }
 
 func (f *Feature) Name() string {
@@ -423,7 +447,6 @@ func newFeature(name, description string, def, dynamic, install bool) *Feature {
 		name:        name,
 		description: description,
 		def:         def,
-		val:         def,
 		dynamic:     dynamic,
 		install:     install,
 	}

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -1,6 +1,7 @@
 package features
 
 import (
+	"fmt"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -65,6 +66,124 @@ func TestInitializeFeatures(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features = test.features // we can't run parallel tests if we modify this package var here. Code should be refactored to not use a package var if more tests cases are added.
 			InitializeFeatures(test.featureMock(), "")
+		})
+	}
+}
+
+func TestRequireRestarts(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	boolStr := func(b *bool) string {
+		if b == nil {
+			return "nil"
+		}
+		return fmt.Sprintf("%v", *b)
+	}
+
+	tests := []struct {
+		def             bool
+		val             *bool
+		specVal         *bool
+		lockedVal       *bool
+		expectedRestart bool
+	}{
+		// Default false, .spec.value
+		// Unset case
+		{def: false, val: nil},
+		{def: false, val: &trueVal, expectedRestart: true},
+		{def: false, val: &falseVal},
+		// Set to true case
+		{def: false, val: nil, specVal: &trueVal, expectedRestart: true},
+		{def: false, val: &trueVal, specVal: &trueVal},
+		{def: false, val: &falseVal, specVal: &trueVal, expectedRestart: true},
+		// Set to false case
+		{def: false, val: nil, specVal: &falseVal},
+		{def: false, val: &falseVal, specVal: &falseVal},
+		{def: false, val: &trueVal, specVal: &falseVal, expectedRestart: true},
+
+		// Default true, .spec.value
+		// Unset case
+		{def: true, val: nil},
+		{def: true, val: &trueVal},
+		{def: true, val: &falseVal, expectedRestart: true},
+		// Set to true case
+		{def: true, val: nil, specVal: &trueVal},
+		{def: true, val: &trueVal, specVal: &trueVal},
+		{def: true, val: &falseVal, specVal: &trueVal, expectedRestart: true},
+		// Set to false case
+		{def: true, val: nil, specVal: &falseVal, expectedRestart: true},
+		{def: true, val: &falseVal, specVal: &falseVal},
+		{def: true, val: &trueVal, specVal: &falseVal, expectedRestart: true},
+
+		// Default false, .status.lockedValue
+		// Unset case
+		{def: false, val: nil},
+		{def: false, val: &trueVal, expectedRestart: true},
+		{def: false, val: &falseVal},
+		// Set to true case
+		{def: false, val: nil, lockedVal: &trueVal, expectedRestart: true},
+		{def: false, val: &trueVal, lockedVal: &trueVal},
+		{def: false, val: &falseVal, lockedVal: &trueVal, expectedRestart: true},
+		// Set to false case
+		{def: false, val: nil, lockedVal: &falseVal},
+		{def: false, val: &falseVal, lockedVal: &falseVal},
+		{def: false, val: &trueVal, lockedVal: &falseVal, expectedRestart: true},
+
+		// Default true, .status.lockedValue
+		// Unset case
+		{def: true, val: nil},
+		{def: true, val: &trueVal},
+		{def: true, val: &falseVal, expectedRestart: true},
+		// Set to true case
+		{def: true, val: nil, lockedVal: &trueVal},
+		{def: true, val: &trueVal, lockedVal: &trueVal},
+		{def: true, val: &falseVal, lockedVal: &trueVal, expectedRestart: true},
+		// Set to false case
+		{def: true, val: nil, lockedVal: &falseVal, expectedRestart: true},
+		{def: true, val: &falseVal, lockedVal: &falseVal},
+		{def: true, val: &trueVal, lockedVal: &falseVal, expectedRestart: true},
+	}
+	for _, test := range tests {
+		name := fmt.Sprintf("non-dynamic,def=%v,val=%s,specVal=%s,lockedVal=%s", test.def, boolStr(test.val), boolStr(test.specVal), boolStr(test.lockedVal))
+		t.Run(name, func(t *testing.T) {
+			feat := &Feature{
+				dynamic: false,
+				def:     test.def,
+				val:     test.val,
+			}
+			featureObj := &v3.Feature{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v3.FeatureSpec{
+					Value: test.specVal,
+				},
+				Status: v3.FeatureStatus{
+					LockedValue: test.lockedVal,
+				},
+			}
+			needsRestart := RequireRestarts(feat, featureObj)
+			assert.Equal(t, test.expectedRestart, needsRestart)
+		})
+	}
+	for _, test := range tests {
+		name := fmt.Sprintf("dynamic,def=%v,val=%s,specVal=%s,lockedVal=%s", test.def, boolStr(test.val), boolStr(test.specVal), boolStr(test.lockedVal))
+		t.Run(name, func(t *testing.T) {
+			feat := &Feature{
+				dynamic: true,
+				def:     test.def,
+				val:     test.val,
+			}
+			featureObj := &v3.Feature{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v3.FeatureSpec{
+					Value: test.specVal,
+				},
+				Status: v3.FeatureStatus{
+					LockedValue: test.lockedVal,
+				},
+			}
+			needsRestart := RequireRestarts(feat, featureObj)
+			assert.False(t, needsRestart)
 		})
 	}
 }


### PR DESCRIPTION
**Backport**

Backport of https://github.com/rancher/rancher/issues/52282


---

# Issue https://github.com/rancher/rancher/issues/52133

It makes no sense to restart Rancher when a default feature flag's value changes. This can only happen during upgrades, and upgrades forces Rancher to restart anyway.

So this PR:
1. Ensures we only restart Rancher when the value of `.spec.value` or `.status.lockedValue` changes. We compare those values with the ones we have in memory.
2. Changes the log message when we restart Rancher. It used to be a fatal error that looked like an error message. Now instead it's an info message, because Rancher is expected to restart at that point. We also change the exit code to 0, to express success, since Rancher restarting is not an error, but expected, in that situation.