### PR TITLE
Improve K8s bump - run go generate and update sha256sum

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -88,11 +88,19 @@ jobs:
             echo "Running updatecli on all targets"
             updatecli apply --clean --values updatecli/values.d/values.yaml \
                                     --config updatecli/updatecli.d/
+            updatecli apply         --values updatecli/values.d/values.yaml \
+                                    --config updatecli/extras/run-go-generate/
           elif [[ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]];
           then
             echo "Running updatecli on ${{ inputs.target }} target"
             updatecli apply --clean --values updatecli/values.d/values.yaml \
                                     --config "updatecli/updatecli.d/update-${{ inputs.target }}/"
+            if [[ "${{ inputs.target }}" = "k8s" ]];
+            then
+              updatecli apply       --values updatecli/values.d/values.yaml \
+                                    --config updatecli/extras/run-go-generate/
+
+            fi
           else
             echo "Invalid event name or target"
           fi

--- a/updatecli/extras/run-go-generate/go-generate.yaml
+++ b/updatecli/extras/run-go-generate/go-generate.yaml
@@ -1,0 +1,65 @@
+name: '{{ .k8s.manifest }}'
+pipelineid: '{{ .k8s.pipelineid }}'
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repo }}'
+      branch: 'updatecli_main_{{ .k8s.pipelineid }}'
+      user: '{{ .scm.user }}'
+      email: '{{ .scm.email }}'
+      username: '{{ .scm.username }}'
+      token: '{{ requiredEnv .scm.token }}'
+      commitusingapi: {{ .scm.commitusingapi }}
+      workingbranch: false
+      force: true
+      commitmessage:
+        type: '{{ .k8s.commitmessage.type }}'
+        scope: '{{ .k8s.commitmessage.scope }}'
+        title: 'Bump patch versions of K8s'
+        body: 'Bump patch versions of K8s'
+
+actions:
+  rancher-pr:
+    kind: github/pullrequest
+    scmid: 'default'
+    spec:
+      labels:
+        - 'dependencies'
+      reviewers:
+        - 'rancher/rancher-team-2-hostbusters-dev'
+        - 'rancher/rancher-security'
+      mergemethod: '{{ .scm.mergemethod }}'
+      title: '[{{ .scm.branch }}] Bump K8s patch version'
+      description: 'Bump patch versions of K8s'
+
+conditions:
+  run-go-generate:
+    name: 'Run go generate'
+    kind: shell
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      command: 'go generate ./... ; git diff --exit-code'
+      environments:
+        - name: HOME
+        - name: PATH
+      changedif:
+        kind: 'exitcode'
+        spec:
+          warning: 0
+          success: 1
+
+targets:
+  check-files-to-commit:
+    name: 'Check go generate changes'
+    kind: shell
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      command: 'go generate ./... ; git diff'
+      environments:
+        - name: HOME
+        - name: PATH

--- a/updatecli/extras/run-go-generate/go-generate.yaml
+++ b/updatecli/extras/run-go-generate/go-generate.yaml
@@ -42,7 +42,7 @@ conditions:
     scmid: 'default'
     disablesourceinput: true
     spec:
-      command: 'go generate ./... ; git diff --exit-code'
+      command: 'go generate ./... && git diff --exit-code'
       environments:
         - name: HOME
         - name: PATH
@@ -59,7 +59,7 @@ targets:
     scmid: 'default'
     disablesourceinput: true
     spec:
-      command: 'go generate ./... ; git diff'
+      command: 'go generate ./... && git diff'
       environments:
         - name: HOME
         - name: PATH

--- a/updatecli/updatecli.d/update-k8s/update-kubectl.yaml
+++ b/updatecli/updatecli.d/update-k8s/update-kubectl.yaml
@@ -34,7 +34,7 @@ sources:
     kind: shell
     disablesourceinput: true
     spec:
-      command: 'curl -sL --output - https://dl.k8s.io/{{source "k8s-release" }}/bin/linux/amd64/kubectl | sha256sum'
+      command: 'wget -t 3 -T 300 https://dl.k8s.io/{{source "k8s-release" }}/bin/linux/amd64/kubectl && sha256sum kubectl && rm kubectl'
     transformers:
       - find: '\S+'
 
@@ -43,7 +43,7 @@ sources:
     kind: shell
     disablesourceinput: true
     spec:
-      command: 'curl -sL --output - https://dl.k8s.io/{{source "k8s-release" }}/bin/linux/arm64/kubectl | sha256sum'
+      command: 'wget -t 3 -T 300 https://dl.k8s.io/{{source "k8s-release" }}/bin/linux/arm64/kubectl && sha256sum kubectl && rm kubectl'
     transformers:
       - find: '\S+'
 

--- a/updatecli/updatecli.d/update-k8s/update-kubectl.yaml
+++ b/updatecli/updatecli.d/update-k8s/update-kubectl.yaml
@@ -29,6 +29,24 @@ sources:
         kind: semver
         pattern: '~{{ source "rancher-go-mod-k8s" }}'
 
+  get-sha256-kubectl-amd64:
+    name: 'Get the sha256sum of Kubectl for {{ source "k8s-release" }} for amd64'
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: 'curl -sL --output - https://dl.k8s.io/{{source "k8s-release" }}/bin/linux/amd64/kubectl | sha256sum'
+    transformers:
+      - find: '\S+'
+
+  get-sha256-kubectl-arm64:
+    name: 'Get the sha256sum of Kubectl for {{ source "k8s-release" }} for arm64'
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: 'curl -sL --output - https://dl.k8s.io/{{source "k8s-release" }}/bin/linux/arm64/kubectl | sha256sum'
+    transformers:
+      - find: '\S+'
+
 conditions:
   check-dockerfile-kubectl-version:
     name: 'Check if ENV|ARG KUBECTL_VERSION is set in Dockerfiles'
@@ -78,3 +96,25 @@ targets:
         - 'tests/validation/tests/v3_api/scripts/build.sh'
       matchpattern: 'KUBECTL_VERSION="\${KUBECTL_VERSION:-\S+}"'
       replacepattern: 'KUBECTL_VERSION="${KUBECTL_VERSION:-{{ source "k8s-release" }}}"'
+
+  update-kubectl-sha256-amd64:
+    name: 'Update the sha256sum of Kubectl for amd64 in Dockerfiles'
+    kind: file
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      files:
+        - 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+KUBECTL_CHECKSUM_amd64[=\s]\S+'
+      replacepattern: '$1 KUBECTL_CHECKSUM_amd64={{ source "get-sha256-kubectl-amd64" }}'
+
+  update-kubectl-sha256-arm64:
+    name: 'Update the sha256sum of Kubectl for arm64 in Dockerfiles'
+    kind: file
+    scmid: 'default'
+    disablesourceinput: true
+    spec:
+      files:
+        - 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+KUBECTL_CHECKSUM_arm64[=\s]\S+'
+      replacepattern: '$1 KUBECTL_CHECKSUM_arm64={{ source "get-sha256-kubectl-arm64" }}'


### PR DESCRIPTION
This PR improves https://github.com/rancher/rancher/pull/54547 with:

1. Add a solution to run `go generate` after K8s deps are updated.
2. Update the checksum values of `KUBECTL`.

An example PR is https://github.com/macedogm/fork-rancher/pull/23.