### PR TITLE
Drop warning when unable to find claim.

### DIFF
--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -795,9 +795,9 @@ func getValueFromClaims[T any](idToken *oidc.IDToken, name string) (T, error) {
 	}
 	claim, ok := mapClaims[name].(T)
 	if !ok {
-		logrus.Warnf("failed to use custom %s claim", name)
+		logrus.Debugf("OpenIDCProvider: failed to use claim %v", name)
 	} else {
-		logrus.Debugf("using custom %s claim", name)
+		logrus.Debugf("OpenIDCProvider: using claim %v", name)
 	}
 
 	return claim, nil


### PR DESCRIPTION
This changes the warning when a claim can't be found to a debug.

This logging is helpful if you configure custom claims and they are not being used.