### PR TITLE
feat: Add a Shell feature flag to allow shell to be disabled

### DIFF
--- a/pkg/api/norman/customization/cluster/formatter.go
+++ b/pkg/api/norman/customization/cluster/formatter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
@@ -34,10 +35,12 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 	if convert.ToBool(resource.Values["internal"]) {
 		delete(resource.Links, "remove")
 	}
-	shellLink := request.URLBuilder.Link("shell", resource)
-	shellLink = strings.Replace(shellLink, "http", "ws", 1)
-	shellLink = strings.Replace(shellLink, "/shell", "?shell=true", 1)
-	resource.Links["shell"] = shellLink
+	if features.ClusterShell.Enabled() {
+		shellLink := request.URLBuilder.Link("shell", resource)
+		shellLink = strings.Replace(shellLink, "http", "ws", 1)
+		shellLink = strings.Replace(shellLink, "/shell", "?shell=true", 1)
+		resource.Links["shell"] = shellLink
+	}
 	resource.AddAction(request, v32.ClusterActionGenerateKubeconfig)
 	resource.AddAction(request, v32.ClusterActionImportYaml)
 

--- a/pkg/api/norman/customization/cluster/formatter_test.go
+++ b/pkg/api/norman/customization/cluster/formatter_test.go
@@ -1,0 +1,99 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/rancher/norman/types"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// stubURLBuilder is a minimal implementation of types.URLBuilder for testing.
+type stubURLBuilder struct{}
+
+func (s *stubURLBuilder) Current() string { return "http://rancher.test" }
+func (s *stubURLBuilder) Collection(_ *types.Schema, _ *types.APIVersion) string { return "" }
+func (s *stubURLBuilder) CollectionAction(_ *types.Schema, _ *types.APIVersion, _ string) string {
+	return ""
+}
+func (s *stubURLBuilder) SubContextCollection(_ *types.Schema, _ string, _ *types.Schema) string {
+	return ""
+}
+func (s *stubURLBuilder) SchemaLink(_ *types.Schema) string                        { return "" }
+func (s *stubURLBuilder) ResourceLink(resource *types.RawResource) string {
+	return "http://rancher.test/v3/clusters/" + resource.ID
+}
+func (s *stubURLBuilder) Link(linkName string, resource *types.RawResource) string {
+	return "http://rancher.test/v3/clusters/" + resource.ID + "/" + linkName
+}
+func (s *stubURLBuilder) RelativeToRoot(path string) string            { return path }
+func (s *stubURLBuilder) Version(_ types.APIVersion) string            { return "" }
+func (s *stubURLBuilder) Marker(marker string) string                  { return marker }
+func (s *stubURLBuilder) ReverseSort(_ types.SortOrder) string         { return "" }
+func (s *stubURLBuilder) Sort(_ string) string                         { return "" }
+func (s *stubURLBuilder) SetSubContext(_ string)                        {}
+func (s *stubURLBuilder) FilterLink(_ *types.Schema, _, _ string) string { return "" }
+func (s *stubURLBuilder) Action(action string, resource *types.RawResource) string {
+	return "http://rancher.test/v3/clusters/" + resource.ID + "?action=" + action
+}
+func (s *stubURLBuilder) ResourceLinkByID(_ *types.Schema, _ string) string         { return "" }
+func (s *stubURLBuilder) ActionLinkByID(_ *types.Schema, _, _ string) string        { return "" }
+
+func TestFormatter_ShellLink(t *testing.T) {
+	tests := []struct {
+		name           string
+		featureEnabled bool
+		wantShellLink  bool
+	}{
+		{
+			name:           "shell link present when ClusterShell feature enabled",
+			featureEnabled: true,
+			wantShellLink:  true,
+		},
+		{
+			name:           "shell link absent when ClusterShell feature disabled",
+			featureEnabled: false,
+			wantShellLink:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features.ClusterShell.Set(tt.featureEnabled)
+			defer features.ClusterShell.Unset()
+
+			formatter := &Formatter{
+				nodeLister: &fakes.NodeListerMock{
+					ListFunc: func(_ string, _ labels.Selector) ([]*apimgmtv3.Node, error) {
+						return nil, nil
+					},
+				},
+			}
+
+			resource := &types.RawResource{
+				ID:      "test-cluster",
+				Schema:  &types.Schema{},
+				Links:   map[string]string{},
+				Actions: map[string]string{},
+				Values:  map[string]interface{}{},
+			}
+
+			apiCtx := &types.APIContext{
+				URLBuilder: &stubURLBuilder{},
+			}
+
+			formatter.Formatter(apiCtx, resource)
+
+			if tt.wantShellLink {
+				assert.Contains(t, resource.Links, "shell", "expected shell link to be present")
+				assert.Contains(t, resource.Links["shell"], "ws://", "expected shell link to use ws scheme")
+				assert.Contains(t, resource.Links["shell"], "?shell=true", "expected shell link query param")
+			} else {
+				assert.NotContains(t, resource.Links, "shell", "expected shell link to be absent")
+			}
+		})
+	}
+}

