### PR TITLE
Add SameSite attribute to Cookies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/rancher/aks-operator v1.15.0-rc.1
 	github.com/rancher/ali-operator v1.15.0-rc.1
-	github.com/rancher/apiserver v0.9.6
+	github.com/rancher/apiserver v0.9.7
 	github.com/rancher/channelserver v0.11.0
 	github.com/rancher/dynamiclistener v0.9.0-rc.1
 	github.com/rancher/eks-operator v1.15.0-rc.1
@@ -127,7 +127,7 @@ require (
 	github.com/rancher/lasso v0.2.9
 	github.com/rancher/machine v0.15.0-rancher143
 	github.com/rancher/muchang v0.1.0
-	github.com/rancher/norman v0.9.5
+	github.com/rancher/norman v0.9.7
 	github.com/rancher/rancher/pkg/apis v0.0.0-20260520140148-1f22fcaec55b
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rancher/pkg/plan v0.0.0-20260428222332-2696373f4152
@@ -408,7 +408,7 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/time v0.15.0
-	golang.org/x/tools v0.44.0 // indirect
+	golang.org/x/tools v0.45.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,8 @@ github.com/rancher/aks-operator v1.15.0-rc.1 h1:+a6A3a1eGgtZVG+/Xi0us/4HVQSsG9j3
 github.com/rancher/aks-operator v1.15.0-rc.1/go.mod h1:cAYS9zWnBcUDn2DPQbYbRty/gyYHXHKr5V9MUB7gG7w=
 github.com/rancher/ali-operator v1.15.0-rc.1 h1:NpYxzQQj/Df7427UrBaOvGRMH2lsD4RvPRJ9xr1uWj0=
 github.com/rancher/ali-operator v1.15.0-rc.1/go.mod h1:jKlIQni2diC19zEvFn/fTOlEj8ruTrODnI8X57ncNVI=
-github.com/rancher/apiserver v0.9.6 h1:oRPbe5ICkS5k9lQq0GR8ElYU5rikhxUZMFqHgXafJAE=
-github.com/rancher/apiserver v0.9.6/go.mod h1:NLkaZ69HiT6/5OcXm2EZcydCv8PKRcIXaIphABvhX1I=
+github.com/rancher/apiserver v0.9.7 h1:b29KuloAFVY3PemDSUdrLmwzX/vJWpWBgr20m7xSvuE=
+github.com/rancher/apiserver v0.9.7/go.mod h1:NLkaZ69HiT6/5OcXm2EZcydCv8PKRcIXaIphABvhX1I=
 github.com/rancher/channelserver v0.11.0 h1:R1oRG2SkGkC0EKHsa+VgBuLKHzEGVE1NMJeP/6c5vPo=
 github.com/rancher/channelserver v0.11.0/go.mod h1:ZWuXGR708g5FoMdmf+fXE2XEOztdm3bcwjdMmriY1kg=
 github.com/rancher/dynamiclistener v0.9.0-rc.1 h1:tmV3fgvB5pXSOMrb7G1DSno5C9XTfoyzHaDeVRhtUd0=
@@ -620,8 +620,8 @@ github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77 h1:k+vzmkZQsH06rZnDr+p
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/muchang v0.1.0 h1:Yuu3b7eFRqnnbp6qbLsP/5SY3IKGDj2mUUTzy4AiUVw=
 github.com/rancher/muchang v0.1.0/go.mod h1:sVg6mngaaZIpSegx/I79rymxm7n5gbI8j5PeoVoIONs=
-github.com/rancher/norman v0.9.5 h1:lcX6zcbCTuapiNUGIowFjTPfHlfzyIrTe5mQBha+F/E=
-github.com/rancher/norman v0.9.5/go.mod h1:J/leyKdI77SKnPdf3mAxevglzb8nFZM4Wu6c5g42v/I=
+github.com/rancher/norman v0.9.7 h1:za9JjsWBUi+0rY3EJ3JdAZFQsadu7fpfC3MHi9a21uE=
+github.com/rancher/norman v0.9.7/go.mod h1:XPdQnSdaiDrQ130ueYppMKIquQz5Ob1tnI6+lcraqqo=
 github.com/rancher/remotedialer v0.6.1 h1:smq2sHKJn+NxxIeQ8To9CGGkz8l6Ir7EPzfAdjUTt2s=
 github.com/rancher/remotedialer v0.6.1/go.mod h1:0+dmsw9TPjcqNUPrgAVFZpvbxy1r/fRaGPpVa84OMjU=
 github.com/rancher/remotedialer-proxy v0.8.0-rc.5 h1:22cdanfJa8OeBhbiZVixgnQOWmUD1BA2QLN06MpKMKM=
@@ -898,8 +898,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
-golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
+golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
 golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/rancher/eks-operator v1.15.0-rc.1
 	github.com/rancher/fleet/pkg/apis v0.16.0-alpha.9
 	github.com/rancher/gke-operator v1.15.0-rc.1
-	github.com/rancher/norman v0.9.5
+	github.com/rancher/norman v0.9.7
 	github.com/rancher/rancher/pkg/plan v0.0.0-20260428222332-2696373f4152
 	github.com/rancher/wrangler/v3 v3.7.0
 	github.com/sirupsen/logrus v1.9.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -76,8 +76,8 @@ github.com/rancher/gke-operator v1.15.0-rc.1 h1:ZkwK9J2KLuu4PlScm2HShUb6koKbXjbm
 github.com/rancher/gke-operator v1.15.0-rc.1/go.mod h1:tc1XZNmqJAhOttKqgAQEoRp11GICuJ3ZgMazQt2n/+0=
 github.com/rancher/lasso v0.2.9 h1:5Xk9Qid+YDOLpa6s5xalcSR0cA5BMbgWcaOZ8kdNU7k=
 github.com/rancher/lasso v0.2.9/go.mod h1:PMtxoVahRQvhEAi1HVOfyLDe1CrtGwTqOtkPVjSSkns=
-github.com/rancher/norman v0.9.5 h1:lcX6zcbCTuapiNUGIowFjTPfHlfzyIrTe5mQBha+F/E=
-github.com/rancher/norman v0.9.5/go.mod h1:J/leyKdI77SKnPdf3mAxevglzb8nFZM4Wu6c5g42v/I=
+github.com/rancher/norman v0.9.7 h1:za9JjsWBUi+0rY3EJ3JdAZFQsadu7fpfC3MHi9a21uE=
+github.com/rancher/norman v0.9.7/go.mod h1:XPdQnSdaiDrQ130ueYppMKIquQz5Ob1tnI6+lcraqqo=
 github.com/rancher/wrangler/v3 v3.7.0 h1:rB6GJpnc4Kz8lWuAH3wZwQPgJqPGOu43Aih6147uZB8=
 github.com/rancher/wrangler/v3 v3.7.0/go.mod h1:kqldrBWdHR5zIipX/nr8yuZBFqFrL7GfVP1uwVJSWPQ=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/pkg/auth/logout/handler.go
+++ b/pkg/auth/logout/handler.go
@@ -49,6 +49,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Secure:   isSecure,
 			Path:     "/",
 			HttpOnly: true,
+			// Lax is the default in most browsers; setting it
+			// explicitly is a good security measure.
+			SameSite: http.SameSiteLaxMode,
 			MaxAge:   -1,
 			Expires:  cookieUnsetTimestamp,
 		}

