### PR TITLE
Bump steve to v0.7.32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/rancher/remotedialer-proxy v0.6.0-rc.4
 	github.com/rancher/rke v1.8.0-rc.4
 	github.com/rancher/shepherd v0.0.0-20251015044355-8c54bf0aaf31
-	github.com/rancher/steve v0.7.30
+	github.com/rancher/steve v0.7.32
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078
 	github.com/rancher/wrangler v1.1.2
 	github.com/rancher/wrangler/v3 v3.3.1

--- a/go.sum
+++ b/go.sum
@@ -615,8 +615,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20251015044355-8c54bf0aaf31 h1:CKxEoFWtmB9tzsDuFDwaOCJm9CxnzBqHEc58xTEUH1w=
 github.com/rancher/shepherd v0.0.0-20251015044355-8c54bf0aaf31/go.mod h1:wZ6Oe7Aa9aam77+4t3lBiixw9JpTTaYQ+Adfi0ICcqQ=
-github.com/rancher/steve v0.7.30 h1:vmf4SW2B25ukD0zqJTM1UTEYyImLxjpE9guS/m+lF9w=
-github.com/rancher/steve v0.7.30/go.mod h1:0s8oO0Y1lsCWLdoky2trPAIuFOPOELEbvR51qYSF5fI=
+github.com/rancher/steve v0.7.32 h1:t+j7k4zPsY2fdb9yz/IuP+KZEY5oLU+Cd0pr46r/AI4=
+github.com/rancher/steve v0.7.32/go.mod h1:a6y+G/bvd6neTiar52HPsYEt1zUATTEO0O7Czyu9zKY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
No changes, the steve bump basically just bumps apiserver to v0.7.7 which was already v0.7.7 here