### PR TITLE
Revert "Refactors namespace clusterrole management"

### DIFF
--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
@@ -29,21 +30,16 @@ const (
 	projectNSAnn                   = "authz.cluster.auth.io/project-namespaces"
 	initialRoleCondition           = "InitialRolesPopulated"
 	manageNSVerb                   = "manage-namespaces"
-	getVerb                        = "get"
-	// "edit" is a readability alias. In RBAC, the edit-level privileges are provided by the "patch" and "update" verbs.
-	editVerb = "edit"
+	projectNSEditVerb              = "*"
 
 	// compatibility with previous norman lifecycle implementation, now implemented inside OnChange's handler
 	normanLifecycleAnnotation = "lifecycle.cattle.io/create.namespace-auth"
 	normanLifecycleFinalizer  = "controller.cattle.io/namespace-auth"
 )
 
-// editVerbs defines the RBAC verbs corresponding to edit-level permissions.
-var editVerbs = []string{"patch", "update"}
 var projectNSVerbToSuffix = map[string]string{
-	getVerb:      "readonly",
-	manageNSVerb: "manage",
-	editVerb:     "edit",
+	"get":             "readonly",
+	projectNSEditVerb: "edit",
 }
 var defaultProjectLabels = labels.Set(map[string]string{"authz.management.cattle.io/default-project": "true"})
 var systemProjectLabels = labels.Set(map[string]string{"authz.management.cattle.io/system-project": "true"})
@@ -178,10 +174,8 @@ func (n *nsLifecycle) syncNS(obj *v1.Namespace) (bool, error) {
 		return false, fmt.Errorf("ensuring PRTBs are added to namespace %s: %w", obj.Name, err)
 	}
 
-	for verb, name := range projectNSVerbToSuffix {
-		if err := n.reconcileNamespaceProjectClusterRole(obj, verb); err != nil {
-			return false, fmt.Errorf("reconciling namespace %s project cluster roles for '%s' failed: %w", obj.Name, name, err)
-		}
+	if err := n.reconcileNamespaceProjectClusterRole(obj); err != nil {
+		return false, fmt.Errorf("reconciling namespace %s project cluster roles: %w", obj.Name, err)
 	}
 
 	return hasPRTBs, nil
@@ -384,158 +378,127 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 	return hasPRTBs, nil
 }
 
