### PR TITLE
[main] scc: use StrictNewVersion for semantic version parsing

### DIFF
--- a/pkg/telemetry/scc.go
+++ b/pkg/telemetry/scc.go
@@ -143,7 +143,7 @@ func GenerateSCCPayload(telG RancherManagerTelemetry) (*SccPayload, error) {
 
 	// Remove pre-release and build metadata from the version
 	productVersion := telG.RancherVersion()
-	semVer, err := semver.NewVersion(productVersion)
+	semVer, err := semver.StrictNewVersion(productVersion)
 	if err == nil {
 		productVersion = fmt.Sprintf(
 			"%d.%d.%d",


### PR DESCRIPTION
Fix for QA feedback:
> While for 2.13-head I see the 2.13.0 version.

2.13-head should really be `v2.13.4` but semver package has no way to know this. So instead we should expect to see `other` as the version.