### PR TITLE
Standardise error when updating user password

### DIFF
--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -213,7 +213,7 @@ func validatePassword(user string, currentPass string, pass string, minPassLen i
 	}
 
 	if user == pass {
-		return errors.New("Password cannot be the same as username")
+		return errors.New("Password cannot be the same as the username")
 	}
 	if pass == currentPass {
 		return errors.New("The new password must not be the same as the current password")

--- a/pkg/auth/api/user/user_actions_test.go
+++ b/pkg/auth/api/user/user_actions_test.go
@@ -11,11 +11,12 @@ import (
 
 func TestValidatePassword(t *testing.T) {
 	tests := []struct {
-		name        string
-		username    string
-		currentpass string
-		password    string
-		expectsErr  bool
+		name         string
+		username     string
+		currentpass  string
+		password     string
+		expectsErr   bool
+		expectErrMsg string
 	}{
 		{
 			name:        "password too short",
@@ -66,15 +67,29 @@ func TestValidatePassword(t *testing.T) {
 			password:    "myfavoritepassword",
 			expectsErr:  true,
 		},
+		{
+			name:         "new password matches username",
+			username:     "administrativeuser",
+			currentpass:  "myfavoritepassword",
+			password:     "administrativeuser",
+			expectsErr:   true,
+			expectErrMsg: "Password cannot be the same as the username",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validatePassword(tt.username, tt.currentpass, tt.password, 12)
-			if err != nil && !tt.expectsErr {
-				t.Errorf("Received unexpected error: %v", err)
-			} else if err == nil && tt.expectsErr {
-				t.Error("Expected error when non received")
+			switch {
+			case tt.expectsErr && tt.expectErrMsg != "":
+				assert.EqualError(t, err, tt.expectErrMsg)
+				return
+			case tt.expectsErr:
+				assert.Error(t, err, "Expected an error but got nil")
+				return
+			case !tt.expectsErr:
+				assert.NoError(t, err, "Expected no error but got one")
+				return
 			}
 		})
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/52446
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This ensures that the error message for creating a user or updating with the password matching the username both emit the same error message.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_