### PR TITLE
[release/v2.13] Un-rc csp-adapter v8.0.0 

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ webhookVersion: 108.0.0+up0.9.0-rc.14
 remoteDialerProxyVersion: 106.0.2+up0.6.0-rc.4
 provisioningCAPIVersion: 108.0.0+up0.9.0
 turtlesVersion: 108.0.0+up0.25.0-rc.4
-cspAdapterMinVersion: 108.0.0+up8.0.0-rc.3
+cspAdapterMinVersion: 108.0.0+up8.0.0
 defaultShellVersion: rancher/shell:v0.6.0-rc.1
 fleetVersion: 108.0.0+up0.14.0-rc.1
 defaultSccOperatorImage: rancher/scc-operator:v0.3.1-rc.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	ClusterAutoscalerChartVersion = "9.50.1"
-	CspAdapterMinVersion          = "108.0.0+up8.0.0-rc.3"
+	CspAdapterMinVersion          = "108.0.0+up8.0.0"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1-rc.2"
 	DefaultShellVersion           = "rancher/shell:v0.6.0-rc.1"
 	FleetVersion                  = "108.0.0+up0.14.0-rc.1"


### PR DESCRIPTION
##Problem:
Un-rc rancher-csp-adapter chart for 2.13 rancher

##Testing:

Scenario 1 (fresh install):

    On an EKS cluster (k8s version 1.34), install locally built rancher with cspAdapterMinVersion: 108.0.0+up8.0.0
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.

scenario 2 (upgrade scenario):

    Start with an EKS cluster k8s version 1.33, upgrade k8s version to 1.34, install rancher 2.12.3 with csp-adapter 7.0.0
    Upgrade rancher to locally built rancher with cspAdapterMinVersion: 108.0.0+up8.0.0
    Update charts url repo/branch and upgrade csp-adapter version to 108.0.0+up8.0.0
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.