### PR TITLE
feat: add a deterministic check for last etcd node protection

### DIFF
--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/utils/ptr"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
@@ -539,7 +540,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	_, isEtcd := machine.Labels[capr.EtcdRoleLabel]
-	logrus.Debugf("[rkebootstrap] %s/%s: start machine=%s/%s isEtcd=%t machineDeleting=%t bootstrapDeleting=%t nodeRef=%t",
+	logrus.Tracef("[rkebootstrap] %s/%s: evaluating machine %s/%s for pre-terminate hook reconciliation (etcd=%t, machineDeleting=%t, bootstrapDeleting=%t, nodeRef=%t)",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 		isEtcd,
@@ -552,7 +553,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if (ok && strings.ToLower(forceRemove) == "true") || !isEtcd {
 		// This delete path only protects etcd membership. If this machine is not etcd, or the caller asked
 		// for force removal, we should not hold the machine behind the pre-terminate hook.
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook early isEtcd=%t forceRemove=%q",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because etcd protection does not apply (etcd=%t, forceRemove=%q)",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 			isEtcd,
@@ -564,7 +565,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	// Add the hook before delete starts. Later, when CAPI begins deleting the machine, delete will pause
 	// here and Rancher will get one last chance to do etcd-safe removal first.
 	if machine.DeletionTimestamp.IsZero() && bootstrap.DeletionTimestamp.IsZero() {
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s pre-delete ensure-hook",
+		logrus.Tracef("[rkebootstrap] %s/%s: ensuring pre-terminate hook on machine %s/%s before delete starts",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 		)
@@ -585,7 +586,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	// Start of safe removal validations
 
 	if bootstrap.Spec.ClusterName == "" {
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=empty-cluster-name",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because cluster name is empty",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 		)
@@ -596,7 +597,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, bootstrap.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=capi-cluster-missing",
+			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the CAPI cluster is missing",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 			)
@@ -607,7 +608,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !capiCluster.Spec.ControlPlaneRef.IsDefined() {
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=controlplane-ref-missing",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the control plane reference is missing",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 		)
@@ -618,7 +619,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	cp, err := h.rkeControlPlanes.Get(capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=rkecontrolplane-missing",
+			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the RKEControlPlane is missing",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 			)
@@ -631,7 +632,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if !cp.DeletionTimestamp.IsZero() || !capiCluster.DeletionTimestamp.IsZero() {
 		// If the whole control plane or whole cluster is being deleted, this machine is no longer being
 		// removed as a single etcd member change. In that case we should not keep this hook.
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=cluster-or-controlplane-deleting cpDeleting=%t clusterDeleting=%t",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the cluster or control plane is deleting (controlPlaneDeleting=%t, clusterDeleting=%t)",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 			!cp.DeletionTimestamp.IsZero(),
@@ -653,7 +654,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if err != nil {
 		return bootstrap, fmt.Errorf("error encountered list plansecrets to validate etcd safe removal: %v", err)
 	}
-	logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s delete-checks planSecret=%t planSecrets=%d",
+	logrus.Tracef("[rkebootstrap] %s/%s: loaded delete state for machine %s/%s (hasPlanSecret=%t, planSecrets=%d)",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 		planSecret != nil,
@@ -666,13 +667,11 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		// can break that replacement before it becomes stable.
 		joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
 		if joinedMachine, joined := machineStillJoinedToJoinURL(planSecrets, joinURL); joined {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s block reason=machine-still-joined joinedMachine=%s joinURL=%s",
+			logrus.Debugf("[rkebootstrap] %s/%s: waiting: deleting etcd machine %s/%s is still the join target for machine %s",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 				joinedMachine,
-				joinURL,
 			)
-			logrus.Errorf("[rkebootstrap] %s/%s: cluster %s/%s machine %s/%s was still joined to deleting etcd machine %s/%s", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name, bootstrap.Namespace, joinedMachine, machine.Namespace, machine.Name)
 			h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
 			return bootstrap, generic.ErrSkip
 		}
@@ -683,7 +682,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=downstream-kubeconfig-missing",
+			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the downstream kubeconfig secret is missing",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 			)
@@ -697,28 +696,20 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, err
 	}
 
-	downstream, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return bootstrap, err
-	}
 	// Before we remove the old member, wait for a real replacement. This is the main timing gate in this
 	// function: Rancher should not remove the old etcd member until another etcd machine has joined and
 	// proved it is stable enough to carry the cluster forward.
-	replacementReady, err := h.replacementEtcdMachineReady(bootstrap, machine, planSecrets, downstream)
+	replacementReady, err := h.replacementEtcdMachineReady(bootstrap, machine, planSecrets)
 	if err != nil {
 		return bootstrap, err
 	}
 	if !replacementReady {
-		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s block reason=replacement-not-ready",
-			bootstrap.Namespace, bootstrap.Name,
-			machine.Namespace, machine.Name,
-		)
-		logrus.Infof("[rkebootstrap] %s/%s: waiting to remove etcd machine %s/%s until another etcd machine has joined, passed plan probes, and reported a ready node",
+		logrus.Debugf("[rkebootstrap] %s/%s: waiting: deleting etcd machine %s/%s does not yet have a replacement machine with NodeReady=True and passed plan probes",
 			bootstrap.Namespace, bootstrap.Name, machine.Namespace, machine.Name)
 		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
 		return bootstrap, generic.ErrSkip
 	}
-	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s replacement-ready",
+	logrus.Debugf("[rkebootstrap] %s/%s: deleting etcd machine %s/%s has a replacement machine ready for safe removal",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 	)
@@ -726,10 +717,6 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if !machine.Status.NodeRef.IsDefined() {
 		// At this point, a missing NodeRef means there is no downstream Node object left for Rancher to mark
 		// for safe removal. There is nothing more this hook can do, so release it.
-		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=node-ref-missing-after-replacement-ready",
-			bootstrap.Namespace, bootstrap.Name,
-			machine.Namespace, machine.Name,
-		)
 		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -741,7 +728,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if err != nil {
 		return bootstrap, err
 	}
-	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s safe-remove-result removed=%t node=%s",
+	logrus.Debugf("[rkebootstrap] %s/%s: safe remove for machine %s/%s returned %t for node %s",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 		removed,
@@ -776,9 +763,9 @@ func (h *handler) ensureMachinePreTerminateAnnotationRemoved(bootstrap *rkev1.RK
 // * etcd role label: only another etcd machine can replace this member
 // * join URL: the machine has progressed far enough in bootstrap to act as a join target
 // * plan probes passed: Rancher has seen the current plan become healthy at least once
-// * ready downstream node: kubelet has registered the machine and the node is usable
+// * machine node ready: the CAPI machine controller has already mirrored node readiness onto the local machine object
 // * not deleting: the replacement is still expected to stay in the cluster
-func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, deletingMachine *capi.Machine, planSecrets []*corev1.Secret, downstream kubernetes.Interface) (bool, error) {
+func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, deletingMachine *capi.Machine, planSecrets []*corev1.Secret) (bool, error) {
 	if deletingMachine == nil {
 		return false, nil
 	}
@@ -792,7 +779,7 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 		// We need a real machine behind the plan secret, otherwise this secret is not enough to trust.
 		machineName := ps.GetLabels()[capr.MachineNameLabel]
 		if machineName == "" {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate skip reason=machine-name-missing", bootstrap.Namespace, bootstrap.Name)
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate skipped because the machine name label is missing", bootstrap.Namespace, bootstrap.Name)
 			continue
 		}
 		machineNamespace := ps.GetLabels()[capr.MachineNamespaceLabel]
@@ -800,20 +787,20 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 			machineNamespace = bootstrap.Namespace
 		}
 		if machineName == deletingMachine.Name && machineNamespace == deletingMachine.Namespace {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=same-machine", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because it is the deleting machine", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			continue
 		}
 
 		// The join URL appears after bootstrap has advanced enough for this machine to act as a join target.
 		// Before that point, Rancher should still treat the replacement as too early.
 		if ps.GetAnnotations()[capr.JoinURLAnnotation] == "" {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=join-url-empty", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because join URL is not set", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			continue
 		}
 		// This tells us Rancher has already seen the current plan become healthy at least once. That makes
 		// it a better late-bootstrap signal than just "the machine object exists".
 		if ps.GetAnnotations()[capr.PlanProbesPassedAnnotation] == "" {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=plan-probes-not-passed joinURL=%s",
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because plan probes have not passed yet (joinURL=%s)",
 				bootstrap.Namespace, bootstrap.Name,
 				machineNamespace, machineName,
 				ps.GetAnnotations()[capr.JoinURLAnnotation],
@@ -824,81 +811,30 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 		machine, err := h.machineCache.Get(machineNamespace, machineName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=machine-not-found", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+				logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because the machine object was not found", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 				continue
 			}
 			return false, err
 		}
 
-		// Node readiness is one of the last signals in this flow. We wait for it because machine objects,
-		// plan secrets, and join metadata all show up earlier than a fully usable downstream node.
-		ready, err := machineHasReadyNode(context.Background(), downstream, machine)
-		if err != nil {
-			return false, err
-		}
-		logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s check deleting=%t ready=%t nodeRef=%t",
+		// The machine controller mirrors node readiness onto the local machine object, so we can
+		// validate replacement readiness without querying the downstream cluster directly.
+		nodeReady := conditions.IsTrue(machine, capi.MachineNodeReadyCondition)
+		logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s evaluated with deleting=%t, nodeReady=%t, phase=%s, nodeRef=%t",
 			bootstrap.Namespace, bootstrap.Name,
 			machineNamespace, machineName,
 			!machine.DeletionTimestamp.IsZero(),
-			ready,
+			nodeReady,
+			machine.Status.Phase,
 			machine.Status.NodeRef.IsDefined(),
 		)
-		if machine.DeletionTimestamp.IsZero() && ready {
-			logrus.Infof("[rkebootstrap] %s/%s: candidate=%s/%s selected replacement", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+		if machine.DeletionTimestamp.IsZero() && machine.Status.NodeRef.IsDefined() && nodeReady {
+			logrus.Debugf("[rkebootstrap] %s/%s: replacement candidate %s/%s is ready", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			return true, nil
 		}
 	}
 
 	return false, nil
-}
-
-func machineHasReadyNode(ctx context.Context, downstream kubernetes.Interface, machine *capi.Machine) (bool, error) {
-	if downstream == nil || machine == nil {
-		return false, nil
-	}
-
-	if machine.Status.NodeRef.IsDefined() {
-		node, err := downstream.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
-		if err == nil {
-			return nodeReady(node), nil
-		}
-		if !apierrors.IsNotFound(err) {
-			return false, err
-		}
-	}
-
-	if machine.UID == "" {
-		return false, nil
-	}
-
-	nodes, err := downstream.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set{capr.MachineUIDLabel: string(machine.UID)}.String(),
-	})
-	if err != nil {
-		return false, err
-	}
-
-	for i := range nodes.Items {
-		if nodeReady(&nodes.Items[i]) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func nodeReady(node *corev1.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
 }
 
 func machineStillJoinedToJoinURL(planSecrets []*corev1.Secret, joinURL string) (string, bool) {

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -46,7 +46,6 @@ const (
 	rkeBootstrapName                       = "rke.cattle.io/rkebootstrap-name"
 	capiMachinePreTerminateAnnotation      = "pre-terminate.delete.hook.machine.cluster.x-k8s.io/rke-bootstrap-cleanup"
 	capiMachinePreTerminateAnnotationOwner = "rke-bootstrap-controller"
-	electionBackoff                        = 20 * time.Second
 )
 
 type handler struct {
@@ -510,40 +509,65 @@ func (h *handler) OnRemove(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEB
 	return h.reconcileMachinePreTerminateAnnotation(bootstrap)
 }
 
-// reconcileMachinePreTerminateAnnotation reconciles the machine object that owns the bootstrap. It only reconciles the machine if it is an
-// etcd machine. Its primary purpose is to manage the pre-terminate.delete.hook.machine.x-k8s.io annotation on the machine
-// object, which is used to prevent premature tear down of infrastructure before it is ready to be teared down, i.e.
-// allowing removal of an etcd member without causing quorum loss.
-// The pre-terminate hook will be set on the machine object if the machine and bootstrap are not deleting, the corresponding
-// CAPI cluster and RKEControlPlane are not deleting, and the force remove annotation is not set on the bootstrap.
-// The annotation will be removed from the machine to allow infrastructure cleanup in the following cases:
-// * The machine is deleting and the "safe remove" logic has fired and removed the etcd member from the etcd cluster
-// * The bootstrap is missing the CAPI cluster label || the CAPI cluster controlPlaneRef is nil || the machine noderef is nil
-// * Any of the following: CAPI kubeconfig secret, CAPI cluster object, RKEControlPlane object are not found
+// reconcileMachinePreTerminateAnnotation reconciles the machine object that owns the bootstrap.
+// Its primary purpose is to manage the pre-terminate.delete.hook.machine.x-k8s.io annotation on
+// etcd machines. That hook is used to stop CAPI from tearing down the backing infrastructure
+// before Rancher has safely removed the etcd member.
 //
-// Notably, CAPI controllers do not trigger a deletion of the RKEBootstrap object if a pre-terminate annotation exists on the corresponding machine object.
-// This means we rely on the OnChange handler to perform node safe removal, when it sees that the corresponding machine is deleting.
+// The hook is normally added before delete starts. Once the machine is deleting, Rancher keeps
+// the hook in place until it is safe to let delete continue.
+//
+// The hook is removed to allow infrastructure cleanup in the following cases:
+//   - force remove is requested, or the machine is not an etcd machine
+//   - the cluster/control plane objects needed for safe removal are missing or already deleting
+//   - Rancher has confirmed no machine is still joined to the deleting machine, a replacement etcd
+//     machine is ready, and the old etcd member has been safely removed
+//   - the deleting machine no longer has a downstream NodeRef after replacement readiness has already
+//     been confirmed
+//
+// Notably, CAPI controllers do not trigger deletion of the RKEBootstrap object while the
+// corresponding machine still has the pre-terminate hook. Because of that, Rancher relies on
+// this reconciliation path to perform safe etcd removal and decide when the hook can be removed.
 func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
 	machine, err := capr.GetMachineByOwner(h.machineCache, bootstrap)
 	if err != nil {
 		if errors.Is(err, capr.ErrNoMachineOwnerRef) || apierrors.IsNotFound(err) {
-			// If we did not find the machine by owner ref or the cache returned a not found, then noop.
+			// If the bootstrap no longer has an owning machine, there is nothing left to manage here.
 			return bootstrap, nil
 		}
 		return bootstrap, err
 	}
 
 	_, isEtcd := machine.Labels[capr.EtcdRoleLabel]
+	logrus.Debugf("[rkebootstrap] %s/%s: start machine=%s/%s isEtcd=%t machineDeleting=%t bootstrapDeleting=%t nodeRef=%t",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+		isEtcd,
+		!machine.DeletionTimestamp.IsZero(),
+		!bootstrap.DeletionTimestamp.IsZero(),
+		machine.Status.NodeRef.IsDefined(),
+	)
 
 	forceRemove, ok := bootstrap.Annotations[capr.ForceRemoveEtcdAnnotation]
 	if (ok && strings.ToLower(forceRemove) == "true") || !isEtcd {
-		// If the force remove annotation is "true" or the node is not an etcd node, then ensure the machine pre terminate annotation is removed.
+		// This delete path only protects etcd membership. If this machine is not etcd, or the caller asked
+		// for force removal, we should not hold the machine behind the pre-terminate hook.
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook early isEtcd=%t forceRemove=%q",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+			isEtcd,
+			forceRemove,
+		)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	// Only add the pre-terminate hook annotation if the corresponding machine and bootstrap are NOT deleting
+	// Add the hook before delete starts. Later, when CAPI begins deleting the machine, delete will pause
+	// here and Rancher will get one last chance to do etcd-safe removal first.
 	if machine.DeletionTimestamp.IsZero() && bootstrap.DeletionTimestamp.IsZero() {
-		// annotate the CAPI machine with the pre-terminate.delete.hook.machine.cluster.x-k8s.io annotation if it is an etcd machine
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s pre-delete ensure-hook",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
 		if val, ok := machine.GetAnnotations()[capiMachinePreTerminateAnnotation]; !ok || val != capiMachinePreTerminateAnnotationOwner {
 			machine = machine.DeepCopy()
 			if machine.Annotations == nil {
@@ -558,7 +582,13 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, nil
 	}
 
+	// Start of safe removal validations
+
 	if bootstrap.Spec.ClusterName == "" {
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=empty-cluster-name",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
 		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster label %s was not found in bootstrap labels, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capi.ClusterNameLabel)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -566,6 +596,10 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, bootstrap.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=capi-cluster-missing",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+			)
 			logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, bootstrap.Namespace, bootstrap.Spec.ClusterName)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
@@ -573,6 +607,10 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !capiCluster.Spec.ControlPlaneRef.IsDefined() {
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=controlplane-ref-missing",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
 		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s controlplane object reference was nil, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -580,6 +618,10 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	cp, err := h.rkeControlPlanes.Get(capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=rkecontrolplane-missing",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+			)
 			logrus.Warnf("[rkebootstrap] %s/%s: RKEControlPlane %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
@@ -587,53 +629,64 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !cp.DeletionTimestamp.IsZero() || !capiCluster.DeletionTimestamp.IsZero() {
+		// If the whole control plane or whole cluster is being deleted, this machine is no longer being
+		// removed as a single etcd member change. In that case we should not keep this hook.
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=cluster-or-controlplane-deleting cpDeleting=%t clusterDeleting=%t",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+			!cp.DeletionTimestamp.IsZero(),
+			!capiCluster.DeletionTimestamp.IsZero(),
+		)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	if !machine.Status.NodeRef.IsDefined() {
-		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+	// Read plan secrets now because they carry the most current join state. During rollout, another node
+	// may still be in bootstrap and still depend on this machine even if the higher-level objects already exist.
+	planSecret, err := h.secretCache.Get(bootstrap.Namespace, capr.PlanSecretFromBootstrapName(bootstrap.Name))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return bootstrap, fmt.Errorf("error retrieving plan secret to validate it was not an init node: %v", err)
 	}
 
-	// If the RKEControlPlane is not deleting, then make sure this node is not being used as an init node.
-	if cp.DeletionTimestamp.IsZero() {
-		planSecret, err := h.secretCache.Get(bootstrap.Namespace, capr.PlanSecretFromBootstrapName(bootstrap.Name))
-		if err != nil && !apierrors.IsNotFound(err) {
-			return bootstrap, fmt.Errorf("error retrieving plan secret to validate it was not an init node: %v", err)
+	planSecrets, err := h.secretCache.List(bootstrap.Namespace, labels.SelectorFromSet(map[string]string{
+		capi.ClusterNameLabel: bootstrap.Spec.ClusterName,
+	}))
+	if err != nil {
+		return bootstrap, fmt.Errorf("error encountered list plansecrets to validate etcd safe removal: %v", err)
+	}
+	logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s delete-checks planSecret=%t planSecrets=%d",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+		planSecret != nil,
+		len(planSecrets),
+	)
+
+	if planSecret != nil {
+		// Wait until no other machine still says it is joined to this one. This check matters early in the
+		// delete path: if a replacement machine is still joining through this node, deleting the node now
+		// can break that replacement before it becomes stable.
+		joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
+		if joinedMachine, joined := machineStillJoinedToJoinURL(planSecrets, joinURL); joined {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s block reason=machine-still-joined joinedMachine=%s joinURL=%s",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+				joinedMachine,
+				joinURL,
+			)
+			logrus.Errorf("[rkebootstrap] %s/%s: cluster %s/%s machine %s/%s was still joined to deleting etcd machine %s/%s", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name, bootstrap.Namespace, joinedMachine, machine.Namespace, machine.Name)
+			h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
+			return bootstrap, generic.ErrSkip
 		}
-
-		if planSecret != nil {
-			// validate that no other nodes are joined to this node, otherwise removing it will cause a bunch of nodes to start crashing.
-			joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
-			planSecrets, err := h.secretCache.List(bootstrap.Namespace, labels.SelectorFromSet(map[string]string{
-				capi.ClusterNameLabel: bootstrap.Spec.ClusterName,
-			}))
-			if err != nil {
-				return bootstrap, fmt.Errorf("error encountered list plansecrets to ensure node was not joined: %v", err)
-			}
-			for _, ps := range planSecrets {
-				if ps.GetAnnotations()[capr.JoinedToAnnotation] == joinURL {
-					logrus.Errorf("[rkebootstrap] %s/%s: cluster %s/%s machine %s/%s was still joined to deleting etcd machine %s/%s", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name, bootstrap.Namespace, ps.GetLabels()[capr.MachineNameLabel], machine.Namespace, machine.Name)
-					h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
-					return bootstrap, generic.ErrSkip
-				}
-			}
-		}
 	}
 
-	if wait, err := h.electionBackoffWait(bootstrap, machine); err != nil {
-		return bootstrap, err
-	} else if wait > 0 {
-		machineDeletionTime := machine.DeletionTimestamp.Time
-		logrus.Infof("[rkebootstrap] %s/%s: single-remaining etcd; deferring safe removal for %s (until %s) to avoid etcd election race",
-			bootstrap.Namespace, bootstrap.Name, wait.Round(time.Second), machineDeletionTime.Add(electionBackoff).Format(time.RFC3339))
-		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, wait)
-		return bootstrap, generic.ErrSkip
-	}
-
+	// Rancher removes the member by talking to the downstream cluster. If that kubeconfig is already gone,
+	// there is nothing left to check or update, so we must release the hook.
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=downstream-kubeconfig-missing",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+			)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
 		return bootstrap, err
@@ -644,10 +697,56 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, err
 	}
 
+	downstream, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return bootstrap, err
+	}
+	// Before we remove the old member, wait for a real replacement. This is the main timing gate in this
+	// function: Rancher should not remove the old etcd member until another etcd machine has joined and
+	// proved it is stable enough to carry the cluster forward.
+	replacementReady, err := h.replacementEtcdMachineReady(bootstrap, machine, planSecrets, downstream)
+	if err != nil {
+		return bootstrap, err
+	}
+	if !replacementReady {
+		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s block reason=replacement-not-ready",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
+		logrus.Infof("[rkebootstrap] %s/%s: waiting to remove etcd machine %s/%s until another etcd machine has joined, passed plan probes, and reported a ready node",
+			bootstrap.Namespace, bootstrap.Name, machine.Namespace, machine.Name)
+		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
+		return bootstrap, generic.ErrSkip
+	}
+	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s replacement-ready",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+	)
+
+	if !machine.Status.NodeRef.IsDefined() {
+		// At this point, a missing NodeRef means there is no downstream Node object left for Rancher to mark
+		// for safe removal. There is nothing more this hook can do, so release it.
+		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=node-ref-missing-after-replacement-ready",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
+		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
+		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+	}
+
+	// The actual etcd-member removal is async. Rancher first marks the downstream Node for removal, then
+	// waits for the downstream controller to confirm the member is gone. Only after that is it safe to let
+	// CAPI delete the backing infrastructure.
 	removed, err := etcdmgmt.SafelyRemoved(restConfig, capr.GetRuntimeCommand(cp.Spec.KubernetesVersion), machine.Status.NodeRef.Name)
 	if err != nil {
 		return bootstrap, err
 	}
+	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s safe-remove-result removed=%t node=%s",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+		removed,
+		machine.Status.NodeRef.Name,
+	)
 	if !removed {
 		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
 		return bootstrap, generic.ErrSkip
@@ -670,37 +769,152 @@ func (h *handler) ensureMachinePreTerminateAnnotationRemoved(bootstrap *rkev1.RK
 	return bootstrap, err
 }
 
-// electionBackoffWait returns how long to defer safe removal when there is
-// exactly one other etcd machine still present which leads to a risky window
-// for leader election. A zero duration means "no backoff".
-func (h *handler) electionBackoffWait(bootstrap *rkev1.RKEBootstrap, machine *capi.Machine) (time.Duration, error) {
-	// Only meaningful when this machine is deleting.
-	if machine == nil || machine.DeletionTimestamp.IsZero() {
-		return 0, nil
+// replacementEtcdMachineReady returns true only when Rancher can see a real replacement for the etcd
+// machine that is being deleted.
+//
+// Each check here matches a later point in the replacement machine lifecycle:
+// * etcd role label: only another etcd machine can replace this member
+// * join URL: the machine has progressed far enough in bootstrap to act as a join target
+// * plan probes passed: Rancher has seen the current plan become healthy at least once
+// * ready downstream node: kubelet has registered the machine and the node is usable
+// * not deleting: the replacement is still expected to stay in the cluster
+func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, deletingMachine *capi.Machine, planSecrets []*corev1.Secret, downstream kubernetes.Interface) (bool, error) {
+	if deletingMachine == nil {
+		return false, nil
 	}
 
-	// List all the etcd machines in the cluster
-	machines, err := h.machineCache.List(bootstrap.Namespace, labels.SelectorFromSet(labels.Set{
-		capi.ClusterNameLabel: bootstrap.Spec.ClusterName,
-		capr.EtcdRoleLabel:    "true",
-	}))
-	if err != nil {
-		return 0, err
-	}
-	if len(machines) != 2 { // Only care about the 2-node transition case.
-		return 0, nil
-	}
+	for _, ps := range planSecrets {
+		// The replacement must also carry the etcd role.
+		if ps.GetLabels()[capr.EtcdRoleLabel] != "true" {
+			continue
+		}
 
-	// Find the other etcd machine; if it’s not deleting, we back off.
-	for _, m := range machines {
-		if m.DeletionTimestamp.IsZero() && m.Name != machine.Name {
-			// Exactly one remaining etcd member; back off to let leadership settle.
-			since := time.Since(machine.DeletionTimestamp.Time)
-			if since < electionBackoff {
-				return electionBackoff - since, nil
+		// We need a real machine behind the plan secret, otherwise this secret is not enough to trust.
+		machineName := ps.GetLabels()[capr.MachineNameLabel]
+		if machineName == "" {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate skip reason=machine-name-missing", bootstrap.Namespace, bootstrap.Name)
+			continue
+		}
+		machineNamespace := ps.GetLabels()[capr.MachineNamespaceLabel]
+		if machineNamespace == "" {
+			machineNamespace = bootstrap.Namespace
+		}
+		if machineName == deletingMachine.Name && machineNamespace == deletingMachine.Namespace {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=same-machine", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+
+		// The join URL appears after bootstrap has advanced enough for this machine to act as a join target.
+		// Before that point, Rancher should still treat the replacement as too early.
+		if ps.GetAnnotations()[capr.JoinURLAnnotation] == "" {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=join-url-empty", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+		// This tells us Rancher has already seen the current plan become healthy at least once. That makes
+		// it a better late-bootstrap signal than just "the machine object exists".
+		if ps.GetAnnotations()[capr.PlanProbesPassedAnnotation] == "" {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=plan-probes-not-passed joinURL=%s",
+				bootstrap.Namespace, bootstrap.Name,
+				machineNamespace, machineName,
+				ps.GetAnnotations()[capr.JoinURLAnnotation],
+			)
+			continue
+		}
+
+		machine, err := h.machineCache.Get(machineNamespace, machineName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=machine-not-found", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+				continue
 			}
+			return false, err
+		}
+
+		// Node readiness is one of the last signals in this flow. We wait for it because machine objects,
+		// plan secrets, and join metadata all show up earlier than a fully usable downstream node.
+		ready, err := machineHasReadyNode(context.Background(), downstream, machine)
+		if err != nil {
+			return false, err
+		}
+		logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s check deleting=%t ready=%t nodeRef=%t",
+			bootstrap.Namespace, bootstrap.Name,
+			machineNamespace, machineName,
+			!machine.DeletionTimestamp.IsZero(),
+			ready,
+			machine.Status.NodeRef.IsDefined(),
+		)
+		if machine.DeletionTimestamp.IsZero() && ready {
+			logrus.Infof("[rkebootstrap] %s/%s: candidate=%s/%s selected replacement", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			return true, nil
 		}
 	}
 
-	return 0, nil
+	return false, nil
+}
+
+func machineHasReadyNode(ctx context.Context, downstream kubernetes.Interface, machine *capi.Machine) (bool, error) {
+	if downstream == nil || machine == nil {
+		return false, nil
+	}
+
+	if machine.Status.NodeRef.IsDefined() {
+		node, err := downstream.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
+		if err == nil {
+			return nodeReady(node), nil
+		}
+		if !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+
+	if machine.UID == "" {
+		return false, nil
+	}
+
+	nodes, err := downstream.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set{capr.MachineUIDLabel: string(machine.UID)}.String(),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for i := range nodes.Items {
+		if nodeReady(&nodes.Items[i]) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func nodeReady(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+func machineStillJoinedToJoinURL(planSecrets []*corev1.Secret, joinURL string) (string, bool) {
+	if joinURL == "" {
+		return "", false
+	}
+
+	for _, ps := range planSecrets {
+		joinedTo := ps.GetAnnotations()[capr.JoinedToAnnotation]
+		if joinedTo == "" {
+			continue
+		}
+		if joinedTo == joinURL {
+			return ps.GetLabels()[capr.MachineNameLabel], true
+		}
+	}
+
+	return "", false
 }

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/utils/ptr"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
@@ -583,7 +584,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	_, isEtcd := machine.Labels[capr.EtcdRoleLabel]
-	logrus.Debugf("[rkebootstrap] %s/%s: start machine=%s/%s isEtcd=%t machineDeleting=%t bootstrapDeleting=%t nodeRef=%t",
+	logrus.Tracef("[rkebootstrap] %s/%s: evaluating machine %s/%s for pre-terminate hook reconciliation (etcd=%t, machineDeleting=%t, bootstrapDeleting=%t, nodeRef=%t)",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 		isEtcd,
@@ -596,7 +597,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if (ok && strings.ToLower(forceRemove) == "true") || !isEtcd {
 		// This delete path only protects etcd membership. If this machine is not etcd, or the caller asked
 		// for force removal, we should not hold the machine behind the pre-terminate hook.
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook early isEtcd=%t forceRemove=%q",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because etcd protection does not apply (etcd=%t, forceRemove=%q)",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 			isEtcd,
@@ -608,7 +609,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	// Add the hook before delete starts. Later, when CAPI begins deleting the machine, delete will pause
 	// here and Rancher will get one last chance to do etcd-safe removal first.
 	if machine.DeletionTimestamp.IsZero() && bootstrap.DeletionTimestamp.IsZero() {
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s pre-delete ensure-hook",
+		logrus.Tracef("[rkebootstrap] %s/%s: ensuring pre-terminate hook on machine %s/%s before delete starts",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 		)
@@ -629,7 +630,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	// Start of safe removal validations
 
 	if bootstrap.Spec.ClusterName == "" {
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=empty-cluster-name",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because cluster name is empty",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 		)
@@ -640,7 +641,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, bootstrap.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=capi-cluster-missing",
+			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the CAPI cluster is missing",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 			)
@@ -651,7 +652,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !capiCluster.Spec.ControlPlaneRef.IsDefined() {
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=controlplane-ref-missing",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the control plane reference is missing",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 		)
@@ -662,7 +663,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	cp, err := h.rkeControlPlanes.Get(capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=rkecontrolplane-missing",
+			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the RKEControlPlane is missing",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 			)
@@ -675,7 +676,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if !cp.DeletionTimestamp.IsZero() || !capiCluster.DeletionTimestamp.IsZero() {
 		// If the whole control plane or whole cluster is being deleted, this machine is no longer being
 		// removed as a single etcd member change. In that case we should not keep this hook.
-		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=cluster-or-controlplane-deleting cpDeleting=%t clusterDeleting=%t",
+		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the cluster or control plane is deleting (controlPlaneDeleting=%t, clusterDeleting=%t)",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
 			!cp.DeletionTimestamp.IsZero(),
@@ -697,7 +698,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if err != nil {
 		return bootstrap, fmt.Errorf("error encountered list plansecrets to validate etcd safe removal: %v", err)
 	}
-	logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s delete-checks planSecret=%t planSecrets=%d",
+	logrus.Tracef("[rkebootstrap] %s/%s: loaded delete state for machine %s/%s (hasPlanSecret=%t, planSecrets=%d)",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 		planSecret != nil,
@@ -710,13 +711,11 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		// can break that replacement before it becomes stable.
 		joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
 		if joinedMachine, joined := machineStillJoinedToJoinURL(planSecrets, joinURL); joined {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s block reason=machine-still-joined joinedMachine=%s joinURL=%s",
+			logrus.Debugf("[rkebootstrap] %s/%s: waiting: deleting etcd machine %s/%s is still the join target for machine %s",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 				joinedMachine,
-				joinURL,
 			)
-			logrus.Errorf("[rkebootstrap] %s/%s: cluster %s/%s machine %s/%s was still joined to deleting etcd machine %s/%s", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name, bootstrap.Namespace, joinedMachine, machine.Namespace, machine.Name)
 			h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
 			return bootstrap, generic.ErrSkip
 		}
@@ -727,7 +726,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=downstream-kubeconfig-missing",
+			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the downstream kubeconfig secret is missing",
 				bootstrap.Namespace, bootstrap.Name,
 				machine.Namespace, machine.Name,
 			)
@@ -741,28 +740,20 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, err
 	}
 
-	downstream, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return bootstrap, err
-	}
 	// Before we remove the old member, wait for a real replacement. This is the main timing gate in this
 	// function: Rancher should not remove the old etcd member until another etcd machine has joined and
 	// proved it is stable enough to carry the cluster forward.
-	replacementReady, err := h.replacementEtcdMachineReady(bootstrap, machine, planSecrets, downstream)
+	replacementReady, err := h.replacementEtcdMachineReady(bootstrap, machine, planSecrets)
 	if err != nil {
 		return bootstrap, err
 	}
 	if !replacementReady {
-		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s block reason=replacement-not-ready",
-			bootstrap.Namespace, bootstrap.Name,
-			machine.Namespace, machine.Name,
-		)
-		logrus.Infof("[rkebootstrap] %s/%s: waiting to remove etcd machine %s/%s until another etcd machine has joined, passed plan probes, and reported a ready node",
+		logrus.Debugf("[rkebootstrap] %s/%s: waiting: deleting etcd machine %s/%s does not yet have a replacement machine with NodeReady=True and passed plan probes",
 			bootstrap.Namespace, bootstrap.Name, machine.Namespace, machine.Name)
 		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
 		return bootstrap, generic.ErrSkip
 	}
-	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s replacement-ready",
+	logrus.Debugf("[rkebootstrap] %s/%s: deleting etcd machine %s/%s has a replacement machine ready for safe removal",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 	)
@@ -770,10 +761,6 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if !machine.Status.NodeRef.IsDefined() {
 		// At this point, a missing NodeRef means there is no downstream Node object left for Rancher to mark
 		// for safe removal. There is nothing more this hook can do, so release it.
-		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=node-ref-missing-after-replacement-ready",
-			bootstrap.Namespace, bootstrap.Name,
-			machine.Namespace, machine.Name,
-		)
 		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -785,7 +772,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if err != nil {
 		return bootstrap, err
 	}
-	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s safe-remove-result removed=%t node=%s",
+	logrus.Debugf("[rkebootstrap] %s/%s: safe remove for machine %s/%s returned %t for node %s",
 		bootstrap.Namespace, bootstrap.Name,
 		machine.Namespace, machine.Name,
 		removed,
@@ -820,9 +807,9 @@ func (h *handler) ensureMachinePreTerminateAnnotationRemoved(bootstrap *rkev1.RK
 // * etcd role label: only another etcd machine can replace this member
 // * join URL: the machine has progressed far enough in bootstrap to act as a join target
 // * plan probes passed: Rancher has seen the current plan become healthy at least once
-// * ready downstream node: kubelet has registered the machine and the node is usable
+// * machine node ready: the CAPI machine controller has already mirrored node readiness onto the local machine object
 // * not deleting: the replacement is still expected to stay in the cluster
-func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, deletingMachine *capi.Machine, planSecrets []*corev1.Secret, downstream kubernetes.Interface) (bool, error) {
+func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, deletingMachine *capi.Machine, planSecrets []*corev1.Secret) (bool, error) {
 	if deletingMachine == nil {
 		return false, nil
 	}
@@ -836,7 +823,7 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 		// We need a real machine behind the plan secret, otherwise this secret is not enough to trust.
 		machineName := ps.GetLabels()[capr.MachineNameLabel]
 		if machineName == "" {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate skip reason=machine-name-missing", bootstrap.Namespace, bootstrap.Name)
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate skipped because the machine name label is missing", bootstrap.Namespace, bootstrap.Name)
 			continue
 		}
 		machineNamespace := ps.GetLabels()[capr.MachineNamespaceLabel]
@@ -844,20 +831,20 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 			machineNamespace = bootstrap.Namespace
 		}
 		if machineName == deletingMachine.Name && machineNamespace == deletingMachine.Namespace {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=same-machine", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because it is the deleting machine", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			continue
 		}
 
 		// The join URL appears after bootstrap has advanced enough for this machine to act as a join target.
 		// Before that point, Rancher should still treat the replacement as too early.
 		if ps.GetAnnotations()[capr.JoinURLAnnotation] == "" {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=join-url-empty", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because join URL is not set", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			continue
 		}
 		// This tells us Rancher has already seen the current plan become healthy at least once. That makes
 		// it a better late-bootstrap signal than just "the machine object exists".
 		if ps.GetAnnotations()[capr.PlanProbesPassedAnnotation] == "" {
-			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=plan-probes-not-passed joinURL=%s",
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because plan probes have not passed yet (joinURL=%s)",
 				bootstrap.Namespace, bootstrap.Name,
 				machineNamespace, machineName,
 				ps.GetAnnotations()[capr.JoinURLAnnotation],
@@ -868,81 +855,30 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 		machine, err := h.machineCache.Get(machineNamespace, machineName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=machine-not-found", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+				logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because the machine object was not found", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 				continue
 			}
 			return false, err
 		}
 
-		// Node readiness is one of the last signals in this flow. We wait for it because machine objects,
-		// plan secrets, and join metadata all show up earlier than a fully usable downstream node.
-		ready, err := machineHasReadyNode(context.Background(), downstream, machine)
-		if err != nil {
-			return false, err
-		}
-		logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s check deleting=%t ready=%t nodeRef=%t",
+		// The machine controller mirrors node readiness onto the local machine object, so we can
+		// validate replacement readiness without querying the downstream cluster directly.
+		nodeReady := conditions.IsTrue(machine, capi.MachineNodeReadyCondition)
+		logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s evaluated with deleting=%t, nodeReady=%t, phase=%s, nodeRef=%t",
 			bootstrap.Namespace, bootstrap.Name,
 			machineNamespace, machineName,
 			!machine.DeletionTimestamp.IsZero(),
-			ready,
+			nodeReady,
+			machine.Status.Phase,
 			machine.Status.NodeRef.IsDefined(),
 		)
-		if machine.DeletionTimestamp.IsZero() && ready {
-			logrus.Infof("[rkebootstrap] %s/%s: candidate=%s/%s selected replacement", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+		if machine.DeletionTimestamp.IsZero() && machine.Status.NodeRef.IsDefined() && nodeReady {
+			logrus.Debugf("[rkebootstrap] %s/%s: replacement candidate %s/%s is ready", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			return true, nil
 		}
 	}
 
 	return false, nil
-}
-
-func machineHasReadyNode(ctx context.Context, downstream kubernetes.Interface, machine *capi.Machine) (bool, error) {
-	if downstream == nil || machine == nil {
-		return false, nil
-	}
-
-	if machine.Status.NodeRef.IsDefined() {
-		node, err := downstream.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
-		if err == nil {
-			return nodeReady(node), nil
-		}
-		if !apierrors.IsNotFound(err) {
-			return false, err
-		}
-	}
-
-	if machine.UID == "" {
-		return false, nil
-	}
-
-	nodes, err := downstream.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set{capr.MachineUIDLabel: string(machine.UID)}.String(),
-	})
-	if err != nil {
-		return false, err
-	}
-
-	for i := range nodes.Items {
-		if nodeReady(&nodes.Items[i]) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func nodeReady(node *corev1.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
 }
 
 func machineStillJoinedToJoinURL(planSecrets []*corev1.Secret, joinURL string) (string, bool) {

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -18,6 +18,7 @@ import (
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta2"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/namespace"
+	planapi "github.com/rancher/rancher/pkg/plan"
 	planv1alpha1 "github.com/rancher/rancher/pkg/plan/api/plan.cattle.io/v1alpha1"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/rancher/pkg/tls"
@@ -554,30 +555,24 @@ func (h *handler) OnRemove(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEB
 	return h.reconcileMachinePreTerminateAnnotation(bootstrap)
 }
 
-// reconcileMachinePreTerminateAnnotation reconciles the machine object that owns the bootstrap.
-// Its primary purpose is to manage the pre-terminate.delete.hook.machine.x-k8s.io annotation on
-// etcd machines. That hook is used to stop CAPI from tearing down the backing infrastructure
-// before Rancher has safely removed the etcd member.
+// reconcileMachinePreTerminateAnnotation reconciles the machine object that owns the bootstrap. It only reconciles the machine if it is an
+// etcd machine. Its primary purpose is to manage the pre-terminate.delete.hook.machine.x-k8s.io annotation on the machine
+// object, which is used to prevent premature tear down of infrastructure before it is ready to be teared down, i.e.
+// allowing removal of an etcd member without causing quorum loss.
+// The pre-terminate hook will be set on the machine object if the machine and bootstrap are not deleting, the corresponding
+// CAPI cluster and RKEControlPlane are not deleting, and the force remove annotation is not set on the bootstrap.
+// The annotation will be removed from the machine to allow infrastructure cleanup in the following cases:
+// * The machine is deleting and the "safe remove" logic has fired and removed the etcd member from the etcd cluster
+// * The bootstrap is missing the CAPI cluster label || the CAPI cluster controlPlaneRef is nil || the machine noderef is nil
+// * Any of the following: CAPI kubeconfig secret, CAPI cluster object, RKEControlPlane object are not found
 //
-// The hook is normally added before delete starts. Once the machine is deleting, Rancher keeps
-// the hook in place until it is safe to let delete continue.
-//
-// The hook is removed to allow infrastructure cleanup in the following cases:
-//   - force remove is requested, or the machine is not an etcd machine
-//   - the cluster/control plane objects needed for safe removal are missing or already deleting
-//   - Rancher has confirmed no machine is still joined to the deleting machine, a replacement etcd
-//     machine is ready, and the old etcd member has been safely removed
-//   - the deleting machine no longer has a downstream NodeRef after replacement readiness has already
-//     been confirmed
-//
-// Notably, CAPI controllers do not trigger deletion of the RKEBootstrap object while the
-// corresponding machine still has the pre-terminate hook. Because of that, Rancher relies on
-// this reconciliation path to perform safe etcd removal and decide when the hook can be removed.
+// Notably, CAPI controllers do not trigger a deletion of the RKEBootstrap object if a pre-terminate annotation exists on the corresponding machine object.
+// This means we rely on the OnChange handler to perform node safe removal, when it sees that the corresponding machine is deleting.
 func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
 	machine, err := capr.GetMachineByOwner(h.machineCache, bootstrap)
 	if err != nil {
 		if errors.Is(err, capr.ErrNoMachineOwnerRef) || apierrors.IsNotFound(err) {
-			// If the bootstrap no longer has an owning machine, there is nothing left to manage here.
+			// If we did not find the machine by owner ref or the cache returned a not found, then noop.
 			return bootstrap, nil
 		}
 		return bootstrap, err
@@ -595,8 +590,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 
 	forceRemove, ok := bootstrap.Annotations[capr.ForceRemoveEtcdAnnotation]
 	if (ok && strings.ToLower(forceRemove) == "true") || !isEtcd {
-		// This delete path only protects etcd membership. If this machine is not etcd, or the caller asked
-		// for force removal, we should not hold the machine behind the pre-terminate hook.
+		// If the force remove annotation is "true" or the node is not an etcd node, then ensure the machine pre terminate annotation is removed.
 		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because etcd protection does not apply (etcd=%t, forceRemove=%q)",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
@@ -606,9 +600,9 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	// Add the hook before delete starts. Later, when CAPI begins deleting the machine, delete will pause
-	// here and Rancher will get one last chance to do etcd-safe removal first.
+	// Only add the pre-terminate hook annotation if the corresponding machine and bootstrap are NOT deleting
 	if machine.DeletionTimestamp.IsZero() && bootstrap.DeletionTimestamp.IsZero() {
+		// annotate the CAPI machine with the pre-terminate.delete.hook.machine.cluster.x-k8s.io annotation if it is an etcd machine
 		logrus.Tracef("[rkebootstrap] %s/%s: ensuring pre-terminate hook on machine %s/%s before delete starts",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
@@ -629,11 +623,14 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 
 	// Start of safe removal validations
 
+	// Safe removal requires the deleting machine's downstream node name. Without a NodeRef, there is no
+	// known downstream node to remove, so release the hook.
+	if !machine.Status.NodeRef.IsDefined() {
+		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
+		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+	}
+
 	if bootstrap.Spec.ClusterName == "" {
-		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because cluster name is empty",
-			bootstrap.Namespace, bootstrap.Name,
-			machine.Namespace, machine.Name,
-		)
 		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster label %s was not found in bootstrap labels, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capi.ClusterNameLabel)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -641,10 +638,6 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, bootstrap.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the CAPI cluster is missing",
-				bootstrap.Namespace, bootstrap.Name,
-				machine.Namespace, machine.Name,
-			)
 			logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, bootstrap.Namespace, bootstrap.Spec.ClusterName)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
@@ -652,10 +645,6 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !capiCluster.Spec.ControlPlaneRef.IsDefined() {
-		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the control plane reference is missing",
-			bootstrap.Namespace, bootstrap.Name,
-			machine.Namespace, machine.Name,
-		)
 		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s controlplane object reference was nil, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -663,10 +652,6 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	cp, err := h.rkeControlPlanes.Get(capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the RKEControlPlane is missing",
-				bootstrap.Namespace, bootstrap.Name,
-				machine.Namespace, machine.Name,
-			)
 			logrus.Warnf("[rkebootstrap] %s/%s: RKEControlPlane %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
@@ -674,8 +659,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !cp.DeletionTimestamp.IsZero() || !capiCluster.DeletionTimestamp.IsZero() {
-		// If the whole control plane or whole cluster is being deleted, this machine is no longer being
-		// removed as a single etcd member change. In that case we should not keep this hook.
+		// Cluster or control plane deletion does not require per-member protection.
 		logrus.Tracef("[rkebootstrap] %s/%s: releasing pre-terminate hook for machine %s/%s because the cluster or control plane is deleting (controlPlaneDeleting=%t, clusterDeleting=%t)",
 			bootstrap.Namespace, bootstrap.Name,
 			machine.Namespace, machine.Name,
@@ -685,8 +669,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	// Read plan secrets now because they carry the most current join state. During rollout, another node
-	// may still be in bootstrap and still depend on this machine even if the higher-level objects already exist.
+	// Plan secrets record whether another machine still depends on this machine's join URL.
 	planSecret, err := h.secretCache.Get(bootstrap.Namespace, capr.PlanSecretFromBootstrapName(bootstrap.Name))
 	if err != nil && !apierrors.IsNotFound(err) {
 		return bootstrap, fmt.Errorf("error retrieving plan secret to validate it was not an init node: %v", err)
@@ -706,23 +689,22 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	)
 
 	if planSecret != nil {
-		// Wait until no other machine still says it is joined to this one. This check matters early in the
-		// delete path: if a replacement machine is still joining through this node, deleting the node now
-		// can break that replacement before it becomes stable.
+		// Do not remove a machine while another plan secret still references its join URL.
 		joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
-		if joinedMachine, joined := machineStillJoinedToJoinURL(planSecrets, joinURL); joined {
-			logrus.Debugf("[rkebootstrap] %s/%s: waiting: deleting etcd machine %s/%s is still the join target for machine %s",
-				bootstrap.Namespace, bootstrap.Name,
-				machine.Namespace, machine.Name,
-				joinedMachine,
-			)
-			h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
-			return bootstrap, generic.ErrSkip
+		if joinURL != "" {
+			if joinedMachine, joined := machineStillJoinedToJoinURL(planSecrets, joinURL); joined {
+				logrus.Debugf("[rkebootstrap] %s/%s: waiting: deleting etcd machine %s/%s is still the join target for machine %s",
+					bootstrap.Namespace, bootstrap.Name,
+					machine.Namespace, machine.Name,
+					joinedMachine,
+				)
+				h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
+				return bootstrap, generic.ErrSkip
+			}
 		}
 	}
 
-	// Rancher removes the member by talking to the downstream cluster. If that kubeconfig is already gone,
-	// there is nothing left to check or update, so we must release the hook.
+	// Without the downstream kubeconfig, Rancher cannot perform member removal, so release the hook.
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -740,9 +722,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, err
 	}
 
-	// Before we remove the old member, wait for a real replacement. This is the main timing gate in this
-	// function: Rancher should not remove the old etcd member until another etcd machine has joined and
-	// proved it is stable enough to carry the cluster forward.
+	// Wait for the elected replacement etcd machine to complete its plan and report NodeReady.
 	replacementReady, err := h.replacementEtcdMachineReady(bootstrap, machine, planSecrets)
 	if err != nil {
 		return bootstrap, err
@@ -758,16 +738,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		machine.Namespace, machine.Name,
 	)
 
-	if !machine.Status.NodeRef.IsDefined() {
-		// At this point, a missing NodeRef means there is no downstream Node object left for Rancher to mark
-		// for safe removal. There is nothing more this hook can do, so release it.
-		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
-	}
-
-	// The actual etcd-member removal is async. Rancher first marks the downstream Node for removal, then
-	// waits for the downstream controller to confirm the member is gone. Only after that is it safe to let
-	// CAPI delete the backing infrastructure.
+	// Member removal is asynchronous; keep the hook until the downstream controller confirms completion.
 	removed, err := etcdmgmt.SafelyRemoved(restConfig, capr.GetRuntimeCommand(cp.Spec.KubernetesVersion), machine.Status.NodeRef.Name)
 	if err != nil {
 		return bootstrap, err
@@ -800,27 +771,31 @@ func (h *handler) ensureMachinePreTerminateAnnotationRemoved(bootstrap *rkev1.RK
 	return bootstrap, err
 }
 
-// replacementEtcdMachineReady returns true only when Rancher can see a real replacement for the etcd
-// machine that is being deleted.
-//
-// Each check here matches a later point in the replacement machine lifecycle:
-// * etcd role label: only another etcd machine can replace this member
-// * join URL: the machine has progressed far enough in bootstrap to act as a join target
-// * plan probes passed: Rancher has seen the current plan become healthy at least once
-// * machine node ready: the CAPI machine controller has already mirrored node readiness onto the local machine object
-// * not deleting: the replacement is still expected to stay in the cluster
+// replacementEtcdMachineReady reports whether another elected init etcd machine has completed its plan
+// and reports NodeReady in CAPI.
 func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, deletingMachine *capi.Machine, planSecrets []*corev1.Secret) (bool, error) {
 	if deletingMachine == nil {
 		return false, nil
 	}
 
 	for _, ps := range planSecrets {
-		// The replacement must also carry the etcd role.
-		if ps.GetLabels()[capr.EtcdRoleLabel] != "true" {
+		// Only consider live machine-plan secrets.
+		if !ps.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if ps.Type != capr.SecretTypeMachinePlan {
 			continue
 		}
 
-		// We need a real machine behind the plan secret, otherwise this secret is not enough to trust.
+		// Only consider the elected init etcd machine as a replacement.
+		if ps.GetLabels()[capr.EtcdRoleLabel] != "true" {
+			continue
+		}
+		if ps.GetLabels()[capr.InitNodeLabel] != "true" {
+			continue
+		}
+
+		// Require a Machine for local cluster and readiness validation.
 		machineName := ps.GetLabels()[capr.MachineNameLabel]
 		if machineName == "" {
 			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate skipped because the machine name label is missing", bootstrap.Namespace, bootstrap.Name)
@@ -835,20 +810,14 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 			continue
 		}
 
-		// The join URL appears after bootstrap has advanced enough for this machine to act as a join target.
-		// Before that point, Rancher should still treat the replacement as too early.
+		// A join URL indicates that the candidate can accept joining members.
 		if ps.GetAnnotations()[capr.JoinURLAnnotation] == "" {
 			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because join URL is not set", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			continue
 		}
-		// This tells us Rancher has already seen the current plan become healthy at least once. That makes
-		// it a better late-bootstrap signal than just "the machine object exists".
-		if ps.GetAnnotations()[capr.PlanProbesPassedAnnotation] == "" {
-			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because plan probes have not passed yet (joinURL=%s)",
-				bootstrap.Namespace, bootstrap.Name,
-				machineNamespace, machineName,
-				ps.GetAnnotations()[capr.JoinURLAnnotation],
-			)
+		// Passed probes show that the candidate's current plan was healthy at least once.
+		if ps.GetAnnotations()[planapi.PlanProbesPassedAnnotation] == "" {
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because plan probes have not passed yet", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
 			continue
 		}
 
@@ -861,31 +830,41 @@ func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, del
 			return false, err
 		}
 
+		if machine.Spec.ClusterName != deletingMachine.Spec.ClusterName {
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because it belongs to a different cluster", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+		if machine.GetLabels()[capr.EtcdRoleLabel] != "true" {
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because the machine object does not carry the etcd role label", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+		if !machine.DeletionTimestamp.IsZero() {
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because the machine is deleting", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+		if !machine.Status.NodeRef.IsDefined() {
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because it has no NodeRef yet", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+
 		// The machine controller mirrors node readiness onto the local machine object, so we can
 		// validate replacement readiness without querying the downstream cluster directly.
-		nodeReady := conditions.IsTrue(machine, capi.MachineNodeReadyCondition)
-		logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s evaluated with deleting=%t, nodeReady=%t, phase=%s, nodeRef=%t",
-			bootstrap.Namespace, bootstrap.Name,
-			machineNamespace, machineName,
-			!machine.DeletionTimestamp.IsZero(),
-			nodeReady,
-			machine.Status.Phase,
-			machine.Status.NodeRef.IsDefined(),
-		)
-		if machine.DeletionTimestamp.IsZero() && machine.Status.NodeRef.IsDefined() && nodeReady {
-			logrus.Debugf("[rkebootstrap] %s/%s: replacement candidate %s/%s is ready", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
-			return true, nil
+		if !conditions.IsTrue(machine, capi.MachineNodeReadyCondition) {
+			logrus.Tracef("[rkebootstrap] %s/%s: replacement candidate %s/%s skipped because NodeReady is not true", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
 		}
+
+		logrus.Debugf("[rkebootstrap] %s/%s: replacement candidate %s/%s is ready", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+		return true, nil
 	}
 
 	return false, nil
 }
 
+// machineStillJoinedToJoinURL reports whether any plan secret in planSecrets records joinURL as its
+// "joined-to" target, meaning that machine joined the cluster through the machine advertising joinURL.
+// It returns the machine-name label of the first matching plan secret and true if found.
 func machineStillJoinedToJoinURL(planSecrets []*corev1.Secret, joinURL string) (string, bool) {
-	if joinURL == "" {
-		return "", false
-	}
-
 	for _, ps := range planSecrets {
 		joinedTo := ps.GetAnnotations()[capr.JoinedToAnnotation]
 		if joinedTo == "" {

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -47,7 +47,6 @@ const (
 	rkeBootstrapName                       = "rke.cattle.io/rkebootstrap-name"
 	capiMachinePreTerminateAnnotation      = "pre-terminate.delete.hook.machine.cluster.x-k8s.io/rke-bootstrap-cleanup"
 	capiMachinePreTerminateAnnotationOwner = "rke-bootstrap-controller"
-	electionBackoff                        = 20 * time.Second
 )
 
 type handler struct {
@@ -554,40 +553,65 @@ func (h *handler) OnRemove(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEB
 	return h.reconcileMachinePreTerminateAnnotation(bootstrap)
 }
 
-// reconcileMachinePreTerminateAnnotation reconciles the machine object that owns the bootstrap. It only reconciles the machine if it is an
-// etcd machine. Its primary purpose is to manage the pre-terminate.delete.hook.machine.x-k8s.io annotation on the machine
-// object, which is used to prevent premature tear down of infrastructure before it is ready to be teared down, i.e.
-// allowing removal of an etcd member without causing quorum loss.
-// The pre-terminate hook will be set on the machine object if the machine and bootstrap are not deleting, the corresponding
-// CAPI cluster and RKEControlPlane are not deleting, and the force remove annotation is not set on the bootstrap.
-// The annotation will be removed from the machine to allow infrastructure cleanup in the following cases:
-// * The machine is deleting and the "safe remove" logic has fired and removed the etcd member from the etcd cluster
-// * The bootstrap is missing the CAPI cluster label || the CAPI cluster controlPlaneRef is nil || the machine noderef is nil
-// * Any of the following: CAPI kubeconfig secret, CAPI cluster object, RKEControlPlane object are not found
+// reconcileMachinePreTerminateAnnotation reconciles the machine object that owns the bootstrap.
+// Its primary purpose is to manage the pre-terminate.delete.hook.machine.x-k8s.io annotation on
+// etcd machines. That hook is used to stop CAPI from tearing down the backing infrastructure
+// before Rancher has safely removed the etcd member.
 //
-// Notably, CAPI controllers do not trigger a deletion of the RKEBootstrap object if a pre-terminate annotation exists on the corresponding machine object.
-// This means we rely on the OnChange handler to perform node safe removal, when it sees that the corresponding machine is deleting.
+// The hook is normally added before delete starts. Once the machine is deleting, Rancher keeps
+// the hook in place until it is safe to let delete continue.
+//
+// The hook is removed to allow infrastructure cleanup in the following cases:
+//   - force remove is requested, or the machine is not an etcd machine
+//   - the cluster/control plane objects needed for safe removal are missing or already deleting
+//   - Rancher has confirmed no machine is still joined to the deleting machine, a replacement etcd
+//     machine is ready, and the old etcd member has been safely removed
+//   - the deleting machine no longer has a downstream NodeRef after replacement readiness has already
+//     been confirmed
+//
+// Notably, CAPI controllers do not trigger deletion of the RKEBootstrap object while the
+// corresponding machine still has the pre-terminate hook. Because of that, Rancher relies on
+// this reconciliation path to perform safe etcd removal and decide when the hook can be removed.
 func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
 	machine, err := capr.GetMachineByOwner(h.machineCache, bootstrap)
 	if err != nil {
 		if errors.Is(err, capr.ErrNoMachineOwnerRef) || apierrors.IsNotFound(err) {
-			// If we did not find the machine by owner ref or the cache returned a not found, then noop.
+			// If the bootstrap no longer has an owning machine, there is nothing left to manage here.
 			return bootstrap, nil
 		}
 		return bootstrap, err
 	}
 
 	_, isEtcd := machine.Labels[capr.EtcdRoleLabel]
+	logrus.Debugf("[rkebootstrap] %s/%s: start machine=%s/%s isEtcd=%t machineDeleting=%t bootstrapDeleting=%t nodeRef=%t",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+		isEtcd,
+		!machine.DeletionTimestamp.IsZero(),
+		!bootstrap.DeletionTimestamp.IsZero(),
+		machine.Status.NodeRef.IsDefined(),
+	)
 
 	forceRemove, ok := bootstrap.Annotations[capr.ForceRemoveEtcdAnnotation]
 	if (ok && strings.ToLower(forceRemove) == "true") || !isEtcd {
-		// If the force remove annotation is "true" or the node is not an etcd node, then ensure the machine pre terminate annotation is removed.
+		// This delete path only protects etcd membership. If this machine is not etcd, or the caller asked
+		// for force removal, we should not hold the machine behind the pre-terminate hook.
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook early isEtcd=%t forceRemove=%q",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+			isEtcd,
+			forceRemove,
+		)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	// Only add the pre-terminate hook annotation if the corresponding machine and bootstrap are NOT deleting
+	// Add the hook before delete starts. Later, when CAPI begins deleting the machine, delete will pause
+	// here and Rancher will get one last chance to do etcd-safe removal first.
 	if machine.DeletionTimestamp.IsZero() && bootstrap.DeletionTimestamp.IsZero() {
-		// annotate the CAPI machine with the pre-terminate.delete.hook.machine.cluster.x-k8s.io annotation if it is an etcd machine
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s pre-delete ensure-hook",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
 		if val, ok := machine.GetAnnotations()[capiMachinePreTerminateAnnotation]; !ok || val != capiMachinePreTerminateAnnotationOwner {
 			machine = machine.DeepCopy()
 			if machine.Annotations == nil {
@@ -602,7 +626,13 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, nil
 	}
 
+	// Start of safe removal validations
+
 	if bootstrap.Spec.ClusterName == "" {
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=empty-cluster-name",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
 		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster label %s was not found in bootstrap labels, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capi.ClusterNameLabel)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -610,6 +640,10 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, bootstrap.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=capi-cluster-missing",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+			)
 			logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, bootstrap.Namespace, bootstrap.Spec.ClusterName)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
@@ -617,6 +651,10 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !capiCluster.Spec.ControlPlaneRef.IsDefined() {
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=controlplane-ref-missing",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
 		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s controlplane object reference was nil, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
@@ -624,6 +662,10 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	cp, err := h.rkeControlPlanes.Get(capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=rkecontrolplane-missing",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+			)
 			logrus.Warnf("[rkebootstrap] %s/%s: RKEControlPlane %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Spec.ControlPlaneRef.Name)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
@@ -631,53 +673,64 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if !cp.DeletionTimestamp.IsZero() || !capiCluster.DeletionTimestamp.IsZero() {
+		// If the whole control plane or whole cluster is being deleted, this machine is no longer being
+		// removed as a single etcd member change. In that case we should not keep this hook.
+		logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=cluster-or-controlplane-deleting cpDeleting=%t clusterDeleting=%t",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+			!cp.DeletionTimestamp.IsZero(),
+			!capiCluster.DeletionTimestamp.IsZero(),
+		)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	if !machine.Status.NodeRef.IsDefined() {
-		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
-		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+	// Read plan secrets now because they carry the most current join state. During rollout, another node
+	// may still be in bootstrap and still depend on this machine even if the higher-level objects already exist.
+	planSecret, err := h.secretCache.Get(bootstrap.Namespace, capr.PlanSecretFromBootstrapName(bootstrap.Name))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return bootstrap, fmt.Errorf("error retrieving plan secret to validate it was not an init node: %v", err)
 	}
 
-	// If the RKEControlPlane is not deleting, then make sure this node is not being used as an init node.
-	if cp.DeletionTimestamp.IsZero() {
-		planSecret, err := h.secretCache.Get(bootstrap.Namespace, capr.PlanSecretFromBootstrapName(bootstrap.Name))
-		if err != nil && !apierrors.IsNotFound(err) {
-			return bootstrap, fmt.Errorf("error retrieving plan secret to validate it was not an init node: %v", err)
+	planSecrets, err := h.secretCache.List(bootstrap.Namespace, labels.SelectorFromSet(map[string]string{
+		capi.ClusterNameLabel: bootstrap.Spec.ClusterName,
+	}))
+	if err != nil {
+		return bootstrap, fmt.Errorf("error encountered list plansecrets to validate etcd safe removal: %v", err)
+	}
+	logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s delete-checks planSecret=%t planSecrets=%d",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+		planSecret != nil,
+		len(planSecrets),
+	)
+
+	if planSecret != nil {
+		// Wait until no other machine still says it is joined to this one. This check matters early in the
+		// delete path: if a replacement machine is still joining through this node, deleting the node now
+		// can break that replacement before it becomes stable.
+		joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
+		if joinedMachine, joined := machineStillJoinedToJoinURL(planSecrets, joinURL); joined {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s block reason=machine-still-joined joinedMachine=%s joinURL=%s",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+				joinedMachine,
+				joinURL,
+			)
+			logrus.Errorf("[rkebootstrap] %s/%s: cluster %s/%s machine %s/%s was still joined to deleting etcd machine %s/%s", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name, bootstrap.Namespace, joinedMachine, machine.Namespace, machine.Name)
+			h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
+			return bootstrap, generic.ErrSkip
 		}
-
-		if planSecret != nil {
-			// validate that no other nodes are joined to this node, otherwise removing it will cause a bunch of nodes to start crashing.
-			joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
-			planSecrets, err := h.secretCache.List(bootstrap.Namespace, labels.SelectorFromSet(map[string]string{
-				capi.ClusterNameLabel: bootstrap.Spec.ClusterName,
-			}))
-			if err != nil {
-				return bootstrap, fmt.Errorf("error encountered list plansecrets to ensure node was not joined: %v", err)
-			}
-			for _, ps := range planSecrets {
-				if ps.GetAnnotations()[capr.JoinedToAnnotation] == joinURL {
-					logrus.Errorf("[rkebootstrap] %s/%s: cluster %s/%s machine %s/%s was still joined to deleting etcd machine %s/%s", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name, bootstrap.Namespace, ps.GetLabels()[capr.MachineNameLabel], machine.Namespace, machine.Name)
-					h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
-					return bootstrap, generic.ErrSkip
-				}
-			}
-		}
 	}
 
-	if wait, err := h.electionBackoffWait(bootstrap, machine); err != nil {
-		return bootstrap, err
-	} else if wait > 0 {
-		machineDeletionTime := machine.DeletionTimestamp.Time
-		logrus.Infof("[rkebootstrap] %s/%s: single-remaining etcd; deferring safe removal for %s (until %s) to avoid etcd election race",
-			bootstrap.Namespace, bootstrap.Name, wait.Round(time.Second), machineDeletionTime.Add(electionBackoff).Format(time.RFC3339))
-		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, wait)
-		return bootstrap, generic.ErrSkip
-	}
-
+	// Rancher removes the member by talking to the downstream cluster. If that kubeconfig is already gone,
+	// there is nothing left to check or update, so we must release the hook.
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logrus.Debugf("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=downstream-kubeconfig-missing",
+				bootstrap.Namespace, bootstrap.Name,
+				machine.Namespace, machine.Name,
+			)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
 		return bootstrap, err
@@ -688,10 +741,56 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, err
 	}
 
+	downstream, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return bootstrap, err
+	}
+	// Before we remove the old member, wait for a real replacement. This is the main timing gate in this
+	// function: Rancher should not remove the old etcd member until another etcd machine has joined and
+	// proved it is stable enough to carry the cluster forward.
+	replacementReady, err := h.replacementEtcdMachineReady(bootstrap, machine, planSecrets, downstream)
+	if err != nil {
+		return bootstrap, err
+	}
+	if !replacementReady {
+		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s block reason=replacement-not-ready",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
+		logrus.Infof("[rkebootstrap] %s/%s: waiting to remove etcd machine %s/%s until another etcd machine has joined, passed plan probes, and reported a ready node",
+			bootstrap.Namespace, bootstrap.Name, machine.Namespace, machine.Name)
+		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
+		return bootstrap, generic.ErrSkip
+	}
+	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s replacement-ready",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+	)
+
+	if !machine.Status.NodeRef.IsDefined() {
+		// At this point, a missing NodeRef means there is no downstream Node object left for Rancher to mark
+		// for safe removal. There is nothing more this hook can do, so release it.
+		logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s release-hook reason=node-ref-missing-after-replacement-ready",
+			bootstrap.Namespace, bootstrap.Name,
+			machine.Namespace, machine.Name,
+		)
+		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
+		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+	}
+
+	// The actual etcd-member removal is async. Rancher first marks the downstream Node for removal, then
+	// waits for the downstream controller to confirm the member is gone. Only after that is it safe to let
+	// CAPI delete the backing infrastructure.
 	removed, err := etcdmgmt.SafelyRemoved(restConfig, capr.GetRuntimeCommand(cp.Spec.KubernetesVersion), machine.Status.NodeRef.Name)
 	if err != nil {
 		return bootstrap, err
 	}
+	logrus.Infof("[rkebootstrap] %s/%s: machine=%s/%s safe-remove-result removed=%t node=%s",
+		bootstrap.Namespace, bootstrap.Name,
+		machine.Namespace, machine.Name,
+		removed,
+		machine.Status.NodeRef.Name,
+	)
 	if !removed {
 		h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
 		return bootstrap, generic.ErrSkip
@@ -714,37 +813,152 @@ func (h *handler) ensureMachinePreTerminateAnnotationRemoved(bootstrap *rkev1.RK
 	return bootstrap, err
 }
 
-// electionBackoffWait returns how long to defer safe removal when there is
-// exactly one other etcd machine still present which leads to a risky window
-// for leader election. A zero duration means "no backoff".
-func (h *handler) electionBackoffWait(bootstrap *rkev1.RKEBootstrap, machine *capi.Machine) (time.Duration, error) {
-	// Only meaningful when this machine is deleting.
-	if machine == nil || machine.DeletionTimestamp.IsZero() {
-		return 0, nil
+// replacementEtcdMachineReady returns true only when Rancher can see a real replacement for the etcd
+// machine that is being deleted.
+//
+// Each check here matches a later point in the replacement machine lifecycle:
+// * etcd role label: only another etcd machine can replace this member
+// * join URL: the machine has progressed far enough in bootstrap to act as a join target
+// * plan probes passed: Rancher has seen the current plan become healthy at least once
+// * ready downstream node: kubelet has registered the machine and the node is usable
+// * not deleting: the replacement is still expected to stay in the cluster
+func (h *handler) replacementEtcdMachineReady(bootstrap *rkev1.RKEBootstrap, deletingMachine *capi.Machine, planSecrets []*corev1.Secret, downstream kubernetes.Interface) (bool, error) {
+	if deletingMachine == nil {
+		return false, nil
 	}
 
-	// List all the etcd machines in the cluster
-	machines, err := h.machineCache.List(bootstrap.Namespace, labels.SelectorFromSet(labels.Set{
-		capi.ClusterNameLabel: bootstrap.Spec.ClusterName,
-		capr.EtcdRoleLabel:    "true",
-	}))
-	if err != nil {
-		return 0, err
-	}
-	if len(machines) != 2 { // Only care about the 2-node transition case.
-		return 0, nil
-	}
+	for _, ps := range planSecrets {
+		// The replacement must also carry the etcd role.
+		if ps.GetLabels()[capr.EtcdRoleLabel] != "true" {
+			continue
+		}
 
-	// Find the other etcd machine; if it’s not deleting, we back off.
-	for _, m := range machines {
-		if m.DeletionTimestamp.IsZero() && m.Name != machine.Name {
-			// Exactly one remaining etcd member; back off to let leadership settle.
-			since := time.Since(machine.DeletionTimestamp.Time)
-			if since < electionBackoff {
-				return electionBackoff - since, nil
+		// We need a real machine behind the plan secret, otherwise this secret is not enough to trust.
+		machineName := ps.GetLabels()[capr.MachineNameLabel]
+		if machineName == "" {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate skip reason=machine-name-missing", bootstrap.Namespace, bootstrap.Name)
+			continue
+		}
+		machineNamespace := ps.GetLabels()[capr.MachineNamespaceLabel]
+		if machineNamespace == "" {
+			machineNamespace = bootstrap.Namespace
+		}
+		if machineName == deletingMachine.Name && machineNamespace == deletingMachine.Namespace {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=same-machine", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+
+		// The join URL appears after bootstrap has advanced enough for this machine to act as a join target.
+		// Before that point, Rancher should still treat the replacement as too early.
+		if ps.GetAnnotations()[capr.JoinURLAnnotation] == "" {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=join-url-empty", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			continue
+		}
+		// This tells us Rancher has already seen the current plan become healthy at least once. That makes
+		// it a better late-bootstrap signal than just "the machine object exists".
+		if ps.GetAnnotations()[capr.PlanProbesPassedAnnotation] == "" {
+			logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=plan-probes-not-passed joinURL=%s",
+				bootstrap.Namespace, bootstrap.Name,
+				machineNamespace, machineName,
+				ps.GetAnnotations()[capr.JoinURLAnnotation],
+			)
+			continue
+		}
+
+		machine, err := h.machineCache.Get(machineNamespace, machineName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s skip reason=machine-not-found", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+				continue
 			}
+			return false, err
+		}
+
+		// Node readiness is one of the last signals in this flow. We wait for it because machine objects,
+		// plan secrets, and join metadata all show up earlier than a fully usable downstream node.
+		ready, err := machineHasReadyNode(context.Background(), downstream, machine)
+		if err != nil {
+			return false, err
+		}
+		logrus.Debugf("[rkebootstrap] %s/%s: candidate=%s/%s check deleting=%t ready=%t nodeRef=%t",
+			bootstrap.Namespace, bootstrap.Name,
+			machineNamespace, machineName,
+			!machine.DeletionTimestamp.IsZero(),
+			ready,
+			machine.Status.NodeRef.IsDefined(),
+		)
+		if machine.DeletionTimestamp.IsZero() && ready {
+			logrus.Infof("[rkebootstrap] %s/%s: candidate=%s/%s selected replacement", bootstrap.Namespace, bootstrap.Name, machineNamespace, machineName)
+			return true, nil
 		}
 	}
 
-	return 0, nil
+	return false, nil
+}
+
+func machineHasReadyNode(ctx context.Context, downstream kubernetes.Interface, machine *capi.Machine) (bool, error) {
+	if downstream == nil || machine == nil {
+		return false, nil
+	}
+
+	if machine.Status.NodeRef.IsDefined() {
+		node, err := downstream.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
+		if err == nil {
+			return nodeReady(node), nil
+		}
+		if !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+
+	if machine.UID == "" {
+		return false, nil
+	}
+
+	nodes, err := downstream.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set{capr.MachineUIDLabel: string(machine.UID)}.String(),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for i := range nodes.Items {
+		if nodeReady(&nodes.Items[i]) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func nodeReady(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+func machineStillJoinedToJoinURL(planSecrets []*corev1.Secret, joinURL string) (string, bool) {
+	if joinURL == "" {
+		return "", false
+	}
+
+	for _, ps := range planSecrets {
+		joinedTo := ps.GetAnnotations()[capr.JoinedToAnnotation]
+		if joinedTo == "" {
+			continue
+		}
+		if joinedTo == joinURL {
+			return ps.GetLabels()[capr.MachineNameLabel], true
+		}
+	}
+
+	return "", false
 }

--- a/pkg/controllers/capr/bootstrap/controller_test.go
+++ b/pkg/controllers/capr/bootstrap/controller_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
@@ -16,6 +18,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -292,6 +296,261 @@ func TestShouldCreateBootstrapSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.phase), func(t *testing.T) {
 			actual := shouldCreateBootstrapSecret(tt.phase)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestReplacementEtcdMachineReady(t *testing.T) {
+	newPlanSecret := func(machineName, machineNamespace, joinURL string, labels, annotations map[string]string) *v1.Secret {
+		resultLabels := map[string]string{
+			capr.MachineNameLabel: machineName,
+		}
+		for k, v := range labels {
+			resultLabels[k] = v
+		}
+		if machineNamespace != "" {
+			resultLabels[capr.MachineNamespaceLabel] = machineNamespace
+		}
+
+		resultAnnotations := map[string]string{}
+		if joinURL != "" {
+			resultAnnotations[capr.JoinURLAnnotation] = joinURL
+		}
+		for k, v := range annotations {
+			resultAnnotations[k] = v
+		}
+
+		return &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      resultLabels,
+				Annotations: resultAnnotations,
+			},
+		}
+	}
+	newReadyNode := func(name string, labels map[string]string) *v1.Node {
+		return &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionTrue,
+				}},
+			},
+		}
+	}
+	newNotReadyNode := func(name string, labels map[string]string) *v1.Node {
+		return &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionFalse,
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		planSecrets       []*v1.Secret
+		setupMachineCache func(*ctrlfake.MockCacheInterface[*capi.Machine])
+		downstreamNodes   []*v1.Node
+		expected          bool
+		expectErr         bool
+	}{
+		{
+			name: "replacement etcd machine ready through noderef",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-1", "", "https://10.0.0.1:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, nil),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+						UID:       types.UID("machine-2-uid"),
+					},
+					Status: capi.MachineStatus{
+						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+					},
+				}, nil)
+			},
+			downstreamNodes: []*v1.Node{
+				newReadyNode("node-2", nil),
+			},
+			expected: true,
+		},
+		{
+			name: "replacement etcd machine ready through machine uid label fallback",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+						UID:       types.UID("machine-2-uid"),
+					},
+				}, nil)
+			},
+			downstreamNodes: []*v1.Node{
+				newReadyNode("node-2", map[string]string{
+					capr.MachineUIDLabel: "machine-2-uid",
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "replacement etcd machine missing joinURL",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "replacement etcd machine missing passed probes",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, nil),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "replacement etcd machine node not ready",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+					},
+					Status: capi.MachineStatus{
+						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+					},
+				}, nil)
+			},
+			downstreamNodes: []*v1.Node{
+				newNotReadyNode("node-2", nil),
+			},
+			expected: false,
+		},
+		{
+			name: "replacement etcd machine deleting",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "machine-2",
+						Namespace:         "fleet-default",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				}, nil)
+			},
+			expected: false,
+		},
+		{
+			name: "machine cache error bubbles up",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(nil, fmt.Errorf("boom"))
+			},
+			expected:  false,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			machineCache := ctrlfake.NewMockCacheInterface[*capi.Machine](ctrl)
+			tt.setupMachineCache(machineCache)
+
+			h := &handler{
+				machineCache: machineCache,
+			}
+			downstream := fake.NewSimpleClientset()
+
+			bootstrap := &rkev1.RKEBootstrap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+				},
+				Spec: rkev1.RKEBootstrapSpec{
+					ClusterName: "cluster",
+				},
+			}
+			deletingMachine := &capi.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-1",
+					Namespace: "fleet-default",
+				},
+			}
+
+			if len(tt.downstreamNodes) > 0 {
+				runtimeObjects := make([]runtime.Object, 0, len(tt.downstreamNodes))
+				for _, node := range tt.downstreamNodes {
+					runtimeObjects = append(runtimeObjects, node)
+				}
+				downstream = fake.NewClientset(runtimeObjects...)
+			}
+
+			actual, err := h.replacementEtcdMachineReady(bootstrap, deletingMachine, tt.planSecrets, downstream)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/controllers/capr/bootstrap/controller_test.go
+++ b/pkg/controllers/capr/bootstrap/controller_test.go
@@ -18,8 +18,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -328,45 +326,16 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 			},
 		}
 	}
-	newReadyNode := func(name string, labels map[string]string) *v1.Node {
-		return &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: labels,
-			},
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
-				}},
-			},
-		}
-	}
-	newNotReadyNode := func(name string, labels map[string]string) *v1.Node {
-		return &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: labels,
-			},
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionFalse,
-				}},
-			},
-		}
-	}
 
 	tests := []struct {
 		name              string
 		planSecrets       []*v1.Secret
 		setupMachineCache func(*ctrlfake.MockCacheInterface[*capi.Machine])
-		downstreamNodes   []*v1.Node
 		expected          bool
 		expectErr         bool
 	}{
 		{
-			name: "replacement etcd machine ready through noderef",
+			name: "replacement etcd machine node ready",
 			planSecrets: []*v1.Secret{
 				newPlanSecret("machine-1", "", "https://10.0.0.1:9345", map[string]string{
 					capr.EtcdRoleLabel: "true",
@@ -384,41 +353,16 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "machine-2",
 						Namespace: "fleet-default",
-						UID:       types.UID("machine-2-uid"),
 					},
 					Status: capi.MachineStatus{
 						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+						Conditions: []metav1.Condition{{
+							Type:   capi.MachineNodeReadyCondition,
+							Status: metav1.ConditionTrue,
+							Reason: capi.MachineNodeReadyReason,
+						}},
 					},
 				}, nil)
-			},
-			downstreamNodes: []*v1.Node{
-				newReadyNode("node-2", nil),
-			},
-			expected: true,
-		},
-		{
-			name: "replacement etcd machine ready through machine uid label fallback",
-			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
-			},
-			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
-				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "machine-2",
-						Namespace: "fleet-default",
-						UID:       types.UID("machine-2-uid"),
-					},
-				}, nil)
-			},
-			downstreamNodes: []*v1.Node{
-				newReadyNode("node-2", map[string]string{
-					capr.MachineUIDLabel: "machine-2-uid",
-				}),
 			},
 			expected: true,
 		},
@@ -464,11 +408,40 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 					},
 					Status: capi.MachineStatus{
 						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+						Conditions: []metav1.Condition{{
+							Type:   capi.MachineNodeReadyCondition,
+							Status: metav1.ConditionFalse,
+							Reason: capi.MachineNodeNotReadyReason,
+						}},
 					},
 				}, nil)
 			},
-			downstreamNodes: []*v1.Node{
-				newNotReadyNode("node-2", nil),
+			expected: false,
+		},
+		{
+			name: "replacement etcd machine missing noderef",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+					},
+					Status: capi.MachineStatus{
+						Conditions: []metav1.Condition{{
+							Type:   capi.MachineNodeReadyCondition,
+							Status: metav1.ConditionTrue,
+							Reason: capi.MachineNodeReadyReason,
+						}},
+					},
+				}, nil)
 			},
 			expected: false,
 		},
