### PR TITLE
telemetry: add Upstream flag to SccSystem to distinguish local vs managed systems

### DIFF
--- a/pkg/telemetry/scc.go
+++ b/pkg/telemetry/scc.go
@@ -49,10 +49,6 @@ type sccSystemKey struct {
 	Upstream bool `json:"upstream,omitempty"`
 }
 
-func (s sccSystemKey) Key() string {
-	return fmt.Sprintf("%d-%d-%s", s.Cpu, s.Memory, s.Arch)
-}
-
 type SccCluster struct {
 	Count    int  `json:"count"`
 	Nodes    int  `json:"nodes"`


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54037
 
This change adds an `Upstream` boolean to `SccSystem` and `sccSystemKey` so SCC telemetry system aggregation can distinguish upstream (local Rancher cluster) nodes from managed cluster nodes, mirroring the existing `Upstream` flag on `SccCluster`.

consumers can now filter `ManagedSystems` entries by `upstream=true|false` to ignore upstream systems more easily.