### PR TITLE
[2.14] Bump Shell to match 2.14 branch

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ webhookVersion: 109.0.0+up0.10.0-rc.11
 remoteDialerProxyVersion: 109.0.0+up0.7.0-rc.5
 turtlesVersion: 109.0.0+up0.26.0-rc.2
 cspAdapterMinVersion: 109.0.0+up9.0.0-rc.3
-defaultShellVersion: rancher/shell:v0.7.0-rc.2
+defaultShellVersion: rancher/shell:v0.7.0-rc.3
 fleetVersion: 109.0.0+up0.15.0-alpha.10
 defaultSccOperatorImage: rancher/scc-operator:v0.3.1-rc.2
 # NOTE: when updating this version, you will also need to update the hardcoded

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,7 +6,7 @@ const (
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "109.0.0+up9.0.0-rc.3"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.3.1-rc.2"
-	DefaultShellVersion           = "rancher/shell:v0.7.0-rc.2"
+	DefaultShellVersion           = "rancher/shell:v0.7.0-rc.3"
 	FleetVersion                  = "109.0.0+up0.15.0-alpha.10"
 	RemoteDialerProxyVersion      = "109.0.0+up0.7.0-rc.5"
 	TurtlesVersion                = "109.0.0+up0.26.0-rc.2"


### PR DESCRIPTION
Per title, shell is still on older version. This brings it up to 2.14 shell branch.