### PR TITLE
[main] remove auto installation of ali-operator chart

### DIFF
--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -51,16 +51,6 @@ var (
 		ReleaseName:      "rancher-gke-operator",
 		ChartName:        "rancher-gke-operator",
 	}
-	AliOperatorCrdChart = chart.Definition{
-		ReleaseNamespace: "cattle-system",
-		ReleaseName:      "rancher-ali-operator-crd",
-		ChartName:        "rancher-ali-operator-crd",
-	}
-	AliOperatorChart = chart.Definition{
-		ReleaseNamespace: "cattle-system",
-		ReleaseName:      "rancher-ali-operator",
-		ChartName:        "rancher-ali-operator",
-	}
 )
 
 type handler struct {
@@ -117,13 +107,6 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 		if gkeOperatorVersion := settings.GkeOperatorVersion.Get(); gkeOperatorVersion != "" {
 			toInstallCrdChartVersion = gkeOperatorVersion
 			toInstallChartVersion = gkeOperatorVersion
-		}
-	} else if cluster.Spec.AliConfig != nil {
-		toInstallCrdChart = &AliOperatorCrdChart
-		toInstallChart = &AliOperatorChart
-		if aliOperatorVersion := settings.AliOperatorVersion.Get(); aliOperatorVersion != "" {
-			toInstallCrdChartVersion = aliOperatorVersion
-			toInstallChartVersion = aliOperatorVersion
 		}
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/50153
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
rancher tries to install ali-operator chart when an alibaba cluster is created.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
  as per the flow for ali-operator the chart will be installed manually by the users and also the chart will not be published in rancher/charts so removing the auto installation logic.
