### PR TITLE
[v2.14] Bump kube-api-auth to v0.2.6

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -5,7 +5,7 @@ var (
 		AuthSystemImages AuthSystemImages
 	}{
 		AuthSystemImages: AuthSystemImages{
-			KubeAPIAuth: "rancher/kube-api-auth:v0.2.5",
+			KubeAPIAuth: "rancher/kube-api-auth:v0.2.6",
 		},
 	}
 )


### PR DESCRIPTION
Backport of #54146 