### PR TITLE
SCIM: Configure principal ID attribute for users and groups

### DIFF
--- a/pkg/auth/providers/scim/auth.go
+++ b/pkg/auth/providers/scim/auth.go
@@ -36,6 +36,7 @@ type tokenAuthenticator struct {
 	secrets            wcorev1.SecretClient
 	isDisabledProvider func(provider string) (bool, error)
 	expireTokensAfter  func() time.Duration
+	getConfig          func(provider string) providerConfig
 }
 
 // Authenticate implements the http middleware for tokenAuthenticator.
@@ -59,6 +60,16 @@ func (a *tokenAuthenticator) Authenticate(next http.Handler) http.Handler {
 		disabled, err := a.isDisabledProvider(provider)
 		if err != nil || disabled {
 			writeError(w, NewError(http.StatusNotFound, http.StatusText(http.StatusNotFound)))
+			return
+		}
+
+		cfg := a.getConfig(provider)
+		if !cfg.Enabled {
+			writeError(w, NewError(http.StatusNotFound, http.StatusText(http.StatusNotFound)))
+			return
+		}
+		if cfg.Paused {
+			writeError(w, NewError(http.StatusServiceUnavailable, "SCIM provisioning is temporarily paused"))
 			return
 		}
 
@@ -102,10 +113,12 @@ func (a *tokenAuthenticator) Authenticate(next http.Handler) http.Handler {
 
 // NewTokenAuthenticator returns a new tokenAuthenticator instance.
 func NewTokenAuthenticator(wContext *wrangler.Context) *tokenAuthenticator {
+	cmCache := wContext.Core.ConfigMap().Cache()
 	return &tokenAuthenticator{
 		secretCache:        wContext.Core.Secret().Cache(),
 		secrets:            wContext.Core.Secret(),
 		isDisabledProvider: providers.IsDisabledProvider,
 		expireTokensAfter:  func() time.Duration { return settings.ExpireSCIMTokensAfter.GetDuration() },
+		getConfig:          func(provider string) providerConfig { return getProviderConfig(cmCache, provider) },
 	}
 }

--- a/pkg/auth/providers/scim/auth_test.go
+++ b/pkg/auth/providers/scim/auth_test.go
@@ -52,6 +52,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return 0 },
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
 		}
 
 		w := httptest.NewRecorder()
@@ -109,6 +110,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
 		}
 
 		w := httptest.NewRecorder()
@@ -202,6 +204,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return 0 },
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
 		}
 
 		w := httptest.NewRecorder()
@@ -238,6 +241,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return 0 },
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
 		}
 
 		someOtherToken := "c4faf0453d39dffa3bf7d3135f6a15e50dbd4b71fe74c5d5b9d45772e36511e1"
@@ -279,6 +283,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secrets:            secrets,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
 		}
 
 		w := httptest.NewRecorder()
@@ -329,6 +334,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secrets:            secrets,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
 		}
 
 		w := httptest.NewRecorder()
@@ -379,6 +385,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secrets:            secrets,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
 		}
 
 		w := httptest.NewRecorder()
@@ -390,5 +397,40 @@ func TestTokenAuthenticator(t *testing.T) {
 
 		// Authentication should succeed despite deletion failure
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("scim not enabled", func(t *testing.T) {
+		auth := &tokenAuthenticator{
+			isDisabledProvider: isDisabledProvider,
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: false} },
+		}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/v1/scim/"+provider+"/Users", nil)
+		r.SetPathValue("provider", provider)
+		r.Header.Set("Authorization", "Bearer "+validToken1)
+
+		auth.Authenticate(next).ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+	})
+
+	t.Run("scim paused", func(t *testing.T) {
+		secretCache := fake.NewMockCacheInterface[*v1.Secret](ctrl)
+
+		auth := &tokenAuthenticator{
+			secretCache:        secretCache,
+			isDisabledProvider: isDisabledProvider,
+			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true, Paused: true} },
+		}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/v1/scim/"+provider+"/Users", nil)
+		r.SetPathValue("provider", provider)
+		r.Header.Set("Authorization", "Bearer "+validToken1)
+
+		auth.Authenticate(next).ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusServiceUnavailable, w.Result().StatusCode)
 	})
 }

--- a/pkg/auth/providers/scim/auth_test.go
+++ b/pkg/auth/providers/scim/auth_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+func enabledProvider(string) providerConfig { return providerConfig{Enabled: true} }
+
 func TestTokenAuthenticator(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -52,7 +54,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return 0 },
-			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
+			getConfig:          enabledProvider,
 		}
 
 		w := httptest.NewRecorder()
@@ -110,7 +112,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
-			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
+			getConfig:          enabledProvider,
 		}
 
 		w := httptest.NewRecorder()
@@ -204,7 +206,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return 0 },
-			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
+			getConfig:          enabledProvider,
 		}
 
 		w := httptest.NewRecorder()
@@ -241,7 +243,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secretCache:        secretCache,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return 0 },
-			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
+			getConfig:          enabledProvider,
 		}
 
 		someOtherToken := "c4faf0453d39dffa3bf7d3135f6a15e50dbd4b71fe74c5d5b9d45772e36511e1"
@@ -283,7 +285,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secrets:            secrets,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
-			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
+			getConfig:          enabledProvider,
 		}
 
 		w := httptest.NewRecorder()
@@ -334,7 +336,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secrets:            secrets,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
-			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
+			getConfig:          enabledProvider,
 		}
 
 		w := httptest.NewRecorder()
@@ -385,7 +387,7 @@ func TestTokenAuthenticator(t *testing.T) {
 			secrets:            secrets,
 			isDisabledProvider: isDisabledProvider,
 			expireTokensAfter:  func() time.Duration { return time.Hour },
-			getConfig:          func(string) providerConfig { return providerConfig{Enabled: true} },
+			getConfig:          enabledProvider,
 		}
 
 		w := httptest.NewRecorder()

--- a/pkg/auth/providers/scim/config_provider.go
+++ b/pkg/auth/providers/scim/config_provider.go
@@ -106,11 +106,21 @@ func getProviderConfig(configMapCache wcorev1.ConfigMapCache, provider string) p
 	}
 
 	if v, ok := cm.Data["enabled"]; ok {
-		cfg.Enabled, _ = strconv.ParseBool(v)
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			logrus.Errorf("scim::getProviderConfig: invalid enabled value %q in configmap %s, using default", v, name)
+		} else {
+			cfg.Enabled = enabled
+		}
 	}
 
 	if v, ok := cm.Data["paused"]; ok {
-		cfg.Paused, _ = strconv.ParseBool(v)
+		paused, err := strconv.ParseBool(v)
+		if err != nil {
+			logrus.Errorf("scim::getProviderConfig: invalid paused value %q in configmap %s, using default", v, name)
+		} else {
+			cfg.Paused = paused
+		}
 	}
 
 	if v := cm.Data["userIdAttribute"]; v != "" {

--- a/pkg/auth/providers/scim/config_provider.go
+++ b/pkg/auth/providers/scim/config_provider.go
@@ -1,0 +1,127 @@
+package scim
+
+import (
+	"encoding/json"
+	"fmt"
+
+	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	configMapNamePrefix = "scim-config-"
+
+	// UserIDUserName selects SCIM userName as the user principal identifier.
+	UserIDUserName = "userName"
+	// UserIDExternalID selects SCIM externalId as the user principal identifier.
+	UserIDExternalID = "externalId"
+
+	// GroupIDDisplayName selects SCIM displayName as the group principal identifier.
+	GroupIDDisplayName = "displayName"
+	// GroupIDExternalID selects SCIM externalId as the group principal identifier.
+	GroupIDExternalID = "externalId"
+)
+
+// providerConfig holds SCIM provisioning settings for a single auth provider.
+// Stored as a ConfigMap in cattle-global-data with name "scim-config-{provider}".
+type providerConfig struct {
+	// UserIDAttribute specifies which SCIM user attribute to use as the
+	// identifier in the Rancher principal ID (e.g. "okta_user://<value>").
+	// Must match what the auth provider's login flow uses.
+	//
+	// Supported values: "userName" (default), "externalId".
+	UserIDAttribute string `json:"userIdAttribute,omitempty"`
+
+	// GroupIDAttribute specifies which SCIM group attribute to use as the
+	// identifier in the Rancher group principal ID.
+	//
+	// Supported values: "displayName" (default), "externalId".
+	GroupIDAttribute string `json:"groupIdAttribute,omitempty"`
+}
+
+func (c *providerConfig) userID(user scimUser) string {
+	switch c.UserIDAttribute {
+	case UserIDExternalID:
+		return user.ExternalID
+	default:
+		return user.UserName
+	}
+}
+
+func (c *providerConfig) groupID(displayName, externalID string) string {
+	switch c.GroupIDAttribute {
+	case GroupIDExternalID:
+		return externalID
+	default:
+		return displayName
+	}
+}
+
+func defaultProviderConfig() providerConfig {
+	return providerConfig{
+		UserIDAttribute:  UserIDUserName,
+		GroupIDAttribute: GroupIDDisplayName,
+	}
+}
+
+var validUserIDAttributes = map[string]bool{
+	UserIDUserName:   true,
+	UserIDExternalID: true,
+}
+
+var validGroupIDAttributes = map[string]bool{
+	GroupIDDisplayName: true,
+	GroupIDExternalID:  true,
+}
+
+// getProviderConfig loads the SCIM configuration for a provider from the ConfigMap.
+// Returns default config if no ConfigMap exists.
+func getProviderConfig(configMapCache wcorev1.ConfigMapCache, provider string) providerConfig {
+	cfg := defaultProviderConfig()
+
+	name := configMapNamePrefix + provider
+	cm, err := configMapCache.Get(tokenSecretNamespace, name)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			logrus.Errorf("scim::getProviderConfig: failed to get configmap %s: %s", name, err)
+		}
+		return cfg
+	}
+
+	data, ok := cm.Data["config"]
+	if !ok {
+		return cfg
+	}
+
+	if err := json.Unmarshal([]byte(data), &cfg); err != nil {
+		logrus.Errorf("scim::getProviderConfig: failed to parse configmap %s: %s", name, err)
+		return defaultProviderConfig()
+	}
+
+	if cfg.UserIDAttribute == "" {
+		cfg.UserIDAttribute = UserIDUserName
+	}
+	if cfg.GroupIDAttribute == "" {
+		cfg.GroupIDAttribute = GroupIDDisplayName
+	}
+
+	if !validUserIDAttributes[cfg.UserIDAttribute] {
+		logrus.Errorf("scim::getProviderConfig: invalid userIdAttribute %q in configmap %s, using default", cfg.UserIDAttribute, name)
+		cfg.UserIDAttribute = UserIDUserName
+	}
+	if !validGroupIDAttributes[cfg.GroupIDAttribute] {
+		logrus.Errorf("scim::getProviderConfig: invalid groupIdAttribute %q in configmap %s, using default", cfg.GroupIDAttribute, name)
+		cfg.GroupIDAttribute = GroupIDDisplayName
+	}
+
+	return cfg
+}
+
+func userPrincipalName(provider, id string) string {
+	return fmt.Sprintf("%s_user://%s", provider, id)
+}
+
+func groupPrincipalName(provider, id string) string {
+	return fmt.Sprintf("%s_group://%s", provider, id)
+}

