### PR TITLE
[FEAT] read KDM from local file instead of remote fetch

### DIFF
--- a/pkg/channelserver/channelserver.go
+++ b/pkg/channelserver/channelserver.go
@@ -72,6 +72,9 @@ func Refresh(ctx context.Context) error {
 type DynamicSource struct{}
 
 func (d *DynamicSource) URL() string {
+	if settings.KDMUseLocalData.Get() == "true" {
+		return "/var/lib/rancher-data/driver-metadata/data.json"
+	}
 	url, _ := GetURLAndInterval()
 	return url
 }

--- a/pkg/channelserver/channelserver_test.go
+++ b/pkg/channelserver/channelserver_test.go
@@ -1,0 +1,118 @@
+package channelserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetURLAndInterval(t *testing.T) {
+	original := settings.RkeMetadataConfig.Get()
+	defer func() {
+		require.NoError(t, settings.RkeMetadataConfig.Set(original))
+	}()
+
+	tests := []struct {
+		name             string
+		config           string
+		expectedURL      string
+		expectedInterval time.Duration
+	}{
+		{
+			name:             "valid URL and interval",
+			config:           `{"url":"https://releases.rancher.com/kontainer-driver-metadata/dev-v2.14/data.json","refresh-interval-minutes":"1440"}`,
+			expectedURL:      "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.14/data.json",
+			expectedInterval: 1440 * time.Minute,
+		},
+		{
+			name:             "custom URL and interval",
+			config:           `{"url":"https://example.com/data.json","refresh-interval-minutes":"60"}`,
+			expectedURL:      "https://example.com/data.json",
+			expectedInterval: 60 * time.Minute,
+		},
+		{
+			name:             "zero interval defaults to 1440",
+			config:           `{"url":"https://example.com/data.json","refresh-interval-minutes":"0"}`,
+			expectedURL:      "https://example.com/data.json",
+			expectedInterval: 1440 * time.Minute,
+		},
+		{
+			name:             "negative interval defaults to 1440",
+			config:           `{"url":"https://example.com/data.json","refresh-interval-minutes":"-5"}`,
+			expectedURL:      "https://example.com/data.json",
+			expectedInterval: 1440 * time.Minute,
+		},
+		{
+			name:             "invalid JSON returns empty string and zero duration",
+			config:           "not-valid-json",
+			expectedURL:      "",
+			expectedInterval: 0,
+		},
+		{
+			name:             "empty URL field",
+			config:           `{"url":"","refresh-interval-minutes":"1440"}`,
+			expectedURL:      "",
+			expectedInterval: 1440 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, settings.RkeMetadataConfig.Set(tt.config))
+			gotURL, gotInterval := GetURLAndInterval()
+			assert.Equal(t, tt.expectedURL, gotURL)
+			assert.Equal(t, tt.expectedInterval, gotInterval)
+		})
+	}
+}
+
+func TestDynamicSourceURL(t *testing.T) {
+	originalUseLocalData := settings.KDMUseLocalData.Get()
+	originalRkeMetadataConfig := settings.RkeMetadataConfig.Get()
+	defer func() {
+		require.NoError(t, settings.KDMUseLocalData.Set(originalUseLocalData))
+		require.NoError(t, settings.RkeMetadataConfig.Set(originalRkeMetadataConfig))
+	}()
+
+	const (
+		remoteURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.14/data.json"
+		localFile = "/var/lib/rancher-data/driver-metadata/data.json"
+	)
+
+	require.NoError(t, settings.RkeMetadataConfig.Set(
+		`{"url":"` + remoteURL + `","refresh-interval-minutes":"1440"}`,
+	))
+
+	tests := []struct {
+		name         string
+		useLocalData string
+		expectedURL  string
+	}{
+		{
+			name:         "returns remote URL when kdm-use-local-data is false",
+			useLocalData: "false",
+			expectedURL:  remoteURL,
+		},
+		{
+			name:         "returns local file path when kdm-use-local-data is true",
+			useLocalData: "true",
+			expectedURL:  localFile,
+		},
+		{
+			name:         "returns remote URL when kdm-use-local-data is empty string",
+			useLocalData: "",
+			expectedURL:  remoteURL,
+		},
+	}
+
+	d := &DynamicSource{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, settings.KDMUseLocalData.Set(tt.useLocalData))
+			assert.Equal(t, tt.expectedURL, d.URL())
+		})
+	}
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -96,6 +96,7 @@ var (
 	KubernetesVersionsCurrent           = NewSetting("k8s-versions-current", "")
 	KubernetesVersionsDeprecated        = NewSetting("k8s-versions-deprecated", "")
 	KDMBranch                           = NewSetting("kdm-branch", "dev-v2.14")
+	KDMUseLocalData                     = NewSetting("kdm-use-local-data", "false")
 	MachineVersion                      = NewSetting("machine-version", "dev")
 	Namespace                           = NewSetting("namespace", os.Getenv("CATTLE_NAMESPACE"))
 	PasswordMinLength                   = NewSetting("password-min-length", "12")

--- a/pkg/settings/setting_test.go
+++ b/pkg/settings/setting_test.go
@@ -203,3 +203,18 @@ func TestGetRancherVersion(t *testing.T) {
 		assert.Equal(t, value, result)
 	}
 }
+
+func TestKDMUseLocalData(t *testing.T) {
+	original := KDMUseLocalData.Get()
+	defer func() {
+		require.NoError(t, KDMUseLocalData.Set(original))
+	}()
+
+	assert.Equal(t, "false", KDMUseLocalData.Get(), "default value should be false")
+
+	require.NoError(t, KDMUseLocalData.Set("true"))
+	assert.Equal(t, "true", KDMUseLocalData.Get())
+
+	require.NoError(t, KDMUseLocalData.Set("false"))
+	assert.Equal(t, "false", KDMUseLocalData.Get())
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Issue - https://github.com/rancher/rancher/issues/53839
Dashboard PR - add settings option https://github.com/rancher/dashboard/pull/16715
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
If you have only the set of images listed in rancher-images.txt for a given release, you cannot provision clusters with newer versions of RKE2 and k3s. KDM is periodically updated from releases.rancher.com which will populate the cluster provisioning dropdown. This causes the appearance that you can provision a cluster with those versions, but it will fail. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR introduces a new setting where you can choose to pull from local KDM data always instead of remotely fetching updates. This would be useful in environments with limited images, certain air gap situations, and for users who want to limit provisioning to set versions (for compliance, security, etc).
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Attempt to provision cluster with refreshed KDM data, necessary resources unavailable, fails. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
1. Build Rancher with default settings
2. Refresh KDM, observe RKE2 and k3s configurations reloaded
3. Change setting to use local file instead
4. Refresh KDM, observe no call to releases.rancher.com

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: Added unit tests for setting changes, covering successful change of setting, default values, and local file path.  


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_