### PR TITLE
fix: delete existing duplicate prtbs

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/prtb_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -55,6 +56,7 @@ func newPRTBHandler(management *config.ManagementContext, clusterManager *cluste
 }
 
 // OnChange syncs the required resources used to implement a PRTB. It does the following:
+//   - Delete duplicate PRTBs with the same content (subject, role template, and project).
 //   - Create the specified user if it doesn't already exist.
 //   - Create the membership bindings to give access to the cluster.
 //   - Create a binding to the project management role if it exists.
@@ -63,7 +65,14 @@ func (p *prtbHandler) OnChange(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 		return nil, nil
 	}
 
-	var err error
+	isDuplicate, err := p.deleteDuplicatePRTBs(prtb)
+	if err != nil {
+		return prtb, err
+	}
+	if isDuplicate {
+		return prtb, nil
+	}
+
 	prtb, err = p.handleMigration(prtb)
 	if err != nil {
 		return prtb, err
@@ -83,6 +92,82 @@ func (p *prtbHandler) OnChange(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 	}
 
 	return prtb, p.reconcileBindings(prtb)
+}
+
+// prtbContentKey returns a string key that uniquely identifies the content of a PRTB.
+// Two PRTBs with the same content key are considered duplicates.
+// The key is built from the subject (using the same priority order as the webhook:
+// UserPrincipalName > UserName > GroupPrincipalName > GroupName), RoleTemplateName, and ProjectName.
+func prtbContentKey(prtb *v3.ProjectRoleTemplateBinding) string {
+	var subject string
+	switch {
+	case prtb.UserPrincipalName != "":
+		subject = prtb.UserPrincipalName
+	case prtb.UserName != "":
+		subject = prtb.UserName
+	case prtb.GroupPrincipalName != "":
+		subject = prtb.GroupPrincipalName
+	case prtb.GroupName != "":
+		subject = prtb.GroupName
+	}
+	return subject + "/" + prtb.RoleTemplateName + "/" + prtb.ProjectName
+}
+
+// deleteDuplicatePRTBs checks if there are duplicate PRTBs with the same content in the same namespace.
+// If duplicates are found, it keeps the oldest one (by creation timestamp, then by name as tiebreaker)
+// and deletes the rest. It returns true if the given prtb was itself deleted as a duplicate.
+func (p *prtbHandler) deleteDuplicatePRTBs(prtb *v3.ProjectRoleTemplateBinding) (bool, error) {
+	allPRTBs, err := p.prtbClient.Cache().List(prtb.Namespace, labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("failed to list PRTBs in namespace %s: %w", prtb.Namespace, err)
+	}
+
+	currentKey := prtbContentKey(prtb)
+
+	// Find all PRTBs with the same content key.
+	var duplicates []*v3.ProjectRoleTemplateBinding
+	for _, other := range allPRTBs {
+		if other.DeletionTimestamp != nil {
+			continue
+		}
+		if prtbContentKey(other) == currentKey {
+			duplicates = append(duplicates, other)
+		}
+	}
+
+	if len(duplicates) <= 1 {
+		return false, nil
+	}
+
+	// Sort: oldest first by CreationTimestamp, then by Name as tiebreaker.
+	sort.Slice(duplicates, func(i, j int) bool {
+		ti := duplicates[i].CreationTimestamp
+		tj := duplicates[j].CreationTimestamp
+		if !ti.Equal(&tj) {
+			return ti.Before(&tj)
+		}
+		return duplicates[i].Name < duplicates[j].Name
+	})
+
+	// Keep the first (oldest), delete the rest.
+	keeper := duplicates[0]
+	logrus.Infof("[prtb-handler] found %d duplicate PRTBs for key %q in namespace %s, keeping %s",
+		len(duplicates), currentKey, prtb.Namespace, keeper.Name)
+
+	currentDeleted := false
+	var returnErr error
+	for _, dup := range duplicates[1:] {
+		logrus.Infof("[prtb-handler] deleting duplicate PRTB %s/%s", dup.Namespace, dup.Name)
+		if err := p.prtbClient.Delete(dup.Namespace, dup.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			returnErr = errors.Join(returnErr, fmt.Errorf("failed to delete duplicate PRTB %s/%s: %w", dup.Namespace, dup.Name, err))
+			continue
+		}
+		if dup.Name == prtb.Name {
+			currentDeleted = true
+		}
+	}
+
+	return currentDeleted, returnErr
 }
 
 // handleMigration handles the migration of PRTBs when toggling the AggregatedRoleTemplates feature flag.

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
@@ -3,6 +3,7 @@ package roletemplates
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/features"
@@ -12,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestPRTBHandlerReconcileSubject(t *testing.T) {
@@ -973,3 +975,355 @@ func TestPRTBHandlerHandleMigration(t *testing.T) {
 		})
 	}
 }
