### PR TITLE
do not remove legacy service

### DIFF
--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -417,22 +417,22 @@ func DeleteLegacyServiceAndSecret(service wranglercorev1.ServiceController, secr
 	}
 
 	// Check if the legacy secret exists before attempting to delete
-	_, err = secrets.Get(Namespace, LegacySecretName, metav1.GetOptions{})
-	if err != nil {
-		logrus.Warnf("failed to get legacy Secret %s/%s: %v", Namespace, LegacySecretName, err)
-	} else {
-		// Secret found, proceed with deletion
-		logrus.Infof("Deleting legacy Secret %s/%s...", Namespace, LegacySecretName)
-		deleteErr := secrets.Delete(Namespace, LegacySecretName, &metav1.DeleteOptions{})
-		if deleteErr != nil {
-			if !apierrors.IsNotFound(deleteErr) {
-				logrus.Warnf("failed to delete legacy Secret %s/%s: %v", Namespace, LegacySecretName, deleteErr)
-			}
-			logrus.Infof("Legacy Secret %s/%s was already gone.", Namespace, LegacySecretName)
-		} else {
-			logrus.Infof("Successfully deleted legacy Secret %s/%s.", Namespace, LegacySecretName)
-		}
-	}
+	// _, err = secrets.Get(Namespace, LegacySecretName, metav1.GetOptions{})
+	// if err != nil {
+	// 	logrus.Warnf("failed to get legacy Secret %s/%s: %v", Namespace, LegacySecretName, err)
+	// } else {
+	// 	// Secret found, proceed with deletion
+	// 	logrus.Infof("Deleting legacy Secret %s/%s...", Namespace, LegacySecretName)
+	// 	deleteErr := secrets.Delete(Namespace, LegacySecretName, &metav1.DeleteOptions{})
+	// 	if deleteErr != nil {
+	// 		if !apierrors.IsNotFound(deleteErr) {
+	// 			logrus.Warnf("failed to delete legacy Secret %s/%s: %v", Namespace, LegacySecretName, deleteErr)
+	// 		}
+	// 		logrus.Infof("Legacy Secret %s/%s was already gone.", Namespace, LegacySecretName)
+	// 	} else {
+	// 		logrus.Infof("Successfully deleted legacy Secret %s/%s.", Namespace, LegacySecretName)
+	// 	}
+	// }
 
 	logrus.Info("Finished attempting to delete legacy Service and Secret.")
 	return nil


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/turtles/issues/1890
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

During the upgrade from `v2.12.3` to `v2.13.0` while there are pods from the old and new versions of rancher both exist, they are both attempting to manage the `ext.cattle.io/v1` `APIService`. This results in both pods fighting over its current state, which may leave rancher broken once all old pods are deleted.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Do not delete the old `APIService` while generating the new one.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_