### PR TITLE
[backport 2.13] Fix embedded shell home directory being read-only

### DIFF
--- a/pkg/api/steve/clusters/shell.go
+++ b/pkg/api/steve/clusters/shell.go
@@ -161,6 +161,26 @@ func (s *shell) createPod(imageOverride string) *v1.Pod {
 					Effect:   "NoExecute",
 				},
 			},
+			InitContainers: []v1.Container{
+				{
+					Name:            "init-home",
+					Image:           imageName,
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Command: []string{
+						"sh", "-c", "cp -r /home/shell/. /home-init/",
+					},
+					SecurityContext: &v1.SecurityContext{
+						AllowPrivilegeEscalation: &f,
+						ReadOnlyRootFilesystem:   &t,
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "home",
+							MountPath: "/home-init",
+						},
+					},
+				},
+			},
 			Containers: []v1.Container{
 				{
 					Name:      "shell",
@@ -189,8 +209,8 @@ func (s *shell) createPod(imageOverride string) *v1.Pod {
 							MountPath: "/run",
 						},
 						{
-							Name:      "helm-run",
-							MountPath: "/home/shell/helm-run",
+							Name:      "home",
+							MountPath: "/home/shell",
 						},
 					},
 				},
@@ -209,7 +229,7 @@ func (s *shell) createPod(imageOverride string) *v1.Pod {
 					},
 				},
 				{
-					Name: "helm-run",
+					Name: "home",
 					VolumeSource: v1.VolumeSource{
 						EmptyDir: &v1.EmptyDirVolumeSource{},
 					},


### PR DESCRIPTION
## Issue
This is a backport of: https://github.com/rancher/rancher/issues/53497
 
## Problem
The embedded shell pod runs with `ReadOnlyRootFilesystem=true`. Because the image stores the user home directory in `/home/shell`, CLI tools that attempt to write configuration files under `$HOME` fail.

For example, `k9s` attempts to create configuration under:

    ~/.config/k9s

Since `/home/shell` is part of the read-only image filesystem, this results in failures unless a workaround such as setting `K9S_CONFIG_DIR=/tmp/k9s` is used.

 
## Solution
This PR makes the shell home directory writable while preserving the contents shipped in the image.

The shell pod spec is updated to:

1. Create an `emptyDir` volume (`home`)
2. Use an init container to copy `/home/shell` from the image into the volume
3. Mount the volume at `/home/shell` for the main container

This approach keeps the default environment provided by the image (e.g. `.bashrc`, `.kube`, `helm-run`) while allowing CLI tools to write configuration files under `$HOME`.

<img width="1911" height="993" alt="Screenshot from 2026-03-06 16-57-52" src="https://github.com/user-attachments/assets/f975a1b9-3721-4a1c-819e-937461ae5113" />
