### PR TITLE
feat(chart): adds HTTPRoute resource

### DIFF
--- a/chart/templates/httproute.yaml
+++ b/chart/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "rancher.fullname" . }}
+  labels:
+{{ include "rancher.labels" . | indent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    - {{ .Values.hostname }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ template "rancher.fullname" $ }}
+          port: {{ $.Values.httpRoute.servicePort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/chart/tests/httproute_test.yaml
+++ b/chart/tests/httproute_test.yaml
@@ -1,0 +1,48 @@
+suite: Test HTTPRoute
+templates:
+- httproute.yaml
+tests:
+- it: should work with service.disableHTTP
+  set:
+    hostname: host.example.com
+    ingress:
+      enabled: false
+    httpRoute:
+      enabled: true
+      servicePort: 443
+    service:
+      disableHTTP: true
+  asserts:
+    - equal:
+        path: spec.rules[0].backendRefs
+        value:
+          - name: RELEASE-NAME-rancher
+            port: 443
+            weight: 1
+- it: can target servicePort 443 without disabling port 80
+  set:
+    hostname: host.example.com
+    ingress:
+      enabled: false
+    httpRoute:
+      enabled: true
+      servicePort: 443
+  asserts:
+    - equal:
+        path: spec.rules[0].backendRefs
+        value:
+          - name: RELEASE-NAME-rancher
+            port: 443
+            weight: 1
+- it: it should fail when disableHTTP is set and servicePort is not 443
+  set:
+    hostname: host.example.com
+    ingress:
+      enabled: false
+    httpRoute:
+      enabled: true
+    service:
+      disableHTTP: true
+  asserts:
+    - failedTemplate:
+        errorPattern: "'/httpRoute/servicePort': value must be 443"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -53,26 +53,64 @@
     }
   },
   "required": [],
-  "if": {
-    "properties": {
-      "service": {
+  "allOf": [
+    {
+      "if": {
         "properties": {
-          "disableHTTP": { "const": true }
-        },
-        "required": ["disableHTTP"]
-      }
-    }
-  },
-  "then": {
-    "properties": {
-      "ingress": {
-        "properties": {
-          "servicePort": {
-            "enum": [443]
+          "service": {
+            "properties": {
+              "disableHTTP": { "const": true }
+            },
+            "required": ["disableHTTP"]
+          },
+          "ingress": {
+            "properties": {
+              "enabled": { "const": true }
+            }
           }
-        },
-        "required": ["servicePort"]
+        }
+      },
+      "then": {
+        "properties": {
+          "ingress": {
+            "properties": {
+              "servicePort": {
+                "enum": [443]
+              }
+            },
+            "required": ["servicePort"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "service": {
+            "properties": {
+              "disableHTTP": { "const": true }
+            },
+            "required": ["disableHTTP"]
+          },
+          "httpRoute": {
+            "properties": {
+              "enabled": { "const": true }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "httpRoute": {
+            "properties": {
+              "servicePort": {
+                "enum": [443]
+              }
+            },
+            "required": ["servicePort"]
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,6 +95,44 @@ ingress:
     source: rancher
     secretName: tls-rancher-ingress
 
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+httpRoute:
+  # HTTPRoute enabled.
+  enabled: false
+  # HTTPRoute annotations.
+  annotations: {}
+  # Backend port number; should use either: 80, or 443.
+  # Must use 443 when `service.disableHTTP` is set to true.
+  servicePort: 80
+  # Which Gateways this Route is attached to.
+  parentRefs:
+  - name: gateway
+    sectionName: http
+    # namespace: default
+  # List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #       - name: My-Overwrite-Header
+  #         value: this-is-the-only-value
+  #       remove:
+  #       - User-Agent
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /echo
+  #     headers:
+  #     - name: version
+  #       value: v2
+
 ### service ###
 # Override to use NodePort or LoadBalancer service type - default is ClusterIP
 service:


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/52796

## Problem
Gateway API is starting to get traction so it would be nice to have support for this in the chart. 
 
## Solution
Adapted the default `httpRoute.yaml` from `helm create` slightly to fit in the chart but kept it as close to the upstream default as possible. Also made the interface as close to the current `Ingress` with the addition of the `servicePort`.

With Gateway API all the TLS config is on the higher level `Gateway` resource which is shared across applications. Therefore no TLS config (like with ingress) is currently required.

## Testing
Took the relevant tests that were there for the ingress and refactored them to suit. Added a test to validate the failure of the JSON Schema for when `disableHTTP: true` and `servicePort` not 443.

## Engineering Testing
### Manual Testing
Verified output of `helm template` against the HTTPRoute CRD schema

### Automated Testing
* Test types added/modified:
    * Unit

## QA Testing Considerations
TBD?

### Regressions Considerations
None really since it can exist next to the current Ingress resource.

Existing / newly added automated tests that provide evidence there are no regressions:
The current helm-unit tests are still passing.