### PR TITLE
[v2.12] Wait for capi-controller-manager before running provisioning tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -246,6 +246,16 @@ echo "Waiting up to 5 minutes for rancher-provisioning-capi deployment"
   --exit-command "dump_rancher_logs" `# Dump logs to find out why capi-controller-manager did not start` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-provisioning-capi-system deploy/capi-controller-manager &>/dev/null"
 
+echo "Waiting up to 5 minutes for capi-controller-manager deployment"
+./scripts/retry \
+  --timeout 300 `# Time out after 300 seconds (5 min)` \
+  --sleep 2 `# Sleep for 2 seconds in between attempts` \
+  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
+  --message "capi-controller-manager was not available after {{elapsed}} seconds" `# Print this progress message` \
+  --exit-command "dump_rancher_logs" `# Dump logs to find out why capi-controller-manager did not start` \
+  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get ns cattle-capi-system &>/dev/null \
+    && kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-capi-system deploy/capi-controller-manager &>/dev/null"
+
 # only push the image if we're not using the default image:tag
 if [ "${CATTLE_AGENT_IMAGE}" != "rancher/rancher-agent:head" ]; then
   ( push_cattle_agent_image & )


### PR DESCRIPTION
backport of https://github.com/rancher/rancher/pull/53810 for release/v2.12

issue: https://github.com/rancher/rancher/issues/53809