--- a/pkg/auth/providers/scim/config_provider.go
+++ b/pkg/auth/providers/scim/config_provider.go
@@ -1,8 +1,8 @@
 package scim
 
 import (
-	"encoding/json"
 	"fmt"
+	"strconv"
 
 	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -25,19 +25,35 @@ const (
 
 // providerConfig holds SCIM provisioning settings for a single auth provider.
 // Stored as a ConfigMap in cattle-global-data with name "scim-config-{provider}".
+//
+// Each field maps directly to a key in ConfigMap.Data:
+//
+//	enabled:          "true" | "false"   (default: false)
+//	paused:           "true" | "false"   (default: false)
+//	userIdAttribute:  "userName" | "externalId"   (default: "userName")
+//	groupIdAttribute: "displayName" | "externalId" (default: "displayName")
 type providerConfig struct {
+	// Enabled controls whether SCIM provisioning is active for this provider.
+	// The SCIM feature flag must also be enabled; this flag alone is not sufficient.
+	Enabled bool
+
+	// Paused suspends SCIM provisioning without revoking tokens or losing configuration.
+	// When paused, the SCIM server returns 503 Service Unavailable.
+	// Once unpaused, the IdP can re-sync and reconcile any changes that occurred in the interim.
+	Paused bool
+
 	// UserIDAttribute specifies which SCIM user attribute to use as the
 	// identifier in the Rancher principal ID (e.g. "okta_user://<value>").
 	// Must match what the auth provider's login flow uses.
 	//
 	// Supported values: "userName" (default), "externalId".
-	UserIDAttribute string `json:"userIdAttribute,omitempty"`
+	UserIDAttribute string
 
 	// GroupIDAttribute specifies which SCIM group attribute to use as the
 	// identifier in the Rancher group principal ID.
 	//
 	// Supported values: "displayName" (default), "externalId".
-	GroupIDAttribute string `json:"groupIdAttribute,omitempty"`
+	GroupIDAttribute string
 }
 
 func (c *providerConfig) userID(user scimUser) string {
@@ -89,30 +105,28 @@ func getProviderConfig(configMapCache wcorev1.ConfigMapCache, provider string) p
 		return cfg
 	}
 
-	data, ok := cm.Data["config"]
-	if !ok {
-		return cfg
+	if v, ok := cm.Data["enabled"]; ok {
+		cfg.Enabled, _ = strconv.ParseBool(v)
 	}
 
-	if err := json.Unmarshal([]byte(data), &cfg); err != nil {
-		logrus.Errorf("scim::getProviderConfig: failed to parse configmap %s: %s", name, err)
-		return defaultProviderConfig()
+	if v, ok := cm.Data["paused"]; ok {
+		cfg.Paused, _ = strconv.ParseBool(v)
 	}
 
-	if cfg.UserIDAttribute == "" {
-		cfg.UserIDAttribute = UserIDUserName
-	}
-	if cfg.GroupIDAttribute == "" {
-		cfg.GroupIDAttribute = GroupIDDisplayName
+	if v := cm.Data["userIdAttribute"]; v != "" {
+		if validUserIDAttributes[v] {
+			cfg.UserIDAttribute = v
+		} else {
+			logrus.Errorf("scim::getProviderConfig: invalid userIdAttribute %q in configmap %s, using default", v, name)
+		}
 	}
 
-	if !validUserIDAttributes[cfg.UserIDAttribute] {
-		logrus.Errorf("scim::getProviderConfig: invalid userIdAttribute %q in configmap %s, using default", cfg.UserIDAttribute, name)
-		cfg.UserIDAttribute = UserIDUserName
-	}
-	if !validGroupIDAttributes[cfg.GroupIDAttribute] {
-		logrus.Errorf("scim::getProviderConfig: invalid groupIdAttribute %q in configmap %s, using default", cfg.GroupIDAttribute, name)
-		cfg.GroupIDAttribute = GroupIDDisplayName
+	if v := cm.Data["groupIdAttribute"]; v != "" {
+		if validGroupIDAttributes[v] {
+			cfg.GroupIDAttribute = v
+		} else {
+			logrus.Errorf("scim::getProviderConfig: invalid groupIdAttribute %q in configmap %s, using default", v, name)
+		}
 	}
 
 	return cfg

--- a/pkg/auth/providers/scim/config_provider_test.go
+++ b/pkg/auth/providers/scim/config_provider_test.go
@@ -106,6 +106,8 @@ func TestDefaultProviderConfig(t *testing.T) {
 	t.Parallel()
 
 	cfg := defaultProviderConfig()
+	assert.False(t, cfg.Enabled)
+	assert.False(t, cfg.Paused)
 	assert.Equal(t, UserIDUserName, cfg.UserIDAttribute)
 	assert.Equal(t, GroupIDDisplayName, cfg.GroupIDAttribute)
 }
@@ -114,10 +116,9 @@ func TestGetProviderConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		setup    func(*fake.MockCacheInterface[*corev1.ConfigMap])
-		wantUser string
-		wantGroup string
+		name       string
+		setup      func(*fake.MockCacheInterface[*corev1.ConfigMap])
+		wantConfig providerConfig
 	}{
 		{
 			name: "configmap not found returns defaults",
@@ -125,11 +126,20 @@ func TestGetProviderConfig(t *testing.T) {
 				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
 					Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "scim-config-azuread"))
 			},
-			wantUser:  UserIDUserName,
-			wantGroup: GroupIDDisplayName,
+			wantConfig: defaultProviderConfig(),
 		},
 		{
-			name: "configmap missing config key returns defaults",
+			name: "empty configmap returns defaults",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+					}, nil)
+			},
+			wantConfig: defaultProviderConfig(),
+		},
+		{
+			name: "unknown keys are ignored",
 			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
 				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
 					Return(&corev1.ConfigMap{
@@ -137,46 +147,77 @@ func TestGetProviderConfig(t *testing.T) {
 						Data:       map[string]string{"other": "value"},
 					}, nil)
 			},
-			wantUser:  UserIDUserName,
-			wantGroup: GroupIDDisplayName,
+			wantConfig: defaultProviderConfig(),
 		},
 		{
-			name: "valid config with externalId for both",
+			name: "enabled true",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"enabled": "true"},
+					}, nil)
+			},
+			wantConfig: providerConfig{Enabled: true, UserIDAttribute: UserIDUserName, GroupIDAttribute: GroupIDDisplayName},
+		},
+		{
+			name: "enabled false",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"enabled": "false"},
+					}, nil)
+			},
+			wantConfig: defaultProviderConfig(),
+		},
+		{
+			name: "enabled missing defaults to false",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"userIdAttribute": "externalId"},
+					}, nil)
+			},
+			wantConfig: providerConfig{Enabled: false, UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDDisplayName},
+		},
+		{
+			name: "paused true",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"enabled": "true", "paused": "true"},
+					}, nil)
+			},
+			wantConfig: providerConfig{Enabled: true, Paused: true, UserIDAttribute: UserIDUserName, GroupIDAttribute: GroupIDDisplayName},
+		},
+		{
+			name: "invalid bool value for enabled defaults to false",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"enabled": "yes"},
+					}, nil)
+			},
+			wantConfig: defaultProviderConfig(),
+		},
+		{
+			name: "externalId for both id attributes",
 			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
 				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
 					Return(&corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
 						Data: map[string]string{
-							"config": `{"userIdAttribute":"externalId","groupIdAttribute":"externalId"}`,
+							"enabled":          "true",
+							"userIdAttribute":  "externalId",
+							"groupIdAttribute": "externalId",
 						},
 					}, nil)
 			},
-			wantUser:  UserIDExternalID,
-			wantGroup: GroupIDExternalID,
-		},
-		{
-			name: "invalid JSON returns defaults",
-			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
-				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
-					Return(&corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
-						Data:       map[string]string{"config": "{invalid json"},
-					}, nil)
-			},
-			wantUser:  UserIDUserName,
-			wantGroup: GroupIDDisplayName,
-		},
-		{
-			name: "empty attribute values filled with defaults",
-			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
-				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
-					Return(&corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
-						Data:       map[string]string{"config": `{}`},
-					}, nil)
-			},
-			wantUser:  UserIDUserName,
-			wantGroup: GroupIDDisplayName,
+			wantConfig: providerConfig{Enabled: true, UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDExternalID},
 		},
 		{
 			name: "invalid attribute values fall back to defaults",
@@ -185,12 +226,12 @@ func TestGetProviderConfig(t *testing.T) {
 					Return(&corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
 						Data: map[string]string{
-							"config": `{"userIdAttribute":"bogus","groupIdAttribute":"invalid"}`,
+							"userIdAttribute":  "bogus",
+							"groupIdAttribute": "invalid",
 						},
 					}, nil)
 			},
-			wantUser:  UserIDUserName,
-			wantGroup: GroupIDDisplayName,
+			wantConfig: defaultProviderConfig(),
 		},
 		{
 			name: "partial config only sets specified attribute",
@@ -198,13 +239,10 @@ func TestGetProviderConfig(t *testing.T) {
 				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
 					Return(&corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
-						Data: map[string]string{
-							"config": `{"userIdAttribute":"externalId"}`,
-						},
+						Data:       map[string]string{"userIdAttribute": "externalId"},
 					}, nil)
 			},
-			wantUser:  UserIDExternalID,
-			wantGroup: GroupIDDisplayName,
+			wantConfig: providerConfig{UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDDisplayName},
 		},
 	}
 
@@ -216,8 +254,7 @@ func TestGetProviderConfig(t *testing.T) {
 			tt.setup(cache)
 
 			cfg := getProviderConfig(cache, "azuread")
-			assert.Equal(t, tt.wantUser, cfg.UserIDAttribute)
-			assert.Equal(t, tt.wantGroup, cfg.GroupIDAttribute)
+			assert.Equal(t, tt.wantConfig, cfg)
 		})
 	}
 }