-// nsInRole checks whether the given namespace name exists in the ResourceNames
-// of any rule within the specified ClusterRole. Returns true if found.
-func nsInRole(cr *rbacv1.ClusterRole, role, nsName string) bool {
-	if cr.Name != role {
-		return false
-	}
-
-	for _, rule := range cr.Rules {
-		if slices.Contains(rule.ResourceNames, nsName) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// removeNSFromRules filters the given namespace from the provided list of rules.
-// It returns the updated slice of rules and a boolean indicating if any modification occurred.
-func removeNSFromRules(rules []rbacv1.PolicyRule, verb, nsName string) ([]rbacv1.PolicyRule, bool) {
-	var (
-		modified      bool
-		filteredRules []rbacv1.PolicyRule
-	)
-
-	for _, rule := range rules {
-		if !slices.Contains(rule.Verbs, verb) ||
-			!slices.Contains(rule.Resources, "namespaces") ||
-			!slices.Contains(rule.ResourceNames, nsName) {
-			filteredRules = append(filteredRules, rule)
-			continue
-		}
-
-		modified = true
-
-		// Rebuild the ResourceNames slice excluding the target namespace.
-		newResourceNames := []string{}
-		for _, rName := range rule.ResourceNames {
-			if rName != nsName {
-				newResourceNames = append(newResourceNames, rName)
+// To ensure that all users in a project can do a GET on the namespaces in that project, this
+// function ensures that a ClusterRole exists for the project that grants get access to the
+// namespaces in the project. A corresponding PRTB handler will ensure that a binding to this
+// ClusterRole exists for every project member
+func (n *nsLifecycle) reconcileNamespaceProjectClusterRole(ns *v1.Namespace) error {
+	for verb, name := range projectNSVerbToSuffix {
+		var desiredRole string
+		var projectName string
+		if ns.DeletionTimestamp == nil {
+			if parts := strings.SplitN(ns.Annotations[projectIDAnnotation], ":", 2); len(parts) == 2 && len(parts[1]) > 0 {
+				projectName = parts[1]
+				desiredRole = fmt.Sprintf(projectNSGetClusterRoleNameFmt, parts[1], name)
 			}
 		}
 
-		// Update and retain the rule if it still has ResourceNames
-		if len(newResourceNames) > 0 {
-			rule.ResourceNames = newResourceNames
-			filteredRules = append(filteredRules, rule)
-		}
-	}
-	return filteredRules, modified
-}
-
-// reconcileNamespaceProjectClusterRole creates and maintains three default ClusterRoles for each project:
-// 1. "readonly" role - read access (get) to project namespaces.
-// 2. "manage" role - namespace management permissions for the project.
-// 3. "edit" role = namespace edit (update/patch) permissions for the project.
-// readonly and edit role are dynamically updated as namespaces are added.
-// A corresponding PRTB handler ensures that a binding to these ClusterRoles exists for every project member.
-func (n *nsLifecycle) reconcileNamespaceProjectClusterRole(ns *v1.Namespace, verb string) error {
-	var desiredRole string
-	var projectName string
-	if ns.DeletionTimestamp == nil {
-		if parts := strings.SplitN(ns.Annotations[projectIDAnnotation], ":", 2); len(parts) == 2 && len(parts[1]) > 0 {
-			projectName = parts[1]
-			desiredRole = fmt.Sprintf(projectNSGetClusterRoleNameFmt, parts[1], projectNSVerbToSuffix[verb])
-		}
-	}
-
-	clusterRoles, err := n.m.crIndexer.ByIndex(crByNSIndex, ns.Name)
-	if err != nil {
-		return err
-	}
-
-	roleCli := n.m.clusterRoles
-	nsInDesiredRole := false
-	for _, c := range clusterRoles {
-		// project-manage role grants manage-ns permissions across all namespaces, so no specific resourceNames to be added.
-		if verb == manageNSVerb {
-			break
-		}
-		cr, ok := c.(*rbacv1.ClusterRole)
-		if !ok {
-			return errors.Errorf("%v is not a ClusterRole", c)
-		}
-
-		if nsInDesiredRole = nsInRole(cr, desiredRole, ns.Name); nsInDesiredRole {
-			continue
-		}
-
-		// This ClusterRole has a reference to the namespace, but is not the desired role. Namespace has been moved; remove it from this ClusterRole
-		undesiredRole := cr.DeepCopy()
-		modifiedRules, modified := removeNSFromRules(undesiredRole.Rules, verb, ns.Name)
-		if len(modifiedRules) == 0 {
-			logrus.Infof("Deleting ClusterRole %s", undesiredRole.Name)
-			if err = roleCli.Delete(undesiredRole.Name, &metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-			continue
-		}
-		if modified {
-			undesiredRole.Rules = modifiedRules
-			if _, err = roleCli.Update(undesiredRole); err != nil {
-				return err
-			}
-		}
-	}
-
-	if !nsInDesiredRole && desiredRole != "" {
-		mustUpdate := true
-		cr, err := n.m.crLister.Get(desiredRole)
-		if err != nil && !apierrors.IsNotFound(err) {
+		clusterRoles, err := n.m.crIndexer.ByIndex(crByNSIndex, ns.Name)
+		if err != nil {
 			return err
 		}
 
-		// Create new role
-		if cr == nil {
-			return n.m.createProjectNSRole(desiredRole, verb, ns.Name, projectName)
-		}
-
-		// Check to see if retrieved role has the namespace (small chance cache could have been updated)
-		for _, r := range cr.Rules {
-			if supportsVerb(r.Verbs, verb) && slices.Contains(r.Resources, "namespaces") && slices.Contains(r.ResourceNames, ns.Name) {
-				// ns already in the role, nothing to do
-				mustUpdate = false
+		roleCli := n.m.clusterRoles
+		nsInDesiredRole := false
+		for _, c := range clusterRoles {
+			cr, ok := c.(*rbacv1.ClusterRole)
+			if !ok {
+				return errors.Errorf("%v is not a ClusterRole", c)
 			}
-		}
-		if mustUpdate && verb != manageNSVerb {
-			cr = cr.DeepCopy()
-			appendedToExisting := false
-			for i := range cr.Rules {
-				rule := &cr.Rules[i]
-				if supportsVerb(rule.Verbs, verb) && slices.Contains(rule.Resources, "namespaces") {
-					cr.Rules[i].ResourceNames = append(cr.Rules[i].ResourceNames, ns.Name)
-					appendedToExisting = true
-					break
+
+			if cr.Name == desiredRole {
+				nsInDesiredRole = true
+				continue
+			}
+
+			// This ClusterRole has a reference to the namespace, but is not the desired role. Namespace has been moved; remove it from this ClusterRole
+			undesiredRole := cr.DeepCopy()
+			modified := false
+			for i := range undesiredRole.Rules {
+				r := &undesiredRole.Rules[i]
+				if slice.ContainsString(r.Verbs, verb) && slice.ContainsString(r.Resources, "namespaces") && slice.ContainsString(r.ResourceNames, ns.Name) {
+					modified = true
+					resNames := r.ResourceNames
+					for i := len(resNames) - 1; i >= 0; i-- {
+						if resNames[i] == ns.Name {
+							resNames = append(resNames[:i], resNames[i+1:]...)
+						}
+					}
+					r.ResourceNames = resNames
 				}
 			}
-
-			if !appendedToExisting {
-				verbs := []string{verb}
-				if verb == editVerb {
-					verbs = editVerbs
+			//if ResourceNames is empty, delete the rule and delete the role if no rules exist
+			toDeleteRules := 0
+			for _, rule := range undesiredRole.Rules {
+				if len(rule.ResourceNames) == 0 {
+					toDeleteRules++
 				}
-				cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
-					APIGroups:     []string{""},
-					Verbs:         verbs,
-					Resources:     []string{"namespaces"},
-					ResourceNames: []string{ns.Name},
-				})
 			}
+			if toDeleteRules == len(undesiredRole.Rules) {
+				logrus.Infof("Deleting ClusterRole %s", undesiredRole.Name)
+				if err = roleCli.Delete(undesiredRole.Name, &metav1.DeleteOptions{}); err != nil {
+					return err
+				}
+				continue
+			} else if toDeleteRules != 0 {
+				var updatedRules []rbacv1.PolicyRule
+				for _, rule := range undesiredRole.Rules {
+					if len(rule.ResourceNames) != 0 {
+						updatedRules = append(updatedRules, rule)
+					}
+				}
+				undesiredRole.Rules = updatedRules
+			}
+			if modified {
+				if _, err = roleCli.Update(undesiredRole); err != nil {
+					return err
+				}
+			}
+		}
 
-			if _, err = roleCli.Update(cr); err != nil {
+		if !nsInDesiredRole && desiredRole != "" {
+			mustUpdate := true
+			cr, err := n.m.crLister.Get(desiredRole)
+			if err != nil && !apierrors.IsNotFound(err) {
 				return err
+			}
+
+			// Create new role
+			if cr == nil {
+				return n.m.createProjectNSRole(desiredRole, verb, ns.Name, projectName)
+			}
+
+			// Check to see if retrieved role has the namespace (small chance cache could have been updated)
+			for _, r := range cr.Rules {
+				if slice.ContainsString(r.Verbs, verb) && slice.ContainsString(r.Resources, "namespaces") && slice.ContainsString(r.ResourceNames, ns.Name) {
+					// ns already in the role, nothing to do
+					mustUpdate = false
+				}
+			}
+			if mustUpdate {
+				cr = cr.DeepCopy()
+				appendedToExisting := false
+				for i := range cr.Rules {
+					r := &cr.Rules[i]
+					if slice.ContainsString(r.Verbs, verb) && slice.ContainsString(r.Resources, "namespaces") {
+						r.ResourceNames = append(r.ResourceNames, ns.Name)
+						appendedToExisting = true
+						break
+					}
+				}
+
+				if !appendedToExisting {
+					cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
+						APIGroups:     []string{""},
+						Verbs:         []string{verb},
+						Resources:     []string{"namespaces"},
+						ResourceNames: []string{ns.Name},
+					})
+				}
+
+				if _, err := roleCli.Update(cr); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -552,33 +515,20 @@ func (m *manager) createProjectNSRole(roleName, verb, ns, projectName string) er
 			Annotations: map[string]string{projectNSAnn: roleName},
 		},
 	}
-	switch verb {
-	case manageNSVerb:
+	if ns != "" {
+		cr.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Verbs:         []string{verb},
+				Resources:     []string{"namespaces"},
+				ResourceNames: []string{ns},
+			},
+		}
+	}
+	// the verbs passed into this function come from projectNSVerbToSuffix which only contains two verbs, one for read
+	// permissions and one for write. Only the write permission should get the manage-ns verb
+	if verb == projectNSEditVerb {
 		cr = addManageNSPermission(cr, projectName)
-	case getVerb:
-		if ns != "" {
-			cr.Rules = []rbacv1.PolicyRule{
-				{
-					APIGroups:     []string{""},
-					Verbs:         []string{verb},
-					Resources:     []string{"namespaces"},
-					ResourceNames: []string{ns},
-				},
-			}
-		}
-	case editVerb:
-		if ns != "" {
-			cr.Rules = []rbacv1.PolicyRule{
-				{
-					APIGroups:     []string{""},
-					Verbs:         editVerbs,
-					Resources:     []string{"namespaces"},
-					ResourceNames: []string{ns},
-				},
-			}
-		}
-	default:
-		return fmt.Errorf("unsupported verb: %s", verb)
 	}
 	_, err := roleCli.Create(cr)
 	return err
@@ -630,7 +580,7 @@ func crByNS(obj interface{}) ([]string, error) {
 
 	var result []string
 	for _, r := range cr.Rules {
-		if slices.Contains(r.Resources, "namespaces") && (slices.Contains(r.Verbs, getVerb) || slices.Contains(r.Verbs, "*")) {
+		if slice.ContainsString(r.Resources, "namespaces") && (slice.ContainsString(r.Verbs, "get") || slice.ContainsString(r.Verbs, "*")) {
 			result = append(result, r.ResourceNames...)
 		}
 	}
@@ -717,12 +667,10 @@ func (n *nsLifecycle) asyncCleanupRBAC(namespaceName string) {
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					// Namespace is fully deleted, clean up RBAC
-					for verb, name := range projectNSVerbToSuffix {
-						err := n.reconcileNamespaceProjectClusterRole(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}, verb)
-						if err != nil {
-							logrus.Errorf("error cleaning up %s RBAC for namespace %s: %v", name, namespaceName, err)
-							return true, err
-						}
+					err := n.reconcileNamespaceProjectClusterRole(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}})
+					if err != nil {
+						logrus.Errorf("error cleaning up RBAC for namespace %s: %v", namespaceName, err)
+						return true, err
 					}
 					logrus.Debugf("successfully cleaned up RBAC for namespace %s", namespaceName)
 					return true, nil
@@ -738,20 +686,4 @@ func (n *nsLifecycle) asyncCleanupRBAC(namespaceName string) {
 			logrus.Errorf("async cleanup of RBAC for namespace %s failed: %v", namespaceName, err)
 		}
 	}()
-}
-
-// supportsVerb returns true if the specified verb exists in `rule.Verbs`.
-// When the verb is "edit", it ensures both "patch" and "update" verbs are present, otherwise returns false.
-func supportsVerb(ruleVerbs []string, verb string) bool {
-	if verb != editVerb {
-		return slices.Contains(ruleVerbs, verb)
-	}
-
-	for _, v := range editVerbs {
-		if !slices.Contains(ruleVerbs, v) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -21,373 +21,244 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-var (
-	testNamespace1 = corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-ns-1",
-			Annotations: map[string]string{
-				projectIDAnnotation: "c-123xyz:p-123xyz",
-			},
-		},
-	}
-	testNamespace2 = corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-ns-2",
-			Annotations: map[string]string{
-				projectIDAnnotation: "c-123xyz:p-123xyz",
-			},
-		},
-	}
-	// The following namespace does not have any projectIDAnnotation
-	unrelatedNamespace = corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-ns-unrelated",
-		},
-	}
-)
-
 func TestReconcileNamespaceProjectClusterRole(t *testing.T) {
-	getCR := createClusterRoleForProject("p-123xyz", testNamespace1.Name, "get")
-	updateGetCR := addNamespaceToClusterRole(testNamespace2.Name, "get", getCR.DeepCopy())
-	manageCR := createClusterRoleForProject("p-123xyz", testNamespace1.Name, manageNSVerb)
-	editCR := createClusterRoleForProject("p-123xyz", testNamespace1.Name, editVerb)
-	noResourceNameCR := createClusterRoleForProject("p-123xyz", unrelatedNamespace.Name, "get")
+	const namespaceName = "test-ns"
+	ctrl := gomock.NewController(t)
 	tests := []struct {
-		name                 string
-		namespace            *corev1.Namespace
-		roleVerb             []string
-		setupCRController    func(*wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], *[]*rbacv1.ClusterRole, *[]string)
-		setupCRLister        func(*wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole])
-		crIndexer            *FakeResourceIndexer[*rbacv1.ClusterRole]
-		currentRoles         []*rbacv1.ClusterRole
-		wantRoles            []*rbacv1.ClusterRole
-		wantDeletedRoleNames []string
-		wantErr              bool
-		wantErrMessage       string
+		name                string
+		indexedRoles        []*rbacv1.ClusterRole
+		currentRoles        []*rbacv1.ClusterRole
+		projectNSAnnotation string
+		indexerError        error
+		updateError         error
+		createError         error
+		deleteError         error
+		getError            error
+
+		wantRoles           []*rbacv1.ClusterRole
+		wantDeleteRoleNames []string
+		wantError           bool
 	}{
 		{
-			name:      "create read-only role",
-			namespace: &testNamespace1,
-			roleVerb:  []string{"get"},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Create(gomock.Any()).DoAndReturn(
-					func(role *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-						created := getCR.DeepCopy()
-						*finalRoles = append(*finalRoles, created)
-						return created, nil
-					})
-			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get(gomock.Any()).Return(nil, nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index:     crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{},
-				err:       nil,
+			name:                "create read-only",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
 			},
 			wantRoles: []*rbacv1.ClusterRole{
-				getCR,
+				createClusterRoleForProject("p-123xyz", namespaceName, "get"),
 			},
-			wantDeletedRoleNames: []string{},
-			wantErr:              false,
+			wantError: false,
 		},
 		{
-			name:      "update existing read-only role",
-			namespace: &testNamespace2,
-			roleVerb:  []string{"get"},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Update(gomock.Any()).DoAndReturn(
-					func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-						updated := updateGetCR.DeepCopy()
-						*finalRoles = append(*finalRoles, updated)
-						return updated, nil
-					}).Times(1)
-			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get("p-123xyz-namespaces-readonly").Return(getCR.DeepCopy(), nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index: crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{
-					testNamespace2.Name: {getCR.DeepCopy()},
-				},
-				err: nil,
+			name:                "update old create new read-only",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
+				addNamespaceToClusterRole("otherNamespace", "get", createClusterRoleForProject("p-123abc", namespaceName, "get")),
 			},
 			wantRoles: []*rbacv1.ClusterRole{
-				updateGetCR,
+				createClusterRoleForProject("p-123xyz", namespaceName, "get"),
+				createClusterRoleForProject("p-123abc", "otherNamespace", "get"),
 			},
-			wantDeletedRoleNames: []string{},
-			wantErr:              false,
+			wantError: false,
 		},
 		{
-			name:      "create manage-ns role",
-			namespace: &testNamespace1,
-			roleVerb:  []string{manageNSVerb},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Create(gomock.Any()).DoAndReturn(
-					func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-						created := manageCR.DeepCopy()
-						*finalRoles = append(*finalRoles, created)
-						return created, nil
-					})
-			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get(gomock.Any()).Return(nil, nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index:     crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{},
-				err:       nil,
+			name:                "delete old create new read-only",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
+				createClusterRoleForProject("p-123abc", namespaceName, "get"),
 			},
 			wantRoles: []*rbacv1.ClusterRole{
-				manageCR,
+				createClusterRoleForProject("p-123xyz", namespaceName, "get"),
 			},
-			wantDeletedRoleNames: []string{},
-			wantErr:              false,
+			wantDeleteRoleNames: []string{createRoleName("p-123abc", "get")},
+			wantError:           false,
 		},
 		{
-			name:      "create edit role",
-			namespace: &testNamespace1,
-			roleVerb:  []string{editVerb},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Create(gomock.Any()).DoAndReturn(
-					func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-						created := editCR.DeepCopy()
-						*finalRoles = append(*finalRoles, created)
-						return created, nil
-					})
+			name:                "delete old update new read-only",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
+				createClusterRoleForProject("p-123abc", namespaceName, "get"),
 			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get(gomock.Any()).Return(nil, nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index:     crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{},
-				err:       nil,
+			currentRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", "otherNamespace", "get"),
 			},
 			wantRoles: []*rbacv1.ClusterRole{
-				editCR,
+				addNamespaceToClusterRole(namespaceName, "get", createClusterRoleForProject("p-123xyz", "otherNamespace", "get")),
 			},
-			wantDeletedRoleNames: []string{},
-			wantErr:              false,
+			wantDeleteRoleNames: []string{createRoleName("p-123abc", "get")},
+			wantError:           false,
 		},
 		{
-			name:      "update get & create manage-ns role",
-			namespace: &testNamespace2,
-			roleVerb:  []string{"get", manageNSVerb},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Create(gomock.Any()).DoAndReturn(
-					func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-						created := createClusterRoleForProject("p-123xyz", testNamespace2.Name, manageNSVerb)
-						*finalRoles = append(*finalRoles, created)
-						return created, nil
-					})
-				c.EXPECT().Update(gomock.Any()).DoAndReturn(
-					func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-						updated := updateGetCR.DeepCopy()
-						*finalRoles = append(*finalRoles, updated)
-						return updated, nil
-					})
-			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get(gomock.Any()).Return(getCR.DeepCopy(), nil)
-				l.EXPECT().Get(gomock.Any()).Return(nil, nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index: crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{
-					testNamespace1.Name: {getCR.DeepCopy()},
-				},
-				err: nil,
+			name:                "create edit",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "get"),
 			},
 			wantRoles: []*rbacv1.ClusterRole{
-				updateGetCR,
-				createClusterRoleForProject("p-123xyz", testNamespace2.Name, manageNSVerb),
+				addManagePermissionToClusterRole("p-123xyz", createClusterRoleForProject("p-123xyz", namespaceName, "*")),
 			},
-			wantDeletedRoleNames: []string{},
-			wantErr:              false,
+			wantError: false,
 		},
 		{
-			// manage-ns role is applied at the project level. It's not expected be updated per namespace reconciliation.
-			name:      "update get & no change to existing manage-ns role",
-			namespace: &testNamespace2,
-			roleVerb:  []string{"get", manageNSVerb},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Update(gomock.Any()).DoAndReturn(
-					func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-						updated := updateGetCR.DeepCopy()
-						*finalRoles = append(*finalRoles, updated)
-						return updated, nil
-					})
-			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get(gomock.Any()).Return(getCR.DeepCopy(), nil)
-				l.EXPECT().Get(gomock.Any()).Return(manageCR.DeepCopy(), nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index: crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{
-					testNamespace1.Name: {getCR.DeepCopy(), manageCR.DeepCopy()},
-				},
-				err: nil,
+			name:                "update old create new edit",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "get"),
+				addManagePermissionToClusterRole("p-123abc", addNamespaceToClusterRole("otherNamespace", "*", createClusterRoleForProject("p-123abc", namespaceName, "*"))),
 			},
 			wantRoles: []*rbacv1.ClusterRole{
-				updateGetCR,
+				addManagePermissionToClusterRole("p-123xyz", createClusterRoleForProject("p-123xyz", namespaceName, "*")),
+				addManagePermissionToClusterRole("p-123abc", createClusterRoleForProject("p-123abc", "otherNamespace", "*")),
 			},
