### PR TITLE
feat: add default value to bool flags and set azure managed disks option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace (
 	github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible // rancher-machine requires a replace is set
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77
+	github.com/rancher/machine => github.com/jferrazbr/machine v0.0.0-20251218210036-111b9c8b09e7
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
 	github.com/stretchr/testify => github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jferrazbr/machine v0.0.0-20251218210036-111b9c8b09e7 h1:CjssPVAgVHD7YSjQv9h2Z9aMvs8dS91MTdV1YOp0904=
+github.com/jferrazbr/machine v0.0.0-20251218210036-111b9c8b09e7/go.mod h1:6hHF1520bEHY0z+qqv0e1IrMM/JRO+3UuS9obe2iGLk=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -597,8 +599,6 @@ github.com/rancher/kubernetes-provider-detector v0.1.6-0.20240606163014-fcae7577
 github.com/rancher/kubernetes-provider-detector v0.1.6-0.20240606163014-fcae75779379/go.mod h1:IfqyXrTiCAg8rTJodbGApTiORgujJnBH+QyHHJlFSII=
 github.com/rancher/lasso v0.2.5 h1:K++lWDDdfeN98Ixc1kCfUq0/q6tLjoHN++Np6QntXw0=
 github.com/rancher/lasso v0.2.5/go.mod h1:71rWfv+KkdSmSxZ9Ly5QYhxAu0nEUcaq9N2ByjcHqAM=
-github.com/rancher/machine v0.15.0-rancher137 h1:KomES1D0LKQ3dE7BbMCXU7SPmF45l+sEiEm+MBZxi/U=
-github.com/rancher/machine v0.15.0-rancher137/go.mod h1:2AabuublGVGsYkvDQTm2LECTsRmsjt/3yd+nmYjMLo8=
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77 h1:k+vzmkZQsH06rZnDr+phskSixG9ByNj9gVdzHcc8nxw=
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/muchang v0.1.0 h1:Yuu3b7eFRqnnbp6qbLsP/5SY3IKGDj2mUUTzy4AiUVw=

--- a/pkg/controllers/management/drivers/nodedriver/flag.go
+++ b/pkg/controllers/management/drivers/nodedriver/flag.go
@@ -4,6 +4,7 @@ type BoolPointerFlag struct {
 	Name   string
 	Usage  string
 	EnvVar string
+	Value  *bool
 }
 
 func (f BoolPointerFlag) String() string {

--- a/pkg/controllers/management/drivers/nodedriver/utils.go
+++ b/pkg/controllers/management/drivers/nodedriver/utils.go
@@ -48,6 +48,7 @@ func FlagToField(flag cli.Flag) (string, v32.Field, error) {
 	case *cli.BoolFlag:
 		field.Type = "boolean"
 		field.Description = v.Usage
+		field.Default.BoolValue = v.Value
 	case *cli.StringSliceFlag:
 		field.Type = "array[string]"
 		field.Description = v.Usage
@@ -56,6 +57,11 @@ func FlagToField(flag cli.Flag) (string, v32.Field, error) {
 	case *BoolPointerFlag:
 		field.Type = "boolean"
 		field.Description = v.Usage
+		if v.Value != nil {
+			field.Default.BoolValue = *v.Value
+		} else {
+			field.Default.BoolValue = false
+		}
 	default:
 		return name, field, fmt.Errorf("unknown type of flag %v: %v", flag, reflect.TypeOf(flag))
 	}

--- a/pkg/controllers/management/drivers/nodedriver/utils_test.go
+++ b/pkg/controllers/management/drivers/nodedriver/utils_test.go
@@ -1,9 +1,12 @@
 package nodedriver
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/rancher/machine/libmachine/mcnflag"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -85,3 +88,188 @@ func TestParseKeyValueString(t *testing.T) {
 		}
 	}
 }
