### PR TITLE
 set advertise-address and tls-san in non-worker node's config properly

### DIFF
--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -4,8 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/data/management"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateConfigWithAddresses(t *testing.T) {
@@ -200,6 +203,32 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 			expectedNodeIPs:         []string{"1.2.3.4", "1.2.3.5", "1.2.3.7", "2001:db8::1"},
 			expectedNodeExternalIPs: []string{"1.2.3.6"},
 		},
+		{
+			name: "Interface names as addresses",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"wt0"},
+			},
+			expectedNodeIPs:         []string{"eth0"},
+			expectedNodeExternalIPs: []string{"wt0"},
+		},
+		{
+			name: "Mixed interface names and IPs",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"1.2.3.4"},
+				IPv6Address:       "2001:db8::1",
+				DriverName:        management.Amazonec2driver,
+			},
+			expectedNodeIPs:         []string{"eth0", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -230,6 +259,185 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 				if len(gotExternal) > 0 {
 					t.Errorf("unexpected node-external-ip: %v", gotExternal)
 				}
+			}
+		})
+	}
+}
+
+func TestUpdateConfigWithAdvertiseAddresses(t *testing.T) {
+	controlPlaneEntry := &planEntry{
+		Metadata: &plan.Metadata{
+			Labels:      map[string]string{capr.ControlPlaneRoleLabel: "true"},
+			Annotations: nil,
+		},
+	}
+	workerEntry := &planEntry{
+		Metadata: &plan.Metadata{
+			Labels:      map[string]string{capr.WorkerRoleLabel: "true"},
+			Annotations: nil,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		initialConfig  map[string]interface{}
+		info           *machineNetworkInfo
+		expectAddrSet  bool
+		expectedConfig map[string]interface{}
+	}{
+		{
+			name:          "control-plane node with different internal and external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.1", "tls-san": []string{"192.168.1.1"}},
+		},
+		{
+			name:          "control-plane node with same internal and external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"192.168.1.1"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with same set of internal and external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"192.168.1.1", "192.168.1.2"},
+				ExternalAddresses: []string{"192.168.1.2", "192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with no internal IP",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with no external IP",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with no internal or external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "worker-only node should be skipped",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             workerEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with multiple different IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.2", "10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.2", "192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.2", "tls-san": []string{"192.168.1.2", "192.168.1.1"}},
+		},
+		{
+			name:          "control-plane node with different internal and external interface names",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"eth1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "eth0", "tls-san": []string{"eth1"}},
+		},
+		{
+			name:          "control-plane node with same internal and external interface names",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"eth0"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with mixed different ip and interface name",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "eth0", "tls-san": []string{"192.168.1.1"}},
+		},
+		{
+			name: "control-plane node with pre-existing tls-san",
+			initialConfig: map[string]interface{}{
+				"tls-san": []string{"existing-san", "192.168.1.1"},
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.1", "192.168.1.2"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet: true,
+			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.1",
+				"tls-san": []string{"existing-san", "192.168.1.1", "192.168.1.2"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.initialConfig
+			updateConfigWithAdvertiseAddresses(config, tt.info)
+			_, ok := config["advertise-address"]
+			if tt.expectAddrSet {
+				assert.True(t, ok, "expected advertise-address to be set")
+				// DeepEqual does not work well with mixed slice types (e.g. []string vs []interface{}), so we test tls-san separately.
+				expectedTlsSan, ok := tt.expectedConfig["tls-san"]
+				if ok {
+					assert.ElementsMatch(t, expectedTlsSan, config["tls-san"])
+				}
+				assert.Equal(t, tt.expectedConfig["advertise-address"], config["advertise-address"])
+			} else {
+				assert.False(t, ok, "expected advertise-address not to be set")
+				assert.Equal(t, len(tt.expectedConfig), len(config))
 			}
 		})
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/52890
 
 
## Problem

In Rancher v2.12 and earlier, the `advertise-address` and `tls-san` fields were set in the node configuration for non-worker nodes whose public IP and private IP are known and differ, which includes two cases:
- in custom clusters when the node's public IP and private IP are set and differ in the node registration command. 
- in the node-driver clusters 

See logic: https://github.com/rancher/rancher/blob/release/v2.12/pkg/capr/planner/config.go#L385-L390

Starting with Rancher v2.13, this behavior changed: Rancher no longer sets these fields for non-worker nodes. Instead, the responsibility for determining the `advertise-address` and `tls-san` values was shifted to the RKE2/K3s engine, whose logic differs from Rancher’s.

As a result, the addresses in the `kubernetes` endpoint changed from the nodes’ private IPs to their public IPs, leading to unexpected behavior and causing issues in certain use cases.

## Solution

Restore the previous logic by setting the `advertise-address` and `tls-san` fields in the node configuration when certain conditions are met. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The PR is validated in the local dev environment, on a control-plane node, the `advertise-address` and `tls-san` fields are set with proper values in the `/etc/rancher/rke2/config.yaml.d/50-rancher.yaml` file: 
```
{
  "advertise-address": "<private-IP>",
   "tls-san": [
    "<public-IP>"
  ],
}
```

and the  `kubernetes` endpoint uses the node's private IP 
```
k get ep 
NAME         ENDPOINTS           AGE
kubernetes   172.x.x.x:6443   4s
```


### Automated Testing
 
Unit tests are added. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

- After upgrading Rancher, on existing qualified clusters, the `kubernetes` endpoint uses the node's private IP
-  On newly-created qualified clusters, the `kubernetes` endpoint uses the node's private IP

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 

- Cluster provisioning is broken 

Existing / newly added automated tests that provide evidence there are no regressions:

n/a 