### PR TITLE
[main] autoscaling: make the min <= max validation fire when both fields are non-nil vs non-zero

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/cluster_types.go
+++ b/pkg/apis/provisioning.cattle.io/v1/cluster_types.go
@@ -166,6 +166,7 @@ type RKEConfig struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRole) || !self.controlPlaneRole || !has(self.autoscalingMinSize) || self.autoscalingMinSize > 0", message="AutoscalingMinSize must be greater than 0 when ControlPlaneRole is true"
 // +kubebuilder:validation:XValidation:rule="!has(self.etcdRole) || !self.etcdRole || !has(self.autoscalingMinSize) || self.autoscalingMinSize > 0", message="AutoscalingMinSize must be greater than 0 when EtcdRole is true"
 // +kubebuilder:validation:XValidation:rule="!has(self.autoscalingMaxSize) || !has(self.autoscalingMinSize) || self.autoscalingMinSize <= self.autoscalingMaxSize", message="AutoscalingMinSize must be less than or equal to AutoscalingMaxSize when both are non-nil"
+// +kubebuilder:validation:XValidation:rule="(has(self.autoscalingMinSize) && has(self.autoscalingMaxSize)) || (!has(self.autoscalingMinSize) && !has(self.autoscalingMaxSize))", message="AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling"
 type RKEMachinePool struct {
 	rkev1.RKECommonNodeConfig `json:",inline"`
 

--- a/pkg/crds/yaml/generated/provisioning.cattle.io_clusters.yaml
+++ b/pkg/crds/yaml/generated/provisioning.cattle.io_clusters.yaml
@@ -2910,6 +2910,10 @@ spec:
                           AutoscalingMaxSize when both are non-nil
                         rule: '!has(self.autoscalingMaxSize) || !has(self.autoscalingMinSize)
                           || self.autoscalingMinSize <= self.autoscalingMaxSize'
+                      - message: AutoscalingMinSize and AutoscalingMaxSize must both
+                          be set if enabling cluster-autoscaling
+                        rule: (has(self.autoscalingMinSize) && has(self.autoscalingMaxSize))
+                          || (!has(self.autoscalingMinSize) && !has(self.autoscalingMaxSize))
                     maxItems: 1000
                     nullable: true
                     type: array

--- a/tests/v2prov/tests/autoscaler/autoscaler_test.go
+++ b/tests/v2prov/tests/autoscaler/autoscaler_test.go
@@ -1,8 +1,8 @@
 package autoscaler
 
 import (
-	"strings"
 	"testing"
+	"time"
 
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/tests/v2prov/clients"
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 )
@@ -354,6 +355,162 @@ func Test_General_RKEMachinePool_Autoscaling_Field_Validation(t *testing.T) {
 			expectedError: "AutoscalingMinSize must be less than or equal to AutoscalingMaxSize when both are non-nil",
 			shouldSucceed: false,
 		},
+		{
+			name: "Invalid - Create WorkerRole with AutoscalingMinSize present but AutoscalingMaxSize nil",
+			clusterSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-create-worker-min-size-max-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "worker-pool",
+									WorkerRole:         true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: nil,
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Create WorkerRole with AutoscalingMaxSize present but AutoscalingMinSize nil",
+			clusterSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-create-worker-max-size-min-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "worker-pool",
+									WorkerRole:         true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: nil,
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Create EtcdRole with AutoscalingMinSize present but AutoscalingMaxSize nil",
+			clusterSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-create-etcd-min-size-max-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "etcd-pool",
+									EtcdRole:           true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: nil,
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Create EtcdRole with AutoscalingMaxSize present but AutoscalingMinSize nil",
+			clusterSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-create-etcd-max-size-min-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "etcd-pool",
+									EtcdRole:           true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: nil,
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Create ControlPlaneRole with AutoscalingMinSize present but AutoscalingMaxSize nil",
+			clusterSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-create-controlplane-min-size-max-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "control-plane-pool",
+									ControlPlaneRole:   true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: nil,
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Create ControlPlaneRole with AutoscalingMaxSize present but AutoscalingMinSize nil",
+			clusterSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-create-controlplane-max-size-min-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "control-plane-pool",
+									ControlPlaneRole:   true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: nil,
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -688,6 +845,186 @@ func Test_General_RKEMachinePool_Autoscaling_Update_Field_Validation(t *testing.
 			expectedError: "AutoscalingMinSize must be greater than 0 when EtcdRole is true",
 			shouldSucceed: false,
 		},
+		{
+			name: "Invalid - Update from valid to invalid WorkerRole with AutoscalingMinSize present but AutoscalingMaxSize nil",
+			initialSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-update-worker-min-size-max-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "worker-pool",
+									WorkerRole:         true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			updateSpec: func(c *v1.Cluster) *v1.Cluster {
+				c.Spec.RKEConfig.MachinePools[0].AutoscalingMaxSize = nil
+				return c
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Update from valid to invalid WorkerRole with AutoscalingMaxSize present but AutoscalingMinSize nil",
+			initialSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-update-worker-max-size-min-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "worker-pool",
+									WorkerRole:         true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			updateSpec: func(c *v1.Cluster) *v1.Cluster {
+				c.Spec.RKEConfig.MachinePools[0].AutoscalingMinSize = nil
+				return c
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Update from valid to invalid EtcdRole with AutoscalingMinSize present but AutoscalingMaxSize nil",
+			initialSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-update-etcd-min-size-max-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "etcd-pool",
+									EtcdRole:           true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			updateSpec: func(c *v1.Cluster) *v1.Cluster {
+				c.Spec.RKEConfig.MachinePools[0].AutoscalingMaxSize = nil
+				return c
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Update from valid to invalid EtcdRole with AutoscalingMaxSize present but AutoscalingMinSize nil",
+			initialSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-update-etcd-max-size-min-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "etcd-pool",
+									EtcdRole:           true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			updateSpec: func(c *v1.Cluster) *v1.Cluster {
+				c.Spec.RKEConfig.MachinePools[0].AutoscalingMinSize = nil
+				return c
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Update from valid to invalid ControlPlaneRole with AutoscalingMinSize present but AutoscalingMaxSize nil",
+			initialSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-update-controlplane-min-size-max-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "control-plane-pool",
+									ControlPlaneRole:   true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			updateSpec: func(c *v1.Cluster) *v1.Cluster {
+				c.Spec.RKEConfig.MachinePools[0].AutoscalingMaxSize = nil
+				return c
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
+		{
+			name: "Invalid - Update from valid to invalid ControlPlaneRole with AutoscalingMaxSize present but AutoscalingMinSize nil",
+			initialSpec: func() *v1.Cluster {
+				return &v1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid-update-controlplane-max-size-min-nil",
+					},
+					Spec: v1.ClusterSpec{
+						RKEConfig: &v1.RKEConfig{
+							MachinePools: []v1.RKEMachinePool{
+								{
+									Name:               "control-plane-pool",
+									ControlPlaneRole:   true,
+									Quantity:           ptr.To[int32](0),
+									AutoscalingMinSize: ptr.To[int32](1),
+									AutoscalingMaxSize: ptr.To[int32](3),
+									NodeConfig:         &corev1.ObjectReference{},
+								},
+							},
+						},
+					},
+				}
+			},
+			updateSpec: func(c *v1.Cluster) *v1.Cluster {
+				c.Spec.RKEConfig.MachinePools[0].AutoscalingMinSize = nil
+				return c
+			},
+			expectedError: "AutoscalingMinSize and AutoscalingMaxSize must both be set if enabling cluster-autoscaling",
+			shouldSucceed: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -699,11 +1036,13 @@ func Test_General_RKEMachinePool_Autoscaling_Update_Field_Validation(t *testing.
 				t.Fatalf("Failed to create initial cluster: %v", err)
 			}
 
-			err = retry.OnError(retry.DefaultBackoff,
-				func(err error) bool {
-					// retry if it's a conflict error
-					return strings.Contains(err.Error(), "the object has been modified; please apply your changes to the latest version and try again")
-				},
+			// using a custom backoff - retrying with retry.DefaultBackoff led to some flakiness.
+			err = retry.RetryOnConflict(wait.Backoff{
+				Duration: 100 * time.Millisecond,
+				Jitter:   0.1,
+				Steps:    5,
+				Cap:      10 * time.Second,
+			},
 				func() error {
 					clusterFromAPIServer, err := client.Provisioning.Cluster().Get(createdCluster.Namespace, createdCluster.Name, metav1.GetOptions{})
 					if err != nil {


### PR DESCRIPTION
Fixes a tiny outlier found by the UI testing - min <= max should fire always not just when both are non-zero, non-nil should be enough.

Added testcase for this as well. 

RFE: https://github.com/rancher/rancher/issues/49680