### PR TITLE
Add a feature flag to disable /v3-public endpoints

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -93,7 +93,9 @@ func newAPIManagement(ctx context.Context, scaledContext *config.ScaledContext, 
 
 	limitingHandler := utils.APIBodyLimitingHandler(apiLimit)
 	root.PathPrefix("/v1-saml").Handler(limitingHandler(saml))
-	root.PathPrefix("/v3-public").Handler(limitingHandler(v3PublicAPI)) // Deprecated. Use /v1-public instead.
+	if features.V3Public.Enabled() {
+		root.PathPrefix("/v3-public").Handler(limitingHandler(v3PublicAPI)) // Deprecated. Use /v1-public instead.
+	}
 	root.PathPrefix("/v1-public").Handler(limitingHandler(v1PublicAPI))
 	root.NotFoundHandler = privateAPI
 

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -195,6 +195,13 @@ var (
 		false,
 		true,
 	)
+	V3Public = newFeature(
+		"v3-public",
+		"Enable /v3-public API endpoints",
+		true,
+		false,
+		true,
+	)
 )
 
 func ListEnabled() []string {

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rancher/rancher/pkg/channelserver"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	rancherdialer "github.com/rancher/rancher/pkg/dialer"
+	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/httpproxy"
 	k8sProxyPkg "github.com/rancher/rancher/pkg/k8sproxy"
 	"github.com/rancher/rancher/pkg/metrics"
@@ -103,7 +104,9 @@ func router(ctx context.Context, localClusterEnabled bool, scaledContext *config
 	unauthed.PathPrefix("/v1-{prefix}-release/channel").Handler(channelserver)
 	unauthed.PathPrefix("/v1-{prefix}-release/release").Handler(channelserver)
 	unauthed.PathPrefix("/v1-saml").Handler(saml.AuthHandler())
-	unauthed.PathPrefix("/v3-public").Handler(v3PublicAPI)
+	if features.V3Public.Enabled() {
+		unauthed.PathPrefix("/v3-public").Handler(v3PublicAPI)
+	}
 	unauthed.PathPrefix("/v1-public").Handler(v1PublicAPI)
 
 	// Authenticated routes


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

#52680
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

We have `/v3-public` and `/v1-public` API endpoints working side-by-side.
It would be great to have a feature flag that disables the deprecated `/v3-public` endpoints so that UI changes can be tried/tested with only new endpoints.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add a temporary (until `/v3-public` is fully sunsetted) feature flag that allows to disable `/v3-public` API endpoints.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_