### PR TITLE
Add audit-loglevel to drop groups.

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 			Name:        "audit-level",
 			Value:       0,
 			EnvVar:      "AUDIT_LEVEL",
-			Usage:       "Audit log level: 0 - audit log event metadata, 1 - log metadata and headers, 2 - log event metadata, headers, and request body, 3 - log event metadata, headers, request body, and response body, 4 - includes all of 3 but without the user's groups",
+			Usage:       "Audit log level: 0 - audit log event metadata, 1 - log metadata and headers, 2 - log event metadata, headers, and request body, 3 - log event metadata, headers, request body, and response body",
 			Destination: &config.AuditLogLevel,
 		},
 		cli.BoolFlag{
@@ -146,6 +146,12 @@ func main() {
 			Usage:       "enable the rancher audit log system",
 			EnvVar:      "AUDIT_LOG_ENABLED",
 			Destination: &config.AuditLogEnabled,
+		},
+		cli.BoolFlag{
+			Name:        "audit-exclude-groups",
+			Usage:       "Indicates that user groups should not be logged in the auditing, this can reduce the bandwidth",
+			EnvVar:      "AUDIT_EXCLUDE_GROUPS",
+			Destination: &config.AuditLogExcludeGroups,
 		},
 		cli.StringFlag{
 			Name:        "profile-listen-address",

--- a/pkg/apis/auditlog.cattle.io/v1/audit_policy_types.go
+++ b/pkg/apis/auditlog.cattle.io/v1/audit_policy_types.go
@@ -90,28 +90,6 @@ const (
 	//     },
 	// }
 	LevelRequestResponse
-
-	// LevelRequestResponseNoGroups indicates that along with the default audit
-	// log metadata and headers, the request and response bodies will also be
-	// included. A LogVerbosity with LevelHeaders is the same as the following
-	// LogVerbosity:
-	//
-	// LogVerbosity {
-	//     Request: {
-	//         Headers: true
-	//         Body: true,
-	//     },
-	//     Response: {
-	//         Headers: true
-	//         Body: true,
-	//     },
-	// }
-	//
-	// But the request user's groups will not be logged out.
-	//
-	// External providers can result in large numbers of groups for a user which
-	// can bloat the logs.
-	LevelRequestResponseNoGroups
 )
 
 // LogVerbosity defines what is included in an audit log. Log metadata (including RequestURI, user info, etc) is always present.

--- a/pkg/auth/audit/middleware.go
+++ b/pkg/auth/audit/middleware.go
@@ -44,11 +44,8 @@ func GetAuditLoggerMiddleware(auditLog *LoggingHandler) func(next http.Handler) 
 
 			verbosityLevel := auditLog.ResolveVerbosity(req.RequestURI)
 
-			// keepGroups determines whether or not to log out the request
-			// user's groups.
-			keepGroups := auditLog.level < auditlogv1.LevelRequestResponseNoGroups
 			auditUser := user
-			if !keepGroups {
+			if auditLog.writer.ExcludeGroups {
 				auditUser.Group = nil
 			}
 			auditLogEntry := newLog(verbosityLevel, auditUser, req, wrappedRw, reqTimestamp, respTimestamp, rawReqBody, userName)

--- a/pkg/auth/audit/middleware_test.go
+++ b/pkg/auth/audit/middleware_test.go
@@ -55,12 +55,17 @@ func newSizedResponseHandler(size int, statusCode int) http.HandlerFunc {
 }
 
 // Helper function to setup audit writer with specific level (mirrors rancher.go setup)
-func newTestAuditWriter(level auditlogv1.Level) (*Writer, *bytes.Buffer) {
+func newTestAuditWriter(level auditlogv1.Level, opts ...func(*WriterOptions)) (*Writer, *bytes.Buffer) {
 	out := &bytes.Buffer{}
-	writer, err := NewWriter(out, WriterOptions{
+	options := WriterOptions{
 		DefaultPolicyLevel:     level,
 		DisableDefaultPolicies: false,
-	})
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	writer, err := NewWriter(out, options)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create audit writer: %v", err))
 	}
@@ -81,7 +86,6 @@ func TestMiddlewareBasicFunctionality(t *testing.T) {
 		{"LevelHeaders", auditlogv1.LevelHeaders},
 		{"LevelRequest", auditlogv1.LevelRequest},
 		{"LevelRequestResponse", auditlogv1.LevelRequestResponse},
-		{"LevelRequestResponseNoGroups", auditlogv1.LevelRequestResponseNoGroups},
 	}
 
 	for _, tt := range tests {
@@ -286,22 +290,46 @@ func TestMiddlewareStatusCodes(t *testing.T) {
 
 // TestMiddlewareGroups tests that request bodies are buffered at appropriate levels
 func TestMiddlewareGroupsLogging(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		name                   string
 		level                  auditlogv1.Level
 		method                 string
 		expectGroupsInAuditLog bool
+		options                []func(*WriterOptions)
 	}{
-		{"LevelNull_HasGroups", auditlogv1.LevelNull, http.MethodPost, true},
-		{"LevelHeaders_HasGroups", auditlogv1.LevelHeaders, http.MethodPost, true},
-		{"LevelRequest_HasGroups", auditlogv1.LevelRequest, http.MethodPost, true},
-		{"LevelRequestResponse_HasGroups", auditlogv1.LevelRequestResponse, http.MethodPost, true},
-		{"LevelRequestResponseNoGroups_HasGroups", auditlogv1.LevelRequestResponseNoGroups, http.MethodPost, false},
+
+		"LevelNull_HasGroups": {
+			level:                  auditlogv1.LevelNull,
+			method:                 http.MethodPost,
+			expectGroupsInAuditLog: true,
+		},
+		"LevelHeaders_HasGroups": {
+			level:                  auditlogv1.LevelHeaders,
+			method:                 http.MethodPost,
+			expectGroupsInAuditLog: true,
+		},
+		"LevelRequest_HasGroups": {
+			level:                  auditlogv1.LevelRequest,
+			method:                 http.MethodPost,
+			expectGroupsInAuditLog: true,
+		},
+		"LevelRequestResponse_HasGroups": {
+			level:                  auditlogv1.LevelRequestResponse,
+			method:                 http.MethodPost,
+			expectGroupsInAuditLog: true,
+		},
+		"LevelRequestResponse_WithNoGroups": {
+			level:  auditlogv1.LevelRequestResponse,
+			method: http.MethodPost,
+			options: []func(*WriterOptions){func(o *WriterOptions) {
+				o.ExcludeGroups = true
+			}},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer, auditOutput := newTestAuditWriter(tt.level)
+			writer, auditOutput := newTestAuditWriter(tt.level, tt.options...)
 			middleware := NewAuditLogMiddleware(writer)
 
 			requestBody := `{"cluster":"test"}`

--- a/pkg/auth/audit/utils.go
+++ b/pkg/auth/audit/utils.go
@@ -43,7 +43,7 @@ func verbosityForLevel(level auditlogv1.Level) auditlogv1.LogVerbosity {
 				Headers: true,
 			},
 		}
-	case auditlogv1.LevelRequestResponse, auditlogv1.LevelRequestResponseNoGroups:
+	case auditlogv1.LevelRequestResponse:
 		return auditlogv1.LogVerbosity{
 			Level: level,
 			Request: auditlogv1.Verbosity{

--- a/pkg/auth/audit/writer.go
+++ b/pkg/auth/audit/writer.go
@@ -92,6 +92,7 @@ type WriterOptions struct {
 	DefaultPolicyLevel auditlogv1.Level
 
 	DisableDefaultPolicies bool
+	ExcludeGroups          bool
 }
 
 type Writer struct {
@@ -119,7 +120,7 @@ func NewWriter(output io.Writer, opts WriterOptions) (*Writer, error) {
 		}
 	}
 
-	if opts.DefaultPolicyLevel > auditlogv1.LevelRequestResponse {
+	if opts.ExcludeGroups {
 		additionalPolicy := auditlogv1.AuditPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "drop-impersonation-groups",

--- a/pkg/auth/audit/writer_test.go
+++ b/pkg/auth/audit/writer_test.go
@@ -148,19 +148,20 @@ func TestNewWriterDropsImpersonateGroups(t *testing.T) {
 	tests := []struct {
 		name           string
 		level          auditlogv1.Level
+		excludeGroups  bool
 		expectPolicy   bool
 		expectedHeader []string
 	}{
 		{
 			name:           "no-groups-level",
-			level:          auditlogv1.LevelRequestResponseNoGroups,
+			level:          auditlogv1.LevelRequestResponse,
+			excludeGroups:  true,
 			expectPolicy:   true,
 			expectedHeader: []string{redacted},
 		},
 		{
 			name:           "request-response-level",
 			level:          auditlogv1.LevelRequestResponse,
-			expectPolicy:   false,
 			expectedHeader: []string{"keycloakoidc_group://testers", "keycloakoidc_group://developers"},
 		},
 	}
@@ -172,6 +173,7 @@ func TestNewWriterDropsImpersonateGroups(t *testing.T) {
 			w, err := NewWriter(lw, WriterOptions{
 				DefaultPolicyLevel:     tt.level,
 				DisableDefaultPolicies: true,
+				ExcludeGroups:          tt.excludeGroups,
 			})
 			assert.NoError(t, err)
 

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -106,6 +106,7 @@ type Options struct {
 	AuditLogMaxbackup              int
 	AuditLogLevel                  int
 	AuditLogEnabled                bool
+	AuditLogExcludeGroups          bool
 	Features                       string
 	ClusterRegistry                string
 	AggregationRegistrationTimeout time.Duration
@@ -343,6 +344,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		auditLogWriter, err = audit.NewWriter(out, audit.WriterOptions{
 			DefaultPolicyLevel:     auditlogv1.Level(opts.AuditLogLevel),
 			DisableDefaultPolicies: !opts.AuditLogEnabled,
+			ExcludeGroups:          opts.AuditLogExcludeGroups,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create audit log writer: %w", err)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/53603
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
The number of groups used for a request can be very large and these are normally logged out in every request.
 
## Solution

This change adds a way to ellide the groups from audit logging by setting an environment variable `AUDIT_EXCLUDE_GROUPS=true` or starting rancher with `--audit-exclude-groups`.

They are redacted from the request headers and not logged in the audit-log.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Connect to an auth-provider that supports groups, enable the audit-level at level 4 and the audit log entries should be redacted/hidden.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_