### PR TITLE
Fix cleanup of Generic OIDC provider

### DIFF
--- a/pkg/auth/cleanup/cleanup.go
+++ b/pkg/auth/cleanup/cleanup.go
@@ -3,7 +3,6 @@ package cleanup
 import (
 	"encoding/json"
 	"errors"
-	"strings"
 
 	"github.com/rancher/rancher/pkg/auth/api/secrets"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -39,37 +38,22 @@ func CleanupUnusedSecretTokens(secretsInterface wcorev1.SecretController, authCo
 			continue
 		}
 
-		var patch []byte
-		if authConfig.Annotations != nil {
-			patch, err = json.Marshal([]jsonPatch{{
-				Op:    "add",
-				Path:  "/metadata/annotations/" + strings.ReplaceAll(cleanedUpSecretsAnnotation, "/", "~1"),
-				Value: "true",
-			}})
-		} else {
-			patch, err = json.Marshal([]jsonPatch{{
-				Op:   "add",
-				Path: "/metadata/annotations",
-				Value: map[string]string{
+		patch, err := json.Marshal(map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]string{
 					cleanedUpSecretsAnnotation: "true",
 				},
-			}})
-		}
+			},
+		})
 		if err != nil {
 			cleanupErr = errors.Join(cleanupErr, err)
 			continue
 		}
 
-		if _, err := authConfigs.Patch(name, types.JSONPatchType, patch); err != nil {
+		if _, err := authConfigs.Patch(name, types.MergePatchType, patch); err != nil {
 			cleanupErr = errors.Join(cleanupErr, err)
 		}
 	}
 
 	return
-}
-
-type jsonPatch struct {
-	Op    string `json:"op"`
-	Path  string `json:"path"`
-	Value any    `json:"value"`
 }

--- a/pkg/auth/cleanup/cleanup_test.go
+++ b/pkg/auth/cleanup/cleanup_test.go
@@ -54,9 +54,9 @@ func TestCleanupUnusedSecretTokens(t *testing.T) {
 	}
 
 	for _, provider := range cleanupProviders {
-		addAnnotationPatch := `[{"op":"add","path":"/metadata/annotations","value":{"auth.cattle.io/unused-secrets-cleaned":"true"}}]`
+		addAnnotationPatch := `{"metadata":{"annotations":{"auth.cattle.io/unused-secrets-cleaned":"true"}}}`
 		if patched := authConfigStore[provider].patched; patched != addAnnotationPatch {
-			t.Errorf("didn't update the annotations for provider %s", provider)
+			t.Errorf("didn't update the annotations for provider %s got %v", provider, patched)
 		}
 	}
 
@@ -92,7 +92,7 @@ func TestCleanupUnusedSecretTokensHandlesErrors(t *testing.T) {
 
 	for _, provider := range cleanupProviders {
 		// Only the non-erroring configs should be updated
-		addAnnotationPatch := `[{"op":"add","path":"/metadata/annotations","value":{"auth.cattle.io/unused-secrets-cleaned":"true"}}]`
+		addAnnotationPatch := `{"metadata":{"annotations":{"auth.cattle.io/unused-secrets-cleaned":"true"}}}`
 		ap := authConfigStore[provider]
 		if ap.err != nil {
 			if ap.patched != "" {
@@ -143,7 +143,7 @@ func TestCleanupUnusedSecretTokensAlreadyAnnotated(t *testing.T) {
 	}
 
 	for _, provider := range cleanupProviders {
-		addAnnotationPatch := `[{"op":"add","path":"/metadata/annotations","value":{"auth.cattle.io/unused-secrets-cleaned":"true"}}]`
+		addAnnotationPatch := `{"metadata":{"annotations":{"auth.cattle.io/unused-secrets-cleaned":"true"}}}`
 		if patched := authConfigStore[provider].patched; authConfigStore[provider].updated && patched != addAnnotationPatch {
 			t.Errorf("didn't update the annotations correctly for provider %s: %v", provider, patched)
 		}
@@ -173,7 +173,7 @@ func getAuthConfigControllerMock(ctrl *gomock.Controller, store map[string]store
 		})
 
 		if v.updated {
-			authConfigs.EXPECT().Patch(v.authConfig.Name, types.JSONPatchType, gomock.Any()).DoAndReturn(func(name string, _ types.PatchType, data []byte, _ ...any) (*v3.OIDCConfig, error) {
+			authConfigs.EXPECT().Patch(v.authConfig.Name, types.MergePatchType, gomock.Any()).DoAndReturn(func(name string, _ types.PatchType, data []byte, _ ...any) (*v3.AuthConfig, error) {
 				stored := store[name]
 				stored.patched = string(data)
 				store[name] = stored


### PR DESCRIPTION
## Issue: #53995
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
During cleanup of the unused tokens the AuthConfig was partially loaded and annotated and written back which caused some keys to be lost.
 
## Solution
During cleanup of the unused OIDC provider tokens the AuthConfig is annotated to indicate that it has been cleaned.

This was only partially loading the AuthConfig and losing the additional configuration which caused the configuration to reset on initial startup after migration.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Configure the GenericOIDC provider in Rancher v2.12.3 and upgrade to v2.13.3 or later and the `genericoidc` provider will have lost its URLs.


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_