### PR TITLE
[release/v2.13] Sorts the tolerations in the Fleet cluster

### DIFF
--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -122,6 +123,7 @@ func (h *handler) addCpTaintsToTolerations(tolerations []corev1.Toleration) ([]c
 			allTaints = append(allTaints, taint)
 		}
 	}
+
 	for _, taint := range allTaints {
 		tolerations = append(tolerations, corev1.Toleration{
 			Key:      taint.Key,
@@ -245,6 +247,9 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 		return nil, status, err
 	}
 
+	// sort tolerations for consistent ordering to avoid unnecessary updates
+	sortTolerations(tolerations)
+
 	return append(objs, &fleet.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cluster.Name,
@@ -286,4 +291,44 @@ func (h *handler) addAPIServer(clientSecret string) {
 	if _, err := h.secretsController.Update(secret); err != nil {
 		logrus.Warnf("local cluster provisioning: failed to update client secret: %v", err)
 	}
+}
+
+func sortTolerations(tols []corev1.Toleration) {
+	sort.Slice(tols, func(i, j int) bool {
+		a := tols[i]
+		b := tols[j]
+
+		// 1. Key
+		if a.Key != b.Key {
+			return a.Key < b.Key
+		}
+
+		// 2. Value
+		if a.Value != b.Value {
+			return a.Value < b.Value
+		}
+
+		// 3. Operator
+		if a.Operator != b.Operator {
+			return a.Operator < b.Operator
+		}
+
+		// 4. Effect
+		if a.Effect != b.Effect {
+			return a.Effect < b.Effect
+		}
+
+		// 5. TolerationSeconds (nil-safe)
+		if a.TolerationSeconds == nil && b.TolerationSeconds != nil {
+			return true // nil sorts first
+		}
+		if a.TolerationSeconds != nil && b.TolerationSeconds == nil {
+			return false
+		}
+		if a.TolerationSeconds == nil && b.TolerationSeconds == nil {
+			return false
+		}
+
+		return *a.TolerationSeconds < *b.TolerationSeconds
+	})
 }


### PR DESCRIPTION
Sorts the tolerations in the Fleet cluster

This PR sorts all the tolerations passed to the Fleet clster in order to avoid unnecessary reconciliations and changes in Content resources.

Refers to: https://github.com/rancher/rancher/issues/52711
Backport of: https://github.com/rancher/rancher/pull/52755

