### PR TITLE
Bump system-agent to v0.3.15-rc.0

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -174,7 +174,7 @@ ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT=https://raw.githubusercontent.com/rancher
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE=rancher/wins:${CATTLE_WINS_AGENT_VERSION}
 ENV CATTLE_CSI_PROXY_AGENT_VERSION=v1.1.3
 # make sure the CATTLE_SYSTEM_AGENT_VERSION is consistent with tests/v2/codecoverage/package/Dockerfile
-ENV CATTLE_SYSTEM_AGENT_VERSION=v0.3.14
+ENV CATTLE_SYSTEM_AGENT_VERSION=v0.3.15-rc.0
 ENV CATTLE_SYSTEM_AGENT_DOWNLOAD_PREFIX=https://github.com/rancher/system-agent/releases/download
 ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE=rancher/system-agent:${CATTLE_SYSTEM_AGENT_VERSION}-suc
 ENV CATTLE_SYSTEM_AGENT_INSTALLER_IMAGE=rancher/system-agent-installer-

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -110,7 +110,7 @@ var (
 	WinsAgentVersion                    = NewSetting("wins-agent-version", "")
 	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
 	CSIProxyAgentURL                    = NewSetting("csi-proxy-agent-url", "https://acs-mirror.azureedge.net/csi-proxy/%[1]s/binaries/csi-proxy-%[1]s.tar.gz")
-	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://github.com/rancher/system-agent/releases/download/v0.3.14/install.sh") // To ensure consistency between SystemAgentInstallScript default value and CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT to utilize the local system-agent-install.sh script when both values are equal.
+	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://github.com/rancher/system-agent/releases/download/v0.3.15-rc0/install.sh") // To ensure consistency between SystemAgentInstallScript default value and CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT to utilize the local system-agent-install.sh script when both values are equal.
 	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.5.3/install.ps1")
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "") // Defined via environment variable
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")   // Defined via environment variable


### PR DESCRIPTION
## Issue: #52870

## Summary

Bump the system-agent version used by Rancher to "v0.3.15-rc.0", which contains the [fix from the system-agent repository](https://github.com/rancher/system-agent/releases/tag/v0.3.15-rc.0). This allows QA to create and register clusters using the fixed agent version and confirm that the permissions problem described in issue #52870 is resolved.

## Testing

Confirmed that the new version is used by Rancher and that a newly created custom cluster registers nodes with system-agent "v0.3.15-rc.0".

## Engineering Testing

### Manual Testing

* Started Rancher locally with the updated system-agent version.
* Created a single node custom RKE2 cluster.
* Registered a DigitalOcean node under a restrictive umask and verified:

  * The node joined the cluster and became Active.
  * The "rancher-system-agent.service" file on the node had mode "0644".

### Automated Testing

* Test types added/modified:

  * None

## QA Testing Considerations

* Use a Rancher build that includes system-agent "v0.3.15-rc.0".
* Reproduce the original scenario from issue #52870:

  * Host with restrictive umask (for example "umask 027").
  * Register the node into a custom cluster and allow system-agent to install.
* Verify:

  * "rancher-system-agent.service" has permissions "0644".
  * No systemd warnings about service file permissions.
  * Node stays Active and system-agent restarts correctly after reboot.