### PR TITLE
fix: use dynamic namespace for imperative-api-extension instead of hardcoded cattle-system

### DIFF
--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -206,7 +206,7 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 		return fmt.Errorf("failed to create label requirement: %w", err)
 	}
 
-	watcher, err := p.secrets.Watch(Namespace, metav1.ListOptions{
+	watcher, err := p.secrets.Watch(GetNamespace(), metav1.ListOptions{
 		LabelSelector: labels.NewSelector().Add(*req).String(),
 	})
 	if err != nil {
@@ -225,7 +225,7 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 		case <-stopChan:
 			logrus.Info("stopping imperative api cert rotator")
 
-			if err := p.secrets.Delete(Namespace, p.secretName, &metav1.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
+			if err := p.secrets.Delete(GetNamespace(), p.secretName, &metav1.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
 				logrus.Error(err)
 			}
 
@@ -266,7 +266,7 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      p.secretName,
-				Namespace: Namespace,
+				Namespace: GetNamespace(),
 				Labels: map[string]string{
 					SecretLabelProvider: p.name,
 				},
@@ -327,7 +327,7 @@ func (p *rotatingSNIProvider) willCertExpireWithinDuration(secret *corev1.Secret
 }
 
 func (p *rotatingSNIProvider) handleCert() error {
-	secret, err := p.secrets.Get(Namespace, p.secretName, metav1.GetOptions{})
+	secret, err := p.secrets.Get(GetNamespace(), p.secretName, metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
 		if err := p.createOrUpdateCerts(nil); err != nil {

--- a/pkg/ext/certs_test.go
+++ b/pkg/ext/certs_test.go
@@ -192,7 +192,7 @@ func setup(t *testing.T) (*rotatingSNIProvider, *fake.MockControllerInterface[*c
 	provider, err := NewSNIProviderForCname(
 		"test-provider",
 		[]string{
-			fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace),
+			fmt.Sprintf("%s.%s.svc", TargetServiceName, GetNamespace()),
 		},
 		secretMock)
 	assert.NoError(t, err)
@@ -215,7 +215,7 @@ func TestRotatingSNIProviderNoExistingSecret(t *testing.T) {
 	}()
 
 	wait.Until(func() {
-		_, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+		_, err := secretMock.Get(GetNamespace(), provider.secretName, metav1.GetOptions{})
 
 		if err == nil {
 			close(stopChan)
@@ -226,7 +226,7 @@ func TestRotatingSNIProviderNoExistingSecret(t *testing.T) {
 
 	wg.Wait()
 
-	secret, err := store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	secret, err := store.Get(fmt.Sprintf("%s/%s", GetNamespace(), provider.secretName))
 	assert.Error(t, err)
 	assert.Nil(t, secret)
 }
@@ -235,13 +235,13 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 	provider, secretMock, store := setup(t)
 	stopChan := make(chan struct{})
 
-	initialCert, initialCa, err := GenerateSelfSignedCertKeyWithOpts(fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace), time.Second*5)
+	initialCert, initialCa, err := GenerateSelfSignedCertKeyWithOpts(fmt.Sprintf("%s.%s.svc", TargetServiceName, GetNamespace()), time.Second*5)
 	assert.NoError(t, err)
 
-	err = store.Create(fmt.Sprintf("%s/%s", Namespace, provider.secretName), &corev1.Secret{
+	err = store.Create(fmt.Sprintf("%s/%s", GetNamespace(), provider.secretName), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      provider.secretName,
-			Namespace: Namespace,
+			Namespace: GetNamespace(),
 		},
 		Data: map[string][]byte{
 			corev1.TLSCertKey:       initialCert,
@@ -262,7 +262,7 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
-		secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+		secret, err := secretMock.Get(GetNamespace(), provider.secretName, metav1.GetOptions{})
 		assert.NoError(t, err)
 
 		cert := secret.Data[corev1.TLSCertKey]
@@ -272,7 +272,7 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 		}
 	}, time.Second)
 
-	secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+	secret, err := secretMock.Get(GetNamespace(), provider.secretName, metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	cert := secret.Data[corev1.TLSCertKey]
@@ -285,7 +285,7 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 
 	wg.Wait()
 
-	secret, err = store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	secret, err = store.Get(fmt.Sprintf("%s/%s", GetNamespace(), provider.secretName))
 	assert.Error(t, err)
 	assert.Nil(t, secret)
 }

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/clusterauthtoken"
 	extstores "github.com/rancher/rancher/pkg/ext/stores"
 	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	steveext "github.com/rancher/steve/pkg/ext"
 	steveserver "github.com/rancher/steve/pkg/server"
@@ -55,8 +56,18 @@ const (
 	Port              = 6666
 	APIServiceName    = "v1.ext.cattle.io"
 	TargetServiceName = "imperative-api-extension"
-	Namespace         = "cattle-system"
+	defaultNamespace  = "cattle-system"
 )
+
+// GetNamespace returns the namespace where Rancher is running.
+// It reads from the "namespace" setting (populated from the CATTLE_NAMESPACE
+// environment variable) and falls back to "cattle-system" if the setting is empty.
+func GetNamespace() string {
+	if ns := settings.Namespace.Get(); ns != "" {
+		return ns
+	}
+	return defaultNamespace
+}
 
 func CreateOrUpdateAPIService(apiservice wranglerapiregistrationv1.APIServiceController, caBundle []byte) error {
 	port := int32(Port)
@@ -69,7 +80,7 @@ func CreateOrUpdateAPIService(apiservice wranglerapiregistrationv1.APIServiceCon
 			GroupPriorityMinimum: 100,
 			CABundle:             caBundle,
 			Service: &apiregv1.ServiceReference{
-				Namespace: Namespace,
+				Namespace: GetNamespace(),
 				Name:      TargetServiceName,
 				Port:      &port,
 			},
@@ -104,7 +115,7 @@ func CreateOrUpdateService(service wranglercorev1.ServiceController, appSelector
 	desired := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TargetServiceName,
-			Namespace: Namespace,
+			Namespace: GetNamespace(),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -118,7 +129,7 @@ func CreateOrUpdateService(service wranglercorev1.ServiceController, appSelector
 		},
 	}
 
-	current, err := service.Get(Namespace, TargetServiceName, metav1.GetOptions{})
+	current, err := service.Get(GetNamespace(), TargetServiceName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		if _, err := service.Create(desired); err != nil {
 			return err
@@ -161,7 +172,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 
 	sniProvider, err := NewSNIProviderForCname(
 		"imperative-api-sni-provider",
-		[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)},
+		[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, GetNamespace())},
 		wranglerContext.Core.Secret(),
 	)
 	if err != nil {

--- a/pkg/ext/extension_apiserver_test.go
+++ b/pkg/ext/extension_apiserver_test.go
@@ -6,25 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetNamespaceDefault(t *testing.T) {
-	// When CATTLE_NAMESPACE is not set (no settings provider configured),
-	// GetNamespace should return the default "cattle-system".
+func TestGetNamespaceDefaultFallback(t *testing.T) {
+	// When no settings provider is configured and CATTLE_NAMESPACE was not set
+	// at init time, GetNamespace should return the default "cattle-system".
 	ns := GetNamespace()
-	assert.Equal(t, "cattle-system", ns)
-}
-
-func TestGetNamespaceFromEnv(t *testing.T) {
-	// When CATTLE_NAMESPACE is set, GetNamespace should return it.
-	t.Setenv("CATTLE_NAMESPACE", "custom-namespace")
-
-	// Since settings.Namespace is initialized at package init time from
-	// os.Getenv("CATTLE_NAMESPACE"), and the settings provider is nil in tests,
-	// settings.Namespace.Get() returns the Default value which was captured
-	// at init time. We can't change it at runtime with t.Setenv for the
-	// settings package. So we validate the default behavior here.
-	ns := GetNamespace()
-	// Without a provider, the setting returns its Default value (from init time),
-	// which is "" since CATTLE_NAMESPACE was not set when the package initialized.
-	// So the fallback to "cattle-system" should apply.
 	assert.Equal(t, "cattle-system", ns)
 }

--- a/pkg/ext/extension_apiserver_test.go
+++ b/pkg/ext/extension_apiserver_test.go
@@ -1,0 +1,30 @@
+package ext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNamespaceDefault(t *testing.T) {
+	// When CATTLE_NAMESPACE is not set (no settings provider configured),
+	// GetNamespace should return the default "cattle-system".
+	ns := GetNamespace()
+	assert.Equal(t, "cattle-system", ns)
+}
+
+func TestGetNamespaceFromEnv(t *testing.T) {
+	// When CATTLE_NAMESPACE is set, GetNamespace should return it.
+	t.Setenv("CATTLE_NAMESPACE", "custom-namespace")
+
+	// Since settings.Namespace is initialized at package init time from
+	// os.Getenv("CATTLE_NAMESPACE"), and the settings provider is nil in tests,
+	// settings.Namespace.Get() returns the Default value which was captured
+	// at init time. We can't change it at runtime with t.Setenv for the
+	// settings package. So we validate the default behavior here.
+	ns := GetNamespace()
+	// Without a provider, the setting returns its Default value (from init time),
+	// which is "" since CATTLE_NAMESPACE was not set when the package initialized.
+	// So the fallback to "cattle-system" should apply.
+	assert.Equal(t, "cattle-system", ns)
+}


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/51827

## Problem
The `imperative-api-extension` APIService and Service are created with a hardcoded `Namespace = "cattle-system"` constant in `pkg/ext/extension_apiserver.go`. When Rancher is installed in any other namespace, the Service has no backing endpoints, kube-apiserver gets 503s reaching the extension API, and Rancher pods crash with:

```
[FATAL] kube-apiserver did not contact the rancher imperative api in time
```

## Solution
Replace the hardcoded `Namespace` constant with a `GetNamespace()` function that reads from `settings.Namespace` (populated from `CATTLE_NAMESPACE` env var), falling back to `"cattle-system"`.

- **`pkg/ext/extension_apiserver.go`**: `Namespace` const → `GetNamespace()` func. Updated APIService ServiceReference, Service ObjectMeta, Service Get call, and SNI cert hostname.
- **`pkg/ext/certs.go`**: Updated secret watch/create/get/delete calls to use `GetNamespace()`.

```go
func GetNamespace() string {
	if ns := settings.Namespace.Get(); ns != "" {
		return ns
	}
	return defaultNamespace // "cattle-system"
}
```

## Testing
Install Rancher via Helm into a namespace other than `cattle-system` (e.g. `rancher-system`). The APIService `v1.ext.cattle.io` should now reference the correct namespace, and the `imperative-api-extension` Service should be created in the actual Rancher namespace.

## Engineering Testing
### Manual Testing
Verified build succeeds and all existing `pkg/ext/` tests pass with the change.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: Added `TestGetNamespaceDefaultFallback` in `extension_apiserver_test.go` to verify the fallback to `"cattle-system"` when `CATTLE_NAMESPACE` is unset. Updated existing `certs_test.go` references to use `GetNamespace()`.

## QA Testing Considerations
Test Rancher Helm install into a non-default namespace (e.g. `rancher-system` or `rancher`) and verify:
1. `imperative-api-extension` Service is created in the install namespace
2. `v1.ext.cattle.io` APIService references the install namespace
3. Extension API aggregation succeeds (no FATAL crash loop)
4. Standard `cattle-system` install still works (regression)

### Regressions Considerations
Low risk. The default fallback is `"cattle-system"`, so existing installs using the standard namespace are unaffected. The `CATTLE_NAMESPACE` env var is already set by Rancher's Helm chart and entrypoint.

Note: `pkg/ext/rdp.go` still uses `namespace.System` (hardcoded `cattle-system`) for RDP-related operations. This is a separate code path gated behind `RDPEnabled()` and out of scope here.

Existing / newly added automated tests that provide evidence there are no regressions:
* `TestGetNamespaceDefaultFallback` — verifies default fallback
* `TestRotatingSNIProviderNoExistingSecret` — cert rotation with dynamic namespace
* `TestRotatingSNIProviderWithExistingExpiringSecret` — cert rotation with expiring secret
