### PR TITLE
[main] Bump shell to corrected 2.15 tag

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ remoteDialerProxyVersion: 109.0.0+up0.7.0
 # NOTE: CAPI controller version has to be updated in scripts/package-env
 turtlesVersion: 109.0.0+up0.26.0
 cspAdapterMinVersion: 109.0.0+up9.0.0-rc.3
-defaultShellVersion: rancher/shell:v0.7.1-rc.1
+defaultShellVersion: rancher/shell:v0.8.0-rc.1
 fleetVersion: 110.0.0+up0.16.0-alpha.3
 defaultSccOperatorImage: rancher/scc-operator:v0.4.0-rc.1
 # NOTE: when updating this version, you will also need to update the hardcoded

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,7 +6,7 @@ const (
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "109.0.0+up9.0.0-rc.3"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.4.0-rc.1"
-	DefaultShellVersion           = "rancher/shell:v0.7.1-rc.1"
+	DefaultShellVersion           = "rancher/shell:v0.8.0-rc.1"
 	FleetVersion                  = "110.0.0+up0.16.0-alpha.3"
 	RemoteDialerProxyVersion      = "109.0.0+up0.7.0"
 	TurtlesVersion                = "109.0.0+up0.26.0"


### PR DESCRIPTION
I incorrectly used a 2.14 RC tag on a 2.15 branch. Corrected that in the Shell repo so now fixing that here too.