### PR TITLE
Fix rke2-machineconfig-cleanup running when provisioning is disabled.

### DIFF
--- a/pkg/controllers/provisioningv2/machineconfigcleanup/controller.go
+++ b/pkg/controllers/provisioningv2/machineconfigcleanup/controller.go
@@ -52,7 +52,7 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 //
 // The logic is triggered on every update to a ClusterRegistrationToken, as the job
 // requires the most recent token to run `kubectl` successfully.
-func (h *handler) onChange(key string, obj *v3apis.ClusterRegistrationToken) (_ *v3apis.ClusterRegistrationToken, err error) {
+func (h *handler) onChange(_ string, obj *v3apis.ClusterRegistrationToken) (_ *v3apis.ClusterRegistrationToken, err error) {
 	if obj == nil || obj.Namespace != "local" || obj.DeletionTimestamp != nil || obj.Status.Token == "" {
 		return obj, nil
 	}
@@ -67,25 +67,31 @@ func (h *handler) onChange(key string, obj *v3apis.ClusterRegistrationToken) (_ 
 	return obj, nil
 }
 
-// cleanupObjects returns the service account, cluster role+binding, config map, & cronjob required for periodically
-// cleaning up outdated & unowned machine configs.
-// This handler always runs, but must return an empty list when the provisioning feature is disabled in order for the
-// cronjob to be cleaned up.
+// cleanupObjects returns the service account, cluster role+binding, config map, and cronjob required for periodically
+// cleaning up outdated and unowned machine configs. This handler is only registered if the features.ProvisioningV2
+// setting is true, but if features.RKE2 is false, the CRDs required for the cronjob script would not exist and the
+// script will fail. For the Harvester use case, features.ProvisioningV2 and features.RKE2 will be enabled, but
+// features.MCM will be disabled (and Harvester local does not have machine configs due to custom clusters), which is
+// why the "fleet-local" cluster is used for this cronjob as it should always exist (as opposed to "fleet-default",
+// which is absent for Harvester).
 func cleanupObjects(token string) []runtime.Object {
-	if !features.ProvisioningV2.Enabled() {
+	// Check features.ProvisioningV2 to be explicit, even though it's checked when registering.
+	if !features.ProvisioningV2.Enabled() || !features.RKE2.Enabled() {
 		return []runtime.Object{}
 	}
 
 	url := settings.ServerURL.Get()
 	ca := systemtemplate.CAChecksum()
 	image := image2.Resolve(settings.AgentImage.Get())
-	fleetNamespace := fleet.ClustersDefaultNamespace
+
+	// Use fleet-local namespace as it's guaranteed to exist.
+	namespace := fleet.ClustersLocalNamespace
 	prefix := "rke2-machineconfig-cleanup"
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      prefix + "-sa",
-			Namespace: fleetNamespace,
+			Namespace: namespace,
 		},
 	}
 
@@ -120,7 +126,7 @@ func cleanupObjects(token string) []runtime.Object {
 			{
 				Kind:      "ServiceAccount",
 				Name:      sa.Name,
-				Namespace: fleetNamespace,
+				Namespace: namespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -133,7 +139,7 @@ func cleanupObjects(token string) []runtime.Object {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      prefix + "-script",
-			Namespace: fleetNamespace,
+			Namespace: namespace,
 		},
 		Data: map[string]string{
 			"cleanup.sh": `#!/bin/bash
@@ -175,7 +181,7 @@ func cleanupObjects(token string) []runtime.Object {
 	cronJob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      prefix + "-cronjob",
-			Namespace: fleetNamespace,
+			Namespace: namespace,
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule: "5 0 * * *", // at 12:05am every day


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/51985
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
`rke2-machineconfig-cleanup-script` handler runs when `provisioningv2` feature flag is disabled. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Continue to run handler, but do not return the job.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manually Tested that a net new env, and one where provisioningv2 was enabled then disabled both work.