### PR TITLE
convert plaintext instead of json output to xml for test upload

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -87,18 +87,16 @@ jobs:
           V2PROV_TEST_DIST: "${{ matrix.V2PROV_TEST_DIST }}"
           CATTLE_FEATURES: "${{ matrix.CATTLE_FEATURES }}"
           CATTLE_AGENT_IMAGE: "${{ env.IMAGE_AGENT}}:${{ env.TAG }}"
-      - name: Rename JSON test output & generate plain text version for debugging
+      - name: Move plaintext test results for upload
+        if: always()
         id: test_output
         run: |
           export TESTSUITE="$(echo '${{ matrix.V2PROV_TEST_RUN_REGEX }}' | sed 's/Test//' | tr -d '()|_^.*$')"
           echo "suite=${TESTSUITE}" >> $GITHUB_OUTPUT
           # need sudo due to this being created in the dapper container
-          sudo mv ./build/out.json /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.json
-
-          cat /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.json | \
-            sed '/^go:/d' | \
-            jq -sr '.[] | .Output' > /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.txt
-      - name: Upload JSON and Plain Text Test Results
+          sudo mv ./build/out.txt /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.txt
+      - name: Upload Plain Text Test Results
+        if: steps.test_output.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "Test Results ${{ matrix.V2PROV_TEST_DIST }} ${{ steps.test_output.outputs.suite }}"
@@ -112,16 +110,16 @@ jobs:
       - name: Install golang
         run: |
           zypper --non-interactive install golang
-      - name: Fetch Raw JSON output
+      - name: Fetch plaintext test output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
           path: /tmp/test-results/
       - name: Convert test results to XML
         run: |
-          for file in $(ls /tmp/test-results/report-*.json); do
+          for file in $(ls /tmp/test-results/report-*.txt); do
              echo "Processing $file..."
-             go run github.com/jstemmer/go-junit-report/v2@latest -parser gojson < $file > $(sed 's/json/xml/g' <<<$file)
+             go run github.com/jstemmer/go-junit-report/v2@latest < $file > $(sed 's/txt/xml/g' <<<$file)
           done
       - name: Upload XML Test Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -260,7 +260,7 @@ fi
 echo Running provisioning-tests $RUNARG
 
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... -json 2>&1 | tee /tmp/out.json || {
+go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... 2>&1 | tee /tmp/out.txt || {
      dump_rancher_logs
      exit 1
 }


### PR DESCRIPTION
This pull request updates the provisioning test workflow to simplify test result handling by switching from JSON to plain text output. The changes remove the JSON-based processing and streamline the upload and conversion of test results.

**Test result output and processing:**

* Changed the test runner in `scripts/provisioning-tests` to output plain text (`out.txt`) instead of JSON (`out.json`).
* Updated the workflow in `.github/workflows/provisioning-tests.yml` to move and upload only the plain text test results, removing the previous step that generated a plain text version from JSON.
* Modified the artifact download and conversion steps to work with plain text files (`.txt`) instead of JSON, and adjusted the conversion to XML accordingly.