-			wantDeletedRoleNames: []string{},
-			wantErr:              false,
+			wantError: false,
 		},
 		{
-			name:      "delete a role with no resourceName",
-			namespace: &unrelatedNamespace,
-			roleVerb:  []string{"get"},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(name string, opts *metav1.DeleteOptions) error {
-						*deletedRoleNames = append(*deletedRoleNames, noResourceNameCR.Name)
-						return nil
-					})
+			name:                "update old update new edit",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "get"),
+				addManagePermissionToClusterRole("p-123abc", createClusterRoleForProject("p-123abc", namespaceName, "*")),
 			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index: crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{
-					unrelatedNamespace.Name: {noResourceNameCR.DeepCopy()},
-				},
-				err: nil,
+			currentRoles: []*rbacv1.ClusterRole{
+				addManagePermissionToClusterRole("p-123xyz", createClusterRoleForProject("p-123xyz", "otherNamespace", "*")),
 			},
-			wantRoles: []*rbacv1.ClusterRole{},
-			wantDeletedRoleNames: []string{
-				noResourceNameCR.Name,
+			wantRoles: []*rbacv1.ClusterRole{
+				addManagePermissionToClusterRole("p-123xyz", addNamespaceToClusterRole(namespaceName, "*", createClusterRoleForProject("p-123xyz", "otherNamespace", "*"))),
+				addManagePermissionToClusterRole("p-123abc", createBaseClusterRoleForProject("p-123abc", "*")),
 			},
-			wantErr: false,
+			wantError: false,
 		},
 		{
-			name:              "indexer error",
-			namespace:         &testNamespace1,
-			roleVerb:          []string{"get"},
-			setupCRController: nil,
-			setupCRLister:     nil,
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index:     crByNSIndex,
-				resources: nil,
-				err:       fmt.Errorf("unable to read from indexer"),
-			},
-			wantErr:        true,
-			wantErrMessage: "unable to read from indexer",
+			name:                "indexer error",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexerError:        fmt.Errorf("unable to read from indexer"),
+			wantError:           true,
 		},
 		{
-			name:      "update error",
-			namespace: &testNamespace2,
-			roleVerb:  []string{"get"},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("unable to update"))
+			name:                "update error",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
+				addNamespaceToClusterRole("otherNamespace", "get", createClusterRoleForProject("p-123abc", namespaceName, "get")),
 			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get("p-123xyz-namespaces-readonly").Return(getCR.DeepCopy(), nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index: crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{
-					testNamespace1.Name: {getCR.DeepCopy()},
-				},
-				err: nil,
-			},
-			wantErr:        true,
-			wantErrMessage: "unable to update",
+			updateError: fmt.Errorf("unable to update"),
+			wantError:   true,
 		},
 		{
-			name:      "create error",
-			namespace: &testNamespace1,
-			roleVerb:  []string{"get"},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("unable to create"))
-			},
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get(gomock.Any()).Return(nil, nil)
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index:     crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{},
-				err:       nil,
-			},
-			wantErr:        true,
-			wantErrMessage: "unable to create",
+			name:                "create error",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			createError:         fmt.Errorf("unable to create"),
+			wantError:           true,
 		},
 		{
-			name:      "delete error",
-			namespace: &unrelatedNamespace,
-			roleVerb:  []string{"get"},
-			setupCRController: func(c *wfakes.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList], finalRoles *[]*rbacv1.ClusterRole, deletedRoleNames *[]string) {
-				c.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(fmt.Errorf("unable to delete"))
+			name:                "delete error",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
+				createClusterRoleForProject("p-123abc", namespaceName, "get"),
 			},
