### PR TITLE
Only create user password namespace in mgmt cluster

### DIFF
--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -443,11 +443,13 @@ func getSQLCacheGCValues(wranglerContext *wrangler.Context) (time.Duration, int)
 }
 
 func (r *Rancher) Start(ctx context.Context) error {
-	// ensure namespace for storing local users password is created
-	if _, err := r.Wrangler.Core.Namespace().Create(&v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: pbkdf2.LocalUserPasswordsNamespace},
-	}); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+	if features.MCM.Enabled() {
+		// ensure namespace for storing local users password is created
+		if _, err := r.Wrangler.Core.Namespace().Create(&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: pbkdf2.LocalUserPasswordsNamespace},
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
 	}
 	if err := dashboardapi.Register(ctx, r.Wrangler); err != nil {
 		return err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54104
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The `cattle-local-user-passwords` namespace is created in the agent on startup but no local user passwords are stored in the agent.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This changes the setup to only create the local-users namespace for users when not running in the agent.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_