--- a/pkg/auth/logout/handler_test.go
+++ b/pkg/auth/logout/handler_test.go
@@ -67,6 +67,7 @@ func TestLogout(t *testing.T) {
 				assert.Equal(t, -1, cookie.MaxAge)
 				assert.True(t, cookie.HttpOnly)
 				assert.Equal(t, "/", cookie.Path)
+				assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
 				assert.Equal(t, cookieUnsetTimestamp, cookie.Expires)
 			default:
 				require.FailNow(t, "unexpected cookie "+cookie.Name)

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -895,10 +895,15 @@ func getValueFromClaims[T any](idToken *oidc.IDToken, name string) (T, error) {
 func deletePKCEVerifier(req *http.Request, w http.ResponseWriter) {
 	isSecure := req.URL.Scheme == "https"
 	pkceCookie := &http.Cookie{
-		Name:    pkceVerifierCookieName,
-		Value:   "",
-		Secure:  isSecure,
-		Expires: time.Now().Add(time.Second * -10),
+		Name:     pkceVerifierCookieName,
+		Value:    "",
+		Secure:   isSecure,
+		Path:     "/",
+		HttpOnly: true,
+		// Lax is the default in most browsers; setting it
+		// explicitly is a good security measure.
+		SameSite: http.SameSiteLaxMode,
+		Expires:  time.Now().Add(time.Second * -10),
 	}
 
 	http.SetCookie(w, pkceCookie)
@@ -914,6 +919,9 @@ func SetPKCEVerifier(req *http.Request, w http.ResponseWriter, value string) {
 		Secure:   isSecure,
 		Path:     "/",
 		HttpOnly: true,
+		// Lax is the default in most browsers; setting it
+		// explicitly is a good security measure.
+		SameSite: http.SameSiteLaxMode,
 		Expires:  time.Now().Add(time.Minute * 10),
 	}
 
@@ -928,6 +936,9 @@ func setIDToken(req *http.Request, w http.ResponseWriter, token string) {
 		Secure:   isSecure,
 		Path:     "/",
 		HttpOnly: true,
+		// Lax is the default in most browsers; setting it
+		// explicitly is a good security measure.
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, tokenCookie)
 }

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -1165,3 +1165,44 @@ func TestGetOIDCRedirectionURL(t *testing.T) {
 		})
 	}
 }
