### PR TITLE
[v2.12] fix: networking comparison for "all" restore type

### DIFF
--- a/pkg/controllers/provisioningv2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/controller.go
@@ -254,7 +254,7 @@ func reconcileClusterSpecEtcdRestore(cluster *rancherv1.Cluster, desiredSpec ran
 		changed = true
 		cluster.Spec.RKEConfig.AdditionalManifest = desiredSpec.RKEConfig.AdditionalManifest
 	}
-	if cluster.Spec.RKEConfig.Networking != desiredSpec.RKEConfig.Networking {
+	if !equality.Semantic.DeepEqual(cluster.Spec.RKEConfig.Networking, desiredSpec.RKEConfig.Networking) {
 		changed = true
 		cluster.Spec.RKEConfig.Networking = desiredSpec.RKEConfig.Networking
 	}


### PR DESCRIPTION
Backport issue: https://github.com/rancher/rancher/issues/52733

Cherry-pick from main of https://github.com/rancher/rancher/pull/52736