@@ -520,7 +493,6 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 			h := &handler{
 				machineCache: machineCache,
 			}
-			downstream := fake.NewSimpleClientset()
 
 			bootstrap := &rkev1.RKEBootstrap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -537,15 +509,7 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 				},
 			}
 
-			if len(tt.downstreamNodes) > 0 {
-				runtimeObjects := make([]runtime.Object, 0, len(tt.downstreamNodes))
-				for _, node := range tt.downstreamNodes {
-					runtimeObjects = append(runtimeObjects, node)
-				}
-				downstream = fake.NewClientset(runtimeObjects...)
-			}
-
-			actual, err := h.replacementEtcdMachineReady(bootstrap, deletingMachine, tt.planSecrets, downstream)
+			actual, err := h.replacementEtcdMachineReady(bootstrap, deletingMachine, tt.planSecrets)
 			if tt.expectErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/controllers/capr/bootstrap/controller_test.go
+++ b/pkg/controllers/capr/bootstrap/controller_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
@@ -16,6 +18,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -301,6 +305,261 @@ func TestShouldCreateBootstrapSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.phase), func(t *testing.T) {
 			actual := shouldCreateBootstrapSecret(tt.phase)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestReplacementEtcdMachineReady(t *testing.T) {
+	newPlanSecret := func(machineName, machineNamespace, joinURL string, labels, annotations map[string]string) *v1.Secret {
+		resultLabels := map[string]string{
+			capr.MachineNameLabel: machineName,
+		}
+		for k, v := range labels {
+			resultLabels[k] = v
+		}
+		if machineNamespace != "" {
+			resultLabels[capr.MachineNamespaceLabel] = machineNamespace
+		}
+
+		resultAnnotations := map[string]string{}
+		if joinURL != "" {
+			resultAnnotations[capr.JoinURLAnnotation] = joinURL
+		}
+		for k, v := range annotations {
+			resultAnnotations[k] = v
+		}
+
+		return &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      resultLabels,
+				Annotations: resultAnnotations,
+			},
+		}
+	}
+	newReadyNode := func(name string, labels map[string]string) *v1.Node {
+		return &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionTrue,
+				}},
+			},
+		}
+	}
+	newNotReadyNode := func(name string, labels map[string]string) *v1.Node {
+		return &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionFalse,
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		planSecrets       []*v1.Secret
+		setupMachineCache func(*ctrlfake.MockCacheInterface[*capi.Machine])
+		downstreamNodes   []*v1.Node
+		expected          bool
+		expectErr         bool
+	}{
+		{
+			name: "replacement etcd machine ready through noderef",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-1", "", "https://10.0.0.1:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, nil),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+						UID:       types.UID("machine-2-uid"),
+					},
+					Status: capi.MachineStatus{
+						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+					},
+				}, nil)
+			},
+			downstreamNodes: []*v1.Node{
+				newReadyNode("node-2", nil),
+			},
+			expected: true,
+		},
+		{
+			name: "replacement etcd machine ready through machine uid label fallback",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+						UID:       types.UID("machine-2-uid"),
+					},
+				}, nil)
+			},
+			downstreamNodes: []*v1.Node{
+				newReadyNode("node-2", map[string]string{
+					capr.MachineUIDLabel: "machine-2-uid",
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "replacement etcd machine missing joinURL",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "replacement etcd machine missing passed probes",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, nil),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "replacement etcd machine node not ready",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+					},
+					Status: capi.MachineStatus{
+						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+					},
+				}, nil)
+			},
+			downstreamNodes: []*v1.Node{
+				newNotReadyNode("node-2", nil),
+			},
+			expected: false,
+		},
+		{
+			name: "replacement etcd machine deleting",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "machine-2",
+						Namespace:         "fleet-default",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				}, nil)
+			},
+			expected: false,
+		},
+		{
+			name: "machine cache error bubbles up",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(nil, fmt.Errorf("boom"))
+			},
+			expected:  false,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			machineCache := ctrlfake.NewMockCacheInterface[*capi.Machine](ctrl)
+			tt.setupMachineCache(machineCache)
+
+			h := &handler{
+				machineCache: machineCache,
+			}
+			downstream := fake.NewSimpleClientset()
+
+			bootstrap := &rkev1.RKEBootstrap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "fleet-default",
+				},
+				Spec: rkev1.RKEBootstrapSpec{
+					ClusterName: "cluster",
+				},
+			}
+			deletingMachine := &capi.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-1",
+					Namespace: "fleet-default",
+				},
+			}
+
+			if len(tt.downstreamNodes) > 0 {
+				runtimeObjects := make([]runtime.Object, 0, len(tt.downstreamNodes))
+				for _, node := range tt.downstreamNodes {
+					runtimeObjects = append(runtimeObjects, node)
+				}
+				downstream = fake.NewClientset(runtimeObjects...)
+			}
+
+			actual, err := h.replacementEtcdMachineReady(bootstrap, deletingMachine, tt.planSecrets, downstream)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/controllers/capr/bootstrap/controller_test.go
+++ b/pkg/controllers/capr/bootstrap/controller_test.go
@@ -10,6 +10,7 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/namespace"
+	planapi "github.com/rancher/rancher/pkg/plan"
 	"github.com/rancher/rancher/pkg/settings"
 	ctrlfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
