### PR TITLE
Add annotations configs to gateway template in chart

### DIFF
--- a/chart/templates/ingate/gateway.yaml
+++ b/chart/templates/ingate/gateway.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "rancher.gateway" . }}
   labels:
 {{ include "rancher.labels" . | indent 4 }}
+  annotations:
+{{- if .Values.gateway.gatewayClass.annotations }}
+{{ toYaml .Values.gateway.gatewayClass.annotations | indent 4 }}
+{{- end }}
 spec:
   gatewayClassName: {{ .Values.gateway.gatewayClass.name }}
   listeners:

--- a/chart/templates/ingate/gateway.yaml
+++ b/chart/templates/ingate/gateway.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ include "rancher.gateway" . }}
   labels:
 {{ include "rancher.labels" . | indent 4 }}
-  annotations:
 {{- if .Values.gateway.gatewayClass.annotations }}
+  annotations:
 {{ toYaml .Values.gateway.gatewayClass.annotations | indent 4 }}
 {{- end }}
 spec:

--- a/chart/tests/gateway_test.yaml
+++ b/chart/tests/gateway_test.yaml
@@ -33,6 +33,36 @@ tests:
           path: apiVersion
           value: gateway.networking.k8s.io/v1
 
+  - it: should not render Gateway annotations when gatewayClass annotations are not provided
+    template: templates/ingate/gateway.yaml
+    set:
+      networkExposure:
+        type: gateway
+      gateway:
+        gatewayClass:
+          annotations: {}
+    asserts:
+      - exists:
+          path: metadata.annotations
+        not: true
+
+  - it: should render Gateway annotations when gatewayClass annotations are provided
+    template: templates/ingate/gateway.yaml
+    set:
+      networkExposure:
+        type: gateway
+      gateway:
+        gatewayClass:
+          annotations:
+            traefik.ingress.kubernetes.io/router.entrypoints: web
+            traefik.ingress.kubernetes.io/router.observability.tracing: true
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            traefik.ingress.kubernetes.io/router.entrypoints: web
+            traefik.ingress.kubernetes.io/router.observability.tracing: true
+
   - it: should configure HTTP listener with default Traefik port 8000
     template: templates/ingate/gateway.yaml
     set:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -112,6 +112,7 @@ gateway:
     ports: # Must match the GatewayClass's configured entrypoints
       http: 8000  # k3s Traefik defaults to web entrypoint to 8000
       https: 8443 # k3s Traefik defaults to websecure entrypoint to 8443
+    annotations: {}
     additionalListeners: [] # Additional listener configs
     #  - name: http
     #    protocol: HTTP


### PR DESCRIPTION
## Issue: 
#54983
<!-- link the issue or issues this PR resolves here -->
## Problem
Rancher Helm chart currently does not support adding custom annotations to the Gateway API `Gateway` resource (`chart/templates/ingate/gateway.yaml`). While the Ingress resource supports `ingress.extraAnnotations`, there is no equivalent configuration for users who expose Rancher via Gateway API and need to attach provider-specific annotations (e.g., Traefik, cert-manager, or external-DNS).
## Solution
- Added `gateway.gatewayClass.annotations: {}` to `chart/values.yaml` to provide a configurable values entry.
- Updated `chart/templates/ingate/gateway.yaml` to conditionally render `metadata.annotations` when `.Values.gateway.gatewayClass.annotations` is provided.
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
## Engineering Testing
### Manual Testing
Rendered the Helm template locally with `helm template` to verify that:
1. When `gateway.gatewayClass.annotations` is empty, the Gateway resource renders without an `annotations` block.
2. When annotations are provided, they are correctly indented under `metadata.annotations`.
### Automated Testing
* Test types added/modified:
    * None
* If "None" - Reason: This is a small Helm template/values change; existing chart tests do not cover Gateway annotation rendering, and no new Go/unit tests were added for this cosmetic values pass-through.
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_
Summary: Helm template rendering verified manually.
## QA Testing Considerations
- Verify Gateway resource is created successfully with and without custom annotations.
- Verify that existing `additionalListeners` behavior is not affected.
  
### Regressions Considerations
Low risk of regression; the change is gated by an `{{- if }}` block and only adds an optional `annotations` field.
_TODO_
Existing / newly added automated tests that provide evidence there are no regressions:
* Existing chart tests (`chart/tests/gateway_test.yaml`) can be run to confirm no breakage.