### PR TITLE
update encryption key rotation

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -24,10 +24,12 @@ type ProbeStatus struct {
 }
 
 type Node struct {
-	Plan           NodePlan                             `json:"plan,omitempty"`
-	AppliedPlan    *NodePlan                            `json:"appliedPlan,omitempty"`
-	JoinedTo       string                               `json:"joinedTo,omitempty"`
-	Output         map[string][]byte                    `json:"-"`
+	Plan        NodePlan          `json:"plan,omitempty"`
+	AppliedPlan *NodePlan         `json:"appliedPlan,omitempty"`
+	JoinedTo    string            `json:"joinedTo,omitempty"`
+	Output      map[string][]byte `json:"-"`
+	// FailedOutput stores SaveOutput content for one-time instructions that failed to apply.
+	FailedOutput   map[string][]byte                    `json:"-"`
 	PeriodicOutput map[string]PeriodicInstructionOutput `json:"-"`
 	Failed         bool                                 `json:"failed,omitempty"`
 	InSync         bool                                 `json:"inSync,omitempty"`

--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -24,11 +24,15 @@ type ProbeStatus struct {
 }
 
 type Node struct {
-	Plan        NodePlan          `json:"plan,omitempty"`
-	AppliedPlan *NodePlan         `json:"appliedPlan,omitempty"`
-	JoinedTo    string            `json:"joinedTo,omitempty"`
-	Output      map[string][]byte `json:"-"`
-	// FailedOutput stores SaveOutput content for one-time instructions that failed to apply.
+	Plan        NodePlan  `json:"plan,omitempty"`
+	AppliedPlan *NodePlan `json:"appliedPlan,omitempty"`
+	JoinedTo    string    `json:"joinedTo,omitempty"`
+	// Output stores SaveOutput content for one-time instructions from the last
+	// successfully applied plan.
+	Output map[string][]byte `json:"-"`
+	// FailedOutput stores SaveOutput content for one-time instructions from a
+	// failed apply attempt. Failed output is persisted separately from applied
+	// output, so it cannot be recovered from Output plus the Failed flag alone.
 	FailedOutput   map[string][]byte                    `json:"-"`
 	PeriodicOutput map[string]PeriodicInstructionOutput `json:"-"`
 	Failed         bool                                 `json:"failed,omitempty"`

--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -23,11 +23,15 @@ type Metadata struct {
 }
 
 type Node struct {
-	Plan        NodePlan          `json:"plan,omitempty"`
-	AppliedPlan *NodePlan         `json:"appliedPlan,omitempty"`
-	JoinedTo    string            `json:"joinedTo,omitempty"`
-	Output      map[string][]byte `json:"-"`
-	// FailedOutput stores SaveOutput content for one-time instructions that failed to apply.
+	Plan        NodePlan  `json:"plan,omitempty"`
+	AppliedPlan *NodePlan `json:"appliedPlan,omitempty"`
+	JoinedTo    string    `json:"joinedTo,omitempty"`
+	// Output stores SaveOutput content for one-time instructions from the last
+	// successfully applied plan.
+	Output map[string][]byte `json:"-"`
+	// FailedOutput stores SaveOutput content for one-time instructions from a
+	// failed apply attempt. Failed output is persisted separately from applied
+	// output, so it cannot be recovered from Output plus the Failed flag alone.
 	FailedOutput   map[string][]byte                    `json:"-"`
 	PeriodicOutput map[string]PeriodicInstructionOutput `json:"-"`
 	Failed         bool                                 `json:"failed,omitempty"`

--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -23,10 +23,12 @@ type Metadata struct {
 }
 
 type Node struct {
-	Plan           NodePlan                             `json:"plan,omitempty"`
-	AppliedPlan    *NodePlan                            `json:"appliedPlan,omitempty"`
-	JoinedTo       string                               `json:"joinedTo,omitempty"`
-	Output         map[string][]byte                    `json:"-"`
+	Plan        NodePlan          `json:"plan,omitempty"`
+	AppliedPlan *NodePlan         `json:"appliedPlan,omitempty"`
+	JoinedTo    string            `json:"joinedTo,omitempty"`
+	Output      map[string][]byte `json:"-"`
+	// FailedOutput stores SaveOutput content for one-time instructions that failed to apply.
+	FailedOutput   map[string][]byte                    `json:"-"`
 	PeriodicOutput map[string]PeriodicInstructionOutput `json:"-"`
 	Failed         bool                                 `json:"failed,omitempty"`
 	InSync         bool                                 `json:"inSync,omitempty"`

--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -28,11 +28,7 @@ type Node struct {
 	JoinedTo    string    `json:"joinedTo,omitempty"`
 	// Output stores SaveOutput content for one-time instructions from the last
 	// successfully applied plan.
-	Output map[string][]byte `json:"-"`
-	// FailedOutput stores SaveOutput content for one-time instructions from a
-	// failed apply attempt. Failed output is persisted separately from applied
-	// output, so it cannot be recovered from Output plus the Failed flag alone.
-	FailedOutput   map[string][]byte                    `json:"-"`
+	Output         map[string][]byte                    `json:"-"`
 	PeriodicOutput map[string]PeriodicInstructionOutput `json:"-"`
 	Failed         bool                                 `json:"failed,omitempty"`
 	InSync         bool                                 `json:"inSync,omitempty"`

--- a/pkg/apis/rke.cattle.io/v1/rotate_encryption_keys_phase.go
+++ b/pkg/apis/rke.cattle.io/v1/rotate_encryption_keys_phase.go
@@ -7,7 +7,7 @@ const (
 	// During this phase, the "secrets-encrypt rotate-keys" subcommand is executed on the elected control plane leader and Rancher observes the resulting runtime status.
 	RotateEncryptionKeysPhaseRotate = RotateEncryptionKeysPhase("Rotate")
 
-	// RotateEncryptionKeysPhasePostRotateRestart is the state assigned to the RKEControlPlane when Rancher is restarting server nodes after rotate-keys in order to converge HA secrets-encrypt status and hashes.
+	// RotateEncryptionKeysPhasePostRotateRestart is the state assigned to the RKEControlPlane when Rancher is restarting server nodes after rotate-keys in order to converge high-availability secrets-encrypt status and hashes.
 	RotateEncryptionKeysPhasePostRotateRestart = RotateEncryptionKeysPhase("PostRotateRestart")
 
 	// RotateEncryptionKeysPhaseDone is the state assigned to the RKEControlPlane upon successful completion of the encryption key rotation operation.

--- a/pkg/apis/rke.cattle.io/v1/rotate_encryption_keys_phase.go
+++ b/pkg/apis/rke.cattle.io/v1/rotate_encryption_keys_phase.go
@@ -3,26 +3,12 @@ package v1
 type RotateEncryptionKeysPhase string
 
 const (
-	// RotateEncryptionKeysPhasePrepare is the state assigned to the RKEControlPlane when the encryption key rotation operation is in the Prepare phase.
-	// During this phase, the "secrets-encrypt prepare" subcommand is executed on the elected controlplane leader.
-	RotateEncryptionKeysPhasePrepare = RotateEncryptionKeysPhase("Prepare")
-
-	// RotateEncryptionKeysPhasePostPrepareRestart is the state assigned to the RKEControlPlane when the encryption key rotation operation is in the Restart phase post executing the prepare command.
-	RotateEncryptionKeysPhasePostPrepareRestart = RotateEncryptionKeysPhase("PostPrepareRestart")
-
-	// RotateEncryptionKeysPhaseRotate is the state assigned to the RKEControlPlane when the encryption key rotation operation is in the Rotate phase.
-	//During this phase, the "secrets-encrypt rotate" subcommand is executed on the elected controlplane leader.
+	// RotateEncryptionKeysPhaseRotate is the state assigned to the RKEControlPlane when the encryption key rotation operation is running on the elected control plane leader.
+	// During this phase, the "secrets-encrypt rotate-keys" subcommand is executed on the elected control plane leader and Rancher observes the resulting runtime status.
 	RotateEncryptionKeysPhaseRotate = RotateEncryptionKeysPhase("Rotate")
 
-	// RotateEncryptionKeysPhasePostRotateRestart is the state assigned to the RKEControlPlane when the encryption key rotation operation is in the Restart phase post executing the rotate command.
+	// RotateEncryptionKeysPhasePostRotateRestart is the state assigned to the RKEControlPlane when Rancher is restarting server nodes after rotate-keys in order to converge HA secrets-encrypt status and hashes.
 	RotateEncryptionKeysPhasePostRotateRestart = RotateEncryptionKeysPhase("PostRotateRestart")
-
-	// RotateEncryptionKeysPhaseReencrypt is the state assigned to the RKEControlPlane when the encryption key rotation operation is in the Reencrypt phase.
-	// During this phase, the "secrets-encrypt reencrypt" subcommand is executed on the elected controlplane leader.
-	RotateEncryptionKeysPhaseReencrypt = RotateEncryptionKeysPhase("Reencrypt")
-
-	// RotateEncryptionKeysPhasePostReencryptRestart is the state assigned to the RKEControlPlane when the encryption key rotation operation is in the Restart phase post executing the reencrypt command.
-	RotateEncryptionKeysPhasePostReencryptRestart = RotateEncryptionKeysPhase("PostReencryptRestart")
 
 	// RotateEncryptionKeysPhaseDone is the state assigned to the RKEControlPlane upon successful completion of the encryption key rotation operation.
 	RotateEncryptionKeysPhaseDone = RotateEncryptionKeysPhase("Done")

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -538,10 +538,6 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	return rotationStatus, status, nil
 }
 
-func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
-	return p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
-}
-
 func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, retryCount int) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
@@ -734,10 +730,6 @@ func encryptionKeyRotationRotateKeysCanRetryAgain(retryCount int) bool {
 
 func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
-}
-
-func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
-	return encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
 }
 
 func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *rkev1.RKEControlPlane, retryCount int) (plan.OneTimeInstruction, error) {

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -27,6 +27,7 @@ const (
 	encryptionKeyRotationCommandRotateKeys = "rotate-keys"
 
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
+	encryptionKeyRotationRotateKeysTimeoutMessage    = "see server log for details"
 
 	encryptionKeyRotationBinPrefix = "capr/encryption-key-rotation/bin"
 
@@ -81,8 +82,8 @@ type encryptionKeyRotationRestartTargets struct {
 	controlPlane []*planEntry
 }
 
-func (r encryptionKeyRotationRestartTargets) count() int {
-	return len(r.etcdOnly) + len(r.controlPlane)
+func (restartTargets encryptionKeyRotationRestartTargets) count() int {
+	return len(restartTargets.etcdOnly) + len(restartTargets.controlPlane)
 }
 
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
@@ -220,7 +221,7 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 // and an error if one was encountered.
 func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil {
-		return false, fmt.Errorf("unable to determine encryption key rotation support for nil controlplane")
+		return false, fmt.Errorf("unable to determine encryption key rotation support for nil control plane")
 	}
 
 	kubernetesVersion, err := semver.Make(strings.TrimPrefix(controlPlane.Spec.KubernetesVersion, "v"))
@@ -297,7 +298,7 @@ func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bo
 // phase is "rotate", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
 // (etcd-only), it will elect the first suitable control plane node. If the phase is not in "rotate" and a re-election
 // of the leader is necessary, the phase will be set to failed as this is unexpected.
-func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, init *planEntry) (*planEntry, error) {
+func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, initNode *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
 	if machine, ok := clusterPlan.Machines[machineName]; ok {
 		entry := &planEntry{
@@ -314,8 +315,8 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 		return nil, fmt.Errorf("cannot elect control plane leader in phase %s", status.RotateEncryptionKeysPhase)
 	}
 
-	leader := init
-	if !isControlPlane(init) {
+	leader := initNode
+	if !isControlPlane(initNode) {
 		machines := collect(clusterPlan, encryptionKeyRotationIsSuitableControlPlane)
 		if len(machines) == 0 {
 			return nil, fmt.Errorf("no suitable control plane nodes for encryption key rotation")
@@ -367,7 +368,7 @@ func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEContro
 
 	// Upstream documents restarting the server that ran rotate-keys before the remaining servers. Rancher follows that
 	// ordering after the init node when they are different, so split-role clusters still bring the designated init server
-	// back first and then restart the elected command leader before the rest of the HA servers.
+	// back first and then restart the elected command leader before the rest of the high-availability servers.
 	targets.etcdOnly = append(targets.etcdOnly, collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane))...)
 	targets.controlPlane = append(targets.controlPlane, collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane))...)
 
@@ -447,7 +448,7 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationRestartPlan creates a restart-only plan. During the HA convergence step Rancher no longer runs
+// encryptionKeyRotationRestartPlan creates a restart-only plan. During the high-availability convergence step Rancher no longer runs
 // additional secrets-encrypt subcommands on follower nodes; it only restarts the server unit and resumes observing the
 // periodic secrets-encrypt status that the system-agent reports back in the node plan.
 func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
@@ -522,6 +523,14 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 			}
 			return encryptionKeyRotationRuntimeStatus{}, status, err
 		}
+		if encryptionKeyRotationRotateKeysTimedOut(leader, nodePlan.Instructions[0].Name) {
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] exceeded the CLI timeout; continuing to observe periodic status because rotation may still be running in the background", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name)
+			rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
+			if periodicStatusErr == nil {
+				return rotationStatus, status, nil
+			}
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after rotate-keys timeout on leader [%s]", leader.Machine.Name)
+		}
 		status, err = p.encryptionKeyRotationFailed(status, err)
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
@@ -562,8 +571,8 @@ func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKECon
 func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
 	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
-		for _, pi := range plan.Plan.Plan.PeriodicInstructions {
-			if pi.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
+		for _, periodicInstruction := range plan.Plan.Plan.PeriodicInstructions {
+			if periodicInstruction.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
 				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
 			}
 		}
@@ -608,23 +617,57 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 // the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
-		return plan.OneTimeInstruction{}, fmt.Errorf("controlplane cannot be nil")
+		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
 	}
 	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
 	}
 
-	return idempotentInstruction(
+	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
+	// can inspect timeout text from the K3s/RKE2 CLI when the client exits before the background rotation finishes.
+	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
 		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
-		capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
+		"/bin/sh",
 		[]string{
-			"secrets-encrypt",
-			encryptionKeyRotationCommandRotateKeys,
+			"-c",
+			fmt.Sprintf("%s secrets-encrypt %s 2>&1", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
 		},
 		[]string{},
-	), nil
+	)
+	instruction.SaveOutput = true
+
+	return instruction, nil
+}
+
+// encryptionKeyRotationRotateKeysTimedOut reports whether the saved one-time instruction output matches the
+// expected timeout signature from the K3s or RKE2 secrets-encrypt client.
+func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
+	if entry == nil || entry.Plan == nil || instructionName == "" {
+		return false
+	}
+
+	outputs := entry.Plan.Output
+	if entry.Plan.Failed {
+		// system-agent writes SaveOutput for failed one-time instructions to the failed-output secret key instead of
+		// applied-output, so Rancher has to inspect the corresponding FailedOutput map on failed plans.
+		outputs = entry.Plan.FailedOutput
+	}
+
+	output, ok := outputs[instructionName]
+	if !ok {
+		return false
+	}
+
+	message := string(output)
+	if !strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) {
+		return false
+	}
+
+	return strings.Contains(message, "Client.Timeout exceeded while awaiting headers") ||
+		strings.Contains(message, "timeout awaiting response headers") ||
+		strings.Contains(message, "context deadline exceeded")
 }
 
 // encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
-	"github.com/rancher/channelserver/pkg/model"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/capr"
@@ -19,13 +18,13 @@ import (
 )
 
 const (
-	encryptionKeyRotationStageReencryptRequest  = "reencrypt_request"
-	encryptionKeyRotationStageReencryptActive   = "reencrypt_active"
+	// start is the pre-rotation steady state reported by current K3s/RKE2 status output. Rancher does not branch on it
+	// directly, but keeping it named documents the expected intermediate state we wait through before convergence.
+	encryptionKeyRotationStageStart             = "start"
 	encryptionKeyRotationStageReencryptFinished = "reencrypt_finished"
+	encryptionKeyRotationHashesMatch            = "All hashes match"
 
-	encryptionKeyRotationCommandPrepare   = "prepare"
-	encryptionKeyRotationCommandRotate    = "rotate"
-	encryptionKeyRotationCommandReencrypt = "reencrypt"
+	encryptionKeyRotationCommandRotateKeys = "rotate-keys"
 
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
 
@@ -33,7 +32,6 @@ const (
 
 	encryptionKeyRotationWaitForSystemctlStatusPath      = "wait_for_systemctl_status.sh"
 	encryptionKeyRotationWaitForSecretsEncryptStatusPath = "wait_for_secrets_encrypt_status.sh"
-	encryptionKeyRotationSecretsEncryptStatusPath        = "secrets_encrypt_status.sh"
 
 	encryptionKeyRotationWaitForSystemctlStatus = `
 #!/bin/sh
@@ -60,31 +58,7 @@ i=0
 while [ $i -lt 10 ]; do
 	$runtime secrets-encrypt status
 	if [ $? -eq 0 ]; then
-			exit 0
-	fi
-	sleep 10
-	i=$((i + 1))
-done
-exit 1
-`
-
-	encryptionKeyRotationSecretsEncryptStatusScript = `
-#!/bin/sh
-
-runtime=$1
-i=0
-
-while [ $i -lt 10 ]; do
-	output="$($runtime secrets-encrypt status)"
-	if [ $? -eq 0 ]; then
-		if [ -n "$2" ]; then
-			echo $output | grep -q "$2"
-				if [ $? -eq 0 ]; then
-					exit 0
-				fi
-		else
-			exit 0
-		fi
+		exit 0
 	fi
 	sleep 10
 	i=$((i + 1))
@@ -94,6 +68,22 @@ exit 1
 
 	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
 )
+
+var encryptionKeyRotationMinimumVersion = semver.Version{Major: 1, Minor: 30}
+
+type encryptionKeyRotationRuntimeStatus struct {
+	Stage       string
+	HashesMatch bool
+}
+
+type encryptionKeyRotationRestartTargets struct {
+	etcdOnly     []*planEntry
+	controlPlane []*planEntry
+}
+
+func (r encryptionKeyRotationRestartTargets) count() int {
+	return len(r.etcdOnly) + len(r.controlPlane)
+}
 
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
 	if equality.Semantic.DeepEqual(status.RotateEncryptionKeys, rotate) && equality.Semantic.DeepEqual(status.RotateEncryptionKeysPhase, phase) {
@@ -105,16 +95,19 @@ func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus
 }
 
 func (p *Planner) resetEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
-	if status.RotateEncryptionKeys == nil && status.RotateEncryptionKeysPhase == "" {
+	if status.RotateEncryptionKeys == nil && status.RotateEncryptionKeysPhase == "" && status.RotateEncryptionKeysLeader == "" {
 		return status, nil
 	}
-	return p.setEncryptionKeyRotateState(status, nil, "")
+	status.RotateEncryptionKeys = nil
+	status.RotateEncryptionKeysPhase = ""
+	status.RotateEncryptionKeysLeader = ""
+	return status, errWaiting("refreshing encryption key rotation state")
 }
 
 // rotateEncryptionKeys first verifies that the control plane is in a state where the next step can be derived. If encryption key rotation is required, the corresponding phase and status fields will be set.
 // The function is expected to be called multiple times throughout encryption key rotation, and will set the next corresponding phase based on previous output.
-func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, releaseData *model.Release) (rkev1.RKEControlPlaneStatus, error) {
-	if controlPlane == nil || releaseData == nil || clusterPlan == nil {
+func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, error) {
+	if controlPlane == nil || clusterPlan == nil {
 		return status, fmt.Errorf("cannot pass nil parameters to rotateEncryptionKeys")
 	}
 
@@ -122,14 +115,19 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.resetEncryptionKeyRotateState(status)
 	}
 
-	if supported, err := encryptionKeyRotationSupported(releaseData); err != nil {
-		return status, err
+	if supported, err := encryptionKeyRotationSupported(controlPlane); err != nil {
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 	} else if !supported {
 		logrus.Debugf("rkecluster %s/%s: marking encryption key rotation phase as failed as it was not supported by version: %s", controlPlane.Namespace, controlPlane.Name, controlPlane.Spec.KubernetesVersion)
+		if err := p.pauseCAPICluster(controlPlane, false); err != nil {
+			return status, errWaiting("unpausing CAPI cluster")
+		}
+		status.RotateEncryptionKeysLeader = ""
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseFailed)
 	}
 
-	if !canRotateEncryptionKeys(controlPlane) {
+	if encryptionKeyRotationShouldSkip(controlPlane) {
 		return status, nil
 	}
 
@@ -149,14 +147,23 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return status, nil
 	}
 
-	if shouldRestartEncryptionKeyRotation(controlPlane) {
-		logrus.Debugf("[planner] rkecluster %s/%s: starting/restarting encryption key rotation", controlPlane.Namespace, controlPlane.Name)
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePrepare)
+	shouldStart, err := encryptionKeyRotationShouldStart(controlPlane)
+	if err != nil {
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 	}
 
+	if shouldStart {
+		logrus.Debugf("[planner] rkecluster %s/%s: starting/restarting encryption key rotation", controlPlane.Namespace, controlPlane.Name)
+		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
+	}
+
+	// The stored leader is part of Rancher's idempotency contract. rotate-keys must only be launched from one server,
+	// and once it has been chosen we keep reconciling through that server until the generation either finishes or fails.
 	leader, err := p.encryptionKeyRotationFindLeader(status, clusterPlan, initNode)
 	if err != nil {
-		return status, err
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 	}
 
 	if status.RotateEncryptionKeysLeader != leader.Machine.Name {
@@ -167,43 +174,36 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	logrus.Debugf("[planner] rkecluster %s/%s: current encryption key rotation phase: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, controlPlane.Status.RotateEncryptionKeysPhase)
 
 	switch controlPlane.Status.RotateEncryptionKeysPhase {
-	case rkev1.RotateEncryptionKeysPhasePrepare:
+	case rkev1.RotateEncryptionKeysPhaseRotate:
 		if err := p.pauseCAPICluster(controlPlane, true); err != nil {
 			return status, errWaiting("pausing CAPI cluster")
 		}
-		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(controlPlane, status, tokensSecret, joinServer, leader)
+
+		rotationStatus, status, err := p.encryptionKeyRotationRotateKeysReconcile(controlPlane, status, tokensSecret, joinServer, leader)
 		if err != nil {
-			return status, err
+			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostPrepareRestart)
-	case rkev1.RotateEncryptionKeysPhasePostPrepareRestart:
-		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
-		if err != nil {
-			return status, err
+		if rotationStatus.Stage != encryptionKeyRotationStageReencryptFinished {
+			return status, errWaitingf("waiting for encryption key rotation stage to finish on leader [%s]", leader.Machine.Name)
 		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
-	case rkev1.RotateEncryptionKeysPhaseRotate:
-		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(controlPlane, status, tokensSecret, joinServer, leader)
-		if err != nil {
-			return status, err
+
+		restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
+		if restartTargets.count() == 1 {
+			if !rotationStatus.HashesMatch {
+				return status, errWaitingf("waiting for encryption key rotation hashes to converge on leader [%s]", leader.Machine.Name)
+			}
+			if err := p.pauseCAPICluster(controlPlane, false); err != nil {
+				return status, errWaiting("unpausing CAPI cluster")
+			}
+			status.RotateEncryptionKeysLeader = ""
+			return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseDone)
 		}
+
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostRotateRestart)
 	case rkev1.RotateEncryptionKeysPhasePostRotateRestart:
 		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
 		if err != nil {
-			return status, err
-		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseReencrypt)
-	case rkev1.RotateEncryptionKeysPhaseReencrypt:
-		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(controlPlane, status, tokensSecret, joinServer, leader)
-		if err != nil {
-			return status, err
-		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostReencryptRestart)
-	case rkev1.RotateEncryptionKeysPhasePostReencryptRestart:
-		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
-		if err != nil {
-			return status, err
+			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 		}
 		if err = p.pauseCAPICluster(controlPlane, false); err != nil {
 			return status, errWaiting("unpausing CAPI cluster")
@@ -212,84 +212,90 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseDone)
 	}
 
-	return status, fmt.Errorf("encountered unknown encryption key rotation phase: %s", controlPlane.Status.RotateEncryptionKeysPhase)
+	status, err = p.encryptionKeyRotationFailed(status, fmt.Errorf("encountered unknown encryption key rotation phase: %s", controlPlane.Status.RotateEncryptionKeysPhase))
+	return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 }
 
-// encryptionKeyRotationSupported returns a boolean indicating whether encryption key rotation is supported by the release,
+// encryptionKeyRotationSupported returns a boolean indicating whether encryption key rotation is supported for the control plane version,
 // and an error if one was encountered.
-func encryptionKeyRotationSupported(releaseData *model.Release) (bool, error) {
-	if releaseData == nil {
-		return false, fmt.Errorf("unable to find KDM release data for encryption key rotation support in release")
+func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
+	if controlPlane == nil {
+		return false, fmt.Errorf("unable to determine encryption key rotation support for nil controlplane")
 	}
-	if featureVersion, ok := releaseData.FeatureVersions["encryption-key-rotation"]; ok {
-		version, err := semver.Make(featureVersion)
-		if err != nil {
-			return false, fmt.Errorf("unable to parse semver version for encryption key rotation: %s", featureVersion)
-		}
-		// v2.6.4 - v2.6.6 are looking for 1.x.x, but encryption key rotation does not work in those versions. Rather than
-		// enable it retroactively, those versions will not be able to rotate encryption keys since some cluster
-		// configurations can break in such a way that they become unrecoverable. Additionally, we want to be careful
-		// updating the encryption-key-rotation feature gate in KDM in the future, so as not to break backwards
-		// compatibility for existing clusters.
-		if version.Major == 2 {
-			return true, nil
-		}
+
+	kubernetesVersion, err := semver.Make(strings.TrimPrefix(controlPlane.Spec.KubernetesVersion, "v"))
+	if err != nil {
+		return false, fmt.Errorf("unable to parse kubernetes version for encryption key rotation: %s", controlPlane.Spec.KubernetesVersion)
 	}
-	return false, nil
+	// Older Rancher releases relied on the KDM encryption-key-rotation feature gate because the legacy orchestration
+	// could not be enabled retroactively for all historical versions without risking unrecoverable clusters. Rancher
+	// v2.15 only supports downstream v1.30+ and only uses the newer rotate-keys flow, so the Kubernetes version itself
+	// is the compatibility boundary for this planner path.
+	if kubernetesVersion.LT(encryptionKeyRotationMinimumVersion) {
+		return false, nil
+	}
+
+	return true, nil
 }
 
-// canRotateEncryptionKeys returns false if the controlplane does not have a Ready: True condition and encryption key rotation is not already in progress, if the spec for
-// encryption key rotation is nil, or if the spec has been reconciled but the phase is done or failed.
-func canRotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane) bool {
-	if (!capr.Ready.IsTrue(controlPlane) && !rotateEncryptionKeyInProgress(controlPlane)) ||
-		controlPlane.Spec.RotateEncryptionKeys == nil ||
-		(controlPlane.Status.RotateEncryptionKeys != nil && controlPlane.Status.RotateEncryptionKeys.Generation == controlPlane.Spec.RotateEncryptionKeys.Generation &&
-			(controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone || controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed)) {
+// encryptionKeyRotationShouldSkip returns true when the planner should ignore the current spec/status combination:
+// either the control plane is not ready and rotation is not already in progress, or the requested generation already
+// finished and should not be re-run.
+func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
+	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
+		return true
+	}
+
+	phase := controlPlane.Status.RotateEncryptionKeysPhase
+	inProgress := phase == rkev1.RotateEncryptionKeysPhaseRotate || phase == rkev1.RotateEncryptionKeysPhasePostRotateRestart
+	if !capr.Ready.IsTrue(controlPlane) && !inProgress {
+		return true
+	}
+
+	return controlPlane.Status.RotateEncryptionKeys != nil &&
+		controlPlane.Status.RotateEncryptionKeys.Generation == controlPlane.Spec.RotateEncryptionKeys.Generation &&
+		(phase == rkev1.RotateEncryptionKeysPhaseDone || phase == rkev1.RotateEncryptionKeysPhaseFailed)
+}
+
+// encryptionKeyRotationShouldStart collapses the phase/generation restart logic for the simplified rotate-keys flow.
+// It returns true when a new reconciliation should initialize the Rotate phase, and returns an error if the current
+// generation is stuck in an unsupported legacy phase.
+func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool, error) {
+	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
+		return false, nil
+	}
+	if controlPlane.Status.RotateEncryptionKeys == nil || controlPlane.Status.RotateEncryptionKeysPhase == "" {
+		return true, nil
+	}
+	if controlPlane.Spec.RotateEncryptionKeys.Generation != controlPlane.Status.RotateEncryptionKeys.Generation {
+		return controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone ||
+			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
+			!encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase), nil
+	}
+	// Rancher v2.15 only understands the simplified rotate-keys flow. If we ever see a stale legacy phase for the
+	// generation currently being reconciled, fail it explicitly instead of trying to map it back into the new flow.
+	if encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
+		return false, nil
+	}
+	return false, fmt.Errorf("unsupported encryption key rotation phase [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
+}
+
+func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bool {
+	switch phase {
+	case "",
+		rkev1.RotateEncryptionKeysPhaseRotate,
+		rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+		rkev1.RotateEncryptionKeysPhaseDone,
+		rkev1.RotateEncryptionKeysPhaseFailed:
+		return true
+	default:
 		return false
 	}
-
-	return true
-}
-
-// shouldRestartEncryptionKeyRotation returns `true` if encryption key rotation is necessary and the fields on the status object are not valid for an encryption key rotation procedure.
-func shouldRestartEncryptionKeyRotation(controlPlane *rkev1.RKEControlPlane) bool {
-	if !capr.Ready.IsTrue(controlPlane) {
-		return false
-	}
-	if controlPlane.Spec.RotateEncryptionKeys.Generation > 0 && controlPlane.Status.RotateEncryptionKeys == nil {
-		return true
-	}
-	if (controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
-		controlPlane.Status.RotateEncryptionKeysPhase == "") &&
-		controlPlane.Spec.RotateEncryptionKeys.Generation != controlPlane.Status.RotateEncryptionKeys.Generation {
-		return true
-	}
-	if !hasValidNonFailedRotateEncryptionKeyStatus(controlPlane) {
-		return true
-	}
-	return false
-}
-
-// hasValidNonFailedRotateEncryptionKeyStatus verifies that the control plane encryption key status is an expected value and is not failed.
-func hasValidNonFailedRotateEncryptionKeyStatus(controlPlane *rkev1.RKEControlPlane) bool {
-	return rotateEncryptionKeyInProgress(controlPlane) ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone
-}
-
-// rotateEncryptionKeyInProgress returns true if the phase of the encryption key rotation indicates that rotation is in progress.
-func rotateEncryptionKeyInProgress(controlPlane *rkev1.RKEControlPlane) bool {
-	return controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePrepare ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePostPrepareRestart ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseRotate ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePostRotateRestart ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseReencrypt ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePostReencryptRestart
 }
 
 // encryptionKeyRotationFindLeader returns the current encryption rotation leader if it is valid, otherwise, if the
-// phase is "prepare", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
-// (etcd-only), it will elect the first suitable control plane node. If the phase is not in "prepare" and a re-election
+// phase is "rotate", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
+// (etcd-only), it will elect the first suitable control plane node. If the phase is not in "rotate" and a re-election
 // of the leader is necessary, the phase will be set to failed as this is unexpected.
 func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, init *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
@@ -304,8 +310,7 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 		}
 	}
 
-	if status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhasePrepare {
-		// if we are electing a leader and are not in the "prepare" phase, something is wrong.
+	if status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return nil, fmt.Errorf("cannot elect control plane leader in phase %s", status.RotateEncryptionKeysPhase)
 	}
 
@@ -344,44 +349,64 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
-// encryptionKeyRotationRestartNodes restarts the leader's server service, extracting the current stage afterwards.
-// The followers (if any exist) are subsequently restarted. Notably, if the encryption key rotation leader is not the init node,
-// it will restart the init node, then restart the encryption key rotation leader,
-// then finalize walking through etcd nodes (that are not controlplane), then finally controlplane nodes.
+// encryptionKeyRotationRestartTargetsForCluster centralizes the restart topology for split-role clusters.
+// The etcd-only and control-plane restart slices are kept separate because only control-plane nodes can be used as
+// secrets-encrypt status sources during convergence, while etcd-only nodes still need to participate in the restart pass.
+func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
+	targets := encryptionKeyRotationRestartTargets{
+		controlPlane: []*planEntry{leader},
+	}
+
+	if initNode != nil && !isInitNode(leader) {
+		if isControlPlane(initNode) {
+			targets.controlPlane = append([]*planEntry{initNode}, targets.controlPlane...)
+		} else {
+			targets.etcdOnly = append(targets.etcdOnly, initNode)
+		}
+	}
+
+	// Upstream documents restarting the server that ran rotate-keys before the remaining servers. Rancher follows that
+	// ordering after the init node when they are different, so split-role clusters still bring the designated init server
+	// back first and then restart the elected command leader before the rest of the HA servers.
+	targets.etcdOnly = append(targets.etcdOnly, collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane))...)
+	targets.controlPlane = append(targets.controlPlane, collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane))...)
+
+	return targets
+}
+
+// encryptionKeyRotationRestartNodes restarts the required server nodes and waits for control plane nodes to converge.
+// Etcd-only nodes are restarted first. Rancher does not use them as local secrets-encrypt status sources during
+// convergence because the local encrypt status handler depends on Runtime.Core, which is not initialized on
+// disable-apiserver servers.
+// Control plane nodes are then restarted in order, with each required to reach the reencrypt_finished stage and the
+// last one also required to report matching hashes.
 func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, leader *planEntry, initNode *planEntry, joinServer string) (rkev1.RKEControlPlaneStatus, error) {
-	// in certain cases with multi-node setups, we must restart the init node before we can proceed to restarting the leader.
-	if !isInitNode(leader) {
-		logrus.Debugf("[planner] rkecluster %s/%s: leader %s was not the init node, finding and restarting etcd nodes", controlPlane.Namespace, controlPlane.Name, leader.Machine.Name)
+	restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
 
-		_, status, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, initNode, false, "")
+	// Restart etcd-only nodes first. These nodes do not produce usable local status output after restart,
+	// so they only participate in the restart portion of the flow.
+	for _, entry := range restartTargets.etcdOnly {
+		_, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
-			return status, err
+			return updatedStatus, err
 		}
-		logrus.Debugf("[planner] rkecluster %s/%s: collecting etcd and not control plane", controlPlane.Namespace, controlPlane.Name)
-		for _, entry := range collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane)) {
-			_, status, err = p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry, false, "")
-			if err != nil {
-				return status, err
-			}
-		}
+		status = updatedStatus
 	}
 
-	leaderStage, status, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, leader, true, "")
-	if err != nil {
-		return status, err
-	}
-
-	logrus.Debugf("[planner] rkecluster %s/%s: collecting control plane and not leader and init nodes", controlPlane.Namespace, controlPlane.Name)
-	for _, entry := range collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane)) {
-		var stage string
-		stage, status, err = p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry, true, leaderStage)
+	// Restart control plane nodes in order and verify secrets-encrypt status convergence.
+	for i, entry := range restartTargets.controlPlane {
+		rotationStatus, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
-			return status, err
+			return updatedStatus, err
+		}
+		status = updatedStatus
+
+		if rotationStatus.Stage != encryptionKeyRotationStageReencryptFinished {
+			return status, errWaitingf("waiting for encryption key rotation stage to finish on machine [%s]", entry.Machine.Name)
 		}
 
-		if stage != leaderStage {
-			// secrets-encrypt command was run on another node. this is considered a failure, but might be a bit too sensitive. to be tested.
-			return p.encryptionKeyRotationFailed(status, fmt.Errorf("leader [%s] with %s stage and follower [%s] with %s stage", leader.Machine.Status.NodeRef.Name, leaderStage, entry.Machine.Status.NodeRef.Name, stage))
+		if i == len(restartTargets.controlPlane)-1 && !rotationStatus.HashesMatch {
+			return status, errWaitingf("waiting for encryption key rotation hashes to converge on machine [%s]", entry.Machine.Name)
 		}
 	}
 
@@ -389,12 +414,46 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 }
 
 // encryptionKeyRotationRestartService restarts the server unit on the downstream node, waits until secrets-encrypt
-// status can be successfully queried, and then gets the status. leaderStage is allowed to be empty if entry is the
-// leader.
-func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry, scrapeStage bool, leaderStage string) (string, rkev1.RKEControlPlaneStatus, error) {
+// status can be successfully queried, and then returns the current runtime status from the periodic status output.
+// For etcd-only nodes (non control plane), the restart is performed but no runtime status is returned. The local
+// secrets-encrypt status endpoint requires Runtime.Core, which is not initialized on disable-apiserver servers.
+func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRestartPlan(controlPlane, tokensSecret, joinServer, entry)
+	if err != nil {
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, entry.Machine.Name), entry, nodePlan, joinedServer, 5, 5)
+	if err != nil {
+		if IsErrWaiting(err) {
+			if planAppliedButWaitingForProbes(entry) {
+				return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("%s: %s", err.Error(), probesMessage(entry.Plan))
+			}
+			return encryptionKeyRotationRuntimeStatus{}, status, err
+		}
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	if !isControlPlane(entry) {
+		return encryptionKeyRotationRuntimeStatus{}, status, nil
+	}
+
+	rotationStatus, err := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(entry)
+	if err != nil {
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	return rotationStatus, status, nil
+}
+
+// encryptionKeyRotationRestartPlan creates a restart-only plan. During the HA convergence step Rancher no longer runs
+// additional secrets-encrypt subcommands on follower nodes; it only restarts the server unit and resumes observing the
+// periodic secrets-encrypt status that the system-agent reports back in the node plan.
+func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, config, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, entry, joinServer, true)
 	if err != nil {
-		return "", status, err
+		return plan.NodePlan{}, "", err
 	}
 
 	nodePlan.Files = append(nodePlan.Files, plan.File{
@@ -404,8 +463,7 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 
 	nodePlan.Instructions = []plan.OneTimeInstruction{}
 
-	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
-	if runtime == capr.RuntimeRKE2 {
+	if capr.GetRuntime(controlPlane.Spec.KubernetesVersion) == capr.RuntimeRKE2 {
 		if generated, instruction := generateManifestRemovalInstruction(controlPlane, entry); generated {
 			nodePlan.Instructions = append(nodePlan.Instructions, convertToIdempotentInstruction(
 				controlPlane,
@@ -420,168 +478,130 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/restart/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
 		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
 		capr.GetRuntimeServerUnit(controlPlane.Spec.KubernetesVersion))...)
+	nodePlan.Instructions = append(nodePlan.Instructions,
+		encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane),
+	)
 
-	nodePlan.Instructions = append(nodePlan.Instructions, encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane))
-
+	// Only control plane nodes get local status polling. Rancher relies on them for convergence because etcd-only
+	// servers cannot satisfy the local encrypt status endpoint after restart.
 	if isControlPlane(entry) {
-		nodePlan.Files = append(nodePlan.Files,
-			plan.File{
-				Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationSecretsEncryptStatusScript)),
-				Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationSecretsEncryptStatusPath),
-			},
-			plan.File{
-				Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
-				Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
-			},
-		)
+		nodePlan.Files = append(nodePlan.Files, plan.File{
+			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
+			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
+		})
 		nodePlan.Instructions = append(nodePlan.Instructions,
 			encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane),
-			encryptionKeyRotationSecretsEncryptStatusScriptOneTimeInstruction(controlPlane, leaderStage),
-			encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction(controlPlane),
 		)
+		nodePlan.PeriodicInstructions = []plan.PeriodicInstruction{
+			encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane),
+		}
 	}
 
 	probes, err := p.generateProbes(controlPlane, entry, config)
 	if err != nil {
-		return "", status, err
+		return plan.NodePlan{}, "", err
 	}
 	nodePlan.Probes = probes
 
-	// retry is important here because without it, we always seem to run into some sort of issue such as:
-	// - the follower node reporting the wrong status after a restart
-	// - the plan failing with the k3s/rke2-server services crashing the first, and resuming subsequent times
-	// It's not necessarily ideal if encryption key rotation can never complete, especially since we don't have access to
-	// the downstream k3s/rke2-server service logs, but it has to be done in order for encryption key rotation to succeed
-	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, entry.Machine.Name), entry, nodePlan, joinedServer, 5, 5)
-	if err != nil {
-		if IsErrWaiting(err) {
-			if planAppliedButWaitingForProbes(entry) {
-				return "", status, errWaitingf("%s: %s", err.Error(), probesMessage(entry.Plan))
-			}
-			return "", status, err
-		}
-		status, err = p.encryptionKeyRotationFailed(status, err)
-		return "", status, err
-	}
-
-	if !scrapeStage || !isControlPlane(entry) {
-		return "", status, nil
-	}
-
-	stage, err := encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(entry)
-	if err != nil {
-		return "", status, err
-	}
-	return stage, status, nil
+	return nodePlan, joinedServer, nil
 }
 
-// encryptionKeyRotationLeaderPhaseReconcile will run the secrets-encrypt command that corresponds to the phase, and scrape output to ensure that it was
-// successful. If the secrets-encrypt command does not exist on the plan, that means this is the first reconciliation, and
-// it must be added, otherwise reenqueue until the plan is in sync.
-func (p *Planner) encryptionKeyRotationLeaderPhaseReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (rkev1.RKEControlPlaneStatus, error) {
-	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
+// encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
+// recent periodic secrets-encrypt status observed on that node.
+func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlan(controlPlane, tokensSecret, joinServer, leader)
 	if err != nil {
-		return status, err
+		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
 
-	apply, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
-	if err != nil {
-		return p.encryptionKeyRotationFailed(status, err)
-	}
-
-	nodePlan.Files = append(nodePlan.Files, []plan.File{
-		{
-			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
-			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
-		},
-		{
-			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationSecretsEncryptStatusScript)),
-			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationSecretsEncryptStatusPath),
-		},
-	}...)
-
-	nodePlan.Instructions = []plan.OneTimeInstruction{
-		apply,
-		encryptionKeyRotationSecretsEncryptStatusScriptOneTimeInstruction(controlPlane, ""),
-		encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction(controlPlane),
-	}
-	nodePlan.PeriodicInstructions = []plan.PeriodicInstruction{
-		encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane),
-	}
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
 	if err != nil {
 		if IsErrWaiting(err) {
 			if strings.HasPrefix(err.Error(), "starting") {
-				logrus.Infof("[planner] rkecluster %s/%s: applying encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, apply.Args[1])
+				logrus.Infof("[planner] rkecluster %s/%s: applying encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, encryptionKeyRotationCommandRotateKeys)
 			}
-			return status, err
+			return encryptionKeyRotationRuntimeStatus{}, status, err
 		}
-		return p.encryptionKeyRotationFailed(status, err)
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
-	scrapedStageFromOneTimeInstructions, err := encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(leader)
+
+	rotationStatus, err := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
 	if err != nil {
-		return status, err
+		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
-	periodic, err := encryptionKeyRotationSecretsEncryptStageFromPeriodic(leader)
-	if err != nil {
-		return status, err
-	}
-	err = encryptionKeyRotationIsCurrentStageAllowed(scrapedStageFromOneTimeInstructions, controlPlane.Status.RotateEncryptionKeysPhase)
-	if err != nil {
-		return p.encryptionKeyRotationFailed(status, err)
-	}
-	if scrapedStageFromOneTimeInstructions == encryptionKeyRotationStageReencryptRequest || scrapedStageFromOneTimeInstructions == encryptionKeyRotationStageReencryptActive {
-		if periodic != encryptionKeyRotationStageReencryptFinished {
-			return status, errWaitingf("waiting for encryption key rotation stage to be finished")
-		}
-	}
-	// successful restart, complete same phases for rotate & reencrypt
-	logrus.Infof("[planner] rkecluster %s/%s: successfully applied encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Plan.Plan.Instructions[0].Args[1])
-	return status, nil
+
+	logrus.Infof("[planner] rkecluster %s/%s: successfully applied encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, encryptionKeyRotationCommandRotateKeys)
+	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationSecretsEncryptStageFromPeriodic will attempt to extract the current stage (secrets-encrypt status) from the
+// encryptionKeyRotationRotateKeysPlan keeps only the rotate-keys command as a one-time instruction and relies on
+// periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
+// preserve one-time status scraping state from an earlier reconcile.
+func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
+	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
+	if err != nil {
+		return plan.NodePlan{}, "", err
+	}
+
+	apply, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
+	if err != nil {
+		return plan.NodePlan{}, "", err
+	}
+
+	nodePlan.Instructions = []plan.OneTimeInstruction{apply}
+	nodePlan.PeriodicInstructions = []plan.PeriodicInstruction{
+		encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane),
+	}
+
+	return nodePlan, joinedServer, nil
+}
+
+// encryptionKeyRotationSecretsEncryptStatusFromPeriodic will attempt to extract the current secrets-encrypt status from the
 // plan by parsing the periodic output.
-func encryptionKeyRotationSecretsEncryptStageFromPeriodic(plan *planEntry) (string, error) {
+func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
 	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
 		for _, pi := range plan.Plan.Plan.PeriodicInstructions {
 			if pi.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
-				return "", errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
+				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
 			}
 		}
-		return "", fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
+		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
 	}
-	periodic, err := encryptionKeyRotationStageFromOutput(plan, string(output.Stdout))
-	return periodic, err
+	return encryptionKeyRotationStatusFromOutput(plan, string(output.Stdout))
 }
 
-// encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus will attempt to extract the current stage (secrets-encrypt status) from the
-// plan by parsing the one time output.
-func encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(plan *planEntry) (string, error) {
-	output, ok := plan.Plan.Output[encryptionKeyRotationSecretsEncryptStatusCommand]
-	if !ok {
-		return "", errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
-	}
-	status, err := encryptionKeyRotationStageFromOutput(plan, string(output))
-	return status, err
-}
+// encryptionKeyRotationStatusFromOutput parses the parts of secrets-encrypt status that Rancher actually reconciles on:
+// the current rotation stage and whether the server hash set has converged.
+func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
+	var status encryptionKeyRotationRuntimeStatus
 
-// encryptionKeyRotationStageFromOutput parses the output of a secrets-encrypt status command.
-func encryptionKeyRotationStageFromOutput(plan *planEntry, output string) (string, error) {
-	a := strings.Split(output, "\n")
-	if len(a) < 2 {
-		return "", errWaitingf("could not extract current stage from plan for [%s]: status output is incomplete", plan.Machine.Name)
-	}
-	for _, v := range a {
-		a = strings.Split(v, ": ")
-		if a[0] != "Current Rotation Stage" {
+	for _, line := range strings.Split(output, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
 			continue
 		}
-		status := a[1]
-		return status, nil
+
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		switch key {
+		case "Current Rotation Stage":
+			status.Stage = value
+		case "Server Encryption Hashes":
+			status.HashesMatch = value == encryptionKeyRotationHashesMatch
+		}
 	}
-	return "", errWaitingf("unable to parse rotation stage from output")
+
+	if status.Stage == "" {
+		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("unable to parse rotation stage from output")
+	}
+	if !strings.Contains(output, "Server Encryption Hashes:") {
+		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("unable to parse rotation hashes from output")
+	}
+
+	return status, nil
 }
 
 // encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
@@ -590,16 +610,7 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("controlplane cannot be nil")
 	}
-
-	var command string
-	switch controlPlane.Status.RotateEncryptionKeysPhase {
-	case rkev1.RotateEncryptionKeysPhasePrepare:
-		command = encryptionKeyRotationCommandPrepare
-	case rkev1.RotateEncryptionKeysPhaseRotate:
-		command = encryptionKeyRotationCommandRotate
-	case rkev1.RotateEncryptionKeysPhaseReencrypt:
-		command = encryptionKeyRotationCommandReencrypt
-	default:
+	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
 	}
 
@@ -610,64 +621,24 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 		capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
 		[]string{
 			"secrets-encrypt",
-			command,
+			encryptionKeyRotationCommandRotateKeys,
 		},
 		[]string{},
 	), nil
 }
 
 // encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans
-// following progression of encryption key rotation. In an HA setup with split role etcd & controlplane nodes, the etcd
-// nodes would have identical plans, so this variable is used to spoof an update and force the system-agent to run the
-// plan.
+// when the planner advances between the rotate-keys and restart phases. assignAndCheckPlan only reapplies when the
+// desired plan changes, so the planner uses phase/generation env vars to deliberately perturb otherwise identical
+// restart and status instructions across reconciliations.
 func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_STAGE=%s", controlPlane.Status.RotateEncryptionKeysPhase)
 }
 
 // encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
-// on subsequent generations, in the event that encryption key rotation is restarting and failed during prepare.
+// on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", controlPlane.Spec.RotateEncryptionKeys.Generation)
-}
-
-// encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction generates a one time instruction which will scrape the secrets-encrypt
-// status.
-func encryptionKeyRotationSecretsEncryptStatusScriptOneTimeInstruction(controlPlane *rkev1.RKEControlPlane, expected string) plan.OneTimeInstruction {
-	i := plan.OneTimeInstruction{
-		Name:    "secrets-encrypt-status-script",
-		Command: "sh",
-		Args: []string{
-			"-x",
-			encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationSecretsEncryptStatusPath),
-			capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
-		},
-		Env: []string{
-			encryptionKeyRotationStatusEnv(controlPlane),
-			encryptionKeyRotationGenerationEnv(controlPlane),
-		},
-	}
-	if expected != "" {
-		i.Args = append(i.Args, expected)
-	}
-	return i
-}
-
-// encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction generates a one time instruction which will scrape the secrets-encrypt
-// status.
-func encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
-	return plan.OneTimeInstruction{
-		Name:    encryptionKeyRotationSecretsEncryptStatusCommand,
-		Command: capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
-		Args: []string{
-			"secrets-encrypt",
-			"status",
-		},
-		Env: []string{
-			encryptionKeyRotationStatusEnv(controlPlane),
-			encryptionKeyRotationGenerationEnv(controlPlane),
-		},
-		SaveOutput: true,
-	}
 }
 
 // encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction generates a periodic instruction which will scrape the secrets-encrypt
@@ -679,6 +650,10 @@ func encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane *
 		Args: []string{
 			"secrets-encrypt",
 			"status",
+		},
+		Env: []string{
+			encryptionKeyRotationStatusEnv(controlPlane),
+			encryptionKeyRotationGenerationEnv(controlPlane),
 		},
 		PeriodSeconds: 5,
 	}
@@ -723,35 +698,26 @@ func encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane *rkev1.RKECon
 	}
 }
 
-// encryptionKeyRotationIsCurrentStageAllowed returns a boolean that indicates whether the scraped stage from the leader is allowed in comparison with the current phase.
-// Since reencrypt can be any of three statuses (reencrypt_request, reencrypt_active, and reencrypt_finished), any of these stages are valid, however the first two (request & active) do
-// not explicitly indicate that the current command was successful, just that it hasn't failed yet. In certain cases, a
-// cluster may never move beyond request and active.
-func encryptionKeyRotationIsCurrentStageAllowed(leaderStage string, currentPhase rkev1.RotateEncryptionKeysPhase) error {
-	switch currentPhase {
-	case rkev1.RotateEncryptionKeysPhasePrepare:
-		if leaderStage == encryptionKeyRotationCommandPrepare {
-			return nil
-		}
-	case rkev1.RotateEncryptionKeysPhaseRotate:
-		if leaderStage == encryptionKeyRotationCommandRotate {
-			return nil
-		}
-	case rkev1.RotateEncryptionKeysPhaseReencrypt:
-		if leaderStage == encryptionKeyRotationStageReencryptRequest ||
-			leaderStage == encryptionKeyRotationStageReencryptActive ||
-			leaderStage == encryptionKeyRotationStageReencryptFinished {
-			return nil
-		}
+// encryptionKeyRotationHandleFailure makes sure the planner leaves the owning CAPI cluster unpaused after an
+// unrecoverable rotation failure. The phase transition to Failed is handled separately so Rancher can persist status
+// and surface the original reconciliation error.
+func (p *Planner) encryptionKeyRotationHandleFailure(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
+	if err == nil || IsErrWaiting(err) || status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseFailed {
+		return status, err
 	}
-	return fmt.Errorf("unexpected encryption key rotation stage [%s] for phase [%s]", leaderStage, currentPhase)
+	if pauseErr := p.pauseCAPICluster(controlPlane, false); pauseErr != nil {
+		return status, errWaiting("unpausing CAPI cluster")
+	}
+	status.RotateEncryptionKeysLeader = ""
+	return status, err
 }
 
 // encryptionKeyRotationFailed updates the various status objects on the control plane, allowing the cluster to
 // continue the reconciliation loop. Encryption key rotation will not be restarted again until requested.
 func (p *Planner) encryptionKeyRotationFailed(status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
 	status.RotateEncryptionKeysPhase = rkev1.RotateEncryptionKeysPhaseFailed
-	return status, errors.Wrap(err, "encryption key rotation failed, please perform an etcd restore")
+	status.RotateEncryptionKeysLeader = ""
+	return status, errors.Wrap(err, "encryption key rotation failed")
 }
 
 func encryptionKeyRotationScriptPath(controlPlane *rkev1.RKEControlPlane, file string) string {

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -228,6 +228,8 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 }
 
+// encryptionKeyRotationSupported returns true when the downstream kubernetes version
+// is new enough to use the upstream rotate-keys flow.
 func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil {
 		return false, fmt.Errorf("unable to determine encryption key rotation support for nil control plane")
@@ -244,6 +246,10 @@ func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, 
 	return true, nil
 }
 
+// encryptionKeyRotationShouldSkip returns true when there is nothing to reconcile for
+// encryption key rotation. Once a generation is already in progress, Rancher keeps
+// reconciling even if the control plane is temporarily not Ready so it can finish or
+// unwind the in-flight rotation instead of abandoning it mid-flow.
 func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return true
@@ -260,6 +266,10 @@ func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 		(phase == rkev1.RotateEncryptionKeysPhaseDone || phase == rkev1.RotateEncryptionKeysPhaseFailed)
 }
 
+// encryptionKeyRotationShouldStart returns true when Rancher should start or restart
+// the current requested generation. Unknown phases are treated as stale state and are
+// restarted instead of surfaced as hard errors so upgrades can recover older planner
+// state by beginning the current generation again.
 func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return false, nil
@@ -267,17 +277,19 @@ func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool
 	if controlPlane.Status.RotateEncryptionKeys == nil || controlPlane.Status.RotateEncryptionKeysPhase == "" {
 		return true, nil
 	}
+	if !encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
+		return true, nil
+	}
 	if controlPlane.Spec.RotateEncryptionKeys.Generation != controlPlane.Status.RotateEncryptionKeys.Generation {
 		return controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone ||
-			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
-			!encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase), nil
+			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed, nil
 	}
-	if encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
-		return false, nil
-	}
-	return false, fmt.Errorf("unsupported encryption key rotation phase [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
+
+	return false, nil
 }
 
+// encryptionKeyRotationPhaseIsKnown reports whether the phase belongs to the
+// simplified rotate-keys state machine implemented in this planner.
 func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bool {
 	switch phase {
 	case "",
@@ -291,6 +303,8 @@ func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bo
 	}
 }
 
+// encryptionKeyRotationFindLeader reuses the stored leader when it is still valid.
+// During the rotate phase, it elects a new suitable control-plane leader when needed.
 func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, initNode *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
 	if machine, ok := clusterPlan.Machines[machineName]; ok {
@@ -320,10 +334,14 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 	return leader, nil
 }
 
+// encryptionKeyRotationIsSuitableControlPlane returns true for control-plane entries
+// that are present, not deleting, Ready, and already joined to the cluster.
 func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 	return isControlPlane(entry) && isNotDeleting(entry) && entry.Machine.Status.NodeRef.IsDefined() && capr.Ready.IsTrue(entry.Machine)
 }
 
+// encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit selects follower control-plane
+// machines that should be restarted after the leader rotation finishes.
 func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isControlPlaneAndNotInitNode(entry) &&
@@ -331,6 +349,8 @@ func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.
 	}
 }
 
+// encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit selects etcd-only
+// followers that should restart before control-plane nodes during post-rotate restart.
 func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isEtcd(entry) && !isControlPlane(entry) &&
@@ -339,6 +359,9 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
+// encryptionKeyRotationRestartTargetsForCluster builds the ordered restart groups for
+// the current cluster topology. Etcd-only nodes are restarted first. Control-plane nodes
+// are restarted after that and are the nodes Rancher uses for local status convergence.
 func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
 	targets := encryptionKeyRotationRestartTargets{
 		controlPlane: []*planEntry{leader},
@@ -347,7 +370,7 @@ func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEContro
 	if initNode != nil && !isInitNode(leader) {
 		if isControlPlane(initNode) {
 			targets.controlPlane = append([]*planEntry{initNode}, targets.controlPlane...)
-		} else {
+		} else if isEtcd(initNode) {
 			targets.etcdOnly = append(targets.etcdOnly, initNode)
 		}
 	}
@@ -391,6 +414,8 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 	return status, nil
 }
 
+// encryptionKeyRotationRestartService applies the restart plan for one node and, for
+// control-plane nodes, returns the local secrets-encrypt status observed after restart.
 func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
 	nodePlan, joinedServer, err := p.encryptionKeyRotationRestartPlan(controlPlane, tokensSecret, joinServer, entry)
 	if err != nil {
@@ -421,6 +446,8 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 	return rotationStatus, status, nil
 }
 
+// encryptionKeyRotationRestartPlan builds the post-rotate restart plan for a single node.
+// Control-plane nodes also get the local secrets-encrypt status checks used for convergence.
 func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, config, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, entry, joinServer, true)
 	if err != nil {
@@ -490,7 +517,7 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	if encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leader, nodePlan.Instructions[0].Name) {
 		rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
 		if periodicStatusErr != nil {
-			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after retryable rotate-keys failure on leader [%s]", leader.Machine.Name)
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after retryable rotate-keys failure on leader [%s]: %v", leader.Machine.Name, periodicStatusErr)
 		}
 		if !encryptionKeyRotationRotateKeysCanRetry(rotationStatus) {
 			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition and current periodic status is stage [%s] with hashesMatch=%t; waiting to retry", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage, rotationStatus.HashesMatch)
@@ -538,6 +565,9 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	return rotationStatus, status, nil
 }
 
+// encryptionKeyRotationRotateKeysPlanWithRetryCount builds the leader plan for one
+// rotate-keys attempt. The retry count is encoded into the one-time instruction so
+// the planner can intentionally reissue the command when needed.
 func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, retryCount int) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
@@ -575,15 +605,17 @@ func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (enc
 
 	switch {
 	case stdout != "" && stderr != "":
-		return encryptionKeyRotationStatusFromOutput(plan, stdout+"\n"+stderr)
+		return encryptionKeyRotationStatusFromOutput(stdout + "\n" + stderr)
 	case stdout != "":
-		return encryptionKeyRotationStatusFromOutput(plan, stdout)
+		return encryptionKeyRotationStatusFromOutput(stdout)
 	default:
-		return encryptionKeyRotationStatusFromOutput(plan, stderr)
+		return encryptionKeyRotationStatusFromOutput(stderr)
 	}
 }
 
-func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
+// encryptionKeyRotationStatusFromOutput parses the human-readable secrets-encrypt status
+// output into the small state used by planner reconciliation.
+func encryptionKeyRotationStatusFromOutput(output string) (encryptionKeyRotationRuntimeStatus, error) {
 	var status encryptionKeyRotationRuntimeStatus
 
 	if encryptionKeyRotationCommandTimedOut(output, encryptionKeyRotationStatusTimeoutEndpoint) {
@@ -617,6 +649,8 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 	return status, nil
 }
 
+// encryptionKeyRotationActiveGeneration returns the generation Rancher should pin into
+// node plans. In-progress phases keep using the status generation until they finish.
 func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) int64 {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return 0
@@ -632,10 +666,14 @@ func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) 
 	return controlPlane.Spec.RotateEncryptionKeys.Generation
 }
 
+// encryptionKeyRotationRotateKeysInstructionValue is the idempotency value for the
+// rotate-keys instruction and changes when generation or retry count changes.
 func encryptionKeyRotationRotateKeysInstructionValue(controlPlane *rkev1.RKEControlPlane, retryCount int) string {
 	return fmt.Sprintf("%d-retry-%d", encryptionKeyRotationActiveGeneration(controlPlane), retryCount)
 }
 
+// encryptionKeyRotationRotateKeysRetryCount restores the persisted retry count for the
+// active generation from the current leader plan.
 func encryptionKeyRotationRotateKeysRetryCount(controlPlane *rkev1.RKEControlPlane, leader *planEntry) int {
 	activeGeneration := encryptionKeyRotationActiveGeneration(controlPlane)
 	plannedGeneration, retryCount, ok := encryptionKeyRotationRotateKeysRetryCountFromPlan(leader)
@@ -646,6 +684,8 @@ func encryptionKeyRotationRotateKeysRetryCount(controlPlane *rkev1.RKEControlPla
 	return 0
 }
 
+// encryptionKeyRotationRotateKeysRetryCountFromPlan reads generation and retry count
+// from the rotate-keys instruction env vars in the current node plan.
 func encryptionKeyRotationRotateKeysRetryCountFromPlan(entry *planEntry) (int64, int, bool) {
 	if entry == nil || entry.Plan == nil {
 		return 0, 0, false
@@ -698,6 +738,8 @@ func encryptionKeyRotationRotateKeysRetryCountFromPlan(entry *planEntry) (int64,
 	return 0, 0, false
 }
 
+// encryptionKeyRotationLegacyRetryCount parses the previous attempt format so in-flight
+// plans written by older code can still resume after upgrade.
 func encryptionKeyRotationLegacyRetryCount(attempt string) (int64, int, bool) {
 	if attempt == "" {
 		return 0, 0, false
@@ -720,18 +762,25 @@ func encryptionKeyRotationLegacyRetryCount(attempt string) (int64, int, bool) {
 	return generation, retryCount, true
 }
 
+// encryptionKeyRotationNextRotateKeysRetryCount returns the next bounded retry index.
 func encryptionKeyRotationNextRotateKeysRetryCount(retryCount int) int {
 	return retryCount + 1
 }
 
+// encryptionKeyRotationRotateKeysCanRetryAgain reports whether the current retry count
+// is still below the planner retry budget.
 func encryptionKeyRotationRotateKeysCanRetryAgain(retryCount int) bool {
 	return retryCount < encryptionKeyRotationMaxRotateKeysRetries
 }
 
+// encryptionKeyRotationRotateKeysRetryCountEnv formats the retry count env var stored
+// on the rotate-keys one-time instruction.
 func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
 }
 
+// encryptionKeyRotationSecretsEncryptInstructionWithRetryCount builds the one-time
+// rotate-keys instruction for the active generation and retry count.
 func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *rkev1.RKEControlPlane, retryCount int) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
@@ -762,6 +811,8 @@ func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *
 	return instruction, nil
 }
 
+// encryptionKeyRotationRotateKeysTimedOut reports whether the saved rotate-keys output
+// matches a known CLI timeout on the upstream /encrypt/config endpoint.
 func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -771,6 +822,9 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
 }
 
+// encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition reports the coarse
+// upstream error shape that Rancher retries after status stabilizes, for example:
+// `time="..." level=fatal msg="Error: see server log for details: secret-encrypt error ID 78467"`
 func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -781,6 +835,8 @@ func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planE
 		strings.Contains(message, encryptionKeyRotationRotateKeysErrorIDMessage)
 }
 
+// encryptionKeyRotationRotateKeysOutput returns the saved one-time output for the given
+// rotate-keys instruction, using failed output when the node plan is marked failed.
 func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName string) (string, bool) {
 	if entry == nil || entry.Plan == nil || instructionName == "" {
 		return "", false
@@ -799,6 +855,9 @@ func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName str
 	return string(output), true
 }
 
+// encryptionKeyRotationCommandTimedOut matches the timeout signatures Rancher has seen
+// from secrets-encrypt CLI calls, for example:
+// `time="..." level=fatal msg="Error: see server log for details: Put \"https://127.0.0.1:9345/v1-rke2/encrypt/config\": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)"`
 func encryptionKeyRotationCommandTimedOut(message, endpoint string) bool {
 	if message == "" || endpoint == "" {
 		return false
@@ -814,6 +873,8 @@ func encryptionKeyRotationCommandTimedOut(message, endpoint string) bool {
 	return false
 }
 
+// encryptionKeyRotationRotateKeysCanRetry only allows retries from stable upstream
+// states where hashes already converged.
 func encryptionKeyRotationRotateKeysCanRetry(status encryptionKeyRotationRuntimeStatus) bool {
 	if !status.HashesMatch {
 		return false

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -18,8 +18,6 @@ import (
 )
 
 const (
-	// start is the pre-rotation steady state reported by current K3s/RKE2 status output. Rancher does not branch on it
-	// directly, but keeping it named documents the expected intermediate state we wait through before convergence.
 	encryptionKeyRotationStageStart             = "start"
 	encryptionKeyRotationStageReencryptFinished = "reencrypt_finished"
 	encryptionKeyRotationHashesMatch            = "All hashes match"
@@ -119,8 +117,9 @@ func (p *Planner) resetEncryptionKeyRotateState(status rkev1.RKEControlPlaneStat
 	return status, errWaiting("refreshing encryption key rotation state")
 }
 
-// rotateEncryptionKeys first verifies that the control plane is in a state where the next step can be derived. If encryption key rotation is required, the corresponding phase and status fields will be set.
-// The function is expected to be called multiple times throughout encryption key rotation, and will set the next corresponding phase based on previous output.
+// rotateEncryptionKeys drives one requested generation through the simplified upstream flow:
+// elect one control-plane leader, run rotate-keys there, then restart the remaining server nodes
+// and wait for secrets-encrypt status to converge before marking the generation done.
 func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, error) {
 	if controlPlane == nil || clusterPlan == nil {
 		return status, fmt.Errorf("cannot pass nil parameters to rotateEncryptionKeys")
@@ -173,8 +172,6 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
 	}
 
-	// The stored leader is part of Rancher's idempotency contract. rotate-keys must only be launched from one server,
-	// and once it has been chosen we keep reconciling through that server until the generation either finishes or fails.
 	leader, err := p.encryptionKeyRotationFindLeader(status, clusterPlan, initNode)
 	if err != nil {
 		status, err = p.encryptionKeyRotationFailed(status, err)
@@ -231,8 +228,6 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 }
 
-// encryptionKeyRotationSupported returns a boolean indicating whether encryption key rotation is supported for the control plane version,
-// and an error if one was encountered.
 func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil {
 		return false, fmt.Errorf("unable to determine encryption key rotation support for nil control plane")
@@ -242,10 +237,6 @@ func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, 
 	if err != nil {
 		return false, fmt.Errorf("unable to parse kubernetes version for encryption key rotation: %s", controlPlane.Spec.KubernetesVersion)
 	}
-	// Older Rancher releases relied on the KDM encryption-key-rotation feature gate because the legacy orchestration
-	// could not be enabled retroactively for all historical versions without risking unrecoverable clusters. Rancher
-	// v2.15 only supports downstream v1.30+ and only uses the newer rotate-keys flow, so the Kubernetes version itself
-	// is the compatibility boundary for this planner path.
 	if kubernetesVersion.LT(encryptionKeyRotationMinimumVersion) {
 		return false, nil
 	}
@@ -253,9 +244,6 @@ func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, 
 	return true, nil
 }
 
-// encryptionKeyRotationShouldSkip returns true when the planner should ignore the current spec/status combination:
-// either the control plane is not ready and rotation is not already in progress, or the requested generation already
-// finished and should not be re-run.
 func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return true
@@ -272,9 +260,6 @@ func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 		(phase == rkev1.RotateEncryptionKeysPhaseDone || phase == rkev1.RotateEncryptionKeysPhaseFailed)
 }
 
-// encryptionKeyRotationShouldStart collapses the phase/generation restart logic for the simplified rotate-keys flow.
-// It returns true when a new reconciliation should initialize the Rotate phase, and returns an error if the current
-// generation is stuck in an unsupported legacy phase.
 func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return false, nil
@@ -287,8 +272,6 @@ func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool
 			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
 			!encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase), nil
 	}
-	// Rancher v2.15 only understands the simplified rotate-keys flow. If we ever see a stale legacy phase for the
-	// generation currently being reconciled, fail it explicitly instead of trying to map it back into the new flow.
 	if encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
 		return false, nil
 	}
@@ -308,10 +291,6 @@ func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bo
 	}
 }
 
-// encryptionKeyRotationFindLeader returns the current encryption rotation leader if it is valid, otherwise, if the
-// phase is "rotate", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
-// (etcd-only), it will elect the first suitable control plane node. If the phase is not in "rotate" and a re-election
-// of the leader is necessary, the phase will be set to failed as this is unexpected.
 func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, initNode *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
 	if machine, ok := clusterPlan.Machines[machineName]; ok {
@@ -341,13 +320,10 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 	return leader, nil
 }
 
-// encryptionKeyRotationIsSuitableControlPlane ensures that a control plane node has not been deleted and has a valid
-// node associated with it.
 func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 	return isControlPlane(entry) && isNotDeleting(entry) && entry.Machine.Status.NodeRef.IsDefined() && capr.Ready.IsTrue(entry.Machine)
 }
 
-// encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit allows us to filter cluster plans to restart healthy follower nodes.
 func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isControlPlaneAndNotInitNode(entry) &&
@@ -355,7 +331,6 @@ func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.
 	}
 }
 
-// encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit allows us to filter cluster plans to restart healthy follower nodes.
 func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isEtcd(entry) && !isControlPlane(entry) &&
@@ -364,9 +339,6 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
-// encryptionKeyRotationRestartTargetsForCluster centralizes the restart topology for split-role clusters.
-// The etcd-only and control-plane restart slices are kept separate because only control-plane nodes can be used as
-// secrets-encrypt status sources during convergence, while etcd-only nodes still need to participate in the restart pass.
 func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
 	targets := encryptionKeyRotationRestartTargets{
 		controlPlane: []*planEntry{leader},
@@ -380,26 +352,18 @@ func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEContro
 		}
 	}
 
-	// Upstream documents restarting the server that ran rotate-keys before the remaining servers. Rancher follows that
-	// ordering after the init node when they are different, so split-role clusters still bring the designated init server
-	// back first and then restart the elected command leader before the rest of the high-availability servers.
 	targets.etcdOnly = append(targets.etcdOnly, collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane))...)
 	targets.controlPlane = append(targets.controlPlane, collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane))...)
 
 	return targets
 }
 
-// encryptionKeyRotationRestartNodes restarts the required server nodes and waits for control plane nodes to converge.
-// Etcd-only nodes are restarted first. Rancher does not use them as local secrets-encrypt status sources during
-// convergence because the local encrypt status handler depends on Runtime.Core, which is not initialized on
-// disable-apiserver servers.
-// Control plane nodes are then restarted in order, with each required to reach the reencrypt_finished stage and the
-// last one also required to report matching hashes.
+// encryptionKeyRotationRestartNodes restarts etcd-only nodes first and then control-plane nodes.
+// Only control-plane nodes are used for local secrets-encrypt status checks during convergence,
+// and the last control-plane node must also report matching hashes before the phase can finish.
 func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, leader *planEntry, initNode *planEntry, joinServer string) (rkev1.RKEControlPlaneStatus, error) {
 	restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
 
-	// Restart etcd-only nodes first. These nodes do not produce usable local status output after restart,
-	// so they only participate in the restart portion of the flow.
 	for _, entry := range restartTargets.etcdOnly {
 		_, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
@@ -408,7 +372,6 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 		status = updatedStatus
 	}
 
-	// Restart control plane nodes in order and verify secrets-encrypt status convergence.
 	for i, entry := range restartTargets.controlPlane {
 		rotationStatus, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
@@ -428,10 +391,6 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 	return status, nil
 }
 
-// encryptionKeyRotationRestartService restarts the server unit on the downstream node, waits until secrets-encrypt
-// status can be successfully queried, and then returns the current runtime status from the periodic status output.
-// For etcd-only nodes (non control plane), the restart is performed but no runtime status is returned. The local
-// secrets-encrypt status endpoint requires Runtime.Core, which is not initialized on disable-apiserver servers.
 func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
 	nodePlan, joinedServer, err := p.encryptionKeyRotationRestartPlan(controlPlane, tokensSecret, joinServer, entry)
 	if err != nil {
@@ -462,9 +421,6 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationRestartPlan creates a restart-only plan. During the high-availability convergence step Rancher no longer runs
-// additional secrets-encrypt subcommands on follower nodes; it only restarts the server unit and resumes observing the
-// periodic secrets-encrypt status that the system-agent reports back in the node plan.
 func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, config, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, entry, joinServer, true)
 	if err != nil {
@@ -499,8 +455,6 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 		encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane),
 	)
 
-	// Only control plane nodes get local status polling. Rancher relies on them for convergence because etcd-only
-	// servers cannot satisfy the local encrypt status endpoint after restart.
 	if isControlPlane(entry) {
 		nodePlan.Files = append(nodePlan.Files, plan.File{
 			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
@@ -523,8 +477,9 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 	return nodePlan, joinedServer, nil
 }
 
-// encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
-// recent periodic secrets-encrypt status observed on that node.
+// encryptionKeyRotationRotateKeysReconcile runs rotate-keys on the elected leader and then trusts
+// periodic secrets-encrypt status as the source of progress. A CLI timeout is treated as ambiguous,
+// so Rancher keeps watching periodic status before deciding whether to wait, retry, or fail.
 func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
 	retryCount := encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader)
 	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
@@ -583,9 +538,6 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationRotateKeysPlan keeps only the rotate-keys command as a one-time instruction and relies on
-// periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
-// preserve one-time status scraping state from an earlier reconcile.
 func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
 	return p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 }
@@ -609,8 +561,8 @@ func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane
 	return nodePlan, joinedServer, nil
 }
 
-// encryptionKeyRotationSecretsEncryptStatusFromPeriodic will attempt to extract the current secrets-encrypt status from the
-// plan by parsing the periodic output.
+// encryptionKeyRotationSecretsEncryptStatusFromPeriodic reads the latest periodic status output from
+// system-agent and converts it into the small runtime state Rancher reconciles on.
 func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
 	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
@@ -635,8 +587,6 @@ func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (enc
 	}
 }
 
-// encryptionKeyRotationStatusFromOutput parses the parts of secrets-encrypt status that Rancher actually reconciles on:
-// the current rotation stage and whether the server hash set has converged.
 func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
 	var status encryptionKeyRotationRuntimeStatus
 
@@ -671,9 +621,6 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 	return status, nil
 }
 
-// encryptionKeyRotationActiveGeneration returns the generation that should be embedded in node plans.
-// Once a rotation has started, the planner must stay pinned to status.RotateEncryptionKeys.Generation until
-// that generation either completes or fails, even if spec has already been bumped to request a later one.
 func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) int64 {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return 0
@@ -789,8 +736,6 @@ func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
 }
 
-// encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
-// the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
 	return encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
 }
@@ -806,8 +751,6 @@ func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *
 		retryCount = 0
 	}
 
-	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
-	// can inspect timeout text from the K3s/RKE2 CLI when the client exits before the background rotation finishes.
 	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
@@ -827,8 +770,6 @@ func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *
 	return instruction, nil
 }
 
-// encryptionKeyRotationRotateKeysTimedOut reports whether the saved one-time instruction output matches the
-// expected timeout signature from the K3s or RKE2 secrets-encrypt client.
 func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -838,9 +779,6 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
 }
 
-// encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition intentionally matches the coarse CLI error shape that
-// K3s/RKE2 exposes to Rancher. The CLI does not include the underlying server-side cause, so the planner only retries
-// after separately observing a stable periodic secrets-encrypt status, and the retry count is strictly bounded.
 func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -858,8 +796,6 @@ func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName str
 
 	outputs := entry.Plan.Output
 	if entry.Plan.Failed {
-		// system-agent writes SaveOutput for failed one-time instructions to the failed-output secret key instead of
-		// applied-output, so Rancher has to inspect the corresponding FailedOutput map on failed plans.
 		outputs = entry.Plan.FailedOutput
 	}
 
@@ -899,22 +835,16 @@ func encryptionKeyRotationRotateKeysCanRetry(status encryptionKeyRotationRuntime
 	}
 }
 
-// encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans
-// when the planner advances between the rotate-keys and restart phases. assignAndCheckPlan only reapplies when the
-// desired plan changes, so the planner uses phase/generation env vars to deliberately perturb otherwise identical
-// restart and status instructions across reconciliations.
+// encryptionKeyRotationStatusEnv forces restart and status instructions to rerun as the planner
+// moves through encryption key rotation phases.
 func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_STAGE=%s", controlPlane.Status.RotateEncryptionKeysPhase)
 }
 
-// encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
-// on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationGenerationEnvName, encryptionKeyRotationActiveGeneration(controlPlane))
 }
 
-// encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction generates a periodic instruction which will scrape the secrets-encrypt
-// status from the node every 5 seconds.
 func encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane *rkev1.RKEControlPlane) plan.PeriodicInstruction {
 	return plan.PeriodicInstruction{
 		Name:    encryptionKeyRotationSecretsEncryptStatusCommand,
@@ -931,10 +861,6 @@ func encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane *
 	}
 }
 
-// encryptionKeyRotationWaitForSystemctlStatusInstruction is intended to run after a node is restart, and wait until the
-// node is online and able to provide systemctl status, ensuring that the server service is able to be restarted. If the
-// service never comes active, the plan advances anyway in order to restart the service. If restarting the service
-// fails, then the plan will fail.
 func encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
 	return plan.OneTimeInstruction{
 		Name:    "wait-for-systemctl-status",
@@ -951,9 +877,6 @@ func encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane *rkev1.
 	}
 }
 
-// encryptionKeyRotationWaitForSecretsEncryptStatus is intended to run after a node is restart, and wait until the node
-// is online and able to provide secrets-encrypt status, ensuring that subsequent status commands from the system-agent
-// will be successful.
 func encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
 	return plan.OneTimeInstruction{
 		Name:    "wait-for-secrets-encrypt-status",
@@ -970,9 +893,6 @@ func encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane *rkev1.RKECon
 	}
 }
 
-// encryptionKeyRotationHandleFailure makes sure the planner leaves the owning CAPI cluster unpaused after an
-// unrecoverable rotation failure. The phase transition to Failed is handled separately so Rancher can persist status
-// and surface the original reconciliation error.
 func (p *Planner) encryptionKeyRotationHandleFailure(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
 	if err == nil || IsErrWaiting(err) || status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseFailed {
 		return status, err
@@ -984,8 +904,6 @@ func (p *Planner) encryptionKeyRotationHandleFailure(controlPlane *rkev1.RKECont
 	return status, err
 }
 
-// encryptionKeyRotationFailed updates the various status objects on the control plane, allowing the cluster to
-// continue the reconciliation loop. Encryption key rotation will not be restarted again until requested.
 func (p *Planner) encryptionKeyRotationFailed(status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
 	status.RotateEncryptionKeysPhase = rkev1.RotateEncryptionKeysPhaseFailed
 	status.RotateEncryptionKeysLeader = ""

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -70,8 +70,12 @@ done
 exit 1
 `
 
-	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
-	encryptionKeyRotationAttemptEnv  = "ENCRYPTION_KEY_ROTATION_ATTEMPT"
+	encryptionKeyRotationEndpointEnv       = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
+	encryptionKeyRotationGenerationEnvName = "ENCRYPTION_KEY_ROTATION_GENERATION"
+	encryptionKeyRotationAttemptEnvName    = "ENCRYPTION_KEY_ROTATION_ATTEMPT"
+	encryptionKeyRotationRetryCountEnv     = "ENCRYPTION_KEY_ROTATION_RETRY_COUNT"
+
+	encryptionKeyRotationMaxRotateKeysRetries = 3
 )
 
 var encryptionKeyRotationMinimumVersion = semver.Version{Major: 1, Minor: 30}
@@ -522,8 +526,8 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 // encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
 // recent periodic secrets-encrypt status observed on that node.
 func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
-	attempt := encryptionKeyRotationRotateKeysAttempt(controlPlane, leader)
-	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
+	retryCount := encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader)
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
 	if err != nil {
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
@@ -537,14 +541,17 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition and current periodic status is stage [%s] with hashesMatch=%t; waiting to retry", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage, rotationStatus.HashesMatch)
 			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for leader [%s] to reach a stable secrets-encrypt state before retrying rotate-keys", leader.Machine.Name)
 		}
+		if !encryptionKeyRotationRotateKeysCanRetryAgain(retryCount) {
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition after retry count [%d]; surfacing the failure instead of retrying indefinitely", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, retryCount)
+		} else {
+			retryCount = encryptionKeyRotationNextRotateKeysRetryCount(retryCount)
+			nodePlan, joinedServer, err = p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
+			if err != nil {
+				return encryptionKeyRotationRuntimeStatus{}, status, err
+			}
 
-		attempt = encryptionKeyRotationNextRotateKeysAttempt(attempt)
-		nodePlan, joinedServer, err = p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
-		if err != nil {
-			return encryptionKeyRotationRuntimeStatus{}, status, err
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition; reissuing rotate-keys once periodic status returned to stage [%s] with converged hashes", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage)
 		}
-
-		logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition; reissuing rotate-keys once periodic status returned to stage [%s] with converged hashes", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage)
 	}
 
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
@@ -580,16 +587,16 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 // periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
 // preserve one-time status scraping state from an earlier reconcile.
 func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
-	return p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysAttempt(controlPlane, leader))
+	return p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 }
 
-func (p *Planner) encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, attempt string) (plan.NodePlan, string, error) {
+func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, retryCount int) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
 
-	apply, err := encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, attempt)
+	apply, err := encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, retryCount)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
@@ -682,67 +689,121 @@ func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) 
 	return controlPlane.Spec.RotateEncryptionKeys.Generation
 }
 
-func encryptionKeyRotationRotateKeysBaseAttempt(controlPlane *rkev1.RKEControlPlane) string {
-	return strconv.FormatInt(encryptionKeyRotationActiveGeneration(controlPlane), 10)
+func encryptionKeyRotationRotateKeysInstructionValue(controlPlane *rkev1.RKEControlPlane, retryCount int) string {
+	return fmt.Sprintf("%d-retry-%d", encryptionKeyRotationActiveGeneration(controlPlane), retryCount)
 }
 
-func encryptionKeyRotationRotateKeysAttempt(controlPlane *rkev1.RKEControlPlane, leader *planEntry) string {
-	baseAttempt := encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
-
-	if attempt, ok := encryptionKeyRotationRotateKeysAttemptFromPlan(leader); ok &&
-		(attempt == baseAttempt || strings.HasPrefix(attempt, baseAttempt+"-retry")) {
-		return attempt
+func encryptionKeyRotationRotateKeysRetryCount(controlPlane *rkev1.RKEControlPlane, leader *planEntry) int {
+	activeGeneration := encryptionKeyRotationActiveGeneration(controlPlane)
+	plannedGeneration, retryCount, ok := encryptionKeyRotationRotateKeysRetryCountFromPlan(leader)
+	if ok && plannedGeneration == activeGeneration {
+		return retryCount
 	}
 
-	return baseAttempt
+	return 0
 }
 
-func encryptionKeyRotationRotateKeysAttemptFromPlan(entry *planEntry) (string, bool) {
+func encryptionKeyRotationRotateKeysRetryCountFromPlan(entry *planEntry) (int64, int, bool) {
 	if entry == nil || entry.Plan == nil {
-		return "", false
+		return 0, 0, false
 	}
 
 	for _, instruction := range entry.Plan.Plan.Instructions {
 		if !strings.HasPrefix(instruction.Name, "idempotent-encryption-key-rotation/rotate-") {
 			continue
 		}
+
+		var generation int64
+		var retryCount int
+		var foundGeneration, foundRetryCount bool
+		var legacyAttempt string
+
 		for _, env := range instruction.Env {
-			if strings.HasPrefix(env, encryptionKeyRotationAttemptEnv+"=") {
-				return strings.TrimPrefix(env, encryptionKeyRotationAttemptEnv+"="), true
+			switch {
+			case strings.HasPrefix(env, encryptionKeyRotationGenerationEnvName+"="):
+				value := strings.TrimPrefix(env, encryptionKeyRotationGenerationEnvName+"=")
+				parsedGeneration, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					return 0, 0, false
+				}
+				generation = parsedGeneration
+				foundGeneration = true
+			case strings.HasPrefix(env, encryptionKeyRotationRetryCountEnv+"="):
+				value := strings.TrimPrefix(env, encryptionKeyRotationRetryCountEnv+"=")
+				parsedRetryCount, err := strconv.Atoi(value)
+				if err != nil || parsedRetryCount < 0 {
+					return 0, 0, false
+				}
+				retryCount = parsedRetryCount
+				foundRetryCount = true
+			case strings.HasPrefix(env, encryptionKeyRotationAttemptEnvName+"="):
+				legacyAttempt = strings.TrimPrefix(env, encryptionKeyRotationAttemptEnvName+"=")
+			}
+		}
+
+		if foundGeneration && foundRetryCount {
+			return generation, retryCount, true
+		}
+		if legacyAttempt != "" {
+			parsedGeneration, parsedRetryCount, ok := encryptionKeyRotationLegacyRetryCount(legacyAttempt)
+			if ok {
+				return parsedGeneration, parsedRetryCount, true
 			}
 		}
 	}
 
-	return "", false
+	return 0, 0, false
 }
 
-func encryptionKeyRotationNextRotateKeysAttempt(attempt string) string {
+func encryptionKeyRotationLegacyRetryCount(attempt string) (int64, int, bool) {
 	if attempt == "" {
-		return "retry"
+		return 0, 0, false
 	}
 
-	return attempt + "-retry"
+	parts := strings.Split(attempt, "-")
+	generation, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	retryCount := 0
+	for _, part := range parts[1:] {
+		if part != "retry" {
+			return 0, 0, false
+		}
+		retryCount++
+	}
+
+	return generation, retryCount, true
 }
 
-func encryptionKeyRotationRotateKeysAttemptEnv(attempt string) string {
-	return fmt.Sprintf("%s=%s", encryptionKeyRotationAttemptEnv, attempt)
+func encryptionKeyRotationNextRotateKeysRetryCount(retryCount int) int {
+	return retryCount + 1
+}
+
+func encryptionKeyRotationRotateKeysCanRetryAgain(retryCount int) bool {
+	return retryCount < encryptionKeyRotationMaxRotateKeysRetries
+}
+
+func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
+	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
 }
 
 // encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
 // the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
-	return encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, encryptionKeyRotationRotateKeysBaseAttempt(controlPlane))
+	return encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
 }
 
-func encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane *rkev1.RKEControlPlane, attempt string) (plan.OneTimeInstruction, error) {
+func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *rkev1.RKEControlPlane, retryCount int) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
 	}
 	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
 	}
-	if attempt == "" {
-		attempt = encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
+	if retryCount < 0 {
+		retryCount = 0
 	}
 
 	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
@@ -750,13 +811,16 @@ func encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane *rke
 	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-		attempt,
+		encryptionKeyRotationRotateKeysInstructionValue(controlPlane, retryCount),
 		"/bin/sh",
 		[]string{
 			"-c",
 			fmt.Sprintf("%s secrets-encrypt %s 2>&1", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
 		},
-		[]string{encryptionKeyRotationRotateKeysAttemptEnv(attempt)},
+		[]string{
+			encryptionKeyRotationGenerationEnv(controlPlane),
+			encryptionKeyRotationRotateKeysRetryCountEnv(retryCount),
+		},
 	)
 	instruction.SaveOutput = true
 
@@ -774,6 +838,9 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
 }
 
+// encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition intentionally matches the coarse CLI error shape that
+// K3s/RKE2 exposes to Rancher. The CLI does not include the underlying server-side cause, so the planner only retries
+// after separately observing a stable periodic secrets-encrypt status, and the retry count is strictly bounded.
 func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -843,7 +910,7 @@ func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string 
 // encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
 // on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
-	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", encryptionKeyRotationActiveGeneration(controlPlane))
+	return fmt.Sprintf("%s=%d", encryptionKeyRotationGenerationEnvName, encryptionKeyRotationActiveGeneration(controlPlane))
 }
 
 // encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction generates a periodic instruction which will scrape the secrets-encrypt

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -28,6 +28,9 @@ const (
 
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
 	encryptionKeyRotationRotateKeysTimeoutMessage    = "see server log for details"
+	encryptionKeyRotationRotateKeysErrorIDMessage    = "secret-encrypt error ID"
+	encryptionKeyRotationRotateKeysTimeoutEndpoint   = "/encrypt/config"
+	encryptionKeyRotationStatusTimeoutEndpoint       = "/encrypt/status"
 
 	encryptionKeyRotationBinPrefix = "capr/encryption-key-rotation/bin"
 
@@ -68,9 +71,16 @@ exit 1
 `
 
 	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
+	encryptionKeyRotationAttemptEnv  = "ENCRYPTION_KEY_ROTATION_ATTEMPT"
 )
 
 var encryptionKeyRotationMinimumVersion = semver.Version{Major: 1, Minor: 30}
+
+var encryptionKeyRotationTimeoutMarkers = []string{
+	"Client.Timeout exceeded while awaiting headers",
+	"timeout awaiting response headers",
+	"context deadline exceeded",
+}
 
 type encryptionKeyRotationRuntimeStatus struct {
 	Stage       string
@@ -456,6 +466,8 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
+	generation := encryptionKeyRotationActiveGeneration(controlPlane)
+	generationValue := strconv.FormatInt(generation, 10)
 
 	nodePlan.Files = append(nodePlan.Files, plan.File{
 		Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSystemctlStatus)),
@@ -469,7 +481,7 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 			nodePlan.Instructions = append(nodePlan.Instructions, convertToIdempotentInstruction(
 				controlPlane,
 				strings.ToLower(fmt.Sprintf("encryption-key-rotation/manifest-cleanup/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-				strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
+				generationValue,
 				instruction))
 		}
 	}
@@ -477,7 +489,7 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 	nodePlan.Instructions = append(nodePlan.Instructions, idempotentRestartInstructions(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/restart/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
+		generationValue,
 		capr.GetRuntimeServerUnit(controlPlane.Spec.KubernetesVersion))...)
 	nodePlan.Instructions = append(nodePlan.Instructions,
 		encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane),
@@ -510,9 +522,29 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 // encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
 // recent periodic secrets-encrypt status observed on that node.
 func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
-	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlan(controlPlane, tokensSecret, joinServer, leader)
+	attempt := encryptionKeyRotationRotateKeysAttempt(controlPlane, leader)
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
 	if err != nil {
 		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	if encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leader, nodePlan.Instructions[0].Name) {
+		rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
+		if periodicStatusErr != nil {
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after retryable rotate-keys failure on leader [%s]", leader.Machine.Name)
+		}
+		if !encryptionKeyRotationRotateKeysCanRetry(rotationStatus) {
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition and current periodic status is stage [%s] with hashesMatch=%t; waiting to retry", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage, rotationStatus.HashesMatch)
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for leader [%s] to reach a stable secrets-encrypt state before retrying rotate-keys", leader.Machine.Name)
+		}
+
+		attempt = encryptionKeyRotationNextRotateKeysAttempt(attempt)
+		nodePlan, joinedServer, err = p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
+		if err != nil {
+			return encryptionKeyRotationRuntimeStatus{}, status, err
+		}
+
+		logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition; reissuing rotate-keys once periodic status returned to stage [%s] with converged hashes", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage)
 	}
 
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
@@ -548,12 +580,16 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 // periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
 // preserve one-time status scraping state from an earlier reconcile.
 func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
+	return p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysAttempt(controlPlane, leader))
+}
+
+func (p *Planner) encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, attempt string) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
 
-	apply, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
+	apply, err := encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, attempt)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
@@ -578,13 +614,28 @@ func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (enc
 		}
 		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
 	}
-	return encryptionKeyRotationStatusFromOutput(plan, string(output.Stdout))
+
+	stdout := strings.TrimSpace(string(output.Stdout))
+	stderr := strings.TrimSpace(string(output.Stderr))
+
+	switch {
+	case stdout != "" && stderr != "":
+		return encryptionKeyRotationStatusFromOutput(plan, stdout+"\n"+stderr)
+	case stdout != "":
+		return encryptionKeyRotationStatusFromOutput(plan, stdout)
+	default:
+		return encryptionKeyRotationStatusFromOutput(plan, stderr)
+	}
 }
 
 // encryptionKeyRotationStatusFromOutput parses the parts of secrets-encrypt status that Rancher actually reconciles on:
 // the current rotation stage and whether the server hash set has converged.
 func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
 	var status encryptionKeyRotationRuntimeStatus
+
+	if encryptionKeyRotationCommandTimedOut(output, encryptionKeyRotationStatusTimeoutEndpoint) {
+		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("waiting for secrets-encrypt status after transient timeout")
+	}
 
 	for _, line := range strings.Split(output, "\n") {
 		key, value, ok := strings.Cut(line, ":")
@@ -613,14 +664,85 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 	return status, nil
 }
 
+// encryptionKeyRotationActiveGeneration returns the generation that should be embedded in node plans.
+// Once a rotation has started, the planner must stay pinned to status.RotateEncryptionKeys.Generation until
+// that generation either completes or fails, even if spec has already been bumped to request a later one.
+func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) int64 {
+	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
+		return 0
+	}
+
+	if controlPlane.Status.RotateEncryptionKeys != nil {
+		switch controlPlane.Status.RotateEncryptionKeysPhase {
+		case rkev1.RotateEncryptionKeysPhaseRotate, rkev1.RotateEncryptionKeysPhasePostRotateRestart:
+			return controlPlane.Status.RotateEncryptionKeys.Generation
+		}
+	}
+
+	return controlPlane.Spec.RotateEncryptionKeys.Generation
+}
+
+func encryptionKeyRotationRotateKeysBaseAttempt(controlPlane *rkev1.RKEControlPlane) string {
+	return strconv.FormatInt(encryptionKeyRotationActiveGeneration(controlPlane), 10)
+}
+
+func encryptionKeyRotationRotateKeysAttempt(controlPlane *rkev1.RKEControlPlane, leader *planEntry) string {
+	baseAttempt := encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
+
+	if attempt, ok := encryptionKeyRotationRotateKeysAttemptFromPlan(leader); ok &&
+		(attempt == baseAttempt || strings.HasPrefix(attempt, baseAttempt+"-retry")) {
+		return attempt
+	}
+
+	return baseAttempt
+}
+
+func encryptionKeyRotationRotateKeysAttemptFromPlan(entry *planEntry) (string, bool) {
+	if entry == nil || entry.Plan == nil {
+		return "", false
+	}
+
+	for _, instruction := range entry.Plan.Plan.Instructions {
+		if !strings.HasPrefix(instruction.Name, "idempotent-encryption-key-rotation/rotate-") {
+			continue
+		}
+		for _, env := range instruction.Env {
+			if strings.HasPrefix(env, encryptionKeyRotationAttemptEnv+"=") {
+				return strings.TrimPrefix(env, encryptionKeyRotationAttemptEnv+"="), true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func encryptionKeyRotationNextRotateKeysAttempt(attempt string) string {
+	if attempt == "" {
+		return "retry"
+	}
+
+	return attempt + "-retry"
+}
+
+func encryptionKeyRotationRotateKeysAttemptEnv(attempt string) string {
+	return fmt.Sprintf("%s=%s", encryptionKeyRotationAttemptEnv, attempt)
+}
+
 // encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
 // the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
+	return encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, encryptionKeyRotationRotateKeysBaseAttempt(controlPlane))
+}
+
+func encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane *rkev1.RKEControlPlane, attempt string) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
 	}
 	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
+	}
+	if attempt == "" {
+		attempt = encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
 	}
 
 	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
@@ -628,13 +750,13 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
+		attempt,
 		"/bin/sh",
 		[]string{
 			"-c",
 			fmt.Sprintf("%s secrets-encrypt %s 2>&1", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
 		},
-		[]string{},
+		[]string{encryptionKeyRotationRotateKeysAttemptEnv(attempt)},
 	)
 	instruction.SaveOutput = true
 
@@ -644,8 +766,27 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 // encryptionKeyRotationRotateKeysTimedOut reports whether the saved one-time instruction output matches the
 // expected timeout signature from the K3s or RKE2 secrets-encrypt client.
 func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
-	if entry == nil || entry.Plan == nil || instructionName == "" {
+	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
+	if !ok {
 		return false
+	}
+
+	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
+}
+
+func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
+	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
+	if !ok {
+		return false
+	}
+
+	return strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) &&
+		strings.Contains(message, encryptionKeyRotationRotateKeysErrorIDMessage)
+}
+
+func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName string) (string, bool) {
+	if entry == nil || entry.Plan == nil || instructionName == "" {
+		return "", false
 	}
 
 	outputs := entry.Plan.Output
@@ -657,17 +798,38 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 
 	output, ok := outputs[instructionName]
 	if !ok {
+		return "", false
+	}
+
+	return string(output), true
+}
+
+func encryptionKeyRotationCommandTimedOut(message, endpoint string) bool {
+	if message == "" || endpoint == "" {
+		return false
+	}
+	if !strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) || !strings.Contains(message, endpoint) {
+		return false
+	}
+	for _, marker := range encryptionKeyRotationTimeoutMarkers {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func encryptionKeyRotationRotateKeysCanRetry(status encryptionKeyRotationRuntimeStatus) bool {
+	if !status.HashesMatch {
 		return false
 	}
 
-	message := string(output)
-	if !strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) {
+	switch status.Stage {
+	case encryptionKeyRotationStageStart, encryptionKeyRotationStageReencryptFinished:
+		return true
+	default:
 		return false
 	}
-
-	return strings.Contains(message, "Client.Timeout exceeded while awaiting headers") ||
-		strings.Contains(message, "timeout awaiting response headers") ||
-		strings.Contains(message, "context deadline exceeded")
 }
 
 // encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans
@@ -681,7 +843,7 @@ func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string 
 // encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
 // on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
-	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", controlPlane.Spec.RotateEncryptionKeys.Generation)
+	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", encryptionKeyRotationActiveGeneration(controlPlane))
 }
 
 // encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction generates a periodic instruction which will scrape the secrets-encrypt

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -126,6 +126,11 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	}
 
 	if controlPlane.Spec.RotateEncryptionKeys == nil {
+		if status.RotateEncryptionKeys != nil || status.RotateEncryptionKeysPhase != "" || status.RotateEncryptionKeysLeader != "" {
+			if err := p.pauseCAPICluster(controlPlane, false); err != nil {
+				return status, errWaiting("unpausing CAPI cluster")
+			}
+		}
 		return p.resetEncryptionKeyRotateState(status)
 	}
 
@@ -589,15 +594,15 @@ func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane
 
 // encryptionKeyRotationSecretsEncryptStatusFromPeriodic reads the latest periodic status output from
 // system-agent and converts it into the small runtime state Rancher reconciles on.
-func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
-	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
+func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(entry *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
+	output, ok := entry.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
-		for _, periodicInstruction := range plan.Plan.Plan.PeriodicInstructions {
+		for _, periodicInstruction := range entry.Plan.Plan.PeriodicInstructions {
 			if periodicInstruction.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
-				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
+				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", entry.Machine.Name)
 			}
 		}
-		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
+		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", entry.Machine.Name)
 	}
 
 	stdout := strings.TrimSpace(string(output.Stdout))

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -28,6 +28,7 @@ const (
 	encryptionKeyRotationCommandRotateKeys = "rotate-keys"
 
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
+	encryptionKeyRotationRotateKeysTimeoutMessage    = "see server log for details"
 
 	encryptionKeyRotationBinPrefix = "capr/encryption-key-rotation/bin"
 
@@ -82,8 +83,8 @@ type encryptionKeyRotationRestartTargets struct {
 	controlPlane []*planEntry
 }
 
-func (r encryptionKeyRotationRestartTargets) count() int {
-	return len(r.etcdOnly) + len(r.controlPlane)
+func (restartTargets encryptionKeyRotationRestartTargets) count() int {
+	return len(restartTargets.etcdOnly) + len(restartTargets.controlPlane)
 }
 
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
@@ -221,7 +222,7 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 // and an error if one was encountered.
 func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil {
-		return false, fmt.Errorf("unable to determine encryption key rotation support for nil controlplane")
+		return false, fmt.Errorf("unable to determine encryption key rotation support for nil control plane")
 	}
 
 	kubernetesVersion, err := semver.Make(strings.TrimPrefix(controlPlane.Spec.KubernetesVersion, "v"))
@@ -298,7 +299,7 @@ func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bo
 // phase is "rotate", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
 // (etcd-only), it will elect the first suitable control plane node. If the phase is not in "rotate" and a re-election
 // of the leader is necessary, the phase will be set to failed as this is unexpected.
-func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, init *planEntry) (*planEntry, error) {
+func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, initNode *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
 	if machine, ok := clusterPlan.Machines[machineName]; ok {
 		entry := &planEntry{
@@ -315,8 +316,8 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 		return nil, fmt.Errorf("cannot elect control plane leader in phase %s", status.RotateEncryptionKeysPhase)
 	}
 
-	leader := init
-	if !isControlPlane(init) {
+	leader := initNode
+	if !isControlPlane(initNode) {
 		machines := collect(clusterPlan, encryptionKeyRotationIsSuitableControlPlane)
 		if len(machines) == 0 {
 			return nil, fmt.Errorf("no suitable control plane nodes for encryption key rotation")
@@ -368,7 +369,7 @@ func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEContro
 
 	// Upstream documents restarting the server that ran rotate-keys before the remaining servers. Rancher follows that
 	// ordering after the init node when they are different, so split-role clusters still bring the designated init server
-	// back first and then restart the elected command leader before the rest of the HA servers.
+	// back first and then restart the elected command leader before the rest of the high-availability servers.
 	targets.etcdOnly = append(targets.etcdOnly, collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane))...)
 	targets.controlPlane = append(targets.controlPlane, collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane))...)
 
@@ -448,7 +449,7 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationRestartPlan creates a restart-only plan. During the HA convergence step Rancher no longer runs
+// encryptionKeyRotationRestartPlan creates a restart-only plan. During the high-availability convergence step Rancher no longer runs
 // additional secrets-encrypt subcommands on follower nodes; it only restarts the server unit and resumes observing the
 // periodic secrets-encrypt status that the system-agent reports back in the node plan.
 func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
@@ -527,6 +528,14 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 			}
 			return encryptionKeyRotationRuntimeStatus{}, status, err
 		}
+		if encryptionKeyRotationRotateKeysTimedOut(leader, nodePlan.Instructions[0].Name) {
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] exceeded the CLI timeout; continuing to observe periodic status because rotation may still be running in the background", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name)
+			rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
+			if periodicStatusErr == nil {
+				return rotationStatus, status, nil
+			}
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after rotate-keys timeout on leader [%s]", leader.Machine.Name)
+		}
 		status, err = p.encryptionKeyRotationFailed(status, err)
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
@@ -573,8 +582,8 @@ func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKECon
 func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
 	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
-		for _, pi := range plan.Plan.Plan.PeriodicInstructions {
-			if pi.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
+		for _, periodicInstruction := range plan.Plan.Plan.PeriodicInstructions {
+			if periodicInstruction.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
 				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
 			}
 		}
@@ -619,23 +628,57 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 // the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
-		return plan.OneTimeInstruction{}, fmt.Errorf("controlplane cannot be nil")
+		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
 	}
 	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
 	}
 
-	return idempotentInstruction(
+	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
+	// can inspect timeout text from the K3s/RKE2 CLI when the client exits before the background rotation finishes.
+	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
 		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
-		capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
+		"/bin/sh",
 		[]string{
-			"secrets-encrypt",
-			encryptionKeyRotationCommandRotateKeys,
+			"-c",
+			fmt.Sprintf("%s secrets-encrypt %s 2>&1", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
 		},
 		[]string{},
-	), nil
+	)
+	instruction.SaveOutput = true
+
+	return instruction, nil
+}
+
+// encryptionKeyRotationRotateKeysTimedOut reports whether the saved one-time instruction output matches the
+// expected timeout signature from the K3s or RKE2 secrets-encrypt client.
+func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
+	if entry == nil || entry.Plan == nil || instructionName == "" {
+		return false
+	}
+
+	outputs := entry.Plan.Output
+	if entry.Plan.Failed {
+		// system-agent writes SaveOutput for failed one-time instructions to the failed-output secret key instead of
+		// applied-output, so Rancher has to inspect the corresponding FailedOutput map on failed plans.
+		outputs = entry.Plan.FailedOutput
+	}
+
+	output, ok := outputs[instructionName]
+	if !ok {
+		return false
+	}
+
+	message := string(output)
+	if !strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) {
+		return false
+	}
+
+	return strings.Contains(message, "Client.Timeout exceeded while awaiting headers") ||
+		strings.Contains(message, "timeout awaiting response headers") ||
+		strings.Contains(message, "context deadline exceeded")
 }
 
 // encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -71,8 +71,12 @@ done
 exit 1
 `
 
-	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
-	encryptionKeyRotationAttemptEnv  = "ENCRYPTION_KEY_ROTATION_ATTEMPT"
+	encryptionKeyRotationEndpointEnv       = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
+	encryptionKeyRotationGenerationEnvName = "ENCRYPTION_KEY_ROTATION_GENERATION"
+	encryptionKeyRotationAttemptEnvName    = "ENCRYPTION_KEY_ROTATION_ATTEMPT"
+	encryptionKeyRotationRetryCountEnv     = "ENCRYPTION_KEY_ROTATION_RETRY_COUNT"
+
+	encryptionKeyRotationMaxRotateKeysRetries = 3
 )
 
 var encryptionKeyRotationMinimumVersion = semver.Version{Major: 1, Minor: 30}
@@ -527,8 +531,8 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 // encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
 // recent periodic secrets-encrypt status observed on that node.
 func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
-	attempt := encryptionKeyRotationRotateKeysAttempt(controlPlane, leader)
-	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
+	retryCount := encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader)
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
 	if err != nil {
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
@@ -542,14 +546,17 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition and current periodic status is stage [%s] with hashesMatch=%t; waiting to retry", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage, rotationStatus.HashesMatch)
 			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for leader [%s] to reach a stable secrets-encrypt state before retrying rotate-keys", leader.Machine.Name)
 		}
+		if !encryptionKeyRotationRotateKeysCanRetryAgain(retryCount) {
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition after retry count [%d]; surfacing the failure instead of retrying indefinitely", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, retryCount)
+		} else {
+			retryCount = encryptionKeyRotationNextRotateKeysRetryCount(retryCount)
+			nodePlan, joinedServer, err = p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
+			if err != nil {
+				return encryptionKeyRotationRuntimeStatus{}, status, err
+			}
 
-		attempt = encryptionKeyRotationNextRotateKeysAttempt(attempt)
-		nodePlan, joinedServer, err = p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
-		if err != nil {
-			return encryptionKeyRotationRuntimeStatus{}, status, err
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition; reissuing rotate-keys once periodic status returned to stage [%s] with converged hashes", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage)
 		}
-
-		logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition; reissuing rotate-keys once periodic status returned to stage [%s] with converged hashes", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage)
 	}
 
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
@@ -585,16 +592,16 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 // periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
 // preserve one-time status scraping state from an earlier reconcile.
 func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
-	return p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysAttempt(controlPlane, leader))
+	return p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 }
 
-func (p *Planner) encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, attempt string) (plan.NodePlan, string, error) {
+func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, retryCount int) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
 
-	apply, err := encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, attempt)
+	apply, err := encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, retryCount)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
@@ -693,67 +700,121 @@ func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) 
 	return controlPlane.Spec.RotateEncryptionKeys.Generation
 }
 
-func encryptionKeyRotationRotateKeysBaseAttempt(controlPlane *rkev1.RKEControlPlane) string {
-	return strconv.FormatInt(encryptionKeyRotationActiveGeneration(controlPlane), 10)
+func encryptionKeyRotationRotateKeysInstructionValue(controlPlane *rkev1.RKEControlPlane, retryCount int) string {
+	return fmt.Sprintf("%d-retry-%d", encryptionKeyRotationActiveGeneration(controlPlane), retryCount)
 }
 
-func encryptionKeyRotationRotateKeysAttempt(controlPlane *rkev1.RKEControlPlane, leader *planEntry) string {
-	baseAttempt := encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
-
-	if attempt, ok := encryptionKeyRotationRotateKeysAttemptFromPlan(leader); ok &&
-		(attempt == baseAttempt || strings.HasPrefix(attempt, baseAttempt+"-retry")) {
-		return attempt
+func encryptionKeyRotationRotateKeysRetryCount(controlPlane *rkev1.RKEControlPlane, leader *planEntry) int {
+	activeGeneration := encryptionKeyRotationActiveGeneration(controlPlane)
+	plannedGeneration, retryCount, ok := encryptionKeyRotationRotateKeysRetryCountFromPlan(leader)
+	if ok && plannedGeneration == activeGeneration {
+		return retryCount
 	}
 
-	return baseAttempt
+	return 0
 }
 
-func encryptionKeyRotationRotateKeysAttemptFromPlan(entry *planEntry) (string, bool) {
+func encryptionKeyRotationRotateKeysRetryCountFromPlan(entry *planEntry) (int64, int, bool) {
 	if entry == nil || entry.Plan == nil {
-		return "", false
+		return 0, 0, false
 	}
 
 	for _, instruction := range entry.Plan.Plan.Instructions {
 		if !strings.HasPrefix(instruction.Name, "idempotent-encryption-key-rotation/rotate-") {
 			continue
 		}
+
+		var generation int64
+		var retryCount int
+		var foundGeneration, foundRetryCount bool
+		var legacyAttempt string
+
 		for _, env := range instruction.Env {
-			if strings.HasPrefix(env, encryptionKeyRotationAttemptEnv+"=") {
-				return strings.TrimPrefix(env, encryptionKeyRotationAttemptEnv+"="), true
+			switch {
+			case strings.HasPrefix(env, encryptionKeyRotationGenerationEnvName+"="):
+				value := strings.TrimPrefix(env, encryptionKeyRotationGenerationEnvName+"=")
+				parsedGeneration, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					return 0, 0, false
+				}
+				generation = parsedGeneration
+				foundGeneration = true
+			case strings.HasPrefix(env, encryptionKeyRotationRetryCountEnv+"="):
+				value := strings.TrimPrefix(env, encryptionKeyRotationRetryCountEnv+"=")
+				parsedRetryCount, err := strconv.Atoi(value)
+				if err != nil || parsedRetryCount < 0 {
+					return 0, 0, false
+				}
+				retryCount = parsedRetryCount
+				foundRetryCount = true
+			case strings.HasPrefix(env, encryptionKeyRotationAttemptEnvName+"="):
+				legacyAttempt = strings.TrimPrefix(env, encryptionKeyRotationAttemptEnvName+"=")
+			}
+		}
+
+		if foundGeneration && foundRetryCount {
+			return generation, retryCount, true
+		}
+		if legacyAttempt != "" {
+			parsedGeneration, parsedRetryCount, ok := encryptionKeyRotationLegacyRetryCount(legacyAttempt)
+			if ok {
+				return parsedGeneration, parsedRetryCount, true
 			}
 		}
 	}
 
-	return "", false
+	return 0, 0, false
 }
 
-func encryptionKeyRotationNextRotateKeysAttempt(attempt string) string {
+func encryptionKeyRotationLegacyRetryCount(attempt string) (int64, int, bool) {
 	if attempt == "" {
-		return "retry"
+		return 0, 0, false
 	}
 
-	return attempt + "-retry"
+	parts := strings.Split(attempt, "-")
+	generation, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	retryCount := 0
+	for _, part := range parts[1:] {
+		if part != "retry" {
+			return 0, 0, false
+		}
+		retryCount++
+	}
+
+	return generation, retryCount, true
 }
 
-func encryptionKeyRotationRotateKeysAttemptEnv(attempt string) string {
-	return fmt.Sprintf("%s=%s", encryptionKeyRotationAttemptEnv, attempt)
+func encryptionKeyRotationNextRotateKeysRetryCount(retryCount int) int {
+	return retryCount + 1
+}
+
+func encryptionKeyRotationRotateKeysCanRetryAgain(retryCount int) bool {
+	return retryCount < encryptionKeyRotationMaxRotateKeysRetries
+}
+
+func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
+	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
 }
 
 // encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
 // the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
-	return encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, encryptionKeyRotationRotateKeysBaseAttempt(controlPlane))
+	return encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
 }
 
-func encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane *rkev1.RKEControlPlane, attempt string) (plan.OneTimeInstruction, error) {
+func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *rkev1.RKEControlPlane, retryCount int) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
 	}
 	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
 	}
-	if attempt == "" {
-		attempt = encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
+	if retryCount < 0 {
+		retryCount = 0
 	}
 
 	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
@@ -761,13 +822,16 @@ func encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane *rke
 	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-		attempt,
+		encryptionKeyRotationRotateKeysInstructionValue(controlPlane, retryCount),
 		"/bin/sh",
 		[]string{
 			"-c",
 			fmt.Sprintf("%s secrets-encrypt %s 2>&1", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
 		},
-		[]string{encryptionKeyRotationRotateKeysAttemptEnv(attempt)},
+		[]string{
+			encryptionKeyRotationGenerationEnv(controlPlane),
+			encryptionKeyRotationRotateKeysRetryCountEnv(retryCount),
+		},
 	)
 	instruction.SaveOutput = true
 
@@ -785,6 +849,9 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
 }
 
+// encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition intentionally matches the coarse CLI error shape that
+// K3s/RKE2 exposes to Rancher. The CLI does not include the underlying server-side cause, so the planner only retries
+// after separately observing a stable periodic secrets-encrypt status, and the retry count is strictly bounded.
 func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -854,7 +921,7 @@ func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string 
 // encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
 // on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
-	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", encryptionKeyRotationActiveGeneration(controlPlane))
+	return fmt.Sprintf("%s=%d", encryptionKeyRotationGenerationEnvName, encryptionKeyRotationActiveGeneration(controlPlane))
 }
 
 // encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction generates a one time instruction which will scrape the secrets-encrypt

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -27,7 +27,6 @@ const (
 
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
 	encryptionKeyRotationRotateKeysTimeoutMessage    = "see server log for details"
-	encryptionKeyRotationRotateKeysErrorIDMessage    = "secret-encrypt error ID"
 	encryptionKeyRotationRotateKeysTimeoutEndpoint   = "/encrypt/config"
 	encryptionKeyRotationStatusTimeoutEndpoint       = "/encrypt/status"
 
@@ -71,10 +70,6 @@ exit 1
 
 	encryptionKeyRotationEndpointEnv       = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
 	encryptionKeyRotationGenerationEnvName = "ENCRYPTION_KEY_ROTATION_GENERATION"
-	encryptionKeyRotationAttemptEnvName    = "ENCRYPTION_KEY_ROTATION_ATTEMPT"
-	encryptionKeyRotationRetryCountEnv     = "ENCRYPTION_KEY_ROTATION_RETRY_COUNT"
-
-	encryptionKeyRotationMaxRotateKeysRetries = 3
 )
 
 var encryptionKeyRotationMinimumVersion = semver.Version{Major: 1, Minor: 30}
@@ -167,13 +162,7 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return status, nil
 	}
 
-	shouldStart, err := encryptionKeyRotationShouldStart(controlPlane)
-	if err != nil {
-		status, err = p.encryptionKeyRotationFailed(status, err)
-		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
-	}
-
-	if shouldStart {
+	if encryptionKeyRotationShouldStart(controlPlane) {
 		logrus.Debugf("[planner] rkecluster %s/%s: starting/restarting encryption key rotation", controlPlane.Namespace, controlPlane.Name)
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
 	}
@@ -253,7 +242,7 @@ func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, 
 }
 
 // encryptionKeyRotationShouldSkip returns true when there is nothing to reconcile for
-// encryption key rotation. Once a generation is already in progress, Rancher keeps
+// encryption key rotation. Once a generation is already in progress, the planner keeps
 // reconciling even if the control plane is temporarily not Ready so it can finish or
 // unwind the in-flight rotation instead of abandoning it mid-flow.
 func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
@@ -272,30 +261,29 @@ func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 		(phase == rkev1.RotateEncryptionKeysPhaseDone || phase == rkev1.RotateEncryptionKeysPhaseFailed)
 }
 
-// encryptionKeyRotationShouldStart returns true when Rancher should start or restart
-// the current requested generation. Unknown phases are treated as stale state and are
-// restarted instead of surfaced as hard errors so upgrades can recover older planner
-// state by beginning the current generation again.
-func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool, error) {
+// encryptionKeyRotationShouldStart returns true when the planner should start or
+// restart the requested generation. Unknown phases are treated as stale state so
+// upgrades can recover older planner state by beginning the current generation again.
+func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) bool {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
-		return false, nil
+		return false
 	}
 	if controlPlane.Status.RotateEncryptionKeys == nil || controlPlane.Status.RotateEncryptionKeysPhase == "" {
-		return true, nil
+		return true
 	}
 	if !encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
-		return true, nil
+		return true
 	}
 	if controlPlane.Spec.RotateEncryptionKeys.Generation != controlPlane.Status.RotateEncryptionKeys.Generation {
 		return controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone ||
-			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed, nil
+			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed
 	}
 
-	return false, nil
+	return false
 }
 
 // encryptionKeyRotationPhaseIsKnown reports whether the phase belongs to the
-// simplified rotate-keys state machine implemented in this planner.
+// RKEControlPlane rotate-keys state machine.
 func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bool {
 	switch phase {
 	case "",
@@ -365,10 +353,9 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
-// encryptionKeyRotationRestartTargetsForCluster groups the nodes for the restart phase.
-// Etcd-only nodes are grouped first because Rancher does not use them for local
-// secrets-encrypt convergence checks. Control-plane nodes are grouped after that
-// for convergence checks.
+// encryptionKeyRotationRestartTargetsForCluster groups nodes for the restart phase.
+// Etcd-only nodes are restarted first but are not used for local status/hash checks.
+// Control-plane nodes are restarted after that and are used for convergence checks.
 func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
 	targets := encryptionKeyRotationRestartTargets{
 		controlPlane: []*planEntry{leader},
@@ -517,34 +504,11 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 
 // encryptionKeyRotationRotateKeysReconcile runs rotate-keys on the elected leader and then trusts
 // periodic secrets-encrypt status as the source of progress. A CLI timeout is treated as ambiguous,
-// so Rancher keeps watching periodic status before deciding whether to wait, retry, or fail.
+// so the planner keeps watching periodic status before deciding whether to wait or fail.
 func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
-	retryCount := encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader)
-	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlan(controlPlane, tokensSecret, joinServer, leader)
 	if err != nil {
 		return encryptionKeyRotationRuntimeStatus{}, status, err
-	}
-
-	if encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leader, nodePlan.Instructions[0].Name) {
-		rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
-		if periodicStatusErr != nil {
-			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after retryable rotate-keys failure on leader [%s]: %v", leader.Machine.Name, periodicStatusErr)
-		}
-		if !encryptionKeyRotationRotateKeysCanRetry(rotationStatus) {
-			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition and current periodic status is stage [%s] with hashesMatch=%t; waiting to retry", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage, rotationStatus.HashesMatch)
-			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for leader [%s] to reach a stable secrets-encrypt state before retrying rotate-keys", leader.Machine.Name)
-		}
-		if !encryptionKeyRotationRotateKeysCanRetryAgain(retryCount) {
-			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition after retry count [%d]; surfacing the failure instead of retrying indefinitely", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, retryCount)
-		} else {
-			retryCount = encryptionKeyRotationNextRotateKeysRetryCount(retryCount)
-			nodePlan, joinedServer, err = p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
-			if err != nil {
-				return encryptionKeyRotationRuntimeStatus{}, status, err
-			}
-
-			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition; reissuing rotate-keys once periodic status returned to stage [%s] with converged hashes", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage)
-		}
 	}
 
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
@@ -557,11 +521,11 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 		}
 		if encryptionKeyRotationRotateKeysTimedOut(leader, nodePlan.Instructions[0].Name) {
 			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] exceeded the CLI timeout; continuing to observe periodic status because rotation may still be running in the background", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name)
-			rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
-			if periodicStatusErr == nil {
+			rotationStatus, err := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
+			if err == nil {
 				return rotationStatus, status, nil
 			}
-			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after rotate-keys timeout on leader [%s]", leader.Machine.Name)
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after rotate-keys timeout on leader [%s]: %v", leader.Machine.Name, err)
 		}
 		status, err = p.encryptionKeyRotationFailed(status, err)
 		return encryptionKeyRotationRuntimeStatus{}, status, err
@@ -576,16 +540,15 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationRotateKeysPlanWithRetryCount builds the leader plan for one
-// rotate-keys attempt. The retry count is encoded into the one-time instruction so
-// the planner can intentionally reissue the command when needed.
-func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, retryCount int) (plan.NodePlan, string, error) {
+// encryptionKeyRotationRotateKeysPlan builds the leader plan that starts the
+// rotate-keys operation and periodically observes secrets-encrypt status.
+func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
 
-	apply, err := encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, retryCount)
+	apply, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
@@ -617,17 +580,10 @@ func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(entry *planEntry) (en
 		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", entry.Machine.Name)
 	}
 
-	stdout := strings.TrimSpace(string(output.Stdout))
-	stderr := strings.TrimSpace(string(output.Stderr))
-
-	switch {
-	case stdout != "" && stderr != "":
-		return encryptionKeyRotationStatusFromOutput(stdout + "\n" + stderr)
-	case stdout != "":
+	if stdout := strings.TrimSpace(string(output.Stdout)); stdout != "" {
 		return encryptionKeyRotationStatusFromOutput(stdout)
-	default:
-		return encryptionKeyRotationStatusFromOutput(stderr)
 	}
+	return encryptionKeyRotationRuntimeStatus{}, errWaitingf("unable to parse rotation stage from output for [%s]", entry.Machine.Name)
 }
 
 // encryptionKeyRotationStatusFromOutput parses the human-readable secrets-encrypt status
@@ -683,136 +639,26 @@ func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) 
 	return controlPlane.Spec.RotateEncryptionKeys.Generation
 }
 
-// encryptionKeyRotationRotateKeysInstructionValue is the idempotency value for the
-// rotate-keys instruction and changes when generation or retry count changes.
-func encryptionKeyRotationRotateKeysInstructionValue(controlPlane *rkev1.RKEControlPlane, retryCount int) string {
-	return fmt.Sprintf("%d-retry-%d", encryptionKeyRotationActiveGeneration(controlPlane), retryCount)
+// encryptionKeyRotationRotateKeysInstructionValue is the idempotency value for
+// the rotate-keys instruction and changes when the requested generation changes.
+func encryptionKeyRotationRotateKeysInstructionValue(controlPlane *rkev1.RKEControlPlane) string {
+	return strconv.FormatInt(encryptionKeyRotationActiveGeneration(controlPlane), 10)
 }
 
-// encryptionKeyRotationRotateKeysRetryCount restores the persisted retry count for the
-// active generation from the current leader plan.
-func encryptionKeyRotationRotateKeysRetryCount(controlPlane *rkev1.RKEControlPlane, leader *planEntry) int {
-	activeGeneration := encryptionKeyRotationActiveGeneration(controlPlane)
-	plannedGeneration, retryCount, ok := encryptionKeyRotationRotateKeysRetryCountFromPlan(leader)
-	if ok && plannedGeneration == activeGeneration {
-		return retryCount
-	}
-
-	return 0
-}
-
-// encryptionKeyRotationRotateKeysRetryCountFromPlan reads generation and retry count
-// from the rotate-keys instruction env vars in the current node plan.
-func encryptionKeyRotationRotateKeysRetryCountFromPlan(entry *planEntry) (int64, int, bool) {
-	if entry == nil || entry.Plan == nil {
-		return 0, 0, false
-	}
-
-	for _, instruction := range entry.Plan.Plan.Instructions {
-		if !strings.HasPrefix(instruction.Name, "idempotent-encryption-key-rotation/rotate-") {
-			continue
-		}
-
-		var generation int64
-		var retryCount int
-		var foundGeneration, foundRetryCount bool
-		var legacyAttempt string
-
-		for _, env := range instruction.Env {
-			switch {
-			case strings.HasPrefix(env, encryptionKeyRotationGenerationEnvName+"="):
-				value := strings.TrimPrefix(env, encryptionKeyRotationGenerationEnvName+"=")
-				parsedGeneration, err := strconv.ParseInt(value, 10, 64)
-				if err != nil {
-					return 0, 0, false
-				}
-				generation = parsedGeneration
-				foundGeneration = true
-			case strings.HasPrefix(env, encryptionKeyRotationRetryCountEnv+"="):
-				value := strings.TrimPrefix(env, encryptionKeyRotationRetryCountEnv+"=")
-				parsedRetryCount, err := strconv.Atoi(value)
-				if err != nil || parsedRetryCount < 0 {
-					return 0, 0, false
-				}
-				retryCount = parsedRetryCount
-				foundRetryCount = true
-			case strings.HasPrefix(env, encryptionKeyRotationAttemptEnvName+"="):
-				legacyAttempt = strings.TrimPrefix(env, encryptionKeyRotationAttemptEnvName+"=")
-			}
-		}
-
-		if foundGeneration && foundRetryCount {
-			return generation, retryCount, true
-		}
-		if legacyAttempt != "" {
-			parsedGeneration, parsedRetryCount, ok := encryptionKeyRotationLegacyRetryCount(legacyAttempt)
-			if ok {
-				return parsedGeneration, parsedRetryCount, true
-			}
-		}
-	}
-
-	return 0, 0, false
-}
-
-// encryptionKeyRotationLegacyRetryCount parses the previous attempt format so in-flight
-// plans written by older code can still resume after upgrade.
-func encryptionKeyRotationLegacyRetryCount(attempt string) (int64, int, bool) {
-	if attempt == "" {
-		return 0, 0, false
-	}
-
-	parts := strings.Split(attempt, "-")
-	generation, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		return 0, 0, false
-	}
-
-	retryCount := 0
-	for _, part := range parts[1:] {
-		if part != "retry" {
-			return 0, 0, false
-		}
-		retryCount++
-	}
-
-	return generation, retryCount, true
-}
-
-// encryptionKeyRotationNextRotateKeysRetryCount returns the next bounded retry index.
-func encryptionKeyRotationNextRotateKeysRetryCount(retryCount int) int {
-	return retryCount + 1
-}
-
-// encryptionKeyRotationRotateKeysCanRetryAgain reports whether the current retry count
-// is still below the planner retry budget.
-func encryptionKeyRotationRotateKeysCanRetryAgain(retryCount int) bool {
-	return retryCount < encryptionKeyRotationMaxRotateKeysRetries
-}
-
-// encryptionKeyRotationRotateKeysRetryCountEnv formats the retry count env var stored
-// on the rotate-keys one-time instruction.
-func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
-	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
-}
-
-// encryptionKeyRotationSecretsEncryptInstructionWithRetryCount builds the one-time
-// rotate-keys instruction for the active generation and retry count.
-func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *rkev1.RKEControlPlane, retryCount int) (plan.OneTimeInstruction, error) {
+// encryptionKeyRotationSecretsEncryptInstruction builds the one-time rotate-keys
+// instruction for the active generation.
+func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
 	}
 	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
 	}
-	if retryCount < 0 {
-		retryCount = 0
-	}
 
 	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-		encryptionKeyRotationRotateKeysInstructionValue(controlPlane, retryCount),
+		encryptionKeyRotationRotateKeysInstructionValue(controlPlane),
 		"/bin/sh",
 		[]string{
 			"-c",
@@ -820,7 +666,6 @@ func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *
 		},
 		[]string{
 			encryptionKeyRotationGenerationEnv(controlPlane),
-			encryptionKeyRotationRotateKeysRetryCountEnv(retryCount),
 		},
 	)
 	instruction.SaveOutput = true
@@ -837,19 +682,6 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 	}
 
 	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
-}
-
-// encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition reports the coarse
-// upstream error shape that Rancher retries after status stabilizes, for example:
-// `time="..." level=fatal msg="Error: see server log for details: secret-encrypt error ID 78467"`
-func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
-	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
-	if !ok {
-		return false
-	}
-
-	return strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) &&
-		strings.Contains(message, encryptionKeyRotationRotateKeysErrorIDMessage)
 }
 
 // encryptionKeyRotationRotateKeysOutput returns the saved one-time output for the given
@@ -888,21 +720,6 @@ func encryptionKeyRotationCommandTimedOut(message, endpoint string) bool {
 		}
 	}
 	return false
-}
-
-// encryptionKeyRotationRotateKeysCanRetry only allows retries from stable upstream
-// states where hashes already converged.
-func encryptionKeyRotationRotateKeysCanRetry(status encryptionKeyRotationRuntimeStatus) bool {
-	if !status.HashesMatch {
-		return false
-	}
-
-	switch status.Stage {
-	case encryptionKeyRotationStageStart, encryptionKeyRotationStageReencryptFinished:
-		return true
-	default:
-		return false
-	}
 }
 
 // encryptionKeyRotationStatusEnv forces restart and status instructions to rerun as the planner

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -127,6 +127,11 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	}
 
 	if controlPlane.Spec.RotateEncryptionKeys == nil {
+		if status.RotateEncryptionKeys != nil || status.RotateEncryptionKeysPhase != "" || status.RotateEncryptionKeysLeader != "" {
+			if err := p.pauseCAPICluster(controlPlane, false); err != nil {
+				return status, errWaiting("unpausing CAPI cluster")
+			}
+		}
 		return p.resetEncryptionKeyRotateState(status)
 	}
 
@@ -600,15 +605,15 @@ func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane
 
 // encryptionKeyRotationSecretsEncryptStatusFromPeriodic reads the latest periodic status output from
 // system-agent and converts it into the small runtime state Rancher reconciles on.
-func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
-	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
+func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(entry *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
+	output, ok := entry.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
-		for _, periodicInstruction := range plan.Plan.Plan.PeriodicInstructions {
+		for _, periodicInstruction := range entry.Plan.Plan.PeriodicInstructions {
 			if periodicInstruction.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
-				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
+				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", entry.Machine.Name)
 			}
 		}
-		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
+		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", entry.Machine.Name)
 	}
 
 	stdout := strings.TrimSpace(string(output.Stdout))

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -208,7 +208,7 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 			return status, errWaitingf("waiting for encryption key rotation stage to finish on leader [%s]", leader.Machine.Name)
 		}
 
-		restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
+		restartTargets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
 		if restartTargets.onlyLeaderNeedsRestart() {
 			// Single-server rotations can finish as soon as the leader reports final
 			// stage and matching hashes because there are no follower servers to restart.
@@ -226,7 +226,7 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	case rkev1.RotateEncryptionKeysPhasePostRotateRestart:
 		// Multi-server rotations finish by restarting all remaining server nodes in
 		// topology order and checking convergence on control-plane nodes.
-		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
+		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, joinServer)
 		if err != nil {
 			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 		}
@@ -352,52 +352,23 @@ func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 	return isControlPlane(entry) && isNotDeleting(entry) && entry.Machine.Status.NodeRef.IsDefined() && capr.Ready.IsTrue(entry.Machine)
 }
 
-// encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit selects follower control-plane
-// machines that should be restarted after the leader rotation finishes.
-func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
-	return func(entry *planEntry) bool {
-		return isControlPlaneAndNotInitNode(entry) &&
-			controlPlane.Status.RotateEncryptionKeysLeader != entry.Machine.Name
-	}
-}
-
-// encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit selects etcd-only
-// followers that should restart before control-plane nodes during post-rotate restart.
-func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
-	return func(entry *planEntry) bool {
-		return isEtcd(entry) && !isControlPlane(entry) &&
-			controlPlane.Status.RotateEncryptionKeysLeader != entry.Machine.Name &&
-			!isInitNode(entry)
-	}
-}
-
 // encryptionKeyRotationRestartTargetsForCluster groups nodes for the restart phase.
 // Etcd-only nodes are restarted first but are not used for local status/hash checks.
 // Control-plane nodes are restarted after that and are used for convergence checks.
-func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
-	targets := encryptionKeyRotationRestartTargets{
-		controlPlane: []*planEntry{leader},
+func encryptionKeyRotationRestartTargetsForCluster(clusterPlan *plan.Plan) encryptionKeyRotationRestartTargets {
+	return encryptionKeyRotationRestartTargets{
+		etcdOnly: collect(clusterPlan, func(entry *planEntry) bool {
+			return isEtcd(entry) && !isControlPlane(entry)
+		}),
+		controlPlane: collect(clusterPlan, isControlPlane),
 	}
-
-	if initNode != nil && !isInitNode(leader) {
-		if isControlPlane(initNode) {
-			targets.controlPlane = append(targets.controlPlane, initNode)
-		} else if isEtcd(initNode) {
-			targets.etcdOnly = append(targets.etcdOnly, initNode)
-		}
-	}
-
-	targets.etcdOnly = append(targets.etcdOnly, collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane))...)
-	targets.controlPlane = append(targets.controlPlane, collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane))...)
-
-	return targets
 }
 
 // encryptionKeyRotationRestartNodes restarts etcd-only nodes first and then control-plane nodes.
 // Only control-plane nodes are used for local secrets-encrypt status checks during convergence,
 // and the last control-plane node must also report matching hashes before the phase can finish.
-func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, leader *planEntry, initNode *planEntry, joinServer string) (rkev1.RKEControlPlaneStatus, error) {
-	restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
+func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, joinServer string) (rkev1.RKEControlPlaneStatus, error) {
+	restartTargets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
 
 	for _, entry := range restartTargets.etcdOnly {
 		_, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -175,23 +175,23 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
 	}
 
-	// Keep the same leader once chosen so requeues keep observing the same
-	// rotate-keys command output instead of moving the operation between servers.
-	leader, err := p.encryptionKeyRotationFindLeader(status, clusterPlan, initNode)
-	if err != nil {
-		status, err = p.encryptionKeyRotationFailed(status, err)
-		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
-	}
-
-	if status.RotateEncryptionKeysLeader != leader.Machine.Name {
-		status.RotateEncryptionKeysLeader = leader.Machine.Name
-		return status, errWaitingf("elected %s as control plane leader for encryption key rotation", leader.Machine.Name)
-	}
-
 	logrus.Debugf("[planner] rkecluster %s/%s: current encryption key rotation phase: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, controlPlane.Status.RotateEncryptionKeysPhase)
 
 	switch controlPlane.Status.RotateEncryptionKeysPhase {
 	case rkev1.RotateEncryptionKeysPhaseRotate:
+		// Keep the same leader once chosen so requeues keep observing the same
+		// rotate-keys command output instead of moving the operation between servers.
+		leader, err := p.encryptionKeyRotationFindLeader(status, clusterPlan, initNode)
+		if err != nil {
+			status, err = p.encryptionKeyRotationFailed(status, err)
+			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
+		}
+
+		if status.RotateEncryptionKeysLeader != leader.Machine.Name {
+			status.RotateEncryptionKeysLeader = leader.Machine.Name
+			return status, errWaitingf("elected %s as control plane leader for encryption key rotation", leader.Machine.Name)
+		}
+
 		// Pause CAPI while rotate-keys is active so unrelated rollout activity does
 		// not race with the encryption-key rotation plan.
 		if err := p.pauseCAPICluster(controlPlane, true); err != nil {

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -29,11 +29,13 @@ const (
 	encryptionKeyRotationRotateKeysTimeoutMessage    = "see server log for details"
 	encryptionKeyRotationRotateKeysTimeoutEndpoint   = "/encrypt/config"
 	encryptionKeyRotationStatusTimeoutEndpoint       = "/encrypt/status"
+	encryptionKeyRotationRotateKeysExitCodePrefix    = "rancher-rotate-keys-exit-code="
 
 	encryptionKeyRotationBinPrefix = "capr/encryption-key-rotation/bin"
 
 	encryptionKeyRotationWaitForSystemctlStatusPath      = "wait_for_systemctl_status.sh"
 	encryptionKeyRotationWaitForSecretsEncryptStatusPath = "wait_for_secrets_encrypt_status.sh"
+	encryptionKeyRotationSecretsEncryptStatusPath        = "secrets_encrypt_status.sh"
 
 	encryptionKeyRotationWaitForSystemctlStatus = `
 #!/bin/sh
@@ -68,6 +70,30 @@ done
 exit 1
 `
 
+	encryptionKeyRotationSecretsEncryptStatusScript = `
+#!/bin/sh
+
+runtime=$1
+i=0
+
+while [ $i -lt 10 ]; do
+	output="$($runtime secrets-encrypt status)"
+	if [ $? -eq 0 ]; then
+		if [ -n "$2" ]; then
+			echo $output | grep -q "$2"
+				if [ $? -eq 0 ]; then
+					exit 0
+				fi
+		else
+			exit 0
+		fi
+	fi
+	sleep 10
+	i=$((i + 1))
+done
+exit 1
+`
+
 	encryptionKeyRotationEndpointEnv       = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
 	encryptionKeyRotationGenerationEnvName = "ENCRYPTION_KEY_ROTATION_GENERATION"
 )
@@ -83,6 +109,11 @@ var encryptionKeyRotationTimeoutMarkers = []string{
 type encryptionKeyRotationRuntimeStatus struct {
 	Stage       string
 	HashesMatch bool
+}
+
+type encryptionKeyRotationCommandResult struct {
+	Output   string
+	ExitCode int
 }
 
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
@@ -450,14 +481,20 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 	)
 
 	if isControlPlane(entry) {
-		nodePlan.Files = append(nodePlan.Files, plan.File{
-			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
-			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
-		})
+		nodePlan.Files = append(nodePlan.Files,
+			plan.File{
+				Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
+				Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
+			},
+			plan.File{
+				Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationSecretsEncryptStatusScript)),
+				Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationSecretsEncryptStatusPath),
+			},
+		)
 		nodePlan.Instructions = append(nodePlan.Instructions,
 			encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane),
 			plan.OneTimeInstruction{
-				CommonInstruction: encryptionKeyRotationSecretsEncryptStatusScriptOneTimeInstruction(controlPlane, leaderStage),
+				CommonInstruction: encryptionKeyRotationSecretsEncryptStatusScriptOneTimeInstruction(controlPlane, ""),
 			},
 			encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction(controlPlane),
 		)
@@ -486,6 +523,7 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
 
+	instructionName := nodePlan.Instructions[0].Name
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
 	if err != nil {
 		if IsErrWaiting(err) {
@@ -494,7 +532,16 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 			}
 			return encryptionKeyRotationRuntimeStatus{}, status, err
 		}
-		if encryptionKeyRotationRotateKeysTimedOut(leader, nodePlan.Instructions[0].Name) {
+		status, err = p.encryptionKeyRotationFailedRequiringEtcdRestore(status, err)
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	result, err := encryptionKeyRotationRotateKeysResult(leader, instructionName)
+	if err != nil {
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+	if result.ExitCode != 0 {
+		if encryptionKeyRotationCommandTimedOut(result.Output, encryptionKeyRotationRotateKeysTimeoutEndpoint) {
 			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] exceeded the CLI timeout; continuing to observe periodic status because rotation may still be running in the background", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name)
 			rotationStatus, err := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
 			if err == nil {
@@ -502,7 +549,7 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 			}
 			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after rotate-keys timeout on leader [%s]: %v", leader.Machine.Name, err)
 		}
-		status, err = p.encryptionKeyRotationFailedRequiringEtcdRestore(status, err)
+		status, err = p.encryptionKeyRotationFailedRequiringEtcdRestore(status, fmt.Errorf("rotate-keys command failed with exit code %d", result.ExitCode))
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
 
@@ -535,6 +582,16 @@ func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKECon
 		},
 		encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction(controlPlane),
 	}
+	nodePlan.Files = append(nodePlan.Files,
+		plan.File{
+			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
+			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
+		},
+		plan.File{
+			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationSecretsEncryptStatusScript)),
+			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationSecretsEncryptStatusPath),
+		},
+	)
 	nodePlan.PeriodicInstructions = []plan.PeriodicInstruction{
 		encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane),
 	}
@@ -639,7 +696,7 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 		"/bin/sh",
 		[]string{
 			"-c",
-			fmt.Sprintf("%s secrets-encrypt %s 2>&1", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
+			encryptionKeyRotationRotateKeysCommand(controlPlane),
 		},
 		[]string{
 			encryptionKeyRotationGenerationEnv(controlPlane),
@@ -650,35 +707,48 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 	return instruction, nil
 }
 
-// encryptionKeyRotationRotateKeysTimedOut reports whether the saved rotate-keys output
-// matches a known CLI timeout on the upstream /encrypt/config endpoint.
-func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
-	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
-	if !ok {
-		return false
-	}
-
-	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
+// encryptionKeyRotationRotateKeysCommand captures the CLI output and exit code
+// in normal saved output. The wrapper exits successfully so the planner can
+// classify timeout and failure cases in Go instead of shell.
+func encryptionKeyRotationRotateKeysCommand(controlPlane *rkev1.RKEControlPlane) string {
+	return strings.Join([]string{
+		fmt.Sprintf("output=\"$(%s secrets-encrypt %s 2>&1)\"", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
+		"exitCode=$?",
+		"printf '%s\\n' \"$output\"",
+		fmt.Sprintf("printf '%s%%s\\n' \"$exitCode\"", encryptionKeyRotationRotateKeysExitCodePrefix),
+		"exit 0",
+	}, "\n")
 }
 
-// encryptionKeyRotationRotateKeysOutput returns the saved one-time output for the given
-// rotate-keys instruction, using failed output when the node plan is marked failed.
-func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName string) (string, bool) {
+// encryptionKeyRotationRotateKeysResult returns the saved rotate-keys output and
+// exit code captured by the one-time instruction wrapper.
+func encryptionKeyRotationRotateKeysResult(entry *planEntry, instructionName string) (encryptionKeyRotationCommandResult, error) {
 	if entry == nil || entry.Plan == nil || instructionName == "" {
-		return "", false
+		return encryptionKeyRotationCommandResult{}, fmt.Errorf("cannot read rotate-keys output without a plan entry and instruction name")
 	}
 
-	outputs := entry.Plan.Output
-	if entry.Plan.Failed {
-		outputs = entry.Plan.FailedOutput
-	}
-
-	output, ok := outputs[instructionName]
+	output, ok := entry.Plan.Output[instructionName]
 	if !ok {
-		return "", false
+		return encryptionKeyRotationCommandResult{}, errWaitingf("waiting for rotate-keys output on machine [%s]", entry.Machine.Name)
 	}
 
-	return string(output), true
+	message := string(output)
+	for _, line := range strings.Split(message, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, encryptionKeyRotationRotateKeysExitCodePrefix) {
+			continue
+		}
+		exitCode, err := strconv.Atoi(strings.TrimPrefix(line, encryptionKeyRotationRotateKeysExitCodePrefix))
+		if err != nil {
+			return encryptionKeyRotationCommandResult{}, fmt.Errorf("failed to parse rotate-keys exit code from output for machine [%s]: %w", entry.Machine.Name, err)
+		}
+		return encryptionKeyRotationCommandResult{
+			Output:   message,
+			ExitCode: exitCode,
+		}, nil
+	}
+
+	return encryptionKeyRotationCommandResult{}, errWaitingf("waiting for rotate-keys exit code output on machine [%s]", entry.Machine.Name)
 }
 
 // encryptionKeyRotationCommandTimedOut matches the timeout signatures Rancher has seen

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -29,6 +29,9 @@ const (
 
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
 	encryptionKeyRotationRotateKeysTimeoutMessage    = "see server log for details"
+	encryptionKeyRotationRotateKeysErrorIDMessage    = "secret-encrypt error ID"
+	encryptionKeyRotationRotateKeysTimeoutEndpoint   = "/encrypt/config"
+	encryptionKeyRotationStatusTimeoutEndpoint       = "/encrypt/status"
 
 	encryptionKeyRotationBinPrefix = "capr/encryption-key-rotation/bin"
 
@@ -69,9 +72,16 @@ exit 1
 `
 
 	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
+	encryptionKeyRotationAttemptEnv  = "ENCRYPTION_KEY_ROTATION_ATTEMPT"
 )
 
 var encryptionKeyRotationMinimumVersion = semver.Version{Major: 1, Minor: 30}
+
+var encryptionKeyRotationTimeoutMarkers = []string{
+	"Client.Timeout exceeded while awaiting headers",
+	"timeout awaiting response headers",
+	"context deadline exceeded",
+}
 
 type encryptionKeyRotationRuntimeStatus struct {
 	Stage       string
@@ -457,6 +467,8 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
+	generation := encryptionKeyRotationActiveGeneration(controlPlane)
+	generationValue := strconv.FormatInt(generation, 10)
 
 	nodePlan.Files = append(nodePlan.Files, plan.File{
 		Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSystemctlStatus)),
@@ -470,7 +482,7 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 			nodePlan.Instructions = append(nodePlan.Instructions, convertToIdempotentInstruction(
 				controlPlane,
 				strings.ToLower(fmt.Sprintf("encryption-key-rotation/manifest-cleanup/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-				strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
+				generationValue,
 				instruction))
 		}
 	}
@@ -478,7 +490,7 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 	nodePlan.Instructions = append(nodePlan.Instructions, idempotentRestartInstructions(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/restart/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
+		generationValue,
 		capr.GetRuntimeServerUnit(controlPlane.Spec.KubernetesVersion))...)
 	nodePlan.Instructions = append(nodePlan.Instructions,
 		encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane),
@@ -515,9 +527,29 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 // encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
 // recent periodic secrets-encrypt status observed on that node.
 func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
-	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlan(controlPlane, tokensSecret, joinServer, leader)
+	attempt := encryptionKeyRotationRotateKeysAttempt(controlPlane, leader)
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
 	if err != nil {
 		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	if encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leader, nodePlan.Instructions[0].Name) {
+		rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
+		if periodicStatusErr != nil {
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after retryable rotate-keys failure on leader [%s]", leader.Machine.Name)
+		}
+		if !encryptionKeyRotationRotateKeysCanRetry(rotationStatus) {
+			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition and current periodic status is stage [%s] with hashesMatch=%t; waiting to retry", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage, rotationStatus.HashesMatch)
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for leader [%s] to reach a stable secrets-encrypt state before retrying rotate-keys", leader.Machine.Name)
+		}
+
+		attempt = encryptionKeyRotationNextRotateKeysAttempt(attempt)
+		nodePlan, joinedServer, err = p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, attempt)
+		if err != nil {
+			return encryptionKeyRotationRuntimeStatus{}, status, err
+		}
+
+		logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition; reissuing rotate-keys once periodic status returned to stage [%s] with converged hashes", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage)
 	}
 
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
@@ -553,12 +585,16 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 // periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
 // preserve one-time status scraping state from an earlier reconcile.
 func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
+	return p.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysAttempt(controlPlane, leader))
+}
+
+func (p *Planner) encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, attempt string) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
 
-	apply, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
+	apply, err := encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, attempt)
 	if err != nil {
 		return plan.NodePlan{}, "", err
 	}
@@ -589,13 +625,28 @@ func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (enc
 		}
 		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
 	}
-	return encryptionKeyRotationStatusFromOutput(plan, string(output.Stdout))
+
+	stdout := strings.TrimSpace(string(output.Stdout))
+	stderr := strings.TrimSpace(string(output.Stderr))
+
+	switch {
+	case stdout != "" && stderr != "":
+		return encryptionKeyRotationStatusFromOutput(plan, stdout+"\n"+stderr)
+	case stdout != "":
+		return encryptionKeyRotationStatusFromOutput(plan, stdout)
+	default:
+		return encryptionKeyRotationStatusFromOutput(plan, stderr)
+	}
 }
 
 // encryptionKeyRotationStatusFromOutput parses the parts of secrets-encrypt status that Rancher actually reconciles on:
 // the current rotation stage and whether the server hash set has converged.
 func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
 	var status encryptionKeyRotationRuntimeStatus
+
+	if encryptionKeyRotationCommandTimedOut(output, encryptionKeyRotationStatusTimeoutEndpoint) {
+		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("waiting for secrets-encrypt status after transient timeout")
+	}
 
 	for _, line := range strings.Split(output, "\n") {
 		key, value, ok := strings.Cut(line, ":")
@@ -624,14 +675,85 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 	return status, nil
 }
 
+// encryptionKeyRotationActiveGeneration returns the generation that should be embedded in node plans.
+// Once a rotation has started, the planner must stay pinned to status.RotateEncryptionKeys.Generation until
+// that generation either completes or fails, even if spec has already been bumped to request a later one.
+func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) int64 {
+	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
+		return 0
+	}
+
+	if controlPlane.Status.RotateEncryptionKeys != nil {
+		switch controlPlane.Status.RotateEncryptionKeysPhase {
+		case rkev1.RotateEncryptionKeysPhaseRotate, rkev1.RotateEncryptionKeysPhasePostRotateRestart:
+			return controlPlane.Status.RotateEncryptionKeys.Generation
+		}
+	}
+
+	return controlPlane.Spec.RotateEncryptionKeys.Generation
+}
+
+func encryptionKeyRotationRotateKeysBaseAttempt(controlPlane *rkev1.RKEControlPlane) string {
+	return strconv.FormatInt(encryptionKeyRotationActiveGeneration(controlPlane), 10)
+}
+
+func encryptionKeyRotationRotateKeysAttempt(controlPlane *rkev1.RKEControlPlane, leader *planEntry) string {
+	baseAttempt := encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
+
+	if attempt, ok := encryptionKeyRotationRotateKeysAttemptFromPlan(leader); ok &&
+		(attempt == baseAttempt || strings.HasPrefix(attempt, baseAttempt+"-retry")) {
+		return attempt
+	}
+
+	return baseAttempt
+}
+
+func encryptionKeyRotationRotateKeysAttemptFromPlan(entry *planEntry) (string, bool) {
+	if entry == nil || entry.Plan == nil {
+		return "", false
+	}
+
+	for _, instruction := range entry.Plan.Plan.Instructions {
+		if !strings.HasPrefix(instruction.Name, "idempotent-encryption-key-rotation/rotate-") {
+			continue
+		}
+		for _, env := range instruction.Env {
+			if strings.HasPrefix(env, encryptionKeyRotationAttemptEnv+"=") {
+				return strings.TrimPrefix(env, encryptionKeyRotationAttemptEnv+"="), true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func encryptionKeyRotationNextRotateKeysAttempt(attempt string) string {
+	if attempt == "" {
+		return "retry"
+	}
+
+	return attempt + "-retry"
+}
+
+func encryptionKeyRotationRotateKeysAttemptEnv(attempt string) string {
+	return fmt.Sprintf("%s=%s", encryptionKeyRotationAttemptEnv, attempt)
+}
+
 // encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
 // the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
+	return encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane, encryptionKeyRotationRotateKeysBaseAttempt(controlPlane))
+}
+
+func encryptionKeyRotationSecretsEncryptInstructionWithAttempt(controlPlane *rkev1.RKEControlPlane, attempt string) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
 	}
 	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
+	}
+	if attempt == "" {
+		attempt = encryptionKeyRotationRotateKeysBaseAttempt(controlPlane)
 	}
 
 	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
@@ -639,13 +761,13 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
-		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
+		attempt,
 		"/bin/sh",
 		[]string{
 			"-c",
 			fmt.Sprintf("%s secrets-encrypt %s 2>&1", capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), encryptionKeyRotationCommandRotateKeys),
 		},
-		[]string{},
+		[]string{encryptionKeyRotationRotateKeysAttemptEnv(attempt)},
 	)
 	instruction.SaveOutput = true
 
@@ -655,8 +777,27 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 // encryptionKeyRotationRotateKeysTimedOut reports whether the saved one-time instruction output matches the
 // expected timeout signature from the K3s or RKE2 secrets-encrypt client.
 func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
-	if entry == nil || entry.Plan == nil || instructionName == "" {
+	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
+	if !ok {
 		return false
+	}
+
+	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
+}
+
+func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
+	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
+	if !ok {
+		return false
+	}
+
+	return strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) &&
+		strings.Contains(message, encryptionKeyRotationRotateKeysErrorIDMessage)
+}
+
+func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName string) (string, bool) {
+	if entry == nil || entry.Plan == nil || instructionName == "" {
+		return "", false
 	}
 
 	outputs := entry.Plan.Output
@@ -668,17 +809,38 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 
 	output, ok := outputs[instructionName]
 	if !ok {
+		return "", false
+	}
+
+	return string(output), true
+}
+
+func encryptionKeyRotationCommandTimedOut(message, endpoint string) bool {
+	if message == "" || endpoint == "" {
+		return false
+	}
+	if !strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) || !strings.Contains(message, endpoint) {
+		return false
+	}
+	for _, marker := range encryptionKeyRotationTimeoutMarkers {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func encryptionKeyRotationRotateKeysCanRetry(status encryptionKeyRotationRuntimeStatus) bool {
+	if !status.HashesMatch {
 		return false
 	}
 
-	message := string(output)
-	if !strings.Contains(message, encryptionKeyRotationRotateKeysTimeoutMessage) {
+	switch status.Stage {
+	case encryptionKeyRotationStageStart, encryptionKeyRotationStageReencryptFinished:
+		return true
+	default:
 		return false
 	}
-
-	return strings.Contains(message, "Client.Timeout exceeded while awaiting headers") ||
-		strings.Contains(message, "timeout awaiting response headers") ||
-		strings.Contains(message, "context deadline exceeded")
 }
 
 // encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans
@@ -692,7 +854,7 @@ func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string 
 // encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
 // on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
-	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", controlPlane.Spec.RotateEncryptionKeys.Generation)
+	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", encryptionKeyRotationActiveGeneration(controlPlane))
 }
 
 // encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction generates a one time instruction which will scrape the secrets-encrypt

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -19,8 +19,6 @@ import (
 )
 
 const (
-	// start is the pre-rotation steady state reported by current K3s/RKE2 status output. Rancher does not branch on it
-	// directly, but keeping it named documents the expected intermediate state we wait through before convergence.
 	encryptionKeyRotationStageStart             = "start"
 	encryptionKeyRotationStageReencryptFinished = "reencrypt_finished"
 	encryptionKeyRotationHashesMatch            = "All hashes match"
@@ -120,8 +118,9 @@ func (p *Planner) resetEncryptionKeyRotateState(status rkev1.RKEControlPlaneStat
 	return status, errWaiting("refreshing encryption key rotation state")
 }
 
-// rotateEncryptionKeys first verifies that the control plane is in a state where the next step can be derived. If encryption key rotation is required, the corresponding phase and status fields will be set.
-// The function is expected to be called multiple times throughout encryption key rotation, and will set the next corresponding phase based on previous output.
+// rotateEncryptionKeys drives one requested generation through the simplified upstream flow:
+// elect one control-plane leader, run rotate-keys there, then restart the remaining server nodes
+// and wait for secrets-encrypt status to converge before marking the generation done.
 func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, error) {
 	if controlPlane == nil || clusterPlan == nil {
 		return status, fmt.Errorf("cannot pass nil parameters to rotateEncryptionKeys")
@@ -174,8 +173,6 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
 	}
 
-	// The stored leader is part of Rancher's idempotency contract. rotate-keys must only be launched from one server,
-	// and once it has been chosen we keep reconciling through that server until the generation either finishes or fails.
 	leader, err := p.encryptionKeyRotationFindLeader(status, clusterPlan, initNode)
 	if err != nil {
 		status, err = p.encryptionKeyRotationFailed(status, err)
@@ -232,8 +229,6 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 }
 
-// encryptionKeyRotationSupported returns a boolean indicating whether encryption key rotation is supported for the control plane version,
-// and an error if one was encountered.
 func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil {
 		return false, fmt.Errorf("unable to determine encryption key rotation support for nil control plane")
@@ -243,10 +238,6 @@ func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, 
 	if err != nil {
 		return false, fmt.Errorf("unable to parse kubernetes version for encryption key rotation: %s", controlPlane.Spec.KubernetesVersion)
 	}
-	// Older Rancher releases relied on the KDM encryption-key-rotation feature gate because the legacy orchestration
-	// could not be enabled retroactively for all historical versions without risking unrecoverable clusters. Rancher
-	// v2.15 only supports downstream v1.30+ and only uses the newer rotate-keys flow, so the Kubernetes version itself
-	// is the compatibility boundary for this planner path.
 	if kubernetesVersion.LT(encryptionKeyRotationMinimumVersion) {
 		return false, nil
 	}
@@ -254,9 +245,6 @@ func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, 
 	return true, nil
 }
 
-// encryptionKeyRotationShouldSkip returns true when the planner should ignore the current spec/status combination:
-// either the control plane is not ready and rotation is not already in progress, or the requested generation already
-// finished and should not be re-run.
 func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return true
@@ -273,9 +261,6 @@ func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 		(phase == rkev1.RotateEncryptionKeysPhaseDone || phase == rkev1.RotateEncryptionKeysPhaseFailed)
 }
 
-// encryptionKeyRotationShouldStart collapses the phase/generation restart logic for the simplified rotate-keys flow.
-// It returns true when a new reconciliation should initialize the Rotate phase, and returns an error if the current
-// generation is stuck in an unsupported legacy phase.
 func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return false, nil
@@ -288,8 +273,6 @@ func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool
 			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
 			!encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase), nil
 	}
-	// Rancher v2.15 only understands the simplified rotate-keys flow. If we ever see a stale legacy phase for the
-	// generation currently being reconciled, fail it explicitly instead of trying to map it back into the new flow.
 	if encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
 		return false, nil
 	}
@@ -309,10 +292,6 @@ func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bo
 	}
 }
 
-// encryptionKeyRotationFindLeader returns the current encryption rotation leader if it is valid, otherwise, if the
-// phase is "rotate", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
-// (etcd-only), it will elect the first suitable control plane node. If the phase is not in "rotate" and a re-election
-// of the leader is necessary, the phase will be set to failed as this is unexpected.
 func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, initNode *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
 	if machine, ok := clusterPlan.Machines[machineName]; ok {
@@ -342,13 +321,10 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 	return leader, nil
 }
 
-// encryptionKeyRotationIsSuitableControlPlane ensures that a control plane node has not been deleted and has a valid
-// node associated with it.
 func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 	return isControlPlane(entry) && isNotDeleting(entry) && entry.Machine.Status.NodeRef.IsDefined() && capr.Ready.IsTrue(entry.Machine)
 }
 
-// encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit allows us to filter cluster plans to restart healthy follower nodes.
 func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isControlPlaneAndNotInitNode(entry) &&
@@ -356,7 +332,6 @@ func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.
 	}
 }
 
-// encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit allows us to filter cluster plans to restart healthy follower nodes.
 func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isEtcd(entry) && !isControlPlane(entry) &&
@@ -365,9 +340,6 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
-// encryptionKeyRotationRestartTargetsForCluster centralizes the restart topology for split-role clusters.
-// The etcd-only and control-plane restart slices are kept separate because only control-plane nodes can be used as
-// secrets-encrypt status sources during convergence, while etcd-only nodes still need to participate in the restart pass.
 func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
 	targets := encryptionKeyRotationRestartTargets{
 		controlPlane: []*planEntry{leader},
@@ -381,26 +353,18 @@ func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEContro
 		}
 	}
 
-	// Upstream documents restarting the server that ran rotate-keys before the remaining servers. Rancher follows that
-	// ordering after the init node when they are different, so split-role clusters still bring the designated init server
-	// back first and then restart the elected command leader before the rest of the high-availability servers.
 	targets.etcdOnly = append(targets.etcdOnly, collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane))...)
 	targets.controlPlane = append(targets.controlPlane, collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane))...)
 
 	return targets
 }
 
-// encryptionKeyRotationRestartNodes restarts the required server nodes and waits for control plane nodes to converge.
-// Etcd-only nodes are restarted first. Rancher does not use them as local secrets-encrypt status sources during
-// convergence because the local encrypt status handler depends on Runtime.Core, which is not initialized on
-// disable-apiserver servers.
-// Control plane nodes are then restarted in order, with each required to reach the reencrypt_finished stage and the
-// last one also required to report matching hashes.
+// encryptionKeyRotationRestartNodes restarts etcd-only nodes first and then control-plane nodes.
+// Only control-plane nodes are used for local secrets-encrypt status checks during convergence,
+// and the last control-plane node must also report matching hashes before the phase can finish.
 func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, leader *planEntry, initNode *planEntry, joinServer string) (rkev1.RKEControlPlaneStatus, error) {
 	restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
 
-	// Restart etcd-only nodes first. These nodes do not produce usable local status output after restart,
-	// so they only participate in the restart portion of the flow.
 	for _, entry := range restartTargets.etcdOnly {
 		_, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
@@ -409,7 +373,6 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 		status = updatedStatus
 	}
 
-	// Restart control plane nodes in order and verify secrets-encrypt status convergence.
 	for i, entry := range restartTargets.controlPlane {
 		rotationStatus, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
@@ -429,10 +392,6 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 	return status, nil
 }
 
-// encryptionKeyRotationRestartService restarts the server unit on the downstream node, waits until secrets-encrypt
-// status can be successfully queried, and then returns the current runtime status from the periodic status output.
-// For etcd-only nodes (non control plane), the restart is performed but no runtime status is returned. The local
-// secrets-encrypt status endpoint requires Runtime.Core, which is not initialized on disable-apiserver servers.
 func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
 	nodePlan, joinedServer, err := p.encryptionKeyRotationRestartPlan(controlPlane, tokensSecret, joinServer, entry)
 	if err != nil {
@@ -463,9 +422,6 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationRestartPlan creates a restart-only plan. During the high-availability convergence step Rancher no longer runs
-// additional secrets-encrypt subcommands on follower nodes; it only restarts the server unit and resumes observing the
-// periodic secrets-encrypt status that the system-agent reports back in the node plan.
 func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, config, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, entry, joinServer, true)
 	if err != nil {
@@ -500,8 +456,6 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 		encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane),
 	)
 
-	// Only control plane nodes get local status polling. Rancher relies on them for convergence because etcd-only
-	// servers cannot satisfy the local encrypt status endpoint after restart.
 	if isControlPlane(entry) {
 		nodePlan.Files = append(nodePlan.Files, plan.File{
 			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
@@ -528,8 +482,9 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 	return nodePlan, joinedServer, nil
 }
 
-// encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
-// recent periodic secrets-encrypt status observed on that node.
+// encryptionKeyRotationRotateKeysReconcile runs rotate-keys on the elected leader and then trusts
+// periodic secrets-encrypt status as the source of progress. A CLI timeout is treated as ambiguous,
+// so Rancher keeps watching periodic status before deciding whether to wait, retry, or fail.
 func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
 	retryCount := encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader)
 	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, retryCount)
@@ -588,9 +543,6 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	return rotationStatus, status, nil
 }
 
-// encryptionKeyRotationRotateKeysPlan keeps only the rotate-keys command as a one-time instruction and relies on
-// periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
-// preserve one-time status scraping state from an earlier reconcile.
 func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
 	return p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 }
@@ -620,8 +572,8 @@ func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane
 	return nodePlan, joinedServer, nil
 }
 
-// encryptionKeyRotationSecretsEncryptStatusFromPeriodic will attempt to extract the current secrets-encrypt status from the
-// plan by parsing the periodic output.
+// encryptionKeyRotationSecretsEncryptStatusFromPeriodic reads the latest periodic status output from
+// system-agent and converts it into the small runtime state Rancher reconciles on.
 func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
 	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
@@ -646,8 +598,6 @@ func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (enc
 	}
 }
 
-// encryptionKeyRotationStatusFromOutput parses the parts of secrets-encrypt status that Rancher actually reconciles on:
-// the current rotation stage and whether the server hash set has converged.
 func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
 	var status encryptionKeyRotationRuntimeStatus
 
@@ -682,9 +632,6 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 	return status, nil
 }
 
-// encryptionKeyRotationActiveGeneration returns the generation that should be embedded in node plans.
-// Once a rotation has started, the planner must stay pinned to status.RotateEncryptionKeys.Generation until
-// that generation either completes or fails, even if spec has already been bumped to request a later one.
 func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) int64 {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return 0
@@ -800,8 +747,6 @@ func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
 }
 
-// encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
-// the current secrets-encrypt phase.
 func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
 	return encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
 }
@@ -817,8 +762,6 @@ func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *
 		retryCount = 0
 	}
 
-	// SaveOutput on one-time instructions only persists stdout. Wrap the runtime command in `sh -c ... 2>&1` so Rancher
-	// can inspect timeout text from the K3s/RKE2 CLI when the client exits before the background rotation finishes.
 	instruction := idempotentInstruction(
 		controlPlane,
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
@@ -838,8 +781,6 @@ func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *
 	return instruction, nil
 }
 
-// encryptionKeyRotationRotateKeysTimedOut reports whether the saved one-time instruction output matches the
-// expected timeout signature from the K3s or RKE2 secrets-encrypt client.
 func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -849,9 +790,6 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
 }
 
-// encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition intentionally matches the coarse CLI error shape that
-// K3s/RKE2 exposes to Rancher. The CLI does not include the underlying server-side cause, so the planner only retries
-// after separately observing a stable periodic secrets-encrypt status, and the retry count is strictly bounded.
 func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -869,8 +807,6 @@ func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName str
 
 	outputs := entry.Plan.Output
 	if entry.Plan.Failed {
-		// system-agent writes SaveOutput for failed one-time instructions to the failed-output secret key instead of
-		// applied-output, so Rancher has to inspect the corresponding FailedOutput map on failed plans.
 		outputs = entry.Plan.FailedOutput
 	}
 
@@ -910,16 +846,12 @@ func encryptionKeyRotationRotateKeysCanRetry(status encryptionKeyRotationRuntime
 	}
 }
 
-// encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans
-// when the planner advances between the rotate-keys and restart phases. assignAndCheckPlan only reapplies when the
-// desired plan changes, so the planner uses phase/generation env vars to deliberately perturb otherwise identical
-// restart and status instructions across reconciliations.
+// encryptionKeyRotationStatusEnv forces restart and status instructions to rerun as the planner
+// moves through encryption key rotation phases.
 func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_STAGE=%s", controlPlane.Status.RotateEncryptionKeysPhase)
 }
 
-// encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
-// on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationGenerationEnvName, encryptionKeyRotationActiveGeneration(controlPlane))
 }
@@ -986,10 +918,6 @@ func encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane *
 	}
 }
 
-// encryptionKeyRotationWaitForSystemctlStatusInstruction is intended to run after a node is restart, and wait until the
-// node is online and able to provide systemctl status, ensuring that the server service is able to be restarted. If the
-// service never comes active, the plan advances anyway in order to restart the service. If restarting the service
-// fails, then the plan will fail.
 func encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
 	return plan.OneTimeInstruction{
 		CommonInstruction: planapi.CommonInstruction{
@@ -1008,9 +936,6 @@ func encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane *rkev1.
 	}
 }
 
-// encryptionKeyRotationWaitForSecretsEncryptStatus is intended to run after a node is restart, and wait until the node
-// is online and able to provide secrets-encrypt status, ensuring that subsequent status commands from the system-agent
-// will be successful.
 func encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
 	return plan.OneTimeInstruction{
 		CommonInstruction: planapi.CommonInstruction{
@@ -1029,9 +954,6 @@ func encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane *rkev1.RKECon
 	}
 }
 
-// encryptionKeyRotationHandleFailure makes sure the planner leaves the owning CAPI cluster unpaused after an
-// unrecoverable rotation failure. The phase transition to Failed is handled separately so Rancher can persist status
-// and surface the original reconciliation error.
 func (p *Planner) encryptionKeyRotationHandleFailure(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
 	if err == nil || IsErrWaiting(err) || status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseFailed {
 		return status, err
@@ -1043,8 +965,6 @@ func (p *Planner) encryptionKeyRotationHandleFailure(controlPlane *rkev1.RKECont
 	return status, err
 }
 
-// encryptionKeyRotationFailed updates the various status objects on the control plane, allowing the cluster to
-// continue the reconciliation loop. Encryption key rotation will not be restarted again until requested.
 func (p *Planner) encryptionKeyRotationFailed(status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
 	status.RotateEncryptionKeysPhase = rkev1.RotateEncryptionKeysPhaseFailed
 	status.RotateEncryptionKeysLeader = ""

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -85,15 +85,6 @@ type encryptionKeyRotationRuntimeStatus struct {
 	HashesMatch bool
 }
 
-type encryptionKeyRotationRestartTargets struct {
-	etcdOnly     []*planEntry
-	controlPlane []*planEntry
-}
-
-func (restartTargets encryptionKeyRotationRestartTargets) onlyLeaderNeedsRestart() bool {
-	return len(restartTargets.etcdOnly) == 0 && len(restartTargets.controlPlane) == 1
-}
-
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
 	if equality.Semantic.DeepEqual(status.RotateEncryptionKeys, rotate) && equality.Semantic.DeepEqual(status.RotateEncryptionKeysPhase, phase) {
 		return status, nil
@@ -208,8 +199,11 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 			return status, errWaitingf("waiting for encryption key rotation stage to finish on leader [%s]", leader.Machine.Name)
 		}
 
-		restartTargets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
-		if restartTargets.onlyLeaderNeedsRestart() {
+		// Etcd-only nodes still need restart, so their presence means followers must be restarted.
+		etcdOnlyEntries := collect(clusterPlan, IsOnlyEtcd)
+		// Control-plane nodes are the only nodes used for local status/hash convergence checks.
+		controlPlaneEntries := collect(clusterPlan, isControlPlane)
+		if len(etcdOnlyEntries) == 0 && len(controlPlaneEntries) == 1 {
 			// Single-server rotations can finish as soon as the leader reports final
 			// stage and matching hashes because there are no follower servers to restart.
 			if !rotationStatus.HashesMatch {
@@ -336,6 +330,7 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 
 	leader := initNode
 	if !isControlPlane(initNode) {
+		// Etcd-only init nodes cannot report local API status, so elect a control-plane node.
 		machines := collect(clusterPlan, encryptionKeyRotationIsSuitableControlPlane)
 		if len(machines) == 0 {
 			return nil, fmt.Errorf("no suitable control plane nodes for encryption key rotation")
@@ -352,23 +347,12 @@ func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 	return isControlPlane(entry) && isNotDeleting(entry) && entry.Machine.Status.NodeRef.IsDefined() && capr.Ready.IsTrue(entry.Machine)
 }
 
-// encryptionKeyRotationRestartTargetsForCluster groups nodes for the restart phase.
-// Etcd-only nodes are restarted first but are not used for local status/hash checks.
-// Control-plane nodes are restarted after that and are used for convergence checks.
-func encryptionKeyRotationRestartTargetsForCluster(clusterPlan *plan.Plan) encryptionKeyRotationRestartTargets {
-	return encryptionKeyRotationRestartTargets{
-		etcdOnly:     collect(clusterPlan, IsOnlyEtcd),
-		controlPlane: collect(clusterPlan, isControlPlane),
-	}
-}
-
 // encryptionKeyRotationRestartNodes restarts etcd-only nodes first and then control-plane nodes.
 // Only control-plane nodes are used for local secrets-encrypt status checks during convergence,
 // and the last control-plane node must also report matching hashes before the phase can finish.
 func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, joinServer string) (rkev1.RKEControlPlaneStatus, error) {
-	restartTargets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
-
-	for _, entry := range restartTargets.etcdOnly {
+	// Etcd-only nodes are restarted first, but are not used for local convergence checks.
+	for _, entry := range collect(clusterPlan, IsOnlyEtcd) {
 		_, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
 			return updatedStatus, err
@@ -376,7 +360,9 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 		status = updatedStatus
 	}
 
-	for i, entry := range restartTargets.controlPlane {
+	// Control-plane nodes are restarted after etcd-only nodes and provide status/hash convergence.
+	controlPlaneEntries := collect(clusterPlan, isControlPlane)
+	for i, entry := range controlPlaneEntries {
 		rotationStatus, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
 			return updatedStatus, err
@@ -387,7 +373,7 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 			return status, errWaitingf("waiting for encryption key rotation stage to finish on machine [%s]", entry.Machine.Name)
 		}
 
-		if i == len(restartTargets.controlPlane)-1 && !rotationStatus.HashesMatch {
+		if i == len(controlPlaneEntries)-1 && !rotationStatus.HashesMatch {
 			return status, errWaitingf("waiting for encryption key rotation hashes to converge on machine [%s]", entry.Machine.Name)
 		}
 	}

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -365,9 +365,10 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
-// encryptionKeyRotationRestartTargetsForCluster builds the ordered restart groups for
-// the current cluster topology. Etcd-only nodes are restarted first. Control-plane nodes
-// are restarted after that and are the nodes Rancher uses for local status convergence.
+// encryptionKeyRotationRestartTargetsForCluster groups the nodes for the restart phase.
+// Etcd-only nodes are grouped first because Rancher does not use them for local
+// secrets-encrypt convergence checks. Control-plane nodes are grouped after that
+// for convergence checks.
 func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
 	targets := encryptionKeyRotationRestartTargets{
 		controlPlane: []*planEntry{leader},
@@ -375,7 +376,7 @@ func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEContro
 
 	if initNode != nil && !isInitNode(leader) {
 		if isControlPlane(initNode) {
-			targets.controlPlane = append([]*planEntry{initNode}, targets.controlPlane...)
+			targets.controlPlane = append(targets.controlPlane, initNode)
 		} else if isEtcd(initNode) {
 			targets.etcdOnly = append(targets.etcdOnly, initNode)
 		}

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -543,10 +543,6 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	return rotationStatus, status, nil
 }
 
-func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
-	return p.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, tokensSecret, joinServer, leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
-}
-
 func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, retryCount int) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
@@ -745,10 +741,6 @@ func encryptionKeyRotationRotateKeysCanRetryAgain(retryCount int) bool {
 
 func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
-}
-
-func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEControlPlane) (plan.OneTimeInstruction, error) {
-	return encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
 }
 
 func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *rkev1.RKEControlPlane, retryCount int) (plan.OneTimeInstruction, error) {

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -229,6 +229,8 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 }
 
+// encryptionKeyRotationSupported returns true when the downstream kubernetes version
+// is new enough to use the upstream rotate-keys flow.
 func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil {
 		return false, fmt.Errorf("unable to determine encryption key rotation support for nil control plane")
@@ -245,6 +247,10 @@ func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, 
 	return true, nil
 }
 
+// encryptionKeyRotationShouldSkip returns true when there is nothing to reconcile for
+// encryption key rotation. Once a generation is already in progress, Rancher keeps
+// reconciling even if the control plane is temporarily not Ready so it can finish or
+// unwind the in-flight rotation instead of abandoning it mid-flow.
 func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return true
@@ -261,6 +267,10 @@ func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
 		(phase == rkev1.RotateEncryptionKeysPhaseDone || phase == rkev1.RotateEncryptionKeysPhaseFailed)
 }
 
+// encryptionKeyRotationShouldStart returns true when Rancher should start or restart
+// the current requested generation. Unknown phases are treated as stale state and are
+// restarted instead of surfaced as hard errors so upgrades can recover older planner
+// state by beginning the current generation again.
 func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool, error) {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return false, nil
@@ -268,17 +278,19 @@ func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool
 	if controlPlane.Status.RotateEncryptionKeys == nil || controlPlane.Status.RotateEncryptionKeysPhase == "" {
 		return true, nil
 	}
+	if !encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
+		return true, nil
+	}
 	if controlPlane.Spec.RotateEncryptionKeys.Generation != controlPlane.Status.RotateEncryptionKeys.Generation {
 		return controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone ||
-			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
-			!encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase), nil
+			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed, nil
 	}
-	if encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
-		return false, nil
-	}
-	return false, fmt.Errorf("unsupported encryption key rotation phase [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
+
+	return false, nil
 }
 
+// encryptionKeyRotationPhaseIsKnown reports whether the phase belongs to the
+// simplified rotate-keys state machine implemented in this planner.
 func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bool {
 	switch phase {
 	case "",
@@ -292,6 +304,8 @@ func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bo
 	}
 }
 
+// encryptionKeyRotationFindLeader reuses the stored leader when it is still valid.
+// During the rotate phase, it elects a new suitable control-plane leader when needed.
 func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, initNode *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
 	if machine, ok := clusterPlan.Machines[machineName]; ok {
@@ -321,10 +335,14 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 	return leader, nil
 }
 
+// encryptionKeyRotationIsSuitableControlPlane returns true for control-plane entries
+// that are present, not deleting, Ready, and already joined to the cluster.
 func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 	return isControlPlane(entry) && isNotDeleting(entry) && entry.Machine.Status.NodeRef.IsDefined() && capr.Ready.IsTrue(entry.Machine)
 }
 
+// encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit selects follower control-plane
+// machines that should be restarted after the leader rotation finishes.
 func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isControlPlaneAndNotInitNode(entry) &&
@@ -332,6 +350,8 @@ func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.
 	}
 }
 
+// encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit selects etcd-only
+// followers that should restart before control-plane nodes during post-rotate restart.
 func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isEtcd(entry) && !isControlPlane(entry) &&
@@ -340,6 +360,9 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
+// encryptionKeyRotationRestartTargetsForCluster builds the ordered restart groups for
+// the current cluster topology. Etcd-only nodes are restarted first. Control-plane nodes
+// are restarted after that and are the nodes Rancher uses for local status convergence.
 func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
 	targets := encryptionKeyRotationRestartTargets{
 		controlPlane: []*planEntry{leader},
@@ -348,7 +371,7 @@ func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEContro
 	if initNode != nil && !isInitNode(leader) {
 		if isControlPlane(initNode) {
 			targets.controlPlane = append([]*planEntry{initNode}, targets.controlPlane...)
-		} else {
+		} else if isEtcd(initNode) {
 			targets.etcdOnly = append(targets.etcdOnly, initNode)
 		}
 	}
@@ -392,6 +415,8 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 	return status, nil
 }
 
+// encryptionKeyRotationRestartService applies the restart plan for one node and, for
+// control-plane nodes, returns the local secrets-encrypt status observed after restart.
 func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
 	nodePlan, joinedServer, err := p.encryptionKeyRotationRestartPlan(controlPlane, tokensSecret, joinServer, entry)
 	if err != nil {
@@ -422,6 +447,8 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 	return rotationStatus, status, nil
 }
 
+// encryptionKeyRotationRestartPlan builds the post-rotate restart plan for a single node.
+// Control-plane nodes also get the local secrets-encrypt status checks used for convergence.
 func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, config, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, entry, joinServer, true)
 	if err != nil {
@@ -495,7 +522,7 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	if encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leader, nodePlan.Instructions[0].Name) {
 		rotationStatus, periodicStatusErr := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
 		if periodicStatusErr != nil {
-			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after retryable rotate-keys failure on leader [%s]", leader.Machine.Name)
+			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after retryable rotate-keys failure on leader [%s]: %v", leader.Machine.Name, periodicStatusErr)
 		}
 		if !encryptionKeyRotationRotateKeysCanRetry(rotationStatus) {
 			logrus.Warnf("[planner] rkecluster %s/%s: rotate-keys command on leader [%s] failed with a retryable precondition and current periodic status is stage [%s] with hashesMatch=%t; waiting to retry", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Machine.Name, rotationStatus.Stage, rotationStatus.HashesMatch)
@@ -543,6 +570,9 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 	return rotationStatus, status, nil
 }
 
+// encryptionKeyRotationRotateKeysPlanWithRetryCount builds the leader plan for one
+// rotate-keys attempt. The retry count is encoded into the one-time instruction so
+// the planner can intentionally reissue the command when needed.
 func (p *Planner) encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry, retryCount int) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
@@ -586,15 +616,17 @@ func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (enc
 
 	switch {
 	case stdout != "" && stderr != "":
-		return encryptionKeyRotationStatusFromOutput(plan, stdout+"\n"+stderr)
+		return encryptionKeyRotationStatusFromOutput(stdout + "\n" + stderr)
 	case stdout != "":
-		return encryptionKeyRotationStatusFromOutput(plan, stdout)
+		return encryptionKeyRotationStatusFromOutput(stdout)
 	default:
-		return encryptionKeyRotationStatusFromOutput(plan, stderr)
+		return encryptionKeyRotationStatusFromOutput(stderr)
 	}
 }
 
-func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
+// encryptionKeyRotationStatusFromOutput parses the human-readable secrets-encrypt status
+// output into the small state used by planner reconciliation.
+func encryptionKeyRotationStatusFromOutput(output string) (encryptionKeyRotationRuntimeStatus, error) {
 	var status encryptionKeyRotationRuntimeStatus
 
 	if encryptionKeyRotationCommandTimedOut(output, encryptionKeyRotationStatusTimeoutEndpoint) {
@@ -628,6 +660,8 @@ func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encr
 	return status, nil
 }
 
+// encryptionKeyRotationActiveGeneration returns the generation Rancher should pin into
+// node plans. In-progress phases keep using the status generation until they finish.
 func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) int64 {
 	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
 		return 0
@@ -643,10 +677,14 @@ func encryptionKeyRotationActiveGeneration(controlPlane *rkev1.RKEControlPlane) 
 	return controlPlane.Spec.RotateEncryptionKeys.Generation
 }
 
+// encryptionKeyRotationRotateKeysInstructionValue is the idempotency value for the
+// rotate-keys instruction and changes when generation or retry count changes.
 func encryptionKeyRotationRotateKeysInstructionValue(controlPlane *rkev1.RKEControlPlane, retryCount int) string {
 	return fmt.Sprintf("%d-retry-%d", encryptionKeyRotationActiveGeneration(controlPlane), retryCount)
 }
 
+// encryptionKeyRotationRotateKeysRetryCount restores the persisted retry count for the
+// active generation from the current leader plan.
 func encryptionKeyRotationRotateKeysRetryCount(controlPlane *rkev1.RKEControlPlane, leader *planEntry) int {
 	activeGeneration := encryptionKeyRotationActiveGeneration(controlPlane)
 	plannedGeneration, retryCount, ok := encryptionKeyRotationRotateKeysRetryCountFromPlan(leader)
@@ -657,6 +695,8 @@ func encryptionKeyRotationRotateKeysRetryCount(controlPlane *rkev1.RKEControlPla
 	return 0
 }
 
+// encryptionKeyRotationRotateKeysRetryCountFromPlan reads generation and retry count
+// from the rotate-keys instruction env vars in the current node plan.
 func encryptionKeyRotationRotateKeysRetryCountFromPlan(entry *planEntry) (int64, int, bool) {
 	if entry == nil || entry.Plan == nil {
 		return 0, 0, false
@@ -709,6 +749,8 @@ func encryptionKeyRotationRotateKeysRetryCountFromPlan(entry *planEntry) (int64,
 	return 0, 0, false
 }
 
+// encryptionKeyRotationLegacyRetryCount parses the previous attempt format so in-flight
+// plans written by older code can still resume after upgrade.
 func encryptionKeyRotationLegacyRetryCount(attempt string) (int64, int, bool) {
 	if attempt == "" {
 		return 0, 0, false
@@ -731,18 +773,25 @@ func encryptionKeyRotationLegacyRetryCount(attempt string) (int64, int, bool) {
 	return generation, retryCount, true
 }
 
+// encryptionKeyRotationNextRotateKeysRetryCount returns the next bounded retry index.
 func encryptionKeyRotationNextRotateKeysRetryCount(retryCount int) int {
 	return retryCount + 1
 }
 
+// encryptionKeyRotationRotateKeysCanRetryAgain reports whether the current retry count
+// is still below the planner retry budget.
 func encryptionKeyRotationRotateKeysCanRetryAgain(retryCount int) bool {
 	return retryCount < encryptionKeyRotationMaxRotateKeysRetries
 }
 
+// encryptionKeyRotationRotateKeysRetryCountEnv formats the retry count env var stored
+// on the rotate-keys one-time instruction.
 func encryptionKeyRotationRotateKeysRetryCountEnv(retryCount int) string {
 	return fmt.Sprintf("%s=%d", encryptionKeyRotationRetryCountEnv, retryCount)
 }
 
+// encryptionKeyRotationSecretsEncryptInstructionWithRetryCount builds the one-time
+// rotate-keys instruction for the active generation and retry count.
 func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *rkev1.RKEControlPlane, retryCount int) (plan.OneTimeInstruction, error) {
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("control plane cannot be nil")
@@ -773,6 +822,8 @@ func encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane *
 	return instruction, nil
 }
 
+// encryptionKeyRotationRotateKeysTimedOut reports whether the saved rotate-keys output
+// matches a known CLI timeout on the upstream /encrypt/config endpoint.
 func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -782,6 +833,9 @@ func encryptionKeyRotationRotateKeysTimedOut(entry *planEntry, instructionName s
 	return encryptionKeyRotationCommandTimedOut(message, encryptionKeyRotationRotateKeysTimeoutEndpoint)
 }
 
+// encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition reports the coarse
+// upstream error shape that Rancher retries after status stabilizes, for example:
+// `time="..." level=fatal msg="Error: see server log for details: secret-encrypt error ID 78467"`
 func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planEntry, instructionName string) bool {
 	message, ok := encryptionKeyRotationRotateKeysOutput(entry, instructionName)
 	if !ok {
@@ -792,6 +846,8 @@ func encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(entry *planE
 		strings.Contains(message, encryptionKeyRotationRotateKeysErrorIDMessage)
 }
 
+// encryptionKeyRotationRotateKeysOutput returns the saved one-time output for the given
+// rotate-keys instruction, using failed output when the node plan is marked failed.
 func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName string) (string, bool) {
 	if entry == nil || entry.Plan == nil || instructionName == "" {
 		return "", false
@@ -810,6 +866,9 @@ func encryptionKeyRotationRotateKeysOutput(entry *planEntry, instructionName str
 	return string(output), true
 }
 
+// encryptionKeyRotationCommandTimedOut matches the timeout signatures Rancher has seen
+// from secrets-encrypt CLI calls, for example:
+// `time="..." level=fatal msg="Error: see server log for details: Put \"https://127.0.0.1:9345/v1-rke2/encrypt/config\": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)"`
 func encryptionKeyRotationCommandTimedOut(message, endpoint string) bool {
 	if message == "" || endpoint == "" {
 		return false
@@ -825,6 +884,8 @@ func encryptionKeyRotationCommandTimedOut(message, endpoint string) bool {
 	return false
 }
 
+// encryptionKeyRotationRotateKeysCanRetry only allows retries from stable upstream
+// states where hashes already converged.
 func encryptionKeyRotationRotateKeysCanRetry(status encryptionKeyRotationRuntimeStatus) bool {
 	if !status.HashesMatch {
 		return false

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -90,8 +90,8 @@ type encryptionKeyRotationRestartTargets struct {
 	controlPlane []*planEntry
 }
 
-func (restartTargets encryptionKeyRotationRestartTargets) count() int {
-	return len(restartTargets.etcdOnly) + len(restartTargets.controlPlane)
+func (restartTargets encryptionKeyRotationRestartTargets) onlyLeaderNeedsRestart() bool {
+	return len(restartTargets.etcdOnly) == 0 && len(restartTargets.controlPlane) == 1
 }
 
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
@@ -121,6 +121,8 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return status, fmt.Errorf("cannot pass nil parameters to rotateEncryptionKeys")
 	}
 
+	// If the spec was cleared, undo any rotation-owned pause/status before the main
+	// planner resumes normal reconciliation.
 	if controlPlane.Spec.RotateEncryptionKeys == nil {
 		if status.RotateEncryptionKeys != nil || status.RotateEncryptionKeysPhase != "" || status.RotateEncryptionKeysLeader != "" {
 			if err := p.pauseCAPICluster(controlPlane, false); err != nil {
@@ -130,6 +132,8 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.resetEncryptionKeyRotateState(status)
 	}
 
+	// Gate the flow before touching plans. Unsupported versions are marked failed so
+	// the requested generation does not keep requeueing forever.
 	if supported, err := encryptionKeyRotationSupported(controlPlane); err != nil {
 		status, err = p.encryptionKeyRotationFailed(status, err)
 		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
@@ -146,6 +150,8 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return status, nil
 	}
 
+	// rotate-keys needs an initialized server and a valid join URL because the same
+	// plan generation may later restart other server nodes.
 	if !ptr.Deref(status.Initialization.ControlPlaneInitialized, false) {
 		// cluster is not yet initialized, so return nil for now.
 		logrus.Warnf("[planner] rkecluster %s/%s: skipping encryption key rotation as cluster was not initialized", controlPlane.Namespace, controlPlane.Name)
@@ -162,11 +168,15 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return status, nil
 	}
 
+	// Starting a generation is a status transition only. The next reconcile elects
+	// the leader and writes the rotate-keys plan using the stored generation.
 	if encryptionKeyRotationShouldStart(controlPlane) {
 		logrus.Debugf("[planner] rkecluster %s/%s: starting/restarting encryption key rotation", controlPlane.Namespace, controlPlane.Name)
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
 	}
 
+	// Keep the same leader once chosen so requeues keep observing the same
+	// rotate-keys command output instead of moving the operation between servers.
 	leader, err := p.encryptionKeyRotationFindLeader(status, clusterPlan, initNode)
 	if err != nil {
 		status, err = p.encryptionKeyRotationFailed(status, err)
@@ -182,10 +192,14 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 
 	switch controlPlane.Status.RotateEncryptionKeysPhase {
 	case rkev1.RotateEncryptionKeysPhaseRotate:
+		// Pause CAPI while rotate-keys is active so unrelated rollout activity does
+		// not race with the encryption-key rotation plan.
 		if err := p.pauseCAPICluster(controlPlane, true); err != nil {
 			return status, errWaiting("pausing CAPI cluster")
 		}
 
+		// rotate-keys is the upstream combined flow. It may finish the reencrypt work
+		// after the CLI times out, so progress is decided from periodic status output.
 		rotationStatus, status, err := p.encryptionKeyRotationRotateKeysReconcile(controlPlane, status, tokensSecret, joinServer, leader)
 		if err != nil {
 			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
@@ -195,7 +209,9 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		}
 
 		restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
-		if restartTargets.count() == 1 {
+		if restartTargets.onlyLeaderNeedsRestart() {
+			// Single-server rotations can finish as soon as the leader reports final
+			// stage and matching hashes because there are no follower servers to restart.
 			if !rotationStatus.HashesMatch {
 				return status, errWaitingf("waiting for encryption key rotation hashes to converge on leader [%s]", leader.Machine.Name)
 			}
@@ -208,6 +224,8 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostRotateRestart)
 	case rkev1.RotateEncryptionKeysPhasePostRotateRestart:
+		// Multi-server rotations finish by restarting all remaining server nodes in
+		// topology order and checking convergence on control-plane nodes.
 		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
 		if err != nil {
 			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -357,9 +357,7 @@ func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 // Control-plane nodes are restarted after that and are used for convergence checks.
 func encryptionKeyRotationRestartTargetsForCluster(clusterPlan *plan.Plan) encryptionKeyRotationRestartTargets {
 	return encryptionKeyRotationRestartTargets{
-		etcdOnly: collect(clusterPlan, func(entry *planEntry) bool {
-			return isEtcd(entry) && !isControlPlane(entry)
-		}),
+		etcdOnly:     collect(clusterPlan, IsOnlyEtcd),
 		controlPlane: collect(clusterPlan, isControlPlane),
 	}
 }
@@ -413,7 +411,7 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 			}
 			return encryptionKeyRotationRuntimeStatus{}, status, err
 		}
-		status, err = p.encryptionKeyRotationFailed(status, err)
+		status, err = p.encryptionKeyRotationFailedRequiringEtcdRestore(status, err)
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
 
@@ -477,6 +475,8 @@ func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEContro
 			},
 			encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction(controlPlane),
 		)
+		// The wait instruction gates command availability after restart. Periodic
+		// status is kept as the convergence source while the planner requeues.
 		nodePlan.PeriodicInstructions = []plan.PeriodicInstruction{
 			encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane),
 		}
@@ -516,7 +516,7 @@ func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.R
 			}
 			return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("waiting for encryption key rotation status after rotate-keys timeout on leader [%s]: %v", leader.Machine.Name, err)
 		}
-		status, err = p.encryptionKeyRotationFailed(status, err)
+		status, err = p.encryptionKeyRotationFailedRequiringEtcdRestore(status, err)
 		return encryptionKeyRotationRuntimeStatus{}, status, err
 	}
 
@@ -602,9 +602,11 @@ func encryptionKeyRotationStatusFromOutput(output string) (encryptionKeyRotation
 	}
 
 	if status.Stage == "" {
+		logrus.Debugf("[planner] unable to parse encryption key rotation stage from secrets-encrypt status output: %q", output)
 		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("unable to parse rotation stage from output")
 	}
 	if !strings.Contains(output, "Server Encryption Hashes:") {
+		logrus.Debugf("[planner] unable to parse encryption key rotation hashes from secrets-encrypt status output: %q", output)
 		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("unable to parse rotation hashes from output")
 	}
 
@@ -783,6 +785,8 @@ func encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane *
 	}
 }
 
+// encryptionKeyRotationWaitForSystemctlStatusInstruction waits for the node to
+// come back after restart and respond to systemctl status before continuing.
 func encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
 	return plan.OneTimeInstruction{
 		CommonInstruction: planapi.CommonInstruction{
@@ -801,6 +805,9 @@ func encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane *rkev1.
 	}
 }
 
+// encryptionKeyRotationWaitForSecretsEncryptStatus waits for a restarted
+// control-plane node to respond to secrets-encrypt status before periodic status
+// output is used for convergence checks.
 func encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
 	return plan.OneTimeInstruction{
 		CommonInstruction: planapi.CommonInstruction{
@@ -830,10 +837,23 @@ func (p *Planner) encryptionKeyRotationHandleFailure(controlPlane *rkev1.RKECont
 	return status, err
 }
 
+// encryptionKeyRotationFailed marks the rotation failed and clears the stored
+// leader for failures that do not imply downstream encryption state changed.
 func (p *Planner) encryptionKeyRotationFailed(status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
+	return p.encryptionKeyRotationFailedWithMessage(status, err, "encryption key rotation failed")
+}
+
+// encryptionKeyRotationFailedRequiringEtcdRestore marks the rotation failed for
+// errors that happen while running rotate-keys or after it may have changed
+// downstream encryption state.
+func (p *Planner) encryptionKeyRotationFailedRequiringEtcdRestore(status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
+	return p.encryptionKeyRotationFailedWithMessage(status, err, "encryption key rotation failed, please perform an etcd restore")
+}
+
+func (p *Planner) encryptionKeyRotationFailedWithMessage(status rkev1.RKEControlPlaneStatus, err error, message string) (rkev1.RKEControlPlaneStatus, error) {
 	status.RotateEncryptionKeysPhase = rkev1.RotateEncryptionKeysPhaseFailed
 	status.RotateEncryptionKeysLeader = ""
-	return status, errors.Wrap(err, "encryption key rotation failed")
+	return status, errors.Wrap(err, message)
 }
 
 func encryptionKeyRotationScriptPath(controlPlane *rkev1.RKEControlPlane, file string) string {

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
-	"github.com/rancher/channelserver/pkg/model"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/capr"
@@ -20,13 +19,13 @@ import (
 )
 
 const (
-	encryptionKeyRotationStageReencryptRequest  = "reencrypt_request"
-	encryptionKeyRotationStageReencryptActive   = "reencrypt_active"
+	// start is the pre-rotation steady state reported by current K3s/RKE2 status output. Rancher does not branch on it
+	// directly, but keeping it named documents the expected intermediate state we wait through before convergence.
+	encryptionKeyRotationStageStart             = "start"
 	encryptionKeyRotationStageReencryptFinished = "reencrypt_finished"
+	encryptionKeyRotationHashesMatch            = "All hashes match"
 
-	encryptionKeyRotationCommandPrepare   = "prepare"
-	encryptionKeyRotationCommandRotate    = "rotate"
-	encryptionKeyRotationCommandReencrypt = "reencrypt"
+	encryptionKeyRotationCommandRotateKeys = "rotate-keys"
 
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
 
@@ -34,7 +33,6 @@ const (
 
 	encryptionKeyRotationWaitForSystemctlStatusPath      = "wait_for_systemctl_status.sh"
 	encryptionKeyRotationWaitForSecretsEncryptStatusPath = "wait_for_secrets_encrypt_status.sh"
-	encryptionKeyRotationSecretsEncryptStatusPath        = "secrets_encrypt_status.sh"
 
 	encryptionKeyRotationWaitForSystemctlStatus = `
 #!/bin/sh
@@ -61,31 +59,7 @@ i=0
 while [ $i -lt 10 ]; do
 	$runtime secrets-encrypt status
 	if [ $? -eq 0 ]; then
-			exit 0
-	fi
-	sleep 10
-	i=$((i + 1))
-done
-exit 1
-`
-
-	encryptionKeyRotationSecretsEncryptStatusScript = `
-#!/bin/sh
-
-runtime=$1
-i=0
-
-while [ $i -lt 10 ]; do
-	output="$($runtime secrets-encrypt status)"
-	if [ $? -eq 0 ]; then
-		if [ -n "$2" ]; then
-			echo $output | grep -q "$2"
-				if [ $? -eq 0 ]; then
-					exit 0
-				fi
-		else
-			exit 0
-		fi
+		exit 0
 	fi
 	sleep 10
 	i=$((i + 1))
@@ -95,6 +69,22 @@ exit 1
 
 	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
 )
+
+var encryptionKeyRotationMinimumVersion = semver.Version{Major: 1, Minor: 30}
+
+type encryptionKeyRotationRuntimeStatus struct {
+	Stage       string
+	HashesMatch bool
+}
+
+type encryptionKeyRotationRestartTargets struct {
+	etcdOnly     []*planEntry
+	controlPlane []*planEntry
+}
+
+func (r encryptionKeyRotationRestartTargets) count() int {
+	return len(r.etcdOnly) + len(r.controlPlane)
+}
 
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
 	if equality.Semantic.DeepEqual(status.RotateEncryptionKeys, rotate) && equality.Semantic.DeepEqual(status.RotateEncryptionKeysPhase, phase) {
@@ -106,16 +96,19 @@ func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus
 }
 
 func (p *Planner) resetEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
-	if status.RotateEncryptionKeys == nil && status.RotateEncryptionKeysPhase == "" {
+	if status.RotateEncryptionKeys == nil && status.RotateEncryptionKeysPhase == "" && status.RotateEncryptionKeysLeader == "" {
 		return status, nil
 	}
-	return p.setEncryptionKeyRotateState(status, nil, "")
+	status.RotateEncryptionKeys = nil
+	status.RotateEncryptionKeysPhase = ""
+	status.RotateEncryptionKeysLeader = ""
+	return status, errWaiting("refreshing encryption key rotation state")
 }
 
 // rotateEncryptionKeys first verifies that the control plane is in a state where the next step can be derived. If encryption key rotation is required, the corresponding phase and status fields will be set.
 // The function is expected to be called multiple times throughout encryption key rotation, and will set the next corresponding phase based on previous output.
-func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, releaseData *model.Release) (rkev1.RKEControlPlaneStatus, error) {
-	if controlPlane == nil || releaseData == nil || clusterPlan == nil {
+func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, error) {
+	if controlPlane == nil || clusterPlan == nil {
 		return status, fmt.Errorf("cannot pass nil parameters to rotateEncryptionKeys")
 	}
 
@@ -123,14 +116,19 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.resetEncryptionKeyRotateState(status)
 	}
 
-	if supported, err := encryptionKeyRotationSupported(releaseData); err != nil {
-		return status, err
+	if supported, err := encryptionKeyRotationSupported(controlPlane); err != nil {
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 	} else if !supported {
 		logrus.Debugf("rkecluster %s/%s: marking encryption key rotation phase as failed as it was not supported by version: %s", controlPlane.Namespace, controlPlane.Name, controlPlane.Spec.KubernetesVersion)
+		if err := p.pauseCAPICluster(controlPlane, false); err != nil {
+			return status, errWaiting("unpausing CAPI cluster")
+		}
+		status.RotateEncryptionKeysLeader = ""
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseFailed)
 	}
 
-	if !canRotateEncryptionKeys(controlPlane) {
+	if encryptionKeyRotationShouldSkip(controlPlane) {
 		return status, nil
 	}
 
@@ -150,14 +148,23 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return status, nil
 	}
 
-	if shouldRestartEncryptionKeyRotation(controlPlane) {
-		logrus.Debugf("[planner] rkecluster %s/%s: starting/restarting encryption key rotation", controlPlane.Namespace, controlPlane.Name)
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePrepare)
+	shouldStart, err := encryptionKeyRotationShouldStart(controlPlane)
+	if err != nil {
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 	}
 
+	if shouldStart {
+		logrus.Debugf("[planner] rkecluster %s/%s: starting/restarting encryption key rotation", controlPlane.Namespace, controlPlane.Name)
+		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
+	}
+
+	// The stored leader is part of Rancher's idempotency contract. rotate-keys must only be launched from one server,
+	// and once it has been chosen we keep reconciling through that server until the generation either finishes or fails.
 	leader, err := p.encryptionKeyRotationFindLeader(status, clusterPlan, initNode)
 	if err != nil {
-		return status, err
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 	}
 
 	if status.RotateEncryptionKeysLeader != leader.Machine.Name {
@@ -168,43 +175,36 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 	logrus.Debugf("[planner] rkecluster %s/%s: current encryption key rotation phase: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, controlPlane.Status.RotateEncryptionKeysPhase)
 
 	switch controlPlane.Status.RotateEncryptionKeysPhase {
-	case rkev1.RotateEncryptionKeysPhasePrepare:
+	case rkev1.RotateEncryptionKeysPhaseRotate:
 		if err := p.pauseCAPICluster(controlPlane, true); err != nil {
 			return status, errWaiting("pausing CAPI cluster")
 		}
-		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(controlPlane, status, tokensSecret, joinServer, leader)
+
+		rotationStatus, status, err := p.encryptionKeyRotationRotateKeysReconcile(controlPlane, status, tokensSecret, joinServer, leader)
 		if err != nil {
-			return status, err
+			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostPrepareRestart)
-	case rkev1.RotateEncryptionKeysPhasePostPrepareRestart:
-		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
-		if err != nil {
-			return status, err
+		if rotationStatus.Stage != encryptionKeyRotationStageReencryptFinished {
+			return status, errWaitingf("waiting for encryption key rotation stage to finish on leader [%s]", leader.Machine.Name)
 		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
-	case rkev1.RotateEncryptionKeysPhaseRotate:
-		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(controlPlane, status, tokensSecret, joinServer, leader)
-		if err != nil {
-			return status, err
+
+		restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
+		if restartTargets.count() == 1 {
+			if !rotationStatus.HashesMatch {
+				return status, errWaitingf("waiting for encryption key rotation hashes to converge on leader [%s]", leader.Machine.Name)
+			}
+			if err := p.pauseCAPICluster(controlPlane, false); err != nil {
+				return status, errWaiting("unpausing CAPI cluster")
+			}
+			status.RotateEncryptionKeysLeader = ""
+			return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseDone)
 		}
+
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostRotateRestart)
 	case rkev1.RotateEncryptionKeysPhasePostRotateRestart:
 		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
 		if err != nil {
-			return status, err
-		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseReencrypt)
-	case rkev1.RotateEncryptionKeysPhaseReencrypt:
-		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(controlPlane, status, tokensSecret, joinServer, leader)
-		if err != nil {
-			return status, err
-		}
-		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostReencryptRestart)
-	case rkev1.RotateEncryptionKeysPhasePostReencryptRestart:
-		status, err = p.encryptionKeyRotationRestartNodes(controlPlane, status, tokensSecret, clusterPlan, leader, initNode, joinServer)
-		if err != nil {
-			return status, err
+			return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 		}
 		if err = p.pauseCAPICluster(controlPlane, false); err != nil {
 			return status, errWaiting("unpausing CAPI cluster")
@@ -213,84 +213,90 @@ func (p *Planner) rotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane, stat
 		return p.setEncryptionKeyRotateState(status, controlPlane.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseDone)
 	}
 
-	return status, fmt.Errorf("encountered unknown encryption key rotation phase: %s", controlPlane.Status.RotateEncryptionKeysPhase)
+	status, err = p.encryptionKeyRotationFailed(status, fmt.Errorf("encountered unknown encryption key rotation phase: %s", controlPlane.Status.RotateEncryptionKeysPhase))
+	return p.encryptionKeyRotationHandleFailure(controlPlane, status, err)
 }
 
-// encryptionKeyRotationSupported returns a boolean indicating whether encryption key rotation is supported by the release,
+// encryptionKeyRotationSupported returns a boolean indicating whether encryption key rotation is supported for the control plane version,
 // and an error if one was encountered.
-func encryptionKeyRotationSupported(releaseData *model.Release) (bool, error) {
-	if releaseData == nil {
-		return false, fmt.Errorf("unable to find KDM release data for encryption key rotation support in release")
+func encryptionKeyRotationSupported(controlPlane *rkev1.RKEControlPlane) (bool, error) {
+	if controlPlane == nil {
+		return false, fmt.Errorf("unable to determine encryption key rotation support for nil controlplane")
 	}
-	if featureVersion, ok := releaseData.FeatureVersions["encryption-key-rotation"]; ok {
-		version, err := semver.Make(featureVersion)
-		if err != nil {
-			return false, fmt.Errorf("unable to parse semver version for encryption key rotation: %s", featureVersion)
-		}
-		// v2.6.4 - v2.6.6 are looking for 1.x.x, but encryption key rotation does not work in those versions. Rather than
-		// enable it retroactively, those versions will not be able to rotate encryption keys since some cluster
-		// configurations can break in such a way that they become unrecoverable. Additionally, we want to be careful
-		// updating the encryption-key-rotation feature gate in KDM in the future, so as not to break backwards
-		// compatibility for existing clusters.
-		if version.Major == 2 {
-			return true, nil
-		}
+
+	kubernetesVersion, err := semver.Make(strings.TrimPrefix(controlPlane.Spec.KubernetesVersion, "v"))
+	if err != nil {
+		return false, fmt.Errorf("unable to parse kubernetes version for encryption key rotation: %s", controlPlane.Spec.KubernetesVersion)
 	}
-	return false, nil
+	// Older Rancher releases relied on the KDM encryption-key-rotation feature gate because the legacy orchestration
+	// could not be enabled retroactively for all historical versions without risking unrecoverable clusters. Rancher
+	// v2.15 only supports downstream v1.30+ and only uses the newer rotate-keys flow, so the Kubernetes version itself
+	// is the compatibility boundary for this planner path.
+	if kubernetesVersion.LT(encryptionKeyRotationMinimumVersion) {
+		return false, nil
+	}
+
+	return true, nil
 }
 
-// canRotateEncryptionKeys returns false if the controlplane does not have a Ready: True condition and encryption key rotation is not already in progress, if the spec for
-// encryption key rotation is nil, or if the spec has been reconciled but the phase is done or failed.
-func canRotateEncryptionKeys(controlPlane *rkev1.RKEControlPlane) bool {
-	if (!capr.Ready.IsTrue(controlPlane) && !rotateEncryptionKeyInProgress(controlPlane)) ||
-		controlPlane.Spec.RotateEncryptionKeys == nil ||
-		(controlPlane.Status.RotateEncryptionKeys != nil && controlPlane.Status.RotateEncryptionKeys.Generation == controlPlane.Spec.RotateEncryptionKeys.Generation &&
-			(controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone || controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed)) {
+// encryptionKeyRotationShouldSkip returns true when the planner should ignore the current spec/status combination:
+// either the control plane is not ready and rotation is not already in progress, or the requested generation already
+// finished and should not be re-run.
+func encryptionKeyRotationShouldSkip(controlPlane *rkev1.RKEControlPlane) bool {
+	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
+		return true
+	}
+
+	phase := controlPlane.Status.RotateEncryptionKeysPhase
+	inProgress := phase == rkev1.RotateEncryptionKeysPhaseRotate || phase == rkev1.RotateEncryptionKeysPhasePostRotateRestart
+	if !capr.Ready.IsTrue(controlPlane) && !inProgress {
+		return true
+	}
+
+	return controlPlane.Status.RotateEncryptionKeys != nil &&
+		controlPlane.Status.RotateEncryptionKeys.Generation == controlPlane.Spec.RotateEncryptionKeys.Generation &&
+		(phase == rkev1.RotateEncryptionKeysPhaseDone || phase == rkev1.RotateEncryptionKeysPhaseFailed)
+}
+
+// encryptionKeyRotationShouldStart collapses the phase/generation restart logic for the simplified rotate-keys flow.
+// It returns true when a new reconciliation should initialize the Rotate phase, and returns an error if the current
+// generation is stuck in an unsupported legacy phase.
+func encryptionKeyRotationShouldStart(controlPlane *rkev1.RKEControlPlane) (bool, error) {
+	if controlPlane == nil || controlPlane.Spec.RotateEncryptionKeys == nil {
+		return false, nil
+	}
+	if controlPlane.Status.RotateEncryptionKeys == nil || controlPlane.Status.RotateEncryptionKeysPhase == "" {
+		return true, nil
+	}
+	if controlPlane.Spec.RotateEncryptionKeys.Generation != controlPlane.Status.RotateEncryptionKeys.Generation {
+		return controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone ||
+			controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
+			!encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase), nil
+	}
+	// Rancher v2.15 only understands the simplified rotate-keys flow. If we ever see a stale legacy phase for the
+	// generation currently being reconciled, fail it explicitly instead of trying to map it back into the new flow.
+	if encryptionKeyRotationPhaseIsKnown(controlPlane.Status.RotateEncryptionKeysPhase) {
+		return false, nil
+	}
+	return false, fmt.Errorf("unsupported encryption key rotation phase [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
+}
+
+func encryptionKeyRotationPhaseIsKnown(phase rkev1.RotateEncryptionKeysPhase) bool {
+	switch phase {
+	case "",
+		rkev1.RotateEncryptionKeysPhaseRotate,
+		rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+		rkev1.RotateEncryptionKeysPhaseDone,
+		rkev1.RotateEncryptionKeysPhaseFailed:
+		return true
+	default:
 		return false
 	}
-
-	return true
-}
-
-// shouldRestartEncryptionKeyRotation returns `true` if encryption key rotation is necessary and the fields on the status object are not valid for an encryption key rotation procedure.
-func shouldRestartEncryptionKeyRotation(controlPlane *rkev1.RKEControlPlane) bool {
-	if !capr.Ready.IsTrue(controlPlane) {
-		return false
-	}
-	if controlPlane.Spec.RotateEncryptionKeys.Generation > 0 && controlPlane.Status.RotateEncryptionKeys == nil {
-		return true
-	}
-	if (controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed ||
-		controlPlane.Status.RotateEncryptionKeysPhase == "") &&
-		controlPlane.Spec.RotateEncryptionKeys.Generation != controlPlane.Status.RotateEncryptionKeys.Generation {
-		return true
-	}
-	if !hasValidNonFailedRotateEncryptionKeyStatus(controlPlane) {
-		return true
-	}
-	return false
-}
-
-// hasValidNonFailedRotateEncryptionKeyStatus verifies that the control plane encryption key status is an expected value and is not failed.
-func hasValidNonFailedRotateEncryptionKeyStatus(controlPlane *rkev1.RKEControlPlane) bool {
-	return rotateEncryptionKeyInProgress(controlPlane) ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseDone
-}
-
-// rotateEncryptionKeyInProgress returns true if the phase of the encryption key rotation indicates that rotation is in progress.
-func rotateEncryptionKeyInProgress(controlPlane *rkev1.RKEControlPlane) bool {
-	return controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePrepare ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePostPrepareRestart ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseRotate ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePostRotateRestart ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseReencrypt ||
-		controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhasePostReencryptRestart
 }
 
 // encryptionKeyRotationFindLeader returns the current encryption rotation leader if it is valid, otherwise, if the
-// phase is "prepare", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
-// (etcd-only), it will elect the first suitable control plane node. If the phase is not in "prepare" and a re-election
+// phase is "rotate", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
+// (etcd-only), it will elect the first suitable control plane node. If the phase is not in "rotate" and a re-election
 // of the leader is necessary, the phase will be set to failed as this is unexpected.
 func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, init *planEntry) (*planEntry, error) {
 	machineName := status.RotateEncryptionKeysLeader
@@ -305,8 +311,7 @@ func (p *Planner) encryptionKeyRotationFindLeader(status rkev1.RKEControlPlaneSt
 		}
 	}
 
-	if status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhasePrepare {
-		// if we are electing a leader and are not in the "prepare" phase, something is wrong.
+	if status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return nil, fmt.Errorf("cannot elect control plane leader in phase %s", status.RotateEncryptionKeysPhase)
 	}
 
@@ -345,44 +350,64 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPla
 	}
 }
 
-// encryptionKeyRotationRestartNodes restarts the leader's server service, extracting the current stage afterwards.
-// The followers (if any exist) are subsequently restarted. Notably, if the encryption key rotation leader is not the init node,
-// it will restart the init node, then restart the encryption key rotation leader,
-// then finalize walking through etcd nodes (that are not controlplane), then finally controlplane nodes.
+// encryptionKeyRotationRestartTargetsForCluster centralizes the restart topology for split-role clusters.
+// The etcd-only and control-plane restart slices are kept separate because only control-plane nodes can be used as
+// secrets-encrypt status sources during convergence, while etcd-only nodes still need to participate in the restart pass.
+func encryptionKeyRotationRestartTargetsForCluster(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader, initNode *planEntry) encryptionKeyRotationRestartTargets {
+	targets := encryptionKeyRotationRestartTargets{
+		controlPlane: []*planEntry{leader},
+	}
+
+	if initNode != nil && !isInitNode(leader) {
+		if isControlPlane(initNode) {
+			targets.controlPlane = append([]*planEntry{initNode}, targets.controlPlane...)
+		} else {
+			targets.etcdOnly = append(targets.etcdOnly, initNode)
+		}
+	}
+
+	// Upstream documents restarting the server that ran rotate-keys before the remaining servers. Rancher follows that
+	// ordering after the init node when they are different, so split-role clusters still bring the designated init server
+	// back first and then restart the elected command leader before the rest of the HA servers.
+	targets.etcdOnly = append(targets.etcdOnly, collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane))...)
+	targets.controlPlane = append(targets.controlPlane, collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane))...)
+
+	return targets
+}
+
+// encryptionKeyRotationRestartNodes restarts the required server nodes and waits for control plane nodes to converge.
+// Etcd-only nodes are restarted first. Rancher does not use them as local secrets-encrypt status sources during
+// convergence because the local encrypt status handler depends on Runtime.Core, which is not initialized on
+// disable-apiserver servers.
+// Control plane nodes are then restarted in order, with each required to reach the reencrypt_finished stage and the
+// last one also required to report matching hashes.
 func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, leader *planEntry, initNode *planEntry, joinServer string) (rkev1.RKEControlPlaneStatus, error) {
-	// in certain cases with multi-node setups, we must restart the init node before we can proceed to restarting the leader.
-	if !isInitNode(leader) {
-		logrus.Debugf("[planner] rkecluster %s/%s: leader %s was not the init node, finding and restarting etcd nodes", controlPlane.Namespace, controlPlane.Name, leader.Machine.Name)
+	restartTargets := encryptionKeyRotationRestartTargetsForCluster(controlPlane, clusterPlan, leader, initNode)
 
-		_, status, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, initNode, false, "")
+	// Restart etcd-only nodes first. These nodes do not produce usable local status output after restart,
+	// so they only participate in the restart portion of the flow.
+	for _, entry := range restartTargets.etcdOnly {
+		_, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
-			return status, err
+			return updatedStatus, err
 		}
-		logrus.Debugf("[planner] rkecluster %s/%s: collecting etcd and not control plane", controlPlane.Namespace, controlPlane.Name)
-		for _, entry := range collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(controlPlane)) {
-			_, status, err = p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry, false, "")
-			if err != nil {
-				return status, err
-			}
-		}
+		status = updatedStatus
 	}
 
-	leaderStage, status, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, leader, true, "")
-	if err != nil {
-		return status, err
-	}
-
-	logrus.Debugf("[planner] rkecluster %s/%s: collecting control plane and not leader and init nodes", controlPlane.Namespace, controlPlane.Name)
-	for _, entry := range collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(controlPlane)) {
-		var stage string
-		stage, status, err = p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry, true, leaderStage)
+	// Restart control plane nodes in order and verify secrets-encrypt status convergence.
+	for i, entry := range restartTargets.controlPlane {
+		rotationStatus, updatedStatus, err := p.encryptionKeyRotationRestartService(controlPlane, status, tokensSecret, joinServer, entry)
 		if err != nil {
-			return status, err
+			return updatedStatus, err
+		}
+		status = updatedStatus
+
+		if rotationStatus.Stage != encryptionKeyRotationStageReencryptFinished {
+			return status, errWaitingf("waiting for encryption key rotation stage to finish on machine [%s]", entry.Machine.Name)
 		}
 
-		if stage != leaderStage {
-			// secrets-encrypt command was run on another node. this is considered a failure, but might be a bit too sensitive. to be tested.
-			return p.encryptionKeyRotationFailed(status, fmt.Errorf("leader [%s] with %s stage and follower [%s] with %s stage", leader.Machine.Status.NodeRef.Name, leaderStage, entry.Machine.Status.NodeRef.Name, stage))
+		if i == len(restartTargets.controlPlane)-1 && !rotationStatus.HashesMatch {
+			return status, errWaitingf("waiting for encryption key rotation hashes to converge on machine [%s]", entry.Machine.Name)
 		}
 	}
 
@@ -390,12 +415,46 @@ func (p *Planner) encryptionKeyRotationRestartNodes(controlPlane *rkev1.RKEContr
 }
 
 // encryptionKeyRotationRestartService restarts the server unit on the downstream node, waits until secrets-encrypt
-// status can be successfully queried, and then gets the status. leaderStage is allowed to be empty if entry is the
-// leader.
-func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry, scrapeStage bool, leaderStage string) (string, rkev1.RKEControlPlaneStatus, error) {
+// status can be successfully queried, and then returns the current runtime status from the periodic status output.
+// For etcd-only nodes (non control plane), the restart is performed but no runtime status is returned. The local
+// secrets-encrypt status endpoint requires Runtime.Core, which is not initialized on disable-apiserver servers.
+func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, entry *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRestartPlan(controlPlane, tokensSecret, joinServer, entry)
+	if err != nil {
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, entry.Machine.Name), entry, nodePlan, joinedServer, 5, 5)
+	if err != nil {
+		if IsErrWaiting(err) {
+			if planAppliedButWaitingForProbes(entry) {
+				return encryptionKeyRotationRuntimeStatus{}, status, errWaitingf("%s: %s", err.Error(), probesMessage(entry.Plan))
+			}
+			return encryptionKeyRotationRuntimeStatus{}, status, err
+		}
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	if !isControlPlane(entry) {
+		return encryptionKeyRotationRuntimeStatus{}, status, nil
+	}
+
+	rotationStatus, err := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(entry)
+	if err != nil {
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	return rotationStatus, status, nil
+}
+
+// encryptionKeyRotationRestartPlan creates a restart-only plan. During the HA convergence step Rancher no longer runs
+// additional secrets-encrypt subcommands on follower nodes; it only restarts the server unit and resumes observing the
+// periodic secrets-encrypt status that the system-agent reports back in the node plan.
+func (p *Planner) encryptionKeyRotationRestartPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, entry *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, config, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, entry, joinServer, true)
 	if err != nil {
-		return "", status, err
+		return plan.NodePlan{}, "", err
 	}
 
 	nodePlan.Files = append(nodePlan.Files, plan.File{
@@ -405,8 +464,7 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 
 	nodePlan.Instructions = []plan.OneTimeInstruction{}
 
-	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
-	if runtime == capr.RuntimeRKE2 {
+	if capr.GetRuntime(controlPlane.Spec.KubernetesVersion) == capr.RuntimeRKE2 {
 		if generated, instruction := generateManifestRemovalInstruction(controlPlane, entry); generated {
 			nodePlan.Instructions = append(nodePlan.Instructions, convertToIdempotentInstruction(
 				controlPlane,
@@ -421,20 +479,17 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 		strings.ToLower(fmt.Sprintf("encryption-key-rotation/restart/%s", controlPlane.Status.RotateEncryptionKeysPhase)),
 		strconv.FormatInt(controlPlane.Spec.RotateEncryptionKeys.Generation, 10),
 		capr.GetRuntimeServerUnit(controlPlane.Spec.KubernetesVersion))...)
+	nodePlan.Instructions = append(nodePlan.Instructions,
+		encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane),
+	)
 
-	nodePlan.Instructions = append(nodePlan.Instructions, encryptionKeyRotationWaitForSystemctlStatusInstruction(controlPlane))
-
+	// Only control plane nodes get local status polling. Rancher relies on them for convergence because etcd-only
+	// servers cannot satisfy the local encrypt status endpoint after restart.
 	if isControlPlane(entry) {
-		nodePlan.Files = append(nodePlan.Files,
-			plan.File{
-				Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationSecretsEncryptStatusScript)),
-				Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationSecretsEncryptStatusPath),
-			},
-			plan.File{
-				Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
-				Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
-			},
-		)
+		nodePlan.Files = append(nodePlan.Files, plan.File{
+			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
+			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
+		})
 		nodePlan.Instructions = append(nodePlan.Instructions,
 			encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane),
 			plan.OneTimeInstruction{
@@ -442,66 +497,62 @@ func (p *Planner) encryptionKeyRotationRestartService(controlPlane *rkev1.RKECon
 			},
 			encryptionKeyRotationSecretsEncryptStatusOneTimeInstruction(controlPlane),
 		)
+		nodePlan.PeriodicInstructions = []plan.PeriodicInstruction{
+			encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane),
+		}
 	}
 
 	probes, err := p.generateProbes(controlPlane, entry, config)
 	if err != nil {
-		return "", status, err
+		return plan.NodePlan{}, "", err
 	}
 	nodePlan.Probes = probes
 
-	// retry is important here because without it, we always seem to run into some sort of issue such as:
-	// - the follower node reporting the wrong status after a restart
-	// - the plan failing with the k3s/rke2-server services crashing the first, and resuming subsequent times
-	// It's not necessarily ideal if encryption key rotation can never complete, especially since we don't have access to
-	// the downstream k3s/rke2-server service logs, but it has to be done in order for encryption key rotation to succeed
-	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, entry.Machine.Name), entry, nodePlan, joinedServer, 5, 5)
-	if err != nil {
-		if IsErrWaiting(err) {
-			if planAppliedButWaitingForProbes(entry) {
-				return "", status, errWaitingf("%s: %s", err.Error(), probesMessage(entry.Plan))
-			}
-			return "", status, err
-		}
-		status, err = p.encryptionKeyRotationFailed(status, err)
-		return "", status, err
-	}
-
-	if !scrapeStage || !isControlPlane(entry) {
-		return "", status, nil
-	}
-
-	stage, err := encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(entry)
-	if err != nil {
-		return "", status, err
-	}
-	return stage, status, nil
+	return nodePlan, joinedServer, nil
 }
 
-// encryptionKeyRotationLeaderPhaseReconcile will run the secrets-encrypt command that corresponds to the phase, and scrape output to ensure that it was
-// successful. If the secrets-encrypt command does not exist on the plan, that means this is the first reconciliation, and
-// it must be added, otherwise reenqueue until the plan is in sync.
-func (p *Planner) encryptionKeyRotationLeaderPhaseReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (rkev1.RKEControlPlaneStatus, error) {
+// encryptionKeyRotationRotateKeysReconcile runs the rotate-keys command on the elected leader and returns the most
+// recent periodic secrets-encrypt status observed on that node.
+func (p *Planner) encryptionKeyRotationRotateKeysReconcile(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, joinServer string, leader *planEntry) (encryptionKeyRotationRuntimeStatus, rkev1.RKEControlPlaneStatus, error) {
+	nodePlan, joinedServer, err := p.encryptionKeyRotationRotateKeysPlan(controlPlane, tokensSecret, joinServer, leader)
+	if err != nil {
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
+	if err != nil {
+		if IsErrWaiting(err) {
+			if strings.HasPrefix(err.Error(), "starting") {
+				logrus.Infof("[planner] rkecluster %s/%s: applying encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, encryptionKeyRotationCommandRotateKeys)
+			}
+			return encryptionKeyRotationRuntimeStatus{}, status, err
+		}
+		status, err = p.encryptionKeyRotationFailed(status, err)
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	rotationStatus, err := encryptionKeyRotationSecretsEncryptStatusFromPeriodic(leader)
+	if err != nil {
+		return encryptionKeyRotationRuntimeStatus{}, status, err
+	}
+
+	logrus.Infof("[planner] rkecluster %s/%s: successfully applied encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, encryptionKeyRotationCommandRotateKeys)
+	return rotationStatus, status, nil
+}
+
+// encryptionKeyRotationRotateKeysPlan keeps only the rotate-keys command as a one-time instruction and relies on
+// periodic status output for progress. That lets the planner resume cleanly after controller restarts without having to
+// preserve one-time status scraping state from an earlier reconcile.
+func (p *Planner) encryptionKeyRotationRotateKeysPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, joinServer string, leader *planEntry) (plan.NodePlan, string, error) {
 	nodePlan, _, joinedServer, err := p.generatePlanWithConfigFiles(controlPlane, tokensSecret, leader, joinServer, true)
 	if err != nil {
-		return status, err
+		return plan.NodePlan{}, "", err
 	}
 
 	apply, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
 	if err != nil {
-		return p.encryptionKeyRotationFailed(status, err)
+		return plan.NodePlan{}, "", err
 	}
-
-	nodePlan.Files = append(nodePlan.Files, []plan.File{
-		{
-			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
-			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
-		},
-		{
-			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationSecretsEncryptStatusScript)),
-			Path:    encryptionKeyRotationScriptPath(controlPlane, encryptionKeyRotationSecretsEncryptStatusPath),
-		},
-	}...)
 
 	nodePlan.Instructions = []plan.OneTimeInstruction{
 		apply,
@@ -513,80 +564,55 @@ func (p *Planner) encryptionKeyRotationLeaderPhaseReconcile(controlPlane *rkev1.
 	nodePlan.PeriodicInstructions = []plan.PeriodicInstruction{
 		encryptionKeyRotationSecretsEncryptStatusPeriodicInstruction(controlPlane),
 	}
-	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", controlPlane.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, joinedServer, 1, 1)
-	if err != nil {
-		if IsErrWaiting(err) {
-			if strings.HasPrefix(err.Error(), "starting") {
-				logrus.Infof("[planner] rkecluster %s/%s: applying encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, apply.Args[1])
-			}
-			return status, err
-		}
-		return p.encryptionKeyRotationFailed(status, err)
-	}
-	scrapedStageFromOneTimeInstructions, err := encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(leader)
-	if err != nil {
-		return status, err
-	}
-	periodic, err := encryptionKeyRotationSecretsEncryptStageFromPeriodic(leader)
-	if err != nil {
-		return status, err
-	}
-	err = encryptionKeyRotationIsCurrentStageAllowed(scrapedStageFromOneTimeInstructions, controlPlane.Status.RotateEncryptionKeysPhase)
-	if err != nil {
-		return p.encryptionKeyRotationFailed(status, err)
-	}
-	if scrapedStageFromOneTimeInstructions == encryptionKeyRotationStageReencryptRequest || scrapedStageFromOneTimeInstructions == encryptionKeyRotationStageReencryptActive {
-		if periodic != encryptionKeyRotationStageReencryptFinished {
-			return status, errWaitingf("waiting for encryption key rotation stage to be finished")
-		}
-	}
-	// successful restart, complete same phases for rotate & reencrypt
-	logrus.Infof("[planner] rkecluster %s/%s: successfully applied encryption key rotation stage command: [%s]", controlPlane.Namespace, controlPlane.Spec.ClusterName, leader.Plan.Plan.Instructions[0].Args[1])
-	return status, nil
+
+	return nodePlan, joinedServer, nil
 }
 
-// encryptionKeyRotationSecretsEncryptStageFromPeriodic will attempt to extract the current stage (secrets-encrypt status) from the
+// encryptionKeyRotationSecretsEncryptStatusFromPeriodic will attempt to extract the current secrets-encrypt status from the
 // plan by parsing the periodic output.
-func encryptionKeyRotationSecretsEncryptStageFromPeriodic(plan *planEntry) (string, error) {
+func encryptionKeyRotationSecretsEncryptStatusFromPeriodic(plan *planEntry) (encryptionKeyRotationRuntimeStatus, error) {
 	output, ok := plan.Plan.PeriodicOutput[encryptionKeyRotationSecretsEncryptStatusCommand]
 	if !ok {
 		for _, pi := range plan.Plan.Plan.PeriodicInstructions {
 			if pi.Name == encryptionKeyRotationSecretsEncryptStatusCommand {
-				return "", errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
+				return encryptionKeyRotationRuntimeStatus{}, errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
 			}
 		}
-		return "", fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
+		return encryptionKeyRotationRuntimeStatus{}, fmt.Errorf("could not extract current status from plan for [%s]: status command not present in plan", plan.Machine.Name)
 	}
-	periodic, err := encryptionKeyRotationStageFromOutput(plan, string(output.Stdout))
-	return periodic, err
+	return encryptionKeyRotationStatusFromOutput(plan, string(output.Stdout))
 }
 
-// encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus will attempt to extract the current stage (secrets-encrypt status) from the
-// plan by parsing the one time output.
-func encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(plan *planEntry) (string, error) {
-	output, ok := plan.Plan.Output[encryptionKeyRotationSecretsEncryptStatusCommand]
-	if !ok {
-		return "", errWaitingf("could not extract current status from plan for [%s]: no output for status", plan.Machine.Name)
-	}
-	status, err := encryptionKeyRotationStageFromOutput(plan, string(output))
-	return status, err
-}
+// encryptionKeyRotationStatusFromOutput parses the parts of secrets-encrypt status that Rancher actually reconciles on:
+// the current rotation stage and whether the server hash set has converged.
+func encryptionKeyRotationStatusFromOutput(plan *planEntry, output string) (encryptionKeyRotationRuntimeStatus, error) {
+	var status encryptionKeyRotationRuntimeStatus
 
-// encryptionKeyRotationStageFromOutput parses the output of a secrets-encrypt status command.
-func encryptionKeyRotationStageFromOutput(plan *planEntry, output string) (string, error) {
-	a := strings.Split(output, "\n")
-	if len(a) < 2 {
-		return "", errWaitingf("could not extract current stage from plan for [%s]: status output is incomplete", plan.Machine.Name)
-	}
-	for _, v := range a {
-		a = strings.Split(v, ": ")
-		if a[0] != "Current Rotation Stage" {
+	for _, line := range strings.Split(output, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
 			continue
 		}
-		status := a[1]
-		return status, nil
+
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		switch key {
+		case "Current Rotation Stage":
+			status.Stage = value
+		case "Server Encryption Hashes":
+			status.HashesMatch = value == encryptionKeyRotationHashesMatch
+		}
 	}
-	return "", errWaitingf("unable to parse rotation stage from output")
+
+	if status.Stage == "" {
+		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("unable to parse rotation stage from output")
+	}
+	if !strings.Contains(output, "Server Encryption Hashes:") {
+		return encryptionKeyRotationRuntimeStatus{}, errWaitingf("unable to parse rotation hashes from output")
+	}
+
+	return status, nil
 }
 
 // encryptionKeyRotationSecretsEncryptInstruction generates a secrets-encrypt command to run on the leader node given
@@ -595,16 +621,7 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 	if controlPlane == nil {
 		return plan.OneTimeInstruction{}, fmt.Errorf("controlplane cannot be nil")
 	}
-
-	var command string
-	switch controlPlane.Status.RotateEncryptionKeysPhase {
-	case rkev1.RotateEncryptionKeysPhasePrepare:
-		command = encryptionKeyRotationCommandPrepare
-	case rkev1.RotateEncryptionKeysPhaseRotate:
-		command = encryptionKeyRotationCommandRotate
-	case rkev1.RotateEncryptionKeysPhaseReencrypt:
-		command = encryptionKeyRotationCommandReencrypt
-	default:
+	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseRotate {
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", controlPlane.Status.RotateEncryptionKeysPhase)
 	}
 
@@ -615,22 +632,22 @@ func encryptionKeyRotationSecretsEncryptInstruction(controlPlane *rkev1.RKEContr
 		capr.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
 		[]string{
 			"secrets-encrypt",
-			command,
+			encryptionKeyRotationCommandRotateKeys,
 		},
 		[]string{},
 	), nil
 }
 
 // encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans
-// following progression of encryption key rotation. In an HA setup with split role etcd & controlplane nodes, the etcd
-// nodes would have identical plans, so this variable is used to spoof an update and force the system-agent to run the
-// plan.
+// when the planner advances between the rotate-keys and restart phases. assignAndCheckPlan only reapplies when the
+// desired plan changes, so the planner uses phase/generation env vars to deliberately perturb otherwise identical
+// restart and status instructions across reconciliations.
 func encryptionKeyRotationStatusEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_STAGE=%s", controlPlane.Status.RotateEncryptionKeysPhase)
 }
 
 // encryptionKeyRotationGenerationEnv returns an environment variable in order to force followers to rerun their plans
-// on subsequent generations, in the event that encryption key rotation is restarting and failed during prepare.
+// on subsequent generations.
 func encryptionKeyRotationGenerationEnv(controlPlane *rkev1.RKEControlPlane) string {
 	return fmt.Sprintf("ENCRYPTION_KEY_ROTATION_GENERATION=%d", controlPlane.Spec.RotateEncryptionKeys.Generation)
 }
@@ -740,35 +757,26 @@ func encryptionKeyRotationWaitForSecretsEncryptStatus(controlPlane *rkev1.RKECon
 	}
 }
 
-// encryptionKeyRotationIsCurrentStageAllowed returns a boolean that indicates whether the scraped stage from the leader is allowed in comparison with the current phase.
-// Since reencrypt can be any of three statuses (reencrypt_request, reencrypt_active, and reencrypt_finished), any of these stages are valid, however the first two (request & active) do
-// not explicitly indicate that the current command was successful, just that it hasn't failed yet. In certain cases, a
-// cluster may never move beyond request and active.
-func encryptionKeyRotationIsCurrentStageAllowed(leaderStage string, currentPhase rkev1.RotateEncryptionKeysPhase) error {
-	switch currentPhase {
-	case rkev1.RotateEncryptionKeysPhasePrepare:
-		if leaderStage == encryptionKeyRotationCommandPrepare {
-			return nil
-		}
-	case rkev1.RotateEncryptionKeysPhaseRotate:
-		if leaderStage == encryptionKeyRotationCommandRotate {
-			return nil
-		}
-	case rkev1.RotateEncryptionKeysPhaseReencrypt:
-		if leaderStage == encryptionKeyRotationStageReencryptRequest ||
-			leaderStage == encryptionKeyRotationStageReencryptActive ||
-			leaderStage == encryptionKeyRotationStageReencryptFinished {
-			return nil
-		}
+// encryptionKeyRotationHandleFailure makes sure the planner leaves the owning CAPI cluster unpaused after an
+// unrecoverable rotation failure. The phase transition to Failed is handled separately so Rancher can persist status
+// and surface the original reconciliation error.
+func (p *Planner) encryptionKeyRotationHandleFailure(controlPlane *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
+	if err == nil || IsErrWaiting(err) || status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseFailed {
+		return status, err
 	}
-	return fmt.Errorf("unexpected encryption key rotation stage [%s] for phase [%s]", leaderStage, currentPhase)
+	if pauseErr := p.pauseCAPICluster(controlPlane, false); pauseErr != nil {
+		return status, errWaiting("unpausing CAPI cluster")
+	}
+	status.RotateEncryptionKeysLeader = ""
+	return status, err
 }
 
 // encryptionKeyRotationFailed updates the various status objects on the control plane, allowing the cluster to
 // continue the reconciliation loop. Encryption key rotation will not be restarted again until requested.
 func (p *Planner) encryptionKeyRotationFailed(status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
 	status.RotateEncryptionKeysPhase = rkev1.RotateEncryptionKeysPhaseFailed
-	return status, errors.Wrap(err, "encryption key rotation failed, please perform an etcd restore")
+	status.RotateEncryptionKeysLeader = ""
+	return status, errors.Wrap(err, "encryption key rotation failed")
 }
 
 func encryptionKeyRotationScriptPath(controlPlane *rkev1.RKEControlPlane, file string) string {

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -735,6 +735,48 @@ func Test_rotateEncryptionKeys_marksFailedWhenNoSuitableLeaderExists(t *testing.
 	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
 }
 
+func Test_rotateEncryptionKeys_postRotateRestartDoesNotRequireStoredLeader(t *testing.T) {
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+		RotateEncryptionKeysLeader: "deleted-leader",
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+	entry := newTestPlanEntryFromPlan(clusterPlan, "server-1")
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRestartPlan(controlPlane, plan.Secret{}, "https://server-1:9345", entry)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["server-1"] = &plan.Node{
+		Plan:    nodePlan,
+		InSync:  true,
+		Healthy: true,
+		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+			encryptionKeyRotationSecretsEncryptStatusCommand: {
+				Stdout: []byte("Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n"),
+			},
+		},
+	}
+
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mockPlanner.capiClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(cluster *capi.Cluster) (*capi.Cluster, error) {
+		assert.False(t, ptr.Deref(cluster.Spec.Paused, true))
+		return cluster, nil
+	})
+
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseDone, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
+}
+
 func Test_rotateEncryptionKeys_marksFailedWhenVersionUnsupported(t *testing.T) {
 	mockPlanner := newMockPlanner(t, InfoFunctions{})
 	mockPlanner.planner.store.equalities = testPlannerEqualities()

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -67,6 +67,32 @@ func Test_rotateEncryptionKeys_noopWhenDoneForSameGeneration(t *testing.T) {
 	assert.Equal(t, status, updatedStatus)
 }
 
+func Test_encryptionKeyRotationShouldStart(t *testing.T) {
+	t.Run("restarts unknown phase for same generation", func(t *testing.T) {
+		controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+			RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+			RotateEncryptionKeysPhase: "legacy-phase",
+		})
+
+		shouldStart, err := encryptionKeyRotationShouldStart(controlPlane)
+
+		assert.NoError(t, err)
+		assert.True(t, shouldStart)
+	})
+
+	t.Run("does not restart known in-progress phase for same generation", func(t *testing.T) {
+		controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+			RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+			RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+		})
+
+		shouldStart, err := encryptionKeyRotationShouldStart(controlPlane)
+
+		assert.NoError(t, err)
+		assert.False(t, shouldStart)
+	})
+}
+
 func Test_encryptionKeyRotationFindLeader(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -283,10 +309,6 @@ func Test_encryptionKeyRotationRotateKeysPlan_pinsGenerationToActiveStatus(t *te
 }
 
 func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
-	entry := &planEntry{
-		Machine: &capi.Machine{ObjectMeta: metav1.ObjectMeta{Name: "server-1"}},
-	}
-
 	testCases := []struct {
 		name       string
 		output     string
@@ -334,7 +356,7 @@ func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			status, err := encryptionKeyRotationStatusFromOutput(entry, testCase.output)
+			status, err := encryptionKeyRotationStatusFromOutput(testCase.output)
 			if testCase.expectWait {
 				assert.True(t, IsErrWaiting(err))
 				return

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -19,15 +19,22 @@ import (
 )
 
 func Test_rotateEncryptionKeys_resetsStateWhenSpecCleared(t *testing.T) {
-	planner := newTestEncryptionKeyRotationPlanner()
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
 	status := rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
 		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
 		RotateEncryptionKeysLeader: "server-1",
 	}
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(nil, status)
 
-	controlPlane := newTestEncryptionKeyRotationControlPlane(nil, status)
-	updatedStatus, err := planner.rotateEncryptionKeys(controlPlane, status, plan.Secret{}, &plan.Plan{})
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mockPlanner.capiClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(cluster *capi.Cluster) (*capi.Cluster, error) {
+		assert.NotNil(t, cluster.Spec.Paused)
+		assert.False(t, *cluster.Spec.Paused)
+		return cluster, nil
+	})
+
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, status, plan.Secret{}, &plan.Plan{})
 
 	assert.True(t, IsErrWaiting(err))
 	assert.Nil(t, updatedStatus.RotateEncryptionKeys)

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -204,7 +204,7 @@ func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 	})
 
-	instruction, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
+	instruction, err := encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
 	commandArguments := strings.Join(instruction.Args, " ")
 
 	assert.NoError(t, err)
@@ -276,7 +276,7 @@ func Test_encryptionKeyRotationRotateKeysPlan_pinsGenerationToActiveStatus(t *te
 	})
 	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
 
-	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
 	assert.NoError(t, err)
 	assert.Contains(t, nodePlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(0))
 	assert.Contains(t, nodePlan.PeriodicInstructions[0].Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
@@ -398,7 +398,7 @@ func Test_encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(t *test
 		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 	})
 	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-	nodePlan, _, err := newTestEncryptionKeyRotationPlanner().encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	nodePlan, _, err := newTestEncryptionKeyRotationPlanner().encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
 	assert.NoError(t, err)
 
 	leaderEntry.Plan = &plan.Node{
@@ -427,7 +427,7 @@ func Test_encryptionKeyRotationRotateKeysPlan_preservesRetryCount(t *testing.T) 
 		Plan: retryPlan,
 	}
 
-	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
 	assert.NoError(t, err)
 	assert.Equal(t, retryPlan.Instructions[0].Name, preservedPlan.Instructions[0].Name)
 	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(2))
@@ -441,14 +441,14 @@ func Test_encryptionKeyRotationRotateKeysPlan_preservesLegacyRetryAttempt(t *tes
 	})
 	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
 
-	legacyPlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	legacyPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
 	assert.NoError(t, err)
 	legacyPlan.Instructions[0].Env = []string{encryptionKeyRotationAttemptEnvName + "=1-retry-retry"}
 	leaderEntry.Plan = &plan.Node{
 		Plan: legacyPlan,
 	}
 
-	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
 	assert.NoError(t, err)
 	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(2))
 }
@@ -547,7 +547,7 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 			})
 			leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-			nodePlan, joinedServer, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+			nodePlan, joinedServer, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
 			if testCase.retryCount > 0 {
 				nodePlan, joinedServer, err = planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, testCase.retryCount)
 			}
@@ -607,7 +607,7 @@ func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *tes
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:    nodePlan,
@@ -648,7 +648,7 @@ func Test_rotateEncryptionKeys_movesToRestartPhaseWhenEtcdOnlyFollowersExist(t *
 		newTestEncryptionKeyRotationMachine("etcd-follower", true, false, false, true, "https://etcd-follower:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "control-plane-leader")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://etcd-init:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://etcd-init:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 	assert.NoError(t, err)
 	clusterPlan.Nodes["control-plane-leader"] = &plan.Node{
 		Plan:    nodePlan,
@@ -686,7 +686,7 @@ func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T)
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:    nodePlan,
@@ -724,7 +724,7 @@ func Test_rotateEncryptionKeys_marksFailedWhenLeaderPlanFails(t *testing.T) {
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:   nodePlan,
@@ -758,7 +758,7 @@ func Test_rotateEncryptionKeys_requeuesWhenLeaderRotateKeysTimesOut(t *testing.T
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:   nodePlan,
@@ -804,7 +804,7 @@ func Test_rotateEncryptionKeys_reissuesLeaderPlanAfterRetryableRotateKeysFailure
 	}
 
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
 	assert.NoError(t, err)
 	nodePlanJSON, err := json.Marshal(nodePlan)
 	assert.NoError(t, err)
@@ -902,7 +902,7 @@ func Test_encryptionKeyRotationRotateKeysReconcile_isIdempotentAcrossRepeatedCal
 		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 	})
 	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
 	assert.NoError(t, err)
 	leaderEntry.Plan = &plan.Node{
 		Plan:    nodePlan,

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -1,7 +1,6 @@
 package planner
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -81,10 +79,7 @@ func Test_encryptionKeyRotationShouldStart(t *testing.T) {
 			RotateEncryptionKeysPhase: "legacy-phase",
 		})
 
-		shouldStart, err := encryptionKeyRotationShouldStart(controlPlane)
-
-		assert.NoError(t, err)
-		assert.True(t, shouldStart)
+		assert.True(t, encryptionKeyRotationShouldStart(controlPlane))
 	})
 
 	t.Run("does not restart known in-progress phase for same generation", func(t *testing.T) {
@@ -93,10 +88,16 @@ func Test_encryptionKeyRotationShouldStart(t *testing.T) {
 			RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 		})
 
-		shouldStart, err := encryptionKeyRotationShouldStart(controlPlane)
+		assert.False(t, encryptionKeyRotationShouldStart(controlPlane))
+	})
 
-		assert.NoError(t, err)
-		assert.False(t, shouldStart)
+	t.Run("does not start new generation while previous generation is in progress", func(t *testing.T) {
+		controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 2}, rkev1.RKEControlPlaneStatus{
+			RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+			RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+		})
+
+		assert.False(t, encryptionKeyRotationShouldStart(controlPlane))
 	})
 }
 
@@ -237,7 +238,7 @@ func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 	})
 
-	instruction, err := encryptionKeyRotationSecretsEncryptInstructionWithRetryCount(controlPlane, 0)
+	instruction, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
 	commandArguments := strings.Join(instruction.Args, " ")
 
 	assert.NoError(t, err)
@@ -248,7 +249,6 @@ func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 	assert.Contains(t, commandArguments, "2>&1")
 	assert.NotContains(t, commandArguments, "prepare")
 	assert.NotContains(t, commandArguments, "reencrypt")
-	assert.Contains(t, instruction.Env, encryptionKeyRotationRotateKeysRetryCountEnv(0))
 	assert.Contains(t, instruction.Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
 }
 
@@ -309,9 +309,8 @@ func Test_encryptionKeyRotationRotateKeysPlan_pinsGenerationToActiveStatus(t *te
 	})
 	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
 
-	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
+	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
 	assert.NoError(t, err)
-	assert.Contains(t, nodePlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(0))
 	assert.Contains(t, nodePlan.PeriodicInstructions[0].Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
 }
 
@@ -421,67 +420,6 @@ func Test_encryptionKeyRotationCommandTimedOut(t *testing.T) {
 	}
 }
 
-func Test_encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(t *testing.T) {
-	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
-		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
-		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
-	})
-	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-	nodePlan, _, err := newTestEncryptionKeyRotationPlanner().encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
-	assert.NoError(t, err)
-
-	leaderEntry.Plan = &plan.Node{
-		Plan:   nodePlan,
-		Failed: true,
-		FailedOutput: map[string][]byte{
-			nodePlan.Instructions[0].Name: []byte("time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n"),
-		},
-	}
-
-	assert.True(t, encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leaderEntry, nodePlan.Instructions[0].Name))
-	assert.False(t, encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leaderEntry, "other-instruction"))
-}
-
-func Test_encryptionKeyRotationRotateKeysPlan_preservesRetryCount(t *testing.T) {
-	planner := newTestEncryptionKeyRotationPlanner()
-	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
-		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
-		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
-	})
-	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-
-	retryPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, 2)
-	assert.NoError(t, err)
-	leaderEntry.Plan = &plan.Node{
-		Plan: retryPlan,
-	}
-
-	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
-	assert.NoError(t, err)
-	assert.Equal(t, retryPlan.Instructions[0].Name, preservedPlan.Instructions[0].Name)
-	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(2))
-}
-
-func Test_encryptionKeyRotationRotateKeysPlan_preservesLegacyRetryAttempt(t *testing.T) {
-	planner := newTestEncryptionKeyRotationPlanner()
-	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
-		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
-		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
-	})
-	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-
-	legacyPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
-	assert.NoError(t, err)
-	legacyPlan.Instructions[0].Env = []string{encryptionKeyRotationAttemptEnvName + "=1-retry-retry"}
-	leaderEntry.Plan = &plan.Node{
-		Plan: legacyPlan,
-	}
-
-	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
-	assert.NoError(t, err)
-	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(2))
-}
-
 func Test_encryptionKeyRotationRestartPlan_pinsGenerationToActiveStatus(t *testing.T) {
 	planner := newTestEncryptionKeyRotationPlanner()
 	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 4}, rkev1.RKEControlPlaneStatus{
@@ -504,7 +442,6 @@ func Test_encryptionKeyRotationRestartPlan_pinsGenerationToActiveStatus(t *testi
 func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 	testCases := []struct {
 		name         string
-		retryCount   int
 		periodicOut  string
 		periodicErr  string
 		savedOutput  string
@@ -540,24 +477,16 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			expectWait:  true,
 		},
 		{
-			name:        "status timeout on periodic output waits for retry",
+			name:        "status timeout on periodic output waits",
 			savedOutput: "time=\"2026-04-08T23:15:39Z\" level=fatal msg=\"Error: see server log for details: Put \\\"https://127.0.0.1:9345/v1-rke2/encrypt/config\\\": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)\"\n",
 			periodicErr: "time=\"2026-04-08T23:22:01Z\" level=fatal msg=\"Error: see server log for details: Get \\\"https://127.0.0.1:9345/v1-rke2/encrypt/status\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\"\n",
 			planFailed:  true,
 			expectWait:  true,
 		},
 		{
-			name:        "retryable precondition waits for stable status before retry",
-			savedOutput: "time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n",
-			periodicOut: "Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: hash mismatch\n",
-			planFailed:  true,
-			expectWait:  true,
-		},
-		{
-			name:         "retryable precondition stops retrying after max retries",
-			retryCount:   encryptionKeyRotationMaxRotateKeysRetries,
+			name:         "rotate-keys error ID marks status failed",
 			savedOutput:  "time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n",
-			periodicOut:  "Current Rotation Stage: start\nServer Encryption Hashes: All hashes match\n",
+			periodicOut:  "Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n",
 			planFailed:   true,
 			expectFailed: true,
 		},
@@ -576,10 +505,7 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 			})
 			leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-			nodePlan, joinedServer, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
-			if testCase.retryCount > 0 {
-				nodePlan, joinedServer, err = planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, testCase.retryCount)
-			}
+			nodePlan, joinedServer, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
 			assert.NoError(t, err)
 			assert.Empty(t, joinedServer)
 
@@ -636,7 +562,7 @@ func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *tes
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:    nodePlan,
@@ -677,7 +603,7 @@ func Test_rotateEncryptionKeys_movesToRestartPhaseWhenEtcdOnlyFollowersExist(t *
 		newTestEncryptionKeyRotationMachine("etcd-follower", true, false, false, true, "https://etcd-follower:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "control-plane-leader")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://etcd-init:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://etcd-init:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["control-plane-leader"] = &plan.Node{
 		Plan:    nodePlan,
@@ -715,7 +641,7 @@ func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T)
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:    nodePlan,
@@ -753,7 +679,7 @@ func Test_rotateEncryptionKeys_marksFailedWhenLeaderPlanFails(t *testing.T) {
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:   nodePlan,
@@ -787,7 +713,7 @@ func Test_rotateEncryptionKeys_requeuesWhenLeaderRotateKeysTimesOut(t *testing.T
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:   nodePlan,
@@ -804,74 +730,6 @@ func Test_rotateEncryptionKeys_requeuesWhenLeaderRotateKeysTimesOut(t *testing.T
 	}
 
 	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
-
-	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
-
-	assert.True(t, IsErrWaiting(err))
-	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseRotate, updatedStatus.RotateEncryptionKeysPhase)
-	assert.Equal(t, "server-1", updatedStatus.RotateEncryptionKeysLeader)
-}
-
-func Test_rotateEncryptionKeys_reissuesLeaderPlanAfterRetryableRotateKeysFailure(t *testing.T) {
-	mockPlanner := newMockPlanner(t, InfoFunctions{})
-	mockPlanner.planner.store.equalities = testPlannerEqualities()
-
-	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
-		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
-		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
-		RotateEncryptionKeysLeader: "server-1",
-		Initialization: rkev1.RKEControlPlaneInitializationStatus{
-			ControlPlaneInitialized: ptr.To(true),
-		},
-	})
-	clusterPlan := newTestEncryptionKeyRotationPlan(
-		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
-	)
-	clusterPlan.Machines["server-1"].Spec.Bootstrap.ConfigRef = capi.ContractVersionedObjectReference{
-		Kind: capr.RKEBootstrapKind,
-		Name: "server-1-bootstrap",
-	}
-
-	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leader, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leader))
-	assert.NoError(t, err)
-	nodePlanJSON, err := json.Marshal(nodePlan)
-	assert.NoError(t, err)
-	clusterPlan.Nodes["server-1"] = &plan.Node{
-		Plan:   nodePlan,
-		Failed: true,
-		InSync: true,
-		FailedOutput: map[string][]byte{
-			nodePlan.Instructions[0].Name: []byte("time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n"),
-		},
-		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
-			encryptionKeyRotationSecretsEncryptStatusCommand: {
-				Stdout: []byte("Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n"),
-			},
-		},
-	}
-
-	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
-	mockPlanner.secretClient.EXPECT().Get(controlPlane.Namespace, capr.PlanSecretFromBootstrapName("server-1-bootstrap"), metav1.GetOptions{}).Return(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      capr.PlanSecretFromBootstrapName("server-1-bootstrap"),
-			Namespace: controlPlane.Namespace,
-		},
-		Type: capr.SecretTypeMachinePlan,
-		Data: map[string][]byte{
-			"plan":            nodePlanJSON,
-			"failure-count":   []byte("1"),
-			"failed-checksum": []byte(PlanHash(nodePlanJSON)),
-		},
-	}, nil)
-	mockPlanner.secretClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(secret *corev1.Secret) (*corev1.Secret, error) {
-		var updatedPlan plan.NodePlan
-		err := json.Unmarshal(secret.Data["plan"], &updatedPlan)
-		assert.NoError(t, err)
-		assert.NotEqual(t, nodePlan.Instructions[0].Name, updatedPlan.Instructions[0].Name)
-		assert.Contains(t, updatedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(1))
-		return secret, nil
-	})
 
 	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
@@ -931,7 +789,7 @@ func Test_encryptionKeyRotationRotateKeysReconcile_isIdempotentAcrossRepeatedCal
 		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
 	})
 	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
-	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, encryptionKeyRotationRotateKeysRetryCount(controlPlane, leaderEntry))
+	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
 	assert.NoError(t, err)
 	leaderEntry.Plan = &plan.Node{
 		Plan:    nodePlan,

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -215,7 +215,8 @@ func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 	assert.Contains(t, commandArguments, "2>&1")
 	assert.NotContains(t, commandArguments, "prepare")
 	assert.NotContains(t, commandArguments, "reencrypt")
-	assert.Contains(t, instruction.Env, encryptionKeyRotationRotateKeysAttemptEnv("3"))
+	assert.Contains(t, instruction.Env, encryptionKeyRotationRotateKeysRetryCountEnv(0))
+	assert.Contains(t, instruction.Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
 }
 
 func Test_encryptionKeyRotationActiveGeneration(t *testing.T) {
@@ -277,7 +278,7 @@ func Test_encryptionKeyRotationRotateKeysPlan_pinsGenerationToActiveStatus(t *te
 
 	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
 	assert.NoError(t, err)
-	assert.Contains(t, nodePlan.Instructions[0].Env, encryptionKeyRotationRotateKeysAttemptEnv("3"))
+	assert.Contains(t, nodePlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(0))
 	assert.Contains(t, nodePlan.PeriodicInstructions[0].Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
 }
 
@@ -412,7 +413,7 @@ func Test_encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(t *test
 	assert.False(t, encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leaderEntry, "other-instruction"))
 }
 
-func Test_encryptionKeyRotationRotateKeysPlan_preservesRetryAttempt(t *testing.T) {
+func Test_encryptionKeyRotationRotateKeysPlan_preservesRetryCount(t *testing.T) {
 	planner := newTestEncryptionKeyRotationPlanner()
 	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
@@ -420,7 +421,7 @@ func Test_encryptionKeyRotationRotateKeysPlan_preservesRetryAttempt(t *testing.T
 	})
 	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
 
-	retryPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, "1-retry")
+	retryPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, 2)
 	assert.NoError(t, err)
 	leaderEntry.Plan = &plan.Node{
 		Plan: retryPlan,
@@ -429,7 +430,27 @@ func Test_encryptionKeyRotationRotateKeysPlan_preservesRetryAttempt(t *testing.T
 	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
 	assert.NoError(t, err)
 	assert.Equal(t, retryPlan.Instructions[0].Name, preservedPlan.Instructions[0].Name)
-	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysAttemptEnv("1-retry"))
+	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(2))
+}
+
+func Test_encryptionKeyRotationRotateKeysPlan_preservesLegacyRetryAttempt(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+	})
+	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
+
+	legacyPlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	assert.NoError(t, err)
+	legacyPlan.Instructions[0].Env = []string{encryptionKeyRotationAttemptEnvName + "=1-retry-retry"}
+	leaderEntry.Plan = &plan.Node{
+		Plan: legacyPlan,
+	}
+
+	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	assert.NoError(t, err)
+	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(2))
 }
 
 func Test_encryptionKeyRotationRestartPlan_pinsGenerationToActiveStatus(t *testing.T) {
@@ -454,6 +475,7 @@ func Test_encryptionKeyRotationRestartPlan_pinsGenerationToActiveStatus(t *testi
 func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 	testCases := []struct {
 		name         string
+		retryCount   int
 		periodicOut  string
 		periodicErr  string
 		savedOutput  string
@@ -503,6 +525,14 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			expectWait:  true,
 		},
 		{
+			name:         "retryable precondition stops retrying after max retries",
+			retryCount:   encryptionKeyRotationMaxRotateKeysRetries,
+			savedOutput:  "time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n",
+			periodicOut:  "Current Rotation Stage: start\nServer Encryption Hashes: All hashes match\n",
+			planFailed:   true,
+			expectFailed: true,
+		},
+		{
 			name:         "plan failure marks status failed",
 			planFailed:   true,
 			expectFailed: true,
@@ -518,6 +548,9 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			})
 			leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
 			nodePlan, joinedServer, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+			if testCase.retryCount > 0 {
+				nodePlan, joinedServer, err = planner.encryptionKeyRotationRotateKeysPlanWithRetryCount(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, testCase.retryCount)
+			}
 			assert.NoError(t, err)
 			assert.Empty(t, joinedServer)
 
@@ -807,7 +840,7 @@ func Test_rotateEncryptionKeys_reissuesLeaderPlanAfterRetryableRotateKeysFailure
 		err := json.Unmarshal(secret.Data["plan"], &updatedPlan)
 		assert.NoError(t, err)
 		assert.NotEqual(t, nodePlan.Instructions[0].Name, updatedPlan.Instructions[0].Name)
-		assert.Contains(t, updatedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysAttemptEnv("1-retry"))
+		assert.Contains(t, updatedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysRetryCountEnv(1))
 		return secret, nil
 	})
 

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -8,6 +9,8 @@ import (
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -212,6 +215,70 @@ func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 	assert.Contains(t, commandArguments, "2>&1")
 	assert.NotContains(t, commandArguments, "prepare")
 	assert.NotContains(t, commandArguments, "reencrypt")
+	assert.Contains(t, instruction.Env, encryptionKeyRotationRotateKeysAttemptEnv("3"))
+}
+
+func Test_encryptionKeyRotationActiveGeneration(t *testing.T) {
+	testCases := []struct {
+		name       string
+		specRotate *rkev1.RotateEncryptionKeys
+		status     rkev1.RKEControlPlaneStatus
+		expected   int64
+	}{
+		{
+			name:       "uses spec generation before rotation starts",
+			specRotate: &rkev1.RotateEncryptionKeys{Generation: 4},
+			expected:   4,
+		},
+		{
+			name:       "pins to status generation during rotate",
+			specRotate: &rkev1.RotateEncryptionKeys{Generation: 4},
+			status: rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 3},
+				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+			},
+			expected: 3,
+		},
+		{
+			name:       "pins to status generation during post rotate restart",
+			specRotate: &rkev1.RotateEncryptionKeys{Generation: 4},
+			status: rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 3},
+				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+			},
+			expected: 3,
+		},
+		{
+			name:       "uses spec generation after previous generation finished",
+			specRotate: &rkev1.RotateEncryptionKeys{Generation: 4},
+			status: rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 3},
+				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseDone,
+			},
+			expected: 4,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			controlPlane := newTestEncryptionKeyRotationControlPlane(testCase.specRotate, testCase.status)
+			assert.Equal(t, testCase.expected, encryptionKeyRotationActiveGeneration(controlPlane))
+		})
+	}
+}
+
+func Test_encryptionKeyRotationRotateKeysPlan_pinsGenerationToActiveStatus(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 4}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 3},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+	})
+	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
+
+	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	assert.NoError(t, err)
+	assert.Contains(t, nodePlan.Instructions[0].Env, encryptionKeyRotationRotateKeysAttemptEnv("3"))
+	assert.Contains(t, nodePlan.PeriodicInstructions[0].Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
 }
 
 func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
@@ -249,6 +316,11 @@ func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
 			expectWait: true,
 		},
 		{
+			name:       "status timeout output waits",
+			output:     "time=\"2026-04-08T19:05:32Z\" level=fatal msg=\"Error: see server log for details: Get \\\"https://127.0.0.1:9345/v1-rke2/encrypt/status\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\"\n",
+			expectWait: true,
+		},
+		{
 			name: "unknown stage handled safely",
 			output: "Current Rotation Stage: mystery\n" +
 				"Server Encryption Hashes: hash mismatch\n",
@@ -273,10 +345,117 @@ func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
 	}
 }
 
+func Test_encryptionKeyRotationCommandTimedOut(t *testing.T) {
+	testCases := []struct {
+		name     string
+		output   string
+		endpoint string
+		expected bool
+	}{
+		{
+			name:     "matches observed rke2 rotate-keys timeout",
+			endpoint: encryptionKeyRotationRotateKeysTimeoutEndpoint,
+			output:   "time=\"2026-04-08T23:15:39Z\" level=fatal msg=\"Error: see server log for details: Put \\\"https://127.0.0.1:9345/v1-rke2/encrypt/config\\\": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)\"",
+			expected: true,
+		},
+		{
+			name:     "matches legacy rotate-keys timeout",
+			endpoint: encryptionKeyRotationRotateKeysTimeoutEndpoint,
+			output:   "level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"",
+			expected: true,
+		},
+		{
+			name:     "status timeout does not match rotate-keys endpoint",
+			endpoint: encryptionKeyRotationRotateKeysTimeoutEndpoint,
+			output:   "time=\"2026-04-08T19:05:32Z\" level=fatal msg=\"Error: see server log for details: Get \\\"https://127.0.0.1:9345/v1-rke2/encrypt/status\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\"",
+			expected: false,
+		},
+		{
+			name:     "status timeout matches status endpoint",
+			endpoint: encryptionKeyRotationStatusTimeoutEndpoint,
+			output:   "time=\"2026-04-08T19:05:32Z\" level=fatal msg=\"Error: see server log for details: Get \\\"https://127.0.0.1:9345/v1-rke2/encrypt/status\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\"",
+			expected: true,
+		},
+		{
+			name:     "unrelated error does not match",
+			endpoint: encryptionKeyRotationRotateKeysTimeoutEndpoint,
+			output:   "level=fatal msg=\"some other error\"",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, encryptionKeyRotationCommandTimedOut(testCase.output, testCase.endpoint))
+		})
+	}
+}
+
+func Test_encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(t *testing.T) {
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+	})
+	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
+	nodePlan, _, err := newTestEncryptionKeyRotationPlanner().encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	assert.NoError(t, err)
+
+	leaderEntry.Plan = &plan.Node{
+		Plan:   nodePlan,
+		Failed: true,
+		FailedOutput: map[string][]byte{
+			nodePlan.Instructions[0].Name: []byte("time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n"),
+		},
+	}
+
+	assert.True(t, encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leaderEntry, nodePlan.Instructions[0].Name))
+	assert.False(t, encryptionKeyRotationRotateKeysFailedWithRetryablePrecondition(leaderEntry, "other-instruction"))
+}
+
+func Test_encryptionKeyRotationRotateKeysPlan_preservesRetryAttempt(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+	})
+	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
+
+	retryPlan, _, err := planner.encryptionKeyRotationRotateKeysPlanWithAttempt(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry, "1-retry")
+	assert.NoError(t, err)
+	leaderEntry.Plan = &plan.Node{
+		Plan: retryPlan,
+	}
+
+	preservedPlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	assert.NoError(t, err)
+	assert.Equal(t, retryPlan.Instructions[0].Name, preservedPlan.Instructions[0].Name)
+	assert.Contains(t, preservedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysAttemptEnv("1-retry"))
+}
+
+func Test_encryptionKeyRotationRestartPlan_pinsGenerationToActiveStatus(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 4}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 3},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+	})
+	entry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
+
+	nodePlan, _, err := planner.encryptionKeyRotationRestartPlan(controlPlane, plan.Secret{}, "https://server-1:9345", entry)
+	assert.NoError(t, err)
+
+	activeGenerationHash := PlanHash([]byte("3"))
+	assert.Contains(t, nodePlan.Instructions[0].Name, activeGenerationHash)
+	assert.Contains(t, nodePlan.Instructions[1].Name, activeGenerationHash)
+	assert.Contains(t, nodePlan.Instructions[2].Name, activeGenerationHash)
+	assert.Contains(t, nodePlan.Instructions[4].Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
+	assert.Contains(t, nodePlan.PeriodicInstructions[0].Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
+}
+
 func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 	testCases := []struct {
 		name         string
 		periodicOut  string
+		periodicErr  string
 		savedOutput  string
 		planFailed   bool
 		expectStage  string
@@ -306,6 +485,20 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 		{
 			name:        "timeout output waits for periodic status when not yet available",
 			savedOutput: "level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n",
+			planFailed:  true,
+			expectWait:  true,
+		},
+		{
+			name:        "status timeout on periodic output waits for retry",
+			savedOutput: "time=\"2026-04-08T23:15:39Z\" level=fatal msg=\"Error: see server log for details: Put \\\"https://127.0.0.1:9345/v1-rke2/encrypt/config\\\": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)\"\n",
+			periodicErr: "time=\"2026-04-08T23:22:01Z\" level=fatal msg=\"Error: see server log for details: Get \\\"https://127.0.0.1:9345/v1-rke2/encrypt/status\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\"\n",
+			planFailed:  true,
+			expectWait:  true,
+		},
+		{
+			name:        "retryable precondition waits for stable status before retry",
+			savedOutput: "time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n",
+			periodicOut: "Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: hash mismatch\n",
 			planFailed:  true,
 			expectWait:  true,
 		},
@@ -341,6 +534,7 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 				PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 					encryptionKeyRotationSecretsEncryptStatusCommand: {
 						Stdout: []byte(testCase.periodicOut),
+						Stderr: []byte(testCase.periodicErr),
 					},
 				},
 			}
@@ -548,6 +742,74 @@ func Test_rotateEncryptionKeys_requeuesWhenLeaderRotateKeysTimesOut(t *testing.T
 	}
 
 	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseRotate, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Equal(t, "server-1", updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_reissuesLeaderPlanAfterRetryableRotateKeysFailure(t *testing.T) {
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
+		RotateEncryptionKeysLeader: "server-1",
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+	clusterPlan.Machines["server-1"].Spec.Bootstrap.ConfigRef = capi.ContractVersionedObjectReference{
+		Kind: capr.RKEBootstrapKind,
+		Name: "server-1-bootstrap",
+	}
+
+	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	assert.NoError(t, err)
+	nodePlanJSON, err := json.Marshal(nodePlan)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["server-1"] = &plan.Node{
+		Plan:   nodePlan,
+		Failed: true,
+		InSync: true,
+		FailedOutput: map[string][]byte{
+			nodePlan.Instructions[0].Name: []byte("time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n"),
+		},
+		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+			encryptionKeyRotationSecretsEncryptStatusCommand: {
+				Stdout: []byte("Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n"),
+			},
+		},
+	}
+
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mockPlanner.secretClient.EXPECT().Get(controlPlane.Namespace, capr.PlanSecretFromBootstrapName("server-1-bootstrap"), metav1.GetOptions{}).Return(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      capr.PlanSecretFromBootstrapName("server-1-bootstrap"),
+			Namespace: controlPlane.Namespace,
+		},
+		Type: capr.SecretTypeMachinePlan,
+		Data: map[string][]byte{
+			"plan":            nodePlanJSON,
+			"failure-count":   []byte("1"),
+			"failed-checksum": []byte(PlanHash(nodePlanJSON)),
+		},
+	}, nil)
+	mockPlanner.secretClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(secret *corev1.Secret) (*corev1.Secret, error) {
+		var updatedPlan plan.NodePlan
+		err := json.Unmarshal(secret.Data["plan"], &updatedPlan)
+		assert.NoError(t, err)
+		assert.NotEqual(t, nodePlan.Instructions[0].Name, updatedPlan.Instructions[0].Name)
+		assert.Contains(t, updatedPlan.Instructions[0].Env, encryptionKeyRotationRotateKeysAttemptEnv("1-retry"))
+		return secret, nil
+	})
 
 	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -1,0 +1,747 @@
+package planner
+
+import (
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/utils/ptr"
+	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
+)
+
+func Test_rotateEncryptionKeys_resetsStateWhenSpecCleared(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	status := rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
+		RotateEncryptionKeysLeader: "server-1",
+	}
+
+	controlPlane := newTestEncryptionKeyRotationControlPlane(nil, status)
+	updatedStatus, err := planner.rotateEncryptionKeys(controlPlane, status, plan.Secret{}, &plan.Plan{})
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Nil(t, updatedStatus.RotateEncryptionKeys)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_startsNewGeneration(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 2}, rkev1.RKEControlPlaneStatus{
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+
+	updatedStatus, err := planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, int64(2), updatedStatus.RotateEncryptionKeys.Generation)
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseRotate, updatedStatus.RotateEncryptionKeysPhase)
+}
+
+func Test_rotateEncryptionKeys_noopWhenDoneForSameGeneration(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	status := rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseDone,
+	}
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, status)
+
+	updatedStatus, err := planner.rotateEncryptionKeys(controlPlane, status, plan.Secret{}, &plan.Plan{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, status, updatedStatus)
+}
+
+func Test_encryptionKeyRotationFindLeader(t *testing.T) {
+	tests := []struct {
+		name          string
+		status        rkev1.RKEControlPlaneStatus
+		clusterPlan   *plan.Plan
+		initNodeName  string
+		expectedName  string
+		expectedError string
+	}{
+		{
+			name: "existing stored leader reused when still valid",
+			status: rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+				RotateEncryptionKeysLeader: "server-2",
+			},
+			clusterPlan: newTestEncryptionKeyRotationPlan(
+				newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+				newTestEncryptionKeyRotationMachine("server-2", true, true, false, true, "https://server-2:9345"),
+			),
+			initNodeName: "server-1",
+			expectedName: "server-2",
+		},
+		{
+			name: "init node selected when valid",
+			status: rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+			},
+			clusterPlan: newTestEncryptionKeyRotationPlan(
+				newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+				newTestEncryptionKeyRotationMachine("server-2", true, true, false, true, "https://server-2:9345"),
+			),
+			initNodeName: "server-1",
+			expectedName: "server-1",
+		},
+		{
+			name: "fallback to first suitable control plane when init node is not suitable",
+			status: rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+			},
+			clusterPlan: newTestEncryptionKeyRotationPlan(
+				newTestEncryptionKeyRotationMachine("server-1", true, false, true, true, "https://server-1:9345"),
+				newTestEncryptionKeyRotationMachine("server-2", true, true, false, true, "https://server-2:9345"),
+				newTestEncryptionKeyRotationMachine("server-3", true, true, false, true, "https://server-3:9345"),
+			),
+			initNodeName: "server-1",
+			expectedName: "server-2",
+		},
+		{
+			name: "error when no suitable control plane leader exists",
+			status: rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+			},
+			clusterPlan: newTestEncryptionKeyRotationPlan(
+				newTestEncryptionKeyRotationMachine("server-1", true, false, true, true, "https://server-1:9345"),
+			),
+			initNodeName:  "server-1",
+			expectedError: "no suitable control plane nodes for encryption key rotation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			planner := newTestEncryptionKeyRotationPlanner()
+			initNode := newTestPlanEntryFromPlan(tt.clusterPlan, tt.initNodeName)
+
+			leader, err := planner.encryptionKeyRotationFindLeader(tt.status, tt.clusterPlan, initNode)
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedName, leader.Machine.Name)
+		})
+	}
+}
+
+func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+		RotateEncryptionKeysLeader: "cp-leader",
+	})
+
+	t.Run("etcd-only init node split from control-plane convergence entries", func(t *testing.T) {
+		clusterPlan := newTestEncryptionKeyRotationPlan(
+			newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
+			newTestEncryptionKeyRotationMachine("cp-leader", true, true, false, true, "https://cp-leader:9345"),
+			newTestEncryptionKeyRotationMachine("etcd-follower", true, false, false, true, "https://etcd-follower:9345"),
+			newTestEncryptionKeyRotationMachine("cp-follower", true, true, false, true, "https://cp-follower:9345"),
+		)
+
+		targets := encryptionKeyRotationRestartTargetsForCluster(
+			controlPlane,
+			clusterPlan,
+			newTestPlanEntryFromPlan(clusterPlan, "cp-leader"),
+			newTestPlanEntryFromPlan(clusterPlan, "etcd-init"),
+		)
+
+		assert.Equal(t, 4, targets.count())
+		assert.Len(t, targets.etcdOnly, 2)
+		assert.Equal(t, "etcd-init", targets.etcdOnly[0].Machine.Name)
+		assert.Equal(t, "etcd-follower", targets.etcdOnly[1].Machine.Name)
+		assert.Len(t, targets.controlPlane, 2)
+		assert.Equal(t, "cp-leader", targets.controlPlane[0].Machine.Name)
+		assert.Equal(t, "cp-follower", targets.controlPlane[1].Machine.Name)
+	})
+
+	t.Run("control plane init node stays in control-plane ordering", func(t *testing.T) {
+		clusterPlan := newTestEncryptionKeyRotationPlan(
+			newTestEncryptionKeyRotationMachine("cp-init", true, true, true, true, "https://cp-init:9345"),
+			newTestEncryptionKeyRotationMachine("cp-leader", true, true, false, true, "https://cp-leader:9345"),
+			newTestEncryptionKeyRotationMachine("cp-follower", true, true, false, true, "https://cp-follower:9345"),
+		)
+
+		targets := encryptionKeyRotationRestartTargetsForCluster(
+			controlPlane,
+			clusterPlan,
+			newTestPlanEntryFromPlan(clusterPlan, "cp-leader"),
+			newTestPlanEntryFromPlan(clusterPlan, "cp-init"),
+		)
+
+		assert.Equal(t, 3, targets.count())
+		assert.Empty(t, targets.etcdOnly)
+		assert.Len(t, targets.controlPlane, 3)
+		assert.Equal(t, "cp-init", targets.controlPlane[0].Machine.Name)
+		assert.Equal(t, "cp-leader", targets.controlPlane[1].Machine.Name)
+		assert.Equal(t, "cp-follower", targets.controlPlane[2].Machine.Name)
+	})
+}
+
+func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 3}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 3},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+	})
+
+	instruction, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/bin/sh", instruction.Command)
+	assert.Contains(t, instruction.Args, "secrets-encrypt")
+	assert.Contains(t, instruction.Args, encryptionKeyRotationCommandRotateKeys)
+	assert.NotContains(t, instruction.Args, "prepare")
+	assert.NotContains(t, instruction.Args, "rotate")
+	assert.NotContains(t, instruction.Args, "reencrypt")
+}
+
+func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
+	entry := &planEntry{
+		Machine: &capi.Machine{ObjectMeta: metav1.ObjectMeta{Name: "server-1"}},
+	}
+
+	tests := []struct {
+		name       string
+		output     string
+		expected   encryptionKeyRotationRuntimeStatus
+		expectWait bool
+	}{
+		{
+			name: "parses start stage",
+			output: "Current Rotation Stage: start\n" +
+				"Server Encryption Hashes: hash mismatch\n",
+			expected: encryptionKeyRotationRuntimeStatus{
+				Stage:       encryptionKeyRotationStageStart,
+				HashesMatch: false,
+			},
+		},
+		{
+			name: "parses finished stage with matching hashes",
+			output: "Current Rotation Stage: reencrypt_finished\n" +
+				"Server Encryption Hashes: All hashes match\n",
+			expected: encryptionKeyRotationRuntimeStatus{
+				Stage:       encryptionKeyRotationStageReencryptFinished,
+				HashesMatch: true,
+			},
+		},
+		{
+			name:       "malformed output waits",
+			output:     "Current Rotation Stage\n",
+			expectWait: true,
+		},
+		{
+			name: "unknown stage handled safely",
+			output: "Current Rotation Stage: mystery\n" +
+				"Server Encryption Hashes: hash mismatch\n",
+			expected: encryptionKeyRotationRuntimeStatus{
+				Stage:       "mystery",
+				HashesMatch: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, err := encryptionKeyRotationStatusFromOutput(entry, tt.output)
+			if tt.expectWait {
+				assert.True(t, IsErrWaiting(err))
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, status)
+		})
+	}
+}
+
+func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
+	tests := []struct {
+		name         string
+		periodicOut  string
+		planFailed   bool
+		expectStage  string
+		expectWait   bool
+		expectFailed bool
+	}{
+		{
+			name: "complete status returned",
+			periodicOut: "Current Rotation Stage: reencrypt_finished\n" +
+				"Server Encryption Hashes: All hashes match\n",
+			expectStage: encryptionKeyRotationStageReencryptFinished,
+		},
+		{
+			name: "incomplete status returned for requeue",
+			periodicOut: "Current Rotation Stage: start\n" +
+				"Server Encryption Hashes: hash mismatch\n",
+			expectStage: encryptionKeyRotationStageStart,
+		},
+		{
+			name:         "plan failure marks status failed",
+			planFailed:   true,
+			expectFailed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			planner := newTestEncryptionKeyRotationPlanner()
+			controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+				RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+				RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+			})
+			leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
+			nodePlan, joinedServer, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+			assert.NoError(t, err)
+			assert.Empty(t, joinedServer)
+
+			leaderEntry.Plan = &plan.Node{
+				Plan:    nodePlan,
+				Failed:  tt.planFailed,
+				InSync:  true,
+				Healthy: true,
+				PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+					encryptionKeyRotationSecretsEncryptStatusCommand: {
+						Stdout: []byte(tt.periodicOut),
+					},
+				},
+			}
+
+			rotationStatus, updatedStatus, err := planner.encryptionKeyRotationRotateKeysReconcile(controlPlane, controlPlane.Status, plan.Secret{}, "https://server-1:9345", leaderEntry)
+			if tt.expectFailed {
+				assert.Error(t, err)
+				assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectStage, rotationStatus.Stage)
+			assert.Equal(t, controlPlane.Status.RotateEncryptionKeysPhase, updatedStatus.RotateEncryptionKeysPhase)
+		})
+	}
+}
+
+func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *testing.T) {
+	mp := newMockPlanner(t, InfoFunctions{})
+	mp.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
+		RotateEncryptionKeysLeader: "server-1",
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
+	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["server-1"] = &plan.Node{
+		Plan:    nodePlan,
+		InSync:  true,
+		Healthy: true,
+		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+			encryptionKeyRotationSecretsEncryptStatusCommand: {
+				Stdout: []byte("Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n"),
+			},
+		},
+	}
+
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+
+	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseDone, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_movesToRestartPhaseWhenEtcdOnlyFollowersExist(t *testing.T) {
+	mp := newMockPlanner(t, InfoFunctions{})
+	mp.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
+		RotateEncryptionKeysLeader: "cp-leader",
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
+		newTestEncryptionKeyRotationMachine("cp-leader", true, true, false, true, "https://cp-leader:9345"),
+		newTestEncryptionKeyRotationMachine("etcd-follower", true, false, false, true, "https://etcd-follower:9345"),
+	)
+	leader := newTestPlanEntryFromPlan(clusterPlan, "cp-leader")
+	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://etcd-init:9345", leader)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["cp-leader"] = &plan.Node{
+		Plan:    nodePlan,
+		InSync:  true,
+		Healthy: true,
+		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+			encryptionKeyRotationSecretsEncryptStatusCommand: {
+				Stdout: []byte("Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n"),
+			},
+		},
+	}
+
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+
+	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhasePostRotateRestart, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Equal(t, "cp-leader", updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T) {
+	mp := newMockPlanner(t, InfoFunctions{})
+	mp.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
+		RotateEncryptionKeysLeader: "server-1",
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
+	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["server-1"] = &plan.Node{
+		Plan:    nodePlan,
+		InSync:  true,
+		Healthy: true,
+		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+			encryptionKeyRotationSecretsEncryptStatusCommand: {
+				Stdout: []byte("Current Rotation Stage: start\nServer Encryption Hashes: hash mismatch\n"),
+			},
+		},
+	}
+
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+
+	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseRotate, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Equal(t, "server-1", updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_marksFailedWhenLeaderPlanFails(t *testing.T) {
+	mp := newMockPlanner(t, InfoFunctions{})
+	mp.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
+		RotateEncryptionKeysLeader: "server-1",
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
+	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["server-1"] = &plan.Node{
+		Plan:   nodePlan,
+		Failed: true,
+		InSync: true,
+	}
+
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+
+	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.Error(t, err)
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_marksFailedWhenNoSuitableLeaderExists(t *testing.T) {
+	mp := newMockPlanner(t, InfoFunctions{})
+	mp.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
+	)
+
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+
+	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.Error(t, err)
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_marksFailedWhenVersionUnsupported(t *testing.T) {
+	mp := newMockPlanner(t, InfoFunctions{})
+	mp.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	controlPlane.Spec.KubernetesVersion = "v1.29.9+rke2r1"
+
+	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+
+	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, &plan.Plan{})
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_encryptionKeyRotationRotateKeysReconcile_isIdempotentAcrossRepeatedCalls(t *testing.T) {
+	planner := newTestEncryptionKeyRotationPlanner()
+	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhaseRotate,
+	})
+	leaderEntry := newTestPlanEntry(newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"))
+	nodePlan, _, err := planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	assert.NoError(t, err)
+	leaderEntry.Plan = &plan.Node{
+		Plan:    nodePlan,
+		InSync:  true,
+		Healthy: true,
+		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+			encryptionKeyRotationSecretsEncryptStatusCommand: {
+				Stdout: []byte("Current Rotation Stage: start\nServer Encryption Hashes: hash mismatch\n"),
+			},
+		},
+	}
+
+	firstStatus, updatedStatus, firstErr := planner.encryptionKeyRotationRotateKeysReconcile(controlPlane, controlPlane.Status, plan.Secret{}, "https://server-1:9345", leaderEntry)
+	secondStatus, secondUpdatedStatus, secondErr := planner.encryptionKeyRotationRotateKeysReconcile(controlPlane, controlPlane.Status, plan.Secret{}, "https://server-1:9345", leaderEntry)
+
+	assert.NoError(t, firstErr)
+	assert.NoError(t, secondErr)
+	assert.Equal(t, firstStatus, secondStatus)
+	assert.Equal(t, updatedStatus, secondUpdatedStatus)
+	assert.Equal(t, encryptionKeyRotationStageStart, firstStatus.Stage)
+}
+
+func newTestEncryptionKeyRotationPlanner() *Planner {
+	return &Planner{
+		store: &PlanStore{
+			equalities: testPlannerEqualities(),
+		},
+	}
+}
+
+func testPlannerEqualities() conversion.Equalities {
+	equalities := equality.Semantic.Copy()
+	_ = equalities.AddFunc(func(a, b plan.File) bool {
+		return a.Content == b.Content && a.Path == b.Path && a.Permissions == b.Permissions && a.Dynamic == b.Dynamic && a.Minor == b.Minor
+	})
+	return equalities
+}
+
+func newTestEncryptionKeyRotationControlPlane(rotate *rkev1.RotateEncryptionKeys, status rkev1.RKEControlPlaneStatus) *rkev1.RKEControlPlane {
+	controlPlane := &rkev1.RKEControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-control-plane",
+			Namespace: "fleet-default",
+		},
+		Spec: rkev1.RKEControlPlaneSpec{
+			ClusterName:          "test-cluster",
+			KubernetesVersion:    "v1.30.6+rke2r1",
+			RotateEncryptionKeys: rotate,
+			UnmanagedConfig:      true,
+		},
+		Status: status,
+	}
+	capr.Ready.True(controlPlane)
+	return controlPlane
+}
+
+func newOwnedEncryptionKeyRotationControlPlane(rotate *rkev1.RotateEncryptionKeys, status rkev1.RKEControlPlaneStatus) *rkev1.RKEControlPlane {
+	controlPlane := newTestEncryptionKeyRotationControlPlane(rotate, status)
+	controlPlane.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: capi.GroupVersion.String(),
+			Kind:       "Cluster",
+			Name:       "capi-cluster",
+			Controller: ptr.To(true),
+		},
+	}
+	return controlPlane
+}
+
+func newTestEncryptionKeyRotationMachine(name string, etcd, controlPlane, initNode, ready bool, joinURL string) *planEntry {
+	labels := map[string]string{}
+	if etcd {
+		labels[capr.EtcdRoleLabel] = "true"
+	}
+	if controlPlane {
+		labels[capr.ControlPlaneRoleLabel] = "true"
+	}
+	if initNode {
+		labels[capr.InitNodeLabel] = "true"
+	}
+
+	machine := &capi.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "fleet-default",
+		},
+		Status: capi.MachineStatus{
+			NodeRef: capi.MachineNodeReference{Name: name},
+		},
+	}
+	metadata := &plan.Metadata{
+		Labels:      labels,
+		Annotations: map[string]string{capr.JoinURLAnnotation: joinURL},
+	}
+
+	if ready {
+		capr.SetCAPIResourceCondition(machine, metav1.Condition{
+			Type:               string(capr.Ready),
+			Status:             metav1.ConditionTrue,
+			Reason:             "Test",
+			LastTransitionTime: metav1.Now(),
+		})
+		capr.SetCAPIResourceCondition(machine, metav1.Condition{
+			Type:               capi.InfrastructureReadyCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Test",
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+
+	return &planEntry{
+		Machine:  machine,
+		Plan:     &plan.Node{},
+		Metadata: metadata,
+	}
+}
+
+func newTestPlanEntry(entry *planEntry) *planEntry {
+	return &planEntry{
+		Machine:  entry.Machine.DeepCopy(),
+		Plan:     copyNode(entry.Plan),
+		Metadata: &plan.Metadata{Labels: copyStringMap(entry.Metadata.Labels), Annotations: copyStringMap(entry.Metadata.Annotations)},
+	}
+}
+
+func newTestEncryptionKeyRotationPlan(entries ...*planEntry) *plan.Plan {
+	clusterPlan := &plan.Plan{
+		Machines: map[string]*capi.Machine{},
+		Nodes:    map[string]*plan.Node{},
+		Metadata: map[string]*plan.Metadata{},
+	}
+
+	for _, entry := range entries {
+		clusterPlan.Machines[entry.Machine.Name] = entry.Machine.DeepCopy()
+		clusterPlan.Nodes[entry.Machine.Name] = copyNode(entry.Plan)
+		clusterPlan.Metadata[entry.Machine.Name] = &plan.Metadata{
+			Labels:      copyStringMap(entry.Metadata.Labels),
+			Annotations: copyStringMap(entry.Metadata.Annotations),
+		}
+	}
+
+	return clusterPlan
+}
+
+func newTestPlanEntryFromPlan(clusterPlan *plan.Plan, machineName string) *planEntry {
+	return &planEntry{
+		Machine:  clusterPlan.Machines[machineName],
+		Plan:     clusterPlan.Nodes[machineName],
+		Metadata: clusterPlan.Metadata[machineName],
+	}
+}
+
+func pausedCluster(namespace string, paused bool) *capi.Cluster {
+	return &capi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "capi-cluster",
+			Namespace: namespace,
+		},
+		Spec: capi.ClusterSpec{
+			Paused: ptr.To(paused),
+		},
+	}
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+
+	return out
+}
+
+func copyNode(in *plan.Node) *plan.Node {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	if in.Output != nil {
+		out.Output = make(map[string][]byte, len(in.Output))
+		for key, value := range in.Output {
+			out.Output[key] = append([]byte(nil), value...)
+		}
+	}
+	if in.PeriodicOutput != nil {
+		out.PeriodicOutput = make(map[string]plan.PeriodicInstructionOutput, len(in.PeriodicOutput))
+		for key, value := range in.PeriodicOutput {
+			value.Stdout = append([]byte(nil), value.Stdout...)
+			value.Stderr = append([]byte(nil), value.Stderr...)
+			out.PeriodicOutput[key] = value
+		}
+	}
+	if in.ProbeStatus != nil {
+		out.ProbeStatus = make(map[string]plan.ProbeStatus, len(in.ProbeStatus))
+		for key, value := range in.ProbeStatus {
+			out.ProbeStatus[key] = value
+		}
+	}
+
+	return &out
+}

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -200,7 +200,6 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 			newTestPlanEntryFromPlan(clusterPlan, "etcd-init"),
 		)
 
-		assert.Equal(t, 4, targets.count())
 		assert.Len(t, targets.etcdOnly, 2)
 		assert.Equal(t, "etcd-init", targets.etcdOnly[0].Machine.Name)
 		assert.Equal(t, "etcd-follower", targets.etcdOnly[1].Machine.Name)
@@ -223,7 +222,6 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 			newTestPlanEntryFromPlan(clusterPlan, "control-plane-init"),
 		)
 
-		assert.Equal(t, 3, targets.count())
 		assert.Empty(t, targets.etcdOnly)
 		assert.Len(t, targets.controlPlane, 3)
 		assert.Equal(t, "control-plane-leader", targets.controlPlane[0].Machine.Name)

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -208,7 +208,7 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 		assert.Equal(t, "control-plane-follower", targets.controlPlane[1].Machine.Name)
 	})
 
-	t.Run("control plane init node stays in control-plane ordering", func(t *testing.T) {
+	t.Run("control plane init node stays in control-plane restart group", func(t *testing.T) {
 		clusterPlan := newTestEncryptionKeyRotationPlan(
 			newTestEncryptionKeyRotationMachine("control-plane-init", true, true, true, true, "https://control-plane-init:9345"),
 			newTestEncryptionKeyRotationMachine("control-plane-leader", true, true, false, true, "https://control-plane-leader:9345"),
@@ -225,8 +225,8 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 		assert.Equal(t, 3, targets.count())
 		assert.Empty(t, targets.etcdOnly)
 		assert.Len(t, targets.controlPlane, 3)
-		assert.Equal(t, "control-plane-init", targets.controlPlane[0].Machine.Name)
-		assert.Equal(t, "control-plane-leader", targets.controlPlane[1].Machine.Name)
+		assert.Equal(t, "control-plane-leader", targets.controlPlane[0].Machine.Name)
+		assert.Equal(t, "control-plane-init", targets.controlPlane[1].Machine.Name)
 		assert.Equal(t, "control-plane-follower", targets.controlPlane[2].Machine.Name)
 	})
 }

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -179,12 +179,6 @@ func Test_encryptionKeyRotationFindLeader(t *testing.T) {
 }
 
 func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
-	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
-		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
-		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhasePostRotateRestart,
-		RotateEncryptionKeysLeader: "control-plane-leader",
-	})
-
 	t.Run("etcd-only init node split from control-plane convergence entries", func(t *testing.T) {
 		clusterPlan := newTestEncryptionKeyRotationPlan(
 			newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
@@ -193,19 +187,14 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 			newTestEncryptionKeyRotationMachine("control-plane-follower", true, true, false, true, "https://control-plane-follower:9345"),
 		)
 
-		targets := encryptionKeyRotationRestartTargetsForCluster(
-			controlPlane,
-			clusterPlan,
-			newTestPlanEntryFromPlan(clusterPlan, "control-plane-leader"),
-			newTestPlanEntryFromPlan(clusterPlan, "etcd-init"),
-		)
+		targets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
 
 		assert.Len(t, targets.etcdOnly, 2)
-		assert.Equal(t, "etcd-init", targets.etcdOnly[0].Machine.Name)
-		assert.Equal(t, "etcd-follower", targets.etcdOnly[1].Machine.Name)
+		assert.Equal(t, "etcd-follower", targets.etcdOnly[0].Machine.Name)
+		assert.Equal(t, "etcd-init", targets.etcdOnly[1].Machine.Name)
 		assert.Len(t, targets.controlPlane, 2)
-		assert.Equal(t, "control-plane-leader", targets.controlPlane[0].Machine.Name)
-		assert.Equal(t, "control-plane-follower", targets.controlPlane[1].Machine.Name)
+		assert.Equal(t, "control-plane-follower", targets.controlPlane[0].Machine.Name)
+		assert.Equal(t, "control-plane-leader", targets.controlPlane[1].Machine.Name)
 	})
 
 	t.Run("control plane init node stays in control-plane restart group", func(t *testing.T) {
@@ -215,18 +204,13 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 			newTestEncryptionKeyRotationMachine("control-plane-follower", true, true, false, true, "https://control-plane-follower:9345"),
 		)
 
-		targets := encryptionKeyRotationRestartTargetsForCluster(
-			controlPlane,
-			clusterPlan,
-			newTestPlanEntryFromPlan(clusterPlan, "control-plane-leader"),
-			newTestPlanEntryFromPlan(clusterPlan, "control-plane-init"),
-		)
+		targets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
 
 		assert.Empty(t, targets.etcdOnly)
 		assert.Len(t, targets.controlPlane, 3)
-		assert.Equal(t, "control-plane-leader", targets.controlPlane[0].Machine.Name)
+		assert.Equal(t, "control-plane-follower", targets.controlPlane[0].Machine.Name)
 		assert.Equal(t, "control-plane-init", targets.controlPlane[1].Machine.Name)
-		assert.Equal(t, "control-plane-follower", targets.controlPlane[2].Machine.Name)
+		assert.Equal(t, "control-plane-leader", targets.controlPlane[2].Machine.Name)
 	})
 }
 
@@ -441,7 +425,6 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 	testCases := []struct {
 		name         string
 		periodicOut  string
-		periodicErr  string
 		savedOutput  string
 		planFailed   bool
 		expectStage  string
@@ -471,13 +454,6 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 		{
 			name:        "timeout output waits for periodic status when not yet available",
 			savedOutput: "level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n",
-			planFailed:  true,
-			expectWait:  true,
-		},
-		{
-			name:        "status timeout on periodic output waits",
-			savedOutput: "time=\"2026-04-08T23:15:39Z\" level=fatal msg=\"Error: see server log for details: Put \\\"https://127.0.0.1:9345/v1-rke2/encrypt/config\\\": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)\"\n",
-			periodicErr: "time=\"2026-04-08T23:22:01Z\" level=fatal msg=\"Error: see server log for details: Get \\\"https://127.0.0.1:9345/v1-rke2/encrypt/status\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\"\n",
 			planFailed:  true,
 			expectWait:  true,
 		},
@@ -520,7 +496,6 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 				PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 					encryptionKeyRotationSecretsEncryptStatusCommand: {
 						Stdout: []byte(testCase.periodicOut),
-						Stderr: []byte(testCase.periodicErr),
 					},
 				},
 			}

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -508,6 +508,7 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			}
 			if testCase.expectFailed {
 				assert.Error(t, err)
+				assert.ErrorContains(t, err, "please perform an etcd restore")
 				assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
 				return
 			}
@@ -666,6 +667,7 @@ func Test_rotateEncryptionKeys_marksFailedWhenLeaderPlanFails(t *testing.T) {
 	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
 	assert.Error(t, err)
+	assert.ErrorContains(t, err, "please perform an etcd restore")
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
 	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
 }
@@ -730,7 +732,9 @@ func Test_rotateEncryptionKeys_marksFailedWhenNoSuitableLeaderExists(t *testing.
 
 	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
-	assert.Error(t, err)
+	if assert.Error(t, err) {
+		assert.NotContains(t, err.Error(), "please perform an etcd restore")
+	}
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
 	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
 }
@@ -774,6 +778,39 @@ func Test_rotateEncryptionKeys_postRotateRestartDoesNotRequireStoredLeader(t *te
 
 	assert.True(t, IsErrWaiting(err))
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseDone, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
+}
+
+func Test_rotateEncryptionKeys_marksFailedWithRestoreWhenPostRotateRestartPlanFails(t *testing.T) {
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase: rkev1.RotateEncryptionKeysPhasePostRotateRestart,
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+	entry := newTestPlanEntryFromPlan(clusterPlan, "server-1")
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRestartPlan(controlPlane, plan.Secret{}, "https://server-1:9345", entry)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["server-1"] = &plan.Node{
+		Plan:   nodePlan,
+		Failed: true,
+		InSync: true,
+	}
+
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "please perform an etcd restore")
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
 	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
 }
 

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"strings"
 	"testing"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
@@ -64,7 +65,7 @@ func Test_rotateEncryptionKeys_noopWhenDoneForSameGeneration(t *testing.T) {
 }
 
 func Test_encryptionKeyRotationFindLeader(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		name          string
 		status        rkev1.RKEControlPlaneStatus
 		clusterPlan   *plan.Plan
@@ -123,19 +124,19 @@ func Test_encryptionKeyRotationFindLeader(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
 			planner := newTestEncryptionKeyRotationPlanner()
-			initNode := newTestPlanEntryFromPlan(tt.clusterPlan, tt.initNodeName)
+			initNode := newTestPlanEntryFromPlan(testCase.clusterPlan, testCase.initNodeName)
 
-			leader, err := planner.encryptionKeyRotationFindLeader(tt.status, tt.clusterPlan, initNode)
-			if tt.expectedError != "" {
-				assert.EqualError(t, err, tt.expectedError)
+			leader, err := planner.encryptionKeyRotationFindLeader(testCase.status, testCase.clusterPlan, initNode)
+			if testCase.expectedError != "" {
+				assert.EqualError(t, err, testCase.expectedError)
 				return
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedName, leader.Machine.Name)
+			assert.Equal(t, testCase.expectedName, leader.Machine.Name)
 		})
 	}
 }
@@ -144,21 +145,21 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
 		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhasePostRotateRestart,
-		RotateEncryptionKeysLeader: "cp-leader",
+		RotateEncryptionKeysLeader: "control-plane-leader",
 	})
 
 	t.Run("etcd-only init node split from control-plane convergence entries", func(t *testing.T) {
 		clusterPlan := newTestEncryptionKeyRotationPlan(
 			newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
-			newTestEncryptionKeyRotationMachine("cp-leader", true, true, false, true, "https://cp-leader:9345"),
+			newTestEncryptionKeyRotationMachine("control-plane-leader", true, true, false, true, "https://control-plane-leader:9345"),
 			newTestEncryptionKeyRotationMachine("etcd-follower", true, false, false, true, "https://etcd-follower:9345"),
-			newTestEncryptionKeyRotationMachine("cp-follower", true, true, false, true, "https://cp-follower:9345"),
+			newTestEncryptionKeyRotationMachine("control-plane-follower", true, true, false, true, "https://control-plane-follower:9345"),
 		)
 
 		targets := encryptionKeyRotationRestartTargetsForCluster(
 			controlPlane,
 			clusterPlan,
-			newTestPlanEntryFromPlan(clusterPlan, "cp-leader"),
+			newTestPlanEntryFromPlan(clusterPlan, "control-plane-leader"),
 			newTestPlanEntryFromPlan(clusterPlan, "etcd-init"),
 		)
 
@@ -167,30 +168,30 @@ func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
 		assert.Equal(t, "etcd-init", targets.etcdOnly[0].Machine.Name)
 		assert.Equal(t, "etcd-follower", targets.etcdOnly[1].Machine.Name)
 		assert.Len(t, targets.controlPlane, 2)
-		assert.Equal(t, "cp-leader", targets.controlPlane[0].Machine.Name)
-		assert.Equal(t, "cp-follower", targets.controlPlane[1].Machine.Name)
+		assert.Equal(t, "control-plane-leader", targets.controlPlane[0].Machine.Name)
+		assert.Equal(t, "control-plane-follower", targets.controlPlane[1].Machine.Name)
 	})
 
 	t.Run("control plane init node stays in control-plane ordering", func(t *testing.T) {
 		clusterPlan := newTestEncryptionKeyRotationPlan(
-			newTestEncryptionKeyRotationMachine("cp-init", true, true, true, true, "https://cp-init:9345"),
-			newTestEncryptionKeyRotationMachine("cp-leader", true, true, false, true, "https://cp-leader:9345"),
-			newTestEncryptionKeyRotationMachine("cp-follower", true, true, false, true, "https://cp-follower:9345"),
+			newTestEncryptionKeyRotationMachine("control-plane-init", true, true, true, true, "https://control-plane-init:9345"),
+			newTestEncryptionKeyRotationMachine("control-plane-leader", true, true, false, true, "https://control-plane-leader:9345"),
+			newTestEncryptionKeyRotationMachine("control-plane-follower", true, true, false, true, "https://control-plane-follower:9345"),
 		)
 
 		targets := encryptionKeyRotationRestartTargetsForCluster(
 			controlPlane,
 			clusterPlan,
-			newTestPlanEntryFromPlan(clusterPlan, "cp-leader"),
-			newTestPlanEntryFromPlan(clusterPlan, "cp-init"),
+			newTestPlanEntryFromPlan(clusterPlan, "control-plane-leader"),
+			newTestPlanEntryFromPlan(clusterPlan, "control-plane-init"),
 		)
 
 		assert.Equal(t, 3, targets.count())
 		assert.Empty(t, targets.etcdOnly)
 		assert.Len(t, targets.controlPlane, 3)
-		assert.Equal(t, "cp-init", targets.controlPlane[0].Machine.Name)
-		assert.Equal(t, "cp-leader", targets.controlPlane[1].Machine.Name)
-		assert.Equal(t, "cp-follower", targets.controlPlane[2].Machine.Name)
+		assert.Equal(t, "control-plane-init", targets.controlPlane[0].Machine.Name)
+		assert.Equal(t, "control-plane-leader", targets.controlPlane[1].Machine.Name)
+		assert.Equal(t, "control-plane-follower", targets.controlPlane[2].Machine.Name)
 	})
 }
 
@@ -201,14 +202,16 @@ func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 	})
 
 	instruction, err := encryptionKeyRotationSecretsEncryptInstruction(controlPlane)
+	commandArguments := strings.Join(instruction.Args, " ")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "/bin/sh", instruction.Command)
-	assert.Contains(t, instruction.Args, "secrets-encrypt")
-	assert.Contains(t, instruction.Args, encryptionKeyRotationCommandRotateKeys)
-	assert.NotContains(t, instruction.Args, "prepare")
-	assert.NotContains(t, instruction.Args, "rotate")
-	assert.NotContains(t, instruction.Args, "reencrypt")
+	assert.True(t, instruction.SaveOutput)
+	assert.Contains(t, commandArguments, "secrets-encrypt")
+	assert.Contains(t, commandArguments, encryptionKeyRotationCommandRotateKeys)
+	assert.Contains(t, commandArguments, "2>&1")
+	assert.NotContains(t, commandArguments, "prepare")
+	assert.NotContains(t, commandArguments, "reencrypt")
 }
 
 func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
@@ -216,7 +219,7 @@ func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
 		Machine: &capi.Machine{ObjectMeta: metav1.ObjectMeta{Name: "server-1"}},
 	}
 
-	tests := []struct {
+	testCases := []struct {
 		name       string
 		output     string
 		expected   encryptionKeyRotationRuntimeStatus
@@ -256,24 +259,25 @@ func Test_encryptionKeyRotationStatusFromOutput(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			status, err := encryptionKeyRotationStatusFromOutput(entry, tt.output)
-			if tt.expectWait {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			status, err := encryptionKeyRotationStatusFromOutput(entry, testCase.output)
+			if testCase.expectWait {
 				assert.True(t, IsErrWaiting(err))
 				return
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, status)
+			assert.Equal(t, testCase.expected, status)
 		})
 	}
 }
 
 func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		name         string
 		periodicOut  string
+		savedOutput  string
 		planFailed   bool
 		expectStage  string
 		expectWait   bool
@@ -292,14 +296,28 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			expectStage: encryptionKeyRotationStageStart,
 		},
 		{
+			name: "timeout output falls back to periodic status",
+			periodicOut: "Current Rotation Stage: reencrypt_finished\n" +
+				"Server Encryption Hashes: All hashes match\n",
+			savedOutput: "level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n",
+			planFailed:  true,
+			expectStage: encryptionKeyRotationStageReencryptFinished,
+		},
+		{
+			name:        "timeout output waits for periodic status when not yet available",
+			savedOutput: "level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n",
+			planFailed:  true,
+			expectWait:  true,
+		},
+		{
 			name:         "plan failure marks status failed",
 			planFailed:   true,
 			expectFailed: true,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
 			planner := newTestEncryptionKeyRotationPlanner()
 			controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 				RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
@@ -310,35 +328,45 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Empty(t, joinedServer)
 
+			failedOutput := map[string][]byte{}
+			if testCase.savedOutput != "" {
+				failedOutput[nodePlan.Instructions[0].Name] = []byte(testCase.savedOutput)
+			}
 			leaderEntry.Plan = &plan.Node{
-				Plan:    nodePlan,
-				Failed:  tt.planFailed,
-				InSync:  true,
-				Healthy: true,
+				Plan:         nodePlan,
+				FailedOutput: failedOutput,
+				Failed:       testCase.planFailed,
+				InSync:       true,
+				Healthy:      true,
 				PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 					encryptionKeyRotationSecretsEncryptStatusCommand: {
-						Stdout: []byte(tt.periodicOut),
+						Stdout: []byte(testCase.periodicOut),
 					},
 				},
 			}
 
 			rotationStatus, updatedStatus, err := planner.encryptionKeyRotationRotateKeysReconcile(controlPlane, controlPlane.Status, plan.Secret{}, "https://server-1:9345", leaderEntry)
-			if tt.expectFailed {
+			if testCase.expectWait {
+				assert.True(t, IsErrWaiting(err))
+				assert.Equal(t, controlPlane.Status.RotateEncryptionKeysPhase, updatedStatus.RotateEncryptionKeysPhase)
+				return
+			}
+			if testCase.expectFailed {
 				assert.Error(t, err)
 				assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
 				return
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectStage, rotationStatus.Stage)
+			assert.Equal(t, testCase.expectStage, rotationStatus.Stage)
 			assert.Equal(t, controlPlane.Status.RotateEncryptionKeysPhase, updatedStatus.RotateEncryptionKeysPhase)
 		})
 	}
 }
 
 func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *testing.T) {
-	mp := newMockPlanner(t, InfoFunctions{})
-	mp.planner.store.equalities = testPlannerEqualities()
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
 
 	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
@@ -352,7 +380,7 @@ func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *tes
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:    nodePlan,
@@ -365,10 +393,10 @@ func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *tes
 		},
 	}
 
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
 
-	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
 	assert.True(t, IsErrWaiting(err))
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseDone, updatedStatus.RotateEncryptionKeysPhase)
@@ -376,26 +404,26 @@ func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *tes
 }
 
 func Test_rotateEncryptionKeys_movesToRestartPhaseWhenEtcdOnlyFollowersExist(t *testing.T) {
-	mp := newMockPlanner(t, InfoFunctions{})
-	mp.planner.store.equalities = testPlannerEqualities()
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
 
 	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
 		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
-		RotateEncryptionKeysLeader: "cp-leader",
+		RotateEncryptionKeysLeader: "control-plane-leader",
 		Initialization: rkev1.RKEControlPlaneInitializationStatus{
 			ControlPlaneInitialized: ptr.To(true),
 		},
 	})
 	clusterPlan := newTestEncryptionKeyRotationPlan(
 		newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
-		newTestEncryptionKeyRotationMachine("cp-leader", true, true, false, true, "https://cp-leader:9345"),
+		newTestEncryptionKeyRotationMachine("control-plane-leader", true, true, false, true, "https://control-plane-leader:9345"),
 		newTestEncryptionKeyRotationMachine("etcd-follower", true, false, false, true, "https://etcd-follower:9345"),
 	)
-	leader := newTestPlanEntryFromPlan(clusterPlan, "cp-leader")
-	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://etcd-init:9345", leader)
+	leader := newTestPlanEntryFromPlan(clusterPlan, "control-plane-leader")
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://etcd-init:9345", leader)
 	assert.NoError(t, err)
-	clusterPlan.Nodes["cp-leader"] = &plan.Node{
+	clusterPlan.Nodes["control-plane-leader"] = &plan.Node{
 		Plan:    nodePlan,
 		InSync:  true,
 		Healthy: true,
@@ -406,18 +434,18 @@ func Test_rotateEncryptionKeys_movesToRestartPhaseWhenEtcdOnlyFollowersExist(t *
 		},
 	}
 
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
 
-	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
 	assert.True(t, IsErrWaiting(err))
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhasePostRotateRestart, updatedStatus.RotateEncryptionKeysPhase)
-	assert.Equal(t, "cp-leader", updatedStatus.RotateEncryptionKeysLeader)
+	assert.Equal(t, "control-plane-leader", updatedStatus.RotateEncryptionKeysLeader)
 }
 
 func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T) {
-	mp := newMockPlanner(t, InfoFunctions{})
-	mp.planner.store.equalities = testPlannerEqualities()
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
 
 	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
@@ -431,7 +459,7 @@ func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T)
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:    nodePlan,
@@ -444,9 +472,9 @@ func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T)
 		},
 	}
 
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
 
-	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
 	assert.True(t, IsErrWaiting(err))
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseRotate, updatedStatus.RotateEncryptionKeysPhase)
@@ -454,8 +482,8 @@ func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T)
 }
 
 func Test_rotateEncryptionKeys_marksFailedWhenLeaderPlanFails(t *testing.T) {
-	mp := newMockPlanner(t, InfoFunctions{})
-	mp.planner.store.equalities = testPlannerEqualities()
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
 
 	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
@@ -469,7 +497,7 @@ func Test_rotateEncryptionKeys_marksFailedWhenLeaderPlanFails(t *testing.T) {
 		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
 	)
 	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
-	nodePlan, _, err := mp.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:   nodePlan,
@@ -477,19 +505,60 @@ func Test_rotateEncryptionKeys_marksFailedWhenLeaderPlanFails(t *testing.T) {
 		InSync: true,
 	}
 
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
 
-	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
 	assert.Error(t, err)
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
 	assert.Empty(t, updatedStatus.RotateEncryptionKeysLeader)
 }
 
+func Test_rotateEncryptionKeys_requeuesWhenLeaderRotateKeysTimesOut(t *testing.T) {
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
+
+	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
+		RotateEncryptionKeys:       &rkev1.RotateEncryptionKeys{Generation: 1},
+		RotateEncryptionKeysPhase:  rkev1.RotateEncryptionKeysPhaseRotate,
+		RotateEncryptionKeysLeader: "server-1",
+		Initialization: rkev1.RKEControlPlaneInitializationStatus{
+			ControlPlaneInitialized: ptr.To(true),
+		},
+	})
+	clusterPlan := newTestEncryptionKeyRotationPlan(
+		newTestEncryptionKeyRotationMachine("server-1", true, true, true, true, "https://server-1:9345"),
+	)
+	leader := newTestPlanEntryFromPlan(clusterPlan, "server-1")
+	nodePlan, _, err := mockPlanner.planner.encryptionKeyRotationRotateKeysPlan(controlPlane, plan.Secret{}, "https://server-1:9345", leader)
+	assert.NoError(t, err)
+	clusterPlan.Nodes["server-1"] = &plan.Node{
+		Plan:   nodePlan,
+		Failed: true,
+		InSync: true,
+		FailedOutput: map[string][]byte{
+			nodePlan.Instructions[0].Name: []byte("level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n"),
+		},
+		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
+			encryptionKeyRotationSecretsEncryptStatusCommand: {
+				Stdout: []byte("Current Rotation Stage: start\nServer Encryption Hashes: hash mismatch\n"),
+			},
+		},
+	}
+
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, true), nil)
+
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+
+	assert.True(t, IsErrWaiting(err))
+	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseRotate, updatedStatus.RotateEncryptionKeysPhase)
+	assert.Equal(t, "server-1", updatedStatus.RotateEncryptionKeysLeader)
+}
+
 func Test_rotateEncryptionKeys_marksFailedWhenNoSuitableLeaderExists(t *testing.T) {
-	mp := newMockPlanner(t, InfoFunctions{})
-	mp.planner.store.equalities = testPlannerEqualities()
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
 
 	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 1},
@@ -502,9 +571,9 @@ func Test_rotateEncryptionKeys_marksFailedWhenNoSuitableLeaderExists(t *testing.
 		newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
 	)
 
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
 
-	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, clusterPlan)
 
 	assert.Error(t, err)
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
@@ -512,8 +581,8 @@ func Test_rotateEncryptionKeys_marksFailedWhenNoSuitableLeaderExists(t *testing.
 }
 
 func Test_rotateEncryptionKeys_marksFailedWhenVersionUnsupported(t *testing.T) {
-	mp := newMockPlanner(t, InfoFunctions{})
-	mp.planner.store.equalities = testPlannerEqualities()
+	mockPlanner := newMockPlanner(t, InfoFunctions{})
+	mockPlanner.planner.store.equalities = testPlannerEqualities()
 
 	controlPlane := newOwnedEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 1}, rkev1.RKEControlPlaneStatus{
 		Initialization: rkev1.RKEControlPlaneInitializationStatus{
@@ -522,9 +591,9 @@ func Test_rotateEncryptionKeys_marksFailedWhenVersionUnsupported(t *testing.T) {
 	})
 	controlPlane.Spec.KubernetesVersion = "v1.29.9+rke2r1"
 
-	mp.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
+	mockPlanner.capiClusters.EXPECT().Get(controlPlane.Namespace, "capi-cluster").Return(pausedCluster(controlPlane.Namespace, false), nil)
 
-	updatedStatus, err := mp.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, &plan.Plan{})
+	updatedStatus, err := mockPlanner.planner.rotateEncryptionKeys(controlPlane, controlPlane.Status, plan.Secret{}, &plan.Plan{})
 
 	assert.True(t, IsErrWaiting(err))
 	assert.Equal(t, rkev1.RotateEncryptionKeysPhaseFailed, updatedStatus.RotateEncryptionKeysPhase)
@@ -726,6 +795,12 @@ func copyNode(in *plan.Node) *plan.Node {
 		out.Output = make(map[string][]byte, len(in.Output))
 		for key, value := range in.Output {
 			out.Output[key] = append([]byte(nil), value...)
+		}
+	}
+	if in.FailedOutput != nil {
+		out.FailedOutput = make(map[string][]byte, len(in.FailedOutput))
+		for key, value := range in.FailedOutput {
+			out.FailedOutput[key] = append([]byte(nil), value...)
 		}
 	}
 	if in.PeriodicOutput != nil {

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -178,42 +178,6 @@ func Test_encryptionKeyRotationFindLeader(t *testing.T) {
 	}
 }
 
-func Test_encryptionKeyRotationRestartTargetsForCluster(t *testing.T) {
-	t.Run("etcd-only init node split from control-plane convergence entries", func(t *testing.T) {
-		clusterPlan := newTestEncryptionKeyRotationPlan(
-			newTestEncryptionKeyRotationMachine("etcd-init", true, false, true, true, "https://etcd-init:9345"),
-			newTestEncryptionKeyRotationMachine("control-plane-leader", true, true, false, true, "https://control-plane-leader:9345"),
-			newTestEncryptionKeyRotationMachine("etcd-follower", true, false, false, true, "https://etcd-follower:9345"),
-			newTestEncryptionKeyRotationMachine("control-plane-follower", true, true, false, true, "https://control-plane-follower:9345"),
-		)
-
-		targets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
-
-		assert.Len(t, targets.etcdOnly, 2)
-		assert.Equal(t, "etcd-follower", targets.etcdOnly[0].Machine.Name)
-		assert.Equal(t, "etcd-init", targets.etcdOnly[1].Machine.Name)
-		assert.Len(t, targets.controlPlane, 2)
-		assert.Equal(t, "control-plane-follower", targets.controlPlane[0].Machine.Name)
-		assert.Equal(t, "control-plane-leader", targets.controlPlane[1].Machine.Name)
-	})
-
-	t.Run("control plane init node stays in control-plane restart group", func(t *testing.T) {
-		clusterPlan := newTestEncryptionKeyRotationPlan(
-			newTestEncryptionKeyRotationMachine("control-plane-init", true, true, true, true, "https://control-plane-init:9345"),
-			newTestEncryptionKeyRotationMachine("control-plane-leader", true, true, false, true, "https://control-plane-leader:9345"),
-			newTestEncryptionKeyRotationMachine("control-plane-follower", true, true, false, true, "https://control-plane-follower:9345"),
-		)
-
-		targets := encryptionKeyRotationRestartTargetsForCluster(clusterPlan)
-
-		assert.Empty(t, targets.etcdOnly)
-		assert.Len(t, targets.controlPlane, 3)
-		assert.Equal(t, "control-plane-follower", targets.controlPlane[0].Machine.Name)
-		assert.Equal(t, "control-plane-init", targets.controlPlane[1].Machine.Name)
-		assert.Equal(t, "control-plane-leader", targets.controlPlane[2].Machine.Name)
-	})
-}
-
 func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 	controlPlane := newTestEncryptionKeyRotationControlPlane(&rkev1.RotateEncryptionKeys{Generation: 3}, rkev1.RKEControlPlaneStatus{
 		RotateEncryptionKeys:      &rkev1.RotateEncryptionKeys{Generation: 3},

--- a/pkg/capr/planner/encryptionkeyrotation_test.go
+++ b/pkg/capr/planner/encryptionkeyrotation_test.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -193,6 +194,9 @@ func Test_encryptionKeyRotationSecretsEncryptInstruction(t *testing.T) {
 	assert.Contains(t, commandArguments, "secrets-encrypt")
 	assert.Contains(t, commandArguments, encryptionKeyRotationCommandRotateKeys)
 	assert.Contains(t, commandArguments, "2>&1")
+	assert.Contains(t, commandArguments, encryptionKeyRotationRotateKeysExitCodePrefix)
+	assert.Contains(t, commandArguments, "exit 0")
+	assert.NotContains(t, commandArguments, "grep")
 	assert.NotContains(t, commandArguments, "prepare")
 	assert.NotContains(t, commandArguments, "reencrypt")
 	assert.Contains(t, instruction.Env, "ENCRYPTION_KEY_ROTATION_GENERATION=3")
@@ -390,6 +394,7 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 		name         string
 		periodicOut  string
 		savedOutput  string
+		exitCode     int
 		planFailed   bool
 		expectStage  string
 		expectWait   bool
@@ -399,12 +404,14 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			name: "complete status returned",
 			periodicOut: "Current Rotation Stage: reencrypt_finished\n" +
 				"Server Encryption Hashes: All hashes match\n",
+			savedOutput: "keys rotated, reencryption finished\n",
 			expectStage: encryptionKeyRotationStageReencryptFinished,
 		},
 		{
 			name: "incomplete status returned for requeue",
 			periodicOut: "Current Rotation Stage: start\n" +
 				"Server Encryption Hashes: hash mismatch\n",
+			savedOutput: "keys rotated, reencryption finished\n",
 			expectStage: encryptionKeyRotationStageStart,
 		},
 		{
@@ -412,20 +419,20 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			periodicOut: "Current Rotation Stage: reencrypt_finished\n" +
 				"Server Encryption Hashes: All hashes match\n",
 			savedOutput: "level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n",
-			planFailed:  true,
+			exitCode:    1,
 			expectStage: encryptionKeyRotationStageReencryptFinished,
 		},
 		{
 			name:        "timeout output waits for periodic status when not yet available",
 			savedOutput: "level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n",
-			planFailed:  true,
+			exitCode:    1,
 			expectWait:  true,
 		},
 		{
 			name:         "rotate-keys error ID marks status failed",
 			savedOutput:  "time=\"2026-04-09T15:16:16Z\" level=fatal msg=\"Error: see server log for details: secret-encrypt error ID 78467\"\n",
+			exitCode:     1,
 			periodicOut:  "Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n",
-			planFailed:   true,
 			expectFailed: true,
 		},
 		{
@@ -447,16 +454,16 @@ func Test_encryptionKeyRotationRotateKeysReconcile(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Empty(t, joinedServer)
 
-			failedOutput := map[string][]byte{}
+			output := map[string][]byte{}
 			if testCase.savedOutput != "" {
-				failedOutput[nodePlan.Instructions[0].Name] = []byte(testCase.savedOutput)
+				output[nodePlan.Instructions[0].Name] = testRotateKeysOutput(testCase.savedOutput, testCase.exitCode)
 			}
 			leaderEntry.Plan = &plan.Node{
-				Plan:         nodePlan,
-				FailedOutput: failedOutput,
-				Failed:       testCase.planFailed,
-				InSync:       true,
-				Healthy:      true,
+				Plan:    nodePlan,
+				Output:  output,
+				Failed:  testCase.planFailed,
+				InSync:  true,
+				Healthy: true,
 				PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 					encryptionKeyRotationSecretsEncryptStatusCommand: {
 						Stdout: []byte(testCase.periodicOut),
@@ -506,6 +513,9 @@ func Test_rotateEncryptionKeys_marksDoneWhenSingleServerHasFinishedStatus(t *tes
 		Plan:    nodePlan,
 		InSync:  true,
 		Healthy: true,
+		Output: map[string][]byte{
+			nodePlan.Instructions[0].Name: testRotateKeysOutput("keys rotated, reencryption finished\n", 0),
+		},
 		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 			encryptionKeyRotationSecretsEncryptStatusCommand: {
 				Stdout: []byte("Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n"),
@@ -547,6 +557,9 @@ func Test_rotateEncryptionKeys_movesToRestartPhaseWhenEtcdOnlyFollowersExist(t *
 		Plan:    nodePlan,
 		InSync:  true,
 		Healthy: true,
+		Output: map[string][]byte{
+			nodePlan.Instructions[0].Name: testRotateKeysOutput("keys rotated, reencryption finished\n", 0),
+		},
 		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 			encryptionKeyRotationSecretsEncryptStatusCommand: {
 				Stdout: []byte("Current Rotation Stage: reencrypt_finished\nServer Encryption Hashes: All hashes match\n"),
@@ -585,6 +598,9 @@ func Test_rotateEncryptionKeys_requeuesWhileLeaderStatusIncomplete(t *testing.T)
 		Plan:    nodePlan,
 		InSync:  true,
 		Healthy: true,
+		Output: map[string][]byte{
+			nodePlan.Instructions[0].Name: testRotateKeysOutput("keys rotated, reencryption finished\n", 0),
+		},
 		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 			encryptionKeyRotationSecretsEncryptStatusCommand: {
 				Stdout: []byte("Current Rotation Stage: start\nServer Encryption Hashes: hash mismatch\n"),
@@ -656,10 +672,9 @@ func Test_rotateEncryptionKeys_requeuesWhenLeaderRotateKeysTimesOut(t *testing.T
 	assert.NoError(t, err)
 	clusterPlan.Nodes["server-1"] = &plan.Node{
 		Plan:   nodePlan,
-		Failed: true,
 		InSync: true,
-		FailedOutput: map[string][]byte{
-			nodePlan.Instructions[0].Name: []byte("level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): " + encryptionKeyRotationRotateKeysTimeoutMessage + "\"\n"),
+		Output: map[string][]byte{
+			nodePlan.Instructions[0].Name: testRotateKeysOutput("level=fatal msg=\"Put \\\"https://127.0.0.1:6443/v1-k3s/encrypt/config\\\": context deadline exceeded (Client.Timeout exceeded while awaiting headers): "+encryptionKeyRotationRotateKeysTimeoutMessage+"\"\n", 1),
 		},
 		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 			encryptionKeyRotationSecretsEncryptStatusCommand: {
@@ -811,6 +826,9 @@ func Test_encryptionKeyRotationRotateKeysReconcile_isIdempotentAcrossRepeatedCal
 		Plan:    nodePlan,
 		InSync:  true,
 		Healthy: true,
+		Output: map[string][]byte{
+			nodePlan.Instructions[0].Name: testRotateKeysOutput("keys rotated, reencryption finished\n", 0),
+		},
 		PeriodicOutput: map[string]plan.PeriodicInstructionOutput{
 			encryptionKeyRotationSecretsEncryptStatusCommand: {
 				Stdout: []byte("Current Rotation Stage: start\nServer Encryption Hashes: hash mismatch\n"),
@@ -983,6 +1001,10 @@ func copyStringMap(in map[string]string) map[string]string {
 	return out
 }
 
+func testRotateKeysOutput(output string, exitCode int) []byte {
+	return []byte(output + encryptionKeyRotationRotateKeysExitCodePrefix + strconv.Itoa(exitCode) + "\n")
+}
+
 func copyNode(in *plan.Node) *plan.Node {
 	if in == nil {
 		return nil
@@ -993,12 +1015,6 @@ func copyNode(in *plan.Node) *plan.Node {
 		out.Output = make(map[string][]byte, len(in.Output))
 		for key, value := range in.Output {
 			out.Output[key] = append([]byte(nil), value...)
-		}
-	}
-	if in.FailedOutput != nil {
-		out.FailedOutput = make(map[string][]byte, len(in.FailedOutput))
-		for key, value := range in.FailedOutput {
-			out.FailedOutput[key] = append([]byte(nil), value...)
 		}
 	}
 	if in.PeriodicOutput != nil {

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -335,7 +335,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 		return status, err
 	}
 
-	if status, err = p.rotateEncryptionKeys(cp, status, clusterSecretTokens, plan, releaseData); err != nil {
+	if status, err = p.rotateEncryptionKeys(cp, status, clusterSecretTokens, plan); err != nil {
 		return status, err
 	}
 

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -243,8 +243,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 		return status, fmt.Errorf("rkecluster %s/%s: error semver parsing kubernetes version %s: %v", cp.Namespace, cp.Name, cp.Spec.KubernetesVersion, err)
 	}
 
-	releaseData := p.retrievalFunctions.ReleaseData(p.ctx, cp)
-	if releaseData == nil {
+	if p.retrievalFunctions.ReleaseData(p.ctx, cp) == nil {
 		return status, errWaitingf("%s/%s: KDM release data is empty for %s", cp.Namespace, cp.Name, cp.Spec.KubernetesVersion)
 	}
 

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -186,6 +186,7 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	appliedPlanData := secret.Data["appliedPlan"]
 	failedChecksum := string(secret.Data["failed-checksum"])
 	output := secret.Data["applied-output"]
+	failedOutput := secret.Data["failed-output"]
 	appliedPeriodicOutput := secret.Data["applied-periodic-output"]
 	probes := secret.Data["probe-statuses"]
 	failureCount := secret.Data["failure-count"]
@@ -247,11 +248,11 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	}
 
 	if len(output) > 0 {
-		gz, err := gzip.NewReader(bytes.NewBuffer(output))
+		gzipReader, err := gzip.NewReader(bytes.NewBuffer(output))
 		if err != nil {
 			return nil, err
 		}
-		output, err = io.ReadAll(gz)
+		output, err = io.ReadAll(gzipReader)
 		if err != nil {
 			return nil, err
 		}
@@ -261,12 +262,27 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		}
 	}
 
-	if len(appliedPeriodicOutput) > 0 {
-		gz, err := gzip.NewReader(bytes.NewBuffer(appliedPeriodicOutput))
+	if len(failedOutput) > 0 {
+		gzipReader, err := gzip.NewReader(bytes.NewBuffer(failedOutput))
 		if err != nil {
 			return nil, err
 		}
-		output, err = io.ReadAll(gz)
+		failedOutput, err = io.ReadAll(gzipReader)
+		if err != nil {
+			return nil, err
+		}
+		result.FailedOutput = map[string][]byte{}
+		if err := json.Unmarshal(failedOutput, &result.FailedOutput); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(appliedPeriodicOutput) > 0 {
+		gzipReader, err := gzip.NewReader(bytes.NewBuffer(appliedPeriodicOutput))
+		if err != nil {
+			return nil, err
+		}
+		output, err = io.ReadAll(gzipReader)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -263,17 +263,11 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	}
 
 	if len(output) > 0 {
-		gzipReader, err := gzip.NewReader(bytes.NewBuffer(output))
+		decodedOutput, err := readGzip(output)
 		if err != nil {
 			return nil, err
 		}
-		output, err = io.ReadAll(gzipReader)
-		if err != nil {
-			return nil, err
-		}
-		if err := gzipReader.Close(); err != nil {
-			return nil, err
-		}
+		output = decodedOutput
 		result.Output = map[string][]byte{}
 		if err := json.Unmarshal(output, &result.Output); err != nil {
 			return nil, err
@@ -281,17 +275,11 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	}
 
 	if len(failedOutput) > 0 {
-		gzipReader, err := gzip.NewReader(bytes.NewBuffer(failedOutput))
+		decodedFailedOutput, err := readGzip(failedOutput)
 		if err != nil {
 			return nil, err
 		}
-		failedOutput, err = io.ReadAll(gzipReader)
-		if err != nil {
-			return nil, err
-		}
-		if err := gzipReader.Close(); err != nil {
-			return nil, err
-		}
+		failedOutput = decodedFailedOutput
 		result.FailedOutput = map[string][]byte{}
 		if err := json.Unmarshal(failedOutput, &result.FailedOutput); err != nil {
 			return nil, err
@@ -299,17 +287,11 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	}
 
 	if len(appliedPeriodicOutput) > 0 {
-		gzipReader, err := gzip.NewReader(bytes.NewBuffer(appliedPeriodicOutput))
+		decodedPeriodicOutput, err := readGzip(appliedPeriodicOutput)
 		if err != nil {
 			return nil, err
 		}
-		output, err = io.ReadAll(gzipReader)
-		if err != nil {
-			return nil, err
-		}
-		if err := gzipReader.Close(); err != nil {
-			return nil, err
-		}
+		output = decodedPeriodicOutput
 		result.PeriodicOutput = map[string]plan.PeriodicInstructionOutput{}
 		if err := json.Unmarshal(output, &result.PeriodicOutput); err != nil {
 			return nil, err
@@ -334,6 +316,20 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		result.InSync = bytes.Equal(planData, appliedPlanData)
 	}
 	return result, nil
+}
+
+func readGzip(data []byte) (_ []byte, err error) {
+	gzipReader, err := gzip.NewReader(bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := gzipReader.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	return io.ReadAll(gzipReader)
 }
 
 func ParseProbeStatuses(probeStatuses []byte) (*map[string]plan.ProbeStatus, bool, error) {

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -187,6 +187,7 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	appliedPlanData := secret.Data["appliedPlan"]
 	failedChecksum := string(secret.Data["failed-checksum"])
 	output := secret.Data["applied-output"]
+	failedOutput := secret.Data["failed-output"]
 	appliedPeriodicOutput := secret.Data["applied-periodic-output"]
 	probes := secret.Data["probe-statuses"]
 	failureCount := secret.Data["failure-count"]
@@ -262,11 +263,11 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	}
 
 	if len(output) > 0 {
-		gz, err := gzip.NewReader(bytes.NewBuffer(output))
+		gzipReader, err := gzip.NewReader(bytes.NewBuffer(output))
 		if err != nil {
 			return nil, err
 		}
-		output, err = io.ReadAll(gz)
+		output, err = io.ReadAll(gzipReader)
 		if err != nil {
 			return nil, err
 		}
@@ -276,12 +277,27 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		}
 	}
 
-	if len(appliedPeriodicOutput) > 0 {
-		gz, err := gzip.NewReader(bytes.NewBuffer(appliedPeriodicOutput))
+	if len(failedOutput) > 0 {
+		gzipReader, err := gzip.NewReader(bytes.NewBuffer(failedOutput))
 		if err != nil {
 			return nil, err
 		}
-		output, err = io.ReadAll(gz)
+		failedOutput, err = io.ReadAll(gzipReader)
+		if err != nil {
+			return nil, err
+		}
+		result.FailedOutput = map[string][]byte{}
+		if err := json.Unmarshal(failedOutput, &result.FailedOutput); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(appliedPeriodicOutput) > 0 {
+		gzipReader, err := gzip.NewReader(bytes.NewBuffer(appliedPeriodicOutput))
+		if err != nil {
+			return nil, err
+		}
+		output, err = io.ReadAll(gzipReader)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -187,7 +187,6 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	appliedPlanData := secret.Data["appliedPlan"]
 	failedChecksum := string(secret.Data["failed-checksum"])
 	output := secret.Data["applied-output"]
-	failedOutput := secret.Data["failed-output"]
 	appliedPeriodicOutput := secret.Data["applied-periodic-output"]
 	probes := secret.Data["probe-statuses"]
 	failureCount := secret.Data["failure-count"]
@@ -270,18 +269,6 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		output = decodedOutput
 		result.Output = map[string][]byte{}
 		if err := json.Unmarshal(output, &result.Output); err != nil {
-			return nil, err
-		}
-	}
-
-	if len(failedOutput) > 0 {
-		decodedFailedOutput, err := readGzip(failedOutput)
-		if err != nil {
-			return nil, err
-		}
-		failedOutput = decodedFailedOutput
-		result.FailedOutput = map[string][]byte{}
-		if err := json.Unmarshal(failedOutput, &result.FailedOutput); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -271,6 +271,9 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := gzipReader.Close(); err != nil {
+			return nil, err
+		}
 		result.Output = map[string][]byte{}
 		if err := json.Unmarshal(output, &result.Output); err != nil {
 			return nil, err
@@ -286,6 +289,9 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := gzipReader.Close(); err != nil {
+			return nil, err
+		}
 		result.FailedOutput = map[string][]byte{}
 		if err := json.Unmarshal(failedOutput, &result.FailedOutput); err != nil {
 			return nil, err
@@ -299,6 +305,9 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		}
 		output, err = io.ReadAll(gzipReader)
 		if err != nil {
+			return nil, err
+		}
+		if err := gzipReader.Close(); err != nil {
 			return nil, err
 		}
 		result.PeriodicOutput = map[string]plan.PeriodicInstructionOutput{}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/53677

## Problem

Rancher provisioning still uses the older encryption key rotation flow for downstream RKE2 and K3s clusters. That older flow is more complex and does not match the streamlined encryption key rotation process that upstream added in RKE2 and K3s v1.30 and newer.

For supported downstream versions, Rancher should follow the newer upstream workflow instead of continuing to manage the older multi-step legacy process. Keeping the older flow in Rancher adds extra complexity and makes Rancher differ from the behavior users now get
directly in newer RKE2 and K3s versions.

## Solution

This PR updates Rancher provisioning to use the newer streamlined encryption key rotation flow for RKE2 and K3s v1.30 and newer.

The planner now follows the modern upstream rotate-keys based workflow instead of the older legacy sequence. The encryption key rotation logic was updated to align with the current upstream process, including how Rancher starts rotation, tracks progress, handles restarts, and reconciles status during the rotation flow. The related unit tests were also updated and expanded to cover the new behavior.

This keeps Rancher aligned with the current upstream encryption key rotation model for supported versions and removes the need to continue using the older flow for these clusters.

## Testing

## Engineering Testing

### Manual Testing

- Rotation with around 3000 secrets and 20 KB payloads
- HA downstream cluster rotation with a split-role topology:
    - 2 nodes with control-plane + etcd + worker
    - 1 node with etcd-only

### Automated Testing

- Test types added/modified:
    - Unit

## QA Testing Considerations

QA should focus on downstream RKE2 and K3s clusters running v1.30 and newer.

Important cases:

- Single-node cluster rotation
- HA cluster rotation
- Split-role cluster rotation with etcd-only and control-plane nodes
- Rotation on a cluster with many secrets