### PR TITLE
[v2.14] Correct Image for System-upgrade-controller

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -332,7 +332,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 					}
 					values["kubectl"] = map[string]interface{}{
 						"image": map[string]interface{}{
-							"repository": fmt.Sprintf("%s/%s", h.registryOverride, "rancher/kubectl"),
+							"repository": fmt.Sprintf("%s/%s", h.registryOverride, "rancher/kuberlr-kubectl"),
 						},
 					}
 				}

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -1167,7 +1167,7 @@ func Test_ChartInstallation(t *testing.T) {
 					},
 					"kubectl": map[string]interface{}{
 						"image": map[string]interface{}{
-							"repository": "rancher-test.io/rancher/kubectl",
+							"repository": "rancher-test.io/rancher/kuberlr-kubectl",
 						},
 					},
 				}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- https://github.com/rancher/rancher/issues/53253 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Rancher overrides the values used to install the System Upgrade Controller into downstream clusters when the system default registry is defined. For details, please see https://github.com/rancher/rancher/pull/48633 

The System Upgrade Controller chart 108.0.0 changed its default image from rancher/kubectl to rancher/kuberlr-kubectl in [values.yaml](https://github.com/rancher/charts/blob/dev-v2.13/charts/system-upgrade-controller/108.0.0/values.yaml#L12). However, this updated image repository was not synchronized with Rancher, which results in the failures described in this issue.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Correct the image to rancher/kuberlr-kubectl for system-upgrade-controller  
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The fix was validated on a Rancher installation that uses the rancher and rancher-agent images built from the branch.  

Rnacher is installed with `-e CATTLE_BASE_REGISTRY="docker.io"`  

1/ On the setup, we see the following correct values on the system-upgrade-controller app on the imported cluster:


<img width="1349" height="559" alt="Screenshot 2026-01-07 at 11 43 02 AM" src="https://github.com/user-attachments/assets/1249dfed-01e4-4d75-b2cb-9572ec6445e5" />

2/ Upgrading the cluster k8s version ( v1.32.9+k3s1 -> v1.32.11+k3s1) via Rancher succeeded, the correct image is used to apply the plan:
 
<img width="1364" height="556" alt="Screenshot 2026-01-07 at 11 48 40 AM" src="https://github.com/user-attachments/assets/161e8729-0d48-4999-af98-f55e9c9046dd" />

### Automated Testing
 
Unit test is updated. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
- Correct values should be passed to the system-upgrade-controller App 
- Upgrading downstream imported or node-driver clusters should succeed; the correct image should be used in the pod for applying the plan in the downstream cluster. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 
n/a 


Existing / newly added automated tests that provide evidence there are no regressions:

n/a 