### PR TITLE
Boostrap controller: consistent error handling with userdata yaml

### DIFF
--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -176,7 +176,7 @@ func (h *handler) getBootstrapSecret(namespace, name string, envVars []corev1.En
 	if bootstrap.Spec.Userdata != nil && bootstrap.Spec.Userdata.InlineUserdata != "" {
 		err = yaml.Unmarshal([]byte(bootstrap.Spec.Userdata.InlineUserdata), &userdata)
 		if err != nil {
-			return nil, fmt.Errorf("could not unmarshal inline userdata: %w", err)
+			return nil, fmt.Errorf("could not unmarshal inline userdata")
 		}
 	}
 


### PR DESCRIPTION
Don't include the sub-error in the error format when unmarshalling, for consistency with the marshal call.

Follow-up PR to https://github.com/rancher/rancher/pull/53736