### PR TITLE
Ensures globalRoleStatus.lastUpdateTime follows RFC3339 format

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -362,7 +362,7 @@ func (gr *globalRoleLifecycle) purgeInvalidNamespacedRoles(roles []*v1.Role, uid
 func (gr *globalRoleLifecycle) setGRAsInProgress(globalRole *v3.GlobalRole) error {
 	globalRole.Status.Conditions = []metav1.Condition{}
 	globalRole.Status.Summary = SummaryInProgress
-	globalRole.Status.LastUpdate = time.Now().String()
+	globalRole.Status.LastUpdate = time.Now().UTC().Format(time.RFC3339)
 	updatedGR, err := gr.grClient.UpdateStatus(globalRole)
 	// For future updates, we want the latest version of our GlobalRole
 	*globalRole = *updatedGR
@@ -377,7 +377,7 @@ func (gr *globalRoleLifecycle) setGRAsCompleted(globalRole *v3.GlobalRole) error
 			break
 		}
 	}
-	globalRole.Status.LastUpdate = time.Now().String()
+	globalRole.Status.LastUpdate = time.Now().UTC().Format(time.RFC3339)
 	globalRole.Status.ObservedGeneration = globalRole.ObjectMeta.Generation
 	_, err := gr.grClient.UpdateStatus(globalRole)
 	return err
@@ -386,7 +386,7 @@ func (gr *globalRoleLifecycle) setGRAsCompleted(globalRole *v3.GlobalRole) error
 func (gr *globalRoleLifecycle) setGRAsTerminating(globalRole *v3.GlobalRole) error {
 	globalRole.Status.Conditions = []metav1.Condition{}
 	globalRole.Status.Summary = SummaryTerminating
-	globalRole.Status.LastUpdate = time.Now().String()
+	globalRole.Status.LastUpdate = time.Now().UTC().Format(time.RFC3339)
 	_, err := gr.grClient.UpdateStatus(globalRole)
 	return err
 }

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -3,6 +3,7 @@ package globalroles
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1314,6 +1315,10 @@ func TestSetGRAsInProgress(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+			// ensure the lastUpdateTime is of format RFC3339
+			if _, err := time.Parse(time.RFC3339, updatedGR.Status.LastUpdate); err != nil {
+				t.Errorf("failed to parse lastUpdate as RFC3339: %v", err)
+			}
 			require.Empty(t, updatedGR.Status.Conditions)
 			require.Equal(t, SummaryInProgress, updatedGR.Status.Summary)
 		})
@@ -1499,6 +1504,10 @@ func TestSetGRAsCompleted(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+			// ensure the lastUpdateTime follows format RFC3339
+			if _, err := time.Parse(time.RFC3339, updatedGR.Status.LastUpdate); err != nil {
+				t.Errorf("failed to parse lastUpdate as RFC3339: %v", err)
+			}
 			if test.summary != "" {
 				require.Equal(t, test.summary, updatedGR.Status.Summary)
 			}
@@ -1575,6 +1584,10 @@ func TestSetGRAsTerminating(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+			// ensure the lastUpdateTime is of format RFC3339
+			if _, err := time.Parse(time.RFC3339, updatedGR.Status.LastUpdate); err != nil {
+				t.Errorf("failed to parse lastUpdate as RFC3339: %v", err)
 			}
 			require.Empty(t, updatedGR.Status.Conditions)
 			require.Equal(t, SummaryTerminating, updatedGR.Status.Summary)


### PR DESCRIPTION
## Issue:  #51370 
 
## Problem
`globalRoleStatus.lastUpdateTime` is stored as a `string`, which lead to inconsistent timestamp while checking the status.

## Solution
This commit updates formats `globalRoleStatus.lastUpdateTime` to follow RFC3339 to maintain consistent time format throughout the status.
 
## Testing
The steps in GitHub issue are valid.

## Engineering Testing
### Manual Testing
Tested manually as per the reproducer steps in #51370 

### Automated Testing
* Test types added/modified:
    * Unit

Summary: The mismatch in format of `lastUpdateTime` and `lastTransitionTime` in GlobalRole status is due to different types being used. This fix ensures storing the `lastUpdateTime` in RFC3339 format.

## QA Testing Considerations
n/a
 
### Regressions Considerations
n/a
