### PR TITLE
Migrate user passwords even if MCM is turned off

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/user"
 	rancherversion "github.com/rancher/rancher/pkg/version"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/data"
@@ -63,6 +64,10 @@ var (
 )
 
 func runMigrations(wranglerContext *wrangler.Context) error {
+	if err := migrateLocalUserPasswords(wranglerContext); err != nil {
+		return err
+	}
+
 	if err := forceUpgradeLogout(wranglerContext.Core.ConfigMap(), wranglerContext.Mgmt.Token(), "v2.6.0"); err != nil {
 		return err
 	}
@@ -85,6 +90,10 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 	}
 
 	return rkeResourcesCleanup(wranglerContext)
+}
+
+func migrateLocalUserPasswords(wranglerContext *wrangler.Context) error {
+	return user.NewPasswordMigrator(wranglerContext).MigrateAll()
 }
 
 func runRKE2Migrations(wranglerContext *wrangler.CAPIContext) error {

--- a/pkg/user/migrate.go
+++ b/pkg/user/migrate.go
@@ -1,0 +1,93 @@
+package user
+
+import (
+	"fmt"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/local/pbkdf2"
+	wranglerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/wrangler"
+	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	PasswordHashAnnotation = "cattle.io/password-hash"
+	BcryptHash             = "bcrypt"
+)
+
+type PasswordMigrator struct {
+	Users   wranglerv3.UserClient
+	Secrets wcorev1.SecretClient
+}
+
+func NewPasswordMigrator(wContext *wrangler.Context) *PasswordMigrator {
+	return &PasswordMigrator{
+		Users:   wContext.Mgmt.User(),
+		Secrets: wContext.Core.Secret(),
+	}
+}
+
+func (m *PasswordMigrator) MigrateAll() error {
+	users, err := m.Users.List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list users: %w", err)
+	}
+
+	for _, user := range users.Items {
+		if err := m.Migrate(&user); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PasswordMigrator) Migrate(user *apiv3.User) error {
+	if user.Password == "" {
+		return nil
+	}
+
+	passwordSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      user.Name,
+			Namespace: pbkdf2.LocalUserPasswordsNamespace,
+			Annotations: map[string]string{
+				PasswordHashAnnotation: BcryptHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name:       user.Name,
+					UID:        user.UID,
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "User",
+				},
+			},
+		},
+		Data: map[string][]byte{
+			"password": []byte(user.Password),
+		},
+	}
+
+	_, err := m.Secrets.Create(passwordSecret)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create password secret: %w", err)
+		}
+		_, err = m.Secrets.Update(passwordSecret)
+		if err != nil {
+			return fmt.Errorf("failed to update password secret: %w", err)
+		}
+	}
+
+	user = user.DeepCopy()
+	user.Password = ""
+	_, err = m.Users.Update(user)
+	if err != nil {
+		return fmt.Errorf("failed to update user: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

#52615
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If MCM is turned off local users passwords are not migrated when Rancher is upagrded.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Run password migrations with all other migrations on Rancher start.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Existing / newly added automated tests that provide evidence there are no regressions: