### PR TITLE
Fix ECC key pair Y comparison in cert matchAndKeySize

### DIFF
--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -44,7 +44,7 @@ func matchAndKeySize(publicKey crypto.PublicKey, privateKey crypto.PrivateKey) (
 		return "", 0, false
 	}
 
-	return "ECC", 256, privKey.X.Cmp(pubKey.X) == 0 && privKey.Y.Cmp(privKey.Y) == 0
+	return "ECC", 256, privKey.X.Cmp(pubKey.X) == 0 && privKey.Y.Cmp(pubKey.Y) == 0
 }
 
 func rsaMatchAndKeySize(publicKey crypto.PublicKey, privateKey crypto.PrivateKey) (string, int, bool) {


### PR DESCRIPTION
## Summary
In `matchAndKeySize`, the ECC branch compared `privKey.Y` to itself (`privKey.Y.Cmp(privKey.Y)`), which is always zero and does not verify that the public and private keys belong to the same curve point.

## Change
Use `privKey.Y.Cmp(pubKey.Y)` so the Y coordinates of the private and public keys are compared, consistent with the X coordinate check.