### PR TITLE
fix: Delete old service before creating new apiservice

### DIFF
--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -255,6 +255,10 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		}
 	}
 
+	if err := ext.DeleteLegacyServiceAndSecret(wranglerContext.Core.Service(), wranglerContext.Core.Secret()); err != nil {
+		return nil, fmt.Errorf("failed to delete legacy service and secret: %w", err)
+	}
+
 	extensionOpts := ext.DefaultOptions()
 
 	extensionAPIServer, err := ext.NewExtensionAPIServer(ctx, wranglerContext, extensionOpts)
@@ -334,10 +338,6 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 
 	auditLogMiddleware := audit.NewAuditLogMiddleware(auditLogWriter)
 	aggregationMiddleware := aggregation.NewMiddleware(ctx, wranglerContext.Mgmt.APIService(), wranglerContext.TunnelServer)
-
-	if err := ext.DeleteLegacyServiceAndSecret(wranglerContext.Core.Service(), wranglerContext.Core.Secret()); err != nil {
-		return nil, fmt.Errorf("failed to delete legacy service and secret: %w", err)
-	}
 
 	wranglerContext.OnLeaderOrDie("rancher-new", func(ctx context.Context) error {
 		serviceaccounttoken.StartServiceAccountSecretCleaner(


### PR DESCRIPTION
## Issue: https://github.com/rancher/turtles/issues/1890
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
After upgrading Rancher to `2.13.0-alpha7` from `2.12.3`, the `v1.ext.cattle.io` apiservice became unavailable because it pointed to a service that was being deleted (`cattle-system/imperative-api-extension`).

```
kubectl get apiservices v1.ext.cattle.io
NAME               SERVICE                                  AVAILABLE                 AGE
v1.ext.cattle.io   cattle-system/imperative-api-extension   False (ServiceNotFound)   2m25s
```

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

To address the issue, I've moved the code that deletes the old service _before_ creating the apiservice that uses the new service.

```
kubectl get apiservices v1.ext.cattle.io
NAME               SERVICE                       AVAILABLE   AGE
v1.ext.cattle.io   cattle-system/api-extension   True        2m29s
```

Important: Once merged, this PR needs to be backported to `release/v2.13`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Run `make quick` and run `helm upgrade` using the local image.