### PR TITLE
Fix pending CompressedEndpoint plugin installation

### DIFF
--- a/pkg/controllers/dashboard/plugin/fscache.go
+++ b/pkg/controllers/dashboard/plugin/fscache.go
@@ -71,55 +71,22 @@ func (c FSCache) SyncWithControllersCache(p *v1.UIPlugin, forceUpdate bool) erro
 		}
 	}
 
-	if plugin.CompressedEndpoint != "" {
-		resp, err := http.Get(plugin.CompressedEndpoint)
+	hasCompressedEndpoint := plugin.CompressedEndpoint != ""
+	hasEndpoint := plugin.Endpoint != ""
+	var err error
+
+	if hasCompressedEndpoint {
+		err = c.cacheCompressedEndpoint(&plugin)
 		if err != nil {
-			return fmt.Errorf("get request failed for URL [%s]. Error: %w", plugin.CompressedEndpoint, err)
+			logrus.Errorf("failed to cache using the compressed endpoint. Error: %s", err)
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode != 200 {
-			return fmt.Errorf("failed to fetch file from URL [%s]. Status code: %d", plugin.CompressedEndpoint, resp.StatusCode)
+	}
+
+	if err != nil || !hasCompressedEndpoint {
+		if hasEndpoint {
+			return c.cacheEndpoint(&plugin)
 		}
-		p, _ := filepathsecure.SecureJoin(FSCacheRootDir, plugin.Name)
-		if err := os.MkdirAll(p, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create cache directory with path [%s]. Error: %w", p, err)
-		}
-		err = Untar(p, resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to untar file: %w", err)
-		}
-	} else if plugin.Endpoint != "" {
-		version, err := getVersionFromPackageJSON(fmt.Sprintf("%s/%s", plugin.Endpoint, PackageJSONFilename))
-		if err != nil {
-			return fmt.Errorf("failed to get version from package.json file. Error: %w", err)
-		}
-		cachedVersion, err := semver.NewVersion(plugin.Version)
-		if err != nil {
-			return fmt.Errorf("spec.plugin.version [%s] is not a semver version. Error: %w", plugin.Version, err)
-		}
-		if !cachedVersion.Equal(version) {
-			return fmt.Errorf("plugin [%s] version [%s] does not match version in controller's cache [%s]", plugin.Name, version.String(), cachedVersion.String())
-		}
-		files, err := fetchFilesTxt(fmt.Sprintf("%s/%s", plugin.Endpoint, FilesTxtFilename))
-		if err != nil {
-			return fmt.Errorf("failed to get files.txt file. Error: %w", err)
-		}
-		for _, file := range files {
-			if file == "" {
-				continue
-			}
-			data, err := fetchFile(plugin.Endpoint + "/" + file)
-			if err != nil {
-				return fmt.Errorf("failed to fetch file [%s] .Error: %w", file, err)
-			}
-			path, err := filepathsecure.SecureJoin(FSCacheRootDir, filepath.Join(plugin.Name, plugin.Version, file))
-			if err != nil {
-				return fmt.Errorf("failed to build file [%s] path for caching. Error: %w", file, err)
-			}
-			if err := c.Save(data, path); err != nil {
-				logrus.Debugf("failed to cache plugin [Name: %s Version: %s] in filesystem [path: %s]", plugin.Name, plugin.Version, path)
-			}
-		}
+		return err
 	}
 
 	return nil
@@ -387,4 +354,59 @@ func validateFilesTxtEntries(entries []string) error {
 		}
 	}
 	return nil
+}
+
+func (c FSCache) cacheCompressedEndpoint(plugin *v1.UIPluginEntry) error {
+	resp, err := http.Get(plugin.CompressedEndpoint)
+	if err != nil {
+		return fmt.Errorf("get request failed for URL [%s]. Error: %w", plugin.CompressedEndpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("failed to fetch file from URL [%s]. Status code: %d", plugin.CompressedEndpoint, resp.StatusCode)
+	}
+	p, _ := filepathsecure.SecureJoin(FSCacheRootDir, plugin.Name)
+	if err := os.MkdirAll(p, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create cache directory with path [%s]. Error: %w", p, err)
+	}
+	err = Untar(p, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to untar file: %w", err)
+	}
+	return err
+}
+
+func (c FSCache) cacheEndpoint(plugin *v1.UIPluginEntry) error {
+	version, err := getVersionFromPackageJSON(fmt.Sprintf("%s/%s", plugin.Endpoint, PackageJSONFilename))
+	if err != nil {
+		return fmt.Errorf("failed to get version from package.json file. Error: %w", err)
+	}
+	cachedVersion, err := semver.NewVersion(plugin.Version)
+	if err != nil {
+		return fmt.Errorf("spec.plugin.version [%s] is not a semver version. Error: %w", plugin.Version, err)
+	}
+	if !cachedVersion.Equal(version) {
+		return fmt.Errorf("plugin [%s] version [%s] does not match version in controller's cache [%s]", plugin.Name, version.String(), cachedVersion.String())
+	}
+	files, err := fetchFilesTxt(fmt.Sprintf("%s/%s", plugin.Endpoint, FilesTxtFilename))
+	if err != nil {
+		return fmt.Errorf("failed to get files.txt file. Error: %w", err)
+	}
+	for _, file := range files {
+		if file == "" {
+			continue
+		}
+		data, err := fetchFile(plugin.Endpoint + "/" + file)
+		if err != nil {
+			return fmt.Errorf("failed to fetch file [%s] .Error: %w", file, err)
+		}
+		path, err := filepathsecure.SecureJoin(FSCacheRootDir, filepath.Join(plugin.Name, plugin.Version, file))
+		if err != nil {
+			return fmt.Errorf("failed to build file [%s] path for caching. Error: %w", file, err)
+		}
+		if err := c.Save(data, path); err != nil {
+			logrus.Debugf("failed to cache plugin [Name: %s Version: %s] in filesystem [path: %s]", plugin.Name, plugin.Version, path)
+		}
+	}
+	return err
 }

--- a/pkg/controllers/dashboard/plugin/fscache.go
+++ b/pkg/controllers/dashboard/plugin/fscache.go
@@ -365,7 +365,11 @@ func (c FSCache) cacheCompressedEndpoint(plugin *v1.UIPluginEntry) error {
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("failed to fetch file from URL [%s]. Status code: %d", plugin.CompressedEndpoint, resp.StatusCode)
 	}
-	p, _ := filepathsecure.SecureJoin(FSCacheRootDir, plugin.Name)
+	p, err := filepathsecure.SecureJoin(FSCacheRootDir, plugin.Name)
+	if err != nil {
+		return fmt.Errorf("failed to build cache directory path for plugin [%s]. Error: %w", plugin.Name, err)
+	}
+
 	if err := os.MkdirAll(p, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create cache directory with path [%s]. Error: %w", p, err)
 	}
@@ -406,7 +410,8 @@ func (c FSCache) cacheEndpoint(plugin *v1.UIPluginEntry) error {
 		}
 		if err := c.Save(data, path); err != nil {
 			logrus.Debugf("failed to cache plugin [Name: %s Version: %s] in filesystem [path: %s]", plugin.Name, plugin.Version, path)
+			return fmt.Errorf("failed to cache file [%s] at path [%s]. Error: %w", file, path, err)
 		}
 	}
-	return err
+	return nil
 }

