### PR TITLE
Fix validate golangci lint

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           version: ${{ env.GOLANG_CI_LINT_VERSION }}
           args: -v
-          only-new-issues: true
+          only-new-issues: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000') }}
           skip-cache: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/53771

Adding branch filter so we don't run validate twice (mostly useful for charts automation like webhook and RDP which creates new branches in r/r directly).

Set only-new-issue only when it makes sense (eg: pull_request or when there is a before SHA that's not NULL)