### PR TITLE
Add missing PublicCredentialFields for exoscale node driver

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -74,6 +74,7 @@ var DriverData = map[string]DriverDataConfig{
 	},
 	ExoscaleDriver: {
 		FileToFieldAliases:      map[string]string{"sshKey": "sshKey", "userdata": "userdata"},
+		PublicCredentialFields:  []string{"apiKey"},
 		PrivateCredentialFields: []string{"apiSecretKey"},
 	},
 	HarvesterDriver: {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/52562
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
On the Create Exoscale Credential page, only the `apiSecretKey` field is available; the `apiKey` field is missing.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add the `apiKey` field in the driver data config for Exoscale Driver.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Steps:
- Run Rnacher from the branch
- Enable the Exoscale node driver 
-  Create a credential for Exoscale Driver

Results:
See the following 2 expected fields:

<img width="1321" height="471" alt="Screenshot 2025-10-31 at 12 17 28 PM" src="https://github.com/user-attachments/assets/c1e3f0a5-ea05-43de-a5ba-02a9331ac70c" />




## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
Third-party node driver, no QA will be done. 