--- a/pkg/controllers/dashboard/plugin/fscache.go
+++ b/pkg/controllers/dashboard/plugin/fscache.go
@@ -73,23 +73,25 @@ func (c FSCache) SyncWithControllersCache(p *v1.UIPlugin, forceUpdate bool) erro
 
 	hasCompressedEndpoint := plugin.CompressedEndpoint != ""
 	hasEndpoint := plugin.Endpoint != ""
-	var err error
+	var errs error
 
 	if hasCompressedEndpoint {
-		err = c.cacheCompressedEndpoint(&plugin)
-		if err != nil {
-			logrus.Errorf("failed to cache using the compressed endpoint. Error: %s", err)
+		cmpCacheErr := c.cacheCompressedEndpoint(&plugin)
+		if cmpCacheErr == nil {
+			return nil
+		}
+		logrus.Warnf("failed to cache using the compressed endpoint. Error: %s", cmpCacheErr)
+		errs = errors.Join(errs, cmpCacheErr)
+	}
+
+	if hasEndpoint {
+		if cacheErr := c.cacheEndpoint(&plugin); cacheErr != nil {
+			logrus.Warnf("failed to cache using the endpoint. Error: %s", cacheErr)
+			errs = errors.Join(errs, cacheErr)
 		}
 	}
 
-	if err != nil || !hasCompressedEndpoint {
-		if hasEndpoint {
-			return c.cacheEndpoint(&plugin)
-		}
-		return err
-	}
-
-	return nil
+	return errs
 }
 
 // SyncWithIndex syncs up entries in the filesystem cache with the index's entries.

