### PR TITLE
fixup(saml): SAML2.0-compliant attribute lookup

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -398,10 +398,7 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 
 	for _, attributeStatement := range assertion.AttributeStatements {
 		for _, attr := range attributeStatement.Attributes {
-			attrName := attr.FriendlyName
-			if attrName == "" {
-				attrName = attr.Name
-			}
+			attrName := attr.Name
 			for _, value := range attr.Values {
 				samlData[attrName] = append(samlData[attrName], value.Value)
 			}


### PR DESCRIPTION
## Problem

SAML client does not obey the SAML 2.0 specification quite correctly. It uses Assertion Attribute's "FriendlyName" as primary identifier of Attributes in the assertion.

Resulting in very surprising behavior when integrating with IDP's.
 
## Solution

In the SAML 2.0 core specification [0], Section 2.7.3.1 explains that:

> FriendlyName [Optional]
>
> A string that provides a more human-readable form of the attribute's name, which may be useful in cases in which the actual Name is complex or opaque, such as an OID or a UUID. This attribute's value MUST NOT be used as a basis for formally identifying SAML attributes.

Indicating that the attribute primary purpose is human readability, systems _must_ use the "Name" attribute as it is guaranteed to be present in the assertion as the specification describes.

[0]: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf

## Testing

## Engineering Testing
### Manual Testing

- Configure a SAML Integration
- Make your IDP send _both_ Name (required) and FriendlyName in the Assertion's AttributeStatement.
- See that Rancher looks up attributes by Name and not Friendly Name.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: None

Summary: I'm not familiar enough with the codebase to include real-world SAML assertion
parsing in the unit-tests.

### Regressions Considerations

It's likely that since this feature existed IDP's tested never really set the
`FriendlyName` in the Assertion, or if they did, it had a value equal to the
`Name` attribute.
