### PR TITLE
[2.14] Remove old capi image from origins.go

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -141,7 +141,6 @@ var OriginMap = map[string]string{
 	"mirrored-cloud-provider-vsphere-csi-release-driver":      "https://github.com/kubernetes-sigs/vsphere-csi-driver",
 	"mirrored-cloud-provider-vsphere-csi-release-syncer":      "https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/pkg/syncer",
 	"mirrored-cloud-provider-vsphere":                         "https://github.com/kubernetes/cloud-provider-vsphere",
-	"mirrored-cluster-api-controller":                         "https://github.com/kubernetes-sigs/cluster-api",
 	"mirrored-coredns-coredns":                                "https://github.com/coredns/coredns",
 	"mirrored-coreos-prometheus-config-reloader":              "https://github.com/prometheus-operator/prometheus-operator/pkgs/container/prometheus-config-reloader",
 	"mirrored-coreos-prometheus-operator":                     "https://github.com/prometheus-operator/prometheus-operator",


### PR DESCRIPTION
The old capi chart was removed as of https://github.com/rancher/rancher/issues/53291, so its main image isn't used anymore.

The capi image installed by Turtles and being used now is another one (`rancher/cluster-api-controller`).