@@ -308,30 +309,129 @@ func TestShouldCreateBootstrapSecret(t *testing.T) {
 	}
 }
 
+func TestReconcileMachinePreTerminateAnnotationReleasesMachineWithoutNodeRef(t *testing.T) {
+	const (
+		namespace     = "fleet-default"
+		bootstrapName = "bootstrap-1"
+		machineName   = "machine-1"
+		clusterName   = "cluster"
+	)
+
+	ctrl := gomock.NewController(t)
+	machineCache := ctrlfake.NewMockCacheInterface[*capi.Machine](ctrl)
+	machineClient := ctrlfake.NewMockClientInterface[*capi.Machine, *capi.MachineList](ctrl)
+
+	deletionTime := metav1.NewTime(time.Now())
+	machine := &capi.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              machineName,
+			Namespace:         namespace,
+			DeletionTimestamp: &deletionTime,
+			Labels: map[string]string{
+				capr.EtcdRoleLabel: "true",
+			},
+			Annotations: map[string]string{
+				capiMachinePreTerminateAnnotation: capiMachinePreTerminateAnnotationOwner,
+			},
+		},
+	}
+
+	machineCache.EXPECT().Get(namespace, machineName).Return(machine, nil)
+	machineClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(updated *capi.Machine) (*capi.Machine, error) {
+		assert.NotContains(t, updated.Annotations, capiMachinePreTerminateAnnotation)
+		return updated, nil
+	})
+
+	h := &handler{
+		machineCache:  machineCache,
+		machineClient: machineClient,
+	}
+	bootstrap := &rkev1.RKEBootstrap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bootstrapName,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: capi.GroupVersion.String(),
+				Kind:       "Machine",
+				Name:       machineName,
+			}},
+		},
+		Spec: rkev1.RKEBootstrapSpec{
+			ClusterName: clusterName,
+		},
+	}
+
+	result, err := h.reconcileMachinePreTerminateAnnotation(bootstrap)
+	assert.NoError(t, err)
+	assert.Same(t, bootstrap, result)
+}
+
 func TestReplacementEtcdMachineReady(t *testing.T) {
-	newPlanSecret := func(machineName, machineNamespace, joinURL string, labels, annotations map[string]string) *v1.Secret {
-		resultLabels := map[string]string{
+	const (
+		deletingMachineName      = "machine-1"
+		deletingMachineNamespace = "fleet-default"
+		clusterName              = "cluster"
+	)
+
+	// planSecretOption changes one property of a replacement candidate.
+	type planSecretOption func(*v1.Secret)
+
+	withNoInitNodeLabel := func(s *v1.Secret) { delete(s.Labels, capr.InitNodeLabel) }
+	withNoEtcdRoleLabel := func(s *v1.Secret) { delete(s.Labels, capr.EtcdRoleLabel) }
+	withNoJoinURL := func(s *v1.Secret) { delete(s.Annotations, capr.JoinURLAnnotation) }
+	withNoProbesPassedAnnotation := func(s *v1.Secret) { delete(s.Annotations, planapi.PlanProbesPassedAnnotation) }
+	withDeletingSecret := func(s *v1.Secret) { s.DeletionTimestamp = &metav1.Time{Time: time.Now()} }
+	withWrongType := func(s *v1.Secret) { s.Type = v1.SecretTypeOpaque }
+
+	// newPlanSecret returns a candidate that satisfies all plan-secret checks by default.
+	newPlanSecret := func(machineName, machineNamespace, joinURL string, opts ...planSecretOption) *v1.Secret {
+		labels := map[string]string{
 			capr.MachineNameLabel: machineName,
-		}
-		for k, v := range labels {
-			resultLabels[k] = v
+			capr.EtcdRoleLabel:    "true",
+			capr.InitNodeLabel:    "true",
 		}
 		if machineNamespace != "" {
-			resultLabels[capr.MachineNamespaceLabel] = machineNamespace
+			labels[capr.MachineNamespaceLabel] = machineNamespace
 		}
-
-		resultAnnotations := map[string]string{}
+		annotations := map[string]string{
+			planapi.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+		}
 		if joinURL != "" {
-			resultAnnotations[capr.JoinURLAnnotation] = joinURL
+			annotations[capr.JoinURLAnnotation] = joinURL
 		}
-		for k, v := range annotations {
-			resultAnnotations[k] = v
-		}
-
-		return &v1.Secret{
+		s := &v1.Secret{
+			Type: capr.SecretTypeMachinePlan,
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      resultLabels,
-				Annotations: resultAnnotations,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+		}
+		for _, opt := range opts {
+			opt(s)
+		}
+		return s
+	}
+
+	// newReadyMachine returns a candidate that satisfies all Machine checks by default.
+	newReadyMachine := func(name, namespace, clusterName string) *capi.Machine {
+		return &capi.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					capr.EtcdRoleLabel: "true",
+				},
+			},
+			Spec: capi.MachineSpec{
+				ClusterName: clusterName,
+			},
+			Status: capi.MachineStatus{
+				NodeRef: capi.MachineNodeReference{Name: "node-2"},
+				Conditions: []metav1.Condition{{
+					Type:   capi.MachineNodeReadyCondition,
+					Status: metav1.ConditionTrue,
+					Reason: capi.MachineNodeReadyReason,
+				}},
 			},
 		}
 	}
@@ -344,146 +444,168 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 		expectErr         bool
 	}{
 		{
-			name: "replacement etcd machine node ready",
+			name: "fully reconciled elected init etcd candidate is accepted",
 			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-1", "", "https://10.0.0.1:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, nil),
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
+				newPlanSecret(deletingMachineName, "", "https://10.0.0.1:9345"),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
 			},
 			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
-				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "machine-2",
-						Namespace: "fleet-default",
-					},
-					Status: capi.MachineStatus{
-						NodeRef: capi.MachineNodeReference{Name: "node-2"},
-						Conditions: []metav1.Condition{{
-							Type:   capi.MachineNodeReadyCondition,
-							Status: metav1.ConditionTrue,
-							Reason: capi.MachineNodeReadyReason,
-						}},
-					},
-				}, nil)
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(newReadyMachine("machine-2", "fleet-default", clusterName), nil)
 			},
 			expected: true,
 		},
 		{
-			name: "replacement etcd machine missing joinURL",
+			name: "candidate without InitNodeLabel is rejected",
 			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", withNoInitNodeLabel),
 			},
 			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
 			expected:          false,
 		},
 		{
-			name: "replacement etcd machine missing passed probes",
+			name: "candidate without EtcdRoleLabel on plan secret is rejected",
 			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, nil),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", withNoEtcdRoleLabel),
 			},
 			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
 			expected:          false,
 		},
 		{
-			name: "replacement etcd machine node not ready",
+			name: "candidate missing joinURL is rejected",
 			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", withNoJoinURL),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "candidate missing PlanProbesPassedAnnotation is rejected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", withNoProbesPassedAnnotation),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "deleting plan secret is rejected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", withDeletingSecret),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "wrong secret type is rejected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", withWrongType),
+			},
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "machine from another cluster is rejected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
 			},
 			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
