### PR TITLE
[main] added duplicate name check for nodepools in aliconfig object

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -743,10 +743,17 @@ func validateAliConfigNodePools(spec *v32.ClusterSpec) error {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, "must have at least one nodepool")
 	}
 
+	existingNodePoolNames := make(map[string]bool)
 	for _, np := range nodePools {
 		if np.Name == "" {
 			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodePool Name cannot be an empty string")
 		}
+
+		if existingNodePoolNames[np.Name] {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodePool Name must be unique")
+		}
+		existingNodePoolNames[np.Name] = true
+
 		if np.ImageID == "" {
 			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodePool ImageId cannot be an empty string")
 		}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/ali-operator/issues/66
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 validation for duplicate nodepool name was missing for alibaba hosted cluster.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 added nodepool duplicate name validation.