+
+func TestPRTBContentKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		prtb     *v3.ProjectRoleTemplateBinding
+		expected string
+	}{
+		{
+			name: "user principal name takes priority",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				UserPrincipalName: "local://user1",
+				UserName:          "user1",
+				RoleTemplateName:  "project-member",
+				ProjectName:       "c-m-1234:p-5678",
+			},
+			expected: "local://user1/project-member/c-m-1234:p-5678",
+		},
+		{
+			name: "user name used when no principal",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				UserName:         "user1",
+				RoleTemplateName: "project-member",
+				ProjectName:      "c-m-1234:p-5678",
+			},
+			expected: "user1/project-member/c-m-1234:p-5678",
+		},
+		{
+			name: "group principal name used",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				GroupPrincipalName: "activedirectory_group://CN=admins",
+				RoleTemplateName:   "project-owner",
+				ProjectName:        "c-m-1234:p-5678",
+			},
+			expected: "activedirectory_group://CN=admins/project-owner/c-m-1234:p-5678",
+		},
+		{
+			name: "group name used as fallback",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				GroupName:        "local-group",
+				RoleTemplateName: "project-member",
+				ProjectName:      "c-m-1234:p-5678",
+			},
+			expected: "local-group/project-member/c-m-1234:p-5678",
+		},
+		{
+			name: "empty subject",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				RoleTemplateName: "project-member",
+				ProjectName:      "c-m-1234:p-5678",
+			},
+			expected: "/project-member/c-m-1234:p-5678",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := prtbContentKey(tt.prtb)
+			if got != tt.expected {
+				t.Errorf("prtbContentKey() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeleteDuplicatePRTBs(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-1 * time.Minute))
+
+	tests := []struct {
+		name              string
+		prtb              *v3.ProjectRoleTemplateBinding
+		cachedPRTBs       []*v3.ProjectRoleTemplateBinding
+		expectDeleted     []string
+		expectIsDuplicate bool
+		wantErr           bool
+		cacheListErr      error
+		deleteErr         map[string]error
+	}{
+		{
+			name: "no duplicates",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: now},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			expectDeleted:     nil,
+			expectIsDuplicate: false,
+		},
+		{
+			name: "two duplicates - newer one is deleted, current is the newer",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-2", Namespace: "ns", CreationTimestamp: now},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-2", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			expectDeleted:     []string{"prtb-2"},
+			expectIsDuplicate: true,
+		},
+		{
+			name: "two duplicates - current is the oldest (keeper)",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-2", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			expectDeleted:     []string{"prtb-2"},
+			expectIsDuplicate: false,
+		},
+		{
+			name: "different content - no duplicates",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: now},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-2", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user2",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			expectDeleted:     nil,
+			expectIsDuplicate: false,
+		},
+		{
+			name: "three duplicates - two deleted",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-3", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-2", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			expectDeleted:     []string{"prtb-2", "prtb-3"},
+			expectIsDuplicate: false,
+		},
+		{
+			name: "cache list error",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: now},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cacheListErr:      errDefault,
+			expectIsDuplicate: false,
+			wantErr:           true,
+		},
+		{
+			name: "delete error is returned",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-2", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			deleteErr:         map[string]error{"prtb-2": errDefault},
+			expectDeleted:     []string{"prtb-2"},
+			expectIsDuplicate: false,
+			wantErr:           true,
+		},
+		{
+			name: "prtb with deletion timestamp is ignored",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-1", Namespace: "ns", CreationTimestamp: earlier},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "prtb-2",
+						Namespace:         "ns",
+						CreationTimestamp:  now,
+						DeletionTimestamp: &now,
+					},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			expectDeleted:     nil,
+			expectIsDuplicate: false,
+		},
+		{
+			name: "same timestamp tiebroken by name",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       metav1.ObjectMeta{Name: "prtb-b", Namespace: "ns", CreationTimestamp: now},
+				UserName:         "user1",
+				RoleTemplateName: "rt1",
+				ProjectName:      "c:p",
+			},
+			cachedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-b", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+				{
+					ObjectMeta:       metav1.ObjectMeta{Name: "prtb-a", Namespace: "ns", CreationTimestamp: now},
+					UserName:         "user1",
+					RoleTemplateName: "rt1",
+					ProjectName:      "c:p",
+				},
+			},
+			expectDeleted:     []string{"prtb-b"},
+			expectIsDuplicate: true,
+		},
+	}
+	ctrl := gomock.NewController(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prtbController := fake.NewMockControllerInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList](ctrl)
+			prtbCache := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
+
+			prtbController.EXPECT().Cache().Return(prtbCache).AnyTimes()
+
+			if tt.cacheListErr != nil {
+				prtbCache.EXPECT().List(tt.prtb.Namespace, labels.Everything()).Return(nil, tt.cacheListErr)
+			} else {
+				prtbCache.EXPECT().List(tt.prtb.Namespace, labels.Everything()).Return(tt.cachedPRTBs, nil)
+			}
+
+			deletedNames := map[string]bool{}
+			if len(tt.expectDeleted) > 0 {
+				prtbController.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ns, name string, opts *metav1.DeleteOptions) error {
+						deletedNames[name] = true
+						if tt.deleteErr != nil {
+							if err, ok := tt.deleteErr[name]; ok {
+								return err
+							}
+						}
+						return nil
+					}).Times(len(tt.expectDeleted))
+			}
+
+			p := &prtbHandler{
+				prtbClient: prtbController,
+			}
+
+			isDuplicate, err := p.deleteDuplicatePRTBs(tt.prtb)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deleteDuplicatePRTBs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if isDuplicate != tt.expectIsDuplicate {
+				t.Errorf("deleteDuplicatePRTBs() isDuplicate = %v, want %v", isDuplicate, tt.expectIsDuplicate)
+			}
+			for _, name := range tt.expectDeleted {
+				if !deletedNames[name] {
+					t.Errorf("expected PRTB %s to be deleted, but it was not", name)
+				}
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54001

## Problem
Duplicate ProjectRoleTemplateBindings (PRTBs) are created when the UI submits the same role assignment simultaneously. The rancher-webhook validates against existing PRTBs, but it cannot prevent truly concurrent requests — if two creation requests hit the API server before either is persisted to etcd, both pass webhook validation and both PRTBs are created.

## Solution
This fix is part 2 of a two-part solution:

1. **Prevention (webhook — [rancher/webhook#1340](https://github.com/rancher/webhook/pull/1340)):** The webhook sets a deterministic name on PRTBs based on their content (subject + role template + project). Two concurrent requests for the same binding produce the same name, and the Kubernetes API server rejects the second with a 409 Conflict.

2. **Cleanup (this PR):** Adds duplicate PRTB detection and deletion in the PRTB handler's `OnChange`. When a PRTB is reconciled, the handler lists all PRTBs in the same namespace from cache, groups them by content key (subject + roleTemplateName + projectName), and if duplicates exist, keeps the oldest (by creation timestamp, then name as tiebreaker) and deletes the rest. If the current PRTB is itself a duplicate, the handler returns early without further reconciliation.

Changes:
- Added `prtbContentKey()` — builds a unique string key from subject fields (priority: UserPrincipalName > UserName > GroupPrincipalName > GroupName), RoleTemplateName, and ProjectName.
- Added `deleteDuplicatePRTBs()` method on `prtbHandler` — finds and deletes duplicate PRTBs in the same namespace.
- Called `deleteDuplicatePRTBs()` at the top of `OnChange`, before migration and reconciliation.

## Testing

## Engineering Testing
### Manual Testing
- Created duplicate PRTBs manually via UI, verified the controller detects and deletes the newer duplicates on the next reconciliation cycle, keeping only the oldest.

### Automated Testing
* Test types added/modified:
    * Unit
* `TestPRTBContentKey` — 5 cases covering all subject priority paths (UserPrincipalName, UserName, GroupPrincipalName, GroupName, empty).
* `TestDeleteDuplicatePRTBs` — 9 cases covering: no duplicates, newer deleted, oldest kept, different content (no false positives), 3+ duplicates, cache list error, delete error propagation, deletion-timestamp PRTBs skipped, same-timestamp name tiebreaker.

Summary: Unit tests cover the content key generation and all duplicate deletion scenarios including error paths and edge cases.

## QA Testing Considerations
- Assign the same user the same project role twice simultaneously from the UI and verify only one PRTB is created (webhook prevention) or if two slip through, verify the controller cleans up the duplicate within seconds.
- Verify existing valid (non-duplicate) PRTBs are not affected.
- Test with group-based PRTBs (GroupPrincipalName / GroupName) in addition to user-based ones.

### Regressions Considerations
- Low risk: the duplicate check runs on every PRTB OnChange but only performs deletions when duplicates actually exist. The cache list is scoped to a single namespace so the overhead is minimal.
- The content key uses the same subject priority order as the webhook to ensure consistency.

Existing / newly added automated tests that provide evidence there are no regressions:
* `TestDeleteDuplicatePRTBs` — confirms no deletions occur when there are no duplicates or when PRTBs have different content.
* All existing `prtb_handler_test.go` tests continue to pass.