--- a/pkg/auth/providers/scim/config_provider_test.go
+++ b/pkg/auth/providers/scim/config_provider_test.go
@@ -1,0 +1,235 @@
+package scim
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestProviderConfigUserID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  providerConfig
+		user scimUser
+		want string
+	}{
+		{
+			name: "default returns userName",
+			cfg:  defaultProviderConfig(),
+			user: scimUser{UserName: "john.doe", ExternalID: "ext-123"},
+			want: "john.doe",
+		},
+		{
+			name: "explicit userName returns userName",
+			cfg:  providerConfig{UserIDAttribute: UserIDUserName},
+			user: scimUser{UserName: "john.doe", ExternalID: "ext-123"},
+			want: "john.doe",
+		},
+		{
+			name: "externalId returns externalId",
+			cfg:  providerConfig{UserIDAttribute: UserIDExternalID},
+			user: scimUser{UserName: "john.doe", ExternalID: "ext-123"},
+			want: "ext-123",
+		},
+		{
+			name: "externalId with empty externalId returns empty",
+			cfg:  providerConfig{UserIDAttribute: UserIDExternalID},
+			user: scimUser{UserName: "john.doe"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.cfg.userID(tt.user))
+		})
+	}
+}
+
+func TestProviderConfigGroupID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         providerConfig
+		displayName string
+		externalID  string
+		want        string
+	}{
+		{
+			name:        "default returns displayName",
+			cfg:         defaultProviderConfig(),
+			displayName: "Engineering",
+			externalID:  "ext-grp-1",
+			want:        "Engineering",
+		},
+		{
+			name:        "explicit displayName returns displayName",
+			cfg:         providerConfig{GroupIDAttribute: GroupIDDisplayName},
+			displayName: "Engineering",
+			externalID:  "ext-grp-1",
+			want:        "Engineering",
+		},
+		{
+			name:        "externalId returns externalId",
+			cfg:         providerConfig{GroupIDAttribute: GroupIDExternalID},
+			displayName: "Engineering",
+			externalID:  "ext-grp-1",
+			want:        "ext-grp-1",
+		},
+		{
+			name:        "externalId with empty externalId returns empty",
+			cfg:         providerConfig{GroupIDAttribute: GroupIDExternalID},
+			displayName: "Engineering",
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.cfg.groupID(tt.displayName, tt.externalID))
+		})
+	}
+}
+
+func TestDefaultProviderConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultProviderConfig()
+	assert.Equal(t, UserIDUserName, cfg.UserIDAttribute)
+	assert.Equal(t, GroupIDDisplayName, cfg.GroupIDAttribute)
+}
+
+func TestGetProviderConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setup    func(*fake.MockCacheInterface[*corev1.ConfigMap])
+		wantUser string
+		wantGroup string
+	}{
+		{
+			name: "configmap not found returns defaults",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "scim-config-azuread"))
+			},
+			wantUser:  UserIDUserName,
+			wantGroup: GroupIDDisplayName,
+		},
+		{
+			name: "configmap missing config key returns defaults",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"other": "value"},
+					}, nil)
+			},
+			wantUser:  UserIDUserName,
+			wantGroup: GroupIDDisplayName,
+		},
+		{
+			name: "valid config with externalId for both",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data: map[string]string{
+							"config": `{"userIdAttribute":"externalId","groupIdAttribute":"externalId"}`,
+						},
+					}, nil)
+			},
+			wantUser:  UserIDExternalID,
+			wantGroup: GroupIDExternalID,
+		},
+		{
+			name: "invalid JSON returns defaults",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"config": "{invalid json"},
+					}, nil)
+			},
+			wantUser:  UserIDUserName,
+			wantGroup: GroupIDDisplayName,
+		},
+		{
+			name: "empty attribute values filled with defaults",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data:       map[string]string{"config": `{}`},
+					}, nil)
+			},
+			wantUser:  UserIDUserName,
+			wantGroup: GroupIDDisplayName,
+		},
+		{
+			name: "invalid attribute values fall back to defaults",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data: map[string]string{
+							"config": `{"userIdAttribute":"bogus","groupIdAttribute":"invalid"}`,
+						},
+					}, nil)
+			},
+			wantUser:  UserIDUserName,
+			wantGroup: GroupIDDisplayName,
+		},
+		{
+			name: "partial config only sets specified attribute",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data: map[string]string{
+							"config": `{"userIdAttribute":"externalId"}`,
+						},
+					}, nil)
+			},
+			wantUser:  UserIDExternalID,
+			wantGroup: GroupIDDisplayName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			cache := fake.NewMockCacheInterface[*corev1.ConfigMap](ctrl)
+			tt.setup(cache)
+
+			cfg := getProviderConfig(cache, "azuread")
+			assert.Equal(t, tt.wantUser, cfg.UserIDAttribute)
+			assert.Equal(t, tt.wantGroup, cfg.GroupIDAttribute)
+		})
+	}
+}
+
+func TestUserPrincipalName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "okta_user://john.doe", userPrincipalName("okta", "john.doe"))
+	assert.Equal(t, "azuread_user://obj-123", userPrincipalName("azuread", "obj-123"))
+}
+
+func TestGroupPrincipalName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "okta_group://Engineering", groupPrincipalName("okta", "Engineering"))
+	assert.Equal(t, "azuread_group://obj-456", groupPrincipalName("azuread", "obj-456"))
+}

--- a/pkg/auth/providers/scim/filter.go
+++ b/pkg/auth/providers/scim/filter.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -162,22 +163,17 @@ func (f *Filter) MatchesCaseExact(value string) bool {
 	return f.MatchesValue(value, true)
 }
 
-// ValidateForAttribute checks if the filter is valid for the specified attributes and operators.
+// ValidateForAttributes checks if the filter is valid for the specified attributes and operators.
 // Returns an error if the filter uses an unsupported attribute or operator.
