### PR TITLE
Make sure older versions of OCI chart are installable

### DIFF
--- a/pkg/catalogv2/oci/oci_test.go
+++ b/pkg/catalogv2/oci/oci_test.go
@@ -3,14 +3,15 @@ package oci
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"helm.sh/helm/v3/pkg/registry"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"helm.sh/helm/v3/pkg/registry"
 
 	corev1 "k8s.io/api/core/v1"
 


### PR DESCRIPTION
Issue : https://github.com/rancher/rancher/issues/53845

### Summary 
- Changing the codebase to use a tag that is valid semver always. Currently `_` is not a valid semver. So we convert `_` into `+` to make it a valid semver. Using the old tags[i] is causing the bug. 
- Introducing our own `indexHas?` function since the once that we have previously is ignoring pre-release information. (this is from the helm library)
- Also, for fetching a particular chart, we make sure we fetch using `_` since fetching cannot be done using `+`

- In short, the codebase needs to correctly convert + to _ and _ to + where needed. 
- Fetching will work with `_` and semver will work with `+`. Helm also does this. https://github.com/helm/helm/issues/10166


# Release Notes

- If anyone is facing this issue, all they have to do is, refresh that particular Helm repository once upgraded to the fixed version.