### PR TITLE
Provisioning tests: Check eventual node affinity propagation to Fleet agent

### DIFF
--- a/tests/v2prov/tests/fleet/fleetcluster_test.go
+++ b/tests/v2prov/tests/fleet/fleetcluster_test.go
@@ -132,9 +132,14 @@ func Test_Fleet_Cluster(t *testing.T) {
 	require.Contains(cluster.Spec.AgentTolerations, tolerations[0])
 
 	// changes are present in deployment
-	agent, err = clients.Apps.Deployment().Get(cluster.Status.Agent.Namespace, "fleet-agent", metav1.GetOptions{})
-	require.NoError(err)
-	require.Equal(&linuxAffinity, agent.Spec.Template.Spec.Affinity)
+	require.Eventually(func() bool {
+		agent, err = clients.Apps.Deployment().Get(cluster.Status.Agent.Namespace, "fleet-agent", metav1.GetOptions{})
+		if err == nil && agent != nil {
+			return reflect.DeepEqual(&linuxAffinity, agent.Spec.Template.Spec.Affinity)
+		}
+		return false
+	}, waitFor, tick)
+
 	for _, container := range agent.Spec.Template.Spec.InitContainers {
 		require.Equal(resourceReq.Limits, container.Resources.Limits)
 		require.Equal(resourceReq.Requests, container.Resources.Requests)


### PR DESCRIPTION
A node affinity may not be immediately propagated from the local management cluster to the corresponding Fleet agent deployment.

Refers to #53102.