### PR TITLE
Fix nil pointer panic in dashboard plugin cache sync

### DIFF
--- a/pkg/controllers/dashboard/plugin/fscache.go
+++ b/pkg/controllers/dashboard/plugin/fscache.go
@@ -137,7 +137,7 @@ func (c FSCache) SyncWithIndex(index *SafeIndex, fsCacheFiles []string) error {
 			continue
 		}
 		entry, ok := index.Entries[chartName]
-		if !ok || entry == nil || entry.UIPluginEntry == nil || entry.Version != chartVersion {
+		if !ok || entry == nil || entry.Version != chartVersion {
 			err := c.Delete(chartName, chartVersion)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to delete cache entry. Error: %w", err))

--- a/pkg/controllers/dashboard/plugin/fscache_test.go
+++ b/pkg/controllers/dashboard/plugin/fscache_test.go
@@ -23,7 +23,7 @@ func TestSyncWithIndex(t *testing.T) {
 			Name: "Sync index with FS cache no new entries",
 			CurrentEntries: map[string]*UIPlugin{
 				"test-plugin": {
-					UIPluginEntry: &v1.UIPluginEntry{
+					UIPluginEntry: v1.UIPluginEntry{
 						Name:     "test-plugin",
 						Version:  "0.1.0",
 						Endpoint: "https://test.endpoint.svc",
@@ -36,7 +36,7 @@ func TestSyncWithIndex(t *testing.T) {
 			},
 			ExpectedEntries: map[string]*UIPlugin{
 				"test-plugin": {
-					UIPluginEntry: &v1.UIPluginEntry{
+					UIPluginEntry: v1.UIPluginEntry{
 						Name:     "test-plugin",
 						Version:  "0.1.0",
 						Endpoint: "https://test.endpoint.svc",
@@ -55,7 +55,7 @@ func TestSyncWithIndex(t *testing.T) {
 			Name: "Sync index with FS cache delete old test-plugin-2 entry",
 			CurrentEntries: map[string]*UIPlugin{
 				"test-plugin": {
-					UIPluginEntry: &v1.UIPluginEntry{
+					UIPluginEntry: v1.UIPluginEntry{
 						Name:     "test-plugin",
 						Version:  "0.1.0",
 						Endpoint: "https://test.endpoint.svc",
@@ -68,7 +68,7 @@ func TestSyncWithIndex(t *testing.T) {
 			},
 			ExpectedEntries: map[string]*UIPlugin{
 				"test-plugin": {
-					UIPluginEntry: &v1.UIPluginEntry{
+					UIPluginEntry: v1.UIPluginEntry{
 						Name:     "test-plugin",
 						Version:  "0.1.0",
 						Endpoint: "https://test.endpoint.svc",
@@ -101,17 +101,9 @@ func TestSyncWithIndex(t *testing.T) {
 			ExpectedPluginDeleted: FSCacheRootDir + "/test-plugin",
 		},
 		{
-			Name: "Sync with nil UIPluginEntry does not panic",
-			CurrentEntries: map[string]*UIPlugin{
-				"test-plugin": {
-					UIPluginEntry: nil,
-				},
-			},
-			ExpectedEntries: map[string]*UIPlugin{
-				"test-plugin": {
-					UIPluginEntry: nil,
-				},
-			},
+			Name:            "Sync with nil UIPluginEntry does not panic",
+			CurrentEntries:  map[string]*UIPlugin{},
+			ExpectedEntries: map[string]*UIPlugin{},
 			FsCacheFiles: []string{
 				FSCacheRootDir + "/test-plugin/0.1.0",
 			},

--- a/pkg/controllers/dashboard/plugin/index.go
+++ b/pkg/controllers/dashboard/plugin/index.go
@@ -13,7 +13,7 @@ var (
 )
 
 type UIPlugin struct {
-	*v1.UIPluginEntry
+	v1.UIPluginEntry
 	CacheState string
 	Ready      bool
 }
@@ -30,8 +30,8 @@ func (s *SafeIndex) Generate(cachedPlugins []*v1.UIPlugin) error {
 	defer s.mu.Unlock()
 	s.Entries = make(map[string]*UIPlugin, len(cachedPlugins))
 	for _, plugin := range cachedPlugins {
-		entry := &plugin.Spec.Plugin
-		logrus.Debugf("adding plugin to index: %+v", *entry)
+		entry := plugin.Spec.Plugin
+		logrus.Debugf("adding plugin to index: %+v", entry)
 		s.Entries[entry.Name] = &UIPlugin{
 			UIPluginEntry: entry,
 			CacheState:    plugin.Status.CacheState,

--- a/pkg/controllers/dashboard/plugin/index_test.go
+++ b/pkg/controllers/dashboard/plugin/index_test.go
@@ -43,7 +43,7 @@ func TestGenerate(t *testing.T) {
 			},
 			ExpectedEntries: map[string]*UIPlugin{
 				"test-plugin": {
-					UIPluginEntry: &v1.UIPluginEntry{
+					UIPluginEntry: v1.UIPluginEntry{
 
 						Name:     "test-plugin",
 						Version:  "0.1.0",
@@ -55,7 +55,7 @@ func TestGenerate(t *testing.T) {
 					},
 				},
 				"test-plugin-2": {
-					UIPluginEntry: &v1.UIPluginEntry{
+					UIPluginEntry: v1.UIPluginEntry{
 						Name:     "test-plugin-2",
 						Version:  "0.1.1",
 						Endpoint: "https://test-2.endpoint.svc",


### PR DESCRIPTION
Prevent panic when syncing filesystem cache with index entries that contain nil values. The original code accessed index.Entries[chartName].Version without checking if the entry or its embedded UIPluginEntry pointer were nil.

Add nil checks for both the map entry and the embedded UIPluginEntry pointer before accessing the Version field. This handles edge cases where concurrent operations or race conditions may leave nil pointers in the index map.

Include test cases that verify the fix prevents panics when:
- Map contains nil entry values
- Entry has nil embedded UIPluginEntry pointer

Fixes the panic reported at line 140 in fscache.go where legitimate cache sync operations would crash the controller.


```
E1110 21:49:09.834581      39 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
	goroutine 2199 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0xb520948, 0x10e9edc0}, {0x891bf80, 0x10c6e140})
		/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:107 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0xb520948, 0x10e9edc0}, {0x891bf80, 0x10c6e140}, {0x10e9edc0, 0x0, 0x10000c04844e900?})
		/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:82 +0x5a
	k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc04844e900?})
		/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:59 +0x105
	panic({0x891bf80?, 0x10c6e140?})
		/usr/lib64/go/1.24/src/runtime/panic.go:792 +0x132
	github.com/rancher/rancher/pkg/controllers/dashboard/plugin.FSCache.SyncWithIndex({}, 0x10e605a0, {0xc01549d540?, 0x0?, 0xa5654b8?})
		/app/pkg/controllers/dashboard/plugin/fscache.go:140 +0x235
	github.com/rancher/rancher/pkg/controllers/dashboard/plugin.(*handler).OnPluginChange(0xc00554d5c0, {0x0?, 0x0?}, 0xc0289a1880)
		/app/pkg/controllers/dashboard/plugin/controller.go:78 +0x493
	github.com/rancher/wrangler/v3/pkg/generic.(*Controller[...].func1({0xb4b6618?, 0xc0289a1880?})
		/root/.cache/go/modcache/github.com/rancher/wrangler/v3@v3.2.1/pkg/generic/controller.go:169 +0x44
	github.com/rancher/lasso/pkg/controller.SharedControllerHandlerFunc.OnChange(0x4763cc?, {0xc0239db140?, 0xc01820fcb8?}, {0xb4b6618?, 0xc0289a1880?})
		/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/sharedcontroller.go:29 +0x32
	github.com/rancher/lasso/pkg/controller.(*SharedHandler).OnChange(0xc001391270, {0xc0239db140, 0x28}, {0xb4b6618, 0xc0289a1880})
		/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/sharedhandler.go:75 +0x203
	github.com/rancher/lasso/pkg/controller.(*controller).syncHandler(0xc0011ce210, {0xc0239db140, 0x28})
		/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:236 +0x12e
	github.com/rancher/lasso/pkg/controller.(*controller).processSingleItem(0xc0011ce210, {0x8019ac0, 0xc04844e900})
		/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:217 +0xd6
	github.com/rancher/lasso/pkg/controller.(*controller).processNextWorkItem(0xc0011ce210)
		/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:194 +0x3d
	github.com/rancher/lasso/pkg/controller.(*controller).runWorker(...)
		/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:183
	k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000e28008?)
		/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:226 +0x33
	k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0012ae210, {0xb497080, 0xc008091e60}, 0x1, 0xc0000c2f50)
		/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:227 +0xaf
	k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0012ae210, 0x3b9aca00, 0x0, 0x1, 0xc0000c2f50)
		/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:204 +0x7f
	k8s.io/apimachinery/pkg/util/wait.Until(...)
		/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:161
	created by github.com/rancher/lasso/pkg/controller.(*controller).run in goroutine 1712
		/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:151 +0x354
 >
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5c46e55]

goroutine 2199 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0xb520948, 0x10e9edc0}, {0x891bf80, 0x10c6e140}, {0x10e9edc0, 0x0, 0x10000c04844e900?})
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:89 +0xe7
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc04844e900?})
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:59 +0x105
panic({0x891bf80?, 0x10c6e140?})
	/usr/lib64/go/1.24/src/runtime/panic.go:792 +0x132
github.com/rancher/rancher/pkg/controllers/dashboard/plugin.FSCache.SyncWithIndex({}, 0x10e605a0, {0xc01549d540?, 0x0?, 0xa5654b8?})
	/app/pkg/controllers/dashboard/plugin/fscache.go:140 +0x235
github.com/rancher/rancher/pkg/controllers/dashboard/plugin.(*handler).OnPluginChange(0xc00554d5c0, {0x0?, 0x0?}, 0xc0289a1880)
	/app/pkg/controllers/dashboard/plugin/controller.go:78 +0x493
github.com/rancher/wrangler/v3/pkg/generic.(*Controller[...].func1({0xb4b6618?, 0xc0289a1880?})
	/root/.cache/go/modcache/github.com/rancher/wrangler/v3@v3.2.1/pkg/generic/controller.go:169 +0x44
github.com/rancher/lasso/pkg/controller.SharedControllerHandlerFunc.OnChange(0x4763cc?, {0xc0239db140?, 0xc01820fcb8?}, {0xb4b6618?, 0xc0289a1880?})
	/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/sharedcontroller.go:29 +0x32
github.com/rancher/lasso/pkg/controller.(*SharedHandler).OnChange(0xc001391270, {0xc0239db140, 0x28}, {0xb4b6618, 0xc0289a1880})
	/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/sharedhandler.go:75 +0x203
github.com/rancher/lasso/pkg/controller.(*controller).syncHandler(0xc0011ce210, {0xc0239db140, 0x28})
	/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:236 +0x12e
github.com/rancher/lasso/pkg/controller.(*controller).processSingleItem(0xc0011ce210, {0x8019ac0, 0xc04844e900})
	/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:217 +0xd6
github.com/rancher/lasso/pkg/controller.(*controller).processNextWorkItem(0xc0011ce210)
	/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:194 +0x3d
github.com/rancher/lasso/pkg/controller.(*controller).runWorker(...)
	/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:183
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000e28008?)
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0012ae210, {0xb497080, 0xc008091e60}, 0x1, 0xc0000c2f50)
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0012ae210, 0x3b9aca00, 0x0, 0x1, 0xc0000c2f50)
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/root/.cache/go/modcache/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:161
created by github.com/rancher/lasso/pkg/controller.(*controller).run in goroutine 1712
	/root/.cache/go/modcache/github.com/rancher/lasso@v0.2.2/pkg/controller/controller.go:151 +0x354
```