### PR TITLE
fix: upgrade Go to 1.25.7 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/rancher
 
-go 1.25.0
+go 1.25.7
 
 toolchain go1.25.7
 


### PR DESCRIPTION
## Summary
Upgrades Go version to 1.25.7 to fix a CRITICAL vulnerability in the Go standard library.

## CVE Fixed
CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability

## Vulnerability Findings

### Trivy Scan Command
```
trivy image --severity HIGH,CRITICAL rancher/rancher:latest
```

### Before Fix (rancher/rancher:latest)
```
Found CVE-2025-68121 in stdlib version v1.25.1
```

### After Fix
Go 1.25.7 contains patches for CVE-2025-68121.

This is a minimal patch-level version bump fix.