### PR TITLE
Register token-key-index indexer for the wrangler context

### DIFF
--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -93,6 +93,11 @@ func NewAuthenticator(ctx context.Context, clusterRouter ClusterRouter, mgmtCtx 
 	tokenInformer := mgmtCtx.Management.Tokens("").Controller().Informer()
 	// Deliberately ignore the error if the indexer was already added.
 	_ = tokenInformer.AddIndexers(map[string]cache.IndexFunc{tokenKeyIndex: tokenKeyIndexer})
+	// Add indexer for the wrangler context as it won't be added if multi-cluster-management is not enabled.
+	wTokenInformer := mgmtCtx.Wrangler.Mgmt.Token().Informer()
+	// Deliberately ignore the error if the indexer was already added.
+	_ = wTokenInformer.AddIndexers(map[string]cache.IndexFunc{tokenKeyIndex: tokenKeyIndexer})
+
 	providerRefresher := providerrefresh.NewUserAuthRefresher(mgmtCtx)
 
 	extTokenStore := exttokenstore.NewSystemFromWrangler(mgmtCtx.Wrangler)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52772
 
## Problem
There is a problem getting the token only when `multi-cluster-management=false` because the `authn.management.cattle.io/token-key-index` index is not registered for the wrangler context.

```
2025/11/21 12:21:16 [ERROR] GetToken failed with error: failed to retrieve auth token from cache, 
error: Index with name authn.management.cattle.io/token-key-index does not exist
```
 
## Solution

Always register the index for wrangler context as well
 