-				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "machine-2",
-						Namespace: "fleet-default",
-					},
-					Status: capi.MachineStatus{
-						NodeRef: capi.MachineNodeReference{Name: "node-2"},
-						Conditions: []metav1.Condition{{
-							Type:   capi.MachineNodeReadyCondition,
-							Status: metav1.ConditionFalse,
-							Reason: capi.MachineNodeNotReadyReason,
-						}},
-					},
-				}, nil)
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(newReadyMachine("machine-2", "fleet-default", "other-cluster"), nil)
 			},
 			expected: false,
 		},
 		{
-			name: "replacement etcd machine missing noderef",
+			name: "machine without the etcd role is rejected",
 			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
 			},
 			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
-				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "machine-2",
-						Namespace: "fleet-default",
-					},
-					Status: capi.MachineStatus{
-						Conditions: []metav1.Condition{{
-							Type:   capi.MachineNodeReadyCondition,
-							Status: metav1.ConditionTrue,
-							Reason: capi.MachineNodeReadyReason,
-						}},
-					},
-				}, nil)
+				m := newReadyMachine("machine-2", "fleet-default", clusterName)
+				delete(m.Labels, capr.EtcdRoleLabel)
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(m, nil)
 			},
 			expected: false,
 		},
 		{
-			name: "replacement etcd machine deleting",
+			name: "missing NodeReady condition is rejected",
 			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
 			},
 			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