-func (f *Filter) ValidateForAttribute(allowedAttributes []string, allowedOperators ...filterOperator) error {
+func (f *Filter) ValidateForAttributes(allowedAttributes []string, allowedOperators ...filterOperator) error {
 	if f == nil {
 		return nil
 	}
 
 	// Check attribute (case-insensitive per SCIM spec).
-	matched := false
-	for _, allowed := range allowedAttributes {
-		if strings.EqualFold(f.Attribute, allowed) {
-			matched = true
-			break
-		}
-	}
-	if !matched {
+	if !slices.ContainsFunc(allowedAttributes, func(a string) bool {
+		return strings.EqualFold(f.Attribute, a)
+	}) {
 		return fmt.Errorf("unsupported filter attribute %q: only %s supported",
 			f.Attribute, strings.Join(allowedAttributes, ", "))
 	}

--- a/pkg/auth/providers/scim/filter.go
+++ b/pkg/auth/providers/scim/filter.go
@@ -162,16 +162,24 @@ func (f *Filter) MatchesCaseExact(value string) bool {
 	return f.MatchesValue(value, true)
 }
 
-// ValidateForAttribute checks if the filter is valid for the specified attribute and operators.
+// ValidateForAttribute checks if the filter is valid for the specified attributes and operators.
 // Returns an error if the filter uses an unsupported attribute or operator.
-func (f *Filter) ValidateForAttribute(allowedAttribute string, allowedOperators ...filterOperator) error {
+func (f *Filter) ValidateForAttribute(allowedAttributes []string, allowedOperators ...filterOperator) error {
 	if f == nil {
 		return nil
 	}
 
 	// Check attribute (case-insensitive per SCIM spec).
-	if !strings.EqualFold(f.Attribute, allowedAttribute) {
-		return fmt.Errorf("unsupported filter attribute %q: only %q is supported", f.Attribute, allowedAttribute)
+	matched := false
+	for _, allowed := range allowedAttributes {
+		if strings.EqualFold(f.Attribute, allowed) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return fmt.Errorf("unsupported filter attribute %q: only %s supported",
+			f.Attribute, strings.Join(allowedAttributes, ", "))
 	}
 
 	// Check operator.

--- a/pkg/auth/providers/scim/filter_test.go
+++ b/pkg/auth/providers/scim/filter_test.go
@@ -389,7 +389,7 @@ func TestFilterMatchesCaseExact(t *testing.T) {
 	}
 }
 
-func TestFilterValidateForAttribute(t *testing.T) {
+func TestFilterValidateForAttributes(t *testing.T) {
 	tests := []struct {
 		name              string
 		filter            *Filter
@@ -454,7 +454,7 @@ func TestFilterValidateForAttribute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.filter.ValidateForAttribute(tt.allowedAttributes, tt.allowedOperators...)
+			err := tt.filter.ValidateForAttributes(tt.allowedAttributes, tt.allowedOperators...)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errContains != "" {

--- a/pkg/auth/providers/scim/filter_test.go
+++ b/pkg/auth/providers/scim/filter_test.go
@@ -391,62 +391,70 @@ func TestFilterMatchesCaseExact(t *testing.T) {
 
 func TestFilterValidateForAttribute(t *testing.T) {
 	tests := []struct {
-		name             string
-		filter           *Filter
-		allowedAttribute string
-		allowedOperators []filterOperator
-		wantErr          bool
-		errContains      string
+		name              string
+		filter            *Filter
+		allowedAttributes []string
+		allowedOperators  []filterOperator
+		wantErr           bool
+		errContains       string
 	}{
 		{
-			name:             "nil filter is valid",
-			filter:           nil,
-			allowedAttribute: "userName",
-			allowedOperators: []filterOperator{opEqual},
-			wantErr:          false,
+			name:              "nil filter is valid",
+			filter:            nil,
+			allowedAttributes: []string{"userName"},
+			allowedOperators:  []filterOperator{opEqual},
 		},
 		{
-			name:             "valid attribute and operator",
-			filter:           &Filter{Attribute: "userName", Operator: opEqual, Value: "john"},
-			allowedAttribute: "userName",
-			allowedOperators: []filterOperator{opEqual},
-			wantErr:          false,
+			name:              "valid attribute and operator",
+			filter:            &Filter{Attribute: "userName", Operator: opEqual, Value: "john"},
+			allowedAttributes: []string{"userName"},
+			allowedOperators:  []filterOperator{opEqual},
 		},
 		{
-			name:             "attribute case insensitive match",
-			filter:           &Filter{Attribute: "USERNAME", Operator: opEqual, Value: "john"},
-			allowedAttribute: "userName",
-			allowedOperators: []filterOperator{opEqual},
-			wantErr:          false,
+			name:              "attribute case insensitive match",
+			filter:            &Filter{Attribute: "USERNAME", Operator: opEqual, Value: "john"},
+			allowedAttributes: []string{"userName"},
+			allowedOperators:  []filterOperator{opEqual},
 		},
 		{
-			name:             "multiple allowed operators",
-			filter:           &Filter{Attribute: "userName", Operator: opStartsWith, Value: "john"},
-			allowedAttribute: "userName",
-			allowedOperators: []filterOperator{opEqual, opStartsWith, opContains},
-			wantErr:          false,
+			name:              "multiple allowed operators",
+			filter:            &Filter{Attribute: "userName", Operator: opStartsWith, Value: "john"},
+			allowedAttributes: []string{"userName"},
+			allowedOperators:  []filterOperator{opEqual, opStartsWith, opContains},
 		},
 		{
-			name:             "unsupported attribute",
-			filter:           &Filter{Attribute: "externalId", Operator: opEqual, Value: "ext-123"},
-			allowedAttribute: "userName",
-			allowedOperators: []filterOperator{opEqual},
-			wantErr:          true,
-			errContains:      "unsupported filter attribute",
+			name:              "multiple allowed attributes matches first",
+			filter:            &Filter{Attribute: "userName", Operator: opEqual, Value: "john"},
+			allowedAttributes: []string{"userName", "externalId"},
+			allowedOperators:  []filterOperator{opEqual},
 		},
 		{
-			name:             "unsupported operator",
-			filter:           &Filter{Attribute: "userName", Operator: opContains, Value: "john"},
-			allowedAttribute: "userName",
-			allowedOperators: []filterOperator{opEqual},
-			wantErr:          true,
-			errContains:      "unsupported filter operator",
+			name:              "multiple allowed attributes matches second",
+			filter:            &Filter{Attribute: "externalId", Operator: opEqual, Value: "ext-123"},
+			allowedAttributes: []string{"userName", "externalId"},
+			allowedOperators:  []filterOperator{opEqual},
+		},
+		{
+			name:              "unsupported attribute",
+			filter:            &Filter{Attribute: "externalId", Operator: opEqual, Value: "ext-123"},
+			allowedAttributes: []string{"userName"},
+			allowedOperators:  []filterOperator{opEqual},
+			wantErr:           true,
+			errContains:       "unsupported filter attribute",
+		},
+		{
+			name:              "unsupported operator",
+			filter:            &Filter{Attribute: "userName", Operator: opContains, Value: "john"},
+			allowedAttributes: []string{"userName"},
+			allowedOperators:  []filterOperator{opEqual},
+			wantErr:           true,
+			errContains:       "unsupported filter operator",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.filter.ValidateForAttribute(tt.allowedAttribute, tt.allowedOperators...)
+			err := tt.filter.ValidateForAttribute(tt.allowedAttributes, tt.allowedOperators...)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errContains != "" {

--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -116,6 +116,9 @@ func (s *SCIMServer) ListGroups(w http.ResponseWriter, r *http.Request) {
 			}
 
 			gid := cfg.groupID(group.DisplayName, group.ExternalID)
+			if gid == "" {
+				continue
+			}
 			gpn := groupPrincipalName(provider, gid)
 
 			resource := map[string]any{
@@ -271,6 +274,11 @@ func (s *SCIMServer) GetGroup(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.getConfig(provider)
 	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	if gid == "" {
+		logrus.Errorf("scim::GetGroup: group %s has empty %s configured as groupIdAttribute", group.Name, cfg.GroupIDAttribute)
+		writeError(w, NewInternalError())
+		return
+	}
 	gpn := groupPrincipalName(provider, gid)
 
 	var members []scimMember
@@ -348,6 +356,11 @@ func (s *SCIMServer) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	if gid == "" {
+		logrus.Errorf("scim::UpdateGroup: group %s has empty %s configured as groupIdAttribute", group.Name, cfg.GroupIDAttribute)
+		writeError(w, NewInternalError())
+		return
+	}
 	gpn := groupPrincipalName(provider, gid)
 	err = s.syncGroupMembers(provider, gpn, group.DisplayName, payload.Members)
 	if err != nil {
@@ -509,6 +522,11 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.getConfig(provider)
 	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	if gid == "" {
+		logrus.Errorf("scim::PatchGroup: group %s has empty %s configured as groupIdAttribute", group.Name, cfg.GroupIDAttribute)
+		writeError(w, NewInternalError())
+		return
+	}
 	gpn := groupPrincipalName(provider, gid)
 
 	// Apply group updates
@@ -594,6 +612,11 @@ func (s *SCIMServer) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.getConfig(provider)
 	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	if gid == "" {
+		logrus.Errorf("scim::DeleteGroup: group %s has empty %s configured as groupIdAttribute", group.Name, cfg.GroupIDAttribute)
+		writeError(w, NewInternalError())
+		return
+	}
 	gpn := groupPrincipalName(provider, gid)
 
 	err = s.removeAllGroupMembers(provider, gpn)

--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -355,6 +355,22 @@ func (s *SCIMServer) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Update DisplayName if it changed (only when externalId is the group ID).
+	if group.DisplayName != payload.DisplayName {
+		if cfg.GroupIDAttribute != GroupIDExternalID {
+			writeError(w, NewError(http.StatusBadRequest, "displayName cannot be changed when it is used as the group principal identifier"))
+			return
+		}
+		group = group.DeepCopy()
+		group.DisplayName = payload.DisplayName
+		group, err = s.groups.Update(group)
+		if err != nil {
+			logrus.Errorf("scim::UpdateGroup: failed to update group %s: %s", group.Name, err)
+			writeError(w, NewInternalError())
+			return
+		}
+	}
+
 	gid := cfg.groupID(group.DisplayName, group.ExternalID)
 	if gid == "" {
 		logrus.Errorf("scim::UpdateGroup: group %s has empty %s configured as groupIdAttribute", group.Name, cfg.GroupIDAttribute)
@@ -429,15 +445,16 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	group = group.DeepCopy()
-	var shouldUpdateGroup bool
+	cfg := s.getConfig(provider)
 
+	var shouldUpdateGroup bool
 	var membersToAdd []scimMember
 	var membersToRemove []string
 
 	for _, op := range payload.Operations {
 		switch strings.ToLower(op.Op) {
 		case "replace":
-			updated, err := applyReplaceGroup(group, op)
+			updated, err := applyReplaceGroup(group, op, cfg)
 			if err != nil {
 				logrus.Errorf("scim::PatchGroup: failed to apply replace operation: %s", err)
 				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply replace operation: %s", err)))
@@ -520,7 +537,6 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	cfg := s.getConfig(provider)
 	gid := cfg.groupID(group.DisplayName, group.ExternalID)
 	if gid == "" {
 		logrus.Errorf("scim::PatchGroup: group %s has empty %s configured as groupIdAttribute", group.Name, cfg.GroupIDAttribute)
@@ -738,6 +754,7 @@ func (s *SCIMServer) syncGroupMembers(provider, principalName, displayName strin
 		}
 	}
 
+	retained := make(map[string]struct{})
 	for _, member := range members {
 		if _, ok := existing[member.Value]; !ok {
 			// New member added.
@@ -745,6 +762,8 @@ func (s *SCIMServer) syncGroupMembers(provider, principalName, displayName strin
 			if err != nil {
 				return fmt.Errorf("failed to add member %s to group %s: %w", member.Value, principalName, err)
 			}
+		} else {
+			retained[member.Value] = struct{}{}
 		}
 		delete(existing, member.Value)
 	}
@@ -754,6 +773,13 @@ func (s *SCIMServer) syncGroupMembers(provider, principalName, displayName strin
 		err := s.removeGroupMember(provider, principalName, value)
 		if err != nil {
 			return fmt.Errorf("failed to remove member %s from group %s: %w", value, principalName, err)
+		}
+	}
+
+	// Update DisplayName on retained members' group principals if it changed.
+	for memberID := range retained {
+		if err := s.updateGroupMemberDisplayName(provider, principalName, displayName, memberID); err != nil {
+			return fmt.Errorf("failed to update display name for member %s in group %s: %w", memberID, principalName, err)
 		}
 	}
 
@@ -799,6 +825,34 @@ func (s *SCIMServer) addGroupMember(provider, principalName, displayName string,
 	_, err = s.userAttributes.Update(attr)
 	if err != nil {
 		return fmt.Errorf("failed to update user attributes for %s: %w", user.Name, err)
+	}
+
+	return nil
+}
+
+// updateGroupMemberDisplayName updates the DisplayName on a member's group principal if it is stale.
+func (s *SCIMServer) updateGroupMemberDisplayName(provider, principalName, displayName, memberID string) error {
+	attr, err := s.userAttributeCache.Get(memberID)
+	if err != nil {
+		return fmt.Errorf("failed to get user attributes for %s: %w", memberID, err)
+	}
+
+	for _, p := range attr.GroupPrincipals[provider].Items {
+		if p.Name == principalName && p.DisplayName != displayName {
+			attr = attr.DeepCopy()
+			items := attr.GroupPrincipals[provider].Items
+			for i := range items {
+				if items[i].Name == principalName {
+					items[i].DisplayName = displayName
+					break
+				}
+			}
+			attr.GroupPrincipals[provider] = v3.Principals{Items: items}
+			if _, err := s.userAttributes.Update(attr); err != nil {
+				return fmt.Errorf("failed to update user attributes for %s: %w", memberID, err)
+			}
+			return nil
+		}
 	}
 
 	return nil
@@ -927,8 +981,7 @@ func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup) (*v3.Gro
 }
 
 // applyReplaceGroup applies a replace operation to a group.
-// Currently only supports replacing externalId.
-func applyReplaceGroup(group *v3.Group, op patchOp) (bool, error) {
+func applyReplaceGroup(group *v3.Group, op patchOp, cfg providerConfig) (bool, error) {
 	if op.Path == "" {
 		// Bulk replace - replace multiple attributes at once
 		fields, ok := op.Value.(map[string]any)
@@ -942,7 +995,7 @@ func applyReplaceGroup(group *v3.Group, op patchOp) (bool, error) {
 				Op:    "replace",
 				Path:  name,
 				Value: value,
-			})
+			}, cfg)
 			if err != nil {
 				return false, fmt.Errorf("failed to apply replace operation: %v", err)
 			}
@@ -955,7 +1008,19 @@ func applyReplaceGroup(group *v3.Group, op patchOp) (bool, error) {
 
 	var updated bool
 	switch strings.ToLower(op.Path) {
-	// Note: We can't change displayName as it is used as the unique identifier for groups.
+	case "displayname":
+		if cfg.GroupIDAttribute != GroupIDExternalID {
+			return false, NewError(http.StatusBadRequest, "displayName cannot be changed when it is used as the group principal identifier")
+		}
+
+		displayName, ok := op.Value.(string)
+		if !ok {
+			return false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid value for displayName: %v", op.Value))
+		}
+		if group.DisplayName != displayName {
+			group.DisplayName = displayName
+			updated = true
+		}
 	case "externalid":
 		externalID, ok := op.Value.(string)
 		if !ok {

--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -60,7 +60,7 @@ func (s *SCIMServer) ListGroups(w http.ResponseWriter, r *http.Request) {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}
-		if err := filter.ValidateForAttribute([]string{"displayName", "externalId"}, opEqual); err != nil {
+		if err := filter.ValidateForAttributes([]string{"displayName", "externalId"}, opEqual); err != nil {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}

--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -60,8 +60,7 @@ func (s *SCIMServer) ListGroups(w http.ResponseWriter, r *http.Request) {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}
-		// Currently only support displayName eq "<value>" filter.
-		if err := filter.ValidateForAttribute("displayName", opEqual); err != nil {
+		if err := filter.ValidateForAttribute([]string{"displayName", "externalId"}, opEqual); err != nil {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}
@@ -90,6 +89,8 @@ func (s *SCIMServer) ListGroups(w http.ResponseWriter, r *http.Request) {
 		return groups[i].Name < groups[j].Name
 	})
 
+	cfg := s.getConfig(provider)
+
 	// Collect all matching resources (needed to compute totalResults).
 	var allResources []any
 	if len(groups) > 0 {
@@ -104,10 +105,18 @@ func (s *SCIMServer) ListGroups(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, group := range groups {
-			// Case insensitive match for displayName.
-			if !filter.Matches(group.DisplayName) {
+			var filterTarget string
+			if filter != nil && strings.EqualFold(filter.Attribute, "externalId") {
+				filterTarget = group.ExternalID
+			} else {
+				filterTarget = group.DisplayName
+			}
+			if !filter.Matches(filterTarget) {
 				continue
 			}
+
+			gid := cfg.groupID(group.DisplayName, group.ExternalID)
+			gpn := groupPrincipalName(provider, gid)
 
 			resource := map[string]any{
 				"schemas":     []string{groupSchemaID},
@@ -120,7 +129,7 @@ func (s *SCIMServer) ListGroups(w http.ResponseWriter, r *http.Request) {
 					"location":     locationURL(r, provider, groupEndpoint, group.Name),
 				},
 			}
-			members, ok := uniqueGroups[group.DisplayName]
+			members, ok := uniqueGroups[gpn]
 			if !ok {
 				members = []scimMember{}
 			}
@@ -174,6 +183,14 @@ func (s *SCIMServer) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg := s.getConfig(provider)
+	gid := cfg.groupID(payload.DisplayName, payload.ExternalID)
+	if gid == "" {
+		writeError(w, NewError(http.StatusBadRequest,
+			fmt.Sprintf("%s is required when configured as groupIdAttribute", cfg.GroupIDAttribute)))
+		return
+	}
+
 	group, created, err := s.ensureRancherGroup(provider, payload)
 	if err != nil {
 		logrus.Errorf("scim::CreateGroup: failed to ensure rancher group: %s", err)
@@ -187,8 +204,9 @@ func (s *SCIMServer) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	gpn := groupPrincipalName(provider, gid)
 	if len(payload.Members) > 0 {
-		err = s.syncGroupMembers(provider, group.DisplayName, payload.Members)
+		err = s.syncGroupMembers(provider, gpn, group.DisplayName, payload.Members)
 		if err != nil {
 			if scimErr, ok := err.(*Error); ok {
 				writeError(w, scimErr)
@@ -251,9 +269,13 @@ func (s *SCIMServer) GetGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg := s.getConfig(provider)
+	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	gpn := groupPrincipalName(provider, gid)
+
 	var members []scimMember
 	if !excludeMembers {
-		members, err = s.getRancherGroupMembers(provider, group.DisplayName)
+		members, err = s.getRancherGroupMembers(provider, gpn)
 		if err != nil {
 			logrus.Errorf("scim::GetGroups: %s", err)
 			writeError(w, NewInternalError())
@@ -311,6 +333,8 @@ func (s *SCIMServer) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg := s.getConfig(provider)
+
 	group, _, err := s.ensureRancherGroup(provider, payload)
 	if err != nil {
 		if scimErr, ok := err.(*Error); ok {
@@ -323,7 +347,9 @@ func (s *SCIMServer) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.syncGroupMembers(provider, group.DisplayName, payload.Members)
+	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	gpn := groupPrincipalName(provider, gid)
+	err = s.syncGroupMembers(provider, gpn, group.DisplayName, payload.Members)
 	if err != nil {
 		logrus.Errorf("scim::UpdateGroup: failed to sync group members for %s: %s", id, err)
 		writeError(w, NewInternalError())
@@ -481,6 +507,10 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	cfg := s.getConfig(provider)
+	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	gpn := groupPrincipalName(provider, gid)
+
 	// Apply group updates
 	if shouldUpdateGroup {
 		if group, err = s.groups.Update(group); err != nil {
@@ -492,7 +522,7 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 	// Apply member additions
 	for _, member := range membersToAdd {
-		err := s.addGroupMember(provider, group.DisplayName, member)
+		err := s.addGroupMember(provider, gpn, group.DisplayName, member)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				writeError(w, NewError(http.StatusNotFound, fmt.Sprintf("User %s not found", member.Value)))
@@ -507,7 +537,7 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 	// Apply member removals
 	for _, memberValue := range membersToRemove {
-		if err := s.removeGroupMember(provider, group.DisplayName, memberValue); err != nil {
+		if err := s.removeGroupMember(provider, gpn, memberValue); err != nil {
 			logrus.Errorf("scim::PatchGroup: failed to remove member %s: %s", memberValue, err)
 			writeError(w, NewInternalError())
 			return
@@ -515,7 +545,7 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch current members for response
-	members, err := s.getRancherGroupMembers(provider, group.DisplayName)
+	members, err := s.getRancherGroupMembers(provider, gpn)
 	if err != nil {
 		logrus.Errorf("scim::PatchGroup: failed to get group members: %s", err)
 		writeError(w, NewInternalError())
@@ -562,7 +592,11 @@ func (s *SCIMServer) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.removeAllGroupMembers(provider, group.DisplayName)
+	cfg := s.getConfig(provider)
+	gid := cfg.groupID(group.DisplayName, group.ExternalID)
+	gpn := groupPrincipalName(provider, gid)
+
+	err = s.removeAllGroupMembers(provider, gpn)
 	if err != nil {
 		logrus.Errorf("scim::DeleteGroup: failed to remove group members: %s", err)
 		writeError(w, NewInternalError())
@@ -600,7 +634,7 @@ func (s *SCIMServer) getAllRancherGroupMembers(provider string) (map[string][]sc
 		}
 
 		for _, group := range attr.GroupPrincipals[provider].Items {
-			uniqueGroups[group.DisplayName] = append(uniqueGroups[group.DisplayName], scimMember{
+			uniqueGroups[group.Name] = append(uniqueGroups[group.Name], scimMember{
 				Value:   user.Name,
 				Display: first(attr.ExtraByProvider[provider]["username"]),
 				Type:    userResource,
@@ -612,7 +646,8 @@ func (s *SCIMServer) getAllRancherGroupMembers(provider string) (map[string][]sc
 }
 
 // getRancherGroupMembers retrieves members of a specific group for the specified provider.
-func (s *SCIMServer) getRancherGroupMembers(provider string, name string) ([]scimMember, error) {
+// principalName is the full group principal name (e.g. "okta_group://Engineering").
+func (s *SCIMServer) getRancherGroupMembers(provider string, principalName string) ([]scimMember, error) {
 	list, err := s.userCache.List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list users: %w", err)
@@ -633,7 +668,7 @@ func (s *SCIMServer) getRancherGroupMembers(provider string, name string) ([]sci
 		}
 
 		for _, group := range attr.GroupPrincipals[provider].Items {
-			if group.DisplayName == name {
+			if group.Name == principalName {
 				members = append(members, scimMember{
 					Value:   user.Name,
 					Display: first(attr.ExtraByProvider[provider]["username"]),
@@ -648,8 +683,10 @@ func (s *SCIMServer) getRancherGroupMembers(provider string, name string) ([]sci
 }
 
 // syncGroupMembers synchronizes the members of a group to match the provided list.
-func (s *SCIMServer) syncGroupMembers(provider, groupName string, members []scimMember) error {
-	rancherMembers, err := s.getRancherGroupMembers(provider, groupName)
+// principalName is the full group principal name (e.g. "okta_group://Engineering").
+// displayName is the human-readable group name, stored on new group principals.
+func (s *SCIMServer) syncGroupMembers(provider, principalName, displayName string, members []scimMember) error {
+	rancherMembers, err := s.getRancherGroupMembers(provider, principalName)
 	if err != nil {
 		return fmt.Errorf("failed to get groups: %w", err)
 	}
@@ -681,9 +718,9 @@ func (s *SCIMServer) syncGroupMembers(provider, groupName string, members []scim
 	for _, member := range members {
 		if _, ok := existing[member.Value]; !ok {
 			// New member added.
-			err := s.addGroupMember(provider, groupName, member)
+			err := s.addGroupMember(provider, principalName, displayName, member)
 			if err != nil {
-				return fmt.Errorf("failed to add member %s to group %s: %w", member.Value, groupName, err)
+				return fmt.Errorf("failed to add member %s to group %s: %w", member.Value, principalName, err)
 			}
 		}
 		delete(existing, member.Value)
@@ -691,9 +728,9 @@ func (s *SCIMServer) syncGroupMembers(provider, groupName string, members []scim
 
 	for value := range existing {
 		// Existing member removed.
-		err := s.removeGroupMember(provider, groupName, value)
+		err := s.removeGroupMember(provider, principalName, value)
 		if err != nil {
-			return fmt.Errorf("failed to remove member %s from group %s: %w", value, groupName, err)
+			return fmt.Errorf("failed to remove member %s from group %s: %w", value, principalName, err)
 		}
 	}
 
@@ -701,7 +738,9 @@ func (s *SCIMServer) syncGroupMembers(provider, groupName string, members []scim
 }
 
 // addGroupMember adds a member to a group.
-func (s *SCIMServer) addGroupMember(provider, groupName string, member scimMember) error {
+// principalName is the full group principal name (e.g. "okta_group://Engineering").
+// displayName is the human-readable group name.
+func (s *SCIMServer) addGroupMember(provider, principalName, displayName string, member scimMember) error {
 	user, err := s.userCache.Get(member.Value)
 	if err != nil {
 		return fmt.Errorf("failed to get user %s: %w", member.Value, err)
@@ -713,7 +752,7 @@ func (s *SCIMServer) addGroupMember(provider, groupName string, member scimMembe
 	}
 
 	for _, principal := range attr.GroupPrincipals[provider].Items {
-		if principal.DisplayName == groupName {
+		if principal.Name == principalName {
 			return nil // Member already exists.
 		}
 	}
@@ -725,9 +764,9 @@ func (s *SCIMServer) addGroupMember(provider, groupName string, member scimMembe
 	principals := attr.GroupPrincipals[provider].Items
 	principals = append(principals, v3.Principal{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s_group://%s", provider, groupName),
+			Name: principalName,
 		},
-		DisplayName:   groupName,
+		DisplayName:   displayName,
 		MemberOf:      true,
 		PrincipalType: "group",
 		Provider:      provider,
@@ -742,7 +781,9 @@ func (s *SCIMServer) addGroupMember(provider, groupName string, member scimMembe
 	return nil
 }
 
-func (s *SCIMServer) removeGroupMember(provider, groupName, value string) error {
+// removeGroupMember removes a member from a group.
+// principalName is the full group principal name (e.g. "okta_group://Engineering").
+func (s *SCIMServer) removeGroupMember(provider, principalName, value string) error {
 	user, err := s.userCache.Get(value)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -763,7 +804,7 @@ func (s *SCIMServer) removeGroupMember(provider, groupName, value string) error 
 	attr = attr.DeepCopy()
 	principals := attr.GroupPrincipals[provider].Items
 	for i, principal := range principals {
-		if principal.DisplayName == groupName {
+		if principal.Name == principalName {
 			// Remove the principal.
 			principals = append(principals[:i], principals[i+1:]...)
 			break
@@ -780,16 +821,17 @@ func (s *SCIMServer) removeGroupMember(provider, groupName, value string) error 
 }
 
 // removeAllGroupMembers removes all members from a group.
-func (s *SCIMServer) removeAllGroupMembers(provider, groupName string) error {
-	members, err := s.getRancherGroupMembers(provider, groupName)
+// principalName is the full group principal name (e.g. "okta_group://Engineering").
+func (s *SCIMServer) removeAllGroupMembers(provider, principalName string) error {
+	members, err := s.getRancherGroupMembers(provider, principalName)
 	if err != nil {
 		return fmt.Errorf("failed to get groups: %w", err)
 	}
 
 	for _, member := range members {
-		err := s.removeGroupMember(provider, groupName, member.Value)
+		err := s.removeGroupMember(provider, principalName, member.Value)
 		if err != nil {
-			return fmt.Errorf("failed to remove member %s from group %s: %w", member.Value, groupName, err)
+			return fmt.Errorf("failed to remove member %s from group %s: %w", member.Value, principalName, err)
 		}
 	}
 

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -368,12 +368,135 @@ func TestSyncGroupMembers(t *testing.T) {
 	})
 }
 
+func TestUpdateGroupMemberDisplayName(t *testing.T) {
+	t.Parallel()
+
+	provider := "okta"
+	principalName := groupPrincipalName(provider, "Engineering")
+
+	t.Run("updates stale displayName", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		memberID := "u-mo773yttt4"
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: memberID},
+			GroupPrincipals: map[string]v3.Principals{
+				provider: {Items: []v3.Principal{
+					{ObjectMeta: metav1.ObjectMeta{Name: principalName}, DisplayName: "Old Name"},
+				}},
+			},
+		}
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(memberID).Return(existingAttr, nil)
+
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+			items := attr.GroupPrincipals[provider].Items
+			require.Len(t, items, 1)
+			assert.Equal(t, "Engineering", items[0].DisplayName)
+			return attr, nil
+		})
+
+		srv := &SCIMServer{
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+		}
+
+		err := srv.updateGroupMemberDisplayName(provider, principalName, "Engineering", memberID)
+		require.NoError(t, err)
+	})
+
+	t.Run("no update when displayName is current", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		memberID := "u-mo773yttt4"
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: memberID},
+			GroupPrincipals: map[string]v3.Principals{
+				provider: {Items: []v3.Principal{
+					{ObjectMeta: metav1.ObjectMeta{Name: principalName}, DisplayName: "Engineering"},
+				}},
+			},
+		}
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(memberID).Return(existingAttr, nil)
+
+		// No Update call expected.
+		srv := &SCIMServer{
+			userAttributeCache: userAttributeCache,
+		}
+
+		err := srv.updateGroupMemberDisplayName(provider, principalName, "Engineering", memberID)
+		require.NoError(t, err)
+	})
+}
+
+func TestSyncGroupMembersUpdatesStaleDisplayName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	provider := "okta"
+	groupName := "Engineering"
+	principalName := groupPrincipalName(provider, groupName)
+	memberID := "u-mo773yttt4"
+
+	// User is already a member but with a stale DisplayName.
+	existingAttr := &v3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{Name: memberID},
+		GroupPrincipals: map[string]v3.Principals{
+			provider: {Items: []v3.Principal{
+				{ObjectMeta: metav1.ObjectMeta{Name: principalName}, DisplayName: "Old Name"},
+			}},
+		},
+		ExtraByProvider: map[string]map[string][]string{
+			provider: {"username": {"john.doe"}},
+		},
+	}
+
+	userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+	userCache.EXPECT().Get(memberID).Return(&v3.User{
+		ObjectMeta: metav1.ObjectMeta{Name: memberID},
+	}, nil).AnyTimes()
+	userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{
+		{ObjectMeta: metav1.ObjectMeta{Name: memberID}},
+	}, nil)
+
+	userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributeCache.EXPECT().Get(memberID).Return(existingAttr, nil).AnyTimes()
+
+	userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+		items := attr.GroupPrincipals[provider].Items
+		require.Len(t, items, 1)
+		assert.Equal(t, "Engineering", items[0].DisplayName)
+		return attr, nil
+	})
+
+	srv := &SCIMServer{
+		userCache:          userCache,
+		userAttributeCache: userAttributeCache,
+		userAttributes:     userAttrClient,
+		getConfig:          testDefaultGetConfig,
+	}
+
+	err := srv.syncGroupMembers(provider, principalName, groupName, []scimMember{
+		{Value: memberID, Display: "john.doe"},
+	})
+	require.NoError(t, err)
+}
+
 func TestApplyReplaceGroup(t *testing.T) {
+	cfg := defaultProviderConfig()
+	externalIDCfg := providerConfig{GroupIDAttribute: GroupIDExternalID}
+
 	t.Run("replaces externalId", func(t *testing.T) {
 		group := &v3.Group{ExternalID: "old-id"}
 		op := patchOp{Op: "replace", Path: "externalId", Value: "new-id"}
 
-		updated, err := applyReplaceGroup(group, op)
+		updated, err := applyReplaceGroup(group, op, cfg)
 
 		require.NoError(t, err)
 		assert.True(t, updated)
@@ -384,7 +507,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{ExternalID: "same-id"}
 		op := patchOp{Op: "replace", Path: "externalId", Value: "same-id"}
 
-		updated, err := applyReplaceGroup(group, op)
+		updated, err := applyReplaceGroup(group, op, cfg)
 
 		require.NoError(t, err)
 		assert.False(t, updated)
@@ -400,7 +523,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 			},
 		}
 
-		updated, err := applyReplaceGroup(group, op)
+		updated, err := applyReplaceGroup(group, op, cfg)
 
 		require.NoError(t, err)
 		assert.True(t, updated)
@@ -411,17 +534,39 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{}
 		op := patchOp{Op: "replace", Path: "unsupported", Value: "value"}
 
-		updated, err := applyReplaceGroup(group, op)
+		updated, err := applyReplaceGroup(group, op, cfg)
 
 		require.Error(t, err)
 		assert.False(t, updated)
 	})
 
-	t.Run("rejects invalid value type", func(t *testing.T) {
+	t.Run("replaces displayName when externalId is group ID", func(t *testing.T) {
+		group := &v3.Group{DisplayName: "Old Name", ExternalID: "ext-123"}
+		op := patchOp{Op: "replace", Path: "displayName", Value: "New Name"}
+
+		updated, err := applyReplaceGroup(group, op, externalIDCfg)
+
+		require.NoError(t, err)
+		assert.True(t, updated)
+		assert.Equal(t, "New Name", group.DisplayName)
+	})
+
+	t.Run("rejects displayName change when displayName is group ID", func(t *testing.T) {
+		group := &v3.Group{DisplayName: "Old Name"}
+		op := patchOp{Op: "replace", Path: "displayName", Value: "New Name"}
+
+		updated, err := applyReplaceGroup(group, op, cfg)
+
+		require.Error(t, err)
+		assert.False(t, updated)
+		assert.Contains(t, err.Error(), "cannot be changed")
+	})
+
+	t.Run("rejects invalid displayName value type", func(t *testing.T) {
 		group := &v3.Group{}
 		op := patchOp{Op: "replace", Path: "displayName", Value: 123}
 
-		updated, err := applyReplaceGroup(group, op)
+		updated, err := applyReplaceGroup(group, op, externalIDCfg)
 
 		require.Error(t, err)
 		assert.False(t, updated)
@@ -2018,6 +2163,95 @@ func TestUpdateGroup(t *testing.T) {
 		assert.Equal(t, groupID, resp["id"])
 		assert.Equal(t, "Engineering", resp["displayName"])
 		assert.Equal(t, "new-ext-id", resp["externalId"])
+	})
+
+	t.Run("updates displayName with externalId config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		groupID := "grp-abc123"
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Old Name",
+			ExternalID:  "ext-123",
+		}
+
+		groupsCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		groupsCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		groupClient := fake.NewMockNonNamespacedClientInterface[*v3.Group, *v3.GroupList](ctrl)
+		groupClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(g *v3.Group) (*v3.Group, error) {
+			assert.Equal(t, "New Name", g.DisplayName)
+			return g, nil
+		})
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
+
+		srv := &SCIMServer{
+			groupsCache: groupsCache,
+			groups:      groupClient,
+			userCache:   userCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{GroupIDAttribute: GroupIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+			"id": "grp-abc123",
+			"displayName": "New Name",
+			"externalId": "ext-123",
+			"members": []
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateGroup(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "New Name", resp["displayName"])
+	})
+
+	t.Run("rejects displayName change with default config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		groupID := "grp-abc123"
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Old Name",
+			ExternalID:  "ext-123",
+		}
+
+		groupsCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		groupsCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		srv := &SCIMServer{
+			groupsCache: groupsCache,
+			getConfig:   testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+			"id": "grp-abc123",
+			"displayName": "New Name",
+			"externalId": "ext-123",
+			"members": []
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateGroup(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		var resp Error
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Detail, "cannot be changed")
 	})
 
 	t.Run("updates group with members", func(t *testing.T) {

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+var testDefaultGetConfig = func(string) providerConfig { return defaultProviderConfig() }
+
 func TestGetRancherGroupMembers(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := "okta"
@@ -46,8 +48,8 @@ func TestGetRancherGroupMembers(t *testing.T) {
 				GroupPrincipals: map[string]v3.Principals{
 					provider: {
 						Items: []v3.Principal{
-							{DisplayName: groupName},
-							{DisplayName: "Other Group"},
+							{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, groupName)}, DisplayName: groupName},
+							{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Other Group")}, DisplayName: "Other Group"},
 						},
 					},
 				},
@@ -61,7 +63,7 @@ func TestGetRancherGroupMembers(t *testing.T) {
 				GroupPrincipals: map[string]v3.Principals{
 					provider: {
 						Items: []v3.Principal{
-							{DisplayName: "Different Group"},
+							{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Different Group")}, DisplayName: "Different Group"},
 						},
 					},
 				},
@@ -84,9 +86,10 @@ func TestGetRancherGroupMembers(t *testing.T) {
 	srv := &SCIMServer{
 		userCache:          userCache,
 		userAttributeCache: userAttributeCache,
+		getConfig:          testDefaultGetConfig,
 	}
 
-	members, err := srv.getRancherGroupMembers(provider, groupName)
+	members, err := srv.getRancherGroupMembers(provider, groupPrincipalName(provider, groupName))
 
 	require.NoError(t, err)
 	require.Len(t, members, 1)
@@ -122,8 +125,8 @@ func TestGetAllRancherGroupMembers(t *testing.T) {
 				GroupPrincipals: map[string]v3.Principals{
 					provider: {
 						Items: []v3.Principal{
-							{DisplayName: "Engineering"},
-							{DisplayName: "Architects"},
+							{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"},
+							{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Architects")}, DisplayName: "Architects"},
 						},
 					},
 				},
@@ -137,8 +140,8 @@ func TestGetAllRancherGroupMembers(t *testing.T) {
 				GroupPrincipals: map[string]v3.Principals{
 					provider: {
 						Items: []v3.Principal{
-							{DisplayName: "Engineering"},
-							{DisplayName: "Developers"},
+							{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"},
+							{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Developers")}, DisplayName: "Developers"},
 						},
 					},
 				},
@@ -161,6 +164,7 @@ func TestGetAllRancherGroupMembers(t *testing.T) {
 	srv := &SCIMServer{
 		userCache:          userCache,
 		userAttributeCache: userAttributeCache,
+		getConfig:          testDefaultGetConfig,
 	}
 
 	groups, err := srv.getAllRancherGroupMembers(provider)
@@ -169,7 +173,7 @@ func TestGetAllRancherGroupMembers(t *testing.T) {
 	require.Len(t, groups, 3) // Engineering, Architects, Developers.
 
 	// Verify Engineering group has 2 members.
-	engineers := groups["Engineering"]
+	engineers := groups[groupPrincipalName(provider, "Engineering")]
 	require.Len(t, engineers, 2)
 
 	// Check both members are present (order may vary).
@@ -178,14 +182,14 @@ func TestGetAllRancherGroupMembers(t *testing.T) {
 	assert.Contains(t, memberNames, "u-yypnjwjmkq")
 
 	// Verify Architects group has 1 member.
-	architects := groups["Architects"]
+	architects := groups[groupPrincipalName(provider, "Architects")]
 	require.Len(t, architects, 1)
 	assert.Equal(t, "u-mo773yttt4", architects[0].Value)
 	assert.Equal(t, "john.doe", architects[0].Display)
 	assert.Equal(t, userResource, architects[0].Type)
 
 	// Verify Developers group has 1 member.
-	developers := groups["Developers"]
+	developers := groups[groupPrincipalName(provider, "Developers")]
 	require.Len(t, developers, 1)
 	assert.Equal(t, "u-yypnjwjmkq", developers[0].Value)
 	assert.Equal(t, "jane.smith", developers[0].Display)
@@ -236,9 +240,10 @@ func TestSyncGroupMembers(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
-		err := srv.syncGroupMembers(provider, groupName, []scimMember{newMember})
+		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{newMember})
 		require.NoError(t, err)
 	})
 
@@ -254,7 +259,7 @@ func TestSyncGroupMembers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 			GroupPrincipals: map[string]v3.Principals{
 				provider: {
-					Items: []v3.Principal{{DisplayName: groupName}},
+					Items: []v3.Principal{{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, groupName)}, DisplayName: groupName}},
 				},
 			},
 			ExtraByProvider: map[string]map[string][]string{
@@ -279,9 +284,10 @@ func TestSyncGroupMembers(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
-		err := srv.syncGroupMembers(provider, groupName, []scimMember{})
+		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{})
 		require.NoError(t, err)
 	})
 
@@ -294,9 +300,10 @@ func TestSyncGroupMembers(t *testing.T) {
 
 		srv := &SCIMServer{
 			userCache: userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
-		err := srv.syncGroupMembers(provider, groupName, []scimMember{
+		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{
 			{Value: "grp-xyz", Type: "Group", Display: "SubTeam"},
 		})
 
@@ -315,9 +322,10 @@ func TestSyncGroupMembers(t *testing.T) {
 
 		srv := &SCIMServer{
 			userCache: userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
-		err := srv.syncGroupMembers(provider, groupName, []scimMember{
+		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{
 			{Value: "something-else", Type: "SomethingElse", Display: "Something Else"},
 		})
 
@@ -346,9 +354,10 @@ func TestSyncGroupMembers(t *testing.T) {
 
 		srv := &SCIMServer{
 			userCache: userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
-		err := srv.syncGroupMembers(provider, groupName, []scimMember{
+		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{
 			{Value: "u-missing", Display: "missing.user"},
 		})
 
@@ -496,7 +505,7 @@ func TestPatchGroup(t *testing.T) {
 		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 			GroupPrincipals: map[string]v3.Principals{
-				provider: {Items: []v3.Principal{{DisplayName: "Engineering"}}},
+				provider: {Items: []v3.Principal{{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"}}},
 			},
 			ExtraByProvider: map[string]map[string][]string{
 				provider: {"username": {"john.doe"}},
@@ -508,6 +517,7 @@ func TestPatchGroup(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -566,6 +576,7 @@ func TestPatchGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -610,6 +621,7 @@ func TestPatchGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -667,6 +679,7 @@ func TestPatchGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupCache,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -720,7 +733,7 @@ func TestPatchGroup(t *testing.T) {
 		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 			GroupPrincipals: map[string]v3.Principals{
-				provider: {Items: []v3.Principal{{DisplayName: "Engineering"}}},
+				provider: {Items: []v3.Principal{{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"}}},
 			},
 		}, nil)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(&v3.UserAttribute{}, nil)
@@ -733,6 +746,7 @@ func TestPatchGroup(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -780,6 +794,7 @@ func TestPatchGroup(t *testing.T) {
 			groups:      groupClient,
 			groupsCache: groupCache,
 			userCache:   userCache,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -835,6 +850,7 @@ func TestListGroupsPagination(t *testing.T) {
 		groupsCache:        groupsCache,
 		userCache:          userCache,
 		userAttributeCache: userAttributeCache,
+		getConfig:          testDefaultGetConfig,
 	}
 
 	tests := []struct {
@@ -966,6 +982,7 @@ func TestListGroupsPaginationConsistency(t *testing.T) {
 		groupsCache:        groupsCache,
 		userCache:          userCache,
 		userAttributeCache: userAttributeCache,
+		getConfig:          testDefaultGetConfig,
 	}
 
 	// Collect all group IDs by paginating through all pages.
@@ -1015,6 +1032,43 @@ func TestListGroupsPaginationConsistency(t *testing.T) {
 	}
 }
 
+func TestListGroupsWithExternalIdFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := "azuread"
+
+	groups := []*v3.Group{
+		{ObjectMeta: metav1.ObjectMeta{Name: "g-aaa", Labels: map[string]string{authProviderLabel: provider}}, DisplayName: "Engineering", ExternalID: "obj-111"},
+		{ObjectMeta: metav1.ObjectMeta{Name: "g-bbb", Labels: map[string]string{authProviderLabel: provider}}, DisplayName: "Marketing", ExternalID: "obj-222"},
+		{ObjectMeta: metav1.ObjectMeta{Name: "g-ccc", Labels: map[string]string{authProviderLabel: provider}}, DisplayName: "Sales", ExternalID: "obj-333"},
+	}
+
+	groupsCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+	groupsCache.EXPECT().List(labels.Set{authProviderLabel: provider}.AsSelector()).Return(groups, nil)
+
+	srv := &SCIMServer{
+		groupsCache: groupsCache,
+		getConfig:   testDefaultGetConfig,
+	}
+
+	r := httptest.NewRequest(http.MethodGet, `/v1-scim/`+provider+`/Groups?filter=externalId%20eq%20%22obj-222%22&excludedAttributes=members`, nil)
+	r.SetPathValue("provider", provider)
+	w := httptest.NewRecorder()
+
+	srv.ListGroups(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp listResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, resp.TotalResults)
+	require.Len(t, resp.Resources, 1)
+
+	resource := resp.Resources[0].(map[string]any)
+	assert.Equal(t, "g-bbb", resource["id"])
+	assert.Equal(t, "Marketing", resource["displayName"])
+}
+
 func TestCreateGroup(t *testing.T) {
 	provider := "okta"
 
@@ -1043,6 +1097,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1128,6 +1183,7 @@ func TestCreateGroup(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttributeClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1165,6 +1221,7 @@ func TestCreateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1198,6 +1255,7 @@ func TestCreateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1264,6 +1322,7 @@ func TestCreateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1296,6 +1355,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1337,6 +1397,7 @@ func TestCreateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1380,6 +1441,7 @@ func TestCreateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1431,6 +1493,7 @@ func TestCreateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1476,6 +1539,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1521,6 +1585,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1577,7 +1642,7 @@ func TestGetGroup(t *testing.T) {
 			},
 			GroupPrincipals: map[string]v3.Principals{
 				provider: {Items: []v3.Principal{
-					{DisplayName: "Engineering"},
+					{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"},
 				}},
 			},
 		}, nil)
@@ -1586,6 +1651,7 @@ func TestGetGroup(t *testing.T) {
 			groupsCache:        groupsCache,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -1628,6 +1694,7 @@ func TestGetGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID+"?excludedAttributes=members,other_attribute", nil)
@@ -1666,6 +1733,7 @@ func TestGetGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -1694,6 +1762,7 @@ func TestGetGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -1720,6 +1789,7 @@ func TestGetGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -1754,6 +1824,7 @@ func TestGetGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -1804,7 +1875,7 @@ func TestGetGroup(t *testing.T) {
 			},
 			GroupPrincipals: map[string]v3.Principals{
 				provider: {Items: []v3.Principal{
-					{DisplayName: "Engineering"},
+					{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"},
 				}},
 			},
 		}, nil)
@@ -1813,6 +1884,7 @@ func TestGetGroup(t *testing.T) {
 			groupsCache:        groupsCache,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -1859,6 +1931,7 @@ func TestUpdateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1922,6 +1995,7 @@ func TestUpdateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1990,6 +2064,7 @@ func TestUpdateGroup(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttributeClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2085,6 +2160,7 @@ func TestUpdateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2125,6 +2201,7 @@ func TestUpdateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2180,7 +2257,7 @@ func TestUpdateGroup(t *testing.T) {
 			},
 			GroupPrincipals: map[string]v3.Principals{
 				provider: {Items: []v3.Principal{
-					{DisplayName: "Engineering"},
+					{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"},
 				}},
 			},
 		}
@@ -2200,6 +2277,7 @@ func TestUpdateGroup(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttributeClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		// Update with empty members list should remove existing member
@@ -2245,6 +2323,7 @@ func TestDeleteGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -2287,7 +2366,7 @@ func TestDeleteGroup(t *testing.T) {
 			},
 			GroupPrincipals: map[string]v3.Principals{
 				provider: {Items: []v3.Principal{
-					{DisplayName: "Engineering"},
+					{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"},
 				}},
 			},
 		}
@@ -2308,6 +2387,7 @@ func TestDeleteGroup(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttributeClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -2328,6 +2408,7 @@ func TestDeleteGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -2354,6 +2435,7 @@ func TestDeleteGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -2388,6 +2470,7 @@ func TestDeleteGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
@@ -2426,6 +2509,7 @@ func TestDeleteGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)

--- a/pkg/auth/providers/scim/handler.go
+++ b/pkg/auth/providers/scim/handler.go
@@ -17,10 +17,12 @@ type SCIMServer struct {
 	userAttributeCache v3.UserAttributeCache
 	userAttributes     v3.UserAttributeClient
 	userMGR            user.Manager
+	getConfig          func(provider string) providerConfig
 }
 
 // NewHandler instantiates [SCIMServer] and returns an [http.Handler] that serves SCIM API endpoints.
 func NewHandler(scaledContext *config.ScaledContext) http.Handler {
+	configMapCache := scaledContext.Wrangler.Core.ConfigMap().Cache()
 	srv := &SCIMServer{
 		groups:             scaledContext.Wrangler.Mgmt.Group(),
 		groupsCache:        scaledContext.Wrangler.Mgmt.Group().Cache(),
@@ -29,6 +31,9 @@ func NewHandler(scaledContext *config.ScaledContext) http.Handler {
 		userAttributeCache: scaledContext.Wrangler.Mgmt.UserAttribute().Cache(),
 		userAttributes:     scaledContext.Wrangler.Mgmt.UserAttribute(),
 		userMGR:            scaledContext.UserManager,
+		getConfig: func(provider string) providerConfig {
+			return getProviderConfig(configMapCache, provider)
+		},
 	}
 
 	authenticator := NewTokenAuthenticator(scaledContext.Wrangler)

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -438,12 +438,18 @@ func (s *SCIMServer) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg := s.getConfig(provider)
+
 	var shouldUpdateAttr, shouldUpdateUser bool
 	attr = attr.DeepCopy()
 	if attr.ExtraByProvider[provider] == nil {
 		attr.ExtraByProvider[provider] = map[string][]string{}
 	}
 	if userName := first(attr.ExtraByProvider[provider]["username"]); userName != payload.UserName {
+		if cfg.UserIDAttribute != UserIDExternalID {
+			writeError(w, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier"))
+			return
+		}
 		attr.ExtraByProvider[provider]["username"] = []string{payload.UserName}
 		shouldUpdateAttr = true
 	}
@@ -599,11 +605,13 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 	attr = attr.DeepCopy()
 	user = user.DeepCopy()
 
+	cfg := s.getConfig(provider)
+
 	var shouldUpdateAttr, shouldUpdateUser bool
 	for _, op := range payload.Operations {
 		switch strings.ToLower(op.Op) {
 		case "replace", "add":
-			updateAttr, updateUser, err := applyPatchUser(provider, attr, user, op)
+			updateAttr, updateUser, err := applyPatchUser(provider, attr, user, op, cfg)
 			if err != nil {
 				logrus.Errorf("scim::PatchUser: failed to apply %s operation: %s", op.Op, err)
 				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply %s operation: %s", op.Op, err)))
@@ -666,7 +674,7 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 
 // applyPatchUser applies a SCIM PATCH add/replace operation to a user.
 // For single-valued attributes, add and replace have identical semantics (RFC 7644 §3.5.2).
-func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op patchOp) (bool, bool, error) {
+func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op patchOp, cfg providerConfig) (bool, bool, error) {
 	if op.Path == "" {
 		fields, ok := op.Value.(map[string]any)
 		if !ok {
@@ -679,7 +687,7 @@ func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op p
 				Op:    "replace",
 				Path:  name,
 				Value: value,
-			})
+			}, cfg)
 			if err != nil {
 				return false, false, fmt.Errorf("failed to apply replace operation: %v", err)
 			}
@@ -718,6 +726,20 @@ func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op p
 		if user.DisplayName != displayName {
 			user.DisplayName = displayName
 			updateUser = true
+		}
+	case "username":
+		if cfg.UserIDAttribute != UserIDExternalID {
+			return false, false, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier")
+		}
+
+		username, ok := op.Value.(string)
+		if !ok {
+			return false, false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid value for userName: %v", op.Value))
+		}
+
+		if first(attr.ExtraByProvider[provider]["username"]) != username {
+			attr.ExtraByProvider[provider]["username"] = []string{username}
+			updateAttr = true
 		}
 	case "externalid":
 		externalID, ok := op.Value.(string)

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -98,8 +98,7 @@ func (s *SCIMServer) ListUsers(w http.ResponseWriter, r *http.Request) {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}
-		// Currently only support userName eq "<value>" filter.
-		if err := filter.ValidateForAttribute("userName", opEqual); err != nil {
+		if err := filter.ValidateForAttribute([]string{"userName", "externalId"}, opEqual); err != nil {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}
@@ -150,7 +149,13 @@ func (s *SCIMServer) ListUsers(w http.ResponseWriter, r *http.Request) {
 		externalID := first(attr.ExtraByProvider[provider]["externalid"])
 
 		// Apply filter.
-		if !filter.Matches(userName) {
+		var filterTarget string
+		if filter != nil && strings.EqualFold(filter.Attribute, "externalId") {
+			filterTarget = externalID
+		} else {
+			filterTarget = userName
+		}
+		if !filter.Matches(filterTarget) {
 			continue
 		}
 
@@ -228,6 +233,14 @@ func (s *SCIMServer) CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg := s.getConfig(provider)
+	uid := cfg.userID(payload)
+	if uid == "" {
+		writeError(w, NewError(http.StatusBadRequest,
+			fmt.Sprintf("%s is required when configured as userIdAttribute", cfg.UserIDAttribute)))
+		return
+	}
+
 	list, err := s.userCache.List(labels.Everything())
 	if err != nil {
 		logrus.Errorf("scim::CreateUser: failed to list users: %s", err)
@@ -254,8 +267,12 @@ func (s *SCIMServer) CreateUser(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	principalName := provider + "_user://" + payload.UserName
-	user, err := s.userMGR.EnsureUser(principalName, payload.UserName)
+	principalName := userPrincipalName(provider, uid)
+	displayName := payload.DisplayName
+	if displayName == "" {
+		displayName = payload.UserName
+	}
+	user, err := s.userMGR.EnsureUser(principalName, displayName)
 	if err != nil {
 		logrus.Errorf("scim::CreateUser: failed to ensure user %s: %s", principalName, err)
 		writeError(w, NewInternalError())
@@ -585,11 +602,11 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 	var shouldUpdateAttr, shouldUpdateUser bool
 	for _, op := range payload.Operations {
 		switch strings.ToLower(op.Op) {
-		case "replace":
+		case "replace", "add":
 			updateAttr, updateUser, err := applyReplaceUser(provider, attr, user, op)
 			if err != nil {
-				logrus.Errorf("scim::PatchUser: failed to apply replace operation: %s", err)
-				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply replace operation: %s", err)))
+				logrus.Errorf("scim::PatchUser: failed to apply %s operation: %s", op.Op, err)
+				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply %s operation: %s", op.Op, err)))
 				return
 			}
 			if updateAttr {
@@ -689,6 +706,16 @@ func applyReplaceUser(provider string, attr *v3.UserAttribute, user *v3.User, op
 			}
 
 			user.Enabled = &active
+			updateUser = true
+		}
+	case "displayname":
+		displayName, ok := op.Value.(string)
+		if !ok {
+			return false, false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid value for displayName: %v", op.Value))
+		}
+
+		if user.DisplayName != displayName {
+			user.DisplayName = displayName
 			updateUser = true
 		}
 	case "externalid":

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -98,7 +98,7 @@ func (s *SCIMServer) ListUsers(w http.ResponseWriter, r *http.Request) {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}
-		if err := filter.ValidateForAttribute([]string{"userName", "externalId"}, opEqual); err != nil {
+		if err := filter.ValidateForAttributes([]string{"userName", "externalId"}, opEqual); err != nil {
 			writeError(w, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -603,7 +603,7 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 	for _, op := range payload.Operations {
 		switch strings.ToLower(op.Op) {
 		case "replace", "add":
-			updateAttr, updateUser, err := applyReplaceUser(provider, attr, user, op)
+			updateAttr, updateUser, err := applyPatchUser(provider, attr, user, op)
 			if err != nil {
 				logrus.Errorf("scim::PatchUser: failed to apply %s operation: %s", op.Op, err)
 				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply %s operation: %s", op.Op, err)))
@@ -664,8 +664,9 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, response)
 }
 
-// applyReplaceUser applies a SCIM PATCH replace operation to a user.
-func applyReplaceUser(provider string, attr *v3.UserAttribute, user *v3.User, op patchOp) (bool, bool, error) {
+// applyPatchUser applies a SCIM PATCH add/replace operation to a user.
+// For single-valued attributes, add and replace have identical semantics (RFC 7644 §3.5.2).
+func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op patchOp) (bool, bool, error) {
 	if op.Path == "" {
 		fields, ok := op.Value.(map[string]any)
 		if !ok {
@@ -674,7 +675,7 @@ func applyReplaceUser(provider string, attr *v3.UserAttribute, user *v3.User, op
 
 		var shouldUpdateAttr, shouldUpdateUser bool
 		for name, value := range fields {
-			updateAttr, updateUser, err := applyReplaceUser(provider, attr, user, patchOp{
+			updateAttr, updateUser, err := applyPatchUser(provider, attr, user, patchOp{
 				Op:    "replace",
 				Path:  name,
 				Value: value,

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -364,6 +364,57 @@ func TestListUsersWithFilter(t *testing.T) {
 	assert.Equal(t, "jane.smith", resource["userName"])
 }
 
+func TestListUsersWithExternalIdFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := "azuread"
+
+	users := []*v3.User{
+		{ObjectMeta: metav1.ObjectMeta{Name: "u-aaa"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "u-bbb"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "u-ccc"}},
+	}
+
+	userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+	userCache.EXPECT().List(labels.Everything()).Return(users, nil).AnyTimes()
+
+	userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributeCache.EXPECT().Get(gomock.Any()).DoAndReturn(func(name string) (*v3.UserAttribute, error) {
+		attrs := map[string]map[string][]string{
+			"u-aaa": {"principalid": {provider + "_user://u-aaa"}, "username": {"john.doe"}, "externalid": {"obj-111"}},
+			"u-bbb": {"principalid": {provider + "_user://u-bbb"}, "username": {"jane.smith"}, "externalid": {"obj-222"}},
+			"u-ccc": {"principalid": {provider + "_user://u-ccc"}, "username": {"bob.wilson"}, "externalid": {"obj-333"}},
+		}
+		return &v3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: name},
+			ExtraByProvider: map[string]map[string][]string{provider: attrs[name]},
+		}, nil
+	}).AnyTimes()
+
+	srv := &SCIMServer{
+		userCache:          userCache,
+		userAttributeCache: userAttributeCache,
+	}
+
+	r := httptest.NewRequest(http.MethodGet, `/v1-scim/`+provider+`/Users?filter=externalId%20eq%20%22obj-222%22`, nil)
+	r.SetPathValue("provider", provider)
+	w := httptest.NewRecorder()
+
+	srv.ListUsers(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp listResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, resp.TotalResults)
+	require.Len(t, resp.Resources, 1)
+
+	resource := resp.Resources[0].(map[string]any)
+	assert.Equal(t, "u-bbb", resource["id"])
+	assert.Equal(t, "jane.smith", resource["userName"])
+	assert.Equal(t, "obj-222", resource["externalId"])
+}
+
 func TestListUsersExcludesSystemUsers(t *testing.T) {
 	provider := "okta"
 
@@ -680,7 +731,7 @@ func TestCreateUser(t *testing.T) {
 
 		enabled := true
 		userMGR := mocks.NewMockManager(ctrl)
-		userMGR.EXPECT().EnsureUser("okta_user://john.doe", "john.doe").Return(&v3.User{
+		userMGR.EXPECT().EnsureUser("okta_user://john.doe", "John Doe").Return(&v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-abc123"},
 			Enabled:    &enabled,
 		}, nil)
@@ -700,11 +751,13 @@ func TestCreateUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userMGR:            userMGR,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
 			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
 			"userName": "john.doe",
+			"displayName": "John Doe",
 			"externalId": "ext-12345",
 			"emails": [{"value": "john.doe@example.com", "primary": true}]
 		}`
@@ -770,6 +823,7 @@ func TestCreateUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userMGR:            userMGR,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -816,6 +870,7 @@ func TestCreateUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -902,6 +957,7 @@ func TestCreateUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -931,6 +987,7 @@ func TestCreateUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userMGR:            userMGR,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -970,6 +1027,7 @@ func TestCreateUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userMGR:            userMGR,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1014,6 +1072,7 @@ func TestCreateUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userMGR:            userMGR,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1944,6 +2003,153 @@ func TestPatchUser(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code)
 	})
 
+	t.Run("replace displayName", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta:  metav1.ObjectMeta{Name: userID},
+			DisplayName: "Old Name",
+			Enabled:     &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username": {"john.doe"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+			assert.Equal(t, "New Name", u.DisplayName)
+			return u, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			users:              userClient,
+			userAttributeCache: userAttributeCache,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "displayName", "value": "New Name"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("add displayName", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username": {"john.doe"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+			assert.Equal(t, "John Doe", u.DisplayName)
+			return u, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			users:              userClient,
+			userAttributeCache: userAttributeCache,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "add", "path": "displayName", "value": "John Doe"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("add operation sets active", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username": {"john.doe"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+			assert.Equal(t, false, *u.Enabled)
+			return u, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			users:              userClient,
+			userAttributeCache: userAttributeCache,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "add", "path": "active", "value": false}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, false, resp["active"])
+	})
+
 	t.Run("no update when value unchanged", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
@@ -2108,7 +2314,7 @@ func TestPatchUser(t *testing.T) {
 
 		body := `{
 			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			"Operations": [{"op": "add", "path": "active", "value": false}]
+			"Operations": [{"op": "remove", "path": "active"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
 		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -1126,6 +1126,9 @@ func TestUpdateUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
 		}
 
 		body := `{
@@ -1156,6 +1159,55 @@ func TestUpdateUser(t *testing.T) {
 		wantLocation := "/v1-scim/" + provider + "/Users/" + userID
 		assert.Contains(t, meta["location"], wantLocation)
 		assert.Contains(t, w.Header().Get("Location"), wantLocation)
+	})
+
+	t.Run("rejects userName change with default config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"old.name"},
+					"externalid": {"ext-12345"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "new.name",
+			"externalId": "ext-12345",
+			"active": true
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateUser(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		var resp Error
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Detail, "cannot be changed")
 	})
 
 	t.Run("deactivates user", func(t *testing.T) {
@@ -1192,6 +1244,7 @@ func TestUpdateUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1248,6 +1301,7 @@ func TestUpdateUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1298,6 +1352,7 @@ func TestUpdateUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1402,6 +1457,7 @@ func TestUpdateUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1503,6 +1559,9 @@ func TestUpdateUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
 		}
 
 		body := `{
@@ -1550,6 +1609,7 @@ func TestUpdateUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1759,6 +1819,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1820,6 +1881,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		// We deliberately use a string "True" here to verify that we handle string booleans.
@@ -1874,6 +1936,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1928,6 +1991,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1989,6 +2053,7 @@ func TestPatchUser(t *testing.T) {
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2037,6 +2102,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2084,6 +2150,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2131,6 +2198,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2148,6 +2216,103 @@ func TestPatchUser(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.Equal(t, false, resp["active"])
+	})
+
+	t.Run("replace userName with externalId config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"old.name"},
+					"externalid": {"ext-123"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+			assert.Equal(t, "new.name", first(attr.ExtraByProvider[provider]["username"]))
+			return attr, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "userName", "value": "new.name"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "new.name", resp["userName"])
+	})
+
+	t.Run("reject userName change with default config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username": {"old.name"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "userName", "value": "new.name"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
 	t.Run("no update when value unchanged", func(t *testing.T) {
@@ -2178,6 +2343,7 @@ func TestPatchUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2270,6 +2436,7 @@ func TestPatchUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2310,6 +2477,7 @@ func TestPatchUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2350,6 +2518,7 @@ func TestPatchUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2415,6 +2584,7 @@ func TestPatchUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2460,6 +2630,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
 			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2504,6 +2675,7 @@ func TestPatchUser(t *testing.T) {
 			userCache:          userCache,
 			users:              userClient,
 			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
 		}
 
 		body := `{


### PR DESCRIPTION
## Issue: #54869 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
SCIM was constructing principal IDs from userName/displayName, but most auth providers use different identifiers at login time (e.g. Azure AD uses objectId). This caused duplicate users because EnsureUser does an exact string match on the principal name.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Add providerConfig (stored in ConfigMap `scim-config-{provider}`) that lets admins select which SCIM attribute maps to the principal ID
- `userName` or `externalId` for users
- `displayName` or `externalId` for groups.

Other changes:
- Support `externalId eq` filter in ListUsers and ListGroups (needed for Azure AD SCIM matching precedence)
- Support add patch operation alongside replace (Azure AD uses it)
- Add `displayName` as a patchable user attribute
- Set `User.DisplayName` from SCIM `displayName` instead of `userName`
- Use principal Name instead of `DisplayName` for group member matching
- Support `userName` and `displayName` changes when `externalId` is the principal ID

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
- Unit tests
- Manual testing provisioning users and groups from AzureAD via SCIM