### PR TITLE
Protect Fleet agent from autoscaling

### DIFF
--- a/pkg/settings/agent_customization.go
+++ b/pkg/settings/agent_customization.go
@@ -119,4 +119,14 @@ const (
 	"minAvailable": "1",
 	"maxUnavailable": "0"
 }`
+
+	FleetAgentPriorityClass = `{
+    "preemptionPolicy": "PreemptLowerPriority",
+    "value": 900000000
+}`
+
+	FleetAgentPodDisruptionBudget = `{
+	"minAvailable": "1",
+	"maxUnavailable": "0"
+}`
 )

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -145,6 +145,8 @@ var (
 
 	ClusterAgentDefaultPriorityClass       = NewSetting("cluster-agent-default-priority-class", ClusterAgentPriorityClass)
 	ClusterAgentDefaultPodDisruptionBudget = NewSetting("cluster-agent-default-pod-disruption-budget", ClusterAgentPodDisruptionBudget)
+	FleetAgentDefaultPriorityClass         = NewSetting("fleet-agent-default-priority-class", FleetAgentPriorityClass)
+	FleetAgentDefaultPodDisruptionBudget   = NewSetting("fleet-agent-default-pod-disruption-budget", FleetAgentPodDisruptionBudget)
 
 	Rke2DefaultVersion = NewSetting("rke2-default-version", "")
 	K3sDefaultVersion  = NewSetting("k3s-default-version", "")


### PR DESCRIPTION
by increasing its priority class value and requiring at least one available pod through disruption budget.

## Issue: #52437
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
After a cluster autoscales down its etcd/cp nodes while under a heavy workload the fleet-agent pod sometimes will not be prioritized over the workload causing the following status: "Deployment does not have minimum availability.".>
 
## Solution
Protect Fleet agent from autoscaling by increasing its priority class value (inspired by ClusterAgentPriorityClass) and requiring at least one available pod through disruption budget.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit