### PR TITLE
[v2.14] Don't use new userdata format for elemental

### DIFF
--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -146,13 +146,14 @@ func (h *handler) getBootstrapSecret(namespace, name string, envVars []corev1.En
 		return nil, err
 	}
 
-	// For CAPR as the infrastructure provider, we only need to set the system agent
+	// For CAPR or elemental as the infrastructure provider, we only need to set the system agent
 	// install script in the bootstrap secret.
 	//
-	// Additional userdata is defined in the machine config and it will be merged with
+	// For CAPR, additional userdata is defined in the machine config and it will be merged with
 	// install script from the secret by rancher-machine.
 	if machine.Spec.InfrastructureRef.APIGroup == capr.RKEMachineAPIGroup ||
-		machine.Spec.InfrastructureRef.APIGroup == capr.RKEAPIGroup {
+		machine.Spec.InfrastructureRef.APIGroup == capr.RKEAPIGroup ||
+		machine.Spec.InfrastructureRef.APIGroup == "elemental.cattle.io" {
 		return &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/pkg/controllers/capr/machinenodelookup/controller.go
+++ b/pkg/controllers/capr/machinenodelookup/controller.go
@@ -77,10 +77,11 @@ func (h *handler) associateMachineWithNode(_ string, bootstrap *rkev1.RKEBootstr
 		return bootstrap, err
 	}
 
-	// Skip this controller when CAPR isn't the infrastructure provider. The external infrastructure provider
+	// Skip this controller when CAPR or elemental isn't the infrastructure provider. The external infrastructure provider
 	// will be responsible for setting the providerID and addresses in the infra machine.
 	if machine.Spec.InfrastructureRef.APIGroup != capr.RKEMachineAPIGroup &&
-		machine.Spec.InfrastructureRef.APIGroup != capr.RKEAPIGroup {
+		machine.Spec.InfrastructureRef.APIGroup != capr.RKEAPIGroup &&
+		machine.Spec.InfrastructureRef.APIGroup != "elemental.cattle.io" {
 		return bootstrap, nil
 	}
 


### PR DESCRIPTION
## Problem
A previous [PR](https://github.com/rancher/rancher/pull/53736) changed the bootstrap controller to generate a new userdata format to be used with CAPI infrastructure providers other than CAPR.

It also disabled the machinenodelookup controller for these providers.

That commit did not consider that elemental could also be used as a infrastructure provider (at least for infra machines), and the changes caused a regression for elemental clusters, which rely on the bootstrap secret being the system agent install script.

## Solution

This PR adds an exception to the elemental.cattle.io group to preserve the previous behavior, both when generating the bootstrap secret by not disabling the machinenodelookup controller.

## Issue: https://github.com/rancher/rancher/issues/53878

