### PR TITLE
[2.12] add pipefail option to provisioning-tests script to ensure proper exit during CI

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 if ./scripts/only-ui-bumps.sh; then
     exit 0
 fi


### PR DESCRIPTION
followup to https://github.com/rancher/rancher/pull/53580

I apparently didn't have the `set -o pipefail` at the top of the script - which resulted in the case where if the tests fail, `tee` swallows the exit code and exits with `0` as long as that operation went well. Whooops.
