### PR TITLE
[main] only start the autoscaling controller if MCM is enabled

### DIFF
--- a/pkg/controllers/capr/controllers.go
+++ b/pkg/controllers/capr/controllers.go
@@ -45,6 +45,7 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigMana
 	})
 	if features.MCM.Enabled() {
 		machineprovision.Register(ctx, clients, kubeconfigManager)
+		autoscaler.Register(ctx, clients)
 	}
 	rkecluster.Register(ctx, clients)
 	bootstrap.Register(ctx, clients)
@@ -55,7 +56,6 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigMana
 	rkecontrolplane.Register(ctx, clients)
 	managesystemagent.Register(ctx, clients)
 	machinedrain.Register(ctx, clients)
-	autoscaler.Register(ctx, clients)
 
 	return nil
 }


### PR DESCRIPTION
## Issue: #52580 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The autoscaling controllers rely on MCM related CRDS, notably Roles/GlobalRoles which are not present when the MCM feature flag is false. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Only start the autoscaling controller if MCM is enabled.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Run Rancher without MCM enabled, observe error messages pertaining to role/globalrole CRDs are not present.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested locally to validate Rancher started up.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Should be quite evident if this is fixed - the CI tests should pass. 
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
n/a
