### PR TITLE
Helm: Add ImagePullSecrets support to batch jobs

### DIFF
--- a/chart/templates/post-delete-hook-job.yaml
+++ b/chart/templates/post-delete-hook-job.yaml
@@ -17,6 +17,10 @@ spec:
       labels: {{ include "rancher.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "rancher.fullname" . }}-post-delete
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
         - name: {{ template "rancher.name" . }}-post-delete

--- a/chart/templates/pre-upgrade-hook-job.yaml
+++ b/chart/templates/pre-upgrade-hook-job.yaml
@@ -16,6 +16,10 @@ spec:
       labels: {{ include "rancher.preupgradelabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "rancher.fullname" . }}-pre-upgrade
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: {{ template "rancher.name" . }}-pre-upgrade

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -2,6 +2,15 @@ suite: Test Deployment
 templates:
 - deployment.yaml
 tests:
+- it: should render imagePullSecrets when set
+  set:
+    imagePullSecrets:
+      - name: my-secret
+  asserts:
+    - contains:
+        path: spec.template.spec.imagePullSecrets
+        content:
+          name: my-secret
 - it: should set --add-local=false
   set:
     addLocal: "false"

--- a/chart/tests/job_test.yaml
+++ b/chart/tests/job_test.yaml
@@ -1,0 +1,26 @@
+suite: Test Jobs
+
+templates:
+  - post-delete-hook-job.yaml
+  - pre-upgrade-hook-job.yaml
+
+tests:
+  - it: should render imagePullSecrets when set
+    set:
+      postDelete:
+        enabled: true
+        image:
+          registry: "docker.io/"
+          repository: "rancher/rancher"
+          tag: "latest"
+        namespaceList:
+          - "ns1"
+        timeout: 60
+        ignoreTimeoutError: false
+      imagePullSecrets:
+        - name: my-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-secret


### PR DESCRIPTION
## Issue: (https://github.com/rancher/rancher/issues/51456)

## Problem
Within the helm chart, the imagePullSecrets value is supported but its not consistently applied throughout the whole helm chart. The postdelete and preupgrade batch jobs have no support for the imagePullSecrets, this makes using the imagePullSecrets difficult.

## Solution
Add the imagePullSecrets to the postdelete and preupgrade batch jobs. Format is exactly the same as in the Deployment.yaml template apart from indentation. Also added tests.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
I tested the changes locally with helm template and applied the templates to a local kind cluster.

### Automated Testing
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
None

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of reg
ressions -->
_TODO_

None

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_
None
