### PR TITLE
Add support for creating OIDCClients

### DIFF
--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -69,6 +69,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 		client.NodeDriverType,
 		client.NodePoolType,
 		client.NodeType,
+		client.OIDCClientType,
 		client.PodSecurityAdmissionConfigurationTemplateType,
 		client.PreferenceType,
 		client.ProjectNetworkPolicyType,
@@ -104,6 +105,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	Project(schemas, apiContext)
 	ProjectRoleTemplateBinding(schemas, apiContext)
 	PodSecurityAdmissionConfigurationTemplate(schemas, apiContext)
+	OIDCClients(schemas, apiContext)
 	GlobalRole(schemas, apiContext)
 	GlobalRoleBindings(schemas, apiContext)
 	RoleTemplate(schemas, apiContext)
@@ -366,4 +368,8 @@ func KontainerDriver(schemas *types.Schemas, management *config.ScaledContext) {
 
 func RancherUserNotifications(schemas *types.Schemas, management *config.ScaledContext) {
 	schemas.Schema(&managementschema.Version, client.RancherUserNotificationType)
+}
+
+func OIDCClients(schemas *types.Schemas, management *config.ScaledContext) {
+	schemas.Schema(&managementschema.Version, client.OIDCClientType)
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54099
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
The OIDCClient schema wasn't registered.
 
## Solution
This registers the OIDCClient schema.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_