-				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "machine-2",
-						Namespace:         "fleet-default",
-						DeletionTimestamp: &metav1.Time{Time: time.Now()},
-					},
-				}, nil)
+				m := newReadyMachine("machine-2", "fleet-default", clusterName)
+				m.Status.Conditions = nil
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(m, nil)
 			},
 			expected: false,
 		},
 		{
-			name: "machine cache error bubbles up",
+			name: "false NodeReady condition is rejected",
 			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				m := newReadyMachine("machine-2", "fleet-default", clusterName)
+				m.Status.Conditions = []metav1.Condition{{
+					Type:   capi.MachineNodeReadyCondition,
+					Status: metav1.ConditionFalse,
+					Reason: capi.MachineNodeNotReadyReason,
+				}}
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(m, nil)
+			},
+			expected: false,
+		},
+		{
+			name: "unknown NodeReady condition is rejected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				m := newReadyMachine("machine-2", "fleet-default", clusterName)
+				m.Status.Conditions = []metav1.Condition{{
+					Type:   capi.MachineNodeReadyCondition,
+					Status: metav1.ConditionUnknown,
+					Reason: capi.MachineNodeReadyUnknownReason,
+				}}
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(m, nil)
+			},
+			expected: false,
+		},
+		{
+			name: "missing NodeRef is rejected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				m := newReadyMachine("machine-2", "fleet-default", clusterName)
+				m.Status.NodeRef = capi.MachineNodeReference{}
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(m, nil)
+			},
+			expected: false,
+		},
+		{
+			name: "deleting candidate machine is rejected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				m := newReadyMachine("machine-2", "fleet-default", clusterName)
+				m.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(m, nil)
+			},
+			expected: false,
+		},
+		{
+			name: "deleting machine is never selected as its own replacement",
+			planSecrets: []*v1.Secret{
+				// The deleting machine otherwise satisfies every candidate check.
+				newPlanSecret(deletingMachineName, deletingMachineNamespace, "https://10.0.0.1:9345"),
+			},
+			// Reject the candidate before reading the machine cache.
+			setupMachineCache: func(_ *ctrlfake.MockCacheInterface[*capi.Machine]) {},
+			expected:          false,
+		},
+		{
+			name: "machine cache error propagates",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345"),
 			},
 			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
 				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(nil, fmt.Errorf("boom"))
