### PR TITLE
ensures cloned DefaultTransport is used for strict CA verification

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -142,10 +142,8 @@ func run(ctx context.Context) error {
 	topContext = context.WithValue(topContext, cavalidator.CACertsValidKey, false)
 
 	// Perform root CA verification
-	var transport *http.Transport
 	systemStoreConnectionCheckRequired := true
-	transport = rootCATransport()
-	if transport != nil {
+	if transport := rootCATransport(caFileLocation); transport != nil {
 		logrus.Infof("Testing connection to %s using trusted certificate authorities within: %s", server, caFileLocation)
 		var httpClient = &http.Client{
 			Timeout:   time.Second * 5,
@@ -160,6 +158,7 @@ func run(ctx context.Context) error {
 			topContext = context.WithValue(topContext, cavalidator.CACertsValidKey, true)
 			systemStoreConnectionCheckRequired = false
 		}
+		transport.CloseIdleConnections()
 	} else if cluster.CAStrictVerify() {
 		logrus.Errorf("Strict CA verification is enabled but encountered error finding root CA")
 		os.Exit(1)
@@ -376,21 +375,21 @@ func configureLogrus() {
 	}
 }
 
-// rootCATransport generates a http.Transport that contains the contents of the CA file as the Root CA for strict validation.
-func rootCATransport() *http.Transport {
-	caFile, err := os.ReadFile(caFileLocation)
+// rootCATransport returns a clone of http.DefaultTransport with a custom root CA for strict TLS validation.
+func rootCATransport(caFilePath string) *http.Transport {
+	caFile, err := os.ReadFile(caFilePath)
 	if err != nil {
-		logrus.Errorf("unable to read CA file from %s: %v", caFileLocation, err)
+		logrus.Errorf("unable to read CA file from %s: %v", caFilePath, err)
 		return nil
 	}
 	certPool := x509.NewCertPool()
 	if ok := certPool.AppendCertsFromPEM(caFile); !ok {
-		logrus.Errorf("unable to parse CA file %s", caFileLocation)
+		logrus.Errorf("unable to parse CA file %s", caFilePath)
 		return nil
 	}
-	return &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs: certPool,
-		},
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		RootCAs: certPool,
 	}
+	return transport
 }

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func Test_RootCATransport(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validCertPath := filepath.Join(tmpDir, "valid.pem")
+	_ = os.WriteFile(validCertPath, generateValidPEM(t), 0644)
+
+	// Create a corrupt PEM file
+	corruptPath := filepath.Join(tmpDir, "corrupt.pem")
+	_ = os.WriteFile(corruptPath, []byte("this is not a certificate"), 0644)
+
+	tests := []struct {
+		name           string
+		caFileLocation string
+		envProxy       string
+		expectNil      bool
+		checkProxyHost string
+	}{
+		{
+			name:           "Valid CA file",
+			caFileLocation: validCertPath,
+			expectNil:      false,
+		},
+		{
+			name:           "Missing CA File",
+			caFileLocation: filepath.Join(tmpDir, "nonexistent.pem"),
+			expectNil:      true,
+		},
+		{
+			name:           "Corrupt CA file",
+			caFileLocation: corruptPath,
+			expectNil:      true,
+		},
+		{
+			name:           "Respects proxy env with valid CA file",
+			caFileLocation: validCertPath,
+			envProxy:       "http://proxy.internal:8080",
+			expectNil:      false,
+			checkProxyHost: "proxy.internal:8080",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envProxy != "" {
+				t.Setenv("HTTPS_PROXY", tc.envProxy)
+			}
+
+			transport := rootCATransport(tc.caFileLocation)
+			if tc.expectNil {
+				if transport != nil {
+					t.Errorf("expected nil transport for case %s", tc.name)
+				}
+				return
+			}
+
+			if transport == nil {
+				t.Fatalf("expected non-nil transport for case %s", tc.name)
+			}
+
+			if tc.checkProxyHost != "" {
+				req, _ := http.NewRequest("GET", "https://google.com", nil)
+				pURL, _ := transport.Proxy(req)
+				if pURL == nil || pURL.Host != tc.checkProxyHost {
+					t.Errorf("expected proxy host %s, got %v", tc.checkProxyHost, pURL)
+				}
+			}
+		})
+	}
+}
+
+func generateValidPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}


### PR DESCRIPTION
## Issue:  Proxy env are not respected when CA strict verification is enabled.
#52886 
 
## Problem
Currently when `CAStrictVerify=true`, [rootCATransport()](https://github.com/rancher/rancher/blob/main/cmd/agent/main.go#L380) returns a `http.Transport` with a custom `TLSClientConfig`. However, the transport does not explicitly preserve proxy configuration from the environment.

As a result:
- Proxy settings defined via environment variables (e.g., HTTP_PROXY, HTTPS_PROXY) are not applied
- Requests are sent directly instead of via the proxy.
- This leads to connection failures in proxy-dependent environments.

## Solution
By cloning `http.DefaultTransport` in `rootCATransport()`, proxy configuration from environment variables is retained (along with the custom tlsConfig), ensuring requests are routed through the configured proxy.
 
## Testing
- Steps in the linked issue are relevant.
- Could also try the following:
  - Provision a Rancher v2.11.3 instance (I used github.com/axeal/tf-do-rke2 to provision it with v1.32.6+rke2r1)
  - Provision a separate VM with the docker daemon and run a forward proxy. Here, ran droplet in DO, with tinyproxy 
    `$ docker run -d --name='tinyproxy' -p 80:8888 dannydirect/tinyproxy:latest ANY`
  - Create a custom RKE2 cluster with all the default settings, and add the following agent env vars, where <PROXY_IP> is the IP of the proxy instance created above:
    ```
    HTTP_PROXY http://<PROXY_IP>:80
    HTTPS_PROXY http://<PROXY_IP>:80
    NO_PROXY localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc,.svc,.cluster.local
    ```
  - Provision a separate VM for the custom cluster
  - Block access from the custom cluster VM to the Rancher instance directly - to verify we are using the proxy for the lab - by creating the following iptables rules on the custom cluster VM:
    ```
     iptables -I FORWARD -d <Rancher IP> -j DROP` and `iptables -I OUTPUT -d <Rancher IP> -j DROP
     ```
   (In this specific instance <Rancher IP> was the DO loadbalancer fronting Rancher, created by tf-do-rke2)
  - Register the custom cluster VM
  - Observe that the cattle-cluster-agent Pod errors with a message of the following format:

## Engineering Testing
### Manual Testing
As mentioned in the `Testing` section above.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: 
- Ensures that a cloned DefaultTransport is returned even when strict_verify=true.
- To improve testability, `rootCATransport` now accepts `caFilePath` as a parameter instead of relying on global constant.

## QA Testing Considerations
- - Along with fresh installations, the behavior on downstream clusters post upgrade should be observed.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_