### PR TITLE
Support OIDC Client based Authentication for Keycloak Provider

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -732,6 +732,11 @@ type OIDCConfig struct {
 	// RancherAPIHost should be the base URL for accessing Rancher through the
 	// web. e.g. https://rancher.example.com.
 	RancherAPIHost string `json:"rancherApiHost"`
+
+	// clientAuthenticatedSearch indicates that we should search with the
+	// client/secret rather than the user credentials if the underlying provider
+	// supports this.
+	ClientAuthenticatedSearch bool `json:"clientAuthenticatedSearch"`
 }
 
 type OIDCTestOutput struct {

--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -173,7 +173,8 @@ func getSearchURL(issuer string) (string, error) {
 	if len(iss) == 2 {
 		return fmt.Sprintf("%s/admin/realms/%s", iss[0], iss[1]), nil
 	}
-	return "", fmt.Errorf("can't parse issuer url")
+
+	return "", fmt.Errorf("can't parse issuer url: %s", issuer)
 }
 
 // URLEncoded encodes the string
@@ -183,11 +184,12 @@ func URLEncoded(str string) string {
 		logrus.Errorf("[keycloak oidc] URLEncoded: Error encoding the url: %s, error: %v", str, err)
 		return str
 	}
+
 	return u.String()
 }
 
 func (k *KeyCloakClient) getFromKeyCloak(url string) ([]byte, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -3,6 +3,7 @@ package keycloakoidc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -61,13 +63,25 @@ func (k *keyCloakOIDCProvider) newClient(config *apiv3.OIDCConfig, token accesso
 	}
 	provider, err := gooidc.NewProvider(ctx, config.Issuer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create new oidc provider: %w", err)
 	}
+
 	oauthConfig := oidc.ConfigToOauthConfig(provider.Endpoint(), config)
-	// get, refresh and update token
-	oauthToken, err := k.getRefreshAndUpdateToken(ctx, oauthConfig, token)
-	if err != nil {
-		return nil, err
+	var oauthToken *oauth2.Token
+	if config.ClientAuthenticatedSearch {
+		token, err := k.getClientCredentialsToken(ctx, provider, config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get client credentials: %w", err)
+		}
+		oauthToken = token
+	} else {
+		// get, refresh and update token
+		token, err := k.getRefreshAndUpdateToken(ctx, oauthConfig, token)
+		if err != nil {
+			return nil, err
+		}
+		oauthToken = token
+
 	}
 	keyCloakClient := &KeyCloakClient{
 		httpClient: oauthConfig.Client(ctx, oauthToken),
@@ -80,7 +94,7 @@ func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType strin
 	var principals []apiv3.Principal
 	var err error
 
-	config, err := k.GetOIDCConfig()
+	config, err := k.GetConfig()
 	if err != nil {
 		return principals, err
 	}
@@ -161,28 +175,109 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token accessor.T
 func (k *keyCloakOIDCProvider) getRefreshAndUpdateToken(ctx context.Context, oauthConfig oauth2.Config, token accessor.TokenAccessor) (*oauth2.Token, error) {
 	var oauthToken *oauth2.Token
 	storedOauthToken, err := k.TokenMgr.GetSecret(token.GetUserID(), token.GetAuthProvider(), []accessor.TokenAccessor{token})
-	if err := json.Unmarshal([]byte(storedOauthToken), &oauthToken); err != nil {
-		return oauthToken, err
-	}
 	if err != nil {
+		// If the secret lookup failed for a reason other than NotFound, surface the error.
 		if !apierrors.IsNotFound(err) {
-			return oauthToken, err
+			return nil, fmt.Errorf("getting access token for user: %w", err)
 		}
-		oauthToken.AccessToken = token.GetProviderInfo()["access_token"]
+
+		// Secret not found: fall back to the access token stored in ProviderInfo.
+		accessToken, ok := token.GetProviderInfo()["access_token"]
+		if !ok || strings.TrimSpace(accessToken) == "" {
+			return nil, fmt.Errorf("no stored access token found for user %s", token.GetUserID())
+		}
+		oauthToken = &oauth2.Token{
+			AccessToken: strings.TrimSpace(accessToken),
+		}
+	} else {
+		// Secret retrieved successfully. First, try to interpret it as JSON-encoded oauth2.Token.
+		stored := strings.TrimSpace(storedOauthToken)
+		if stored == "" {
+			return nil, fmt.Errorf("empty access token secret for user %s", token.GetUserID())
+		}
+		if unmarshalErr := json.Unmarshal([]byte(stored), &oauthToken); unmarshalErr != nil || oauthToken == nil {
+			// If unmarshalling fails or yields nil, fall back to treating the secret as a raw access token string.
+			oauthToken = &oauth2.Token{
+				AccessToken: stored,
+			}
+		}
 	}
+
 	// Valid will return false if access token is expired
 	if !oauthToken.Valid() {
 		// since token is not valid, the TokenSource func used in the Client func will attempt to refresh the access token
 		// if the refresh token has not expired
-		logrus.Debugf("[generic oidc] RefeshAndUpdateToken: attempting to refresh access token")
+		logrus.Debugf("[generic oidc] RefreshAndUpdateToken: attempting to refresh access token")
 	}
+
 	reusedToken, err := oauth2.ReuseTokenSource(oauthToken, oauthConfig.TokenSource(ctx, oauthToken)).Token()
 	if err != nil {
-		return oauthToken, err
+		return oauthToken, fmt.Errorf("setting up reusable token: %w", err)
 	}
 
 	if !reflect.DeepEqual(oauthToken, reusedToken) {
-		k.UpdateToken(reusedToken, token.GetUserID())
+		if err := k.UpdateToken(reusedToken, token.GetUserID()); err != nil {
+			logrus.Errorf("updating cached oauth token for user %s: %s", token.GetUserID(), err)
+		}
 	}
+
+	return reusedToken, nil
+}
+
+func (k *keyCloakOIDCProvider) getClientCredentialsToken(ctx context.Context, provider *gooidc.Provider, config *apiv3.OIDCConfig) (*oauth2.Token, error) {
+	var oauthToken *oauth2.Token
+	secretExists := true
+	storedOauthToken, err := k.TokenMgr.GetSecret(k.GetName(), k.GetName(), nil)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			secretExists = false
+		} else {
+			return nil, fmt.Errorf("finding oauth token for provider %s: %w", k.GetName(), err)
+		}
+	}
+	if storedOauthToken != "" {
+		if err := json.Unmarshal([]byte(storedOauthToken), &oauthToken); err != nil {
+			return nil, fmt.Errorf("unmarshalling cached oauth token for provider %s: %w", k.GetName(), err)
+		}
+	}
+	oauthConfig := oidc.ConfigToOauthConfig(provider.Endpoint(), config)
+	clientConf := clientcredentials.Config{
+		ClientID:     oauthConfig.ClientID,
+		ClientSecret: oauthConfig.ClientSecret,
+		TokenURL:     provider.Endpoint().TokenURL,
+		AuthStyle:    oauth2.AuthStyleInParams,
+		Scopes:       oauthConfig.Scopes,
+	}
+	if oauthToken != nil && (!oauthToken.Valid() || oauthToken.AccessToken == "") {
+		logrus.Debugf("[keycloak oidc] RefreshAndUpdateToken: attempting to refresh access token from client credentials")
+		tok, err := clientConf.Token(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch token: %w", err)
+		}
+		oauthToken = tok
+	}
+
+	reusedToken, err := oauth2.ReuseTokenSource(oauthToken, clientConf.TokenSource(ctx)).Token()
+	if err != nil {
+		return nil, fmt.Errorf("reusing the token source for provider %s: %w", k.GetName(), err)
+	}
+
+	if !reflect.DeepEqual(oauthToken, reusedToken) {
+		if !secretExists {
+			tokenBytes, err := json.Marshal(reusedToken)
+			if err != nil {
+				logrus.Errorf("marshalling oauth token for provider %s: %s", k.GetName(), err)
+			} else {
+				if err := k.TokenMgr.CreateSecret(k.GetName(), k.GetName(), string(tokenBytes)); err != nil {
+					logrus.Errorf("creating cached oauth token for provider %s: %s", k.GetName(), err)
+				}
+			}
+		} else {
+			if err := k.UpdateToken(reusedToken, k.GetName()); err != nil {
+				logrus.Errorf("updating cached oauth token for provider %s: %s", k.GetName(), err)
+			}
+		}
+	}
+
 	return reusedToken, nil
 }

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider_test.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider_test.go
@@ -1,0 +1,221 @@
+package keycloakoidc
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/rancher/norman/types"
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/accessor"
+	"github.com/rancher/rancher/pkg/auth/providers/oidc"
+	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestKeycloakOIDCProvider_SearchPrincipals(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	expectedResult := []apiv3.Principal{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "keycloakoidc_user://9f3f3bab-1c7f-4f1e-970c-6bd2db77684b",
+			},
+			DisplayName:   "Testing",
+			LoginName:     "testing",
+			PrincipalType: UserType,
+			Provider:      Name,
+		},
+	}
+
+	t.Run("test search for user principal with client authenticated search", func(t *testing.T) {
+		testSrv := newFakeKeycloakServer(t, privateKey, func(t *testing.T, r *http.Request) bool {
+			bearerString := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			claims := jwt.MapClaims{}
+			_, err := jwt.ParseWithClaims(bearerString, &claims, nil)
+			// the client authentication doesn't use an Access Token so it has
+			// no claims.
+			return errors.Is(err, jwt.ErrTokenUnverifiable) && claims["auth_provider"] == nil
+
+		})
+		oidcConfig := testOIDCConfig(testSrv.URL, func(o *v3.OIDCConfig) {
+			o.ClientAuthenticatedSearch = true
+		})
+		var createdSecret string
+		createTokenManager := &fakeTokenManager{
+			getSecretFunc: func(userID string, provider string, fallbackTokens []accessor.TokenAccessor) (string, error) {
+				return "", apierrors.NewNotFound(core.Resource("Secret"), "cattle-tokens/"+provider)
+			},
+			createSecretFunc: func(userID, provider, secret string) error {
+				createdSecret = secret
+				return nil
+			},
+		}
+		g := &keyCloakOIDCProvider{
+			oidc.OpenIDCProvider{
+				Name:     Name,
+				Type:     client.KeyCloakOIDCConfigType,
+				TokenMgr: createTokenManager,
+			},
+		}
+		g.GetConfig = func() (*apiv3.OIDCConfig, error) {
+			return oidcConfig, nil
+		}
+
+		result, err := g.SearchPrincipals("user1", UserType, &apiv3.Token{})
+		require.NoError(t, err, "SearchPrincipals() returned an error")
+		assert.Equal(t, expectedResult, result)
+		assert.NotEmpty(t, createdSecret)
+	})
+
+	t.Run("test search for user principal with client authenticated search when token secret exists", func(t *testing.T) {
+		testSrv := newFakeKeycloakServer(t, privateKey, func(t *testing.T, r *http.Request) bool {
+			bearerString := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			claims := jwt.MapClaims{}
+			_, err := jwt.ParseWithClaims(bearerString, &claims, nil)
+			// the client authentication doesn't use an Access Token so it has
+			// no claims.
+			return errors.Is(err, jwt.ErrTokenUnverifiable) && claims["auth_provider"] == nil
+
+		})
+		oidcConfig := testOIDCConfig(testSrv.URL, func(o *v3.OIDCConfig) {
+			o.ClientAuthenticatedSearch = true
+		})
+		createTokenManager := &fakeTokenManager{
+			getSecretFunc: func(userID, provider string, fallbackTokens []accessor.TokenAccessor) (string, error) {
+				return `{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vMTI3LjAuMC4xOjQyMDc5IiwiYXVkIjpbInRlc3QiXSwiZXhwIjoxNzczNDA1NDA5fQ.Omk646OoB9XGwC4RQIhGwrfpwj3mE73SB29l2A24KOaJ3s8HoC8JjfD6xRsDscE2MSW0Y6MI7lZodkToChBYk5drT8wU0_kOHgOey4vfobDvXpS7NhH0ECXmQ_HjxCpA651gFQYa1FyUr2exOmult5MTZOeTbFaxZYz6MSmjM4YcNrXkknZAwsS6FdX5kMVhcrGnAzi387QF8Kt0UnGlsmb-6oZ82Fw8-XXpnhNBB7KCgC1ehWwnEt2z1CXjIvAqKTBiGsd7vzbuDn-H9eqpii2_lEACCIW3PM0SNd49tMnF_JjdPjb_LdUKUW_0n7dDVm5-VRAfrlU9fgQJBKSipw","refresh_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vMTI3LjAuMC4xOjQyMDc5IiwiYXVkIjpbInRlc3QiXSwiZXhwIjoxNzczNDA1NDA5fQ.Omk646OoB9XGwC4RQIhGwrfpwj3mE73SB29l2A24KOaJ3s8HoC8JjfD6xRsDscE2MSW0Y6MI7lZodkToChBYk5drT8wU0_kOHgOey4vfobDvXpS7NhH0ECXmQ_HjxCpA651gFQYa1FyUr2exOmult5MTZOeTbFaxZYz6MSmjM4YcNrXkknZAwsS6FdX5kMVhcrGnAzi387QF8Kt0UnGlsmb-6oZ82Fw8-XXpnhNBB7KCgC1ehWwnEt2z1CXjIvAqKTBiGsd7vzbuDn-H9eqpii2_lEACCIW3PM0SNd49tMnF_JjdPjb_LdUKUW_0n7dDVm5-VRAfrlU9fgQJBKSipw","expiry":"0001-01-01T00:00:00Z"}`, nil
+			},
+		}
+		g := &keyCloakOIDCProvider{
+			oidc.OpenIDCProvider{
+				Name:     Name,
+				Type:     client.KeyCloakOIDCConfigType,
+				TokenMgr: createTokenManager,
+			},
+		}
+		g.GetConfig = func() (*apiv3.OIDCConfig, error) {
+			return oidcConfig, nil
+		}
+
+		result, err := g.SearchPrincipals("user1", UserType, &apiv3.Token{})
+		require.NoError(t, err, "SearchPrincipals() returned an error")
+		assert.Equal(t, expectedResult, result)
+	})
+
+	t.Run("test search for user principal user authenticated search", func(t *testing.T) {
+		testSrv := newFakeKeycloakServer(t, privateKey, func(t *testing.T, r *http.Request) bool {
+			bearerString := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			claims := jwt.MapClaims{}
+			_, err := jwt.ParseWithClaims(bearerString, &claims, nil)
+			return errors.Is(err, jwt.ErrTokenUnverifiable) && claims["auth_provider"] == "auth-provider"
+		})
+		oidcConfig := testOIDCConfig(testSrv.URL, func(o *v3.OIDCConfig) {
+			o.ClientAuthenticatedSearch = false
+		})
+		fakeAccessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+			"aud":           []interface{}{"client-id"},
+			"exp":           float64(time.Now().Add(10 * time.Hour).Unix()),
+			"iss":           oidcConfig.Issuer,
+			"iat":           float64(time.Now().Unix()),
+			"sub":           "test-user",
+			"auth_provider": "auth-provider",
+			"scope":         []string{"openid", "profile"},
+		})
+		fakeAccessTokenString, err := fakeAccessToken.SignedString(privateKey)
+		require.NoError(t, err, "Failed to sign fake access token")
+		createTokenManager := &fakeTokenManager{
+			getSecretFunc: func(userID string, provider string, fallbackTokens []accessor.TokenAccessor) (string, error) {
+				b, err := json.Marshal(map[string]string{
+					"access_token": fakeAccessTokenString,
+				})
+
+				return string(b), err
+			},
+		}
+		g := &keyCloakOIDCProvider{
+			oidc.OpenIDCProvider{
+				Name:     Name,
+				Type:     client.KeyCloakOIDCConfigType,
+				TokenMgr: createTokenManager,
+			},
+		}
+		g.GetConfig = func() (*apiv3.OIDCConfig, error) {
+			return oidcConfig, nil
+		}
+		result, err := g.SearchPrincipals("user1", UserType, &apiv3.Token{
+			ProviderInfo: map[string]string{
+				"access_token": fakeAccessTokenString,
+			},
+		})
+		require.NoError(t, err, "SearchPrincipals() returned an error")
+		assert.Equal(t, result, expectedResult)
+	})
+}
+
+func testOIDCConfig(baseURL string, opts ...func(*v3.OIDCConfig)) *v3.OIDCConfig {
+	issuerURL := baseURL + "/realms/testing"
+	cfg := &v3.OIDCConfig{
+		Issuer:           issuerURL,
+		ClientID:         "test",
+		JWKSUrl:          issuerURL + "/.well-known/jwks.json",
+		AuthEndpoint:     issuerURL + "/auth",
+		TokenEndpoint:    issuerURL + "/token",
+		UserInfoEndpoint: issuerURL + "/user",
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return cfg
+}
+
+type fakeTokenManager struct {
+	getSecretFunc               func(userID string, provider string, fallbackTokens []accessor.TokenAccessor) (string, error)
+	createTokenAndSetCookieFunc func(userID string, userPrincipal apiv3.Principal, groupPrincipals []apiv3.Principal, providerToken string, ttl int, description string, request *types.APIContext) error
+	createSecretFunc            func(userID, provider, secret string) error
+	updateSecretFunc            func(userID, provider, secret string) error
+}
+
+func (m *fakeTokenManager) GetSecret(userID, provider string, fallbackTokens []accessor.TokenAccessor) (string, error) {
+	if m.getSecretFunc == nil {
+		return "", errors.New("GetSecret called but no function provided")
+	}
+
+	return m.getSecretFunc(userID, provider, fallbackTokens)
+}
+
+func (m *fakeTokenManager) CreateSecret(userID, provider, secret string) error {
+	if m.createSecretFunc == nil {
+		return errors.New("CreateSecret called but no function provided")
+	}
+
+	return m.createSecretFunc(userID, provider, secret)
+}
+
+func (m *fakeTokenManager) CreateTokenAndSetCookie(userID string, userPrincipal apiv3.Principal, groupPrincipals []apiv3.Principal, providerToken string, ttl int, description string, request *types.APIContext) error {
+	if m.createTokenAndSetCookieFunc == nil {
+		return errors.New("CreateTokenAndSetCookie called but no function provided")
+	}
+
+	return m.createTokenAndSetCookieFunc(userID, userPrincipal, groupPrincipals, providerToken, ttl, description, request)
+}
+
+func (m *fakeTokenManager) UpdateSecret(userID, provider, secret string) error {
+	if m.updateSecretFunc == nil {
+		return errors.New("UpdateSecret called but no function provided")
+	}
+
+	return m.updateSecretFunc(userID, provider, secret)
+}

--- a/pkg/auth/providers/keycloakoidc/keycloak_server_test.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_server_test.go
@@ -1,0 +1,163 @@
+package keycloakoidc
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+)
+
+// newFakeKeycloakServer creates an http server that responds like a Keycloak
+// server.
+func newFakeKeycloakServer(t *testing.T, privateKey *rsa.PrivateKey, verifyFunc func(t *testing.T, r *http.Request) bool) *httptest.Server {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	resp := newOIDCResponses(t, privateKey, server.Listener.Addr().String())
+
+	mux.HandleFunc("/realms/testing/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp.config)
+	})
+	mux.HandleFunc("/realms/testing/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp.jwks)
+	})
+	mux.HandleFunc("/realms/testing/user", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp.user))
+	})
+	mux.HandleFunc("/realms/testing/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp.token)
+	})
+
+	mux.HandleFunc("/admin/realms/testing/users", func(w http.ResponseWriter, r *http.Request) {
+		if !verifyFunc(t, r) {
+			http.Error(w, "Failed to verify request", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp.searchResults)
+	})
+
+	return server
+}
+
+type fakeOIDCResponses struct {
+	user          string
+	config        providerJSON
+	jwks          jsonWebKeySet
+	token         *Token
+	searchResults any
+}
+
+type Token struct {
+	oauth2.Token
+	IDToken string `json:"id_token"`
+}
+
+func newOIDCResponses(t *testing.T, privateKey *rsa.PrivateKey, addr string) fakeOIDCResponses {
+	jwtToken := jwt.New(jwt.SigningMethodRS256)
+	jwtToken.Claims = jwt.RegisteredClaims{
+		Audience:  []string{"test"},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		Issuer:    "http://" + addr,
+	}
+	jwtSrt, err := jwtToken.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("failed to sign fake JWT: %v", err)
+	}
+	// token returned from the /token endpoint
+	token := &Token{
+		Token: oauth2.Token{
+			AccessToken:  jwtSrt,
+			Expiry:       time.Now().Add(5 * time.Minute), // expires in the future
+			RefreshToken: jwtSrt,
+		},
+		IDToken: jwtSrt,
+	}
+
+	realmURL := "http://" + addr + "/realms/testing"
+	return fakeOIDCResponses{
+		user: `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				"email_verified": true,
+				"groups": [
+					"admingroup"
+				],
+				"full_group_path": [
+					"/admingroup"
+				],
+				"roles": [
+					"adminrole"
+				]
+      }`,
+		config: providerJSON{
+			Issuer:      realmURL,
+			UserInfoURL: realmURL + "/user",
+			JWKSURL:     realmURL + "/.well-known/jwks.json",
+			AuthURL:     realmURL + "/auth",
+			TokenURL:    realmURL + "/token",
+		},
+		token: token,
+		jwks: jsonWebKeySet{
+			Keys: []jsonWebKey{
+				{
+					Kty: "RSA",
+					Kid: "example-key-id",
+					Use: "sig",
+					Alg: "RS256",
+					N:   base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.N.Bytes()),
+					E:   base64.RawURLEncoding.EncodeToString(bigIntToBytes(privateKey.PublicKey.E)),
+				},
+			},
+		},
+		searchResults: []map[string]any{
+			{
+				"id":        "9f3f3bab-1c7f-4f1e-970c-6bd2db77684b",
+				"email":     "user@example.com",
+				"username":  "testing",
+				"enabled":   true,
+				"firstName": "Testing",
+				"lastName":  "User",
+			},
+		},
+	}
+}
+
+type jsonWebKeySet struct {
+	Keys []jsonWebKey `json:"keys"`
+}
+
+type jsonWebKey struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// Helper function to convert an integer exponent to its minimal big-endian byte representation.
+func bigIntToBytes(i int) []byte {
+	return big.NewInt(int64(i)).Bytes()
+}
+
+type providerJSON struct {
+	Issuer        string   `json:"issuer"`
+	AuthURL       string   `json:"authorization_endpoint"`
+	TokenURL      string   `json:"token_endpoint"`
+	DeviceAuthURL string   `json:"device_authorization_endpoint"`
+	JWKSURL       string   `json:"jwks_uri"`
+	UserInfoURL   string   `json:"userinfo_endpoint"`
+	Algorithms    []string `json:"id_token_signing_alg_values_supported"`
+}

