### PR TITLE
fix: delete existing duplicate crtbs

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/common.go
+++ b/pkg/controllers/management/auth/roletemplates/common.go
@@ -401,6 +401,27 @@ func handleAggregationMigration[T any](
 	return resource, nil
 }
 
+// rtbContentKey returns a string that uniquely identifies the content of a role template
+// binding. Two bindings with the same content key are considered duplicates regardless
+// of their metadata.name.
+// The subject is resolved using the same priority order as the webhook:
+// UserPrincipalName → UserName → GroupPrincipalName → GroupName.
+// The scope is the binding-specific identifier (ClusterName for CRTBs, ProjectName for PRTBs).
+func rtbContentKey(userPrincipalName, userName, groupPrincipalName, groupName, roleTemplateName, scope string) string {
+	var subject string
+	switch {
+	case userPrincipalName != "":
+		subject = userPrincipalName
+	case userName != "":
+		subject = userName
+	case groupPrincipalName != "":
+		subject = groupPrincipalName
+	case groupName != "":
+		subject = groupName
+	}
+	return subject + "/" + roleTemplateName + "/" + scope
+}
+
 // AddAggregationManagementFeatureLabel adds the aggregation management label to the given resource.
 func AddAggregationManagementFeatureLabel(obj metav1.Object) {
 	labels := obj.GetLabels()

--- a/pkg/controllers/management/auth/roletemplates/common_test.go
+++ b/pkg/controllers/management/auth/roletemplates/common_test.go
@@ -992,3 +992,78 @@ func TestAddAggregationManagementFeatureLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestRTBContentKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		userPrincipalName  string
+		userName           string
+		groupPrincipalName string
+		groupName          string
+		roleTemplateName   string
+		scope              string
+		want               string
+	}{
+		{
+			name:               "user principal name takes priority",
+			userPrincipalName:  "local://user1",
+			userName:           "user1",
+			groupPrincipalName: "group-principal",
+			groupName:          "group1",
+			roleTemplateName:   "cluster-owner",
+			scope:              "c-abc123",
+			want:               "local://user1/cluster-owner/c-abc123",
+		},
+		{
+			name:             "falls back to user name",
+			userName:         "user1",
+			roleTemplateName: "cluster-member",
+			scope:            "c-abc123",
+			want:             "user1/cluster-member/c-abc123",
+		},
+		{
+			name:               "falls back to group principal name",
+			groupPrincipalName: "keycloak_group://admins",
+			groupName:          "admins",
+			roleTemplateName:   "cluster-owner",
+			scope:              "c-abc123",
+			want:               "keycloak_group://admins/cluster-owner/c-abc123",
+		},
+		{
+			name:             "falls back to group name",
+			groupName:        "admins",
+			roleTemplateName: "cluster-member",
+			scope:            "c-abc123",
+			want:             "admins/cluster-member/c-abc123",
+		},
+		{
+			name:             "empty subject fields",
+			roleTemplateName: "cluster-member",
+			scope:            "c-abc123",
+			want:             "/cluster-member/c-abc123",
+		},
+		{
+			name:              "works for CRTB scope",
+			userPrincipalName: "local://user1",
+			roleTemplateName:  "cluster-owner",
+			scope:             "c-abc123",
+			want:              "local://user1/cluster-owner/c-abc123",
+		},
+		{
+			name:              "works for PRTB scope",
+			userPrincipalName: "local://user1",
+			roleTemplateName:  "project-member",
+			scope:             "c-m-1234:p-5678",
+			want:              "local://user1/project-member/c-m-1234:p-5678",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := rtbContentKey(tt.userPrincipalName, tt.userName, tt.groupPrincipalName, tt.groupName, tt.roleTemplateName, tt.scope)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+

--- a/pkg/controllers/management/auth/roletemplates/crtb_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -77,7 +78,16 @@ func (c *crtbHandler) OnChange(_ string, crtb *v3.ClusterRoleTemplateBinding) (*
 		return nil, nil
 	}
 
-	var err error
+	// Delete duplicate CRTBs (same subject + roleTemplateName + clusterName).
+	// If this CRTB is itself the duplicate that got deleted, stop processing.
+	isDup, err := c.deleteDuplicateCRTBs(crtb)
+	if err != nil {
+		return crtb, err
+	}
+	if isDup {
+		return nil, nil
+	}
+
 	crtb, err = c.handleMigration(crtb)
 	if err != nil {
 		return crtb, err
@@ -98,6 +108,67 @@ func (c *crtbHandler) OnChange(_ string, crtb *v3.ClusterRoleTemplateBinding) (*
 	}
 
 	return crtb, errors.Join(c.reconcileBindings(crtb, &localConditions), c.updateStatus(crtb, localConditions))
+}
+
+// deleteDuplicateCRTBs checks for other CRTBs in the same namespace that have the same content
+// (subject + roleTemplateName + clusterName). If duplicates are found, only the oldest one (by
+// CreationTimestamp, then by Name as tiebreaker) is kept. All others are deleted.
+// It returns true if the current CRTB was itself a duplicate that was deleted.
+func (c *crtbHandler) deleteDuplicateCRTBs(crtb *v3.ClusterRoleTemplateBinding) (bool, error) {
+	allCRTBs, err := c.crtbCache.List(crtb.Namespace, labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("failed to list CRTBs in namespace %s: %w", crtb.Namespace, err)
+	}
+
+	currentKey := rtbContentKey(crtb.UserPrincipalName, crtb.UserName, crtb.GroupPrincipalName, crtb.GroupName,
+		crtb.RoleTemplateName, crtb.ClusterName)
+
+	// Collect all non-deleting CRTBs with the same content key.
+	var duplicates []*v3.ClusterRoleTemplateBinding
+	for _, crtb := range allCRTBs {
+		if crtb.DeletionTimestamp != nil {
+			continue
+		}
+		if rtbContentKey(crtb.UserPrincipalName,
+			crtb.UserName,
+			crtb.GroupPrincipalName,
+			crtb.GroupName,
+			crtb.RoleTemplateName,
+			crtb.ClusterName) == currentKey {
+			duplicates = append(duplicates, crtb)
+		}
+	}
+
+	if len(duplicates) <= 1 {
+		return false, nil
+	}
+
+	// Sort: oldest CreationTimestamp first, then lexicographically by Name as tiebreaker.
+	sort.Slice(duplicates, func(i, j int) bool {
+		ti := duplicates[i].CreationTimestamp.Time
+		tj := duplicates[j].CreationTimestamp.Time
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		return duplicates[i].Name < duplicates[j].Name
+	})
+
+	// The first element is the "winner" that we keep.
+	keeper := duplicates[0]
+	currentIsDuplicate := crtb.Name != keeper.Name
+
+	logrus.Infof("[mgmt-crtb-change-handler] found %d duplicate CRTBs for content key %q in namespace %s, keeping %s",
+		len(duplicates), currentKey, crtb.Namespace, keeper.Name)
+
+	var returnErr error
+	for _, dup := range duplicates[1:] {
+		logrus.Infof("[mgmt-crtb-change-handler] deleting duplicate CRTB %s/%s", dup.Namespace, dup.Name)
+		if err := c.crtbClient.Delete(dup.Namespace, dup.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			returnErr = errors.Join(returnErr, fmt.Errorf("failed to delete duplicate CRTB %s/%s: %w", dup.Namespace, dup.Name, err))
+		}
+	}
+
+	return currentIsDuplicate, returnErr
 }
 
 // handleMigration handles the migration of CRTBs when toggling the AggregatedRoleTemplates feature flag.

--- a/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
@@ -517,7 +517,7 @@ func TestCRTBHandlerGetDesiredRoleBindings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controllers := controllers{
-				crController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl),
+				crController:  fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl),
 				projectCache: fake.NewMockCacheInterface[*v3.Project](ctrl),
 			}
 			if tt.setupControllers != nil {
@@ -1209,3 +1209,169 @@ func TestCRTBHandlerHandleMigration(t *testing.T) {
 		})
 	}
 }
