### PR TITLE
Bump version of rancher/shell that is used

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ remoteDialerProxyVersion: 106.0.2+up0.6.0
 provisioningCAPIVersion: 108.0.0+up0.9.0
 turtlesVersion: 108.0.0+up0.25.0-rc.4
 cspAdapterMinVersion: 108.0.0+up8.0.0
-defaultShellVersion: rancher/shell:v0.6.0-rc.1
+defaultShellVersion: rancher/shell:v0.6.1-rc.1
 fleetVersion: 109.0.0+up0.15.0-alpha.1
 defaultSccOperatorImage: rancher/scc-operator:v0.3.1-rc.2
 # NOTE: when updating this version, you will also need to update the hardcoded

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,7 +6,7 @@ const (
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "108.0.0+up8.0.0"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1-rc.2"
-	DefaultShellVersion           = "rancher/shell:v0.6.0-rc.1"
+	DefaultShellVersion           = "rancher/shell:v0.6.1-rc.1"
 	FleetVersion                  = "109.0.0+up0.15.0-alpha.1"
 	ProvisioningCAPIVersion       = "108.0.0+up0.9.0"
 	RemoteDialerProxyVersion      = "106.0.2+up0.6.0"


### PR DESCRIPTION
This PR bumps the version of rancher/shell that is used by Rancher, in anticipation of the 2.13.1 release.