### PR TITLE
ensures no crtb reconciliation during clusterNotFound

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -182,7 +182,7 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding,
 // When a CRTB is created or updated, translate it into several k8s roles and bindings to actually enforce the RBAC
 // Specifically:
 // - ensure the subject can see the cluster in the mgmt API
-// - if the subject was granted owner permissions for the clsuter, ensure they can create/update/delete the cluster
+// - if the subject was granted owner permissions for the cluster, ensure they can create/update/delete the cluster
 // - if the subject was granted privileges to mgmt plane resources that are scoped to the cluster, enforce those rules in the cluster's mgmt plane namespace
 func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding, localConditions *[]metav1.Condition) error {
 	condition := metav1.Condition{Type: bindingExists}
@@ -193,14 +193,15 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 
 	clusterName := binding.ClusterName
 	cluster, err := c.clusterLister.Get("", clusterName)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		c.s.AddCondition(localConditions, condition, failedToGetCluster, err)
 		return err
 	}
 	if cluster == nil {
-		err = fmt.Errorf("cannot create binding because cluster %s was not found", clusterName)
-		c.s.AddCondition(localConditions, condition, clusterNotFound, err)
-		return err
+		notFoundErr := fmt.Errorf("cannot create binding %s/%s because cluster %s was not found", binding.Namespace, binding.Name, clusterName)
+		logrus.Warn(notFoundErr)
+		c.s.AddCondition(localConditions, condition, clusterNotFound, notFoundErr)
+		return nil
 	}
 	// if roletemplate is not builtin, check if it's inherited/cloned
 	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName, clusterContext, 0)

--- a/pkg/controllers/management/auth/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/crtb_handler_test.go
@@ -22,6 +22,10 @@ import (
 var (
 	errDefault  = fmt.Errorf("error")
 	defaultCRTB = v3.ClusterRoleTemplateBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-crtb",
+			Namespace: "testns",
+		},
 		UserName:           "test",
 		GroupName:          "",
 		GroupPrincipalName: "",
@@ -131,14 +135,14 @@ func TestReconcileBindings(t *testing.T) {
 					return nil, nil
 				}
 			},
-			wantError: true,
+			wantError: false,
 			crtb:      defaultCRTB.DeepCopy(),
 			wantConditions: []v1.Condition{
 				{
 					Type:    bindingExists,
 					Status:  v1.ConditionFalse,
 					Reason:  clusterNotFound,
-					Message: "cannot create binding because cluster clusterName was not found",
+					Message: "cannot create binding testns/test-crtb because cluster clusterName was not found",
 					LastTransitionTime: v1.Time{
 						Time: mockTime,
 					},


### PR DESCRIPTION
## Issue: #54428 
 
## Problem
The check for `not found` errors while fetching the cluster was skipped, due to which the controller framework requeues on any `non-nil` error. This leads orphaned CRTBs referencing deleted clusters retried indefinitely.
 
## Solution
Enhanced the error handling.

## Engineering Testing
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
n/a
 
### Regressions Considerations
n/a

Existing / newly added automated tests that provide evidence there are no regressions:
n/a