### PR TITLE
[backport v2.14] scc: update rancherProductIdentifier to rancher-prime (#54191)

### DIFF
--- a/pkg/telemetry/scc.go
+++ b/pkg/telemetry/scc.go
@@ -14,7 +14,7 @@ const (
 	SccSecretName = "rancher-scc-telemetry"
 
 	archUnknown              = "unknown"
-	rancherProductIdentifier = "rancher"
+	rancherProductIdentifier = "rancher-prime"
 )
 
 // SccPayload represents the canonical golang implementation of `schemas/scc-RMSSubscription.json`


### PR DESCRIPTION
Backport to 2.14: https://github.com/rancher/rancher/pull/54191