+
+func TestCRTBHandlerDeleteDuplicateCRTBs(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+	later := metav1.NewTime(now.Add(time.Minute))
+
+	baseCRTB := func(name string, ts metav1.Time) *v3.ClusterRoleTemplateBinding {
+		return &v3.ClusterRoleTemplateBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "c-test",
+				CreationTimestamp: ts,
+			},
+			UserName:         "user1",
+			RoleTemplateName: "cluster-member",
+			ClusterName:      "c-test",
+		}
+	}
+
+	tests := []struct {
+		name           string
+		crtb           *v3.ClusterRoleTemplateBinding
+		cachedCRTBs    []*v3.ClusterRoleTemplateBinding
+		wantDeleted    []string // names of CRTBs expected to be deleted
+		wantIsDup      bool
+		wantErr        bool
+		deleteErr      error
+	}{
+		{
+			name: "no duplicates - single CRTB",
+			crtb: baseCRTB("crtb-1", now),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", now),
+			},
+			wantIsDup: false,
+		},
+		{
+			name: "no duplicates - different content keys",
+			crtb: baseCRTB("crtb-1", now),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", now),
+				func() *v3.ClusterRoleTemplateBinding {
+					c := baseCRTB("crtb-2", now)
+					c.RoleTemplateName = "cluster-owner" // different role
+					return c
+				}(),
+			},
+			wantIsDup: false,
+		},
+		{
+			name: "two duplicates - current is older (keeper), deletes the newer one",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", later),
+			},
+			wantDeleted: []string{"crtb-2"},
+			wantIsDup:   false,
+		},
+		{
+			name: "two duplicates - current is newer (duplicate), gets itself deleted",
+			crtb: baseCRTB("crtb-2", later),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", later),
+			},
+			wantDeleted: []string{"crtb-2"},
+			wantIsDup:   true,
+		},
+		{
+			name: "three duplicates - oldest is kept, two newer are deleted",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", now),
+				baseCRTB("crtb-3", later),
+			},
+			wantDeleted: []string{"crtb-2", "crtb-3"},
+			wantIsDup:   false,
+		},
+		{
+			name: "same timestamp - tiebreak by name, earlier name wins",
+			crtb: baseCRTB("crtb-b", now),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-a", now),
+				baseCRTB("crtb-b", now),
+			},
+			wantDeleted: []string{"crtb-b"},
+			wantIsDup:   true,
+		},
+		{
+			name: "skip CRTBs with deletion timestamp",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				func() *v3.ClusterRoleTemplateBinding {
+					c := baseCRTB("crtb-2", later)
+					delTime := metav1.Now()
+					c.DeletionTimestamp = &delTime
+					return c
+				}(),
+			},
+			wantIsDup: false, // only one non-deleting CRTB, so no duplicates
+		},
+		{
+			name: "error listing CRTBs from cache",
+			crtb: baseCRTB("crtb-1", now),
+			// cachedCRTBs is nil but we'll set up the mock to return error
+			wantErr: true,
+		},
+		{
+			name: "error deleting duplicate CRTB",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", later),
+			},
+			wantDeleted: []string{"crtb-2"},
+			deleteErr:   fmt.Errorf("delete failed"),
+			wantIsDup:   false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			crtbCache := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+			crtbClient := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
+
+			if tt.name == "error listing CRTBs from cache" {
+				crtbCache.EXPECT().List(tt.crtb.Namespace, gomock.Any()).Return(nil, fmt.Errorf("cache error"))
+			} else {
+				crtbCache.EXPECT().List(tt.crtb.Namespace, gomock.Any()).Return(tt.cachedCRTBs, nil)
+			}
+
+			for _, delName := range tt.wantDeleted {
+				if tt.deleteErr != nil {
+					crtbClient.EXPECT().Delete(tt.crtb.Namespace, delName, gomock.Any()).Return(tt.deleteErr)
+				} else {
+					crtbClient.EXPECT().Delete(tt.crtb.Namespace, delName, gomock.Any()).Return(nil)
+				}
+			}
+
+			c := &crtbHandler{
+				crtbCache:  crtbCache,
+				crtbClient: crtbClient,
+			}
+
+			isDup, err := c.deleteDuplicateCRTBs(tt.crtb)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantIsDup, isDup)
+		})
+	}
+}
+

