### PR TITLE
adding image pull secrets value when used for jobs templates in the c…

### DIFF
--- a/chart/templates/post-delete-hook-job.yaml
+++ b/chart/templates/post-delete-hook-job.yaml
@@ -18,6 +18,10 @@ spec:
     spec:
       serviceAccountName: {{ template "rancher.fullname" . }}-post-delete
       restartPolicy: OnFailure
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 6 }}
+{{- end }}
       containers:
         - name: {{ template "rancher.name" . }}-post-delete
           image: "{{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . .Values.postDelete.image.registry)) .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"

--- a/chart/templates/pre-upgrade-hook-job.yaml
+++ b/chart/templates/pre-upgrade-hook-job.yaml
@@ -16,6 +16,10 @@ spec:
       labels: {{ include "rancher.preupgradelabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "rancher.fullname" . }}-pre-upgrade
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 6 }}
+{{- end }}
       restartPolicy: Never
       containers:
         - name: {{ template "rancher.name" . }}-pre-upgrade


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/53230 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When deploying Rancher using the current helm chart, while using private registry for rancher images, the 'pre-upgrade' job manifest (in the template) does not use the 'imagePullSecrets' provided in the values. Resulting in error 'image pull backoff' for the pod trying to pull the image from private registry.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Adding a block in the templates to use the pullsecrets that is defined in the values (when defined) to be able to pull images from private registries for jobs execution
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Templated the chart with explicit value for pullsecret and no value at all and check whether or not the blocks were present depending on the value

### Automated Testing


Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
- Checking that images are being pulled from private registry properly on an actual cluster
 