### PR TITLE
[main] Bump SCC operator to static tag from rolling tag

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,7 +5,7 @@ turtlesVersion: 108.0.0+up0.25.0-rc.3
 cspAdapterMinVersion: 108.0.0+up8.0.0-rc.3
 defaultShellVersion: rancher/shell:v0.6.0-rc.1
 fleetVersion: 108.0.0+up0.14.0-beta.1
-defaultSccOperatorImage: rancher/scc-operator:head
+defaultSccOperatorImage: rancher/scc-operator:v0.3.1-rc.1
 # NOTE: when updating this version, you will also need to update the hardcoded
 # k8s minor <-> image tag mapping in pkg/controllers/capr/autoscaler/fleet.go (imageTagVersions variable).
 # if adding support for a new k8s minor release (e.g. new rancher release)

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,7 +5,7 @@ package buildconfig
 const (
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "108.0.0+up8.0.0-rc.3"
-	DefaultSccOperatorImage       = "rancher/scc-operator:head"
+	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1-rc.1"
 	DefaultShellVersion           = "rancher/shell:v0.6.0-rc.1"
 	FleetVersion                  = "108.0.0+up0.14.0-beta.1"
 	ProvisioningCAPIVersion       = "108.0.0+up0.9.0"


### PR DESCRIPTION
## Issue
https://github.com/rancher/scc-operator/issues/55

From: `rancher/scc-operator:head` -> `rancher/scc-operator:v0.3.1-rc.1`

These are equivalent but one is rolling release tag and one is stable. The `head` rolling release tag is meant for Rancher `main` branch - but we swap it for a static tag before Minor release and back to rolling after.