### PR TITLE
Downgrade v1.35.0+k3s3 to v1.35.0+k3s1, attempting to fix CI

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -108,6 +108,11 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
   export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.14/data/data.json | jq -r ".$DIST.releases[-1].version")
 fi
 
+if [ $SOME_K8S_VERSION = "v1.35.0+k3s3" ]; then
+  echo "WARNING: Downgrading k3s version v1.35.0+k3s3 to v1.35.0+k3s1 to skip temporary test problem"
+  export SOME_K8S_VERSION="v1.35.0+k3s1"
+fi
+
 if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
 # If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so GitHub is used instead of
 # the default `https://git.rancher.io/charts` to reduce the reliance and load on our Git mirror


### PR DESCRIPTION
Make provisioning tests skip `v1.35.0+k3s3` by downgrading it to `v1.35.0+k3s1`, as the new version makes one of the tests (`Test_Provisioning_Single_Node_All_Roles_Drain`) fail consistently.