### PR TITLE
Mirror core capi from docker hub

### DIFF
--- a/scripts/package-env
+++ b/scripts/package-env
@@ -12,7 +12,7 @@ SYSTEM_AGENT_UPGRADE_IMAGE=${REPO}/system-agent:${SYSTEM_AGENT_UPGRADE_TAG}
 WINS_AGENT_UPGRADE_TAG=$(grep "ENV CATTLE_WINS_AGENT_VERSION" ../package/Dockerfile | awk -F'=' '{ print $NF }')
 WINS_AGENT_UPGRADE_IMAGE=${REPO}/wins:${WINS_AGENT_UPGRADE_TAG}
 CLUSTER_API_CONTROLLER_TAG=v1.10.6
-CLUSTER_API_CONTROLLER_IMAGE=registry.k8s.io/cluster-api/cluster-api-controller:${CLUSTER_API_CONTROLLER_TAG}
+CLUSTER_API_CONTROLLER_IMAGE=rancher/cluster-api-controller:${CLUSTER_API_CONTROLLER_TAG}
 
 # Query KDM data for RKE2 released versions where server args are defined.
 RKE2_RELEASE_VERSIONS=$(jq -r 'def semver_array: (if startswith("v") then ltrimstr("v") else . end) | split(".") | map(tonumber? // .);


### PR DESCRIPTION
## Problem

The Cluster API controller image is not set in the `rancher/turtles` chart and must be added to the image list to make it available in air-gapped environments. With `rancher:v2.13.1-alpha5`, the CAPI controller is failing to fetch the image from `rancher/cluster-api-controller:v1.10.6` because it is not mirrored.

This change never made it to `release/v2.13` and a new PR was added to address this: #53132 
 
## Solution
Add `rancher/cluster-api-controller:v1.10.6` to image list.
 
## Testing

## Engineering Testing
### Manual Testing

### Automated Testing


## QA Testing Considerations

 
### Regressions Considerations