--- a/pkg/auth/providers/mocks/tokenmanager.go
+++ b/pkg/auth/providers/mocks/tokenmanager.go
@@ -42,6 +42,20 @@ func (m *MocktokenManager) EXPECT() *MocktokenManagerMockRecorder {
 	return m.recorder
 }
 
+// CreateSecret mocks base method.
+func (m *MocktokenManager) CreateSecret(userID, provider, secret string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSecret", userID, provider, secret)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateSecret indicates an expected call of CreateSecret.
+func (mr *MocktokenManagerMockRecorder) CreateSecret(userID, provider, secret any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MocktokenManager)(nil).CreateSecret), userID, provider, secret)
+}
+
 // CreateTokenAndSetCookie mocks base method.
 func (m *MocktokenManager) CreateTokenAndSetCookie(userID string, userPrincipal v3.Principal, groupPrincipals []v3.Principal, providerToken string, ttl int, description string, request *types.APIContext) error {
 	m.ctrl.T.Helper()

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -49,6 +49,7 @@ const (
 type tokenManager interface {
 	UpdateSecret(userID, provider, secret string) error
 	CreateTokenAndSetCookie(userID string, userPrincipal apiv3.Principal, groupPrincipals []apiv3.Principal, providerToken string, ttl int, description string, request *types.APIContext) error
+	CreateSecret(userID, provider, secret string) error
 	GetSecret(userID string, provider string, fallbackTokens []accessor.TokenAccessor) (string, error)
 }
 
@@ -231,7 +232,6 @@ func GetOIDCRedirectionURL(config map[string]any, pkceVerifier string, values ur
 	values.Add("client_id", config["clientId"].(string))
 	values.Add("response_type", "code")
 
-	logrus.Debug("Checking for PKCE")
 	if pkceMethod, ok := config[client.GenericOIDCConfigFieldPKCEMethod]; ok {
 		if pkceVerifier != "" {
 			switch pkceMethod {
@@ -408,12 +408,6 @@ func (o *OpenIDCProvider) GetOIDCConfig() (*apiv3.OIDCConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode OidcConfig: %w", err)
 	}
-	if storedOidcConfig.PKCEMethod != "" {
-		logrus.Debugf("GetOIDCConfig PKCE Enabled for %s", o.Name)
-	} else {
-		logrus.Debugf("GetOIDCConfig PKCE IS NOT Enabled %s", o.Name)
-	}
-
 	if storedOidcConfig.PrivateKey != "" {
 		value, err := common.ReadFromSecret(o.Secrets, storedOidcConfig.PrivateKey, strings.ToLower(client.OIDCConfigFieldPrivateKey))
 		if err != nil {

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -895,8 +896,7 @@ type Token struct {
 func newOIDCResponses(privateKey *rsa.PrivateKey, port string) oidcResponses {
 	jwtToken := jwt.New(jwt.SigningMethodRS256)
 	jwtToken.Claims = jwt.RegisteredClaims{
-		Audience: []string{"test"},
-		// has expired
+		Audience:  []string{"test"},
 		ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		Issuer:    "http://localhost:" + port,
 	}
@@ -979,14 +979,9 @@ type jsonWebKey struct {
 	E   string `json:"e"`
 }
 
-// Helper function to convert a big.Int (exponent) to []byte
+// Helper function to convert an integer exponent to its minimal big-endian byte representation.
 func bigIntToBytes(i int) []byte {
-	var b [4]byte
-	b[0] = byte(i >> 24)
-	b[1] = byte(i >> 16)
-	b[2] = byte(i >> 8)
-	b[3] = byte(i)
-	return b[:]
+	return big.NewInt(int64(i)).Bytes()
 }
 
 type providerJSON struct {

--- a/pkg/client/generated/management/v3/zz_generated_cognito_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_cognito_config.go
@@ -1,78 +1,80 @@
 package client
 
 const (
-	CognitoConfigType                     = "cognitoConfig"
-	CognitoConfigFieldAccessMode          = "accessMode"
-	CognitoConfigFieldAcrValue            = "acrValue"
-	CognitoConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
-	CognitoConfigFieldAnnotations         = "annotations"
-	CognitoConfigFieldAuthEndpoint        = "authEndpoint"
-	CognitoConfigFieldCertificate         = "certificate"
-	CognitoConfigFieldClientID            = "clientId"
-	CognitoConfigFieldClientSecret        = "clientSecret"
-	CognitoConfigFieldCreated             = "created"
-	CognitoConfigFieldCreatorID           = "creatorId"
-	CognitoConfigFieldEmailClaim          = "emailClaim"
-	CognitoConfigFieldEnabled             = "enabled"
-	CognitoConfigFieldEndSessionEndpoint  = "endSessionEndpoint"
-	CognitoConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
-	CognitoConfigFieldGroupsClaim         = "groupsClaim"
-	CognitoConfigFieldIssuer              = "issuer"
-	CognitoConfigFieldJWKSUrl             = "jwksUrl"
-	CognitoConfigFieldLabels              = "labels"
-	CognitoConfigFieldLogoutAllEnabled    = "logoutAllEnabled"
-	CognitoConfigFieldLogoutAllForced     = "logoutAllForced"
-	CognitoConfigFieldLogoutAllSupported  = "logoutAllSupported"
-	CognitoConfigFieldName                = "name"
-	CognitoConfigFieldNameClaim           = "nameClaim"
-	CognitoConfigFieldOwnerReferences     = "ownerReferences"
-	CognitoConfigFieldPKCEMethod          = "pkceMethod"
-	CognitoConfigFieldPrivateKey          = "privateKey"
-	CognitoConfigFieldRancherAPIHost      = "rancherApiHost"
-	CognitoConfigFieldRancherURL          = "rancherUrl"
-	CognitoConfigFieldRemoved             = "removed"
-	CognitoConfigFieldScopes              = "scope"
-	CognitoConfigFieldStatus              = "status"
-	CognitoConfigFieldTokenEndpoint       = "tokenEndpoint"
-	CognitoConfigFieldType                = "type"
-	CognitoConfigFieldUUID                = "uuid"
-	CognitoConfigFieldUserInfoEndpoint    = "userInfoEndpoint"
+	CognitoConfigType                           = "cognitoConfig"
+	CognitoConfigFieldAccessMode                = "accessMode"
+	CognitoConfigFieldAcrValue                  = "acrValue"
+	CognitoConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
+	CognitoConfigFieldAnnotations               = "annotations"
+	CognitoConfigFieldAuthEndpoint              = "authEndpoint"
+	CognitoConfigFieldCertificate               = "certificate"
+	CognitoConfigFieldClientAuthenticatedSearch = "clientAuthenticatedSearch"
+	CognitoConfigFieldClientID                  = "clientId"
+	CognitoConfigFieldClientSecret              = "clientSecret"
+	CognitoConfigFieldCreated                   = "created"
+	CognitoConfigFieldCreatorID                 = "creatorId"
+	CognitoConfigFieldEmailClaim                = "emailClaim"
+	CognitoConfigFieldEnabled                   = "enabled"
+	CognitoConfigFieldEndSessionEndpoint        = "endSessionEndpoint"
+	CognitoConfigFieldGroupSearchEnabled        = "groupSearchEnabled"
+	CognitoConfigFieldGroupsClaim               = "groupsClaim"
+	CognitoConfigFieldIssuer                    = "issuer"
+	CognitoConfigFieldJWKSUrl                   = "jwksUrl"
+	CognitoConfigFieldLabels                    = "labels"
+	CognitoConfigFieldLogoutAllEnabled          = "logoutAllEnabled"
+	CognitoConfigFieldLogoutAllForced           = "logoutAllForced"
+	CognitoConfigFieldLogoutAllSupported        = "logoutAllSupported"
+	CognitoConfigFieldName                      = "name"
+	CognitoConfigFieldNameClaim                 = "nameClaim"
+	CognitoConfigFieldOwnerReferences           = "ownerReferences"
+	CognitoConfigFieldPKCEMethod                = "pkceMethod"
+	CognitoConfigFieldPrivateKey                = "privateKey"
+	CognitoConfigFieldRancherAPIHost            = "rancherApiHost"
+	CognitoConfigFieldRancherURL                = "rancherUrl"
+	CognitoConfigFieldRemoved                   = "removed"
+	CognitoConfigFieldScopes                    = "scope"
+	CognitoConfigFieldStatus                    = "status"
+	CognitoConfigFieldTokenEndpoint             = "tokenEndpoint"
+	CognitoConfigFieldType                      = "type"
+	CognitoConfigFieldUUID                      = "uuid"
+	CognitoConfigFieldUserInfoEndpoint          = "userInfoEndpoint"
 )
 
 type CognitoConfig struct {
-	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
-	AcrValue            string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
-	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
-	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
-	Certificate         string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret        string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	EmailClaim          string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
-	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	EndSessionEndpoint  string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
-	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
-	GroupsClaim         string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
-	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
-	JWKSUrl             string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LogoutAllEnabled    bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
-	LogoutAllForced     bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
-	LogoutAllSupported  bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
-	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NameClaim           string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
-	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	PKCEMethod          string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
-	PrivateKey          string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
-	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
-	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
-	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Scopes              string            `json:"scope,omitempty" yaml:"scope,omitempty"`
-	Status              *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
-	TokenEndpoint       string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
-	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
-	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	UserInfoEndpoint    string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
+	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Certificate               string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	ClientAuthenticatedSearch bool              `json:"clientAuthenticatedSearch,omitempty" yaml:"clientAuthenticatedSearch,omitempty"`
+	ClientID                  string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret              string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	Created                   string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID                 string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	EmailClaim                string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
+	Enabled                   bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EndSessionEndpoint        string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
+	GroupSearchEnabled        *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
+	GroupsClaim               string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
+	Issuer                    string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	JWKSUrl                   string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LogoutAllEnabled          bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
+	LogoutAllForced           bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
+	LogoutAllSupported        bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
+	Name                      string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NameClaim                 string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
+	OwnerReferences           []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PKCEMethod                string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
+	PrivateKey                string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
+	RancherAPIHost            string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
+	RancherURL                string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed                   string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Scopes                    string            `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Status                    *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	TokenEndpoint             string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
+	Type                      string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                      string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	UserInfoEndpoint          string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_generic_oidcconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_generic_oidcconfig.go
@@ -1,78 +1,80 @@
 package client
 
 const (
-	GenericOIDCConfigType                     = "genericOIDCConfig"
-	GenericOIDCConfigFieldAccessMode          = "accessMode"
-	GenericOIDCConfigFieldAcrValue            = "acrValue"
-	GenericOIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
-	GenericOIDCConfigFieldAnnotations         = "annotations"
-	GenericOIDCConfigFieldAuthEndpoint        = "authEndpoint"
-	GenericOIDCConfigFieldCertificate         = "certificate"
-	GenericOIDCConfigFieldClientID            = "clientId"
-	GenericOIDCConfigFieldClientSecret        = "clientSecret"
-	GenericOIDCConfigFieldCreated             = "created"
-	GenericOIDCConfigFieldCreatorID           = "creatorId"
-	GenericOIDCConfigFieldEmailClaim          = "emailClaim"
-	GenericOIDCConfigFieldEnabled             = "enabled"
-	GenericOIDCConfigFieldEndSessionEndpoint  = "endSessionEndpoint"
-	GenericOIDCConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
-	GenericOIDCConfigFieldGroupsClaim         = "groupsClaim"
-	GenericOIDCConfigFieldIssuer              = "issuer"
-	GenericOIDCConfigFieldJWKSUrl             = "jwksUrl"
-	GenericOIDCConfigFieldLabels              = "labels"
-	GenericOIDCConfigFieldLogoutAllEnabled    = "logoutAllEnabled"
-	GenericOIDCConfigFieldLogoutAllForced     = "logoutAllForced"
-	GenericOIDCConfigFieldLogoutAllSupported  = "logoutAllSupported"
-	GenericOIDCConfigFieldName                = "name"
-	GenericOIDCConfigFieldNameClaim           = "nameClaim"
-	GenericOIDCConfigFieldOwnerReferences     = "ownerReferences"
-	GenericOIDCConfigFieldPKCEMethod          = "pkceMethod"
-	GenericOIDCConfigFieldPrivateKey          = "privateKey"
-	GenericOIDCConfigFieldRancherAPIHost      = "rancherApiHost"
-	GenericOIDCConfigFieldRancherURL          = "rancherUrl"
-	GenericOIDCConfigFieldRemoved             = "removed"
-	GenericOIDCConfigFieldScopes              = "scope"
-	GenericOIDCConfigFieldStatus              = "status"
-	GenericOIDCConfigFieldTokenEndpoint       = "tokenEndpoint"
-	GenericOIDCConfigFieldType                = "type"
-	GenericOIDCConfigFieldUUID                = "uuid"
-	GenericOIDCConfigFieldUserInfoEndpoint    = "userInfoEndpoint"
+	GenericOIDCConfigType                           = "genericOIDCConfig"
+	GenericOIDCConfigFieldAccessMode                = "accessMode"
+	GenericOIDCConfigFieldAcrValue                  = "acrValue"
+	GenericOIDCConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
+	GenericOIDCConfigFieldAnnotations               = "annotations"
+	GenericOIDCConfigFieldAuthEndpoint              = "authEndpoint"
+	GenericOIDCConfigFieldCertificate               = "certificate"
+	GenericOIDCConfigFieldClientAuthenticatedSearch = "clientAuthenticatedSearch"
+	GenericOIDCConfigFieldClientID                  = "clientId"
+	GenericOIDCConfigFieldClientSecret              = "clientSecret"
+	GenericOIDCConfigFieldCreated                   = "created"
+	GenericOIDCConfigFieldCreatorID                 = "creatorId"
+	GenericOIDCConfigFieldEmailClaim                = "emailClaim"
+	GenericOIDCConfigFieldEnabled                   = "enabled"
+	GenericOIDCConfigFieldEndSessionEndpoint        = "endSessionEndpoint"
+	GenericOIDCConfigFieldGroupSearchEnabled        = "groupSearchEnabled"
+	GenericOIDCConfigFieldGroupsClaim               = "groupsClaim"
+	GenericOIDCConfigFieldIssuer                    = "issuer"
+	GenericOIDCConfigFieldJWKSUrl                   = "jwksUrl"
+	GenericOIDCConfigFieldLabels                    = "labels"
+	GenericOIDCConfigFieldLogoutAllEnabled          = "logoutAllEnabled"
+	GenericOIDCConfigFieldLogoutAllForced           = "logoutAllForced"
+	GenericOIDCConfigFieldLogoutAllSupported        = "logoutAllSupported"
+	GenericOIDCConfigFieldName                      = "name"
+	GenericOIDCConfigFieldNameClaim                 = "nameClaim"
+	GenericOIDCConfigFieldOwnerReferences           = "ownerReferences"
+	GenericOIDCConfigFieldPKCEMethod                = "pkceMethod"
+	GenericOIDCConfigFieldPrivateKey                = "privateKey"
+	GenericOIDCConfigFieldRancherAPIHost            = "rancherApiHost"
+	GenericOIDCConfigFieldRancherURL                = "rancherUrl"
+	GenericOIDCConfigFieldRemoved                   = "removed"
+	GenericOIDCConfigFieldScopes                    = "scope"
+	GenericOIDCConfigFieldStatus                    = "status"
+	GenericOIDCConfigFieldTokenEndpoint             = "tokenEndpoint"
+	GenericOIDCConfigFieldType                      = "type"
+	GenericOIDCConfigFieldUUID                      = "uuid"
+	GenericOIDCConfigFieldUserInfoEndpoint          = "userInfoEndpoint"
 )
 
 type GenericOIDCConfig struct {
-	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
-	AcrValue            string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
-	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
-	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
-	Certificate         string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret        string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	EmailClaim          string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
-	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	EndSessionEndpoint  string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
-	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
-	GroupsClaim         string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
-	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
-	JWKSUrl             string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LogoutAllEnabled    bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
-	LogoutAllForced     bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
-	LogoutAllSupported  bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
-	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NameClaim           string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
-	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	PKCEMethod          string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
-	PrivateKey          string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
-	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
-	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
-	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Scopes              string            `json:"scope,omitempty" yaml:"scope,omitempty"`
-	Status              *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
-	TokenEndpoint       string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
-	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
-	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	UserInfoEndpoint    string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
+	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Certificate               string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	ClientAuthenticatedSearch bool              `json:"clientAuthenticatedSearch,omitempty" yaml:"clientAuthenticatedSearch,omitempty"`
+	ClientID                  string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret              string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	Created                   string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID                 string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	EmailClaim                string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
+	Enabled                   bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EndSessionEndpoint        string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
+	GroupSearchEnabled        *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
+	GroupsClaim               string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
+	Issuer                    string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	JWKSUrl                   string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LogoutAllEnabled          bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
+	LogoutAllForced           bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
+	LogoutAllSupported        bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
+	Name                      string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NameClaim                 string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
+	OwnerReferences           []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PKCEMethod                string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
+	PrivateKey                string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
+	RancherAPIHost            string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
+	RancherURL                string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed                   string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Scopes                    string            `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Status                    *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	TokenEndpoint             string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
+	Type                      string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                      string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	UserInfoEndpoint          string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
@@ -1,78 +1,80 @@
 package client
 
 const (
-	KeyCloakOIDCConfigType                     = "keyCloakOIDCConfig"
-	KeyCloakOIDCConfigFieldAccessMode          = "accessMode"
-	KeyCloakOIDCConfigFieldAcrValue            = "acrValue"
-	KeyCloakOIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
-	KeyCloakOIDCConfigFieldAnnotations         = "annotations"
-	KeyCloakOIDCConfigFieldAuthEndpoint        = "authEndpoint"
-	KeyCloakOIDCConfigFieldCertificate         = "certificate"
-	KeyCloakOIDCConfigFieldClientID            = "clientId"
-	KeyCloakOIDCConfigFieldClientSecret        = "clientSecret"
-	KeyCloakOIDCConfigFieldCreated             = "created"
-	KeyCloakOIDCConfigFieldCreatorID           = "creatorId"
-	KeyCloakOIDCConfigFieldEmailClaim          = "emailClaim"
-	KeyCloakOIDCConfigFieldEnabled             = "enabled"
-	KeyCloakOIDCConfigFieldEndSessionEndpoint  = "endSessionEndpoint"
-	KeyCloakOIDCConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
-	KeyCloakOIDCConfigFieldGroupsClaim         = "groupsClaim"
-	KeyCloakOIDCConfigFieldIssuer              = "issuer"
-	KeyCloakOIDCConfigFieldJWKSUrl             = "jwksUrl"
-	KeyCloakOIDCConfigFieldLabels              = "labels"
-	KeyCloakOIDCConfigFieldLogoutAllEnabled    = "logoutAllEnabled"
-	KeyCloakOIDCConfigFieldLogoutAllForced     = "logoutAllForced"
-	KeyCloakOIDCConfigFieldLogoutAllSupported  = "logoutAllSupported"
-	KeyCloakOIDCConfigFieldName                = "name"
-	KeyCloakOIDCConfigFieldNameClaim           = "nameClaim"
-	KeyCloakOIDCConfigFieldOwnerReferences     = "ownerReferences"
-	KeyCloakOIDCConfigFieldPKCEMethod          = "pkceMethod"
-	KeyCloakOIDCConfigFieldPrivateKey          = "privateKey"
-	KeyCloakOIDCConfigFieldRancherAPIHost      = "rancherApiHost"
-	KeyCloakOIDCConfigFieldRancherURL          = "rancherUrl"
-	KeyCloakOIDCConfigFieldRemoved             = "removed"
-	KeyCloakOIDCConfigFieldScopes              = "scope"
-	KeyCloakOIDCConfigFieldStatus              = "status"
-	KeyCloakOIDCConfigFieldTokenEndpoint       = "tokenEndpoint"
-	KeyCloakOIDCConfigFieldType                = "type"
-	KeyCloakOIDCConfigFieldUUID                = "uuid"
-	KeyCloakOIDCConfigFieldUserInfoEndpoint    = "userInfoEndpoint"
+	KeyCloakOIDCConfigType                           = "keyCloakOIDCConfig"
+	KeyCloakOIDCConfigFieldAccessMode                = "accessMode"
+	KeyCloakOIDCConfigFieldAcrValue                  = "acrValue"
+	KeyCloakOIDCConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
+	KeyCloakOIDCConfigFieldAnnotations               = "annotations"
+	KeyCloakOIDCConfigFieldAuthEndpoint              = "authEndpoint"
+	KeyCloakOIDCConfigFieldCertificate               = "certificate"
+	KeyCloakOIDCConfigFieldClientAuthenticatedSearch = "clientAuthenticatedSearch"
+	KeyCloakOIDCConfigFieldClientID                  = "clientId"
+	KeyCloakOIDCConfigFieldClientSecret              = "clientSecret"
+	KeyCloakOIDCConfigFieldCreated                   = "created"
+	KeyCloakOIDCConfigFieldCreatorID                 = "creatorId"
+	KeyCloakOIDCConfigFieldEmailClaim                = "emailClaim"
+	KeyCloakOIDCConfigFieldEnabled                   = "enabled"
+	KeyCloakOIDCConfigFieldEndSessionEndpoint        = "endSessionEndpoint"
+	KeyCloakOIDCConfigFieldGroupSearchEnabled        = "groupSearchEnabled"
+	KeyCloakOIDCConfigFieldGroupsClaim               = "groupsClaim"
+	KeyCloakOIDCConfigFieldIssuer                    = "issuer"
+	KeyCloakOIDCConfigFieldJWKSUrl                   = "jwksUrl"
+	KeyCloakOIDCConfigFieldLabels                    = "labels"
+	KeyCloakOIDCConfigFieldLogoutAllEnabled          = "logoutAllEnabled"
+	KeyCloakOIDCConfigFieldLogoutAllForced           = "logoutAllForced"
+	KeyCloakOIDCConfigFieldLogoutAllSupported        = "logoutAllSupported"
+	KeyCloakOIDCConfigFieldName                      = "name"
+	KeyCloakOIDCConfigFieldNameClaim                 = "nameClaim"
+	KeyCloakOIDCConfigFieldOwnerReferences           = "ownerReferences"
+	KeyCloakOIDCConfigFieldPKCEMethod                = "pkceMethod"
+	KeyCloakOIDCConfigFieldPrivateKey                = "privateKey"
+	KeyCloakOIDCConfigFieldRancherAPIHost            = "rancherApiHost"
+	KeyCloakOIDCConfigFieldRancherURL                = "rancherUrl"
+	KeyCloakOIDCConfigFieldRemoved                   = "removed"
+	KeyCloakOIDCConfigFieldScopes                    = "scope"
+	KeyCloakOIDCConfigFieldStatus                    = "status"
+	KeyCloakOIDCConfigFieldTokenEndpoint             = "tokenEndpoint"
+	KeyCloakOIDCConfigFieldType                      = "type"
+	KeyCloakOIDCConfigFieldUUID                      = "uuid"
+	KeyCloakOIDCConfigFieldUserInfoEndpoint          = "userInfoEndpoint"
 )
 
 type KeyCloakOIDCConfig struct {
-	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
-	AcrValue            string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
-	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
-	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
-	Certificate         string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret        string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	EmailClaim          string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
-	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	EndSessionEndpoint  string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
-	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
-	GroupsClaim         string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
-	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
-	JWKSUrl             string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LogoutAllEnabled    bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
-	LogoutAllForced     bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
-	LogoutAllSupported  bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
-	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NameClaim           string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
-	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	PKCEMethod          string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
-	PrivateKey          string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
-	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
-	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
-	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Scopes              string            `json:"scope,omitempty" yaml:"scope,omitempty"`
-	Status              *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
-	TokenEndpoint       string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
-	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
-	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	UserInfoEndpoint    string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
+	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Certificate               string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	ClientAuthenticatedSearch bool              `json:"clientAuthenticatedSearch,omitempty" yaml:"clientAuthenticatedSearch,omitempty"`
+	ClientID                  string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret              string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	Created                   string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID                 string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	EmailClaim                string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
+	Enabled                   bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EndSessionEndpoint        string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
+	GroupSearchEnabled        *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
+	GroupsClaim               string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
+	Issuer                    string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	JWKSUrl                   string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LogoutAllEnabled          bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
+	LogoutAllForced           bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
+	LogoutAllSupported        bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
+	Name                      string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NameClaim                 string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
+	OwnerReferences           []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PKCEMethod                string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
+	PrivateKey                string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
+	RancherAPIHost            string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
+	RancherURL                string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed                   string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Scopes                    string            `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Status                    *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	TokenEndpoint             string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
+	Type                      string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                      string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	UserInfoEndpoint          string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_oidc_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_oidc_config.go
@@ -1,78 +1,80 @@
 package client
 
 const (
-	OIDCConfigType                     = "oidcConfig"
-	OIDCConfigFieldAccessMode          = "accessMode"
-	OIDCConfigFieldAcrValue            = "acrValue"
-	OIDCConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
-	OIDCConfigFieldAnnotations         = "annotations"
-	OIDCConfigFieldAuthEndpoint        = "authEndpoint"
-	OIDCConfigFieldCertificate         = "certificate"
-	OIDCConfigFieldClientID            = "clientId"
-	OIDCConfigFieldClientSecret        = "clientSecret"
-	OIDCConfigFieldCreated             = "created"
-	OIDCConfigFieldCreatorID           = "creatorId"
-	OIDCConfigFieldEmailClaim          = "emailClaim"
-	OIDCConfigFieldEnabled             = "enabled"
-	OIDCConfigFieldEndSessionEndpoint  = "endSessionEndpoint"
-	OIDCConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
-	OIDCConfigFieldGroupsClaim         = "groupsClaim"
-	OIDCConfigFieldIssuer              = "issuer"
-	OIDCConfigFieldJWKSUrl             = "jwksUrl"
-	OIDCConfigFieldLabels              = "labels"
-	OIDCConfigFieldLogoutAllEnabled    = "logoutAllEnabled"
-	OIDCConfigFieldLogoutAllForced     = "logoutAllForced"
-	OIDCConfigFieldLogoutAllSupported  = "logoutAllSupported"
-	OIDCConfigFieldName                = "name"
-	OIDCConfigFieldNameClaim           = "nameClaim"
-	OIDCConfigFieldOwnerReferences     = "ownerReferences"
-	OIDCConfigFieldPKCEMethod          = "pkceMethod"
-	OIDCConfigFieldPrivateKey          = "privateKey"
-	OIDCConfigFieldRancherAPIHost      = "rancherApiHost"
-	OIDCConfigFieldRancherURL          = "rancherUrl"
-	OIDCConfigFieldRemoved             = "removed"
-	OIDCConfigFieldScopes              = "scope"
-	OIDCConfigFieldStatus              = "status"
-	OIDCConfigFieldTokenEndpoint       = "tokenEndpoint"
-	OIDCConfigFieldType                = "type"
-	OIDCConfigFieldUUID                = "uuid"
-	OIDCConfigFieldUserInfoEndpoint    = "userInfoEndpoint"
+	OIDCConfigType                           = "oidcConfig"
+	OIDCConfigFieldAccessMode                = "accessMode"
+	OIDCConfigFieldAcrValue                  = "acrValue"
+	OIDCConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
+	OIDCConfigFieldAnnotations               = "annotations"
+	OIDCConfigFieldAuthEndpoint              = "authEndpoint"
+	OIDCConfigFieldCertificate               = "certificate"
+	OIDCConfigFieldClientAuthenticatedSearch = "clientAuthenticatedSearch"
+	OIDCConfigFieldClientID                  = "clientId"
+	OIDCConfigFieldClientSecret              = "clientSecret"
+	OIDCConfigFieldCreated                   = "created"
+	OIDCConfigFieldCreatorID                 = "creatorId"
+	OIDCConfigFieldEmailClaim                = "emailClaim"
+	OIDCConfigFieldEnabled                   = "enabled"
+	OIDCConfigFieldEndSessionEndpoint        = "endSessionEndpoint"
+	OIDCConfigFieldGroupSearchEnabled        = "groupSearchEnabled"
+	OIDCConfigFieldGroupsClaim               = "groupsClaim"
+	OIDCConfigFieldIssuer                    = "issuer"
+	OIDCConfigFieldJWKSUrl                   = "jwksUrl"
+	OIDCConfigFieldLabels                    = "labels"
+	OIDCConfigFieldLogoutAllEnabled          = "logoutAllEnabled"
+	OIDCConfigFieldLogoutAllForced           = "logoutAllForced"
+	OIDCConfigFieldLogoutAllSupported        = "logoutAllSupported"
+	OIDCConfigFieldName                      = "name"
+	OIDCConfigFieldNameClaim                 = "nameClaim"
+	OIDCConfigFieldOwnerReferences           = "ownerReferences"
+	OIDCConfigFieldPKCEMethod                = "pkceMethod"
+	OIDCConfigFieldPrivateKey                = "privateKey"
+	OIDCConfigFieldRancherAPIHost            = "rancherApiHost"
+	OIDCConfigFieldRancherURL                = "rancherUrl"
+	OIDCConfigFieldRemoved                   = "removed"
+	OIDCConfigFieldScopes                    = "scope"
+	OIDCConfigFieldStatus                    = "status"
+	OIDCConfigFieldTokenEndpoint             = "tokenEndpoint"
+	OIDCConfigFieldType                      = "type"
+	OIDCConfigFieldUUID                      = "uuid"
+	OIDCConfigFieldUserInfoEndpoint          = "userInfoEndpoint"
 )
 
 type OIDCConfig struct {
-	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
-	AcrValue            string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
-	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
-	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
-	Certificate         string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret        string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	EmailClaim          string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
-	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	EndSessionEndpoint  string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
-	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
-	GroupsClaim         string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
-	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
-	JWKSUrl             string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LogoutAllEnabled    bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
-	LogoutAllForced     bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
-	LogoutAllSupported  bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
-	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NameClaim           string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
-	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	PKCEMethod          string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
-	PrivateKey          string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
-	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
-	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
-	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Scopes              string            `json:"scope,omitempty" yaml:"scope,omitempty"`
-	Status              *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
-	TokenEndpoint       string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
-	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
-	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	UserInfoEndpoint    string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
+	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Certificate               string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	ClientAuthenticatedSearch bool              `json:"clientAuthenticatedSearch,omitempty" yaml:"clientAuthenticatedSearch,omitempty"`
+	ClientID                  string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret              string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	Created                   string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID                 string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	EmailClaim                string            `json:"emailClaim,omitempty" yaml:"emailClaim,omitempty"`
+	Enabled                   bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EndSessionEndpoint        string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
+	GroupSearchEnabled        *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
+	GroupsClaim               string            `json:"groupsClaim,omitempty" yaml:"groupsClaim,omitempty"`
+	Issuer                    string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	JWKSUrl                   string            `json:"jwksUrl,omitempty" yaml:"jwksUrl,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LogoutAllEnabled          bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
+	LogoutAllForced           bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
+	LogoutAllSupported        bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
+	Name                      string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NameClaim                 string            `json:"nameClaim,omitempty" yaml:"nameClaim,omitempty"`
+	OwnerReferences           []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PKCEMethod                string            `json:"pkceMethod,omitempty" yaml:"pkceMethod,omitempty"`
+	PrivateKey                string            `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
+	RancherAPIHost            string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
+	RancherURL                string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed                   string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Scopes                    string            `json:"scope,omitempty" yaml:"scope,omitempty"`
+	Status                    *AuthConfigStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	TokenEndpoint             string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
+	Type                      string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                      string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	UserInfoEndpoint          string            `json:"userInfoEndpoint,omitempty" yaml:"userInfoEndpoint,omitempty"`
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43765
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
When using Keycloak OIDC as an AuthProvider if a user doesn't have `view-users` permission (as a default role, or explicitly assigned) then the REST api fails with an authorization error when searching for users.

## Solution
This adds an additional field to the OIDC Configuration and the Keycloak client can use this to query the Keycloak API with the existing client credentials.

This means that users do not need to be able to search users.

**This will need a tweak to the UI to allow enabling the client search**
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Login to rancher with a Keycloak user without "view-users" permission (ensure it's not inherited).

Searching for users will return empty results and in the Rancher logs...

```
2026/03/13 09:41:30 [ERROR] [keycloak oidc] SearchPrincipals: problem searching keycloak: PermissionDenied 403: access denied
```
Set the `clientSearchEnabled` flag in the keycloakoidc authconfig to `true` and try again and it should search and find users.

Also, in debug mode the normal message about "attempting to refresh access token" will indicate that it's using the client credentials to create the token.

```
2026/03/13 09:37:50 [DEBUG] [keycloak oidc] RefeshAndUpdateToken: attempting to refresh access token from client credentials
```

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_