-			setupCRLister: nil,
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index: crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{
-					unrelatedNamespace.Name: {noResourceNameCR.DeepCopy()},
-				},
-				err: nil,
-			},
-			wantErr:        true,
-			wantErrMessage: "unable to delete",
+			deleteError: fmt.Errorf("unable to delete"),
+			wantError:   true,
 		},
 		{
-			name:              "get error",
-			namespace:         &testNamespace1,
-			roleVerb:          []string{"get"},
-			setupCRController: nil,
-			setupCRLister: func(l *wfakes.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]) {
-				l.EXPECT().Get(gomock.Any()).Return(nil, fmt.Errorf("unable to get"))
-			},
-			crIndexer: &FakeResourceIndexer[*rbacv1.ClusterRole]{
-				index:     crByNSIndex,
-				resources: map[string][]*rbacv1.ClusterRole{},
-				err:       nil,
-			},
-			wantErr:        true,
-			wantErrMessage: "unable to get",
+			name:                "get error",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			getError:            fmt.Errorf("unable to get"),
+			wantError:           true,
 		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			mockCRController := wfakes.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
-			var finalRoles []*rbacv1.ClusterRole
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			var newRoles []*rbacv1.ClusterRole
 			var deletedRoleNames []string
-			if tc.setupCRController != nil {
-				tc.setupCRController(mockCRController, &finalRoles, &deletedRoleNames)
+			indexer := FakeResourceIndexer[*rbacv1.ClusterRole]{
+				index: crByNSIndex,
+				resources: map[string][]*rbacv1.ClusterRole{
+					namespaceName: test.indexedRoles,
+				},
+				err: test.indexerError,
 			}
-
-			mockCRLister := wfakes.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-			if tc.setupCRLister != nil {
-				tc.setupCRLister(mockCRLister)
-			}
-
-			mockNSLifecycle := &nsLifecycle{
+			fakeLister := wfakes.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
+			fakeLister.EXPECT().Get(gomock.Any()).DoAndReturn(
+				func(in1 string) (*rbacv1.ClusterRole, error) {
+					if test.getError != nil {
+						return nil, test.getError
+					}
+					for _, role := range test.currentRoles {
+						if role.Name == in1 {
+							return role, nil
+						}
+					}
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    "rbac.authorization.k8s.io",
+						Resource: "ClusterRoles",
+					}, in1)
+				},
+			).AnyTimes()
+			fakeClusterRoles := wfakes.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+			fakeClusterRoles.EXPECT().Create(gomock.Any()).DoAndReturn(
+				func(in *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+					newRoles = append(newRoles, in)
+					if test.createError != nil {
+						return nil, test.createError
+					}
+					return in, nil
+				},
+			).AnyTimes()
+			fakeClusterRoles.EXPECT().Update(gomock.Any()).DoAndReturn(
+				func(in *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+					newRoles = append(newRoles, in)
+					if test.updateError != nil {
+						return nil, test.updateError
+					}
+					return in, nil
+				},
+			).AnyTimes()
+			fakeClusterRoles.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(name string, options *metav1.DeleteOptions) error {
+					deletedRoleNames = append(deletedRoleNames, name)
+					if test.deleteError != nil {
+						return test.deleteError
+					}
+					return nil
+				},
+			).AnyTimes()
+			lifecycle := nsLifecycle{
 				m: &manager{
-					crIndexer:    tc.crIndexer,
-					crLister:     mockCRLister,
-					clusterRoles: mockCRController,
+					crLister:     fakeLister,
+					crIndexer:    &indexer,
+					clusterRoles: fakeClusterRoles,
 				},
 			}
