### PR TITLE
[backport v2.10] Handle concurrent confict not from secret creation

### DIFF
--- a/pkg/serviceaccounttoken/secret.go
+++ b/pkg/serviceaccounttoken/secret.go
@@ -303,16 +303,14 @@ func logKeyFromObject(obj metav1.Object) string {
 }
 
 func secretRefFromSA(sa *corev1.ServiceAccount) (*types.NamespacedName, error) {
-	if sa.Annotations == nil {
-		return nil, nil
+	ann := sa.Annotations[ServiceAccountSecretRefAnnotation]
+	if ann == "" {
+		return nil, fmt.Errorf("ServiceAccount %q is missing the annotation %q", logKeyFromObject(sa), ServiceAccountSecretRefAnnotation)
 	}
-	if ann := sa.Annotations[ServiceAccountSecretRefAnnotation]; ann != "" {
-		elements := strings.Split(ann, "/")
-		if len(elements) != 2 {
-			return nil, fmt.Errorf("too many elements parsing ServiceAccount secret reference: %s", ann)
-		}
-		return &types.NamespacedName{Namespace: elements[0], Name: elements[1]}, nil
+	elements := strings.Split(ann, "/")
+	if len(elements) != 2 {
+		return nil, fmt.Errorf("too many elements parsing ServiceAccount secret reference: %s", ann)
 	}
 
-	return nil, nil
+	return &types.NamespacedName{Namespace: elements[0], Name: elements[1]}, nil
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50287
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
In EnsureSecretForServiceAccount the code was making an assumption that a conflict was caused by a concurrent secret creation. This may not be true and can cause the reloaded SA to not reference a secret.

In this case `secretRef` comes back `nil` and Rancher panics.

In this case it's safest to fail and be retried.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This prevents the `secretRef` calculation code from returning a `nil` value.

## Testing
This is very tricky to reproduce but this is the safest thing that can be done.


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_