### PR TITLE
[v2.12][backport] scc: use StrictNewVersion for semantic version parsing

### DIFF
--- a/pkg/telemetry/scc.go
+++ b/pkg/telemetry/scc.go
@@ -143,7 +143,7 @@ func GenerateSCCPayload(telG RancherManagerTelemetry) (*SccPayload, error) {
 
 	// Remove pre-release and build metadata from the version
 	productVersion := telG.RancherVersion()
-	semVer, err := semver.NewVersion(productVersion)
+	semVer, err := semver.StrictNewVersion(productVersion)
 	if err == nil {
 		productVersion = fmt.Sprintf(
 			"%d.%d.%d",


### PR DESCRIPTION
Backport of: https://github.com/rancher/rancher/pull/54017