### PR TITLE
Add checksum checks to tini: Option 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 TARGETS := $(shell ls scripts)
 DEV_TARGETS := $(shell ls dev-scripts)
 
+include hack/make/deps.mk
+export DEPS_BUILD_ARGS
+
 .dapper:
 	@echo Downloading dapper
 	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp

--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -38,6 +38,7 @@ BUILD_ARGS+=("--build-arg=CATTLE_FLEET_VERSION=${CATTLE_FLEET_VERSION}")
 BUILD_ARGS+=("--build-arg=CATTLE_HELM_VERSION=${CATTLE_HELM_VERSION}")
 BUILD_ARGS+=("--build-arg=RANCHER_TAG=${TAG}")
 BUILD_ARGS+=("--build-arg=RANCHER_REPO=${REPO}")
+BUILD_ARGS+=(${DEPS_BUILD_ARGS})
 if [ "$BINARY_DEBUG" = true ]; then
   # Remove -s (strip symbols)
   BUILD_ARGS+=("--build-arg=LINKFLAGS=-extldflags -static")

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,0 +1,15 @@
+TINI_VERSION := v0.18.0
+TINI_URL_amd64 := https://github.com/krallin/tini/releases/download/$(TINI_VERSION)/tini
+TINI_URL_arm64 := https://github.com/krallin/tini/releases/download/$(TINI_VERSION)/tini-arm64
+TINI_URL_s390x := https://github.com/krallin/tini/releases/download/$(TINI_VERSION)/tini-s390x
+TINI_HASH_amd64 := 12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
+TINI_HASH_arm64 := 7c5463f55393985ee22357d976758aaaecd08defb3c5294d353732018169b019
+TINI_HASH_s390x := c8aaa618ea7897f26979ea10920373e06f3e6dfeb41ef95342eda2eb5672f24d
+
+DEPS_BUILD_ARGS := --build-arg TINI_VERSION=$(TINI_VERSION) \
+	--build-arg TINI_URL_amd64=$(TINI_URL_amd64) \
+	--build-arg TINI_URL_arm64=$(TINI_URL_arm64) \
+	--build-arg TINI_URL_s390x=$(TINI_URL_s390x) \
+	--build-arg TINI_HASH_amd64=$(TINI_HASH_amd64) \
+	--build-arg TINI_HASH_arm64=$(TINI_HASH_arm64) \
+	--build-arg TINI_HASH_s390x=$(TINI_HASH_s390x)

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -24,6 +24,14 @@ ARG RKE2_CHART_DEFAULT_BRANCH=main
 ARG CATTLE_KDM_BRANCH=dev-v2.14
 ARG VERSION=${VERSION}
 
+ARG TINI_VERSION
+ARG TINI_URL_amd64
+ARG TINI_URL_arm64
+ARG TINI_URL_s390x
+ARG TINI_HASH_amd64
+ARG TINI_HASH_arm64
+ARG TINI_HASH_s390x
+
 FROM --platform=$BUILDPLATFORM ${GODEP_APISERVER} AS godep-apiserver
 FROM --platform=$BUILDPLATFORM ${GODEP_LASSO} AS godep-lasso
 FROM --platform=$BUILDPLATFORM ${GODEP_NORMAN} AS godep-norman
@@ -109,12 +117,24 @@ RUN mkdir -p /var/lib/rancher-data/driver-metadata && \
 
 FROM builder AS tini
 ARG ARCH
-ENV TINI_VERSION=v0.18.0
-ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
-    TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
-    TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
-    TINI_URL=TINI_URL_${ARCH}
-RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
+ARG TINI_URL_amd64
+ARG TINI_URL_arm64
+ARG TINI_URL_s390x
+ARG TINI_HASH_amd64
+ARG TINI_HASH_arm64
+ARG TINI_HASH_s390x
+
+ENV TINI_URL_amd64=${TINI_URL_amd64} \
+    TINI_URL_arm64=${TINI_URL_arm64} \
+    TINI_URL_s390x=${TINI_URL_s390x} \
+    TINI_HASH_amd64=${TINI_HASH_amd64} \
+    TINI_HASH_arm64=${TINI_HASH_arm64} \
+    TINI_HASH_s390x=${TINI_HASH_s390x}
+
+RUN TINI_URL=TINI_URL_${ARCH} && \
+    TINI_HASH=TINI_HASH_${ARCH} && \
+    curl -sLf ${!TINI_URL} > /usr/bin/tini && \
+    echo "${!TINI_HASH}  /usr/bin/tini" | sha256sum -c - && \
     chmod +x /usr/bin/tini
 
 

--- a/scripts/package
+++ b/scripts/package
@@ -32,6 +32,7 @@ docker build \
     --build-arg CATTLE_RANCHER_TURTLES_VERSION="${CATTLE_RANCHER_TURTLES_VERSION}" \
     --build-arg CATTLE_CSP_ADAPTER_MIN_VERSION="${CATTLE_CSP_ADAPTER_MIN_VERSION}" \
     --build-arg CATTLE_FLEET_VERSION="${CATTLE_FLEET_VERSION}" \
+    ${DEPS_BUILD_ARGS} \
     --target server \
     -t ${IMAGE} .
 
@@ -42,6 +43,7 @@ docker build \
     --build-arg CATTLE_RANCHER_WEBHOOK_VERSION="${CATTLE_RANCHER_WEBHOOK_VERSION}" \
     --build-arg CATTLE_RANCHER_TURTLES_VERSION="${CATTLE_RANCHER_TURTLES_VERSION}" \
     --build-arg RANCHER_REPO=${REPO} \
+    ${DEPS_BUILD_ARGS} \
     --target agent \
     -t ${AGENT_IMAGE} .
 


### PR DESCRIPTION
# Issue

Adds checksumming of tini using an included deps.mk file.

This PR prevents building rancher with `./dev-scripts/quick` because it doesn't include the necessary build args for tini.

Seems fairly easy to extend to other dependencies too.

(Note: We'll want to add renovate at some point for these)

There are two other options:
- Option 2: https://github.com/rancher/rancher/pull/54435
- Option 3: https://github.com/rancher/rancher/pull/54433