### PR TITLE
docs: fix typos in comments

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_template_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_template_types.go
@@ -72,7 +72,7 @@ type ClusterTemplateRevision struct {
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 	Spec   ClusterTemplateRevisionSpec   `json:"spec"`
 	Status ClusterTemplateRevisionStatus `json:"status"`

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -99,7 +99,7 @@ type Cluster struct {
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 	Spec ClusterSpec `json:"spec"`
 	// Most recent observed status of the cluster. More info:
@@ -287,7 +287,7 @@ type ClusterRegistrationToken struct {
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 	Spec ClusterRegistrationTokenSpec `json:"spec"`
 	// Most recent observed status of the cluster. More info:

--- a/pkg/apis/management.cattle.io/v3/compose_types.go
+++ b/pkg/apis/management.cattle.io/v3/compose_types.go
@@ -16,7 +16,7 @@ type ComposeConfig struct {
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 	Spec   ComposeSpec   `json:"spec,omitempty"`
 	Status ComposeStatus `json:"status,omitempty"`

--- a/pkg/apis/management.cattle.io/v3/kontainer_types.go
+++ b/pkg/apis/management.cattle.io/v3/kontainer_types.go
@@ -15,7 +15,7 @@ type KontainerDriver struct {
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 	Spec KontainerDriverSpec `json:"spec"`
 	// Most recent observed status of the cluster. More info:

--- a/pkg/apis/management.cattle.io/v3/machine_types.go
+++ b/pkg/apis/management.cattle.io/v3/machine_types.go
@@ -21,7 +21,7 @@ type NodeTemplate struct {
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 	Spec NodeTemplateSpec `json:"spec"`
 	// Most recent observed status of the cluster. More info:
@@ -66,7 +66,7 @@ type Node struct {
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the the cluster. More info:
+	// Specification of the desired behavior of the cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 	Spec NodeSpec `json:"spec"`
 	// Most recent observed status of the cluster. More info:

--- a/pkg/apis/management.cattle.io/v3/schema_types.go
+++ b/pkg/apis/management.cattle.io/v3/schema_types.go
@@ -35,7 +35,7 @@ type DynamicSchema struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Specification of the desired behavior of the the dynamic schema. More info:
+	// Specification of the desired behavior of the dynamic schema. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	Spec DynamicSchemaSpec `json:"spec"`
 	// Most recent observed status of the dynamic schema. More info:

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -468,7 +468,7 @@ func (s *Provider) combineSamlAndLdapConfig(config *apiv3.SamlConfig) (runtime.O
 	if err != nil {
 		logrus.Warnf("error pulling %s ldap configs: %s\n", s.name, err)
 
-		// if the the config subkey not in the crd
+		// if the config subkey not in the crd
 		if ldapConfig == nil {
 			return config, nil
 		}

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -122,7 +122,7 @@ type manager struct {
 }
 
 // When a CRTB is created that gives a subject some permissions in a project or cluster, we need to create a "membership" binding
-// that gives the subject access to the the cluster custom resource itself
+// that gives the subject access to the cluster custom resource itself
 // This is painfully similar to ensureProjectMemberBinding, but making one function that handles both is overly complex
 func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, cluster *v3.Cluster, makeOwner bool, subject v1.Subject) error {
 	key := rbRoleSubjectKey(roleName, subject)
@@ -204,7 +204,7 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, 
 }
 
 // When a PRTB is created that gives a subject some permissions in a project or cluster, we need to create a "membership" binding
-// that gives the subject access to the the project/cluster custom resource itself
+// that gives the subject access to the project/cluster custom resource itself
 func (m *manager) ensureProjectMembershipBinding(roleName, rtbNsAndName, namespace string, project *v3.Project, makeOwner bool, subject v1.Subject) error {
 	key := rbRoleSubjectKey(roleName, subject)
 	rbs, err := m.rbIndexer.ByIndex(membershipBindingOwnerIndex, namespace+"/"+rtbNsAndName)

--- a/pkg/controllers/management/authprovisioningv2/crtb.go
+++ b/pkg/controllers/management/authprovisioningv2/crtb.go
@@ -15,7 +15,7 @@ import (
 
 const CRTBRoleBindingID = "auth-prov-v2-crtb-rolebinding"
 
-// OnCRTB create a "membership" binding that gives the subject access to the the cluster custom resource itself
+// OnCRTB create a "membership" binding that gives the subject access to the cluster custom resource itself
 // along with granting any clusterIndexed permissions based on the roleTemplate
 func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
 	if crtb == nil || crtb.DeletionTimestamp != nil || crtb.RoleTemplateName == "" || crtb.ClusterName == "" {

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1401,7 +1401,7 @@ func (tp *tokenAuth) UserName(ctx context.Context, store *SystemStore, verb stri
 }
 
 // SessionID hides the details of extracting the name of the authenticated token
-// governing the current session from the request context, for a a store. It
+// governing the current session from the request context, for a store. It
 // exists purely to allow unit testing to intercept and mock responses.  It also
 // DIFFERS from the core function, see below, in that it ignores errors.
 // I.e. in case of error the result is simply the empty string. Which means that

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -133,7 +133,7 @@ func GrbCRBName(grb *v3.GlobalRoleBinding) string {
 }
 
 // GetGRBSubject creates and returns a subject that is
-// determined by inspecting the the GRB's target fields
+// determined by inspecting the GRB's target fields
 func GetGRBSubject(grb *v3.GlobalRoleBinding) rbacv1.Subject {
 	kind := "User"
 	name := grb.UserName


### PR DESCRIPTION
## Summary

Fix duplicated word typos in comments:

- `the the` → `the`
- `a a` → `a`
- `of the the` → `of the`

## Files Changed

- pkg/rbac/common.go
- pkg/apis/management.cattle.io/v3/kontainer_types.go
- pkg/apis/management.cattle.io/v3/cluster_template_types.go
- pkg/apis/management.cattle.io/v3/machine_types.go
- pkg/apis/management.cattle.io/v3/cluster_types.go
- pkg/apis/management.cattle.io/v3/compose_types.go
- pkg/apis/management.cattle.io/v3/schema_types.go
- pkg/auth/providers/saml/saml_provider.go
- pkg/ext/stores/tokens/tokens.go
- pkg/controllers/management/authprovisioningv2/crtb.go
- pkg/controllers/management/auth/manager.go