### PR TITLE
fix: networking comparison for "all" restore type

### DIFF
--- a/pkg/controllers/provisioningv2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/controller.go
@@ -265,7 +265,7 @@ func reconcileClusterSpecEtcdRestore(cluster *rancherv1.Cluster, desiredSpec ran
 		changed = true
 		cluster.Spec.RKEConfig.AdditionalManifest = desiredSpec.RKEConfig.AdditionalManifest
 	}
-	if cluster.Spec.RKEConfig.Networking != desiredSpec.RKEConfig.Networking {
+	if !equality.Semantic.DeepEqual(cluster.Spec.RKEConfig.Networking, desiredSpec.RKEConfig.Networking) {
 		changed = true
 		cluster.Spec.RKEConfig.Networking = desiredSpec.RKEConfig.Networking
 	}


### PR DESCRIPTION
## Issue: [#52730](https://github.com/rancher/rancher/issues/52730)


## Problem

When restoring with the "all" mode, the provisioning cluster update did not propagate to the downstream cluster. The control plane update was not triggered because the controller compared pointers instead of using a deep equality comparison. This made the reconciliation loop think there was always a change, which kept the handler in a loop and it never reached the code path that applies the update to the control plane.

## Solution

Use a deep equality check for the relevant fields in the provisioning cluster controller so that the controller can detect true no-op cases and proceed to the section that updates the control plane when appropriate. The change is targeted to the comparison used in the provisioning cluster reconcile logic so that we exit the loop and reach the code that updates the downstream cluster.

## Testing

Repro steps from the issue were validated and updated as needed.

## Engineering Testing

### Manual Testing

1. Create a downstream RKE2 cluster.
2. Take an etcd snapshot.
3. Perform a restore using "all".
4. Observe that the control plane update is triggered and the downstream cluster spec is updated.
5. Repeat to confirm the reconcile does not get stuck in a loop.

## QA Testing Considerations

* Verify "all" restore updates are reflected on the downstream cluster.
* Verify "kubernetesVersion" and "none" restore paths still behave correctly.
* Test both fresh installs and upgrades from a build without this fix.
* Observe logs to ensure the reconcile does not loop indefinitely and that OnRancherClusterChange proceeds to the update path.
