### PR TITLE
[2.13] set advertise-address and tls-san in non-worker node's config properly

### DIFF
--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -4,8 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/data/management"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateConfigWithAddresses(t *testing.T) {
@@ -200,6 +203,32 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 			expectedNodeIPs:         []string{"1.2.3.4", "1.2.3.5", "1.2.3.7", "2001:db8::1"},
 			expectedNodeExternalIPs: []string{"1.2.3.6"},
 		},
+		{
+			name: "Interface names as addresses",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"wt0"},
+			},
+			expectedNodeIPs:         []string{"eth0"},
+			expectedNodeExternalIPs: []string{"wt0"},
+		},
+		{
+			name: "Mixed interface names and IPs",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"1.2.3.4"},
+				IPv6Address:       "2001:db8::1",
+				DriverName:        management.Amazonec2driver,
+			},
+			expectedNodeIPs:         []string{"eth0", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -230,6 +259,185 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 				if len(gotExternal) > 0 {
 					t.Errorf("unexpected node-external-ip: %v", gotExternal)
 				}
+			}
+		})
+	}
+}
+
+func TestUpdateConfigWithAdvertiseAddresses(t *testing.T) {
+	controlPlaneEntry := &planEntry{
+		Metadata: &plan.Metadata{
+			Labels:      map[string]string{capr.ControlPlaneRoleLabel: "true"},
+			Annotations: nil,
+		},
+	}
+	workerEntry := &planEntry{
+		Metadata: &plan.Metadata{
+			Labels:      map[string]string{capr.WorkerRoleLabel: "true"},
+			Annotations: nil,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		initialConfig  map[string]interface{}
+		info           *machineNetworkInfo
+		expectAddrSet  bool
+		expectedConfig map[string]interface{}
+	}{
+		{
+			name:          "control-plane node with different internal and external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.1", "tls-san": []string{"192.168.1.1"}},
+		},
+		{
+			name:          "control-plane node with same internal and external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"192.168.1.1"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with same set of internal and external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"192.168.1.1", "192.168.1.2"},
+				ExternalAddresses: []string{"192.168.1.2", "192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with no internal IP",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with no external IP",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with no internal or external IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "worker-only node should be skipped",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             workerEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with multiple different IPs",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.2", "10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.2", "192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.2", "tls-san": []string{"192.168.1.2", "192.168.1.1"}},
+		},
+		{
+			name:          "control-plane node with different internal and external interface names",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"eth1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "eth0", "tls-san": []string{"eth1"}},
+		},
+		{
+			name:          "control-plane node with same internal and external interface names",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"eth0"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{},
+		},
+		{
+			name:          "control-plane node with mixed different ip and interface name",
+			initialConfig: map[string]interface{}{},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"eth0"},
+				ExternalAddresses: []string{"192.168.1.1"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "eth0", "tls-san": []string{"192.168.1.1"}},
+		},
+		{
+			name: "control-plane node with pre-existing tls-san",
+			initialConfig: map[string]interface{}{
+				"tls-san": []string{"existing-san", "192.168.1.1"},
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.1"},
+				ExternalAddresses: []string{"192.168.1.1", "192.168.1.2"},
+				Entry:             controlPlaneEntry,
+			},
+			expectAddrSet: true,
+			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.1",
+				"tls-san": []string{"existing-san", "192.168.1.1", "192.168.1.2"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.initialConfig
+			updateConfigWithAdvertiseAddresses(config, tt.info)
+			_, ok := config["advertise-address"]
+			if tt.expectAddrSet {
+				assert.True(t, ok, "expected advertise-address to be set")
+				// DeepEqual does not work well with mixed slice types (e.g. []string vs []interface{}), so we test tls-san separately.
+				expectedTlsSan, ok := tt.expectedConfig["tls-san"]
+				if ok {
+					assert.ElementsMatch(t, expectedTlsSan, config["tls-san"])
+				}
+				assert.Equal(t, tt.expectedConfig["advertise-address"], config["advertise-address"])
+			} else {
+				assert.False(t, ok, "expected advertise-address not to be set")
+				assert.Equal(t, len(tt.expectedConfig), len(config))
 			}
 		})
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/52903

Back port of https://github.com/rancher/rancher/pull/52914, where you can find more information about the change 