### PR TITLE
fix CI failures

### DIFF
--- a/tests/integration/suite/test_workloads.py
+++ b/tests/integration/suite/test_workloads.py
@@ -408,6 +408,8 @@ def test_perform_workload_action_read_only(admin_mc, admin_pc, remove_resource,
 
     workload = client.reload(workload)
     wait_for_workload(client, workload.id, ns.id)
+
+    workload = client.reload(workload)
     original_rev_id = workload.revisions().data[0].id
 
     # Read-only users should receive a 404 error.


### PR DESCRIPTION
## Issues 

- https://github.com/rancher/rancher/issues/52694
- https://github.com/rancher/rancher/issues/52695


## Summary

This PR fixes several race conditions observed in test cases identified in https://github.com/rancher/rancher/pull/52664 

### Test `test_perform_workload_action_read_only`:

ref: https://github.com/rancher/rancher/actions/runs/19237120701/job/55015678868#step:18:2479
```
        workload = client.reload(workload)
        wait_for_workload(client, workload.id, ns.id)
>       original_rev_id = workload.revisions().data[0].id
E       IndexError: list index out of range

test_workloads.py:411: IndexError
```

**Cause**: 
The test sometimes uses a stale workload object before its revision data is fully available.

**Fix**: 
Reload the workload to fetch the latest state before checking its revision.
 
### Test `Test_Provisioning_MP_SingleNodeAllRolesWithDelete`

ref: https://github.com/rancher/rancher/actions/runs/19237120701/job/55035836894#step:10:1210
`{"Time":"2025-11-11T00:52:50.653611785Z","Action":"output","Package":"github.com/rancher/rancher/tests/v2prov/tests/machineprovisioning","Test":"Test_Provisioning_MP_SingleNodeAllRolesWithDelete","Output":"    machine_test.go:82: Unauthorized\n"}`

**Cause**: 
The test can fail with an Unauthorized error because the required RBAC rules for the client may not have propagated yet.

**Fix**: 
Add a retry with exponential backoff to wait for the RBAC rules to take effect.