### PR TITLE
[backport 2.12] telemetry: add Upstream flag to SccSystem to distinguish local vs managed systems

### DIFF
--- a/pkg/telemetry/scc.go
+++ b/pkg/telemetry/scc.go
@@ -49,10 +49,6 @@ type sccSystemKey struct {
 	Upstream bool `json:"upstream,omitempty"`
 }
 
-func (s sccSystemKey) Key() string {
-	return fmt.Sprintf("%d-%d-%s", s.Cpu, s.Memory, s.Arch)
-}
-
 type SccCluster struct {
 	Count    int  `json:"count"`
 	Nodes    int  `json:"nodes"`


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/54069