@@ -505,16 +627,19 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 
 			bootstrap := &rkev1.RKEBootstrap{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fleet-default",
+					Namespace: deletingMachineNamespace,
 				},
 				Spec: rkev1.RKEBootstrapSpec{
-					ClusterName: "cluster",
+					ClusterName: clusterName,
 				},
 			}
 			deletingMachine := &capi.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-1",
-					Namespace: "fleet-default",
+					Name:      deletingMachineName,
+					Namespace: deletingMachineNamespace,
+				},
+				Spec: capi.MachineSpec{
+					ClusterName: clusterName,
 				},
 			}
 
@@ -525,6 +650,73 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestMachineStillJoinedToJoinURL(t *testing.T) {
+	newPlanSecret := func(machineName, joinedTo string) *v1.Secret {
+		annotations := map[string]string{}
+		if joinedTo != "" {
+			annotations[capr.JoinedToAnnotation] = joinedTo
+		}
+		return &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					capr.MachineNameLabel: machineName,
+				},
+				Annotations: annotations,
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		planSecrets  []*v1.Secret
+		joinURL      string
+		expectedName string
+		expectedOk   bool
+	}{
+		{
+			name: "matching non-empty URL is detected",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "https://10.0.0.1:9345"),
+			},
+			joinURL:      "https://10.0.0.1:9345",
+			expectedName: "machine-2",
+			expectedOk:   true,
+		},
+		{
+			name: "non-matching URL is ignored",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "https://10.0.0.9:9345"),
+			},
+			joinURL:    "https://10.0.0.1:9345",
+			expectedOk: false,
+		},
+		{
+			name: "empty join URL does not match",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "https://10.0.0.1:9345"),
+			},
+			joinURL:    "",
+			expectedOk: false,
+		},
+		{
+			name: "empty joined-to annotation does not match",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", ""),
+			},
+			joinURL:    "https://10.0.0.1:9345",
+			expectedOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, ok := machineStillJoinedToJoinURL(tt.planSecrets, tt.joinURL)
+			assert.Equal(t, tt.expectedOk, ok)
+			assert.Equal(t, tt.expectedName, name)
 		})
 	}
 }