--- a/pkg/api/steve/clusters/clusters.go
+++ b/pkg/api/steve/clusters/clusters.go
@@ -68,7 +68,9 @@ func Register(ctx context.Context, server *steve.Server, wrangler *wrangler.Cont
 			if schema.LinkHandlers == nil {
 				schema.LinkHandlers = map[string]http.Handler{}
 			}
-			schema.LinkHandlers["shell"] = shellHandler
+			if shellHandler != nil {
+				schema.LinkHandlers["shell"] = shellHandler
+			}
 			schema.LinkHandlers["log"] = log
 			if schema.ActionHandlers == nil {
 				schema.ActionHandlers = map[string]http.Handler{}
@@ -83,7 +85,7 @@ func Register(ctx context.Context, server *steve.Server, wrangler *wrangler.Cont
 			schema.ByIDHandler = func(request *types.APIRequest) (types.APIObject, error) {
 				// By pass authorization for local shell because the user might not have
 				// GET granted for local cluster
-				if request.Name == "local" && request.Link == "shell" {
+				if request.Name == "local" && request.Link == "shell" && shellHandler != nil {
 					shellHandler.ServeHTTP(request.Response, request.Request)
 					return types.APIObject{}, validation.ErrComplete
 				}

--- a/pkg/api/steve/norman/formatter.go
+++ b/pkg/api/steve/norman/formatter.go
@@ -8,6 +8,7 @@ import (
 	types2 "github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/urlbuilder"
+	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/schemas/cluster.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/sirupsen/logrus"
@@ -73,6 +74,10 @@ func (a *LinksAndActionsFormatter) Formatter(request *types.APIRequest, resource
 	}
 	for k, v := range normanResource.Actions {
 		resource.Actions[k] = v
+	}
+
+	if !features.ClusterShell.Enabled() {
+		delete(resource.Links, "shell")
 	}
 }
 

--- a/pkg/api/steve/norman/formatter.go
+++ b/pkg/api/steve/norman/formatter.go
@@ -8,7 +8,6 @@ import (
 	types2 "github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/urlbuilder"
-	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/schemas/cluster.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/sirupsen/logrus"
@@ -74,10 +73,6 @@ func (a *LinksAndActionsFormatter) Formatter(request *types.APIRequest, resource
 	}
 	for k, v := range normanResource.Actions {
 		resource.Actions[k] = v
-	}
-
-	if !features.ClusterShell.Enabled() {
-		delete(resource.Links, "shell")
 	}
 }
 

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -217,6 +217,13 @@ var (
 		false,
 		true,
 	)
+	ClusterShell = newFeature(
+		"cluster-shell",
+		"Enable the Rancher cluster shell feature",
+		true,
+		false,
+		true,
+	)
 )
 
 func ListEnabled() []string {


### PR DESCRIPTION
## Issue: Partial fix for SURE-8604
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Some customers wish to disable the Rancher cluster shell feature.
 
## Solution
Add a feature flag to allow customers to disable the cluster shell feature.

When the feature is disabled the Shell handler and Shell links are not attached to the cluster resource. In turn the UI "automagically" adapts to the missing `link.shell` and hides or disables all UI buttons.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Turned of the feature and found that the buttons in UI are gone, observed resource schemas and found `links.shell` gone (as desired) and verified shell can be turned back on. Tested MAPS to ensure helm-ops pods are not affected.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_