### PR TITLE
[main] Make sure JSURL and CSURL are nil to norman response writer

### DIFF
--- a/pkg/api/norman/server.go
+++ b/pkg/api/norman/server.go
@@ -16,29 +16,5 @@ func NewServer(schemas *types.Schemas) (*normanapi.Server, error) {
 }
 
 func ConfigureAPIUI(server *normanapi.Server) {
-	server.CustomAPIUIResponseWriter(cssURL, jsURL, settings.APIUIVersion.Get)
-}
-
-func cssURL() string {
-	switch settings.UIOfflinePreferred.Get() {
-	case "dynamic":
-		if !settings.IsRelease() {
-			return ""
-		}
-	case "false":
-		return ""
-	}
-	return "/api-ui/ui.min.css"
-}
-
-func jsURL() string {
-	switch settings.UIOfflinePreferred.Get() {
-	case "dynamic":
-		if !settings.IsRelease() {
-			return ""
-		}
-	case "false":
-		return ""
-	}
-	return "/api-ui/ui.min.js"
+	server.CustomAPIUIResponseWriter(nil, nil, settings.APIUIVersion.Get)
 }


### PR DESCRIPTION
Issue :  https://github.com/rancher/rancher/issues/52911

### Summary 

- The PRs for the issue https://github.com/rancher/rancher/issues/51794 made sure that `API UI assets` for `v1` `steve` following `ui-offline-preferred` settings properly. It was buggy before.
- The PRs made some changes in routing codebase in `rancher/rancher` and to `rancher/steve` for this. These changes broke `v3` norman part. This current PR fixes the `v3` norman part. 
- There is future work for `v3` norman to make sure it follows `ui-offline-preferred` settings properly.
- This PR sends `JSURL` and `CSSURL` as nil for `norman`. For `steve` `v1` we already send nil. The JSURL and CSSURL are buggy. They don't consider the `local` value of `setting`. This PR changes them to nil just like for steve https://github.com/rancher/apiserver/blob/f73998654f48195e784417398f651af6a61062c3/pkg/server/server.go#L51.
- We could complete get rid of `JSURL` and `CSSURL` but we wanted to minimum change possible and tackle dead code for later.

