### PR TITLE
Fix custom userName claims for OIDC providers.

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -85,7 +85,7 @@ func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType strin
 	}
 	keyCloakClient, err := k.newClient(config, token)
 	if err != nil {
-		logrus.Errorf("[keycloak oidc] SsearchPrincipals: error creating new http client: %v", err)
+		logrus.Errorf("[keycloak oidc] SearchPrincipals: error creating new http client: %v", err)
 		return principals, err
 	}
 	accts, err := keyCloakClient.searchPrincipals(searchValue, principalType, config)

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -480,9 +480,6 @@ func (o *OpenIDCProvider) getUserInfoFromAuthCode(ctx context.Context, config *a
 	if err != nil {
 		return userInfo, oauth2Token, "", err
 	}
-	if err := userInfo.Claims(&claimInfo); err != nil {
-		return userInfo, oauth2Token, "", err
-	}
 
 	return userInfo, oauth2Token, rawIDToken, nil
 }

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -149,12 +149,7 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				FullGroupPath: []string{"/admingroup"},
 				Roles:         []string{"adminrole"},
 			},
-			expectedClaimInfo: &ClaimInfo{
-				Subject:       "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
-				Groups:        []string{"admingroup"},
-				FullGroupPath: []string{"/admingroup"},
-				Roles:         []string{"adminrole"},
-			},
+			expectedClaimInfo: &ClaimInfo{},
 		},
 		"get groups with GroupsClaims": {
 			config: func(port string) *apiv3.OIDCConfig {
@@ -200,8 +195,7 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
 			},
 			expectedClaimInfo: &ClaimInfo{
-				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
-				Groups:  []string{"group1", "group2"},
+				Groups: []string{"group1", "group2"},
 			},
 		},
 		"error - invalid certificate": {
@@ -301,9 +295,8 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
 			},
 			expectedClaimInfo: &ClaimInfo{
-				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
-				Name:    "Test User",
-				Email:   "test@example.com",
+				Name:  "Test User",
+				Email: "test@example.com",
 			},
 		},
 		"display name with custom emailClaim": {
@@ -351,8 +344,7 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
 			},
 			expectedClaimInfo: &ClaimInfo{
-				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
-				Email:   "test.dev@example.com",
+				Email: "test.dev@example.com",
 			},
 		},
 	}


### PR DESCRIPTION
## Issue: #52405 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Custom claims weren't being respected for the user name.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 The claim info is being modified with the custom claims but this was being overwritten with the data from the userinfo endpoint.

This fixes the code to not overwrite the claim info.

**This will need UI changes to the Keycloak provider screen to allow custom claims for the Keycloak provider - these are already present on the Generic OIDC page.**
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

I manually modified the  `keycloakoidc`  `AuthConfig` to add `nameClaim` and ensured that it's picking up my custom field and populating the `displayName` field in the created v3.User resource.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_