### PR TITLE
Fix login for Google OAuth

### DIFF
--- a/pkg/auth/providers/common/transformer.go
+++ b/pkg/auth/providers/common/transformer.go
@@ -13,7 +13,13 @@ func TransformToAuthProvider(authConfig map[string]any) map[string]any {
 	}
 
 	if t, _ := authConfig["type"].(string); t != "" {
-		result["type"] = strings.Replace(t, "Config", "Provider", -1)
+		p := strings.ReplaceAll(t, "Config", "Provider")
+		// The config type "googleOauthConfig" produces "googleOauthProvider" but
+		// the canonical provider type is "googleOAuthProvider" (capital 'A').
+		if p == "googleOauthProvider" {
+			p = "googleOAuthProvider"
+		}
+		result["type"] = p
 	}
 
 	for _, key := range []string{"logoutAllSupported", "logoutAllEnabled", "logoutAllForced"} {

--- a/pkg/auth/providers/common/transformer_test.go
+++ b/pkg/auth/providers/common/transformer_test.go
@@ -66,6 +66,22 @@ func TestTransformToAuthProvider(t *testing.T) {
 				"logoutAllForced":    false,
 			},
 		},
+		{
+			desc: "Google OAuth config type is corrected to canonical provider type",
+			authConfig: map[string]any{
+				"metadata": map[string]any{
+					"name": "googleoauth",
+				},
+				"type": "googleOauthConfig",
+			},
+			provider: map[string]any{
+				"id":                 "googleoauth",
+				"type":               "googleOAuthProvider",
+				"logoutAllSupported": false,
+				"logoutAllEnabled":   false,
+				"logoutAllForced":    false,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -206,7 +206,7 @@ func providerInputForType(providerType string) loginAccessor {
 			GenericLogin: apiv3.GenericLogin{Type: providerType, Name: saml.ShibbolethName},
 		}
 		// isSAMLProvider = true
-	case client.GoogleOAuthProviderType:
+	case client.GoogleOAuthProviderType, "googleOauthProvider":
 		return &apiv3.GoogleOauthLogin{
 			GenericLogin: apiv3.GenericLogin{Type: providerType, Name: googleoauth.Name},
 		}

--- a/pkg/auth/providers/publicapi/login_test.go
+++ b/pkg/auth/providers/publicapi/login_test.go
@@ -1,0 +1,66 @@
+package publicapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	client "github.com/rancher/rancher/pkg/client/generated/management/v3public"
+)
+
+func TestProviderInputForType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		providerType string
+		wantNil      bool
+		wantType     string
+		wantName     string
+	}{
+		{
+			name:         "canonical Google OAuth type",
+			providerType: client.GoogleOAuthProviderType,
+			wantType:     client.GoogleOAuthProviderType,
+			wantName:     "googleoauth",
+		},
+		{
+			name:         "lowercase Google OAuth variant",
+			providerType: "googleOauthProvider",
+			wantType:     "googleOauthProvider",
+			wantName:     "googleoauth",
+		},
+		{
+			name:         "local provider",
+			providerType: client.LocalProviderType,
+			wantType:     client.LocalProviderType,
+			wantName:     "local",
+		},
+		{
+			name:         "unknown provider returns nil",
+			providerType: "unknownProvider",
+			wantNil:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := providerInputForType(tt.providerType)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantType, got.GetType())
+			assert.Equal(t, tt.wantName, got.GetName())
+
+			if tt.providerType == client.GoogleOAuthProviderType || tt.providerType == "googleOauthProvider" {
+				_, ok := got.(*apiv3.GoogleOauthLogin)
+				assert.True(t, ok, "expected *apiv3.GoogleOauthLogin")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54387

## Problem

The `/v1-public` auth endpoints introduced a type casing mismatch that breaks Google OAuth login.

The stored auth config type `"googleOauthConfig"` is transformed to `"googleOauthProvider"` (lowercase 'a') by `TransformToAuthProvider`'s, but the login handler's `providerInputForType` switch expects `"googleOAuthProvider"` (uppercase 'A').

This causes `providerInputForType` to return `nil`, resulting in `json: Unmarshal(nil)` and a redirect to `/dashboard/auth/login?err=client`.

## Solution

- `TransformToAuthProvider` now corrects `"googleOauthProvider"` to `"googleOAuthProvider"` so the `/v1-public/authproviders` response returns the canonical type.
- `providerInputForType` now also accepts `"googleOauthProvider"` so login succeeds even if a client sends the legacy casing.
