### PR TITLE
Run the annotation filter only in sql mode.

### DIFF
--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -566,6 +566,17 @@ type listTestType struct {
 	expectContains bool
 }
 
+var sqlOnlyListTests = []listTestType{
+	{
+		description: "user:user-a,namespace:test-ns-2,query:filter=metadata.annotations[management.cattle.io/project-scoped-secret-copy]=spuds",
+		user:        "user-a",
+		namespace:   "test-ns-2",
+		query:       "filter=metadata.annotations[management.cattle.io/project-scoped-secret-copy]=spuds",
+		expect: []map[string]string{
+			{"name": "test4", "namespace": "test-ns-2"},
+		},
+	},
+}
 var nonSQLListTests = []listTestType{
 	{
 		description: "user:user-a,namespace:none,query:limit=8",
@@ -984,15 +995,6 @@ func (s *steveAPITestSuite) TestList() {
 				{"name": "test3", "namespace": "test-ns-5"},
 				{"name": "test4", "namespace": "test-ns-5"},
 				{"name": "test5", "namespace": "test-ns-5"},
-			},
-		},
-		{
-			description: "user:user-a,namespace:test-ns-2,query:filter=metadata.annotations[management.cattle.io/project-scoped-secret-copy]=spuds",
-			user:        "user-a",
-			namespace:   "test-ns-2",
-			query:       "filter=metadata.annotations[management.cattle.io/project-scoped-secret-copy]=spuds",
-			expect: []map[string]string{
-				{"name": "test4", "namespace": "test-ns-2"},
 			},
 		},
 		{
@@ -2495,6 +2497,7 @@ func (s *steveAPITestSuite) TestList() {
 	if !usingSQLCache {
 		tests = append(tests, nonSQLListTests...)
 	} else {
+		tests = append(tests, sqlOnlyListTests...)
 		// map labelSelector and fieldSelector params to the VAI equivalents
 		// ensure metadata.namespace tests are doing partial matching because
 		// the actual namespaces are given an `auto` prefix and a random suffix


### PR DESCRIPTION
The test `filter=metadata.annotations[management.cattle.io/project-scoped-secret-copy]=spuds` fails
in non-vai mode because the non-sql filter splits the search term on `.` and this breaks on labels and
annotations that contain dotted accessors.  No intention to fix this known error on non-vai mode because
that code will be obsolete eventually.

Note that to run these tests in non-VAI mode you need to make this change:
```
diff --git a/pkg/features/feature.go b/pkg/features/feature.go
index 9c4bb5deb..a6393f6ba 100644
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -131,7 +131,7 @@
        UISQLCache = newFeature(
                "ui-sql-cache",
                "Improve performance by enabling SQLite-backed caching. This also enables server-side pagination and other scaling based performance improvements.",
-               true,
+               false,
                false,
                true)
        RKE1UI = newFeature(
```

and also add `-timeout 30m` on the `go test` command-line because non-VAI tests are slower and there are more of them.