### PR TITLE
Bump Rancher CLI to v2.15.0-rc.1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -275,7 +275,7 @@ RUN mkdir -p /var/lib/rancher/k3s/agent/images/ && \
 ENV CATTLE_UI_VERSION=2.14.0-alpha7
 ENV CATTLE_DASHBOARD_UI_VERSION=v2.14.0-alpha7
 
-ENV CATTLE_CLI_VERSION=v2.12.0-rc.1
+ENV CATTLE_CLI_VERSION=v2.15.0-rc.1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=


### PR DESCRIPTION
https://github.com/rancher/cli/releases/tag/v2.15.0-rc.1