--- a/pkg/controllers/capr/bootstrap/controller_test.go
+++ b/pkg/controllers/capr/bootstrap/controller_test.go
@@ -18,8 +18,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -337,45 +335,16 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 			},
 		}
 	}
-	newReadyNode := func(name string, labels map[string]string) *v1.Node {
-		return &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: labels,
-			},
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
-				}},
-			},
-		}
-	}
-	newNotReadyNode := func(name string, labels map[string]string) *v1.Node {
-		return &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: labels,
-			},
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionFalse,
-				}},
-			},
-		}
-	}
 
 	tests := []struct {
 		name              string
 		planSecrets       []*v1.Secret
 		setupMachineCache func(*ctrlfake.MockCacheInterface[*capi.Machine])
-		downstreamNodes   []*v1.Node
 		expected          bool
 		expectErr         bool
 	}{
 		{
-			name: "replacement etcd machine ready through noderef",
+			name: "replacement etcd machine node ready",
 			planSecrets: []*v1.Secret{
 				newPlanSecret("machine-1", "", "https://10.0.0.1:9345", map[string]string{
 					capr.EtcdRoleLabel: "true",
@@ -393,41 +362,16 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "machine-2",
 						Namespace: "fleet-default",
-						UID:       types.UID("machine-2-uid"),
 					},
 					Status: capi.MachineStatus{
 						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+						Conditions: []metav1.Condition{{
+							Type:   capi.MachineNodeReadyCondition,
+							Status: metav1.ConditionTrue,
+							Reason: capi.MachineNodeReadyReason,
+						}},
 					},
 				}, nil)
-			},
-			downstreamNodes: []*v1.Node{
-				newReadyNode("node-2", nil),
-			},
-			expected: true,
-		},
-		{
-			name: "replacement etcd machine ready through machine uid label fallback",
-			planSecrets: []*v1.Secret{
-				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
-					capr.EtcdRoleLabel: "true",
-					capr.InitNodeLabel: "true",
-				}, map[string]string{
-					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
-				}),
-			},
-			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
-				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "machine-2",
-						Namespace: "fleet-default",
-						UID:       types.UID("machine-2-uid"),
-					},
-				}, nil)
-			},
-			downstreamNodes: []*v1.Node{
-				newReadyNode("node-2", map[string]string{
-					capr.MachineUIDLabel: "machine-2-uid",
-				}),
 			},
 			expected: true,
 		},
@@ -473,11 +417,40 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 					},
 					Status: capi.MachineStatus{
 						NodeRef: capi.MachineNodeReference{Name: "node-2"},
+						Conditions: []metav1.Condition{{
+							Type:   capi.MachineNodeReadyCondition,
+							Status: metav1.ConditionFalse,
+							Reason: capi.MachineNodeNotReadyReason,
+						}},
 					},
 				}, nil)
 			},
-			downstreamNodes: []*v1.Node{
-				newNotReadyNode("node-2", nil),
+			expected: false,
+		},
+		{
+			name: "replacement etcd machine missing noderef",
+			planSecrets: []*v1.Secret{
+				newPlanSecret("machine-2", "", "https://10.0.0.2:9345", map[string]string{
+					capr.EtcdRoleLabel: "true",
+					capr.InitNodeLabel: "true",
+				}, map[string]string{
+					capr.PlanProbesPassedAnnotation: time.Now().UTC().Format(time.RFC3339),
+				}),
+			},
+			setupMachineCache: func(machineCache *ctrlfake.MockCacheInterface[*capi.Machine]) {
+				machineCache.EXPECT().Get("fleet-default", "machine-2").Return(&capi.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: "fleet-default",
+					},
+					Status: capi.MachineStatus{
+						Conditions: []metav1.Condition{{
+							Type:   capi.MachineNodeReadyCondition,
+							Status: metav1.ConditionTrue,
+							Reason: capi.MachineNodeReadyReason,
+						}},
+					},
+				}, nil)
 			},
 			expected: false,
 		},
@@ -529,7 +502,6 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 			h := &handler{
 				machineCache: machineCache,
 			}
-			downstream := fake.NewSimpleClientset()
 
 			bootstrap := &rkev1.RKEBootstrap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -546,15 +518,7 @@ func TestReplacementEtcdMachineReady(t *testing.T) {
 				},
 			}
 
-			if len(tt.downstreamNodes) > 0 {
-				runtimeObjects := make([]runtime.Object, 0, len(tt.downstreamNodes))
-				for _, node := range tt.downstreamNodes {
-					runtimeObjects = append(runtimeObjects, node)
-				}
-				downstream = fake.NewClientset(runtimeObjects...)
-			}
-
-			actual, err := h.replacementEtcdMachineReady(bootstrap, deletingMachine, tt.planSecrets, downstream)
+			actual, err := h.replacementEtcdMachineReady(bootstrap, deletingMachine, tt.planSecrets)
 			if tt.expectErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/controllers/capr/etcdmgmt/saferemoval.go
