### PR TITLE
Clarify OCI repo configmap debug log message

### DIFF
--- a/pkg/controllers/dashboard/helm/repo_oci.go
+++ b/pkg/controllers/dashboard/helm/repo_oci.go
@@ -179,7 +179,7 @@ func (o *OCIRepohandler) onClusterRepoChange(key string, clusterRepo *catalog.Cl
 			index.SortEntries()
 			_, err := createOrUpdateMap(clusterRepo.Namespace, index, owner, o.apply)
 			if err != nil {
-				logrus.Debugf("failed to create/udpate the configmap incase of 4xx statuscode for %s", clusterRepo.Name)
+				logrus.Debugf("failed to create/update configmap after 4xx response for %s", clusterRepo.Name)
 			}
 		}
 


### PR DESCRIPTION
### What this PR does

Clarifies a debug log message in the OCI repo reconciliation flow by improving wording and readability.

### Why this is needed

Clearer debug logs make troubleshooting easier without changing any runtime behavior.

### How to test

No functional change. Verified the updated log message reads correctly.
