### PR TITLE
 Support multiple chart repos in rancher-images.txt file generation logic

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		log.Fatal("\"main.go\" requires 1 argument. Usage: go run main.go [CHART_PATH] [OPTIONAL]...")
+		log.Fatal("\"main.go\" requires 1 argument. Usage: go run main.go [CHART_PATHS] [OPTIONAL]...")
 	}
 
 	if err := run(os.Args[1], os.Args[2:]); err != nil {

--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -152,32 +152,32 @@ func TestGetImages(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name         string
-		expected     []string
-		notExpected  []string
-		exportConfig ExportConfig
+		name            string
+		chartsPath      string
+		rancherVersion  string
+		OsType          OSType
+		GithubEndpoints []GithubEndpoint
+		expected        []string
+		notExpected     []string
 	}{
 		{
-			name: "exportConfig is completely empty",
-			exportConfig: ExportConfig{
-				ChartsPath:      "",
-				OsType:          Linux,
-				RancherVersion:  "",
-				GithubEndpoints: []GithubEndpoint{},
-			},
-			expected:    []string{},
-			notExpected: []string{"rancher/ui-plugin-catalog"},
+			name:            "exportConfig is completely empty",
+			chartsPath:      "",
+			OsType:          Linux,
+			rancherVersion:  "",
+			GithubEndpoints: []GithubEndpoint{},
+			expected:        []string{},
+			notExpected:     []string{"rancher/ui-plugin-catalog"},
 		},
 		{
-			name: "only extensions is set in exportConfig",
-			exportConfig: ExportConfig{
-				ChartsPath:     "",
-				OsType:         Linux,
-				RancherVersion: "",
-				GithubEndpoints: []GithubEndpoint{
-					{URL: server.URL},
-				},
+			name:           "only extensions is set in exportConfig",
+			chartsPath:     "",
+			OsType:         Linux,
+			rancherVersion: "",
+			GithubEndpoints: []GithubEndpoint{
+				{URL: server.URL},
 			},
+
 			expected:    []string{"rancher/ui-plugin-catalog"},
 			notExpected: []string{},
 		},
@@ -185,7 +185,7 @@ func TestGetImages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			imagesList, _, err := GetImages(tt.exportConfig, make(map[string][]string), []string{})
+			imagesList, _, err := GetImages(tt.chartsPath, tt.OsType, tt.rancherVersion, tt.GithubEndpoints, make(map[string][]string), []string{})
 			assertlib.NoError(t, err)
 
 			for _, expected := range tt.expected {

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -53,10 +53,10 @@ type ImageTargetsAndSources struct {
 	TargetWindowsImagesAndSources []string
 }
 
-// GatherTargetImagesAndSources queries KDM, charts and system-charts to gather all the images used by Rancher and their source.
+// GatherTargetImagesAndSources queries KDM, multiple chart repos to gather all the images used by Rancher and their source.
 // It returns an aggregate type, ImageTargetsAndSources, which contains the images required to run Rancher on Linux and Windows, as well
 // as the source of each image.
-func GatherTargetImagesAndSources(chartsPath string, imagesFromArgs []string) (ImageTargetsAndSources, error) {
+func GatherTargetImagesAndSources(chartPaths string, imagesFromArgs []string) (ImageTargetsAndSources, error) {
 	rancherVersion, ok := os.LookupEnv("TAG")
 	if !ok {
 		return ImageTargetsAndSources{}, fmt.Errorf("no tag defining current Rancher version, cannot gather target images and sources")
@@ -115,19 +115,12 @@ func GatherTargetImagesAndSources(chartsPath string, imagesFromArgs []string) (I
 	winsAgentUpdateImage := imagesFromArgs[winsIndex]
 	linuxImagesFromArgs := append(imagesFromArgs[:winsIndex], imagesFromArgs[winsIndex+1:]...)
 
-	exportConfig := img.ExportConfig{
-		ChartsPath:      chartsPath,
-		OsType:          img.Linux,
-		RancherVersion:  rancherVersion,
-		GithubEndpoints: img.ExtensionEndpoints,
-	}
-	targetImages, targetImagesAndSources, err := img.GetImages(exportConfig, externalLinuxImages, linuxImagesFromArgs)
+	targetImages, targetImagesAndSources, err := img.GetImages(chartPaths, img.Linux, rancherVersion, img.ExtensionEndpoints, externalLinuxImages, linuxImagesFromArgs)
 	if err != nil {
 		return ImageTargetsAndSources{}, err
 	}
 
-	exportConfig.OsType = img.Windows
-	targetWindowsImages, targetWindowsImagesAndSources, err := img.GetImages(exportConfig, nil, []string{winsAgentUpdateImage})
+	targetWindowsImages, targetWindowsImagesAndSources, err := img.GetImages(chartPaths, img.Windows, rancherVersion, img.ExtensionEndpoints, externalLinuxImages, []string{winsAgentUpdateImage})
 	if err != nil {
 		return ImageTargetsAndSources{}, err
 	}

--- a/scripts/create-components-images-files.sh
+++ b/scripts/create-components-images-files.sh
@@ -21,6 +21,8 @@ if [ ! -d $CHART_REPO_DIR ]; then
     git clone --branch $CHART_DEFAULT_BRANCH https://github.com/rancher/charts $CHART_REPO_DIR
 fi
 
+CHARTS_DIRS="${CHARTS_DIRS:+${CHARTS_DIRS},}${CHART_REPO_DIR}"
+
 if [ ! -d $SMALL_FORK_REPO_DIR ]; then
     mkdir -p $SMALL_FORK_REPO_DIR
     git clone --branch main https://github.com/rancher/charts-small-fork $SMALL_FORK_REPO_DIR
@@ -28,7 +30,7 @@ fi
 
 if [ ${ARCH} == amd64 ]; then
     # Move this out of ARCH check for local dev on non-amd64 hardware.
-    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR $IMAGE $AGENT_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $WINS_AGENT_UPGRADE_IMAGE $CLUSTER_API_CONTROLLER_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}
+    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $CHARTS_DIRS $IMAGE $AGENT_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $WINS_AGENT_UPGRADE_IMAGE $CLUSTER_API_CONTROLLER_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}
 fi
 
 # Create components file used for pre-release notes


### PR DESCRIPTION
Issue : https://github.com/rancher/rancher/issues/52546

### Summary 

1. Fixes point 1 in Acceptance criteria of the issue https://github.com/rancher/rancher/issues/52546
2. Adds ` CHARTS_DIR` environment variable which can take a list of github repositories to include the images inside the `rancher-images.txt` file. 
3. Refer to the [RFD](https://github.com/SUSE/rancher-architecture/blob/main/docs/RFD%200027%20Prime-Exclusive%20Helm%20Charts%20in%20OCI%20Registry.md#rancher-imagestxt) on how exactly `CHARTS_DIR` will be used for Rancher community and Rancher Prime in the Github release pipelines.
