### PR TITLE
Use an older version of urllib3 with integration tests

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -11,6 +11,7 @@ pyyaml==6.0.3
 netaddr==0.8.0
 requests==2.32.5
 kubernetes==12.0.1
+urllib3<2.0.0
 jinja2>=2.10
 cryptography==44.0.3
 werkzeug==3.0.6


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Getting errors when running integration tests

```
self = <kubernetes.client.rest.RESTResponse object at 0x7f52dc4ff520>

    def getheaders(self):
        """Returns a dictionary of the response headers."""
>       return self.urllib3_response.getheaders()
E       AttributeError: 'HTTPResponse' object has no attribute 'getheaders'

../.tox/rancher/lib/python3.11/site-packages/kubernetes/client/rest.py:43: AttributeError
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

A quick workaround is to downgrade the `urllib3` library.

We should follow this up by considering upgrading the kubernetes library instead.