--- a/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
@@ -1209,3 +1209,168 @@ func TestCRTBHandlerHandleMigration(t *testing.T) {
 		})
 	}
 }
+
+func TestCRTBHandlerDeleteDuplicateCRTBs(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+	later := metav1.NewTime(now.Add(time.Minute))
+
+	baseCRTB := func(name string, ts metav1.Time) *v3.ClusterRoleTemplateBinding {
+		return &v3.ClusterRoleTemplateBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "c-test",
+				CreationTimestamp: ts,
+			},
+			UserName:         "user1",
+			RoleTemplateName: "cluster-member",
+			ClusterName:      "c-test",
+		}
+	}
+
+	tests := []struct {
+		name        string
+		crtb        *v3.ClusterRoleTemplateBinding
+		cachedCRTBs []*v3.ClusterRoleTemplateBinding
+		wantDeleted []string // names of CRTBs expected to be deleted
+		wantIsDup   bool
+		wantErr     bool
+		deleteErr   error
+	}{
+		{
+			name: "no duplicates - single CRTB",
+			crtb: baseCRTB("crtb-1", now),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", now),
+			},
+			wantIsDup: false,
+		},
+		{
+			name: "no duplicates - different content keys",
+			crtb: baseCRTB("crtb-1", now),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", now),
+				func() *v3.ClusterRoleTemplateBinding {
+					c := baseCRTB("crtb-2", now)
+					c.RoleTemplateName = "cluster-owner" // different role
+					return c
+				}(),
+			},
+			wantIsDup: false,
+		},
+		{
+			name: "two duplicates - current is older (keeper), deletes the newer one",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", later),
+			},
+			wantDeleted: []string{"crtb-2"},
+			wantIsDup:   false,
+		},
+		{
+			name: "two duplicates - current is newer (duplicate), gets itself deleted",
+			crtb: baseCRTB("crtb-2", later),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", later),
+			},
+			wantDeleted: []string{"crtb-2"},
+			wantIsDup:   true,
+		},
+		{
+			name: "three duplicates - oldest is kept, two newer are deleted",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", now),
+				baseCRTB("crtb-3", later),
+			},
+			wantDeleted: []string{"crtb-2", "crtb-3"},
+			wantIsDup:   false,
+		},
+		{
+			name: "same timestamp - tiebreak by name, earlier name wins",
+			crtb: baseCRTB("crtb-b", now),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-a", now),
+				baseCRTB("crtb-b", now),
+			},
+			wantDeleted: []string{"crtb-b"},
+			wantIsDup:   true,
+		},
+		{
+			name: "skip CRTBs with deletion timestamp",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				func() *v3.ClusterRoleTemplateBinding {
+					c := baseCRTB("crtb-2", later)
+					delTime := metav1.Now()
+					c.DeletionTimestamp = &delTime
+					return c
+				}(),
+			},
+			wantIsDup: false, // only one non-deleting CRTB, so no duplicates
+		},
+		{
+			name: "error listing CRTBs from cache",
+			crtb: baseCRTB("crtb-1", now),
+			// cachedCRTBs is nil but we'll set up the mock to return error
+			wantErr: true,
+		},
+		{
+			name: "error deleting duplicate CRTB",
+			crtb: baseCRTB("crtb-1", earlier),
+			cachedCRTBs: []*v3.ClusterRoleTemplateBinding{
+				baseCRTB("crtb-1", earlier),
+				baseCRTB("crtb-2", later),
+			},
+			wantDeleted: []string{"crtb-2"},
+			deleteErr:   fmt.Errorf("delete failed"),
+			wantIsDup:   false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			crtbCache := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+			crtbClient := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
+
+			if tt.name == "error listing CRTBs from cache" {
+				crtbCache.EXPECT().List(tt.crtb.Namespace, gomock.Any()).Return(nil, fmt.Errorf("cache error"))
+			} else {
+				crtbCache.EXPECT().List(tt.crtb.Namespace, gomock.Any()).Return(tt.cachedCRTBs, nil)
+			}
+
+			for _, delName := range tt.wantDeleted {
+				if tt.deleteErr != nil {
+					crtbClient.EXPECT().Delete(tt.crtb.Namespace, delName, gomock.Any()).Return(tt.deleteErr)
+				} else {
+					crtbClient.EXPECT().Delete(tt.crtb.Namespace, delName, gomock.Any()).Return(nil)
+				}
+			}
+
+			c := &crtbHandler{
+				crtbCache:  crtbCache,
+				crtbClient: crtbClient,
+			}
+
+			isDup, err := c.deleteDuplicateCRTBs(tt.crtb)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantIsDup, isDup)
+		})
+	}
+}

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler.go
@@ -94,25 +94,6 @@ func (p *prtbHandler) OnChange(_ string, prtb *v3.ProjectRoleTemplateBinding) (*
 	return prtb, p.reconcileBindings(prtb)
 }
 
