### PR TITLE
fix missing machine shell and sshkeys links

### DIFF
--- a/pkg/api/steve/machine/machine.go
+++ b/pkg/api/steve/machine/machine.go
@@ -27,7 +27,7 @@ func Register(server *steve.Server, clients *wrangler.Context) {
 				schema.LinkHandlers["sshkeys"] = sshClient
 				schema.Formatter = func(request *types.APIRequest, resource *types.RawResource) {
 					if err := request.AccessControl.CanUpdate(request, types.APIObject{}, request.Schema); err != nil ||
-						resource.APIObject.Data().String("spec", "infrastructureRef", "apiVersion") != capr.RKEMachineAPIVersion {
+						resource.APIObject.Data().String("spec", "infrastructureRef", "apiGroup") != capr.RKEMachineAPIGroup {
 						delete(resource.Links, "shell")
 						delete(resource.Links, "sshkeys")
 					}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/52034

**Problem**:

The `SSH Shell` and `Download SSH Key` options are missing on the machines in node-driver clusters. 

**Cause** 

Cluster API v1beta2 removed the field `spec.infrastructureRef.apiVersion`. 
Rancher relies on this field to decide whether to display the relevant links on the Machine object, so the links are no longer shown.

**Fix**

Update Rancher to check the new field `spec.infrastructureRef.apiGroup` instead.
 

**Tests**


In the lcoal development setup, the `SSH Shell` and `Download SSH Key` options are available again and functional on the machines in node-driver clusters.

<img width="277" height="338" alt="Screenshot 2026-02-12 at 2 45 50 PM" src="https://github.com/user-attachments/assets/3d199622-e734-4ab2-8232-74f4656e26e8" />



