### PR TITLE
Change to a semantic equality check

### DIFF
--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -181,6 +181,50 @@ func Test_manager_reconcileRoleForProjectAccessToGlobalResource(t *testing.T) {
 			want: "myrole-promoted",
 		},
 		{
+			name: "existing ClusterRole with out of order rules should not update",
+			args: args{
+				rtName: "myrole",
+				promotedRules: []rbacv1.PolicyRule{
+					{
+						Resources:     []string{"myresource"},
+						Verbs:         []string{"list", "delete"},
+						APIGroups:     []string{"management.cattle.io"},
+						ResourceNames: []string{"local"},
+					},
+					{
+						Resources:     []string{"anotherresource"},
+						Verbs:         []string{"get", "watch"},
+						APIGroups:     []string{"management.cattle.io"},
+						ResourceNames: []string{"remote"},
+					},
+				},
+			},
+			setupControllers: func(c controllers) {
+				existingRole := &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "myrole-promoted",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							Resources:     []string{"anotherresource"},
+							Verbs:         []string{"get", "watch"},
+							APIGroups:     []string{"management.cattle.io"},
+							ResourceNames: []string{"remote"},
+						},
+						{
+							Resources:     []string{"myresource"},
+							Verbs:         []string{"list", "delete"},
+							APIGroups:     []string{"management.cattle.io"},
+							ResourceNames: []string{"local"},
+						},
+					},
+				}
+				c.crLister.EXPECT().Get("myrole-promoted").Return(existingRole, nil)
+				// No Update call expected since rules are equivalent
+			},
+			want: "myrole-promoted",
+		},
+		{
 			name: "non existing ClusterRole will create a new promoted ClusterRole",
 			args: args{
 				rtName:        "myrole",


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/53630
 
## Problem
When checking for promoted rules, we use the [function](https://github.com/rancher/rancher/blob/5460540d149d5ef14138f93bce66b093985d94da/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go#L140) `ExtractPromotedRules` to take the rules from a roletemplate and extract any that are considered "promoted". To do so, we iterate through each item in a [map](https://github.com/rancher/rancher/blob/5460540d149d5ef14138f93bce66b093985d94da/pkg/controllers/managementuser/rbac/roletemplates/roletemplate_handler.go#L129) and check if the policy rule is a global resource.

Then, when we have that list of promoted rules, we compare it against the rules in the promoted cluster role that already exists. If there are differences, we update the clusterrole.

The problem is that since maps in go aren't always iterated through in order, the extraction process can return the same rules in a different order. When that happens, the prtb handler sees that the promoted cluster role rules and extracted rules are different and triggers an update even though semantically they are equivalent.
 
## Solution
Instead of doing an ordered equality check, we instead do a semantic equality check. So if both sets of rules contain the same items, we consider them equal even if they are in different orders.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_