-// prtbContentKey returns a string key that uniquely identifies the content of a PRTB.
-// Two PRTBs with the same content key are considered duplicates.
-// The key is built from the subject (using the same priority order as the webhook:
-// UserPrincipalName > UserName > GroupPrincipalName > GroupName), RoleTemplateName, and ProjectName.
-func prtbContentKey(prtb *v3.ProjectRoleTemplateBinding) string {
-	var subject string
-	switch {
-	case prtb.UserPrincipalName != "":
-		subject = prtb.UserPrincipalName
-	case prtb.UserName != "":
-		subject = prtb.UserName
-	case prtb.GroupPrincipalName != "":
-		subject = prtb.GroupPrincipalName
-	case prtb.GroupName != "":
-		subject = prtb.GroupName
-	}
-	return subject + "/" + prtb.RoleTemplateName + "/" + prtb.ProjectName
-}
-
 // deleteDuplicatePRTBs checks if there are duplicate PRTBs with the same content in the same namespace.
 // If duplicates are found, it keeps the oldest one (by creation timestamp, then by name as tiebreaker)
 // and deletes the rest. It returns true if the given prtb was itself deleted as a duplicate.
@@ -122,7 +103,8 @@ func (p *prtbHandler) deleteDuplicatePRTBs(prtb *v3.ProjectRoleTemplateBinding) 
 		return false, fmt.Errorf("failed to list PRTBs in namespace %s: %w", prtb.Namespace, err)
 	}
 
