### PR TITLE
[2.15] better handle node-external-ip

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -394,15 +394,15 @@ func getMachineNetworkInfo(secrets corecontrollers.SecretCache, entry *planEntry
 	info.Entry = entry
 	if ips := entry.Metadata.Annotations[capr.InternalAddressAnnotation]; ips != "" {
 		for _, ip := range strings.Split(ips, ",") {
-			if ip != "" {
-				info.InternalAddresses = append(info.InternalAddresses, strings.TrimSpace(ip))
+			if ip = strings.TrimSpace(ip); ip != "" {
+				info.InternalAddresses = append(info.InternalAddresses, ip)
 			}
 		}
 	}
 	if ips := entry.Metadata.Annotations[capr.AddressAnnotation]; ips != "" {
 		for _, ip := range strings.Split(ips, ",") {
-			if ip != "" {
-				info.ExternalAddresses = append(info.ExternalAddresses, strings.TrimSpace(ip))
+			if ip = strings.TrimSpace(ip); ip != "" {
+				info.ExternalAddresses = append(info.ExternalAddresses, ip)
 			}
 		}
 	}
@@ -491,11 +491,11 @@ func updateConfigWithAddresses(config map[string]interface{}, info *machineNetwo
 	config["node-ip"] = nodeIPs
 
 	// If a cloud provider is configured, it will manage the external IP.
-	// If no cloud provider is set, assign node-external-ip if public IPs are available,
-	// and have not already been assigned to node-ip.
-	if convert.ToString(config["cloud-provider-name"]) == "" {
+	// If node-ip is not set, then do not set node-external-ip.
+	if convert.ToString(config["cloud-provider-name"]) == "" && len(nodeIPs) > 0 {
 		nodeExternalIPs := convert.ToStringSlice(config["node-external-ip"])
 		for _, ip := range info.ExternalAddresses {
+			// Assign node public IPs to node-external-ip if it has not already been assigned to node-ip.
 			if ip == "" || slices.Contains(nodeExternalIPs, ip) || slices.Contains(nodeIPs, ip) {
 				continue
 			}

--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -258,6 +258,72 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 			expectedNodeIPs:         []string{"10.0.0.5"},
 			expectedNodeExternalIPs: []string{"2001:db8::dead:beef"},
 		},
+		// Azure (and other drivers that only populate Driver.IPAddress with no PrivateIPAddress):
+		// node-ip and node-external-ip must both remain unset when there is no internal IP.
+		{
+			name: "Azure default config: only external IP, no internal IP - neither node-ip nor node-external-ip set",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{"20.1.2.3"},
+				DriverName:        management.Azuredriver,
+			},
+			expectedNodeIPs:         []string{},
+			expectedNodeExternalIPs: []string{},
+		},
+		// Other drivers without PrivateIPAddress (e.g. vSphere, Google) also hit the default
+		// case and must not have node-external-ip set when InternalAddresses is empty.
+		{
+			name: "Generic driver with only external IP and no internal IP - neither node-ip nor node-external-ip set",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{"10.0.0.5"},
+				DriverName:        "vsphere",
+			},
+			expectedNodeIPs:         []string{},
+			expectedNodeExternalIPs: []string{},
+		},
+		// When InternalAddresses is empty but an IPv6 address is present, nodeIPs is non-empty
+		// after the IPv6 append, so node-external-ip must still be set from ExternalAddresses.
+		{
+			name: "No internal IP but IPv6 address present: node-external-ip still set",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{},
+				ExternalAddresses: []string{"20.1.2.3"},
+				IPv6Address:       "2001:db8::1",
+				DriverName:        management.Azuredriver,
+			},
+			expectedNodeIPs:         []string{"2001:db8::1"},
+			expectedNodeExternalIPs: []string{"20.1.2.3"},
+		},
+		// When all external IPs are already present in node-ip (duplicates), node-external-ip
+		// must not be written to the config at all (new len(nodeExternalIPs)>0 guard).
+		{
+			name: "All external IPs are duplicates of node-ip: node-external-ip key not written",
+			initialConfig: map[string]interface{}{
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.5"},
+				ExternalAddresses: []string{"10.0.0.5"},
+			},
+			expectedNodeIPs:         []string{"10.0.0.5"},
+			expectedNodeExternalIPs: []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
- https://github.com/rancher/rancher/issues/54105 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Rancher generates and distributes a configuration file to each node in an RKE2 / K3s cluster to bootstrap the cluster.

For node-driver-based clusters, the `node-external-ip` and `node-ip` values in the configuration are derived from the node IP information that Rancher receives from rancher-machine.

Before Rancher v2.13, `node-external-ip` was set only when Rancher detected both an internal IP and an external IP, and those two addresses were different.

Starting with Rancher v2.13.0, Rancher added support for multiple internal and external IP addresses. However, when determining whether to set `node-external-ip`, the logic checks whether the external IP differs from the internal IP but does not verify that an internal IP is actually present.

As a result, if Rancher knows only a single external IP and no internal IP, it still sets `node-external-ip` in the generated configuration, which leads to the issue.


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This PR fixes the logic so that the `node-external-ip` is set only when Rancher detects both an internal IP and an external IP, and those two addresses are different.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The PR is tested in the local development setup. Following the same steps as in the issue, we now see that:

- The `node-external-ip` flag is NOT set in the node configuration anymore (`/etc/rancher/rke2/config.yaml.d/50-rancher.yaml`) 
- In control-plane-1, we can check the logs of pods in another node by running the `kubectl logs` command. 

The above applies to both RKE2 and K3s node-driver clusters.

### Automated Testing

This PR adds more cases to the unit test. 

## QA Testing Considerations
 
- The exact issue described in the issue should be fixed. 
- The  `node-external-ip` flag should not be set in Azure node-driver clusters. 
 

Existing / newly added automated tests that provide evidence there are no regressions:

N/A 