--- a/tests/v2/integration/catalogv2/ui_plugin_test.go
+++ b/tests/v2/integration/catalogv2/ui_plugin_test.go
@@ -298,7 +298,7 @@ func (w *UIPluginTest) TestCompressedEndpoint() {
 }
 
 func (w *UIPluginTest) TestExponentialBackoff() {
-	ts, err := StartUIPluginServer()
+	ts, err := StartUIPluginServerWithBackoff()
 	if err != nil {
 		w.T().Fatal(err)
 	}
@@ -345,6 +345,39 @@ func (w *UIPluginTest) TestExponentialBackoff() {
 	w.Require().NoError(err)
 }
 
+func (w *UIPluginTest) TestUnreachableCompressedEndpoint() {
+	ts, err := StartUIPluginServer()
+	if err != nil {
+		w.T().Fatal(err)
+	}
+	url := ts.URL
+
+	uiplugin, err := w.catalogClient.UIPlugins(namespace.UIPluginNamespace).Get(context.TODO(), "homepage", metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	uiplugin.Spec.Plugin.CompressedEndpoint = "https://some-unreachable.location.tgz"
+	uiplugin.Spec.Plugin.Endpoint = url
+	_, err = w.catalogClient.UIPlugins(namespace.UIPluginNamespace).Update(context.TODO(), uiplugin, metav1.UpdateOptions{})
+	if err != nil {
+		return
+	}
+
+	t := 360
+	err = kwait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, time.Duration(t)*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		uiplugin, err := w.catalogClient.UIPlugins(namespace.UIPluginNamespace).Get(ctx, "homepage", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if uiplugin.Status.Ready {
+			return true, nil
+		}
+		return false, nil
+	})
+	w.Require().NoError(err)
+}
+
 func StartUIPluginTgzServer() (*httptest.Server, error) {
 
 	customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -365,6 +398,25 @@ func StartUIPluginTgzServer() (*httptest.Server, error) {
 }
 
 func StartUIPluginServer() (*httptest.Server, error) {
+
+	customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.FileServer(http.Dir("../../../testdata/uiext")).ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewUnstartedServer(customHandler)
+
+	ip := getOutboundIP()
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", ip.String()))
+	if err != nil {
+		return nil, err
+	}
+	ts.Listener = listener
+	ts.Start()
+
+	return ts, nil
+}
+
+func StartUIPluginServerWithBackoff() (*httptest.Server, error) {
 	reqCount := 1
 
 	customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/v2/integration/catalogv2/ui_plugin_test.go
+++ b/tests/v2/integration/catalogv2/ui_plugin_test.go
@@ -50,7 +50,6 @@ func (w *UIPluginTest) TearDownSuite() {
 	w.Require().NoError(w.uninstallApp(namespace.UIPluginNamespace, "homepage"))
 	w.Require().NoError(w.catalogClient.ClusterRepos().Delete(context.Background(), "extensions-examples", metav1.DeleteOptions{PropagationPolicy: &propagation}))
 	w.session.Cleanup()
-
 }
 
 func (w *UIPluginTest) SetupSuite() {
@@ -146,7 +145,7 @@ func (w *UIPluginTest) SetupSuite() {
 	}, "extensions-examples"))
 	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "homepage", 0))
 
-	//Waiting for controller cache to update
+	// Waiting for controller cache to update
 	time.Sleep(10 * time.Second)
 }
 
