### PR TITLE
delete stale tls-rancher-internal cert if ClusterIP SAN is missing

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/dynamiclistener"
 	"github.com/rancher/dynamiclistener/cert"
+	"github.com/rancher/dynamiclistener/factory"
 	"github.com/rancher/dynamiclistener/server"
 	"github.com/rancher/dynamiclistener/storage/kubernetes"
 	"github.com/rancher/lasso/pkg/metrics"
@@ -128,6 +129,12 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 	if len(hostIPs) > 0 {
 		serverOptions.TLSListenerConfig = dynamiclistener.Config{
 			SANs: hostIPs,
+		}
+	}
+
+	if clusterIP != "" {
+		if err := ensureInternalCertSANs(core.Core().V1().Secret(), clusterIP); err != nil {
+			return err
 		}
 	}
 
@@ -439,4 +446,47 @@ func readPEM(path string) (string, error) {
 	}
 
 	return string(content), nil
+}
+
+// ensureInternalCertSANs checks whether the existing tls-rancher-internal secret
+// has clusterIP recorded in its dynamiclistener SAN annotations. If not, the
+// secret is deleted so that dynamiclistener will regenerate it with the correct
+// SANs when the internal listener starts.
+//
+// Static (user-provided) secrets are never deleted.
+// A NotFound error on delete is silently ignored (another HA pod beat us to it).
+// A no-op when clusterIP is already present — safe on stable upgrades.
+func ensureInternalCertSANs(secrets corev1controllers.SecretController, clusterIP string) error {
+	if clusterIP == "" {
+		return nil
+	}
+
+	secret, err := secrets.Get(namespace.System, "tls-rancher-internal", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// No pre-existing secret — dynamiclistener will create a fresh one with correct SANs.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed checking tls-rancher-internal for SAN mismatch: %w", err)
+	}
+
+	// Never touch user-provided (static) certificates.
+	if factory.IsStatic(secret) {
+		return nil
+	}
+
+	// If the clusterIP is already recorded in the SAN annotations, nothing to do.
+	if !factory.NeedsUpdate(0, secret, clusterIP) {
+		return nil
+	}
+
+	// The secret exists but does not include clusterIP — delete it so dynamiclistener
+	// regenerates it with the correct SANs before the internal listener starts.
+	logrus.Infof("tls: tls-rancher-internal certificate does not include ClusterIP %s, deleting to force regeneration", clusterIP)
+	err = secrets.Delete(namespace.System, "tls-rancher-internal", &metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		// Another HA pod already deleted it — that's fine.
+		return nil
+	}
+	return err
 }

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,175 @@
+package tls
+
+import (
+	"testing"
+
+	"github.com/rancher/dynamiclistener/factory"
+	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// makeInternalSecret builds a tls-rancher-internal secret with the given IPs
+// already recorded in dynamiclistener's CN annotations.
+func makeInternalSecret(ips ...string) *corev1.Secret {
+	annotations := map[string]string{}
+	for _, ip := range ips {
+		annotations["listener.cattle.io/cn-"+ip] = ip
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "tls-rancher-internal",
+			Namespace:   namespace.System,
+			Annotations: annotations,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       []byte("fake-cert"),
+			corev1.TLSPrivateKeyKey: []byte("fake-key"),
+		},
+	}
+}
+
+// makeStaticSecret builds a tls-rancher-internal secret marked as static
+// (user-provided — must never be deleted).
+func makeStaticSecret() *corev1.Secret {
+	s := makeInternalSecret()
+	s.Annotations[factory.Static] = "true"
+	return s
+}
+
+func TestEnsureInternalCertSANs(t *testing.T) {
+	t.Parallel()
+
+	const clusterIP = "10.43.187.204"
+
+	tests := []struct {
+		name         string
+		secret       *corev1.Secret // nil means secret does not exist
+		clusterIP    string
+		expectDelete bool
+		expectError  bool
+	}{
+		{
+			name:         "no existing secret — no action needed",
+			secret:       nil,
+			clusterIP:    clusterIP,
+			expectDelete: false,
+		},
+		{
+			name:         "secret already contains clusterIP — no-op",
+			secret:       makeInternalSecret(clusterIP),
+			clusterIP:    clusterIP,
+			expectDelete: false,
+		},
+		{
+			name:         "secret has wrong IP — must delete",
+			secret:       makeInternalSecret("10.43.32.193"),
+			clusterIP:    clusterIP,
+			expectDelete: true,
+		},
+		{
+			name: "secret has no annotations at all — must delete",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tls-rancher-internal",
+					Namespace: namespace.System,
+				},
+				Type: corev1.SecretTypeTLS,
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       []byte("fake-cert"),
+					corev1.TLSPrivateKeyKey: []byte("fake-key"),
+				},
+			},
+			clusterIP:    clusterIP,
+			expectDelete: true,
+		},
+		{
+			name:         "static secret (user-provided) — must NOT delete even if IP missing",
+			secret:       makeStaticSecret(),
+			clusterIP:    clusterIP,
+			expectDelete: false,
+		},
+		{
+			name:         "secret has multiple IPs including clusterIP — no-op",
+			secret:       makeInternalSecret("10.43.32.193", clusterIP, "172.18.0.2"),
+			clusterIP:    clusterIP,
+			expectDelete: false,
+		},
+		{
+			name:         "empty clusterIP — no action",
+			secret:       makeInternalSecret("10.43.32.193"),
+			clusterIP:    "",
+			expectDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			secretController := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+
+			// Set up Get expectation (only called when clusterIP is non-empty)
+			if tt.clusterIP != "" {
+				secretController.EXPECT().
+					Get(namespace.System, "tls-rancher-internal", gomock.Any()).
+					DoAndReturn(func(ns, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
+						if tt.secret == nil {
+							return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, name)
+						}
+						return tt.secret, nil
+					}).Times(1)
+			}
+
+			// Set up Delete expectation
+			if tt.expectDelete {
+				secretController.EXPECT().
+					Delete(namespace.System, "tls-rancher-internal", gomock.Any()).
+					Return(nil).
+					Times(1)
+			}
+
+			err := ensureInternalCertSANs(secretController, tt.clusterIP)
+			if tt.expectError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestEnsureInternalCertSANs_DeleteNotFound verifies that a NotFound error
+// on delete (another HA pod already deleted it) is silently ignored.
+func TestEnsureInternalCertSANs_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+
+	const clusterIP = "10.43.187.204"
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	secretController := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	secretController.EXPECT().
+		Get(namespace.System, "tls-rancher-internal", gomock.Any()).
+		Return(makeInternalSecret("10.43.32.193"), nil).
+		Times(1)
+	secretController.EXPECT().
+		Delete(namespace.System, "tls-rancher-internal", gomock.Any()).
+		Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "tls-rancher-internal")).
+		Times(1)
+
+	err := ensureInternalCertSANs(secretController, clusterIP)
+	if err != nil {
+		t.Fatalf("expected nil error on NotFound delete, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Issue 

- https://github.com/rancher/rancher/issues/54407

## Problem

On the first upgrade to v2.14.0, the `rancher-internal` Service is created for the first time. Its new ClusterIP is absent from the pre-existing `tls-rancher-internal` certificate, resulting in x509 errors and K3s/RKE2 downstream clusters stuck on `"waiting for kubelet to update"`.

A deeper issue could be related to the dynamic listener’s initialization flow, where duplicate keys in the internal work queue may cause it to process an existing secret instead of the updated one. This is likely outside the current scope, and I’m hesitant to dig further into that rabbit hole right now.  See https://github.com/rancher/dynamiclistener/issues/247 


The issue is consistently reproducible when Rancher runs as a Docker container. It is more difficult to reproduce in a K8s deployment because three pods are running the HTTPS listener, and one of them usually updates the tls-rancher-internal certificate to include the new ClusterIP. 

## Solution 

Before starting the internal TLS listener, `ensureInternalCertSANs()` now checks whether the existing `tls-rancher-internal` secret has the current ClusterIP in its dynamiclistener SAN annotations. If not, it deletes the secret, so dynamiclistener regenerates it with the correct SANs synchronously — before any connections are attempted.

Static (user-provided) secrets are never touched. NotFound on delete is silently ignored for HA safety. No-op on stable upgrades where the ClusterIP is already present.
 
## Testing 

### Manual Test:

The fix is tested in the Docker installation mode, upgrading cases.   The `tls-rancher-internal` cert now contains the rancher-internal service cluster IP after upgrading Rancher to v2.14.x. 

Rancher logs show:  
```
2026/03/31 00:56:58 [INFO] tls: tls-rancher-internal certificate does not include ClusterIP 10.43.126.131, deleting to force regeneration
```

### Automated Testing

Unit tests are added for the ensureInternalCertSANs function 


## QA Testing Considerations

- We need to validate that the exact issue described in the issue is fixed. 
- The same test needs to be done in the HA installation mode 

 

