### PR TITLE
Prevent provisioning test workflow failure when artifacts are missing

### DIFF
--- a/.github/workflows/publish-provisioning-test-results.yaml
+++ b/.github/workflows/publish-provisioning-test-results.yaml
@@ -28,6 +28,9 @@ jobs:
         run: mkdir -p /tmp/test-results
 
       - name: Download All XML Test Reports
+        id: xml_reports
+        # don't error the entire job if the artifact is not there
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           run-id: ${{ github.event.workflow_run.id }}
@@ -38,6 +41,9 @@ jobs:
           name: "XML Results"
 
       - name: Download the Event File
+        id: event_file
+        continue-on-error: true
+        if: steps.xml_reports.outcome == 'success'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           run-id: ${{ github.event.workflow_run.id }}
@@ -47,8 +53,8 @@ jobs:
           name: "Event File"
 
       - name: Publish Test Results
+        if: steps.xml_reports.outcome == 'success' && steps.event_file.outcome == 'success'
         uses: rancher/publish-unit-test-result-action/linux@29a85161a9d18bf8cbf186abc523927ce71221b0
-        if: (!cancelled())
         with:
           check_name: Provisioning Tests Results
           commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Problem

This PR updates the `publish-provisioning-test-results` workflow to gracefully handle missing artifacts and prevent misleading job failures.

Currently, if a workflow run doesn't generate the expected XML test reports or event files, the `actions/download-artifact` step hard-fails the entire job. This creates a false-failure scenario where the job appears broken (red), even though the failure is simply due to an absence of test results to publish.

## Solution

* Added `continue-on-error: true` to the artifact download steps so the workflow survives a missing file.
* Assigned step IDs (`xml_reports`, `event_file`) to capture the download execution status.
* Added conditional logic (`if: steps.<id>.outcome == 'success'`) to ensure we only attempt to download the event file and run the `publish-unit-test-result-action` step if the prerequisite artifacts were actually found.

---

Sidenote: there will still be red steps but the entire job won't result in a failure (e.g. an email). Copilot said the only way to really check and see if an artifact exists and handle it is by using `gh` like this which is a little more yucky:

```yaml
- name: Download artifact gracefully via CLI
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    run: |
      # Attempt to download; if it fails, echo a message instead of failing the step
      if gh run download ${{ github.run_id }} -n "XML Results" ; then
        echo "Artifact downloaded successfully."
      else
        echo "Artifact not found, skipping."
      fi
```