+++ b/pkg/controllers/capr/etcdmgmt/saferemoval.go
@@ -44,6 +44,9 @@ func SafelyRemoved(restConfig *rest.Config, runtime, nodeName string) (bool, err
 			if err != nil {
 				return err
 			}
+			if node.Annotations == nil {
+				node.Annotations = map[string]string{}
+			}
 			node.Annotations[removeAnnotation] = "true"
 			_, err = clientset.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 			return err

--- a/tests/v2prov/tests/machineprovisioning/machine_test.go
+++ b/tests/v2prov/tests/machineprovisioning/machine_test.go
@@ -12,6 +12,7 @@ import (
 	provisioningv1api "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/capr"
+	planapi "github.com/rancher/rancher/pkg/plan"
 	"github.com/rancher/rancher/tests/v2prov/clients"
 	"github.com/rancher/rancher/tests/v2prov/cluster"
 	"github.com/rancher/rancher/tests/v2prov/defaults"
@@ -31,6 +32,8 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
 func Test_Provisioning_SetA_MP_SingleNodeAllRolesWithDelete(t *testing.T) {
@@ -831,6 +834,286 @@ func Test_Provisioning_SetB_Single_Node_All_Roles_Drain(t *testing.T) {
 		latest, err := clients.Provisioning.Cluster().Get(c.Namespace, c.Name, metav1.GetOptions{})
 		return err == nil && latest.Status.Ready
 	}, 10*time.Minute, 10*time.Second, "cluster did not return to Ready after rollout")
+}
+
+func Test_Provisioning_Single_Node_Drain_Unhealthy_Replacement(t *testing.T) {
+	if capr.GetRuntime(defaults.SomeK8sVersion) != capr.RuntimeRKE2 {
+		t.Skip("this test injects an RKE2 control-plane probe failure")
+	}
+
+	clients, err := clients.New()
+	require.NoError(t, err)
+	defer clients.Close()
+
+	ctx := clients.Ctx
+	const (
+		preTerminateHook       = capi.PreTerminateDeleteHookAnnotationPrefix + "/rke-bootstrap-cleanup"
+		kubeSchedulerProbePort = "10259"
+	)
+
+	drainOptions := rkev1.DrainOptions{
+		Enabled:                         true,
+		DeleteEmptyDirData:              true,
+		DisableEviction:                 false,
+		GracePeriod:                     -1,
+		Force:                           false,
+		IgnoreDaemonSets:                ptr.To(true),
+		SkipWaitForDeleteTimeoutSeconds: 0,
+		Timeout:                         120,
+	}
+
+	// Create a single-node all-roles cluster with draining enabled to exercise a control-plane replacement.
+	provClusterSchema := &provisioningv1api.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-single-node-drain",
+		},
+		Spec: provisioningv1api.ClusterSpec{
+			KubernetesVersion: defaults.SomeK8sVersion,
+			RKEConfig: &provisioningv1api.RKEConfig{
+				ClusterConfiguration: rkev1.ClusterConfiguration{
+					UpgradeStrategy: rkev1.ClusterUpgradeStrategy{
+						ControlPlaneDrainOptions: drainOptions,
+						ControlPlaneConcurrency:  "1",
+						WorkerDrainOptions:       drainOptions,
+						WorkerConcurrency:        "1",
+					},
+				},
+				MachinePools: []provisioningv1api.RKEMachinePool{{
+					EtcdRole:         true,
+					ControlPlaneRole: true,
+					WorkerRole:       true,
+					Quantity:         &defaults.One,
+				}},
+			},
+		},
+	}
+
+	c, err := cluster.New(clients, provClusterSchema)
+	require.NoError(t, err)
+
+	c, err = cluster.WaitForCreate(clients, c)
+	require.NoError(t, err)
+
+	// Verify the initial Machine and downstream Node are ready before starting the rollout.
+	machines, err := cluster.Machines(clients, c)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(machines.Items), "expected exactly one machine initially")
+
+	firstMachine := machines.Items[0]
+	require.True(t, firstMachine.Status.NodeRef.IsDefined(), "initial machine has no NodeRef")
+	require.True(t, conditions.IsTrue(&firstMachine, capi.MachineNodeReadyCondition), "initial machine is not NodeReady")
+	firstNodeName := firstMachine.Status.NodeRef.Name
+	firstMachineHash := firstMachine.Labels["machine-template-hash"]
+	require.NotEmpty(t, firstMachineHash, "initial machine is missing the template-hash label")
+
+	// Confirm the initial Machine is protected before requesting its replacement.
+	require.Eventually(t, func() bool {
+		m, err := clients.CAPI.Machine().Get(firstMachine.Namespace, firstMachine.Name, metav1.GetOptions{})
+		return err == nil && m.Annotations[preTerminateHook] != ""
+	}, 2*time.Minute, 2*time.Second, "initial machine never received the pre-terminate hook")
+
+	clusterClients, err := clients.ForCluster(c.Namespace, c.Name)
+	require.NoError(t, err)
+
+	// Create a fresh machine config to trigger the replacement rollout. The probe failure is
+	// injected later so infrastructure and system-agent initialization can complete normally.
+	newCfgRef, err := nodeconfig.NewPodConfig(clients, c.Namespace)
+	require.NoError(t, err)
+
+	err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return true
+	}, func() error {
+		gvrPodConfig := schema.GroupVersionResource{
+			Group: "rke-machine-config.cattle.io", Version: "v1", Resource: "podconfigs",
+		}
+		newPodConfig, err := clients.Dynamic.Resource(gvrPodConfig).Namespace(c.Namespace).Get(ctx, newCfgRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		currentUserData, ok := unstructuredString(newPodConfig.Object, "userdata")
+		require.True(t, ok)
+		newPodConfig.Object["userdata"] = currentUserData + "\n# Trigger the replacement rollout."
+		_, err = clients.Dynamic.Resource(gvrPodConfig).Namespace(c.Namespace).Update(ctx, newPodConfig, metav1.UpdateOptions{})
+		return err
+	})
+
+	require.NoError(t, err)
+
+	provCluster, err := clients.Provisioning.Cluster().Get(c.Namespace, c.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	require.NotNil(t, provCluster.Spec.RKEConfig)
+	require.GreaterOrEqual(t, len(provCluster.Spec.RKEConfig.MachinePools), 1)
+
+	// Update the pool template to start the replacement rollout.
+	provCluster.Spec.RKEConfig.MachinePools[0].NodeConfig = newCfgRef
+	c, err = clients.Provisioning.Cluster().Update(provCluster)
+	require.NoError(t, err)
+
+	// Identify the replacement by its new machine-template hash.
+	var secondMachine *capi.Machine
+	require.Eventually(t, func() bool {
+		machines, err = cluster.Machines(clients, c)
+		if err != nil {
+			return false
+		}
+		for i := range machines.Items {
+			m := &machines.Items[i]
+			hash := m.Labels["machine-template-hash"]
+			if hash != "" && hash != firstMachineHash {
+				secondMachine = m.DeepCopy()
+				return true
+			}
+		}
+		return false
+	}, 5*time.Minute, 2*time.Second, "replacement machine never appeared")
+
+	require.NotEqual(t, firstMachine.UID, secondMachine.UID, "replacement reused the initial machine")
+	require.Equal(t, "PodMachine", secondMachine.Spec.InfrastructureRef.Kind, "test requires the pod machine driver")
+	require.True(t, secondMachine.Spec.Bootstrap.ConfigRef.IsDefined(), "replacement has no bootstrap reference")
+	planSecretName := capr.PlanSecretFromBootstrapName(secondMachine.Spec.Bootstrap.ConfigRef.Name)
+
+	// Resolve the PodMachine's backing Pod so the test can inject the probe failure into only the replacement.
+	var replacementPodNamespace, replacementPodName string
+	require.Eventually(t, func() bool {
+		infraMachine, err := external.GetObjectFromContractVersionedRef(ctx, clients.Client, secondMachine.Spec.InfrastructureRef, secondMachine.Namespace)
+		if err != nil {
+			return false
+		}
+		replacementPodNamespace = infraMachine.GetNamespace()
+		replacementPodName = strings.ReplaceAll(infraMachine.GetName(), ".", "-")
+		pod, err := clients.Core.Pod().Get(replacementPodNamespace, replacementPodName, metav1.GetOptions{})
+		return err == nil && pod.Status.Phase == corev1.PodRunning
+	}, 5*time.Minute, 2*time.Second, "replacement systemd-node pod never became Running")
+
+	// Wait for the system agent so the fault does not interrupt infrastructure or agent initialization.
+	var systemAgentOutput string
+	var systemAgentErr error
+	systemAgentReady := false
+	for deadline := time.Now().Add(2 * time.Minute); time.Now().Before(deadline); time.Sleep(2 * time.Second) {
+		systemAgentOutput, systemAgentErr = cluster.ExecOnPod(clients, replacementPodNamespace, replacementPodName,
+			"systemctl", "is-active", "rancher-system-agent")
+		if systemAgentErr == nil && strings.TrimSpace(systemAgentOutput) == "active" {
+			systemAgentReady = true
+			break
+		}
+	}
+	require.True(t, systemAgentReady, "replacement system agent did not become active: output=%q err=%v", systemAgentOutput, systemAgentErr)
+
+	// Block only the replacement's local kube-scheduler health endpoint. The kubelet can register
+	// and become NodeReady, but the machine plan cannot pass until the rule is removed.
+	faultOutput, err := cluster.ExecOnPod(clients, replacementPodNamespace, replacementPodName,
+		"iptables", "-I", "OUTPUT", "-o", "lo", "-p", "tcp", "--dport", kubeSchedulerProbePort, "-j", "REJECT")
+	require.NoError(t, err, "failed to inject the kube-scheduler probe block: %s", faultOutput)
+	faultCleared := false
+	defer func() {
+		if !faultCleared {
+			_, _ = cluster.ExecOnPod(clients, replacementPodNamespace, replacementPodName,
+				"iptables", "-D", "OUTPUT", "-o", "lo", "-p", "tcp", "--dport", kubeSchedulerProbePort, "-j", "REJECT")
+		}
+	}()
+
+	checkOutput, err := cluster.ExecOnPod(clients, replacementPodNamespace, replacementPodName,
+		"iptables", "-C", "OUTPUT", "-o", "lo", "-p", "tcp", "--dport", kubeSchedulerProbePort, "-j", "REJECT")
+	require.NoError(t, err, "kube-scheduler probe block was not present after injection: %s", checkOutput)
+
+	// Confirm the replacement has not reported a healthy plan while the probe is blocked.
+	var planSecret *corev1.Secret
+	require.Eventually(t, func() bool {
+		planSecret, err = clients.Core.Secret().Get(secondMachine.Namespace, planSecretName, metav1.GetOptions{})
+		return err == nil
+	}, 2*time.Minute, 2*time.Second, "replacement plan secret never appeared")
+	require.Empty(t, planSecret.Annotations[planapi.PlanProbesPassedAnnotation], "replacement probes passed before the fault was injected")
+
+	// Verify CAPI sees the replacement Node as ready despite the failed component probe.
+	var secondNodeName string
+	require.Eventually(t, func() bool {
+		m, err := clients.CAPI.Machine().Get(secondMachine.Namespace, secondMachine.Name, metav1.GetOptions{})
+		if err != nil || !m.Status.NodeRef.IsDefined() || !conditions.IsTrue(m, capi.MachineNodeReadyCondition) {
+			return false
+		}
+		secondNodeName = m.Status.NodeRef.Name
+		return true
+	}, 20*time.Minute, 2*time.Second, "replacement never reached NodeReady while its kube-scheduler probe was blocked")
+
+	// Wait for deletion to begin so the protection checks exercise the pre-terminate hook.
+	require.Eventually(t, func() bool {
+		m, err := clients.CAPI.Machine().Get(firstMachine.Namespace, firstMachine.Name, metav1.GetOptions{})
+		return err == nil && !m.DeletionTimestamp.IsZero() && m.Annotations[preTerminateHook] != ""
+	}, 15*time.Minute, 2*time.Second, "initial machine never entered protected deletion")
+
+	// Keep the fault active across multiple reconciliation cycles and verify the old Machine and Node remain protected.
+	protectionDeadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(protectionDeadline) {
+		oldMachine, err := clients.CAPI.Machine().Get(firstMachine.Namespace, firstMachine.Name, metav1.GetOptions{})
+		require.NoError(t, err, "initial machine was removed while the replacement probe was failing")
+		require.Equal(t, firstMachine.UID, oldMachine.UID)
+		require.NotEmpty(t, oldMachine.Annotations[preTerminateHook], "pre-terminate hook was removed while the replacement probe was failing")
+
+		replacement, err := clients.CAPI.Machine().Get(secondMachine.Namespace, secondMachine.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.True(t, conditions.IsTrue(replacement, capi.MachineNodeReadyCondition), "replacement unexpectedly lost NodeReady")
+		planSecret, err := clients.Core.Secret().Get(secondMachine.Namespace, planSecretName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, corev1.SecretType(capr.SecretTypeMachinePlan), planSecret.Type)
+		require.Equal(t, "true", planSecret.Labels[capr.InitNodeLabel], "replacement is not the elected init node")
+		require.Empty(t, planSecret.Annotations[planapi.PlanProbesPassedAnnotation], "replacement probes passed while the kube-scheduler probe was blocked")
+
+		oldNode, err := clusterClients.Core.Node().Get(firstNodeName, metav1.GetOptions{})
+		require.NoError(t, err, "initial downstream node disappeared while the replacement probe was failing")
+		require.True(t, nodeReady(oldNode), "initial downstream node became NotReady while the replacement probe was failing")
+		time.Sleep(2 * time.Second)
+	}
+
+	// Remove the fault so the replacement can complete its machine plan.
+	_, err = cluster.ExecOnPod(clients, replacementPodNamespace, replacementPodName,
+		"iptables", "-D", "OUTPUT", "-o", "lo", "-p", "tcp", "--dport", kubeSchedulerProbePort, "-j", "REJECT")
+	require.NoError(t, err, "failed to restore the replacement's kube-scheduler health probe")
+	faultCleared = true
+
+	// Wait for the repaired replacement to report a healthy plan.
+	require.Eventually(t, func() bool {
+		planSecret, err := clients.Core.Secret().Get(secondMachine.Namespace, planSecretName, metav1.GetOptions{})
+		return err == nil && planSecret.Annotations[planapi.PlanProbesPassedAnnotation] != ""
+	}, 5*time.Minute, 2*time.Second, "replacement plan probes did not recover")
+
+	// Verify the old CAPI Machine is removed after the replacement becomes healthy.
+	require.Eventually(t, func() bool {
+		_, err := clients.CAPI.Machine().Get(firstMachine.Namespace, firstMachine.Name, metav1.GetOptions{})
+		return apierror.IsNotFound(err)
+	}, 15*time.Minute, 2*time.Second, "initial machine was not removed after the replacement recovered")
+
+	// Verify the replacement is the only remaining Machine and is ready.
+	require.Eventually(t, func() bool {
+		ml, err := cluster.Machines(clients, c)
+		return err == nil && len(ml.Items) == 1 && ml.Items[0].UID == secondMachine.UID &&
+			ml.Items[0].DeletionTimestamp.IsZero() && conditions.IsTrue(&ml.Items[0], capi.MachineNodeReadyCondition)
+	}, 15*time.Minute, 2*time.Second, "cluster did not converge to the recovered replacement")
+
+	// Verify the old downstream Node is also removed.
+	require.Eventually(t, func() bool {
+		_, err := clusterClients.Core.Node().Get(firstNodeName, metav1.GetOptions{})
+		return apierror.IsNotFound(err)
+	}, 10*time.Minute, 2*time.Second, "initial downstream node was not removed")
+
+	secondNode, err := clusterClients.Core.Node().Get(secondNodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, nodeReady(secondNode), "replacement downstream node is not Ready")
+	require.False(t, secondNode.Spec.Unschedulable, "replacement downstream node is cordoned")
+
+	// Verify the provisioning Cluster returns to its fully ready state.
+	_, err = cluster.WaitForCreate(clients, c)
+	require.NoError(t, err, "cluster did not return to Ready after the replacement recovered")
+}
+
+func nodeReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // unstructuredString safely returns a top-level string field from an Unstructured.Object

--- a/tests/v2prov/tests/machineprovisioning/machine_test.go
+++ b/tests/v2prov/tests/machineprovisioning/machine_test.go
@@ -836,7 +836,7 @@ func Test_Provisioning_SetB_Single_Node_All_Roles_Drain(t *testing.T) {
 	}, 10*time.Minute, 10*time.Second, "cluster did not return to Ready after rollout")
 }
 
-func Test_Provisioning_SetA_Single_Node_Drain_Unhealthy_Replacement(t *testing.T) {
+func Test_Provisioning_SetB_Single_Node_Drain_Unhealthy_Replacement(t *testing.T) {
 	if capr.GetRuntime(defaults.SomeK8sVersion) != capr.RuntimeRKE2 {
 		t.Skip("this test injects an RKE2 control-plane probe failure")
 	}

--- a/tests/v2prov/tests/machineprovisioning/machine_test.go
+++ b/tests/v2prov/tests/machineprovisioning/machine_test.go
@@ -836,7 +836,7 @@ func Test_Provisioning_SetB_Single_Node_All_Roles_Drain(t *testing.T) {
 	}, 10*time.Minute, 10*time.Second, "cluster did not return to Ready after rollout")
 }
 
-func Test_Provisioning_Single_Node_Drain_Unhealthy_Replacement(t *testing.T) {
+func Test_Provisioning_SetA_Single_Node_Drain_Unhealthy_Replacement(t *testing.T) {
 	if capr.GetRuntime(defaults.SomeK8sVersion) != capr.RuntimeRKE2 {
 		t.Skip("this test injects an RKE2 control-plane probe failure")
 	}


### PR DESCRIPTION
## Issue:
  https://github.com/rancher/rancher/issues/53836

## Problem

  `reconcileMachinePreTerminateAnnotation` manages the full lifecycle of the pre-terminate hook for etcd machines.

  Before delete starts, Rancher adds the pre-terminate annotation to the machine so CAPI will pause machine teardown later. After delete starts, Rancher uses the same flow to decide when that hook can be removed and when the etcd machine can finally be deleted.

  The problem was in that second part of the flow. Rancher was using a fixed time-based backoff instead of checking whether a real replacement etcd machine was actually ready. Because of that, Rancher could remove the hook and allow delete to continue before the replacement machine had fully joined, passed plan probes, and become a ready downstream node.

  That is risky in single-node and small etcd topologies, because the deleting machine may still be needed as the join target for the replacement, or the replacement may exist but still not be stable enough to safely take over.

  ## Solution

  This change keeps the same role for `reconcileMachinePreTerminateAnnotation`, but makes the delete release decision state-based instead of time-based.

  Rancher still adds the pre-terminate hook before delete starts, so CAPI will pause deletion for etcd machines. The change is in how Rancher decides that it is safe to remove that hook after delete has started.

  Instead of waiting for a fixed backoff, Rancher now waits until it can prove that a real replacement etcd machine is ready. Before removing the hook, Rancher now checks that:

  - no other machine is still joined to the deleting machine's join URL
  - another etcd machine exists
  - the replacement machine has a join URL
  - the replacement machine has `plan-probes-passed`
  - the replacement machine is not deleting
  - the replacement machine has a ready downstream node

  This PR adds `replacementEtcdMachineReady()` for that validation, plus helpers to check downstream node readiness through `NodeRef` first and through the machine UID label as a fallback.

  As a small safety improvement, `etcdmgmt.SafelyRemoved()` now initializes the node annotations map before writing the etcd removal annotation.

  This PR also adds comments around the pre-terminate flow and adds targeted controller logs to make the decision timing easier to follow during debugging.

  ## Testing

  Validated with the single-node all-roles drain scenario used by `SnapshotTestDrainTest_Provisioning_Single_Node_All_Roles_Drain`.

  ## Engineering Testing

  ### Manual Testing

  - Ran the single-node all-roles drain scenario through the VS Code debug target `SnapshotTestDrainTest_Provisioning_Single_Node_All_Roles_Drain`.
  - Observed the bootstrap controller keep the pre-terminate hook while the replacement machine was still joining or not yet ready.
  - Verified the flow only moved forward after the replacement machine had the expected join state, passed plan probes, and reported a ready downstream node.
  - Verified the scenario completed successfully after the replacement became ready.

  ### Automated Testing

  * Test types added/modified:
      * Unit

  Summary: Added unit coverage for `replacementEtcdMachineReady()` to verify that Rancher only accepts a replacement etcd machine when the replacement has the expected join metadata, passed plan probes, and a ready downstream node.

  ## QA Testing Considerations

  - Test a fresh single-node all-roles provisioning cluster and trigger the drain and replacement flow.
  - Confirm the old etcd machine is not deleted while another machine is still joined to its join URL.
  - Confirm the old etcd machine is not deleted before the replacement reports `plan-probes-passed`.
  - Confirm the old etcd machine is not deleted before the replacement node is Ready downstream.
  - Confirm delete proceeds once the replacement is ready and the old etcd member has been safely removed.
  - Confirm non-etcd machine deletion is not blocked by this logic.
  - Confirm full cluster deletion still removes the hook and does not leave machines stuck.

  ### Regressions Considerations

  This change is limited to the etcd machine pre-terminate path, so the regression surface is narrow. The main regression risk is that delete may wait longer than before if replacement readiness signals never appear. That is an intentional tradeoff, because it is safer to block delete than to remove an etcd member too early.
