### PR TITLE
Add checksum checks to tini (Option 3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,39 @@
+include hack/make/deps.mk
+
+# Build defaults
+REPO ?= rancher
+TAG ?= dev
+ARCH ?= amd64
+OS ?= linux
+COMMIT ?= $(shell $(CURDIR)/scripts/version | grep 'COMMIT:' | cut -d' ' -f2)
+
+# Common build arguments
+COMMON_ARGS += --build-arg VERSION=$(TAG)
+COMMON_ARGS += --build-arg ARCH=$(ARCH)
+COMMON_ARGS += --build-arg IMAGE_REPO=$(REPO)
+COMMON_ARGS += --build-arg COMMIT=$(COMMIT)
+COMMON_ARGS += $(DEPS_BUILD_ARGS)
+
+# Platform
+PLATFORM ?= $(OS)/$(ARCH)
+
+# Build command
+BUILD := docker buildx build
+
+.PHONY: target-%
+target-%: ## Builds the specified target defined in the Dockerfile.
+	$(BUILD) \
+		--target=$* \
+		--platform=$(PLATFORM) \
+		$(COMMON_ARGS) \
+		$(TARGET_ARGS) \
+		--file ./package/Dockerfile .
+
 TARGETS := $(shell ls scripts)
 DEV_TARGETS := $(shell ls dev-scripts)
+
+include hack/make/deps.mk
+export DEPS_BUILD_ARGS
 
 .dapper:
 	@echo Downloading dapper

--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -110,32 +110,20 @@ if [ "$needs_workdir" = "true" ]; then
   BUILD_ARGS+=("--build-arg=BUILD_WORKDIR=$PWD")
 fi
 
+# Convert BUILD_ARGS array to a string for make
+TARGET_ARGS="${BUILD_ARGS[*]}"
+
 if [ "$TARGET" = "k3s-images" ]; then
-  docker buildx build \
-    "${BUILD_ARGS[@]}" \
-    --output=type=local,dest=$PWD/bin \
-    --platform="${OS}/${ARCH}" \
-    --target k3s-images \
-    --file ./package/Dockerfile .
+  make target-k3s-images TARGET_ARGS="--output=type=local,dest=$PWD/bin $TARGET_ARGS"
 fi
 
 if [ "$TARGET" = "binary-server" ]; then
-  docker buildx build \
-    "${BUILD_ARGS[@]}" \
-    --output=type=local,dest=$PWD \
-    --platform="${OS}/${ARCH}" \
-    --target server-binary \
-    --file ./package/Dockerfile .
+  make target-server-binary TARGET_ARGS="--output=type=local,dest=$PWD $TARGET_ARGS"
 fi
 
 if [ -z "$TARGET" ] || [ "$TARGET" = "server" ]; then
   # start the builds
-  docker buildx build \
-    "${BUILD_ARGS[@]}" \
-    --tag "${REPO}"/rancher:"${TAG}" \
-    --platform="${OS}/${ARCH}" \
-    --target server \
-    --file ./package/Dockerfile .
+  make target-server TARGET_ARGS="--tag ${REPO}/rancher:${TAG} $TARGET_ARGS"
 
   if [ "$PUSH" = "true" ]; then
     docker push "${REPO}"/rancher:"${TAG}" &
@@ -143,12 +131,7 @@ if [ -z "$TARGET" ] || [ "$TARGET" = "server" ]; then
 fi
 
 if [ -z "$TARGET" ] || [ "$TARGET" = "agent" ]; then
-  docker buildx build \
-    "${BUILD_ARGS[@]}" \
-    --tag "${REPO}"/rancher-agent:"${TAG}" \
-    --platform="${OS}/${ARCH}" \
-    --target agent \
-    --file ./package/Dockerfile .
+  make target-agent TARGET_ARGS="--tag ${REPO}/rancher-agent:${TAG} $TARGET_ARGS"
 
   if [ "$PUSH" = "true" ]; then
     docker push "${REPO}"/rancher-agent:"${TAG}" &

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,0 +1,15 @@
+TINI_VERSION := v0.18.0
+TINI_URL_amd64 := https://github.com/krallin/tini/releases/download/$(TINI_VERSION)/tini
+TINI_URL_arm64 := https://github.com/krallin/tini/releases/download/$(TINI_VERSION)/tini-arm64
+TINI_URL_s390x := https://github.com/krallin/tini/releases/download/$(TINI_VERSION)/tini-s390x
+TINI_HASH_amd64 := 12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
+TINI_HASH_arm64 := 7c5463f55393985ee22357d976758aaaecd08defb3c5294d353732018169b019
+TINI_HASH_s390x := c8aaa618ea7897f26979ea10920373e06f3e6dfeb41ef95342eda2eb5672f24d
+
+DEPS_BUILD_ARGS := --build-arg TINI_VERSION=$(TINI_VERSION) \
+	--build-arg TINI_URL_amd64=$(TINI_URL_amd64) \
+	--build-arg TINI_URL_arm64=$(TINI_URL_arm64) \
+	--build-arg TINI_URL_s390x=$(TINI_URL_s390x) \
+	--build-arg TINI_HASH_amd64=$(TINI_HASH_amd64) \
+	--build-arg TINI_HASH_arm64=$(TINI_HASH_arm64) \
+	--build-arg TINI_HASH_s390x=$(TINI_HASH_s390x)

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -24,6 +24,14 @@ ARG RKE2_CHART_DEFAULT_BRANCH=main
 ARG CATTLE_KDM_BRANCH=dev-v2.14
 ARG VERSION=${VERSION}
 
+ARG TINI_VERSION
+ARG TINI_URL_amd64
+ARG TINI_URL_arm64
+ARG TINI_URL_s390x
+ARG TINI_HASH_amd64
+ARG TINI_HASH_arm64
+ARG TINI_HASH_s390x
+
 FROM --platform=$BUILDPLATFORM ${GODEP_APISERVER} AS godep-apiserver
 FROM --platform=$BUILDPLATFORM ${GODEP_LASSO} AS godep-lasso
 FROM --platform=$BUILDPLATFORM ${GODEP_NORMAN} AS godep-norman
@@ -109,12 +117,24 @@ RUN mkdir -p /var/lib/rancher-data/driver-metadata && \
 
 FROM builder AS tini
 ARG ARCH
-ENV TINI_VERSION=v0.18.0
-ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
-    TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
-    TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
-    TINI_URL=TINI_URL_${ARCH}
-RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
+ARG TINI_URL_amd64
+ARG TINI_URL_arm64
+ARG TINI_URL_s390x
+ARG TINI_HASH_amd64
+ARG TINI_HASH_arm64
+ARG TINI_HASH_s390x
+
+ENV TINI_URL_amd64=${TINI_URL_amd64} \
+    TINI_URL_arm64=${TINI_URL_arm64} \
+    TINI_URL_s390x=${TINI_URL_s390x} \
+    TINI_HASH_amd64=${TINI_HASH_amd64} \
+    TINI_HASH_arm64=${TINI_HASH_arm64} \
+    TINI_HASH_s390x=${TINI_HASH_s390x}
+
+RUN TINI_URL=TINI_URL_${ARCH} && \
+    TINI_HASH=TINI_HASH_${ARCH} && \
+    curl -sLf ${!TINI_URL} > /usr/bin/tini && \
+    echo "${!TINI_HASH}  /usr/bin/tini" | sha256sum -c - && \
     chmod +x /usr/bin/tini
 
 

--- a/scripts/package
+++ b/scripts/package
@@ -14,36 +14,31 @@ cp ../bin/rancher ../bin/agent ../bin/data.json ../bin/k3s-airgap-images.tar .
 # Make sure the used data.json is a release artifact
 cp ../bin/data.json ../bin/rancher-data.json
 
-if [ ${ARCH} == arm64 ]; then
+if [ "${ARCH}" == "arm64" ]; then
     ETCD_UNSUPPORTED_ARCH=arm64
 fi
-if [ ${ARCH} == s390x ]; then
+if [ "${ARCH}" == "s390x" ]; then
     ETCD_UNSUPPORTED_ARCH=s390x
 fi
 
-docker build \
-    --build-arg VERSION=${TAG} \
-    --build-arg ETCD_UNSUPPORTED_ARCH=${ETCD_UNSUPPORTED_ARCH} \
-    --build-arg ARCH=${ARCH} \
-    --build-arg IMAGE_REPO=${REPO} \
-    --build-arg CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH} \
-    --build-arg CATTLE_RANCHER_WEBHOOK_VERSION="${CATTLE_RANCHER_WEBHOOK_VERSION}" \
-    --build-arg CATTLE_REMOTEDIALER_PROXY_VERSION="${CATTLE_REMOTEDIALER_PROXY_VERSION}" \
-    --build-arg CATTLE_RANCHER_TURTLES_VERSION="${CATTLE_RANCHER_TURTLES_VERSION}" \
-    --build-arg CATTLE_CSP_ADAPTER_MIN_VERSION="${CATTLE_CSP_ADAPTER_MIN_VERSION}" \
-    --build-arg CATTLE_FLEET_VERSION="${CATTLE_FLEET_VERSION}" \
-    --target server \
-    -t ${IMAGE} .
+BUILD_ARGS=()
+BUILD_ARGS+=("--build-arg=VERSION=${TAG}")
+BUILD_ARGS+=("--build-arg=ETCD_UNSUPPORTED_ARCH=${ETCD_UNSUPPORTED_ARCH}")
+BUILD_ARGS+=("--build-arg=ARCH=${ARCH}")
+BUILD_ARGS+=("--build-arg=IMAGE_REPO=${REPO}")
+BUILD_ARGS+=("--build-arg=CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH}")
+BUILD_ARGS+=("--build-arg=CATTLE_RANCHER_WEBHOOK_VERSION=${CATTLE_RANCHER_WEBHOOK_VERSION}")
+BUILD_ARGS+=("--build-arg=CATTLE_REMOTEDIALER_PROXY_VERSION=${CATTLE_REMOTEDIALER_PROXY_VERSION}")
+BUILD_ARGS+=("--build-arg=CATTLE_RANCHER_TURTLES_VERSION=${CATTLE_RANCHER_TURTLES_VERSION}")
+BUILD_ARGS+=("--build-arg=CATTLE_CSP_ADAPTER_MIN_VERSION=${CATTLE_CSP_ADAPTER_MIN_VERSION}")
+BUILD_ARGS+=("--build-arg=CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION}")
 
-docker build \
-    --build-arg VERSION=${TAG} \
-    --build-arg ARCH=${ARCH} \
-    --build-arg RANCHER_TAG=${TAG} \
-    --build-arg CATTLE_RANCHER_WEBHOOK_VERSION="${CATTLE_RANCHER_WEBHOOK_VERSION}" \
-    --build-arg CATTLE_RANCHER_TURTLES_VERSION="${CATTLE_RANCHER_TURTLES_VERSION}" \
-    --build-arg RANCHER_REPO=${REPO} \
-    --target agent \
-    -t ${AGENT_IMAGE} .
+# Convert BUILD_ARGS to string for make
+TARGET_ARGS="${BUILD_ARGS[*]}"
+
+make target-server TARGET_ARGS="--tag ${IMAGE} ${TARGET_ARGS}"
+
+make target-agent TARGET_ARGS="--tag ${AGENT_IMAGE} ${TARGET_ARGS}"
 
 mkdir -p ../dist
 echo ${IMAGE} > ../dist/images


### PR DESCRIPTION
# Issue

Option 3 to add checksuming of tini

This makes the `Makefile` the source of truth for building rancher where `dev-scripts/quick` calls to that.