### PR TITLE
Decouple kube-api-auth from cattle SA with dedicated, scoped ClusterRole

### DIFF
--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -426,6 +426,65 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				"cattle-credentials-5ec1f7e700": "38a97eb12e58ccc7ab0b07c8730e0c61fe71f8197aa98ac509431ff265cb2861",
 			},
 		},
+		{
+			name: "test-kube-api-auth-enabled",
+
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-auth",
+				},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName:    "testing-kube-api-auth",
+					ImportedConfig: &apimgmtv3.ImportedConfig{},
+				},
+				Status: apimgmtv3.ClusterStatus{
+					Driver:   "imported",
+					Provider: "rke2",
+				},
+			},
+
+			agentImage: "my/agent:image",
+			authImage:  "my/kube-api-auth:image",
+			url:        "https://example.com",
+			token:      "dummy-token",
+
+			expectedDeploymentHashes: map[string]string{
+				"cattle-cluster-agent": "e99508716bf42e1d9190e6957b5c7745d62d94a0e6b9f3d7ada4f656afcb6efe",
+			},
+
+			expectedDaemonSetHashes: map[string]string{
+				"kube-api-auth": "71cdcb54a60bab2f82a2f65c97d3ef2a133f1780256f6de6c34a50e9741e63fe",
+			},
+
+			expectedClusterRoleHashes: map[string]string{
+				"proxy-clusterrole-kubeapiserver": "0b1d7f692252b3f498855fa24f669499ba1c061d0ae0eab0db2bb570bc25e63c",
+				"cattle-admin":                    "d2b6b43774ce046f3e4e157b94167d6be596d697c3c9411d4ef4d6f29c2d5fde",
+				"kube-api-auth":                   "5edba6ae199bce61bbbe1c8c689a6900981e3320e1c3b16b08cba8be1ea1b11b",
+			},
+
+			expectedClusterRoleBindingHashes: map[string]string{
+				"proxy-role-binding-kubernetes-master": "8e33b2e67243b5a87012489fcd12b4e805c6b6b3c3c2bb4063eee04ca7bc372e",
+				"cattle-admin-binding":                 "d646e3b685d8f931a11f4938e4c95a97151286fa391ef03898e6d44f6827cf16",
+				"kube-api-auth":                        "50d6e64be34295d7631e5e25323146e8a9f009a992acc924a1109e4965c67193",
+			},
+
+			expectedNamespaceHashes: map[string]string{
+				"cattle-system": "53b1582048d8703999612a3b41f7301b4136e8dd3041d57e9a59c97e76dfa564",
+			},
+
+			expectedServiceHashes: map[string]string{
+				"cattle-cluster-agent": "03b629bf7287d1a70f31fdf138ea5ec38201040e757b21a808ea0d413e27d65f",
+			},
+
+			expectedServiceAccountHashes: map[string]string{
+				"cattle":        "ba41ec07896a1e2d2319c0ca1405c81faf4ad4c7c0a3c183909860531863202b",
+				"kube-api-auth": "0d766aa7dcaa099ce355d8baaab533beb33b7766e54fa74fac8f9393c4ed18de",
+			},
+
+			expectedSecretHashes: map[string]string{
+				"cattle-credentials-8f25b52916": "24570c6bceef80892243253fefb8ac4d8651e23808633d7b532ca04f8472caa8",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/53788

<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
Currently, the systemtemplate couples the authentication proxy to the management agent's identity. Update the systemtemplate source by adding a scoped ServiceAccount `kube-api-auth` and ClusterRole...
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
- Created a downstream cluster and successfully enabled the Authorized Cluster Endpoint (ACE) feature.
- ServiceAccount Validation, Verified the `kube-api-auth` ServiceAccount configuration. Confirmed it is correctly referenced and utilized by the kube-api-auth DS
- Monitored the kube-api-auth pod logs post-fix and no new errors were observed, indicating that the SA now has the necessary permissions to list and watch the required RBAC...

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_