### PR TITLE
[backport 2.13] Downgrade v1.34.3+k3s3 to v1.34.3+k3s1, attempting to fix CI

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -108,9 +108,9 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
   export SOME_K8S_VERSION=$(curl -sS https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.13/data/data.json | jq -r ".$DIST.releases[-1].version")
 fi
 
-if [ $SOME_K8S_VERSION = "v1.35.0+k3s3" ]; then
-  echo "WARNING: Downgrading k3s version v1.35.0+k3s3 to v1.35.0+k3s1 to skip temporary test problem"
-  export SOME_K8S_VERSION="v1.35.0+k3s1"
+if [ $SOME_K8S_VERSION = "v1.34.3+k3s3" ]; then
+  echo "WARNING: Downgrading k3s version v1.34.3+k3s3 to v1.34.3+k3s1 to skip temporary test problem"
+  export SOME_K8S_VERSION="v1.34.3+k3s1"
 fi
 
 if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then


### PR DESCRIPTION
this is a backport of https://github.com/rancher/rancher/pull/53713 to temporarily fix CI. 