### PR TITLE
Pass annotations from fleetworkspace to namespace

### DIFF
--- a/pkg/controllers/provisioningv2/fleetworkspace/controller.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller.go
@@ -99,8 +99,9 @@ func (h *handle) OnChange(workspace *mgmt.FleetWorkspace, status mgmt.FleetWorks
 	return []runtime.Object{
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   workspace.Name,
-				Labels: yaml.CleanAnnotationsForExport(workspace.Labels),
+				Name:        workspace.Name,
+				Labels:      yaml.CleanAnnotationsForExport(workspace.Labels),
+				Annotations: yaml.CleanAnnotationsForExport(workspace.Annotations),
 			},
 		},
 	}, status, nil

--- a/pkg/controllers/provisioningv2/fleetworkspace/controller_test.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller_test.go
@@ -1,0 +1,169 @@
+package fleetworkspace
+
+import (
+	"testing"
+
+	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOnChange(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		workspace       *mgmt.FleetWorkspace
+		wantNoObjects   bool
+		wantAnnotations map[string]string
+		wantLabels      map[string]string
+	}{
+		"unmanaged workspace returns no objects": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						managed: "false",
+					},
+				},
+			},
+			wantNoObjects: true,
+		},
+		"workspace with no labels or annotations produces empty namespace metadata": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+				},
+			},
+			wantAnnotations: map[string]string{},
+			wantLabels:      map[string]string{},
+		},
+		"cattle.io annotations are stripped from namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"cattle.io/internal":  "should-be-stripped",
+						"foo.cattle.io/owner": "also-stripped",
+						"example.com/keep":    "should-be-kept",
+					},
+				},
+			},
+			wantAnnotations: map[string]string{
+				"example.com/keep": "should-be-kept",
+			},
+			wantLabels: map[string]string{},
+		},
+		"cattle.io labels are stripped from namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Labels: map[string]string{
+						"cattle.io/internal":  "should-be-stripped",
+						"foo.cattle.io/owner": "also-stripped",
+						"example.com/keep":    "should-be-kept",
+					},
+				},
+			},
+			wantAnnotations: map[string]string{},
+			wantLabels: map[string]string{
+				"example.com/keep": "should-be-kept",
+			},
+		},
+		"kubectl.kubernetes.io annotations are stripped from namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": "should-be-stripped",
+						"example.com/keep": "should-be-kept",
+					},
+				},
+			},
+			wantAnnotations: map[string]string{
+				"example.com/keep": "should-be-kept",
+			},
+			wantLabels: map[string]string{},
+		},
+		"non-cattle annotations and labels are passed through to namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"owner":            "team-a",
+						"cost-center":      "12345",
+						"example.com/keep": "yes",
+					},
+					Labels: map[string]string{
+						"team":    "team-a",
+						"project": "example",
+					},
+				},
+			},
+			wantAnnotations: map[string]string{
+				"owner":            "team-a",
+				"cost-center":      "12345",
+				"example.com/keep": "yes",
+			},
+			wantLabels: map[string]string{
+				"team":    "team-a",
+				"project": "example",
+			},
+		},
+		"mix of cattle.io and user-defined annotations: only user-defined survive": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"field.cattle.io/creatorId": "user-xyz",
+						"owner":                     "team-a",
+					},
+					Labels: map[string]string{
+						"cattle.io/something": "stripped",
+						"environment":         "production",
+					},
+				},
+			},
+			wantAnnotations: map[string]string{
+				"owner": "team-a",
+			},
+			wantLabels: map[string]string{
+				"environment": "production",
+			},
+		},
+		"namespace name matches workspace name": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-custom-workspace",
+				},
+			},
+			wantAnnotations: map[string]string{},
+			wantLabels:      map[string]string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &handle{}
+			objs, _, err := h.OnChange(tc.workspace, mgmt.FleetWorkspaceStatus{})
+
+			require.NoError(t, err)
+
+			if tc.wantNoObjects {
+				assert.Empty(t, objs)
+				return
+			}
+
+			require.Len(t, objs, 1)
+			ns, ok := objs[0].(*corev1.Namespace)
+			require.True(t, ok, "expected returned object to be a *corev1.Namespace")
+
+			assert.Equal(t, tc.workspace.Name, ns.Name)
+			assert.Equal(t, tc.wantAnnotations, ns.Annotations)
+			assert.Equal(t, tc.wantLabels, ns.Labels)
+		})
+	}
+}


### PR DESCRIPTION


## Issue: <!-- link the issue or issues this PR resolves here -->
Refers to
  - rancher/rancher#53965
  - rancher/fleet#4605
 
 
## Solution
Pass annotations down to namespace.
 
## Testing
Manual testing performed, uni tests written.

## Engineering Testing
### Manual Testing
1. Create workspace with annotations
2. Check corresponding namespace and check for annotations created from workspace

### Automated Testing
The `TestOnChange` function covers the `OnChange` handler with 8 table-driven cases, grouped into three areas:

**Early exit (1 case)**
- A workspace with `provisioning.cattle.io/managed=false` returns no objects at all — the namespace reconciliation is skipped entirely.

**Annotation filtering — the change (4 cases)**
- Any annotation containing `cattle.io/` (including subdomains like `field.cattle.io/`) is stripped and does not appear on the produced namespace.
- The `kubectl.kubernetes.io/` prefix is also stripped (e.g. `last-applied-configuration`).
- User-defined annotations with no internal prefix pass through unchanged.
- When both internal and user-defined annotations are present on the same workspace, only the user-defined ones survive on the namespace.

**Label filtering and namespace identity (3 cases)**
- Labels containing `cattle.io/` are stripped, mirroring the same filtering already applied before your change — these are regression guards.
- A workspace with no labels or annotations at all produces a namespace with empty (not nil) maps for both.
- The produced namespace name always matches the workspace name, regardless of its metadata content.


## QA Testing Considerations

### Prerequisites
- Rancher running with Fleet enabled
- `kubectl` access to the management cluster

### Steps

**1. Create a FleetWorkspace with a mix of internal and user-defined annotations**

```/dev/null/fleetworkspace.yaml#L1-14
apiVersion: management.cattle.io/v3
kind: FleetWorkspace
metadata:
  name: test-workspace
  annotations:
    field.cattle.io/creatorId: "user-xyz"
    provisioning.cattle.io/something: "internal"
    kubectl.kubernetes.io/last-applied-configuration: "{}"
    owner: "team-a"
    cost-center: "12345"
    example.com/environment: "staging"
```

**2. Verify the namespace was created**
```/dev/null/shell.sh#L1
kubectl get namespace test-workspace
```

**3. Inspect the namespace annotations**
```/dev/null/shell.sh#L1
kubectl get namespace test-workspace -o jsonpath='{.metadata.annotations}' | jq .
```

### Expected Result

| Annotation | Expected |
|---|---|
| `field.cattle.io/creatorId` | ❌ absent |
| `provisioning.cattle.io/something` | ❌ absent |
| `kubectl.kubernetes.io/last-applied-configuration` | ❌ absent |
| `owner` | ✅ `team-a` |
| `cost-center` | ✅ `12345` |
| `example.com/environment` | ✅ `staging` |

### Cleanup
```/dev/null/shell.sh#L1
kubectl delete fleetworkspace test-workspace
```


 
### Regressions Considerations

No regressions expected.
