### PR TITLE
Bump steve and add integration tests to verify new node fields are accessible.

### DIFF
--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -3036,6 +3036,114 @@ func (s *steveAPITestSuite) TestList() {
 	}
 }
 
+func (s *steveAPITestSuite) TestNodes() {
+	client, err := rest.HTTPClientFor(s.client.WranglerContext.RESTConfig)
+	require.NoError(s.T(), err)
+	host := s.client.WranglerContext.RESTConfig.Host
+	placeholderBuf := bytes.NewBuffer([]byte{})
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/v1/nodes", host), placeholderBuf)
+	require.NoError(s.T(), err)
+
+	resp, err := client.Do(req)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+	buf := make([]byte, 1000000)
+	data2, err := resp.Body.Read(buf)
+	if err != nil && err != io.EOF {
+		require.NoError(s.T(), err)
+	}
+	require.True(s.T(), data2 <= 1000000-1)
+	buf2 := buf[0:data2]
+
+	// corev1.NodeList doesn't work because the json is more generic
+	// use raw rancher JSON because working with nodes is tough
+
+	var mapResp map[string]interface{}
+	err = json.Unmarshal(buf2, &mapResp)
+	require.NoError(s.T(), err)
+	count := mapResp["count"].(float64)
+	require.True(s.T(), count > 0)
+	data := mapResp["data"].([]any)
+	data0 := data[0].(map[string]interface{})
+	id := data0["id"].(string)
+
+	taintKeys := make([]string, 0)
+	addressTypes := make([]string, 0)
+	taints, ok := data0["spec"].(map[string]interface{})["taints"]
+	if ok {
+		for _, taint := range taints.([]map[string]interface{}) {
+			taintKeys = append(taintKeys, taint["key"].(string))
+		}
+	}
+	addresses, ok := data0["status"].(map[string]interface{})["addresses"]
+	if ok {
+		for _, address := range addresses.([]interface{}) {
+			addressTypes = append(addressTypes, address.(map[string]interface{})["type"].(string))
+		}
+	}
+
+	if len(taintKeys) > 0 {
+		testURL := fmt.Sprintf(`https://%s/v1/nodes?filter=spec.taints.key~"%s"`,
+			host, taintKeys[0])
+		req, err := http.NewRequest(http.MethodGet, testURL, placeholderBuf)
+		require.NoError(s.T(), err)
+
+		resp, err := client.Do(req)
+		if err != nil && err != io.EOF {
+			require.NoError(s.T(), err)
+		}
+		require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+		defer resp.Body.Close()
+
+		data2, err := resp.Body.Read(buf)
+		if err != nil && err != io.EOF {
+			require.NoError(s.T(), err)
+		}
+		require.True(s.T(), data2 <= 1000000-1)
+		buf2 := buf[0:data2]
+
+		var mapResp map[string]interface{}
+		err = json.Unmarshal(buf2, &mapResp)
+		require.NoError(s.T(), err)
+		count := mapResp["count"].(float64)
+		require.Equal(s.T(), float64(1), count)
+		data := mapResp["data"].([]any)
+		data0 := data[0].(map[string]interface{})
+		require.Equal(s.T(), id, data0["id"].(string))
+	}
+
+	if len(addressTypes) > 0 {
+		testURL := fmt.Sprintf(`https://%s/v1/nodes?filter=status.addresses.type~"%s"`,
+			host, addressTypes[0])
+		req, err := http.NewRequest(http.MethodGet, testURL, placeholderBuf)
+		require.NoError(s.T(), err)
+
+		resp, err := client.Do(req)
+		if err != nil && err != io.EOF {
+			require.NoError(s.T(), err)
+		}
+		require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+		defer resp.Body.Close()
+
+		data2, err := resp.Body.Read(buf)
+		if err != nil && err != io.EOF {
+			require.NoError(s.T(), err)
+		}
+		require.True(s.T(), data2 <= 1000000-1)
+		buf2 := buf[0:data2]
+
+		var mapResp map[string]interface{}
+		err = json.Unmarshal(buf2, &mapResp)
+		require.NoError(s.T(), err)
+		count := mapResp["count"].(float64)
+		require.Equal(s.T(), float64(1), count)
+		data := mapResp["data"].([]any)
+		data0 := data[0].(map[string]interface{})
+		require.Equal(s.T(), id, data0["id"].(string))
+	}
+}
+
 func getFileName(user, ns, query string) string {
 	if user == "" {
 		user = "none"

--- a/tests/v2/integration/steveapi/testdata/json/user-a_none_filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&summary=metadata.name.json
+++ b/tests/v2/integration/steveapi/testdata/json/user-a_none_filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&summary=metadata.name.json
@@ -174,16 +174,19 @@
     {
       "actions": null,
       "apiVersion": "v1",
-      "id": "test-ns-3/test4",
+      "id": "test-ns-2/test4",
       "kind": "Secret",
       "links": {
-        "patch": "https://rancherurl/v1/secrets/test-ns-3/test4",
-        "remove": "https://rancherurl/v1/secrets/test-ns-3/test4",
-        "self": "https://rancherurl/v1/secrets/test-ns-3/test4",
-        "update": "https://rancherurl/v1/secrets/test-ns-3/test4",
-        "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test4"
+        "patch": "https://rancherurl/v1/secrets/test-ns-2/test4",
+        "remove": "https://rancherurl/v1/secrets/test-ns-2/test4",
+        "self": "https://rancherurl/v1/secrets/test-ns-2/test4",
+        "update": "https://rancherurl/v1/secrets/test-ns-2/test4",
+        "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test4"
       },
       "metadata": {
+        "annotations": {
+          "management.cattle.io/project-scoped-secret-copy": "spuds"
+        },
         "fields": [
           "test4",
           "Opaque",
@@ -195,7 +198,7 @@
           "test.cattle.io/steveapi": "nondeterministicid"
         },
         "name": "test4",
-        "namespace": "test-ns-3",
+        "namespace": "test-ns-2",
         "resourceVersion": "1000",
         "state": {
           "message": "Resource is always ready",

--- a/tests/v2/integration/steveapi/testdata/json/user-a_none_filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&summary=metadata.name.json
+++ b/tests/v2/integration/steveapi/testdata/json/user-a_none_filter=metadata.labels.test-label-gte=3&sort=-metadata.name&pagesize=6&summary=metadata.name.json
@@ -174,19 +174,16 @@
     {
       "actions": null,
       "apiVersion": "v1",
-      "id": "test-ns-2/test4",
+      "id": "test-ns-3/test4",
       "kind": "Secret",
       "links": {
-        "patch": "https://rancherurl/v1/secrets/test-ns-2/test4",
-        "remove": "https://rancherurl/v1/secrets/test-ns-2/test4",
-        "self": "https://rancherurl/v1/secrets/test-ns-2/test4",
-        "update": "https://rancherurl/v1/secrets/test-ns-2/test4",
-        "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test4"
+        "patch": "https://rancherurl/v1/secrets/test-ns-3/test4",
+        "remove": "https://rancherurl/v1/secrets/test-ns-3/test4",
+        "self": "https://rancherurl/v1/secrets/test-ns-3/test4",
+        "update": "https://rancherurl/v1/secrets/test-ns-3/test4",
+        "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test4"
       },
       "metadata": {
-        "annotations": {
-          "management.cattle.io/project-scoped-secret-copy": "spuds"
-        },
         "fields": [
           "test4",
           "Opaque",
@@ -198,7 +195,7 @@
           "test.cattle.io/steveapi": "nondeterministicid"
         },
         "name": "test4",
-        "namespace": "test-ns-2",
+        "namespace": "test-ns-3",
         "resourceVersion": "1000",
         "state": {
           "message": "Resource is always ready",


### PR DESCRIPTION
Reference tests for [Steve PR 1004](https://github.com/rancher/steve/pull/1004)

adding indices for `spec.taints.key` and `status.addresses.type` for nodes.

Hard to write these tests in the steve integration framework because it failed trying to
access the Node resources.