### PR TITLE
Verify the client secret in refresh token.

### DIFF
--- a/pkg/oidc/provider/token.go
+++ b/pkg/oidc/provider/token.go
@@ -160,7 +160,6 @@ func (h *tokenHandler) createTokenFromCode(r *http.Request) (TokenResponse, *oid
 	}
 
 	// verify clientID and secret. They can be set in the Authorization header or as a form param as specified in the OIDC spec.
-	var clientID string
 	clientID, clientSecret, ok := r.BasicAuth()
 	if !ok {
 		clientID = r.FormValue("client_id")
@@ -173,22 +172,9 @@ func (h *tokenHandler) createTokenFromCode(r *http.Request) (TokenResponse, *oid
 	if err != nil {
 		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, "failed to get OIDC client")
 	}
-	secret, err := h.secretCache.Get(secretsNamespace, clientID)
-	if err != nil {
-		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, "failed to get client secret")
-	}
-	clientSecretFound := false
-	for key, cs := range secret.Data {
-		if clientSecret == string(cs) {
-			clientSecretFound = true
-			if err := h.updateClientSecretUsedTimeStamp(oidcClient, key); err != nil {
-				logrus.Errorf("[OIDC provider] failed to update client secret's used timestamp: %v", err)
-			}
-			break
-		}
-	}
-	if !clientSecretFound {
-		return TokenResponse{}, oidcerror.New(oidcerror.InvalidRequest, "invalid client_secret")
+
+	if oidcErr := h.isValidClientSecret(clientSecret, oidcClient); oidcErr != nil {
+		return TokenResponse{}, oidcErr
 	}
 
 	// PKCE verification
@@ -215,6 +201,30 @@ func (h *tokenHandler) createTokenFromCode(r *http.Request) (TokenResponse, *oid
 	return resp, oidcErr
 }
 
+func (h *tokenHandler) isValidClientSecret(clientSecret string, oidcClient *v3.OIDCClient) *oidcerror.Error {
+	secret, err := h.secretCache.Get(secretsNamespace, oidcClient.Status.ClientID)
+	if err != nil {
+		return oidcerror.New(oidcerror.ServerError, "failed to get client secret")
+	}
+
+	clientSecretFound := false
+	for key, cs := range secret.Data {
+		if clientSecret == string(cs) {
+			clientSecretFound = true
+			if err := h.updateClientSecretUsedTimeStamp(oidcClient, key); err != nil {
+				logrus.Errorf("[OIDC provider] failed to update client secret's used timestamp: %v", err)
+			}
+			break
+		}
+	}
+
+	if !clientSecretFound {
+		return oidcerror.New(oidcerror.InvalidRequest, "invalid client_secret")
+	}
+
+	return nil
+}
+
 // createRefreshToken issues a new id_token, access_token and refresh_token using a refresh_token
 func (h *tokenHandler) createRefreshToken(r *http.Request) (TokenResponse, *oidcerror.Error) {
 	refreshToken := r.Form.Get("refresh_token")
@@ -239,7 +249,7 @@ func (h *tokenHandler) createRefreshToken(r *http.Request) (TokenResponse, *oidc
 		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, fmt.Sprintf("failed to parse refresh token: %v", err))
 	}
 	claims, ok := token.Claims.(*RefreshTokenClaims)
-	if !ok && !token.Valid {
+	if !ok || !token.Valid {
 		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, "refresh token not valid")
 	}
 
@@ -270,6 +280,14 @@ func (h *tokenHandler) createRefreshToken(r *http.Request) (TokenResponse, *oidc
 	oidcClient, err := h.getOIDCClientByClientID(claims.Audience[0])
 	if err != nil {
 		return TokenResponse{}, oidcerror.New(oidcerror.ServerError, fmt.Sprintf("failed to get oidc client: %v", err))
+	}
+
+	_, clientSecret, ok := r.BasicAuth()
+	if !ok {
+		clientSecret = r.FormValue("client_secret")
+	}
+	if oidcErr := h.isValidClientSecret(clientSecret, oidcClient); oidcErr != nil {
+		return TokenResponse{}, oidcErr
 	}
 
 	return h.createTokenResponse(rancherToken, oidcClient, "", claims.Scope)
@@ -422,7 +440,7 @@ func CreateAccessToken(oidcClient *v3.OIDCClient, rancherToken *v3.Token, scopes
 	return accessToken
 }
 
-func (h *tokenHandler) updateClientSecretUsedTimeStamp(oidcClient *v3.OIDCClient, clientSecretID string) interface{} {
+func (h *tokenHandler) updateClientSecretUsedTimeStamp(oidcClient *v3.OIDCClient, clientSecretID string) error {
 	var patch []byte
 	var err error
 	if oidcClient.Annotations != nil {

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -427,6 +427,8 @@ func TestTokenEndpoint(t *testing.T) {
 				m.useAttributeLister.EXPECT().Get(fakeUserID).Return(fakeUserAttributes, nil)
 				m.signingKeyGetter.EXPECT().GetSigningKey().Return(privateKey, fakeSigningKey, nil)
 				m.signingKeyGetter.EXPECT().GetPublicKey(fakeSigningKey).Return(&privateKey.PublicKey, nil)
+				m.secretCache.EXPECT().Get("cattle-oidc-client-secrets", fakeClientID).Return(fakeClientk8sSecret, nil)
+				m.oidcClient.EXPECT().Patch(fakeClientName, types.JSONPatchType, clientSecretIDPatch).Return(fakeOIDCClient, nil)
 			},
 			wantIdTokenClaims: &jwt.MapClaims{
 				"aud":           []any{fakeClientID},
@@ -491,7 +493,6 @@ func TestTokenEndpoint(t *testing.T) {
 				m.tokenCache.EXPECT().List(labels.SelectorFromSet(map[string]string{
 					tokens.UserIDLabel: fakeUserID,
 				})).Return([]*v3.Token{}, nil)
-
 			},
 			wantError: `{"error":"access_denied","error_description":"Rancher token no longer present."}`,
 		},
@@ -511,7 +512,9 @@ func TestTokenEndpoint(t *testing.T) {
 				m.tokenCache.EXPECT().List(labels.SelectorFromSet(map[string]string{
 					tokens.UserIDLabel: fakeUserID,
 				})).Return(fakeTokenExpiredList, nil)
+				m.secretCache.EXPECT().Get("cattle-oidc-client-secrets", fakeClientID).Return(fakeClientk8sSecret, nil)
 				m.signingKeyGetter.EXPECT().GetPublicKey(fakeSigningKey).Return(&privateKey.PublicKey, nil)
+				m.oidcClient.EXPECT().Patch(fakeClientName, types.JSONPatchType, clientSecretIDPatch).Return(fakeOIDCClient, nil)
 			},
 			wantError: `{"error":"access_denied","error_description":"Rancher token has expired"}`,
 		},
@@ -532,7 +535,6 @@ func TestTokenEndpoint(t *testing.T) {
 					tokens.UserIDLabel: fakeUserID,
 				})).Return(fakeTokenList, nil)
 				m.oidcClientCache.EXPECT().GetByIndex("oidc.management.cattle.io/oidcclient-by-id", fakeClientID).Return([]*v3.OIDCClient{}, nil)
-
 			},
 			wantError: `{"error":"server_error","error_description":"failed to get oidc client: no OIDC clients found"}`,
 		},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54401
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

While we were verifying the refresh_token, there was no verification that the client requesting the refresh was authenticated.

Client authentication is required when the client has a secret.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This adds verification of the secret for refresh_tokens

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_