### PR TITLE
Update Nutanix node driver to version 3.8.0 / Rancher 2.12

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -198,7 +198,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	if err := addMachineDriver(SoftLayerDriver, "local://", "", "", nil, false, true, false, nil, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(NutanixDriver, "https://github.com/nutanix/docker-machine/releases/download/v3.7.0/docker-machine-driver-nutanix", "https://nutanix.github.io/rancher-ui-driver/v3.7.0/component.js", "2f70c4bdccd3c5e68bd8c32aadb5b525275a3cda5799f29736f37bdd168caa94", []string{"nutanix.github.io"}, false, false, false, nil, management); err != nil {
+	if err := addMachineDriver(NutanixDriver, "https://github.com/nutanix/docker-machine/releases/download/v3.8.0/docker-machine-driver-nutanix", "https://nutanix.github.io/rancher-ui-driver/v3.8.0/component.js", "ad18a0150f37e6cf0aef99a529f9541be72daa9e6dc3dad835d095d44e600f6a", []string{"nutanix.github.io"}, false, false, false, nil, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(OutscaleDriver, "https://github.com/outscale/docker-machine-driver-outscale/releases/download/v0.2.0/docker-machine-driver-outscale_0.2.0_linux_amd64.zip", "https://oos.eu-west-2.outscale.com/rancher-ui-driver-outscale/v0.2.0/component.js", "bb539ed4e2b0f1a1083b29cbdbab59bde3efed0a3145fefc0b2f47026c48bfe0", []string{"oos.eu-west-2.outscale.com"}, false, false, false, nil, management); err != nil {


### PR DESCRIPTION
This pull request updates the Nutanix machine driver to the latest version in the `addMachineDrivers` function. This ensures Rancher will use the most recent Nutanix driver and UI component, along with the correct checksum for validation.

Driver version update:

* Updated the Nutanix machine driver from v3.7.0 to v3.8.0, including the download URL, UI component URL, and checksum in `machinedriver_data.go`.

Issue: #53018 