### PR TITLE
[release/v2.13] fix: Add origin for turtles provider images

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -31,6 +31,7 @@ var OriginMap = map[string]string{
 	"appco-redis":                                             "https://github.com/redis/redis",
 	"appco-thanos":                                            "https://github.com/thanos-io/thanos",
 	"aks-operator":                                            "https://github.com/rancher/aks-operator",
+	"azureserviceoperator":                                    "https://github.com/rancher-sandbox/azure-service-operator",
 	"backup-restore-operator":                                 "https://github.com/rancher/backup-restore-operator",
 	"cnideploy":                                               "https://github.com/containernetworking/plugins",
 	"coreos-kube-state-metrics":                               "https://github.com/kubernetes/kube-state-metrics",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> rancher/turtles#2017
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The [tooling](https://github.com/rancher/rancher/blob/release/v2.13/pkg/image/export/main.go) we have for generating the list of images for air-gapped installations, expects to find an image name as the key in the [origin map](https://github.com/rancher/rancher/blob/d63436c6a3c7716beabe16920400056c1d4a7120/pkg/image/origins.go#L21), for all images that it extracts from the system charts. After adding the Turtles providers images in the chart's `values.yaml` file ([PR](https://github.com/rancher/turtles/pull/2019)), the tooling failed to generate the list of images because of missing origins.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added origin repositories for Turtles provider images.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
After running the tooling with this change, I was able to successfully generate `rancher-images.txt`, `rancher-images-origins.txt` and `rancher-images-sources.txt` among other files.