### PR TITLE
[v2.13] Backporting: update csp-adapter version (#52666)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ webhookVersion: 108.0.0+up0.9.0-rc.14
 remoteDialerProxyVersion: 106.0.2+up0.6.0-rc.4
 provisioningCAPIVersion: 108.0.0+up0.9.0
 turtlesVersion: 108.0.0+up0.25.0-rc.4
-cspAdapterMinVersion: 108.0.0+up8.0.0-rc.3
+cspAdapterMinVersion: 108.0.0+up8.0.0
 defaultShellVersion: rancher/shell:v0.6.0-rc.1
 fleetVersion: 108.0.0+up0.14.0-rc.1
 defaultSccOperatorImage: rancher/scc-operator:v0.3.1-rc.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	ClusterAutoscalerChartVersion = "9.50.1"
-	CspAdapterMinVersion          = "108.0.0+up8.0.0-rc.3"
+	CspAdapterMinVersion          = "108.0.0+up8.0.0"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1-rc.2"
 	DefaultShellVersion           = "rancher/shell:v0.6.0-rc.1"
 	FleetVersion                  = "108.0.0+up0.14.0-rc.1"


### PR DESCRIPTION
(cherry picked from commit bc6106ba45ea889e3d896fc028af877b5074fa9a)

Backporting updates to csp-adapter to release/v2.13