### PR TITLE
Add a log dump job for provisioning test failures

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -80,7 +80,9 @@ jobs:
           docker tag "$image_agent_id" ${{ env.REGISTRY }}/${{ env.IMAGE_AGENT }}:${{ env.TAG }}
           echo "the image created is ${{ env.REGISTRY }}/${{ env.IMAGE_AGENT }}:${{ env.TAG }}"
       - name: Run tests
-        run: ./.dapper provisioning-tests
+        run: |
+          set -eo pipefail
+          ./.dapper provisioning-tests | tee provtest_output.txt
         env:
           DRONE_BUILD_EVENT: "${{ github.event_name }}"
           V2PROV_TEST_RUN_REGEX: "${{ matrix.V2PROV_TEST_RUN_REGEX }}"
@@ -96,11 +98,18 @@ jobs:
           # need sudo due to this being created in the dapper container
           sudo mv ./build/out.txt /tmp/report-${{ matrix.V2PROV_TEST_DIST }}-$TESTSUITE.txt
       - name: Upload Plain Text Test Results
-        if: steps.test_output.outcome == 'success'
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "Test Results ${{ matrix.V2PROV_TEST_DIST }} ${{ steps.test_output.outputs.suite }}"
           path: "/tmp/report-${{ matrix.V2PROV_TEST_DIST }}-${{ steps.test_output.outputs.suite }}.*"
+      - name: Upload logdump artifact if we had some tests failures
+        if: failure()
+        uses: rancherlabs/cowboy@be178bda40ee2199a674861d8ba1a399b28d5451
+        with:
+          log-file-path: provtest_output.txt
+          artifact-retention-days: 7
+          artifact-name: "Parsed Failure Log Dump (${{ matrix.V2PROV_TEST_DIST }}, ${{ steps.test_output.outputs.suite }})"
 
   convert-to-xml:
     needs: [provisioning_tests]


### PR DESCRIPTION
## Summary
- Add a Log Dump step to the provisioning-tests workflow so that when provisioning test runs fail we capture, parse, and upload a parsed failure logdump artifact to make root-cause analysis easier.

## Changes
- .github/workflows/provisioning-tests.yml
  - Run the provisioning tests with the dapper output piped through tee to save stdout/stderr to provtest_output.txt:
    - Use a small shell wrapper: set -eo pipefail; ./.dapper provisioning-tests | tee provtest_output.txt
  - Make the plain-text test result upload step run unconditionally (if: always()) so results are available even on failure (this was a problem before)
  - Add a new step that uploads a parsed failure log artifact only on failure:
    - Uses the [rancherlabs/cowboy@main](https://github.com/rancherlabs/cowboy) action
    - Input: log-file-path: provtest_output.txt
    - artifact-retention-days: 7
    - artifact-name: "Parsed Failure Log Dump (\<dist\>, \<suite\>)"
    - Step guarded by if: failure() so it runs only when the job failed.

## Motivation / Rationale
- Provisioning test failures can produce large noisy logdumps (well, they still do we just won't have to deal with them) and it can be time-consuming re-parsing things over and over again
- Capturing the provisioning-test output and producing a parsed failure artifact helps developers quickly gather the necessary information from CI runs for debugging.

---

Example artifacts from a run: https://github.com/rancher/rancher/actions/runs/22005183444?pr=53755#artifacts