### PR TITLE
[v2.12][v2prov tests] bump systemd-node tag to v0.0.8

### DIFF
--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	PodTestImage           = "rancher/systemd-node:v0.0.5"
+	PodTestImage           = "rancher/systemd-node:v0.0.8"
 	ObjectStoreServerImage = "rancher/mirrored-minio-minio:RELEASE.2022-12-12T19-27-27Z"
 	ObjectStoreUtilImage   = "rancher/mirrored-minio-mc:RELEASE.2022-12-13T00-23-28Z"
 	SomeK8sVersion         = os.Getenv("SOME_K8S_VERSION")


### PR DESCRIPTION
bumping systemd-node to pull in some changes to make december k8s patches work.

2.12 version of https://github.com/rancher/rancher/pull/53299