### PR TITLE
Backport for fix: use dynamic namespace for imperative-api-extension instead of hardcoded cattle-system

### DIFF
--- a/pkg/ext/certs.go
+++ b/pkg/ext/certs.go
@@ -206,7 +206,7 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 		return fmt.Errorf("failed to create label requirement: %w", err)
 	}
 
-	watcher, err := p.secrets.Watch(Namespace, metav1.ListOptions{
+	watcher, err := p.secrets.Watch(GetNamespace(), metav1.ListOptions{
 		LabelSelector: labels.NewSelector().Add(*req).String(),
 	})
 	if err != nil {
@@ -225,7 +225,7 @@ func (p *rotatingSNIProvider) Run(stopChan <-chan struct{}) error {
 		case <-stopChan:
 			logrus.Info("stopping imperative api cert rotator")
 
-			if err := p.secrets.Delete(Namespace, p.secretName, &metav1.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
+			if err := p.secrets.Delete(GetNamespace(), p.secretName, &metav1.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
 				logrus.Error(err)
 			}
 
@@ -266,7 +266,7 @@ func (p *rotatingSNIProvider) createOrUpdateCerts(secret *corev1.Secret) error {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      p.secretName,
-				Namespace: Namespace,
+				Namespace: GetNamespace(),
 				Labels: map[string]string{
 					SecretLabelProvider: p.name,
 				},
@@ -327,7 +327,7 @@ func (p *rotatingSNIProvider) willCertExpireWithinDuration(secret *corev1.Secret
 }
 
 func (p *rotatingSNIProvider) handleCert() error {
-	secret, err := p.secrets.Get(Namespace, p.secretName, metav1.GetOptions{})
+	secret, err := p.secrets.Get(GetNamespace(), p.secretName, metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
 		if err := p.createOrUpdateCerts(nil); err != nil {

--- a/pkg/ext/certs_test.go
+++ b/pkg/ext/certs_test.go
@@ -192,7 +192,7 @@ func setup(t *testing.T) (*rotatingSNIProvider, *fake.MockControllerInterface[*c
 	provider, err := NewSNIProviderForCname(
 		"test-provider",
 		[]string{
-			fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace),
+			fmt.Sprintf("%s.%s.svc", TargetServiceName, GetNamespace()),
 		},
 		secretMock)
 	assert.NoError(t, err)
@@ -215,7 +215,7 @@ func TestRotatingSNIProviderNoExistingSecret(t *testing.T) {
 	}()
 
 	wait.Until(func() {
-		_, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+		_, err := secretMock.Get(GetNamespace(), provider.secretName, metav1.GetOptions{})
 
 		if err == nil {
 			close(stopChan)
@@ -226,7 +226,7 @@ func TestRotatingSNIProviderNoExistingSecret(t *testing.T) {
 
 	wg.Wait()
 
-	secret, err := store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	secret, err := store.Get(fmt.Sprintf("%s/%s", GetNamespace(), provider.secretName))
 	assert.Error(t, err)
 	assert.Nil(t, secret)
 }
@@ -235,13 +235,13 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 	provider, secretMock, store := setup(t)
 	stopChan := make(chan struct{})
 
-	initialCert, initialCa, err := GenerateSelfSignedCertKeyWithOpts(fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace), time.Second*5)
+	initialCert, initialCa, err := GenerateSelfSignedCertKeyWithOpts(fmt.Sprintf("%s.%s.svc", TargetServiceName, GetNamespace()), time.Second*5)
 	assert.NoError(t, err)
 
-	err = store.Create(fmt.Sprintf("%s/%s", Namespace, provider.secretName), &corev1.Secret{
+	err = store.Create(fmt.Sprintf("%s/%s", GetNamespace(), provider.secretName), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      provider.secretName,
-			Namespace: Namespace,
+			Namespace: GetNamespace(),
 		},
 		Data: map[string][]byte{
 			corev1.TLSCertKey:       initialCert,
@@ -262,7 +262,7 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
-		secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+		secret, err := secretMock.Get(GetNamespace(), provider.secretName, metav1.GetOptions{})
 		assert.NoError(t, err)
 
 		cert := secret.Data[corev1.TLSCertKey]
@@ -272,7 +272,7 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 		}
 	}, time.Second)
 
-	secret, err := secretMock.Get(Namespace, provider.secretName, metav1.GetOptions{})
+	secret, err := secretMock.Get(GetNamespace(), provider.secretName, metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	cert := secret.Data[corev1.TLSCertKey]
@@ -285,7 +285,7 @@ func TestRotatingSNIProviderWithExistingExpiringSecret(t *testing.T) {
 
 	wg.Wait()
 
-	secret, err = store.Get(fmt.Sprintf("%s/%s", Namespace, provider.secretName))
+	secret, err = store.Get(fmt.Sprintf("%s/%s", GetNamespace(), provider.secretName))
 	assert.Error(t, err)
 	assert.Nil(t, secret)
 }

--- a/pkg/ext/extension_apiserver.go
+++ b/pkg/ext/extension_apiserver.go
@@ -11,6 +11,7 @@ import (
 
 	extstores "github.com/rancher/rancher/pkg/ext/stores"
 	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	steveext "github.com/rancher/steve/pkg/ext"
 	steveserver "github.com/rancher/steve/pkg/server"
@@ -54,8 +55,18 @@ const (
 	Port              = 6666
 	APIServiceName    = "v1.ext.cattle.io"
 	TargetServiceName = "imperative-api-extension"
-	Namespace         = "cattle-system"
+	defaultNamespace  = "cattle-system"
 )
+
+// GetNamespace returns the namespace where Rancher is running.
+// It reads from the "namespace" setting (populated from the CATTLE_NAMESPACE
+// environment variable) and falls back to "cattle-system" if the setting is empty.
+func GetNamespace() string {
+	if ns := settings.Namespace.Get(); ns != "" {
+		return ns
+	}
+	return defaultNamespace
+}
 
 func CreateOrUpdateAPIService(apiservice wranglerapiregistrationv1.APIServiceController, caBundle []byte) error {
 	port := int32(Port)
@@ -68,7 +79,7 @@ func CreateOrUpdateAPIService(apiservice wranglerapiregistrationv1.APIServiceCon
 			GroupPriorityMinimum: 100,
 			CABundle:             caBundle,
 			Service: &apiregv1.ServiceReference{
-				Namespace: Namespace,
+				Namespace: GetNamespace(),
 				Name:      TargetServiceName,
 				Port:      &port,
 			},
@@ -103,7 +114,7 @@ func CreateOrUpdateService(service wranglercorev1.ServiceController, appSelector
 	desired := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TargetServiceName,
-			Namespace: Namespace,
+			Namespace: GetNamespace(),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -117,7 +128,7 @@ func CreateOrUpdateService(service wranglercorev1.ServiceController, appSelector
 		},
 	}
 
-	current, err := service.Get(Namespace, TargetServiceName, metav1.GetOptions{})
+	current, err := service.Get(GetNamespace(), TargetServiceName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		if _, err := service.Create(desired); err != nil {
 			return err
@@ -160,7 +171,7 @@ func NewExtensionAPIServer(ctx context.Context, wranglerContext *wrangler.Contex
 
 	sniProvider, err := NewSNIProviderForCname(
 		"imperative-api-sni-provider",
-		[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, Namespace)},
+		[]string{fmt.Sprintf("%s.%s.svc", TargetServiceName, GetNamespace())},
 		wranglerContext.Core.Secret(),
 	)
 	if err != nil {

--- a/pkg/ext/extension_apiserver_test.go
+++ b/pkg/ext/extension_apiserver_test.go
@@ -3,6 +3,7 @@ package ext
 import (
 	"testing"
 
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,4 +12,16 @@ func TestGetNamespaceDefaultFallback(t *testing.T) {
 	// at init time, GetNamespace should return the default "cattle-system".
 	ns := GetNamespace()
 	assert.Equal(t, "cattle-system", ns)
+}
+
+func TestGetNamespaceCustomValue(t *testing.T) {
+	// When the namespace setting is set, GetNamespace should return that value.
+	err := settings.Namespace.Set("rancher-system")
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		_ = settings.Namespace.Set("")
+	})
+
+	ns := GetNamespace()
+	assert.Equal(t, "rancher-system", ns)
 }

--- a/pkg/ext/extension_apiserver_test.go
+++ b/pkg/ext/extension_apiserver_test.go
@@ -1,0 +1,14 @@
+package ext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNamespaceDefaultFallback(t *testing.T) {
+	// When no settings provider is configured and CATTLE_NAMESPACE was not set
+	// at init time, GetNamespace should return the default "cattle-system".
+	ns := GetNamespace()
+	assert.Equal(t, "cattle-system", ns)
+}


### PR DESCRIPTION
this is a backport for #54203, whenever it is merged