### PR TITLE
add core capi image origin

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -35,6 +35,7 @@ var OriginMap = map[string]string{
 	"coreos-kube-state-metrics":                               "https://github.com/kubernetes/kube-state-metrics",
 	"coreos-prometheus-config-reloader":                       "https://github.com/prometheus-operator/prometheus-operator/pkgs/container/prometheus-config-reloader",
 	"coreos-prometheus-operator":                              "https://github.com/prometheus-operator/prometheus-operator",
+	"cluster-api-controller":                                  "https://github.com/rancher-sandbox/cluster-api",
 	"eks-operator":                                            "https://github.com/rancher/eks-operator",
 	"externalip-webhook":                                      "https://github.com/rancher/externalip-webhook",
 	"fleet":                                                   "https://github.com/rancher/fleet",


### PR DESCRIPTION
This cherry-picks the `v2.13` fix from #53139 

## Problem
As reported by @tashima42:
```
[ERROR] not all images have a source code origin defined. Please provide origin URL's within rancher/pkg/image/origins.go for the following images: 
cluster-api-controller
cluster-api-controller
```
 
## Solution
Add the `cluster-api-controller` image origin to `pkg/images/origins.go`
 