### PR TITLE
[v2.13] Bump Shell for 2.13.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ remoteDialerProxyVersion: 106.0.2+up0.6.0
 provisioningCAPIVersion: 108.0.0+up0.9.0
 turtlesVersion: 108.0.0+up0.25.0
 cspAdapterMinVersion: 108.0.0+up8.0.0
-defaultShellVersion: rancher/shell:v0.6.0
+defaultShellVersion: rancher/shell:v0.6.1-rc.1
 fleetVersion: 108.0.1+up0.14.1-rc.1
 defaultSccOperatorImage: rancher/scc-operator:v0.3.1
 # NOTE: when updating this version, you will also need to update the hardcoded

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,7 +6,7 @@ const (
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "108.0.0+up8.0.0"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1"
-	DefaultShellVersion           = "rancher/shell:v0.6.0"
+	DefaultShellVersion           = "rancher/shell:v0.6.1-rc.1"
 	FleetVersion                  = "108.0.1+up0.14.1-rc.1"
 	ProvisioningCAPIVersion       = "108.0.0+up0.9.0"
 	RemoteDialerProxyVersion      = "106.0.2+up0.6.0"


### PR DESCRIPTION
Follow up to: https://github.com/rancher/rancher/pull/53005/files

This was intended for 2.13 but `main` is already _primed_ (unintentional pun) for 2.14.