### PR TITLE
[backport 2.13] Add Helm chart value to enable hostNetwork mode for Rancher pods

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
       {{- if .Values.extraTolerations }}
       {{- toYaml .Values.extraTolerations | nindent 8 }}
       {{- end }}
+{{- if .Values.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+{{- end }}
       containers:
       - image: "{{ template "rancher.image" . }}:{{ template "rancher.imageTag" . }}"
         imagePullPolicy: {{ include "rancher.imagePullPolicy" . }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -738,3 +738,19 @@ tests:
           value: RELEASE-NAME-rancher
         - name: CACHE_SYNC_TIMEOUT
           value: 10m
+- it: should enable hostNetwork and set dnsPolicy when hostNetwork is true
+  set:
+    hostNetwork: true
+  asserts:
+    - equal:
+        path: spec.template.spec.hostNetwork
+        value: true
+    - equal:
+        path: spec.template.spec.dnsPolicy
+        value: ClusterFirstWithHostNet
+- it: should not enable hostNetwork by default
+  asserts:
+    - notExists:
+        path: spec.template.spec.hostNetwork
+    - notExists:
+        path: spec.template.spec.dnsPolicy

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -248,6 +248,10 @@ readinessProbe:
   periodSeconds: 30
   failureThreshold: 5
 
+# Enable host networking for Rancher pods.
+# Required for EKS clusters using non-VPC CNIs (e.g. Calico).
+hostNetwork: false
+
 # helm values to use when installing the rancher-webhook chart.
 # helm values set here will override all other global values used when installing the webhook such as priorityClassName and systemRegistry settings.
 webhook: ""


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/53251