### PR TITLE
[BUGFIX] Add CriticalAddonsOnly toleration to helm-operation pods

### DIFF
--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -1061,6 +1061,11 @@ func (s *Operations) createPod(secretData map[string][]byte, kustomize bool, ima
 			Value:    "true",
 			Effect:   "NoSchedule",
 		},
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: corev1.TolerationOpExists,
+			Effect:   "NoSchedule",
+		},
 	}
 	uniqueTolerations := mergeTolerations(defaultPodTolerations, tolerations)
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Fixes #46228
Relates to #41578
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
helm-operation pods are created by Rancher to execute Helm operations
(install webhooks, charts, etc.). On clusters where all nodes have taints
(such as OVH MKS with node pool isolation or AKS with system pools),
these pods cannot be scheduled because they lack the CriticalAddonsOnly
toleration.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
 This fix adds CriticalAddonsOnly toleration with Exists operator to the
default pod tolerations, allowing helm-operation pods to schedule on
nodes with CriticalAddonsOnly=true:NoSchedule taint.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_