### PR TITLE
[release/v2.13] added duplicate name check for nodepools in aliconfig object

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -743,10 +743,17 @@ func validateAliConfigNodePools(spec *v32.ClusterSpec) error {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, "must have at least one nodepool")
 	}
 
+	existingNodePoolNames := make(map[string]bool)
 	for _, np := range nodePools {
 		if np.Name == "" {
 			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodePool Name cannot be an empty string")
 		}
+
+		if existingNodePoolNames[np.Name] {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodePool Name must be unique")
+		}
+		existingNodePoolNames[np.Name] = true
+
 		if np.ImageID == "" {
 			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodePool ImageId cannot be an empty string")
 		}


### PR DESCRIPTION
backport for PR: https://github.com/rancher/rancher/pull/53288
issue: https://github.com/rancher/ali-operator/issues/95