### PR TITLE
Set Content-Type before WriteHeader in clusterrouter response

### DIFF
--- a/pkg/clusterrouter/router.go
+++ b/pkg/clusterrouter/router.go
@@ -43,7 +43,7 @@ func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func response(rw http.ResponseWriter, code httperror.ErrorCode, message string) {
-	rw.WriteHeader(code.Status)
 	rw.Header().Set("content-type", "application/json")
+	rw.WriteHeader(code.Status)
 	json.NewEncoder(rw).Encode(httperror.NewAPIError(code, message))
 }


### PR DESCRIPTION
## Problem
`response()` called `WriteHeader` before setting `Content-Type`. For `net/http.ResponseWriter`, headers should be set before the status is written so clients see `application/json` for the encoded API error body.

## Change
Set `content-type: application/json` first, then `WriteHeader`, then encode the JSON body.