### PR TITLE
add support for additional annotations for gateway in chart

### DIFF
--- a/chart/templates/ingate/gateway.yaml
+++ b/chart/templates/ingate/gateway.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "rancher.gateway" . }}
   labels:
 {{ include "rancher.labels" . | indent 4 }}
+  {{- with .Values.gateway.gatewayClass.extraAnnotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   gatewayClassName: {{ .Values.gateway.gatewayClass.name }}
   listeners:

--- a/chart/tests/gateway_test.yaml
+++ b/chart/tests/gateway_test.yaml
@@ -175,6 +175,25 @@ tests:
           path: spec.gatewayClassName
           value: nginx
 
+  - it: shoulde set additional annotations on Gateway
+    template: templates/ingate/gateway.yaml
+    set:
+      networkExposure:
+        type: gateway
+      gateway:
+        gatewayClass:
+          extraAnnotations:
+            annotation1: value1
+            annotation2: value2
+    asserts:
+      - equal:
+          path: metadata.annotations.annotation1
+          value: value1
+      - equal:
+          path: metadata.annotations.annotation2
+          value: value2
+
+
   - it: should render HTTPRoute when networkExposure type is gateway
     template: templates/ingate/httproute.yaml
     set:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -116,6 +116,13 @@
                 }
               }
             },
+            "extraAnnotations": {
+              "type": "object",
+              "description": "Additional annotations to add to the Gateway resource",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "tls": {
               "type": "object",
               "description": "The default rancher gateway class tls configuration",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -126,7 +126,7 @@ gateway:
     #      certificateRefs:
     #        - name: app-tls
     #          kind: Secret
-
+    extraAnnotations: {}
     tls:
       # options: rancher, letsEncrypt, secret
       source: rancher


### PR DESCRIPTION
## Issue: 
#54406 
 
## Problem
Helm Chart is missing the option to set additional annotations in the gateway manifest.

## Solution
Adds optional annotations to gateway via values
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
ran local helm templating and unit tests