### PR TITLE
Allow Access Token and OIDC Client scope control

### DIFF
--- a/pkg/apis/management.cattle.io/v3/oidc_provider_types.go
+++ b/pkg/apis/management.cattle.io/v3/oidc_provider_types.go
@@ -66,4 +66,11 @@ type OIDCClientSpec struct {
 	// a refresh token remains valid before expiration.
 	// +kubebuilder:validation:Minimum=1
 	RefreshTokenExpirationSeconds int64 `json:"refreshTokenExpirationSeconds"`
+
+	// Scopes is the list of scopes allowed for this client.
+	//
+	// If configured, the client will only be able to request these scopes.
+	//
+	// +optional
+	Scopes []string `json:"scopes"`
 }

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -5301,6 +5301,11 @@ func (in *OIDCClientSpec) DeepCopyInto(out *OIDCClientSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Scopes != nil {
+		in, out := &in.Scopes, &out.Scopes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -186,7 +186,7 @@ func (l *Provider) getGroupPrincipals(user *apiv3.User) ([]apiv3.Principal, erro
 				continue
 			}
 
-			//find group for this member mapping
+			// find group for this member mapping
 			localGroup, err := l.groupLister.Get("", gm.GroupName)
 			if err != nil {
 				logrus.Errorf("Failed to get Group resource %v: %v", gm.GroupName, err)

--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -356,8 +356,16 @@ func (a *tokenAuthenticator) TokenFromRequest(req *http.Request) (accessor.Token
 			return nil, ErrMustAuthenticate
 		}
 
+		obj, exists, err := a.tokenIndexer.GetByKey(claims.Token)
+		if err != nil || !exists {
+			logrus.Errorf("Unknown token in OAuth Token: %s", claims.Token)
+			return nil, ErrMustAuthenticate
+		}
+
+		token := obj.(*apiv3.Token)
+
 		tokenClaims = claims
-		tokenName, tokenKey = tokens.SplitTokenParts(claims.Token)
+		tokenName, tokenKey = token.Name, token.Token
 		logrus.Debug("Parsed tokenName and TokenKey from JWT")
 	}
 

--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -38,6 +38,8 @@ import (
 
 const tokenKeyIndex = "authn.management.cattle.io/token-key-index"
 
+// ErrMustAuthenticate is returned by the authenticator when the request cannot
+// be authenticated.
 var ErrMustAuthenticate = httperror.NewAPIError(httperror.Unauthorized, "must authenticate")
 
 // AuthTokenGetter retrieves a token from the request.

--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens/hashers"
 	"github.com/rancher/rancher/pkg/clusterrouter"
 	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
+	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	mgmtFakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/rancher/rancher/pkg/oidc/mocks"
@@ -1203,6 +1204,12 @@ func TestAuthenticateWithAccessToken(t *testing.T) {
 		_ = settings.ServerURL.Set(existingServerURL)
 	})
 	_ = settings.ServerURL.Set("https://rancher.example.com")
+
+	previousOIDCProvider := features.OIDCProvider.Enabled()
+	features.OIDCProvider.Set(true)
+	t.Cleanup(func() {
+		features.OIDCProvider.Set(previousOIDCProvider)
+	})
 
 	fakeProvider := &fakeProvider{
 		name: "fake",

--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -1253,6 +1253,8 @@ func TestAuthenticateWithAccessToken(t *testing.T) {
 		}).AnyTimes()
 		tokenIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		tokenIndexer.AddIndexers(cache.Indexers{tokenKeyIndex: tokenKeyIndexer})
+		tokenIndexer.Add(token)
+
 		testOIDCClient := &apiv3.OIDCClient{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-client-id",

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -187,7 +187,6 @@ func (m *Manager) GetToken(tokenAuthValue string) (*apiv3.Token, int, error) {
 
 // GetTokens will list all (login and derived, and even expired) tokens of the authenticated user
 func (m *Manager) getTokens(tokenAuthValue string) ([]apiv3.Token, int, error) {
-	logrus.Debug("LIST Tokens Invoked")
 	tokens := make([]apiv3.Token, 0)
 
 	storedToken, _, err := m.GetToken(tokenAuthValue)

--- a/pkg/auth/tokens/token_util.go
+++ b/pkg/auth/tokens/token_util.go
@@ -88,6 +88,7 @@ func GetTokenAuthFromRequest(req *http.Request) string {
 			tokenAuthValue = cookie.Value
 		}
 	}
+
 	return tokenAuthValue
 }
 

--- a/pkg/client/generated/management/v3/zz_generated_oidc_client.go
+++ b/pkg/client/generated/management/v3/zz_generated_oidc_client.go
@@ -16,6 +16,7 @@ const (
 	OIDCClientFieldRedirectURIs                  = "redirectURIs"
 	OIDCClientFieldRefreshTokenExpirationSeconds = "refreshTokenExpirationSeconds"
 	OIDCClientFieldRemoved                       = "removed"
+	OIDCClientFieldScopes                        = "scopes"
 	OIDCClientFieldState                         = "state"
 	OIDCClientFieldStatus                        = "status"
 	OIDCClientFieldTokenExpirationSeconds        = "tokenExpirationSeconds"
@@ -36,6 +37,7 @@ type OIDCClient struct {
 	RedirectURIs                  []string          `json:"redirectURIs,omitempty" yaml:"redirectURIs,omitempty"`
 	RefreshTokenExpirationSeconds int64             `json:"refreshTokenExpirationSeconds,omitempty" yaml:"refreshTokenExpirationSeconds,omitempty"`
 	Removed                       string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Scopes                        []string          `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	State                         string            `json:"state,omitempty" yaml:"state,omitempty"`
 	Status                        OIDCClientStatus  `json:"status,omitempty" yaml:"status,omitempty"`
 	TokenExpirationSeconds        int64             `json:"tokenExpirationSeconds,omitempty" yaml:"tokenExpirationSeconds,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_oidc_client_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_oidc_client_spec.go
@@ -5,6 +5,7 @@ const (
 	OIDCClientSpecFieldDescription                   = "description"
 	OIDCClientSpecFieldRedirectURIs                  = "redirectURIs"
 	OIDCClientSpecFieldRefreshTokenExpirationSeconds = "refreshTokenExpirationSeconds"
+	OIDCClientSpecFieldScopes                        = "scopes"
 	OIDCClientSpecFieldTokenExpirationSeconds        = "tokenExpirationSeconds"
 )
 
@@ -12,5 +13,6 @@ type OIDCClientSpec struct {
 	Description                   string   `json:"description,omitempty" yaml:"description,omitempty"`
 	RedirectURIs                  []string `json:"redirectURIs,omitempty" yaml:"redirectURIs,omitempty"`
 	RefreshTokenExpirationSeconds int64    `json:"refreshTokenExpirationSeconds,omitempty" yaml:"refreshTokenExpirationSeconds,omitempty"`
+	Scopes                        []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	TokenExpirationSeconds        int64    `json:"tokenExpirationSeconds,omitempty" yaml:"tokenExpirationSeconds,omitempty"`
 }

--- a/pkg/crds/yaml/generated/management.cattle.io_oidcclients.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_oidcclients.yaml
@@ -67,6 +67,14 @@ spec:
                 format: int64
                 minimum: 1
                 type: integer
+              scopes:
+                description: |-
+                  Scopes is the list of scopes allowed for this client.
+
+                  If configured, the client will only be able to request these scopes.
+                items:
+                  type: string
+                type: array
               tokenExpirationSeconds:
                 description: |-
                   TokenExpirationSeconds specifies the duration (in seconds) before

--- a/pkg/oidc/provider/authorize.go
+++ b/pkg/oidc/provider/authorize.go
@@ -111,7 +111,7 @@ func (h *authorizeHandler) authEndpoint(w http.ResponseWriter, r *http.Request) 
 	if redirectURL.Host == r.URL.Host && redirectURL.Path == r.URL.Path {
 		oidcerror.WriteError(oidcerror.InvalidRequest, "redirect_uri can't be the same as the host uri", http.StatusBadRequest, w)
 	}
-	oidcClients, err := h.oidcClientCache.GetByIndex(oidcClientByIDIndex, params.clientID)
+	oidcClients, err := h.oidcClientCache.GetByIndex(OIDCClientByIDIndex, params.clientID)
 	if err != nil {
 		oidcerror.WriteError(oidcerror.InvalidRequest, fmt.Sprintf("error retrieving OIDC client: %v", err), http.StatusBadRequest, w)
 		return

--- a/pkg/oidc/provider/authorize.go
+++ b/pkg/oidc/provider/authorize.go
@@ -140,10 +140,6 @@ func (h *authorizeHandler) authEndpoint(w http.ResponseWriter, r *http.Request) 
 		oidcerror.RedirectWithError(params.redirectURI, oidcerror.InvalidRequest, "challenge_method not supported, only S256 is supported", params.state, w, r)
 		return
 	}
-	if !slices.Contains(params.scopes, "openid") {
-		oidcerror.RedirectWithError(params.redirectURI, oidcerror.InvalidScope, "missing openid scope", params.state, w, r)
-		return
-	}
 
 	if err := h.validateScopes(params.scopes, oidcClient); err != nil {
 		oidcerror.RedirectWithError(params.redirectURI, oidcerror.InvalidScope, err.Error(), params.state, w, r)

--- a/pkg/oidc/provider/authorize_test.go
+++ b/pkg/oidc/provider/authorize_test.go
@@ -71,7 +71,7 @@ func TestAuthEndpoint(t *testing.T) {
 					CodeChallenge: "code-challenge",
 					CreatedAt:     fakeTime,
 				})
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,
@@ -176,7 +176,7 @@ func TestAuthEndpoint(t *testing.T) {
 						Name: fakeUserID,
 					},
 				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,
@@ -223,7 +223,7 @@ func TestAuthEndpoint(t *testing.T) {
 						Name: fakeUserID,
 					},
 				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,
@@ -270,7 +270,7 @@ func TestAuthEndpoint(t *testing.T) {
 						Name: fakeUserID,
 					},
 				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,
@@ -317,7 +317,7 @@ func TestAuthEndpoint(t *testing.T) {
 						Name: fakeUserID,
 					},
 				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,
@@ -336,14 +336,13 @@ func TestAuthEndpoint(t *testing.T) {
 			wantRedirect:                       fakeRedirectUri + "?error=invalid_scope&error_description=invalid+scope%3A+invalidscope",
 			wantAccessControlAllowOriginHeader: fakeRedirectUri,
 		},
-
 		"configured scopes": {
 			req: func() *http.Request {
 				req := &http.Request{
 					URL: &url.URL{
 						Scheme:   "https",
 						Host:     "rancher.com",
-						RawQuery: "code_challenge_method=S256&response_type=code&code_challenge=code-challenge&client_id=client-id&scope=openid+profile+rancher:test&redirect_uri=" + fakeRedirectUri,
+						RawQuery: "code_challenge_method=S256&response_type=code&code_challenge=code-challenge&client_id=client-id&scope=openid+offline_access+profile+rancher:test&redirect_uri=" + fakeRedirectUri,
 					},
 					Method: http.MethodGet,
 				}
@@ -369,18 +368,18 @@ func TestAuthEndpoint(t *testing.T) {
 				m.sessionAdder.EXPECT().Add(fakeCode, session.Session{
 					ClientID:      fakeClientID,
 					TokenName:     fakeTokenName,
-					Scope:         []string{"openid", "profile", "rancher:test"},
+					Scope:         []string{"openid", "offline_access", "profile", "rancher:test"},
 					CodeChallenge: "code-challenge",
 					CreatedAt:     fakeTime,
 				})
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,
 						},
 						Spec: v3.OIDCClientSpec{
 							RedirectURIs: []string{fakeRedirectUri},
-							Scopes:       []string{"openid", "profile", "rancher:test"},
+							Scopes:       []string{"openid", "profile", "rancher:test", "offline_access"},
 						},
 						Status: v3.OIDCClientStatus{
 							ClientID: fakeClientID,
@@ -422,7 +421,7 @@ func TestAuthEndpoint(t *testing.T) {
 						Name: fakeUserID,
 					},
 				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,
@@ -487,7 +486,7 @@ func TestAuthEndpoint(t *testing.T) {
 						Name: fakeUserID,
 					},
 				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return(nil, errors.NewNotFound(schema.GroupResource{}, fakeClientID))
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return(nil, errors.NewNotFound(schema.GroupResource{}, fakeClientID))
 			},
 			req: func() *http.Request {
 				req := &http.Request{
@@ -521,7 +520,7 @@ func TestAuthEndpoint(t *testing.T) {
 						Name: fakeUserID,
 					},
 				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
+				m.oidcClientCache.EXPECT().GetByIndex(OIDCClientByIDIndex, fakeClientID).Return([]*v3.OIDCClient{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fakeClientName,

--- a/pkg/oidc/provider/authorize_test.go
+++ b/pkg/oidc/provider/authorize_test.go
@@ -241,53 +241,6 @@ func TestAuthEndpoint(t *testing.T) {
 			wantRedirect:                       fakeRedirectUri + "?error=invalid_request&error_description=challenge_method+not+supported%2C+only+S256+is+supported",
 			wantAccessControlAllowOriginHeader: fakeRedirectUri,
 		},
-		"missing openid": {
-			req: func() *http.Request {
-				req := &http.Request{
-					URL: &url.URL{
-						Scheme:   "https",
-						Host:     "rancher.com",
-						RawQuery: "code_challenge_method=S256&response_type=code&code_challenge=code-challenge&client_id=client-id&scope=profile&redirect_uri=" + fakeRedirectUri,
-					},
-					Method: http.MethodGet,
-				}
-				req.Header = map[string][]string{
-					"Cookie": {"R_SESS=" + fakeTokenName + ":" + fakeTokenValue},
-				}
-
-				return req
-			},
-			mockSetup: func(m mockParams) {
-				m.tokenCache.EXPECT().Get(fakeTokenName).Return(&v3.Token{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fakeTokenName,
-					},
-					Token:  fakeTokenValue,
-					UserID: fakeUserID,
-				}, nil)
-				m.userLister.EXPECT().Get(fakeUserID).Return(&v3.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fakeUserID,
-					},
-				}, nil)
-				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: fakeClientName,
-						},
-						Spec: v3.OIDCClientSpec{
-							RedirectURIs: []string{fakeRedirectUri},
-						},
-						Status: v3.OIDCClientStatus{
-							ClientID: fakeClientID,
-						},
-					},
-				}, nil)
-			},
-			wantHttpCode:                       http.StatusFound,
-			wantRedirect:                       fakeRedirectUri + "?error=invalid_scope&error_description=missing+openid+scope",
-			wantAccessControlAllowOriginHeader: fakeRedirectUri,
-		},
 		"invalid scope with no configured scopes": {
 			req: func() *http.Request {
 				req := &http.Request{

--- a/pkg/oidc/provider/jwks.go
+++ b/pkg/oidc/provider/jwks.go
@@ -54,7 +54,7 @@ type oidcKeyClient struct {
 func (h *oidcKeyClient) GetPublicKey(kid string) (*rsa.PublicKey, error) {
 	s, err := h.secretCache.Get(keySecretNamespace, keySecretName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting public key: %w", err)
 	}
 	for name, value := range s.Data {
 		if name == kid+".pub" {

--- a/pkg/oidc/provider/jwks_test.go
+++ b/pkg/oidc/provider/jwks_test.go
@@ -274,7 +274,8 @@ func TestGetPublicKey(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			h := jwksHandler{secretCache: test.secretCache()}
+			cache := test.secretCache()
+			h := jwksHandler{secretCache: cache, oidcKeyClient: NewOIDCKeyClient(cache)}
 
 			key, err := h.GetPublicKey(test.kid)
 

--- a/pkg/oidc/provider/jwks_test.go
+++ b/pkg/oidc/provider/jwks_test.go
@@ -254,7 +254,7 @@ func TestGetPublicKey(t *testing.T) {
 
 				return mock
 			},
-			expectedErr: "unexpected error",
+			expectedErr: "getting public key: unexpected error",
 		},
 		"no signing key in secret": {
 			secretCache: func() corecontrollers.SecretCache {

--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -317,49 +317,15 @@ func (h *tokenHandler) createTokenResponse(rancherToken *v3.Token, oidcClient *v
 	if err != nil {
 		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, fmt.Sprintf("failed to get signing key: %v", err))
 	}
-	// create id_token
-	idClaims := jwt.MapClaims{
-		"aud": []string{oidcClient.Status.ClientID},
-		"exp": h.now().Add(time.Duration(oidcClient.Spec.TokenExpirationSeconds) * time.Second).Unix(),
-		"iss": settings.ServerURL.Get() + "/oidc",
-		"iat": h.now().Unix(),
-		"sub": rancherToken.UserID,
-	}
-	if slices.Contains(scopes, "profile") {
-		idClaims["name"] = user.DisplayName
-	}
-	if nonce != "" {
-		idClaims["nonce"] = nonce
-	}
-	if groups != nil {
-		idClaims["groups"] = groups
-	}
-	if rancherToken.AuthProvider != "" {
-		idClaims["auth_provider"] = rancherToken.AuthProvider
-	}
-	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, idClaims)
-	idToken.Header["kid"] = kid
+
+	idToken := h.createIDToken(oidcClient, rancherToken, scopes, user, nonce, groups, kid)
 	idTokenString, err := idToken.SignedString(key)
 	if err != nil {
 		logrus.Errorf("[OIDC provider] failed to sign id token %v", err)
 		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, fmt.Sprintf("failed to sign id token: %v", err))
 	}
 
-	// create access_token
-	accessClaims := jwt.MapClaims{
-		"aud":   []string{oidcClient.Status.ClientID},
-		"exp":   h.now().Add(time.Duration(oidcClient.Spec.TokenExpirationSeconds) * time.Second).Unix(),
-		"iss":   settings.ServerURL.Get() + "/oidc",
-		"iat":   h.now().Unix(),
-		"sub":   rancherToken.UserID,
-		"scope": scopes,
-	}
-	if rancherToken.AuthProvider != "" {
-		accessClaims["auth_provider"] = rancherToken.AuthProvider
-	}
-	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
-	accessToken.Header["kid"] = kid
-
+	accessToken := CreateAccessToken(oidcClient, rancherToken, scopes, kid, h.now())
 	accessTokenString, err := accessToken.SignedString(key)
 	if err != nil {
 		logrus.Errorf("[OIDC provider] failed to sign access token %v", err)
@@ -403,6 +369,52 @@ func (h *tokenHandler) createTokenResponse(rancherToken *v3.Token, oidcClient *v
 	resp.ExpiresIn = time.Duration(oidcClient.Spec.TokenExpirationSeconds) * time.Second
 
 	return resp, nil
+}
+
+func (h *tokenHandler) createIDToken(oidcClient *v3.OIDCClient, rancherToken *v3.Token, scopes []string, user *v3.User, nonce string, groups []string, kid string) *jwt.Token {
+	idClaims := jwt.MapClaims{
+		"aud": []string{oidcClient.Status.ClientID},
+		"exp": h.now().Add(time.Duration(oidcClient.Spec.TokenExpirationSeconds) * time.Second).Unix(),
+		"iss": settings.ServerURL.Get() + "/oidc",
+		"iat": h.now().Unix(),
+		"sub": rancherToken.UserID,
+	}
+
+	if slices.Contains(scopes, "profile") {
+		idClaims["name"] = user.DisplayName
+	}
+	if nonce != "" {
+		idClaims["nonce"] = nonce
+	}
+	if groups != nil {
+		idClaims["groups"] = groups
+	}
+	if rancherToken.AuthProvider != "" {
+		idClaims["auth_provider"] = rancherToken.AuthProvider
+	}
+	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, idClaims)
+	idToken.Header["kid"] = kid
+	return idToken
+}
+
+// CreateAccessToken creates and returns a JWT access token.
+func CreateAccessToken(oidcClient *v3.OIDCClient, rancherToken *v3.Token, scopes []string, kid string, now time.Time) *jwt.Token {
+	accessClaims := jwt.MapClaims{
+		"aud":   []string{oidcClient.Status.ClientID},
+		"exp":   now.Add(time.Duration(oidcClient.Spec.TokenExpirationSeconds) * time.Second).Unix(),
+		"iss":   settings.ServerURL.Get() + "/oidc",
+		"iat":   now.Unix(),
+		"sub":   rancherToken.UserID,
+		"scope": scopes,
+		"token": rancherToken.Name + ":" + rancherToken.Token,
+	}
+	if rancherToken.AuthProvider != "" {
+		accessClaims["auth_provider"] = rancherToken.AuthProvider
+	}
+	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
+	accessToken.Header["kid"] = kid
+
+	return accessToken
 }
 
 func (h *tokenHandler) updateClientSecretUsedTimeStamp(oidcClient *v3.OIDCClient, clientSecretID string) interface{} {
@@ -459,9 +471,9 @@ func (h *tokenHandler) addOIDCClientIDToRancherToken(oidcClientName string, ranc
 }
 
 func (h *tokenHandler) getOIDCClientByClientID(clientID string) (*v3.OIDCClient, error) {
-	oidcClients, err := h.oidcClientCache.GetByIndex(oidcClientByIDIndex, clientID)
+	oidcClients, err := h.oidcClientCache.GetByIndex(OIDCClientByIDIndex, clientID)
 	if err != nil {
-		return nil, fmt.Errorf("error retreiving OIDC client: %w", err)
+		return nil, fmt.Errorf("error retrieving OIDC client %s: %w", clientID, err)
 	}
 	if len(oidcClients) == 0 {
 		return nil, fmt.Errorf("no OIDC clients found")

--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -159,7 +159,7 @@ func (h *tokenHandler) createTokenFromCode(r *http.Request) (TokenResponse, *oid
 	}
 
 	// verify clientID and secret. They can be set in the Authorization header or as a form param as specified in the OIDC spec.
-	var clientID, _ string
+	var clientID string
 	clientID, clientSecret, ok := r.BasicAuth()
 	if !ok {
 		clientID = r.FormValue("client_id")
@@ -176,6 +176,7 @@ func (h *tokenHandler) createTokenFromCode(r *http.Request) (TokenResponse, *oid
 	if err != nil {
 		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, "failed to get client secret")
 	}
+
 	clientSecretFound := false
 	for key, cs := range secret.Data {
 		if clientSecret == string(cs) {

--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -407,7 +407,7 @@ func CreateAccessToken(oidcClient *v3.OIDCClient, rancherToken *v3.Token, scopes
 		"iat":   now.Unix(),
 		"sub":   rancherToken.UserID,
 		"scope": scopes,
-		"token": rancherToken.Name + ":" + rancherToken.Token,
+		"token": rancherToken.Name,
 	}
 	if rancherToken.AuthProvider != "" {
 		accessClaims["auth_provider"] = rancherToken.AuthProvider

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -229,7 +229,7 @@ func TestTokenEndpoint(t *testing.T) {
 				"sub":           fakeUserID,
 				"auth_provider": fakeAuthProvider,
 				"scope":         fakeScopes,
-				"token":         fakeToken.Name + ":" + fakeToken.Token,
+				"token":         fakeToken.Name,
 			},
 		},
 		"authorization_code fails for an invalid code": {
@@ -394,7 +394,7 @@ func TestTokenEndpoint(t *testing.T) {
 				"sub":           fakeUserID,
 				"auth_provider": fakeAuthProvider,
 				"scope":         fakeScopesOfflineAccess,
-				"token":         fakeToken.Name + ":" + fakeToken.Token,
+				"token":         fakeToken.Name,
 			},
 			wantRefreshTokenClaims: &jwt.MapClaims{
 				"aud":                []any{fakeClientID},
@@ -446,7 +446,7 @@ func TestTokenEndpoint(t *testing.T) {
 				"sub":           fakeUserID,
 				"auth_provider": fakeAuthProvider,
 				"scope":         fakeScopesOfflineAccess,
-				"token":         fakeToken.Name + ":" + fakeToken.Token,
+				"token":         fakeToken.Name,
 			},
 			wantRefreshTokenClaims: &jwt.MapClaims{
 				"aud":                []any{fakeClientID},

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -99,7 +99,6 @@ func TestTokenEndpoint(t *testing.T) {
 			ClientID: fakeClientID,
 		},
 	}
-
 	fakeToken := &v3.Token{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fakeTokenName,

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -563,6 +563,56 @@ func TestTokenEndpoint(t *testing.T) {
 			},
 			wantError: `{"error":"server_error","error_description":"failed to parse refresh token: token has invalid claims: token is expired"}`,
 		},
+		"authorization_code does not return an id token if the openid scope is not provided": {
+			req: func() *http.Request {
+				data := url.Values{}
+				data.Set("grant_type", "authorization_code")
+				data.Set("code", fakeCode)
+				data.Set("code_verifier", fakeCodeVerifier)
+				req, _ := http.NewRequest("POST", "https://rancher.com", bytes.NewBufferString(data.Encode()))
+				req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+				req.Header.Add("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fakeClientID+":"+fakeClientSecret))))
+
+				return req
+			},
+			mockSetup: func(m mockParams) {
+				fakeSession := &session.Session{
+					ClientID:      fakeClientID,
+					TokenName:     fakeTokenName,
+					Scope:         []string{"profile", "offline_access", "testing:scope"},
+					CodeChallenge: oauth2.S256ChallengeFromVerifier(fakeCodeVerifier),
+				}
+				m.sessionClient.EXPECT().Get(fakeCode).Return(fakeSession, nil)
+				m.sessionClient.EXPECT().Remove(fakeCode).Return(nil)
+				m.secretCache.EXPECT().Get("cattle-oidc-client-secrets", fakeClientID).Return(fakeClientk8sSecret, nil)
+				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{fakeOIDCClient}, nil)
+				m.tokenCache.EXPECT().Get(fakeTokenName).Return(fakeToken, nil)
+				m.userLister.EXPECT().Get(fakeUserID).Return(fakeUser, nil)
+				m.useAttributeLister.EXPECT().Get(fakeUserID).Return(fakeUserAttributes, nil)
+				m.tokenClient.EXPECT().Patch(fakeTokenName, types.JSONPatchType, tokenPatch).Return(fakeToken, nil)
+				m.signingKeyGetter.EXPECT().GetSigningKey().Return(privateKey, fakeSigningKey, nil)
+				m.oidcClient.EXPECT().Patch(fakeClientName, types.JSONPatchType, clientSecretIDPatch).Return(fakeOIDCClient, nil)
+			},
+			wantAccessTokenClaims: &jwt.MapClaims{
+				"aud":           []any{fakeClientID},
+				"exp":           float64(fakeTime().Add(fakeTokenLifespan * time.Second).Unix()),
+				"iss":           settings.ServerURL.Get() + "/oidc",
+				"iat":           float64(fakeTime().Unix()),
+				"sub":           fakeUserID,
+				"auth_provider": fakeAuthProvider,
+				"scope":         []any{"profile", "offline_access", "testing:scope"},
+				"token":         fakeToken.Name,
+			},
+			wantRefreshTokenClaims: &jwt.MapClaims{
+				"aud":                []any{fakeClientID},
+				"exp":                float64(fakeTime().Add(fakeRefreshTokenLifespan * time.Second).Unix()),
+				"iat":                float64(fakeTime().Unix()),
+				"sub":                fakeUserID,
+				"auth_provider":      fakeAuthProvider,
+				"scope":              []any{"profile", "offline_access", "testing:scope"},
+				"rancher_token_hash": rancherTokenHash,
+			},
+		},
 	}
 
 	// register auth provider


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52716
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The Access token that is issued by the OIDC Provider can't be used to authenticate to Rancher.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This adds two new features...
 * Support for configuring the allowed scopes that a relying party can use with a set of client credentials
 * The Access Token from the OIDC Exchange in the OIDC Provider can now be used with the Rancher API
 
The allowed scopes are not currently used beyond validating that the authorize request scopes are allowed by the client.
If an OIDC Client has no configured scopes, it will default to the previously supported scopes i.e. `openid`, `offline_access` and `profile`.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Create an `OIDCClient` with or without scopes, authenticate via OIDC and use the OIDC Access Token to access the Rancher API.

Adding scopes and changing the client to request those scopes will result in errors from the API.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Created a small Go tool that bounces through Rancher for OIDC and then queries the API with the token and this works.

I'm happy to make this (and the `OIDCClient`) available 😄 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_