### PR TITLE
Removed unused image from origins.go

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -116,7 +116,6 @@ var OriginMap = map[string]string{
 	"mirrored-cilium-operator-azure":                          "https://github.com/cilium/cilium/tree/master/pkg/azure",
 	"mirrored-cilium-operator-generic":                        "https://github.com/cilium/cilium",
 	"mirrored-cilium-startup-script":                          "https://github.com/cilium/cilium",
-	"mirrored-cloud-provider-vsphere-cpi-release-manager":     "https://github.com/kubernetes/cloud-provider-vsphere/blob/master/cluster/images/controller-manager/Dockerfile",
 	"mirrored-cloud-provider-vsphere-csi-release-driver":      "https://github.com/kubernetes-sigs/vsphere-csi-driver",
 	"mirrored-cloud-provider-vsphere-csi-release-syncer":      "https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/pkg/syncer",
 	"mirrored-cloud-provider-vsphere":                         "https://github.com/kubernetes/cloud-provider-vsphere",


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52642
 
## Problem
The rancher-vsphere-csi/cpi charts were removed from rancher/charts, because they were specific to RKE1.

One of the images in origins.go (`mirrored-cloud-provider-vsphere-cpi-release-manager`) was only referenced to by these charts. The RKE2 vsphere charts use a more recent image (`mirrored-cloud-provider-vsphere`) for the k8s versions supported in 2.13.
 
## Solution
Remove the image from `origins.go`. Note that the auto-generated `rancher-images.txt` doesn't have the old image anymore.
 
## Testing
## Engineering Testing
### Manual Testing
Running `scripts/create-components-images-files.sh` doesn't complain about missing origins after the charts were removed from rancher/charts.