+
+func TestCookieSecurityAttributes(t *testing.T) {
+	tests := map[string]struct {
+		setCookie  func(req *http.Request, w http.ResponseWriter)
+		cookieName string
+	}{
+		"SetPKCEVerifier": {
+			setCookie:  func(req *http.Request, w http.ResponseWriter) { SetPKCEVerifier(req, w, "verifier-value") },
+			cookieName: pkceVerifierCookieName,
+		},
+		"deletePKCEVerifier": {
+			setCookie:  deletePKCEVerifier,
+			cookieName: pkceVerifierCookieName,
+		},
+		"setIDToken": {
+			setCookie:  func(req *http.Request, w http.ResponseWriter) { setIDToken(req, w, "id-token-value") },
+			cookieName: IDTokenCookie,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "https://rancher.example.com/", nil)
+			w := httptest.NewRecorder()
+
+			tc.setCookie(req, w)
+
+			var got *http.Cookie
+			for _, c := range w.Result().Cookies() {
+				if c.Name == tc.cookieName {
+					got = c
+					break
+				}
+			}
+			require.NotNil(t, got, "expected cookie %q to be set", tc.cookieName)
+			assert.True(t, got.HttpOnly, "HttpOnly must be true")
+			assert.Equal(t, "/", got.Path, "Path must be /")
+			assert.Equal(t, http.SameSiteLaxMode, got.SameSite, "SameSite must be Lax")
+		})
+	}
+}

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -353,6 +353,9 @@ func (h *loginHandler) login(w http.ResponseWriter, r *http.Request, input login
 			Secure:   true,
 			Path:     "/",
 			HttpOnly: true,
+			// Lax is the default in most browsers; setting it
+			// explicitly is a good security measure.
+			SameSite: http.SameSiteLaxMode,
 		}
 		http.SetCookie(w, tokenCookie)
 

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -618,6 +618,9 @@ func (s *Provider) setRancherToken(w http.ResponseWriter, tokenMGR *tokens.Manag
 		Secure:   isSecure,
 		Path:     "/",
 		HttpOnly: true,
+		// Lax is the default in most browsers; setting it
+		// explicitly is a good security measure.
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, tokenCookie)
 

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -554,6 +554,9 @@ func (m *Manager) CreateTokenAndSetCookie(userID string, userPrincipal apiv3.Pri
 		Secure:   isSecure,
 		Path:     "/",
 		HttpOnly: true,
+		// Lax is the default in most browsers; setting it
+		// explicitly is a good security measure.
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(request.Response, tokenCookie)
 	request.WriteResponse(http.StatusOK, nil)


### PR DESCRIPTION
Issue: SURE-10293
Github Issue : https://github.com/rancher/rancher/issues/54805

### Summary 

- Added `lax` to SameSite as it is default for some browswers but having it explicitly stated will help in Pen testing reports for customers as in the JIRA issue. Please check the JIRA for more details.
- Defaulting to `lax` mode since it is the default and this will not break  anything.


### Dev Testing 
- Tested using keycloak docker image hosting at keycloak.local (cross-site) locally with SAML and OIDC. Log in and Logout seems to be working.