### PR TITLE
Revert "Update dependency urllib3 to v2 [SECURITY] (main)"

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -11,7 +11,7 @@ pyyaml==6.0.3
 netaddr==0.8.0
 requests==2.32.5
 kubernetes==12.0.1
-urllib3<2.6.3
+urllib3<2.0.0
 jinja2>=2.10
 cryptography==44.0.3
 werkzeug==3.1.4


### PR DESCRIPTION
Reverts rancher/rancher#52985 because it still [breaks](https://github.com/rancher/rancher/actions/runs/20365542001/job/58519671287?pr=52896#step:8:12) the validate pull request check, even though the original pr was green.

This was the original [pr](https://github.com/rancher/rancher/pull/52973).