### PR TITLE
[backport v2.12] treat disconnected like all other errors, no exception

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -290,7 +290,7 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				// This is because the impersonator service account does exist on the downstream cluster, and
 				// it has sufficient permissions to perform the TokenReview.
 				token, err = r.impersonatorAccountTokenGetter(userInfo, r.clusterContextGetter, r.cluster.Name)
-				if err != nil && !strings.Contains(err.Error(), dialer2.ErrAgentDisconnected.Error()) {
+				if err != nil {
 					er.Error(rw, req, fmt.Errorf("unable to create impersonator account: %w", err))
 					return
 				}

--- a/pkg/clusterrouter/proxy/proxy_server_test.go
+++ b/pkg/clusterrouter/proxy/proxy_server_test.go
@@ -83,6 +83,21 @@ func TestServeHTTP(t *testing.T) {
 			wantHeader: map[string][]string{},
 			wantErr:    "can't create token",
 		},
+		"get impersonation token - disconnected error": {
+			header: map[string][]string{},
+			ctx: func() context.Context {
+				ctx := context.TODO()
+				return request.WithUser(ctx, &user.DefaultInfo{
+					Name: "user",
+					UID:  "user",
+				})
+			},
+			impersonatorAccountTokenGetter: func(_ user.Info, _ ClusterContextGetter, _ string) (string, error) {
+				return "", errors.New("cluster agent disconnected")
+			},
+			wantHeader: map[string][]string{},
+			wantErr:    "cluster agent disconnected",
+		},
 		"impersonate sa - create token error": {
 			tokenCreator: func(ctx context.Context, getter ClusterContextGetter, s string, s2 string) (string, error) {
 				return "", errors.New("can't create token")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#54550
 
## Problem

This PR is a backport of https://github.com/rancher/rancher/pull/54524, the fix for the original issue.

A disconnection error in the remote dialer proxying should not be treated differently from all other possible errors.
 
## Solution
 
Removed the code making the exception.

## Testing

Added unit test to verify that disconnection is not exceptional

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_