### PR TITLE
[main] run prebootstrap flow by default

### DIFF
--- a/pkg/agent/rancher/rancher.go
+++ b/pkg/agent/rancher/rancher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/rancher/rancher/pkg/agent/cluster"
@@ -25,6 +26,8 @@ import (
 var (
 	started bool
 )
+
+const preBootstrapEnvVar = "CATTLE_PREBOOTSTRAP"
 
 func Run(ctx context.Context) error {
 	if err := setupSteveAggregation(ctx); err != nil {
@@ -70,7 +73,7 @@ type handler struct {
 }
 
 func (h *handler) startRancher() {
-	if features.ProvisioningPreBootstrap.Enabled() {
+	if isPreBootstrap() {
 		logrus.Debugf("not starting embedded rancher due to pre-bootstrap...")
 		return
 	}
@@ -100,6 +103,10 @@ func (h *handler) startRancher() {
 			}
 		}
 	}()
+}
+
+func isPreBootstrap() bool {
+	return strings.EqualFold(os.Getenv(preBootstrapEnvVar), "true")
 }
 
 func (h *handler) OnChange(key string, service *corev1.Service) (*corev1.Service, error) {

--- a/pkg/agent/rancher/rancher.go
+++ b/pkg/agent/rancher/rancher.go
@@ -105,10 +105,6 @@ func (h *handler) startRancher() {
 	}()
 }
 
-func isPreBootstrap() bool {
-	return strings.EqualFold(os.Getenv(preBootstrapEnvVar), "true")
-}
-
 func (h *handler) OnChange(key string, service *corev1.Service) (*corev1.Service, error) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
@@ -187,4 +183,8 @@ func setupSteveAggregation(ctx context.Context) error {
 			},
 			Data: data,
 		})
+}
+
+func isPreBootstrap() bool {
+	return strings.EqualFold(os.Getenv(preBootstrapEnvVar), "true")
 }

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -77,6 +78,7 @@ const (
 	UnCordonAnnotation                         = "rke.cattle.io/uncordon"
 	WorkerRoleLabel                            = "rke.cattle.io/worker-role"
 	AuthorizedObjectAnnotation                 = "rke.cattle.io/object-authorized-for-clusters"
+	PreBootstrapSyncAnnotation                 = "provisioning.cattle.io/sync-bootstrap"
 	PlanUpdatedTimeAnnotation                  = "rke.cattle.io/plan-last-updated"
 	PlanProbesPassedAnnotation                 = "rke.cattle.io/plan-probes-passed"
 	DeleteMissingCustomMachinesAfterAnnotation = "rke.cattle.io/delete-missing-custom-machines-after"
@@ -653,6 +655,76 @@ func PreBootstrap(mgmtCluster *v3.Cluster) bool {
 	}
 
 	return !v3.ClusterConditionPreBootstrapped.IsTrue(mgmtCluster)
+}
+
+// ShouldPreBootstrap determines whether the given cluster should enter the pre-bootstrap flow.
+// It checks whether the feature flag is enabled, whether the cluster has already been pre-bootstrapped,
+// and whether there are any authorized sync-bootstrap secrets for this cluster.
+func ShouldPreBootstrap(secretCache corecontrollers.SecretCache, cluster *v3.Cluster) (bool, error) {
+	if !PreBootstrap(cluster) {
+		return false, nil
+	}
+
+	// The bootstrap gate is annotation-based (`provisioning.cattle.io/sync-bootstrap=true`), so we must list
+	// and inspect secrets in-memory because annotation selectors are not supported by the Kubernetes API.
+	secrets, err := secretCache.List(cluster.Spec.FleetWorkspaceName, labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("failed to list secrets in namespace %s for cluster %s: %w", cluster.Spec.FleetWorkspaceName, cluster.Name, err)
+	}
+
+	for _, secret := range secrets {
+		if secret.Annotations == nil {
+			continue
+		}
+
+		if secret.Annotations[PreBootstrapSyncAnnotation] != "true" {
+			continue
+		}
+
+		// Keep this aligned with managementuser/secret bootstrap sync authorization, which authorizes by
+		// management cluster display name.
+		if !ClusterAuthorizedForSecret(secret.Annotations[AuthorizedObjectAnnotation], cluster.Spec.DisplayName) {
+			continue
+		}
+
+		return true, nil
+	}
+
+	logrus.Debugf("[pre-bootstrap] no authorized sync-bootstrap secrets found for cluster %s, skipping pre-bootstrap flow", cluster.Name)
+	return false, nil
+}
+
+// AuthorizedClusterNames returns the authorized cluster names from a comma-separated annotation value.
+func AuthorizedClusterNames(authorizedClusters string) []string {
+	if authorizedClusters == "" {
+		return nil
+	}
+
+	var clusterNames []string
+	for _, authorizedCluster := range strings.Split(authorizedClusters, ",") {
+		clusterName := strings.TrimSpace(authorizedCluster)
+		if clusterName == "" {
+			continue
+		}
+		clusterNames = append(clusterNames, clusterName)
+	}
+
+	return clusterNames
+}
+
+// ClusterAuthorizedForSecret checks whether a cluster name appears in a comma-separated list of authorized clusters.
+func ClusterAuthorizedForSecret(authorizedClusters, clusterName string) bool {
+	if clusterName == "" {
+		return false
+	}
+
+	for _, authorizedCluster := range AuthorizedClusterNames(authorizedClusters) {
+		if authorizedCluster == clusterName {
+			return true
+		}
+	}
+
+	return false
 }
 
 // AutoscalerEnabledByCAPI looks at the cluster object for the ClusterAutoscalerEnabledAnnotation, and

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -18,10 +18,10 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/channelserver"
-	"github.com/rancher/rancher/pkg/features"
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta2"
 	provcontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