-
-			for _, verb := range tc.roleVerb {
-				err := mockNSLifecycle.reconcileNamespaceProjectClusterRole(tc.namespace, verb)
-				if tc.wantErr {
-					if assert.Error(t, err, "expected error but got none") && tc.wantErrMessage != "" {
-						assert.EqualError(t, err, tc.wantErrMessage)
-					}
-				} else {
-					assert.NoError(t, err, "expected no error but got one")
+			err := lifecycle.reconcileNamespaceProjectClusterRole(&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+					Annotations: map[string]string{
+						projectIDAnnotation: test.projectNSAnnotation,
+					},
+				},
+			})
+			if test.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, newRoles, len(test.wantRoles))
+				for _, role := range test.wantRoles {
+					assert.Contains(t, newRoles, role)
+				}
+				assert.Len(t, deletedRoleNames, len(test.wantDeleteRoleNames))
+				for _, roleName := range test.wantDeleteRoleNames {
+					assert.Contains(t, deletedRoleNames, roleName)
 				}
 			}
-			assert.ElementsMatch(t, tc.wantRoles, finalRoles, "expected roles to match")
-			assert.ElementsMatch(t, tc.wantDeletedRoleNames, deletedRoleNames, "expected deleted roles to match")
 		})
 	}
+
 }
 
 func TestCreateProjectNSRole(t *testing.T) {
@@ -399,7 +270,6 @@ func TestCreateProjectNSRole(t *testing.T) {
 		verb        string
 		namespace   string
 		projectName string
-		crSetup     func()
 		startingCR  *rbacv1.ClusterRole
 		expectedCR  *rbacv1.ClusterRole
 		createError error
@@ -420,14 +290,14 @@ func TestCreateProjectNSRole(t *testing.T) {
 			},
 		},
 		{
-			description: "create manage role",
-			verb:        "manage-namespaces",
+			description: "create edit role",
+			verb:        "*",
 			projectName: "p-123xyz",
 			expectedCR: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 					Annotations: map[string]string{
-						projectNSAnn: "p-123xyz-namespaces-manage",
+						projectNSAnn: "p-123xyz-namespaces-edit",
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
@@ -442,13 +312,13 @@ func TestCreateProjectNSRole(t *testing.T) {
 		},
 		{
 			description: "do not change role if already exists and return AlreadyExists error",
-			verb:        "manage-namespaces",
+			verb:        "*",
 			projectName: "p-123xyz",
 			expectedCR: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 					Annotations: map[string]string{
-						projectNSAnn: "p-123xyz-namespaces-manage",
+						projectNSAnn: "p-123xyz-namespaces-edit",
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
@@ -462,9 +332,9 @@ func TestCreateProjectNSRole(t *testing.T) {
 			},
 			startingCR: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 					Annotations: map[string]string{
-						projectNSAnn: "p-123xyz-namespaces-manage",
+						projectNSAnn: "p-123xyz-namespaces-edit",
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
@@ -476,11 +346,11 @@ func TestCreateProjectNSRole(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: `roletemplates.management.cattle.io "p-123xyz-namespaces-manage" already exists`,
+			expectedErr: `roletemplates.management.cattle.io "p-123xyz-namespaces-edit" already exists`,
 		},
 		{
 			description: "test should return non-AlreadyExists error",
-			verb:        "manage-namespaces",
+			verb:        "*",
 			projectName: "p-123xyz",
 			createError: apierrors.NewInternalError(fmt.Errorf("some error")),
 			expectedErr: "Internal error occurred: some error",
@@ -570,20 +440,13 @@ func addNamespaceToClusterRole(namespace string, verb string, clusterRole *rbacv
 		clusterRole.Rules[foundIdx].ResourceNames = append(clusterRole.Rules[foundIdx].ResourceNames, namespace)
 		return clusterRole
 	}
-
-	verbs := []string{verb}
-	if verb == editVerb {
-		verbs = editVerbs
-	}
-
 	rule := rbacv1.PolicyRule{
 		APIGroups:     []string{""},
-		Verbs:         verbs,
+		Verbs:         []string{verb},
 		Resources:     []string{"namespaces"},
 		ResourceNames: []string{namespace},
 	}
 	clusterRole.Rules = append(clusterRole.Rules, rule)
-
 	return clusterRole
 }
 

--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -158,13 +158,13 @@ func (p *pLifecycle) ensureSystemNamespaceAssigned(project *v3.Project) error {
 
 // ensureNamespaceRolesUpdated makes sure that the namespace roles have up-to-date rules, and issues updates if they don't
 func (p *pLifecycle) ensureNamespaceRolesUpdated(project *v3.Project) error {
-	// right now, only the manage role for namespaces has need of an update
-	suffix := projectNSVerbToSuffix[manageNSVerb]
+	// right now, only the edit role for namespaces has need of an update
+	suffix := projectNSVerbToSuffix[projectNSEditVerb]
 	roleName := fmt.Sprintf(projectNSGetClusterRoleNameFmt, project.Name, suffix)
 	cr, err := p.m.crLister.Get(roleName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return p.m.createProjectNSRole(roleName, manageNSVerb, "", project.Name)
+			return p.m.createProjectNSRole(roleName, projectNSEditVerb, "", project.Name)
 		}
 		return fmt.Errorf("unable to get backing cluster role for project %s: %w", project.Name, err)
 	}

--- a/pkg/controllers/managementuser/rbac/project_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/project_handler_test.go
@@ -39,9 +39,9 @@ func TestCreate(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "p-123xyz-namespaces-manage",
+						Name: "p-123xyz-namespaces-edit",
 						Annotations: map[string]string{
-							projectNSAnn: "p-123xyz-namespaces-manage",
+							projectNSAnn: "p-123xyz-namespaces-edit",
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -50,14 +50,6 @@ func TestCreate(t *testing.T) {
 							Verbs:         []string{"manage-namespaces"},
 							Resources:     []string{"projects"},
 							ResourceNames: []string{"p-123xyz"},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "p-123xyz-namespaces-edit",
-						Annotations: map[string]string{
-							projectNSAnn: "p-123xyz-namespaces-edit",
 						},
 					},
 				},
@@ -75,7 +67,7 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			name:                     "roles already exist",
-			existingClusterRoleNames: []string{"p-123xyz-namespaces-readonly", "p-123xyz-namespaces-manage", "p-123xyz-namespaces-edit"},
+			existingClusterRoleNames: []string{"p-123xyz-namespaces-readonly", "p-123xyz-namespaces-edit"},
 			wantErr:                  false,
 		},
 	}
@@ -157,22 +149,35 @@ func TestUpdated(t *testing.T) {
 			name: "missing cluster role annotation",
 			currentClusterRole: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 					Annotations: map[string]string{
-						projectNSAnn: "p-123xyz-namespaces-manage",
+						projectNSAnn: "p-123xyz-namespaces-edit",
 					},
 				},
-				Rules: []rbacv1.PolicyRule{},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						Verbs:         []string{"*"},
+						Resources:     []string{"namespaces"},
+						ResourceNames: []string{"test-ns"},
+					},
+				},
 			},
 			wantError: false,
 			wantClusterRole: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 					Annotations: map[string]string{
-						projectNSAnn: "p-123xyz-namespaces-manage",
+						projectNSAnn: "p-123xyz-namespaces-edit",
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						Verbs:         []string{"*"},
+						Resources:     []string{"namespaces"},
+						ResourceNames: []string{"test-ns"},
+					},
 					{
 						APIGroups:     []string{"management.cattle.io"},
 						Verbs:         []string{"manage-namespaces"},
@@ -186,12 +191,18 @@ func TestUpdated(t *testing.T) {
 			name: "annotation present",
 			currentClusterRole: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 					Annotations: map[string]string{
-						projectNSAnn: "p-123xyz-namespaces-manage",
+						projectNSAnn: "p-123xyz-namespaces-edit",
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						Verbs:         []string{"*"},
+						Resources:     []string{"namespaces"},
+						ResourceNames: []string{"test-ns"},
+					},
 					{
 						APIGroups:     []string{"management.cattle.io"},
 						Verbs:         []string{"manage-namespaces"},
@@ -206,9 +217,9 @@ func TestUpdated(t *testing.T) {
 			name: "missing cluster role",
 			wantClusterRole: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 					Annotations: map[string]string{
-						projectNSAnn: "p-123xyz-namespaces-manage",
+						projectNSAnn: "p-123xyz-namespaces-edit",
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
@@ -236,9 +247,16 @@ func TestUpdated(t *testing.T) {
 			name: "update error",
 			currentClusterRole: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "p-123xyz-namespaces-manage",
+					Name: "p-123xyz-namespaces-edit",
 				},
-				Rules: []rbacv1.PolicyRule{},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						Verbs:         []string{"*"},
+						Resources:     []string{"namespaces"},
+						ResourceNames: []string{"test-ns"},
+					},
+				},
 			},
 			updError:  fmt.Errorf("unexpected error"),
 			wantError: true,

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
@@ -104,27 +104,14 @@ func (m *manager) ensureGlobalResourcesRolesForPRTB(projectName string, rts map[
 		return nil, nil
 	}
 
-	var roleSuffix string
-	var roleVerb []string
+	var roleVerb, roleSuffix string
 	for _, r := range rts {
 		for _, rule := range r.Rules {
 			hasNamespaceResources := slice.ContainsString(rule.Resources, "namespaces") || slice.ContainsString(rule.Resources, "*")
 			hasNamespaceGroup := slice.ContainsString(rule.APIGroups, "") || slice.ContainsString(rule.APIGroups, "*")
 			if hasNamespaceGroup && hasNamespaceResources && len(rule.ResourceNames) == 0 {
-				readVerbs := sets.New("get", "list", "watch")
-				ruleVerbs := sets.New(rule.Verbs...)
-
-				hasNonReadVerbs := ruleVerbs.Difference(readVerbs).Len() > 0
-				hasCreateVerbs := ruleVerbs.HasAny("*", "create")
-				hasEditVerbs := hasCreateVerbs || ruleVerbs.HasAny("patch", "update")
-
-				if hasNonReadVerbs {
-					roleVerb = append(roleVerb, manageNSVerb)
-				}
-				if hasEditVerbs {
-					roleVerb = append(roleVerb, editVerb)
-				}
-				if hasCreateVerbs {
+				if slice.ContainsString(rule.Verbs, "*") || slice.ContainsString(rule.Verbs, "create") {
+					roleVerb = "*"
 					roles.Insert("create-ns")
 					if nsRole, _ := m.crLister.Get("create-ns"); nsRole == nil {
 						createNSRT, err := m.rtLister.Get("create-ns")
@@ -138,16 +125,15 @@ func (m *manager) ensureGlobalResourcesRolesForPRTB(projectName string, rts map[
 					break
 				}
 			}
+
 		}
 	}
-
-	getRole := fmt.Sprintf(projectNSGetClusterRoleNameFmt, projectName, projectNSVerbToSuffix[getVerb])
-	roles.Insert(getRole)
-	for _, verb := range roleVerb {
-		roleSuffix = projectNSVerbToSuffix[verb]
-		role := fmt.Sprintf(projectNSGetClusterRoleNameFmt, projectName, roleSuffix)
-		roles.Insert(role)
+	if roleVerb == "" {
+		roleVerb = "get"
 	}
+	roleSuffix = projectNSVerbToSuffix[roleVerb]
+	role := fmt.Sprintf(projectNSGetClusterRoleNameFmt, projectName, roleSuffix)
+	roles.Insert(role)
 
 	for _, rt := range rts {
 		// Get the rules of the RoleTemplate

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate_test.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate_test.go
@@ -64,9 +64,9 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 			},
 		},
 		{
-			description:   "namespace create rule should grant create-ns, namespace-edit, namespace-manage and namespace-readonly role",
+			description:   "namespace create rule should grant create-ns and a namespaces-edit role",
 			projectName:   "testproject",
-			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testproject-namespaces-manage", "testproject-namespaces-readonly"},
+			expectedRoles: []string{"create-ns", "testproject-namespaces-edit"},
 			roleTemplates: map[string]*v3.RoleTemplate{
 				"testrt2": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -178,9 +178,9 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 			},
 		},
 		{
-			description:   "* resources and * APIGroup should result in namespace-edit, namespaces-manage, namespace-readonly and promoted role",
+			description:   "* resources and * APIGroup should only result in namespace-readonly and promoted role",
 			projectName:   "testproject",
-			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testproject-namespaces-manage", "testproject-namespaces-readonly", "testrt8-promoted"},
+			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testrt8-promoted"},
 			roleTemplates: map[string]*v3.RoleTemplate{
 				"testrt8": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -197,9 +197,9 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 			},
 		},
 		{
-			description:   "* resources and core (\"\") APIGroup should result in namespace-edit, namespace-manage, namespace-readonly and promoted role",
+			description:   "* resources and core (\"\") APIGroup should only result in namespace-readonly and promoted role",
 			projectName:   "testproject",
-			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testproject-namespaces-manage", "testproject-namespaces-readonly", "testrt9-promoted"},
+			expectedRoles: []string{"create-ns", "testproject-namespaces-edit", "testrt9-promoted"},
 			roleTemplates: map[string]*v3.RoleTemplate{
 				"testrt9": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -268,101 +268,6 @@ func TestEnsureGlobalResourcesRolesForPRTB(t *testing.T) {
 						},
 					},
 					External: true,
-				},
-			},
-		},
-		{
-			description:   "returns readOnly role for only get permission",
-			projectName:   "testproject",
-			expectedRoles: []string{"testproject-namespaces-readonly"},
-			roleTemplates: map[string]*v3.RoleTemplate{
-				"testGetRT": {
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testGetRT",
-					},
-					Rules: []v1.PolicyRule{
-						{
-							Verbs:     []string{"get"},
-							APIGroups: []string{""},
-							Resources: []string{"namespaces"},
-						},
-					},
-				},
-			},
-		},
-		{
-			description:   "returns readOnly role for only watch permission",
-			projectName:   "testproject",
-			expectedRoles: []string{"testproject-namespaces-readonly"},
-			roleTemplates: map[string]*v3.RoleTemplate{
-				"testReadRT": {
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testReadRT",
-					},
-					Rules: []v1.PolicyRule{
-						{
-							Verbs:     []string{"watch"},
-							APIGroups: []string{""},
-							Resources: []string{"namespaces"},
-						},
-					},
-				},
-			},
-		},
-		{
-			description:   "returns readOnly role for list & watch permission",
-			projectName:   "testproject",
-			expectedRoles: []string{"testproject-namespaces-readonly"},
-			roleTemplates: map[string]*v3.RoleTemplate{
-				"testReadRT": {
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testReadRT",
-					},
-					Rules: []v1.PolicyRule{
-						{
-							Verbs:     []string{"list", "watch"},
-							APIGroups: []string{""},
-							Resources: []string{"namespaces"},
-						},
-					},
-				},
-			},
-		},
-		{
-			description:   "returns readOnly & manageNamespace role for delete permission",
-			projectName:   "testproject",
-			expectedRoles: []string{"testproject-namespaces-manage", "testproject-namespaces-readonly"},
-			roleTemplates: map[string]*v3.RoleTemplate{
-				"testDeleteRT": {
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testDeleteRT",
-					},
-					Rules: []v1.PolicyRule{
-						{
-							Verbs:     []string{"delete"},
-							APIGroups: []string{""},
-							Resources: []string{"namespaces"},
-						},
-					},
-				},
-			},
-		},
-		{
-			description:   "returns edit, readOnly & manageNamespace role for edit & read permissions",
-			projectName:   "testproject",
-			expectedRoles: []string{"testproject-namespaces-edit", "testproject-namespaces-manage", "testproject-namespaces-readonly"},
-			roleTemplates: map[string]*v3.RoleTemplate{
-				"testRT": {
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testEditRT",
-					},
-					Rules: []v1.PolicyRule{
-						{
-							Verbs:     []string{"patch", "update", "get"},
-							APIGroups: []string{""},
-							Resources: []string{"namespaces"},
-						},
-					},
 				},
 			},
 		},

--- a/tests/v2/integration/actions/namespaces/create.go
+++ b/tests/v2/integration/actions/namespaces/create.go
@@ -28,7 +28,7 @@ const (
 )
 
 // CreateNamespace is a helper function that uses the dynamic client to create a namespace on a project.
-// It registers a delete function with a wait.WatchWait to ensure the namespace is deleted cleanly.
+// It registers a delete function with a wait.WatchWait to ensure the namspace is deleted cleanly.
 func CreateNamespace(client *rancher.Client, namespaceName, containerDefaultResourceLimit string, labels, annotations map[string]string, project *management.Project) (*v1.SteveAPIObject, error) {
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -110,9 +110,6 @@ func CreateNamespace(client *rancher.Client, namespaceName, containerDefaultReso
 		}
 
 		nameSpaceClient = steveClient.SteveType(NamespaceSteveType)
-		if resp == nil {
-			return nil
-		}
 		err := nameSpaceClient.Delete(resp)
 		if errors.IsNotFound(err) {
 			return nil

--- a/tests/v2/integration/projects/project_user_test.go
+++ b/tests/v2/integration/projects/project_user_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/rancher/rancher/tests/v2/integration/actions/namespaces"
@@ -9,7 +8,6 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
-	"github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,10 +78,9 @@ func (p *ProjectUserTestSuite) TestCreateNamespaceProjectMember() {
 	testUser, err := client.AsUser(p.testUser)
 	require.NoError(p.T(), err)
 
-	testNamespaceName := fmt.Sprintf("%s-%s", namespaceName, namegenerator.RandStringLower(5))
-	createdNamespace, err := namespaces.CreateNamespace(testUser, testNamespaceName, "{}", map[string]string{}, map[string]string{}, p.project)
+	createdNamespace, err := namespaces.CreateNamespace(testUser, namespaceName, "{}", map[string]string{}, map[string]string{}, p.project)
 	assert.NoError(p.T(), err)
-	assert.Equal(p.T(), testNamespaceName, createdNamespace.Name)
+	assert.Equal(p.T(), namespaceName, createdNamespace.Name)
 }
 
 func (p *ProjectUserTestSuite) TestCreateNamespaceProjectOwner() {
@@ -99,10 +96,9 @@ func (p *ProjectUserTestSuite) TestCreateNamespaceProjectOwner() {
 	testUser, err := client.AsUser(p.testUser)
 	require.NoError(p.T(), err)
 
-	testNamespaceName := fmt.Sprintf("%s-%s", namespaceName, namegenerator.RandStringLower(5))
-	createdNamespace, err := namespaces.CreateNamespace(testUser, testNamespaceName, "{}", map[string]string{}, map[string]string{}, p.project)
+	createdNamespace, err := namespaces.CreateNamespace(testUser, namespaceName, "{}", map[string]string{}, map[string]string{}, p.project)
 	assert.NoError(p.T(), err)
-	assert.Equal(p.T(), testNamespaceName, createdNamespace.Name)
+	assert.Equal(p.T(), namespaceName, createdNamespace.Name)
 }
 
 func TestProjectUserTestSuite(t *testing.T) {


### PR DESCRIPTION
Reverts rancher/rancher#51110

The PR caused this issue https://github.com/rancher/rancher/issues/54033

Additionally, when I added delete permissions to the project owner/member roles in https://github.com/rancher/rancher/pull/54046, it doesn't restrict the delete namespace permissions to namespaces within the project the user is assigned, which is a privilege escalation.