### PR TITLE
fix: Add etcd-s3-retention flag to the planner config

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/norman/types/values"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
@@ -67,9 +68,43 @@ func (p *Planner) addETCD(config map[string]interface{}, controlPlane *rkev1.RKE
 			}
 		}
 		result = files
+		if hasEtcdS3RetentionFlag(controlPlane.Spec.KubernetesVersion) && controlPlane.Spec.ETCD.SnapshotRetention > 0 {
+			config["etcd-s3-retention"] = controlPlane.Spec.ETCD.SnapshotRetention
+		}
+
 	}
 
 	return
+}
+
+// hasEtcdS3RetentionFlag returns true if the etcd S3 retention flag should be
+// Starting in RkE2 versions v1.34.0+rke2r1, v1.33.4+rke2r1, v1.32.8+rke2r1, v1.31.12+rke2r1,
+// See:
+// https://documentation.suse.com/cloudnative/rke2/latest/en/datastore/backup_restore.html#:~:text=S3%20Retention,-Version%20Gate&text=Starting%20in%20versions%20v1.,as%20the%20local%20snapshot%20retention.
+func hasEtcdS3RetentionFlag(vStr string) bool {
+	v, err := semver.NewVersion(vStr)
+	if err != nil {
+		return false
+	}
+
+	constraints := []string{
+		">= 1.34.0",
+		">= 1.33.4",
+		">= 1.32.8",
+		">= 1.31.12",
+	}
+
+	for _, constraint := range constraints {
+		c, err := semver.NewConstraint(constraint)
+		if err != nil {
+			continue
+		}
+		if c.Check(v) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func addDefaults(config map[string]interface{}, controlPlane *rkev1.RKEControlPlane) {


### PR DESCRIPTION
## Issue: #52710
## Problem
In Rancher 2.13, the RKE2 provisioning planner fails to pass the specific `--etcd-s3-retention` flag to downstream clusters. While the Rancher UI provides a "Snapshots" retention field, the backend only populates the local disk retention key (`etcd-snapshot-retention`). 

Because RKE2 (v1.28+) split local and S3 retention into separate flags, the absence of the S3-specific flag causes RKE2 to fall back to its internal hardcoded default of **5** S3 snapshots. This results in the unexpected pruning of cloud backups regardless of the user's input in the Rancher UI.

## Solution
Modified the RKE2 `Planner` component to conditionally inject the `etcd-s3-retention` configuration key. This fix maps the existing user-defined `SnapshotRetention` value to the S3 retention flag whenever S3 rendering is active.

To prevent "unknown flag" errors on older clusters, this injection is gated by the Kubernetes version. Per the [official RKE2 documentation](https://documentation.suse.com/cloudnative/rke2/latest/en/datastore/backup_restore.html#:~:text=S3%20Retention,-Version%20Gate&text=Starting%20in%20versions%20v1.,as%20the%20local%20snapshot%20retention.), the separate S3 retention flag was introduced in the August 2024 release cycle. 

The flag is now only passed if the cluster version meets the following criteria:
* `v1.34.0+rke2r1` or higher
* `v1.33.4+rke2r1` or higher
* `v1.32.8+rke2r1` or higher
* `v1.31.12+rke2r1` or higher

This addresses the issue while maintaining backward compatibility for legacy RKE2 versions.

## Testing
1. Repro steps confirmed: On an unpatched 2.13 Rancher, S3 snapshots are capped at 5 even if the UI is set to 15.
2. Verification: Verified that after the patch, a v1.34.4 cluster correctly renders `etcd-s3-retention: 15` as an integer in the node's `50-rancher.yaml`.

## Engineering Testing
### Manual Testing
* **Modern Cluster (v1.34.4):** Verified that both `etcd-snapshot-retention` and `etcd-s3-retention` are correctly populated as integers in the downstream config.
* **Legacy Cluster (v1.28.x):** Verified that the `etcd-s3-retention` flag is **NOT** passed, ensuring the RKE2 process does not crash due to an unknown flag.
* **S3 Verification:** Confirmed that the S3 bucket retains the expected number of snapshots (matching the UI value) rather than defaulting to 5.

### Automated Testing
* Test types added/modified:
    * None
* If "None" - Reason: This is a configuration mapping fix for an existing field. No new application logic or API types were introduced.

Summary: Verified that the `planner` now correctly renders the S3 retention key in the node's configuration map for supported RKE2 versions.

## QA Testing Considerations
QA should verify the fix on a cluster using one of the "Version Gate" releases (e.g., v1.34.0+) to ensure S3 retention matches the UI. They should also verify that an older version (e.g., v1.27.x) still provisions successfully without the new flag.

### Regressions Considerations
**Probability of regression: Low.** The fix uses a version gate to protect older RKE2 versions from receiving an unsupported flag.
* **Legacy versions:** Will continue to use previous behavior (relying on RKE2's internal handling).
* **Newer versions:** Will now correctly apply the user's intended retention count to S3 backups.

Existing / newly added automated tests that provide evidence there are no regressions:
* Existing RKE2 provisioning and snapshot validation tests.