+	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/data"
@@ -647,27 +647,21 @@ func SafeConcatName(maxLength int, name ...string) string {
 	return fullPath[0:maxLength-(hashLength+1)] + "-" + hex.EncodeToString(digest[0:])[0:hashLength]
 }
 
-func PreBootstrap(mgmtCluster *v3.Cluster) bool {
-	// if the upstream rancher _does not_ have pre-bootstrapping enabled just always return false.
-	if !features.ProvisioningPreBootstrap.Enabled() {
-		logrus.Debug("[pre-bootstrap] feature-flag disabled, skipping pre-bootstrap flow")
-		return false
+// ShouldPreBootstrap determines whether the given cluster should enter the pre-bootstrap flow.
+// It checks whether the cluster has already been pre-bootstrapped, and whether there are any authorized
+// sync-bootstrap secrets for this cluster.
+func ShouldPreBootstrap(secretLister v1.SecretLister, cluster *v3.Cluster) (bool, error) {
+	if v3.ClusterConditionPreBootstrapped.IsTrue(cluster) {
+		return false, nil
 	}
 
-	return !v3.ClusterConditionPreBootstrapped.IsTrue(mgmtCluster)
-}
-
-// ShouldPreBootstrap determines whether the given cluster should enter the pre-bootstrap flow.
-// It checks whether the feature flag is enabled, whether the cluster has already been pre-bootstrapped,
-// and whether there are any authorized sync-bootstrap secrets for this cluster.
-func ShouldPreBootstrap(secretCache corecontrollers.SecretCache, cluster *v3.Cluster) (bool, error) {
-	if !PreBootstrap(cluster) {
+	if cluster.Spec.FleetWorkspaceName == "" {
 		return false, nil
 	}
 
 	// The bootstrap gate is annotation-based (`provisioning.cattle.io/sync-bootstrap=true`), so we must list
 	// and inspect secrets in-memory because annotation selectors are not supported by the Kubernetes API.
-	secrets, err := secretCache.List(cluster.Spec.FleetWorkspaceName, labels.Everything())
+	secrets, err := secretLister.List(cluster.Spec.FleetWorkspaceName, labels.Everything())
 	if err != nil {
 		return false, fmt.Errorf("failed to list secrets in namespace %s for cluster %s: %w", cluster.Spec.FleetWorkspaceName, cluster.Name, err)
 	}

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -78,7 +78,6 @@ const (
 	UnCordonAnnotation                         = "rke.cattle.io/uncordon"
 	WorkerRoleLabel                            = "rke.cattle.io/worker-role"
 	AuthorizedObjectAnnotation                 = "rke.cattle.io/object-authorized-for-clusters"
-	PreBootstrapSyncAnnotation                 = "provisioning.cattle.io/sync-bootstrap"
 	PlanUpdatedTimeAnnotation                  = "rke.cattle.io/plan-last-updated"
 	PlanProbesPassedAnnotation                 = "rke.cattle.io/plan-probes-passed"
 	DeleteMissingCustomMachinesAfterAnnotation = "rke.cattle.io/delete-missing-custom-machines-after"
@@ -203,6 +202,13 @@ const (
 	MaximumHostnameLengthLimit = 63
 
 	SystemAgentDataDirEnvVar = "CATTLE_AGENT_VAR_DIR"
+
+	// various sync-related annotations for the secret-sync mechanism
+	SyncAnnotation             = "provisioning.cattle.io/sync"
+	SyncPreBootstrapAnnotation = "provisioning.cattle.io/sync-bootstrap"
+	SyncNamespaceAnnotation    = "provisioning.cattle.io/sync-target-namespace"
+	SyncNameAnnotation         = "provisioning.cattle.io/sync-target-name"
+	SyncedAtAnnotation         = "provisioning.cattle.io/synced-at"
 )
 
 var (
@@ -671,7 +677,7 @@ func ShouldPreBootstrap(secretLister v1.SecretLister, cluster *v3.Cluster) (bool
 			continue
 		}
 
-		if secret.Annotations[PreBootstrapSyncAnnotation] != "true" {
+		if secret.Annotations[SyncPreBootstrapAnnotation] != "true" {
 			continue
 		}
 

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -21,7 +21,6 @@ import (
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta2"
 	provcontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
-	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/data"
@@ -653,10 +652,15 @@ func SafeConcatName(maxLength int, name ...string) string {
 	return fullPath[0:maxLength-(hashLength+1)] + "-" + hex.EncodeToString(digest[0:])[0:hashLength]
 }
 
+// SecretLister is a minimal interface for listing secrets in order to be compatible with core controllers, norman, etc
+type SecretLister interface {
+	List(namespace string, selector labels.Selector) ([]*corev1.Secret, error)
+}
+
 // ShouldPreBootstrap determines whether the given cluster should enter the pre-bootstrap flow.
 // It checks whether the cluster has already been pre-bootstrapped, and whether there are any authorized
 // sync-bootstrap secrets for this cluster.
-func ShouldPreBootstrap(secretLister v1.SecretLister, cluster *v3.Cluster) (bool, error) {
+func ShouldPreBootstrap(secretLister SecretLister, cluster *v3.Cluster) (bool, error) {
 	if v3.ClusterConditionPreBootstrapped.IsTrue(cluster) {
 		return false, nil
 	}

--- a/pkg/capr/common_test.go
+++ b/pkg/capr/common_test.go
@@ -785,7 +785,7 @@ func TestShouldPreBootstrap(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bootstrap-secret",
 						Annotations: map[string]string{
-							PreBootstrapSyncAnnotation: "true",
+							SyncPreBootstrapAnnotation: "true",
 							AuthorizedObjectAnnotation: "c-test",
 						},
 					},
@@ -807,7 +807,7 @@ func TestShouldPreBootstrap(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bootstrap-secret",
 						Annotations: map[string]string{
-							PreBootstrapSyncAnnotation: "true",
+							SyncPreBootstrapAnnotation: "true",
 							AuthorizedObjectAnnotation: "c-other",
 						},
 					},

--- a/pkg/capr/common_test.go
+++ b/pkg/capr/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
@@ -11,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -760,4 +762,136 @@ func TestSetCAPIResourceCondition(t *testing.T) {
 			assert.True(t, v1beta1Found, "v1beta1 condition should be set on status.deprecated.v1beta1.conditions")
 		})
 	}
+}
+
+func TestShouldPreBootstrap(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *apimgmtv3.Cluster
+		secrets []*corev1.Secret
+		want    bool
+	}{
+		{
+			name: "authorized sync-bootstrap secret exists",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c-m-abc"},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName:        "c-test",
+					FleetWorkspaceName: "fleet-default",
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bootstrap-secret",
+						Annotations: map[string]string{
+							PreBootstrapSyncAnnotation: "true",
+							AuthorizedObjectAnnotation: "c-test",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "sync-bootstrap secret not authorized for cluster",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c-m-abc"},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName:        "c-test",
+					FleetWorkspaceName: "fleet-default",
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bootstrap-secret",
+						Annotations: map[string]string{
+							PreBootstrapSyncAnnotation: "true",
+							AuthorizedObjectAnnotation: "c-other",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no sync-bootstrap secret",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c-m-abc"},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName:        "c-test",
+					FleetWorkspaceName: "fleet-default",
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "non-bootstrap-secret",
+						Annotations: map[string]string{
+							AuthorizedObjectAnnotation: "c-test",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			secretCache.EXPECT().List("fleet-default", labels.Everything()).Return(tt.secrets, nil)
+
+			got, err := ShouldPreBootstrap(secretCache, tt.cluster)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestShouldPreBootstrapWhenClusterAlreadyPreBootstrapped(t *testing.T) {
+	cluster := &apimgmtv3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c-m-abc"},
+		Spec: apimgmtv3.ClusterSpec{
+			DisplayName:        "c-test",
+			FleetWorkspaceName: "fleet-default",
+		},
+	}
+	apimgmtv3.ClusterConditionPreBootstrapped.True(cluster)
+
+	ctrl := gomock.NewController(t)
+	secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	// No EXPECT — cache should not be called for already pre-bootstrapped clusters
+
+	got, err := ShouldPreBootstrap(secretCache, cluster)
+	assert.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestShouldPreBootstrapWhenSecretListFails(t *testing.T) {
+	cluster := &apimgmtv3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c-m-abc"},
+		Spec: apimgmtv3.ClusterSpec{
+			DisplayName:        "c-test",
+			FleetWorkspaceName: "fleet-default",
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	secretCache.EXPECT().List("fleet-default", labels.Everything()).Return(nil, errors.New("list failed"))
+
+	got, err := ShouldPreBootstrap(secretCache, cluster)
+	assert.Error(t, err)
+	assert.False(t, got)
+}
+
+func TestClusterAuthorizedForSecret(t *testing.T) {
+	assert.True(t, ClusterAuthorizedForSecret("a,b,c-test", "c-test"))
+	assert.True(t, ClusterAuthorizedForSecret("a, c-test", "c-test"))
+	assert.False(t, ClusterAuthorizedForSecret("a,b", "c-test"))
+	assert.False(t, ClusterAuthorizedForSecret("", "c-test"))
+	assert.False(t, ClusterAuthorizedForSecret("c-test", ""))
 }

--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -609,15 +609,14 @@ func clusterObjectAuthorized(obj runtime.Object, annotation, clusterName string)
 	}
 	copiedObj := obj.DeepCopyObject()
 	if objMeta, err := meta.Accessor(copiedObj); err == nil && objMeta != nil {
-		authorizedClusters := strings.Split(objMeta.GetAnnotations()[annotation], ",")
-		if len(authorizedClusters) > 0 {
+		authorizedClusters := objMeta.GetAnnotations()[annotation]
+		// Preserve the existing "found" behavior for callers while delegating the match
+		// decision to the shared CAPR authorization helper.
+		splitAuthorizedClusters := strings.Split(authorizedClusters, ",")
+		if len(splitAuthorizedClusters) > 0 {
 			annotationValueFound = true
 		}
-		for _, authorizedCluster := range authorizedClusters {
-			if clusterName == authorizedCluster {
-				return true, annotationValueFound
-			}
-		}
+		return capr.ClusterAuthorizedForSecret(authorizedClusters, clusterName), annotationValueFound
 	}
 	return false, annotationValueFound
 }

--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -15,7 +15,65 @@ import (
 	"github.com/rancher/rancher/pkg/data/management"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestClusterObjectAuthorized(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            *corev1.Secret
+		annotation     string
+		clusterName    string
+		wantAuthorized bool
+		wantFound      bool
+	}{
+		{
+			name: "authorized cluster",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						capr.AuthorizedObjectAnnotation: "cluster-a,cluster-b",
+					},
+				},
+			},
+			annotation:     capr.AuthorizedObjectAnnotation,
+			clusterName:    "cluster-b",
+			wantAuthorized: true,
+			wantFound:      true,
+		},
+		{
+			name: "unauthorized cluster",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						capr.AuthorizedObjectAnnotation: "cluster-a",
+					},
+				},
+			},
+			annotation:     capr.AuthorizedObjectAnnotation,
+			clusterName:    "cluster-b",
+			wantAuthorized: false,
+			wantFound:      true,
+		},
+		{
+			name:           "nil object",
+			obj:            nil,
+			annotation:     capr.AuthorizedObjectAnnotation,
+			clusterName:    "cluster-b",
+			wantAuthorized: false,
+			wantFound:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorized, found := clusterObjectAuthorized(tt.obj, tt.annotation, tt.clusterName)
+			assert.Equal(t, tt.wantAuthorized, authorized)
+			assert.Equal(t, tt.wantFound, found)
+		})
+	}
+}
 
 func TestUpdateConfigWithAddresses(t *testing.T) {
 	tests := []struct {

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -216,9 +216,21 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 
 	// pre-bootstrap the cluster if it's not already bootstrapped
 	apimgmtv3.ClusterConditionPreBootstrapped.CreateUnknownIfNotExists(rec.clusterRec)
-	if capr.PreBootstrap(rec.clusterRec) {
+	shouldPreBootstrap, err := capr.ShouldPreBootstrap(m.ScaledContext.Wrangler.Core.Secret().Cache(), rec.clusterRec)
+	if err != nil {
+		transaction.Rollback()
+		return err
+	}
+
+	if shouldPreBootstrap {
 		err := clusterController.PreBootstrap(transaction, m.ScaledContext, rec.cluster, rec.clusterRec, m)
 		if err != nil {
+			transaction.Rollback()
+			return err
+		}
+	} else if !apimgmtv3.ClusterConditionPreBootstrapped.IsTrue(rec.clusterRec) {
+		apimgmtv3.ClusterConditionPreBootstrapped.True(rec.clusterRec)
+		if _, err := m.clusters.Update(rec.clusterRec); err != nil {
 			transaction.Rollback()
 			return err
 		}

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -228,7 +228,8 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 			transaction.Rollback()
 			return err
 		}
-	} else if !apimgmtv3.ClusterConditionPreBootstrapped.IsTrue(rec.clusterRec) {
+	} else {
+		// mark as prebootstrapped implicitly in order to prevent cluster-agent from being deployed in prebootstrap mode
 		apimgmtv3.ClusterConditionPreBootstrapped.True(rec.clusterRec)
 		if _, err := m.clusters.Update(rec.clusterRec); err != nil {
 			transaction.Rollback()

--- a/pkg/controllers/capr/planner/controller.go
+++ b/pkg/controllers/capr/planner/controller.go
@@ -3,7 +3,6 @@ package planner
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/condition"
@@ -52,7 +51,7 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext, planner *caprp
 			}
 			authorizedObjects := secret.Annotations[capr.AuthorizedObjectAnnotation]
 			if authorizedObjects != "" {
-				for _, clusterName = range strings.Split(authorizedObjects, ",") {
+				for _, clusterName = range capr.AuthorizedClusterNames(authorizedObjects) {
 					logrus.Tracef("[planner] rkecluster %s/%s enqueue triggered by authorized secret %s/%s", secret.Namespace, clusterName, secret.Namespace, secret.Name)
 					relatedResources = append(relatedResources, relatedresource.Key{
 						Namespace: secret.Namespace,
@@ -74,7 +73,7 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext, planner *caprp
 			var relatedResources []relatedresource.Key
 			authorizedObjects := configmap.Annotations[capr.AuthorizedObjectAnnotation]
 			if authorizedObjects != "" {
-				for _, clusterName := range strings.Split(authorizedObjects, ",") {
+				for _, clusterName := range capr.AuthorizedClusterNames(authorizedObjects) {
 					logrus.Tracef("[planner] rkecluster %s/%s enqueue triggered by authorized configmap %s/%s", configmap.Namespace, clusterName, configmap.Namespace, configmap.Name)
 					relatedResources = append(relatedResources, relatedresource.Key{
 						Namespace: configmap.Namespace,

--- a/pkg/controllers/management/clusterconnected/clusterconnected.go
+++ b/pkg/controllers/management/clusterconnected/clusterconnected.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/v3/pkg/condition"
+	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/ticker"
 	"github.com/sirupsen/logrus"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -29,6 +30,7 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 	c := checker{
 		clusterCache: wrangler.Mgmt.Cluster().Cache(),
 		clusters:     wrangler.Mgmt.Cluster(),
+		secretCache:  wrangler.Core.Secret().Cache(),
 		tunnelServer: wrangler.TunnelServer,
 	}
 
@@ -44,6 +46,7 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 type checker struct {
 	clusterCache managementcontrollers.ClusterCache
 	clusters     managementcontrollers.ClusterClient
+	secretCache  corecontrollers.SecretCache
 	tunnelServer *remotedialer.Server
 }
 
@@ -104,8 +107,13 @@ func (c *checker) checkCluster(cluster *v3.Cluster) error {
 		return nil
 	}
 
+	preboostrapping, err := capr.ShouldPreBootstrap(c.secretCache, cluster)
+	if err != nil {
+		return err
+	}
+
 	// RKE2: wait to update the connected condition until it is pre-bootstrapped
-	if capr.PreBootstrap(cluster) &&
+	if preboostrapping &&
 		cluster.Annotations["provisioning.cattle.io/administrated"] == "true" &&
 		cluster.Name != "local" {
 		// overriding it to be disconnected until bootstrapping is done

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -584,9 +584,14 @@ func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authIma
 		return nil, fmt.Errorf("waiting for server-url setting to be set")
 	}
 
+	prebootstrap, err := capr.ShouldPreBootstrap(cd.secretLister, cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	buf := &bytes.Buffer{}
 	err = systemtemplate.SystemTemplate(buf, agentImage, authImage, cluster.Name,
-		token, url, capr.PreBootstrap(cluster), cluster, features,
+		token, url, prebootstrap, cluster, features,
 		taints, cd.secretLister, priorityClassExists, namespace.GetMutator())
 
 	return buf.Bytes(), err

--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -26,14 +26,6 @@ import (
 // reads secrets from the management namespace of corresponding project,
 // and creates the secrets in the cluster namespace
 
-const (
-	syncAnnotation             = "provisioning.cattle.io/sync"
-	syncPreBootstrapAnnotation = "provisioning.cattle.io/sync-bootstrap"
-	syncNamespaceAnnotation    = "provisioning.cattle.io/sync-target-namespace"
-	syncNameAnnotation         = "provisioning.cattle.io/sync-target-name"
-	syncedAtAnnotation         = "provisioning.cattle.io/synced-at"
-)
-
 var (
 	// as of right now kube-system is the only appropriate target for this functionality.
 	// also included is "" to support copying into the same ns the secret is in
@@ -110,7 +102,7 @@ func (c *ResourceSyncController) bootstrap(mgmtClusterClient v3.ClusterInterface
 
 func (c *ResourceSyncController) syncable(obj *corev1.Secret) bool {
 	// no sync annotations, we don't care about this secret
-	if obj.Annotations[syncAnnotation] == "" && obj.Annotations[syncPreBootstrapAnnotation] == "" {
+	if obj.Annotations[capr.SyncAnnotation] == "" && obj.Annotations[capr.SyncPreBootstrapAnnotation] == "" {
 		return false
 	}
 
@@ -120,7 +112,7 @@ func (c *ResourceSyncController) syncable(obj *corev1.Secret) bool {
 	}
 
 	// if the secret is not in a namespace that we are allowed to sync to
-	if !slices.Contains(approvedPreBootstrapTargetNamespaces, obj.Annotations[syncNamespaceAnnotation]) {
+	if !slices.Contains(approvedPreBootstrapTargetNamespaces, obj.Annotations[capr.SyncNamespaceAnnotation]) {
 		return false
 	}
 
@@ -129,7 +121,7 @@ func (c *ResourceSyncController) syncable(obj *corev1.Secret) bool {
 
 func (c *ResourceSyncController) bootstrapSyncable(obj *corev1.Secret) bool {
 	// only difference between sync and bootstrapSync is requiring the boostrap sync annotation to be set to "true"
-	return c.syncable(obj) && obj.Annotations[syncPreBootstrapAnnotation] == "true"
+	return c.syncable(obj) && obj.Annotations[capr.SyncPreBootstrapAnnotation] == "true"
 }
 
 func (c *ResourceSyncController) injectClusterIdIntoSecretData(sec *corev1.Secret) *corev1.Secret {
@@ -161,11 +153,11 @@ func (c *ResourceSyncController) sync(_ string, obj *corev1.Secret) (*corev1.Sec
 		return obj, nil
 	}
 
-	name := obj.Annotations[syncNameAnnotation]
+	name := obj.Annotations[capr.SyncNameAnnotation]
 	if name == "" {
 		name = obj.Name
 	}
-	ns := obj.Annotations[syncNamespaceAnnotation]
+	ns := obj.Annotations[capr.SyncNamespaceAnnotation]
 	if ns == "" {
 		ns = obj.Namespace
 	}
@@ -210,6 +202,6 @@ func (c *ResourceSyncController) sync(_ string, obj *corev1.Secret) (*corev1.Sec
 
 	logrus.Debugf("[resource-sync][secret] successfully synchronized secret %v/%v to %v/%v for cluster %v", obj.Namespace, obj.Name, ns, name, c.clusterName)
 
-	obj.Annotations[syncedAtAnnotation] = time.Now().Format(time.RFC3339)
+	obj.Annotations[capr.SyncedAtAnnotation] = time.Now().Format(time.RFC3339)
 	return obj, nil
 }

--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"strings"
 	"time"
 
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -116,7 +115,7 @@ func (c *ResourceSyncController) syncable(obj *corev1.Secret) bool {
 	}
 
 	// if secret is authorized to be synchronized to the cluster
-	if !slices.Contains(strings.Split(obj.Annotations[capr.AuthorizedObjectAnnotation], ","), c.clusterName) {
+	if !capr.ClusterAuthorizedForSecret(obj.Annotations[capr.AuthorizedObjectAnnotation], c.clusterName) {
 		return false
 	}
 

--- a/pkg/controllers/managementuser/secret/secret_test.go
+++ b/pkg/controllers/managementuser/secret/secret_test.go
@@ -3,8 +3,10 @@ package secret
 import (
 	"testing"
 
+	"github.com/rancher/rancher/pkg/capr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestInjectClusterIdIntoSecretData(t *testing.T) {
@@ -25,4 +27,63 @@ func TestRemoveClusterIdFromSecretData(t *testing.T) {
 	c := ResourceSyncController{clusterId: "foobar"}
 
 	assert.Equal(t, c.removeClusterIdFromSecretData(sec).Data["bazqux"], []byte("{{clusterId}}"))
+}
+
+func TestSyncable(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		secret      *corev1.Secret
+		want        bool
+	}{
+		{
+			name:        "authorized cluster in allowed namespace",
+			clusterName: "cluster-b",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						syncPreBootstrapAnnotation:      "true",
+						syncNamespaceAnnotation:         "kube-system",
+						capr.AuthorizedObjectAnnotation: "cluster-a,cluster-b",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:        "unauthorized cluster",
+			clusterName: "cluster-b",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						syncPreBootstrapAnnotation:      "true",
+						syncNamespaceAnnotation:         "kube-system",
+						capr.AuthorizedObjectAnnotation: "cluster-a",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:        "disallowed namespace",
+			clusterName: "cluster-b",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						syncPreBootstrapAnnotation:      "true",
+						syncNamespaceAnnotation:         "default",
+						capr.AuthorizedObjectAnnotation: "cluster-a,cluster-b",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := ResourceSyncController{clusterName: tt.clusterName}
+			assert.Equal(t, tt.want, controller.syncable(tt.secret))
+		})
+	}
 }

--- a/pkg/controllers/managementuser/secret/secret_test.go
+++ b/pkg/controllers/managementuser/secret/secret_test.go
@@ -42,8 +42,8 @@ func TestSyncable(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						syncPreBootstrapAnnotation:      "true",
-						syncNamespaceAnnotation:         "kube-system",
+						capr.SyncPreBootstrapAnnotation: "true",
+						capr.SyncNamespaceAnnotation:    "kube-system",
 						capr.AuthorizedObjectAnnotation: "cluster-a,cluster-b",
 					},
 				},
@@ -56,8 +56,8 @@ func TestSyncable(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						syncPreBootstrapAnnotation:      "true",
-						syncNamespaceAnnotation:         "kube-system",
+						capr.SyncPreBootstrapAnnotation: "true",
+						capr.SyncNamespaceAnnotation:    "kube-system",
 						capr.AuthorizedObjectAnnotation: "cluster-a",
 					},
 				},
@@ -70,8 +70,8 @@ func TestSyncable(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						syncPreBootstrapAnnotation:      "true",
-						syncNamespaceAnnotation:         "default",
+						capr.SyncPreBootstrapAnnotation: "true",
+						capr.SyncNamespaceAnnotation:    "default",
 						capr.AuthorizedObjectAnnotation: "cluster-a,cluster-b",
 					},
 				},

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -137,7 +137,7 @@ var (
 	ProvisioningPreBootstrap = newFeature(
 		"provisioningprebootstrap",
 		"Support running pre-bootstrap workloads on downstream clusters",
-		false,
+		true,
 		false,
 		true)
 	CleanStaleSecrets = newFeature(

--- a/pkg/provisioningv2/prebootstrap/resolve.go
+++ b/pkg/provisioningv2/prebootstrap/resolve.go
@@ -33,7 +33,10 @@ type Retriever struct {
 }
 
 func (r *Retriever) GeneratePreBootstrapClusterAgentManifest(controlPlane *rkev1.RKEControlPlane) ([]plan.File, error) {
-	shouldDo, _ := r.preBootstrapCluster(controlPlane)
+	shouldDo, err := r.preBootstrapCluster(controlPlane)
+	if err != nil {
+		return nil, err
+	}
 	if !shouldDo {
 		return nil, nil
 	}
@@ -77,5 +80,5 @@ func (r *Retriever) preBootstrapCluster(cp *rkev1.RKEControlPlane) (bool, error)
 		return false, fmt.Errorf("failed to get mgmt Cluster %v: %w", cp.Spec.ManagementClusterName, err)
 	}
 
-	return capr.PreBootstrap(mgmtCluster), nil
+	return capr.ShouldPreBootstrap(r.secretCache, mgmtCluster)
 }

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -290,19 +290,21 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 		features.ProvisioningV2.Name():                 false,
 		features.Turtles.Name():                        false,
 		features.UISQLCache.Name():                     features.UISQLCache.Enabled(),
-		features.ProvisioningPreBootstrap.Name():       capr.PreBootstrap(cluster),
 		features.ManagedSystemUpgradeController.Name(): enableMSUC,
 	}
 }
 
 func ForCluster(cluster *apimgmtv3.Cluster, token string, taints []corev1.Taint, secretLister v1.SecretLister) ([]byte, error) {
-
 	status := util.GetAgentSchedulingCustomizationStatus(cluster)
 	pcExists := status != nil && status.PriorityClass != nil
+	prebootstrapping, err := capr.ShouldPreBootstrap(secretLister, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("error checking for pre-bootstrap secrets: %w", err)
+	}
 
 	buf := &bytes.Buffer{}
-	err := SystemTemplate(buf, GetDesiredAgentImage(cluster), GetDesiredAuthImage(cluster),
-		cluster.Name, token, settings.ServerURL.Get(), capr.PreBootstrap(cluster), cluster, GetDesiredFeatures(cluster), taints, secretLister, pcExists, namespace.GetMutator())
+	err = SystemTemplate(buf, GetDesiredAgentImage(cluster), GetDesiredAuthImage(cluster),
+		cluster.Name, token, settings.ServerURL.Get(), prebootstrapping, cluster, GetDesiredFeatures(cluster), taints, secretLister, pcExists, namespace.GetMutator())
 	return buf.Bytes(), err
 }
 

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -216,7 +216,8 @@ spec:
             value: '{{.NamespaceOptions | mustToJson}}'
           {{- end }}
           {{- if .IsPreBootstrap }}
-          # since we're on the host network, talk to the apiserver over localhost
+          - name: CATTLE_PREBOOTSTRAP
+            value: "true"
           {{- end }}
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/53923

## Problem
The `provisioningprebootstrap` feature flag has historically been kept disabled by default because it lengthened the provisioning process slightly and wasn't needed for all usecases.

As a result, the feature remained behind a flag even though the long-term goal is for pre-bootstrap behavior to be part of the normal provisioning flow. This PRs goal is to make that behavior the default and move toward eventual removal of the feature flag.

## Solution
This PR enables the pre-bootstrap flow by default and updates the provisioning decision logic so it no longer depends solely on the `provisioningprebootstrap` feature flag.

The changes in this PR:
- set `provisioningprebootstrap` to `true` by default
- update provisioning logic to check for secrets annotated with `provisioning.cattle.io/sync-bootstrap`
    - if they exist, run the prebootstrap cluster-agent
    - otherwise, just continue normally, treating the cluster as effectively prebootstrapped
- changing the prebootstrap cluster agent to key off of an environment variable rather than feature flag to prepare for the eventual removal of the feature flag entirely

This aligns the implementation with the end goal of making pre-bootstrap behavior depend on the presence of relevant bootstrap secrets and cluster authorization, instead of relying only on a feature flag gate.

## Testing
- `provisioningprebootstrap` is enabled by default
- clusters provision normally when no bootstrap secrets are found
- annotated bootstrap secrets continue to trigger the pre-bootstrap path only when they are relevant and authorized for the cluster

## Engineering Testing
### Manual Testing
Manual validation was focused on the updated provisioning decision logic and the default-on behavior for pre-bootstrap.


### Automated Testing
* Test types added/modified:
    * Unit tests
    * Modified provisioning tests to always run

## QA Testing Considerations
QA should focus on validating that updating to this on image should result in new clusters provisioning fine as well as updates persisting to backend secrets. 

Suggested areas to test:
- fresh install behavior with `provisioningprebootstrap` enabled by default
- provisioning a cluster with no bootstrap secrets present
- provisioning a cluster with secrets annotated with `provisioning.cattle.io/sync-bootstrap`
- scenarios where annotated secrets exist but are not authorized for the target cluster
- upgrade scenarios from versions where this feature flag was previously disabled by default
- existing clusters that were created before enabling pre-bootstrap by default
- regression checks for ACE / ChartValues delivery during pre-bootstrap
- confirmation that clusters do not get stuck in `Updating` or waiting-for-prebootstrap states because of this default change

### Regressions Considerations
The only regression that _may_ happen is if there are clusters provisioned the old way and then get updated, but the UI seems to be doing the right thing from my scanning. 

Areas with higher regression potential:
- clusters with existing synchronized bootstrap secrets
- upgrade paths for clusters created before this feature became default-on