-	currentKey := prtbContentKey(prtb)
+	currentKey := rtbContentKey(prtb.UserPrincipalName, prtb.UserName, prtb.GroupPrincipalName, prtb.GroupName,
+		prtb.RoleTemplateName, prtb.ProjectName)
 
 	// Find all PRTBs with the same content key.
 	var duplicates []*v3.ProjectRoleTemplateBinding
@@ -130,7 +112,12 @@ func (p *prtbHandler) deleteDuplicatePRTBs(prtb *v3.ProjectRoleTemplateBinding) 
 		if other.DeletionTimestamp != nil {
 			continue
 		}
-		if prtbContentKey(other) == currentKey {
+		if rtbContentKey(other.UserPrincipalName,
+			other.UserName,
+			other.GroupPrincipalName,
+			other.GroupName,
+			other.RoleTemplateName,
+			other.ProjectName) == currentKey {
 			duplicates = append(duplicates, other)
 		}
 	}

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
@@ -976,69 +976,6 @@ func TestPRTBHandlerHandleMigration(t *testing.T) {
 	}
 }
 
-func TestPRTBContentKey(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		prtb     *v3.ProjectRoleTemplateBinding
-		expected string
-	}{
-		{
-			name: "user principal name takes priority",
-			prtb: &v3.ProjectRoleTemplateBinding{
-				UserPrincipalName: "local://user1",
-				UserName:          "user1",
-				RoleTemplateName:  "project-member",
-				ProjectName:       "c-m-1234:p-5678",
-			},
-			expected: "local://user1/project-member/c-m-1234:p-5678",
-		},
-		{
-			name: "user name used when no principal",
-			prtb: &v3.ProjectRoleTemplateBinding{
-				UserName:         "user1",
-				RoleTemplateName: "project-member",
-				ProjectName:      "c-m-1234:p-5678",
-			},
-			expected: "user1/project-member/c-m-1234:p-5678",
-		},
-		{
-			name: "group principal name used",
-			prtb: &v3.ProjectRoleTemplateBinding{
-				GroupPrincipalName: "activedirectory_group://CN=admins",
-				RoleTemplateName:   "project-owner",
-				ProjectName:        "c-m-1234:p-5678",
-			},
-			expected: "activedirectory_group://CN=admins/project-owner/c-m-1234:p-5678",
-		},
-		{
-			name: "group name used as fallback",
-			prtb: &v3.ProjectRoleTemplateBinding{
-				GroupName:        "local-group",
-				RoleTemplateName: "project-member",
-				ProjectName:      "c-m-1234:p-5678",
-			},
-			expected: "local-group/project-member/c-m-1234:p-5678",
-		},
-		{
-			name: "empty subject",
-			prtb: &v3.ProjectRoleTemplateBinding{
-				RoleTemplateName: "project-member",
-				ProjectName:      "c-m-1234:p-5678",
-			},
-			expected: "/project-member/c-m-1234:p-5678",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := prtbContentKey(tt.prtb)
-			if got != tt.expected {
-				t.Errorf("prtbContentKey() = %q, want %q", got, tt.expected)
-			}
-		})
-	}
-}
 
 func TestDeleteDuplicatePRTBs(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54007

## Problem

Duplicate CRTBs created if the same user is assigned the same role multiple times during downstream cluster provisioning.

## Solution

This is a **two-stage solution**:

1. **Prevention (webhook)** — [rancher/webhook#1361](https://github.com/rancher/webhook/pull/1361) adds a mutating admission webhook for CRTB resources that replaces the server-side random name generation with a deterministic name derived from the binding's content. This ensures that truly concurrent requests for the same binding result in a single object (the second create gets an `AlreadyExists` error).

2. **Cleanup (this PR)** — In `OnChange` handler for CRTB, we now detect and delete pre-existing duplicates that were created before the webhook was in place. On each invocation:
   - Compute a content key (`subject/roleTemplateName/clusterName`) for the current binding.
   - List all sibling CRTBs in the same namespace from cache.
   - Collect those with the same content key (excluding objects with a `DeletionTimestamp`).
   - If duplicates exist, sort by `CreationTimestamp` (oldest first, `Name` as tiebreaker), keep the oldest, and delete the rest.
   - If the current binding is itself a duplicate, return early to skip further reconciliation.

A shared `rtbContentKey` helper derives the content key. Subject resolution priority is: `UserPrincipalName → UserName → GroupPrincipalName → GroupName`.

## Testing

Reproduced by sending two simultaneous CRTB creation requests from the UI and confirmed duplicates are created. After the fix, the controller detects and deletes the extra binding on the next reconciliation loop, leaving only one.

## Engineering Testing

### Manual Testing

- Created duplicate CRTBs by sending concurrent requests. Verified the controller detects and deletes the duplicates, keeping only the oldest binding.
- Verified normal (non-duplicate) CRTB creation and reconciliation is unaffected.

### Automated Testing

* Test types added/modified:
    * Unit

* Unit tests added:
  - `TestRTBContentKey` — validates the shared content key function, including subject priority resolution.
  - `TestCRTBHandlerDeleteDuplicateCRTBs` — 8 test cases covering: no duplicates, single CRTB, multiple duplicates with same/different timestamps, current binding is the duplicate, deletion errors, and CRTBs with `DeletionTimestamp` set.

Summary: Unit tests cover the duplicate detection, sorting, keeper selection, and deletion logic for the CRTB handler.

## QA Testing Considerations

- Test concurrent CRTB creation (e.g. rapid double-click on "Add Member" in the UI) on both fresh installs and upgrades.
- Verify that pre-existing duplicate CRTBs from before the upgrade are cleaned up once the controller processes them.
- Verify that legitimate distinct bindings (different role or different user on the same cluster) are not affected.

### Regressions Considerations

- Low risk: the duplicate detection runs before existing reconciliation logic and only deletes objects with identical content keys. Non-duplicate bindings are untouched.
- The cache listing (`crtbCache.List`) adds a small overhead per `OnChange` invocation, but is scoped to a single namespace.

Existing / newly added automated tests that provide evidence there are no regressions:
* `TestRTBContentKey`, `TestCRTBHandlerDeleteDuplicateCRTBs` — validate that keeper selection is deterministic and only true duplicates are deleted.
* Existing CRTB handler tests continue to pass, confirming reconciliation logic is unaffected.
