### PR TITLE
[v2.13] Bump SCC-operator image

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,7 +5,7 @@ turtlesVersion: 108.0.0+up0.25.0-rc.3
 cspAdapterMinVersion: 108.0.0+up8.0.0-rc.3
 defaultShellVersion: rancher/shell:v0.6.0-rc.1
 fleetVersion: 108.0.0+up0.14.0-rc.1
-defaultSccOperatorImage: rancher/scc-operator:v0.3.1-rc.1
+defaultSccOperatorImage: rancher/scc-operator:v0.3.1-rc.2
 # NOTE: when updating this version, you will also need to update the hardcoded
 # k8s minor <-> image tag mapping in pkg/controllers/capr/autoscaler/fleet.go (imageTagVersions variable).
 # if adding support for a new k8s minor release (e.g. new rancher release)

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,7 +5,7 @@ package buildconfig
 const (
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "108.0.0+up8.0.0-rc.3"
-	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1-rc.1"
+	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1-rc.2"
 	DefaultShellVersion           = "rancher/shell:v0.6.0-rc.1"
 	FleetVersion                  = "108.0.0+up0.14.0-rc.1"
 	ProvisioningCAPIVersion       = "108.0.0+up0.9.0"


### PR DESCRIPTION
Bump to new RC: https://github.com/rancher/scc-operator/releases/tag/v0.3.1-rc.2

Fix for this issue: https://github.com/rancher/scc-operator/issues/57