### PR TITLE
backport fleet 109.0.0+up0.15.0-rc.2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ remoteDialerProxyVersion: 109.0.0+up0.7.0-rc.5
 turtlesVersion: 109.0.0+up0.26.0-rc.6
 cspAdapterMinVersion: 109.0.0+up9.0.0-rc.3
 defaultShellVersion: rancher/shell:v0.7.0-rc.6
-fleetVersion: 109.0.0+up0.15.0-rc.1
+fleetVersion: 109.0.0+up0.15.0-rc.2
 defaultSccOperatorImage: rancher/scc-operator:v0.4.0-rc.1
 # NOTE: when updating this version, you will also need to update the hardcoded
 # k8s minor <-> image tag mapping in pkg/controllers/capr/autoscaler/fleet.go (imageTagVersions variable).

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,7 +7,7 @@ const (
 	CspAdapterMinVersion          = "109.0.0+up9.0.0-rc.3"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.4.0-rc.1"
 	DefaultShellVersion           = "rancher/shell:v0.7.0-rc.6"
-	FleetVersion                  = "109.0.0+up0.15.0-rc.1"
+	FleetVersion                  = "109.0.0+up0.15.0-rc.2"
 	RemoteDialerProxyVersion      = "109.0.0+up0.7.0-rc.5"
 	TurtlesVersion                = "109.0.0+up0.26.0-rc.6"
 	WebhookVersion                = "109.0.0+up0.10.0-rc.11"


### PR DESCRIPTION
- **Updating to Fleet v0.15.0-rc.2 (#54076)**
