### PR TITLE
[v2.13] Fix cleanup of Generic OIDC provider (#53999)

### DIFF
--- a/pkg/auth/cleanup/cleanup.go
+++ b/pkg/auth/cleanup/cleanup.go
@@ -1,12 +1,14 @@
 package cleanup
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/rancher/rancher/pkg/auth/api/secrets"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var cleanupProviders = []string{"genericoidc", "cognito"}
@@ -36,13 +38,19 @@ func CleanupUnusedSecretTokens(secretsInterface wcorev1.SecretController, authCo
 			continue
 		}
 
-		authConfig = authConfig.DeepCopy()
-		if authConfig.Annotations == nil {
-			authConfig.Annotations = map[string]string{}
+		patch, err := json.Marshal(map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]string{
+					cleanedUpSecretsAnnotation: "true",
+				},
+			},
+		})
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
 		}
 
-		authConfig.Annotations[cleanedUpSecretsAnnotation] = "true"
-		if _, err := authConfigs.Update(authConfig); err != nil {
+		if _, err := authConfigs.Patch(name, types.MergePatchType, patch); err != nil {
 			cleanupErr = errors.Join(cleanupErr, err)
 		}
 	}

--- a/pkg/auth/cleanup/cleanup_test.go
+++ b/pkg/auth/cleanup/cleanup_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestCleanupUnusedSecretTokens(t *testing.T) {
@@ -54,10 +55,12 @@ func TestCleanupUnusedSecretTokens(t *testing.T) {
 	}
 
 	for _, provider := range cleanupProviders {
-		if ann := authConfigStore[provider].authConfig.Annotations; ann[cleanedUpSecretsAnnotation] != "true" {
-			t.Errorf("didn't update the annotations: %#v", ann)
+		addAnnotationPatch := `{"metadata":{"annotations":{"auth.cattle.io/unused-secrets-cleaned":"true"}}}`
+		if patched := authConfigStore[provider].patched; patched != addAnnotationPatch {
+			t.Errorf("didn't update the annotations for provider %s got %v", provider, patched)
 		}
 	}
+
 }
 
 func TestCleanupUnusedSecretTokensHandlesErrors(t *testing.T) {
@@ -90,9 +93,15 @@ func TestCleanupUnusedSecretTokensHandlesErrors(t *testing.T) {
 
 	for _, provider := range cleanupProviders {
 		// Only the non-erroring configs should be updated
-		if authConfigStore[provider].err == nil {
-			if ann := authConfigStore[provider].authConfig.Annotations; ann[cleanedUpSecretsAnnotation] != "true" {
-				t.Errorf("didn't update the annotations: %#v", ann)
+		addAnnotationPatch := `{"metadata":{"annotations":{"auth.cattle.io/unused-secrets-cleaned":"true"}}}`
+		ap := authConfigStore[provider]
+		if ap.err != nil {
+			if ap.patched != "" {
+				t.Errorf("patched the resource incorrectly: %s", provider)
+			}
+		} else {
+			if ap.patched != addAnnotationPatch {
+				t.Errorf("did not patch the resource correctly for %s: %s", provider, ap.patched)
 			}
 		}
 	}
@@ -135,8 +144,9 @@ func TestCleanupUnusedSecretTokensAlreadyAnnotated(t *testing.T) {
 	}
 
 	for _, provider := range cleanupProviders {
-		if ann := authConfigStore[provider].authConfig.Annotations; ann[cleanedUpSecretsAnnotation] != "true" {
-			t.Errorf("didn't update the annotations: %#v", ann)
+		addAnnotationPatch := `{"metadata":{"annotations":{"auth.cattle.io/unused-secrets-cleaned":"true"}}}`
+		if patched := authConfigStore[provider].patched; authConfigStore[provider].updated && patched != addAnnotationPatch {
+			t.Errorf("didn't update the annotations correctly for provider %s: %v", provider, patched)
 		}
 	}
 }
@@ -145,6 +155,8 @@ type storedAuthConfig struct {
 	authConfig *v3.AuthConfig
 	updated    bool
 	err        error
+
+	patched string
 }
 
 func getAuthConfigControllerMock(ctrl *gomock.Controller, store map[string]storedAuthConfig) mgmtv3.AuthConfigController {
@@ -162,11 +174,11 @@ func getAuthConfigControllerMock(ctrl *gomock.Controller, store map[string]store
 		})
 
 		if v.updated {
-			authConfigs.EXPECT().Update(gomock.Any()).DoAndReturn(func(ac *v3.AuthConfig) (*v3.AuthConfig, error) {
-				stored := store[ac.GetName()]
-				stored.authConfig = ac
-				store[ac.GetName()] = stored
-				return ac, nil
+			authConfigs.EXPECT().Patch(v.authConfig.Name, types.MergePatchType, gomock.Any()).DoAndReturn(func(name string, _ types.PatchType, data []byte, _ ...any) (*v3.AuthConfig, error) {
+				stored := store[name]
+				stored.patched = string(data)
+				store[name] = stored
+				return nil, nil
 			})
 		}
 	}


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/53999

Fix cleanup of Generic OIDC provider

During cleanup of the unused OIDC provider tokens the AuthConfig is annotated to indicate that it has been cleaned.

This was only partially loading the AuthConfig and losing the additional configuration which caused the configuration to reset on initial startup after migration.