### PR TITLE
fix: merge two conversion functions into a single

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/resource_quota_calculate_used.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_calculate_used.go
@@ -81,7 +81,7 @@ func (c *calculateLimitController) calculateProjectResourceQuota(projectID strin
 		}
 		nsResourceList, err := validate.ConvertLimitToResourceList(nsLimit)
 		if err != nil {
-			return err
+			return fmt.Errorf("parsing namespace quota limits: %w", err)
 		}
 		nssResourceList = quota.Add(nssResourceList, nsResourceList)
 	}

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -1,6 +1,7 @@
 package resourcequota
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -12,8 +13,22 @@ import (
 	quota "k8s.io/apiserver/pkg/quota/v1"
 )
 
+const ExtendedKey = "extended"
+
 var (
-	projectLockCache = cache.NewLRUExpireCache(1000)
+	projectLockCache        = cache.NewLRUExpireCache(1000)
+	resourceQuotaConversion = map[string]string{
+		"replicationControllers": "replicationcontrollers",
+		"configMaps":             "configmaps",
+		"persistentVolumeClaims": "persistentvolumeclaims",
+		"servicesNodePorts":      "services.nodeports",
+		"servicesLoadBalancers":  "services.loadbalancers",
+		"requestsCpu":            "requests.cpu",
+		"requestsMemory":         "requests.memory",
+		"requestsStorage":        "requests.storage",
+		"limitsCpu":              "limits.cpu",
+		"limitsMemory":           "limits.memory",
+	}
 )
 
 func GetProjectLock(projectID string) *sync.Mutex {
@@ -30,21 +45,21 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 	nssResourceList := api.ResourceList{}
 	nsResourceList, err := ConvertLimitToResourceList(nsLimit)
 	if err != nil {
-		return false, nil, err
+		return false, nil, fmt.Errorf("checking quota fit: %w", err)
 	}
 	nssResourceList = quota.Add(nssResourceList, nsResourceList)
 
 	for _, nsLimit := range nsLimits {
 		nsResourceList, err := ConvertLimitToResourceList(nsLimit)
 		if err != nil {
-			return false, nil, err
+			return false, nil, fmt.Errorf("checking namespace limits: %w", err)
 		}
 		nssResourceList = quota.Add(nssResourceList, nsResourceList)
 	}
 
 	projectResourceList, err := ConvertLimitToResourceList(projectLimit)
 	if err != nil {
-		return false, nil, err
+		return false, nil, fmt.Errorf("checking project limits: %w", err)
 	}
 
 	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
@@ -58,17 +73,44 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 }
 
 func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList, error) {
+	// TECH DEBT: Any change here has to be reflected in rancher/webhook
+	//   pkg/resources/management.cattle.io/v3/project/quota_validate.go
+	// until such time as both places are unified in a single function shared between r/r and r/w
+
 	toReturn := api.ResourceList{}
 	converted, err := convert.EncodeToMap(limit)
 	if err != nil {
 		return nil, err
 	}
-	for key, value := range converted {
-		q, err := resource.ParseQuantity(convert.ToString(value))
-		if err != nil {
-			return nil, err
+
+	// convert the extended set first, ...
+	if extended, ok := converted[ExtendedKey]; ok {
+		delete(converted, ExtendedKey)
+		for key, value := range extended.(map[string]any) {
+			resourceName := api.ResourceName(key)
+			resourceQuantity, err := resource.ParseQuantity(value.(string))
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse value for key %q: %w", key, err)
+			}
+
+			toReturn[resourceName] = resourceQuantity
 		}
-		toReturn[api.ResourceName(key)] = q
+	}
+
+	// then place the fixed data. this order ensures that in case of
+	// conflicts between arbitrary and fixed data the fixed data wins.
+	for key, value := range converted {
+		var resourceName api.ResourceName
+		if val, ok := resourceQuotaConversion[key]; ok {
+			resourceName = api.ResourceName(val)
+		} else {
+			resourceName = api.ResourceName(key)
+		}
+		resourceQuantity, err := resource.ParseQuantity(convert.ToString(value))
+		if err != nil {
+			return nil, fmt.Errorf("parsing quantity %q: %w", key, err)
+		}
+		toReturn[resourceName] = resourceQuantity
 	}
 	return toReturn, nil
 }

--- a/tests/v2/integration/projects/resource_quota_test.go
+++ b/tests/v2/integration/projects/resource_quota_test.go
@@ -149,7 +149,7 @@ func (s *ResourceQuotaSuite) TestCreateNamespaceWithOverriddenQuotaInProject() {
 
 	resourceList = quotas.Items[0].Spec.Hard
 	want = v1.ResourceList{
-		v1.ResourceLimitsCPU: resource.MustParse("0"),
+		v1.ResourceLimitsCPU: resource.MustParse("400m"),
 	}
 	s.Require().Equal(want, resourceList)
 	s.Require().NoError(err)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

This PR is a followup to PR #52544.
It has an associated webhook PR https://github.com/rancher/webhook/pull/1192
 
## Problem

My work on the resource quota conversion functions in `pkg/controllers/managetuser/resourcequota/` missed a conversion function in `pkg/resourcequota/`. 
 
## Solution

The two separate yet equivalent conversion functions (`convertProjectResourceLimitToResourceList`, `ConvertLimitToResourceList`) were essentially merged into a single function.
 
## Testing

unit testing passes.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_