### PR TITLE
Remove duplicate error check in catalogv2 git Ensure test

### DIFF
--- a/pkg/catalogv2/git/download_test.go
+++ b/pkg/catalogv2/git/download_test.go
@@ -75,11 +75,6 @@ func Test_Ensure(t *testing.T) {
 			if tc.expectedError == nil && tc.expectedError != err {
 				t.Errorf("Expected error: %v |But got: %v", tc.expectedError, err)
 			}
-
-			// Check the error
-			if tc.expectedError == nil && tc.expectedError != err {
-				t.Errorf("Expected error: %v |But got: %v", tc.expectedError, err)
-			}
 			// Only testing error in some cases
 			if err != nil {
 				assert.EqualError(t, tc.expectedError, err.Error())


### PR DESCRIPTION
## Summary
`Test_Ensure` had two identical blocks checking the nil `expectedError` case. Remove the duplicate so the assertion runs once.

No behavior change to the test logic beyond deduplication.