### PR TITLE
[main] Updated ha deploy python test to use our org dockerhub credentials to bypass the docker rate limiting error

### DIFF
--- a/tests/validation/tests/v3_api/Jenkinsfile
+++ b/tests/validation/tests/v3_api/Jenkinsfile
@@ -34,6 +34,11 @@ node {
                         string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
                         string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
                         string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                        usernamePassword(
+                                credentialsId: 'jenkins-dockerhub-org-token', 
+                                usernameVariable: 'DOCKER_ORG_TOKEN_USERNAME', 
+                                passwordVariable: 'DOCKER_ORG_TOKEN_PASSWORD'
+                        ),
                         string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
                         string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
                         string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
@@ -103,7 +108,6 @@ node {
                 writeFile file: AWS_SSH_KEY_NAME, text: decoded
               }
             }
-
             sh "./tests/v3_api/scripts/configure.sh"
             sh "./tests/v3_api/scripts/build.sh"
           }

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/install_rke2_master.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/install_rke2_master.sh
@@ -10,6 +10,11 @@ write-kubeconfig-mode: "0644"
 tls-san:
   - ${2}
 node-name: ${hostname}
+registries:
+  "docker.io":
+    auth:
+      username: "${DOCKERHUB_USERNAME}"
+      password: "${DOCKERHUB_PASSWORD}"
 EOF
 
 if [ ! -z "${7}" ] && [[ "${7}" == *":"* ]]

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/join_rke2_master.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/join_rke2_master.sh
@@ -11,6 +11,11 @@ tls-san:
 server: https://${3}:9345
 token:  "${4}"
 node-name: "${hostname}"
+registries:
+  "docker.io":
+    auth:
+      username: "${DOCKERHUB_USERNAME}"
+      password: "${DOCKERHUB_PASSWORD}"
 EOF
 
 if [ ! -z "${9}" ] && [[ "${9}" == *":"* ]]

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/variables.tf
@@ -4,6 +4,8 @@ variable "availability_zone" {}
 variable "aws_ami" {}
 variable "aws_user" {}
 variable "cluster_type" {}
+variable "docker_org_token_username" {}
+variable "docker_org_token_password" {}
 variable "ec2_instance_class" {}
 variable "volume_size" {}
 variable "iam_role" {}

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/worker/join_rke2_agent.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/worker/join_rke2_agent.sh
@@ -8,6 +8,11 @@ cat <<EOF >>/etc/rancher/rke2/config.yaml
 server: https://${3}:9345
 token:  "${4}"
 node-name: "${hostname}"
+registries:
+  "docker.io":
+    auth:
+      username: "${DOCKERHUB_USERNAME}"
+      password: "${DOCKERHUB_PASSWORD}"
 EOF
 
 if [ ! -z "${9}" ] && [[ "${9}" == *":"* ]]

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/worker/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/worker/variables.tf
@@ -8,6 +8,8 @@ variable "dependency" {
   type    = any
   default = null
 }
+variable "docker_org_token_username" {}
+variable "docker_org_token_password" {}
 variable "ec2_instance_class" {}
 variable "volume_size" {}
 variable "iam_role" {}

--- a/tests/validation/tests/v3_api/test_import_rke2_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_rke2_cluster.py
@@ -17,6 +17,8 @@ RANCHER_EC2_WINDOWS_INSTANCE_CLASS = os.environ.get("AWS_WINDOWS_INSTANCE_TYPE",
 HOST_NAME = os.environ.get('RANCHER_HOST_NAME', "sa")
 RANCHER_IAM_ROLE = os.environ.get("RANCHER_IAM_ROLE")
 RKE2_CREATE_LB = os.environ.get("RKE2_CREATE_LB", False)
+DOCKER_ORG_TOKEN_USERNAME = os.environ.get("DOCKER_ORG_TOKEN_USERNAME", "")
+DOCKER_ORG_TOKEN_PASSWORD = os.environ.get("DOCKER_ORG_TOKEN_PASSWORD", "")
 
 RANCHER_RKE2_VERSION = os.environ.get("RANCHER_RKE2_VERSION", "")
 RANCHER_RKE2_CHANNEL = os.environ.get("RANCHER_RKE2_CHANNEL", "null")
@@ -132,6 +134,8 @@ def create_rke2_multiple_control_cluster(cluster_type, cluster_version):
                               'resource_name': RANCHER_HOSTNAME_PREFIX,
                               'access_key': keyPath,
                               'access_key_name': AWS_SSH_KEY_NAME.replace(".pem", ""),
+                              'docker_org_token_username': DOCKER_ORG_TOKEN_USERNAME,
+                              'docker_org_token_password': DOCKER_ORG_TOKEN_PASSWORD,
                               'ec2_instance_class': RANCHER_EC2_INSTANCE_CLASS,
                               'username': RANCHER_RKE2_RHEL_USERNAME,
                               'password': RANCHER_RKE2_RHEL_PASSWORD,
@@ -174,6 +178,8 @@ def create_rke2_multiple_control_cluster(cluster_type, cluster_version):
                                   'aws_ami': RANCHER_AWS_AMI,
                                   'aws_user': RANCHER_AWS_USER,
                                   'ec2_instance_class': RANCHER_EC2_INSTANCE_CLASS,
+                                  'docker_org_token_username': DOCKER_ORG_TOKEN_USERNAME,
+                                  'docker_org_token_password': DOCKER_ORG_TOKEN_PASSWORD,
                                   'resource_name': RANCHER_HOSTNAME_PREFIX,
                                   'access_key': keyPath,
                                   'access_key_name': AWS_SSH_KEY_NAME.replace(".pem", ""),


### PR DESCRIPTION
Updated rke2 terraform files to include the dockerhub credentials. Updated Jenkinsfile, and ha_deplay python test.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> When running our Jenkins ha deploy job we would hit a docker rate limiting error
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. --> Use our org dockerhub credentials to avoid it
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. --> Ran pipeline in our staging environment. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_