@@ -350,25 +349,28 @@ func (w *UIPluginTest) TestUnreachableCompressedEndpoint() {
 	if err != nil {
 		w.T().Fatal(err)
 	}
-	url := ts.URL
+	compressedEndpoint := "https://some-unreachable.location.tgz"
+	endpoint := ts.URL
 
 	uiplugin, err := w.catalogClient.UIPlugins(namespace.UIPluginNamespace).Get(context.TODO(), "homepage", metav1.GetOptions{})
-	if err != nil {
-		return
-	}
+	require.NoError(w.T(), err)
 
-	uiplugin.Spec.Plugin.CompressedEndpoint = "https://some-unreachable.location.tgz"
-	uiplugin.Spec.Plugin.Endpoint = url
+	uiplugin.Spec.Plugin.CompressedEndpoint = compressedEndpoint
+	uiplugin.Spec.Plugin.Endpoint = endpoint
 	_, err = w.catalogClient.UIPlugins(namespace.UIPluginNamespace).Update(context.TODO(), uiplugin, metav1.UpdateOptions{})
-	if err != nil {
-		return
-	}
+	require.NoError(w.T(), err)
 
 	t := 360
 	err = kwait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, time.Duration(t)*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		uiplugin, err := w.catalogClient.UIPlugins(namespace.UIPluginNamespace).Get(ctx, "homepage", metav1.GetOptions{})
 		if err != nil {
 			return false, err
+		}
+		if uiplugin.Spec.Plugin.CompressedEndpoint != compressedEndpoint {
+			return false, nil
+		}
+		if uiplugin.Spec.Plugin.Endpoint != endpoint {
+			return false, nil
 		}
 		if uiplugin.Status.Ready {
 			return true, nil
@@ -379,7 +381,6 @@ func (w *UIPluginTest) TestUnreachableCompressedEndpoint() {
 }
 
 func StartUIPluginTgzServer() (*httptest.Server, error) {
-
 	customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "../../../testdata/uiext/0.4.1.tgz")
 	})
@@ -398,7 +399,6 @@ func StartUIPluginTgzServer() (*httptest.Server, error) {
 }
 
 func StartUIPluginServer() (*httptest.Server, error) {
-
 	customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.FileServer(http.Dir("../../../testdata/uiext")).ServeHTTP(w, r)
 	})
@@ -423,8 +423,9 @@ func StartUIPluginServerWithBackoff() (*httptest.Server, error) {
 		if reqCount <= 2 {
 			reqCount++
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		} else {
+			http.FileServer(http.Dir("../../../testdata/uiext")).ServeHTTP(w, r)
 		}
-		http.FileServer(http.Dir("../../../testdata/uiext")).ServeHTTP(w, r)
 	})
 
 	ts := httptest.NewUnstartedServer(customHandler)


### PR DESCRIPTION
## Issue

https://github.com/rancher/rancher/issues/54396

## Problem

When an unreachable endpoint is provided to the field `plugin.CompressedEndpoint`, the plugin installation will be stuck in a pending state until the provided value is removed.

## Solution

The fix improves the error handling logic within the plugin package to prevent this pending state from happening. We have extracted the validation logic for `plugin.CompressedEndpoint` and `plugin.Endpoint` into separate procedures, each checking whether the provided values are reachable and valid.

## Testing

## Engineering Testing

### Manual Testing

### Automated Testing

A new integration test `TestUIPluginSuite/TestCompressedEndpoint` was added in commit [4d0c16978](https://github.com/rancher/rancher/pull/54582/changes/4d0c169782f06e2b03e714007bc1fad5c895c8a8).

## QA Testing Considerations

To test the new behavior, follow these steps:

1. Add the [ui-plugin-examples](https://github.com/rancher/ui-plugin-examples) git repository to Rancher.
2. Go to the extensions tab and add the plugin `homepage`.
3. Go to the `UIPlugins` page and edit the YAML of the recent added `homepage` plugin;
4. Cut the field `.spec.plugin.endpoint`, add an unreachable URL in the field `.spec.plugin.CompressedEndpoint`, and save. The plugin will be in a pending state, which is expected.

```diff
metadata:
   uid: 94fb66f1-4f5b-41f2-9b5a-31ff1734c37c
 spec:
   plugin:
+    compressedEndpoint: https://some-unreachable.location.tgz
-    endpoint: https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/extensions/homepage/0.4.2
     metadata:
       catalog.cattle.io/kube-version: '>= 1.16.0-0'
       catalog.cattle.io/rancher-version: '>= 2.10.0-0'
```

5. Re-add the endpoint field and save. The plugin should be cached after that.

```diff
metadata:
   uid: 94fb66f1-4f5b-41f2-9b5a-31ff1734c37c
 spec:
   plugin:
     compressedEndpoint: https://some-unreachable.location.tgz
+    endpoint: https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/extensions/homepage/0.4.2
     metadata:
       catalog.cattle.io/kube-version: '>= 1.16.0-0'
       catalog.cattle.io/rancher-version: '>= 2.10.0-0'
```

Before this fix, the same steps would render a plugin stuck in a pending state.