### PR TITLE
Restore permissions to Project Owner and Project Member roles

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -204,7 +204,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("ui.cattle.io").resources("navlinks").verbs("get", "list", "watch").
 		addRule().apiGroups("").resources("nodes").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectroletemplatebindings").verbs("*").
-		addRule().apiGroups("").resources("namespaces").verbs("create").
+		addRule().apiGroups("").resources("namespaces").verbs("*").
 		addRule().apiGroups("").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("storage.k8s.io").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("apiregistration.k8s.io").resources("apiservices").verbs("get", "list", "watch").
@@ -228,7 +228,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	rb.addRoleTemplate("Project Member", "project-member", "project", false, false, false).
 		addRule().apiGroups("ui.cattle.io").resources("navlinks").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectroletemplatebindings").verbs("get", "list", "watch").
-		addRule().apiGroups("").resources("namespaces").verbs("create").
+		addRule().apiGroups("").resources("namespaces").verbs("*").
 		addRule().apiGroups("").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("storage.k8s.io").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("apiregistration.k8s.io").resources("apiservices").verbs("get", "list", "watch").
@@ -271,7 +271,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		setRoleTemplateNames("view")
 
 	rb.addRoleTemplate("Create Namespaces", "create-ns", "project", false, false, false).
-		addRule().apiGroups("").resources("namespaces").verbs("create")
+		addRule().apiGroups("").resources("namespaces").verbs("*")
 
 	rb.addRoleTemplate("Manage Workloads", "workloads-manage", "project", false, false, false).
 		addRule().


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54033
 
## Problem
With the solution introduced to fix this issue https://github.com/rancher/rancher/issues/50863, we made it so when a user is given `create` permissions for namespaces within a project, they no longer are given `*` permissions. That way users have more control over what they grant users.

The problem is that 3 built in project roles had just `create` on namespaces and by making the changes we actually reduced their overall permissions. They can no longer delete namespaces, which they could prior to the changes.
 
## Solution
Instead of having those roles contain only `create` for namespaces, we give them `*` to match the permissions they had prior to the changes in https://github.com/rancher/rancher/pull/51110
 
Note: We may want to re-evaluate giving these project roles `*` on namespaces in the future, but this restores their permissions to the previous levels which is enough for now.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Users with the following built in project role templates had the same permissions from v2.13, to now _with_ the updated built in roles
- Create Namespaces
- Project Owner
- Project Member

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_