### PR TITLE
fix: helm chart features value rendering

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -51,7 +51,6 @@ Prepare the Rancher Image repo value w/ new fields as opt-in for now.
 {{ default "rancher/rancher" .Values.image.repository -}}
 {{ end -}}
 
-
 {{/*
 Prepare the Rancher Image Tag value w/ new fields as opt-in for now.
 */}}
@@ -112,6 +111,17 @@ app.kubernetes.io/component: {{ . | quote }}
 app.kubernetes.io/part-of: {{ . | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+Convert "features" map into a comma separates string to conform with CATTLE_FEATURES env
+*/}}
+{{- define "rancher-features" -}}
+{{- $list := list -}}
+{{- range $k, $v := .Values.features -}}
+{{- $list = append $list (printf "%s=%t" $k $v ) -}}
+{{- end -}}
+{{ join "," $list }}
+{{- end -}}
 
 # Windows Support
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -112,7 +112,7 @@ spec:
           value: {{ template "rancher.fullname" . }}
 {{- if .Values.features }}
         - name: CATTLE_FEATURES
-          value: "{{ .Values.features }}"
+          value: {{ include "rancher-features" . }}
 {{- end}}
 {{- if .Values.noDefaultAdmin }}
         - name: CATTLE_NO_DEFAULT_ADMIN


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54451
 
## Problem

The current implementation:
```yaml
{{- if .Values.features }}
        - name: CATTLE_FEATURES
          value: "{{ .Values.features }}"
{{- end}}
```

Result into:
```
CATTLE_FEATURES="map[managed-system-upgrade-controller=false]"
```
which is not a comma seperated list
 
## Solution

render features into a comma seperated list via a new helper functions since helm templates functions can't do this oob.
 
## Testing

```
$ tail values.yaml            
#   - name: CATTLE_PROMETHEUS_METRICS
#     value: "true"
#   - name: CATTLE_FEATURES
#     value: "managed-system-upgrade-controller=false,foo=true,bar=false"

features:
  managed-system-upgrade-controller: false
  foo: false
  bar: true
```

```
$ helm template . -s templates/deployment.yaml | grep env -A 3
          env:
            - name: CATTLE_FEATURES
              value: bar=true,foo=false,managed-system-upgrade-controller=false
          ports:
```