+
+func TestFlagToField_Focused(t *testing.T) {
+	tests := []struct {
+		name     string
+		flag     mcnflag.Flag
+		expected v32.Field
+		wantErr  bool
+	}{
+		{
+			name: "StringFlag with default",
+			flag: &mcnflag.StringFlag{
+				Name:  "driver-test-flag",
+				Usage: "A test string flag",
+				Value: "default-string",
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "string",
+				Description: "A test string flag",
+				Default:     v32.Values{StringValue: "default-string"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "StringFlag no default",
+			flag: &mcnflag.StringFlag{
+				Name:  "driver-test-flag-no-default",
+				Usage: "A test string flag with no default",
+				Value: "",
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "string",
+				Description: "A test string flag with no default",
+				Default:     v32.Values{StringValue: ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "IntFlag with default",
+			flag: &mcnflag.IntFlag{
+				Name:  "driver-test-int",
+				Usage: "A test int flag",
+				Value: 7,
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "string",
+				Description: "A test int flag",
+				Default:     v32.Values{StringValue: strconv.Itoa(7)},
+			},
+			wantErr: false,
+		},
+		{
+			name: "IntFlag no default",
+			flag: &mcnflag.IntFlag{
+				Name:  "driver-test-int-no-default",
+				Usage: "A test int flag with no default",
+				Value: 0,
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "string",
+				Description: "A test int flag with no default",
+				Default:     v32.Values{StringValue: "0"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "BoolFlag default true",
+			flag: &mcnflag.BoolFlag{
+				Name:  "driver-test-bool",
+				Usage: "A test bool flag",
+				Value: true,
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "boolean",
+				Description: "A test bool flag",
+				Default:     v32.Values{BoolValue: true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "BoolFlag default false",
+			flag: &mcnflag.BoolFlag{
+				Name:  "driver-test-bool-false",
+				Usage: "A test bool flag default false",
+				Value: false,
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "boolean",
+				Description: "A test bool flag default false",
+				Default:     v32.Values{BoolValue: false},
+			},
+			wantErr: false,
+		},
+		{
+			name: "StringSliceFlag",
+			flag: &mcnflag.StringSliceFlag{
+				Name:  "driver-test-stringslice",
+				Usage: "A test string slice flag",
+				Value: []string{"one", "two"},
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "array[string]",
+				Description: "A test string slice flag",
+				Nullable:    true,
+				Default:     v32.Values{StringSliceValue: []string{"one", "two"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "BoolPointerFlag nil",
+			flag: &BoolPointerFlag{
+				Name:  "driver-test-boolpointer-nil",
+				Usage: "A test bool pointer flag nil",
+				Value: nil,
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "boolean",
+				Description: "A test bool pointer flag nil",
+				Default:     v32.Values{BoolValue: false},
+			},
+			wantErr: false,
+		},
+		{
+			name: "BoolPointerFlag true",
+			flag: &BoolPointerFlag{
+				Name:  "driver-test-boolpointer-true",
+				Usage: "A test bool pointer flag true",
+				Value: func() *bool { b := true; return &b }(),
+			},
+			expected: v32.Field{
+				Create:      true,
+				Update:      true,
+				Type:        "boolean",
+				Description: "A test bool pointer flag true",
+				Default:     v32.Values{BoolValue: true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "UnsupportedFlag",
+			flag: &mockFlag{
+				name: "unsupported-flag",
+			},
+			expected: v32.Field{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, field, err := FlagToField(tt.flag)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, field)
+			assert.NotEmpty(t, name)
+			assert.NotContains(t, name, "-")
+		})
+	}
+}
+
+// mockFlag implements mcnflag.Flag but is not one of the handled concrete types
+type mockFlag struct {
+	name string
+}
+
+func (m *mockFlag) String() string       { return m.name }
+func (m *mockFlag) Default() interface{} { return nil }


### PR DESCRIPTION
## Issue: #52464

## Problem

Rancher builds the Azure provisioning schema from node driver flags. For boolean flags, Rancher was not propagating default values into the API schema. This made it impossible to set a default `true` for fields like Azure managed disks when the user does not explicitly set the option.

To keep defaults consistent with the related changes in [`rancher/machine`](https://github.com/rancher/machine/pull/355) (and the [terraform provider](https://github.com/rancher/terraform-provider-rancher2/pull/1973)), Rancher needs to surface boolean defaults correctly in the generated field schema.

## Solution

* **Use updated rancher/machine that supports bool defaults (Temporary)**

  * Add a `go.mod` replace for `github.com/rancher/machine` pointing to the branch/version that introduces `BoolFlag.Value` and default support.

* **Propagate bool defaults into the node driver field schema**

  * Extend `BoolPointerFlag` to include `Value *bool`.
  * Update `FlagToField` to set `field.Default.BoolValue`:

    * For `*cli.BoolFlag`, use `v.Value` as the default.
    * For `*BoolPointerFlag`, use `*v.Value` when set, otherwise default to `false`.

* **Add unit tests for default propagation**

  * Add `TestFlagToField_Focused` to cover:

    * `StringFlag`, `IntFlag`, `BoolFlag` (default true/false), `StringSliceFlag`
    * `BoolPointerFlag` (nil, true)
    * unsupported flag type returns an error

## Testing

### Manual Testing

* Validate the API schema/UI defaults for Azure driver fields:

  * Create an `AzureConfig` without explicitly setting the managed disks option.
  * Confirm the generated schema/default results in `managedDisks` being **true** by default.
  * Confirm explicitly setting it to `false` is still respected.

### Automated Testing

* Unit tests added/updated:

  * `pkg/controllers/management/drivers/nodedriver/utils_test.go` (`TestFlagToField_Focused`)

## QA Testing Considerations

* Confirm Azure managed disks defaults to **true** when omitted in the provisioning flow.
* Confirm toggling the field to **false** works end-to-end.
* Confirm other boolean driver fields still behave as before (no unintended default flips).
* Note: this PR is part of a set with matching changes in [`rancher/machine`](https://github.com/rancher/machine/pull/355) and [`terraform-provider-rancher2`](https://github.com/rancher/terraform-provider-rancher2/pull/1973) to keep defaults aligned.
