### PR TITLE
Remove kustomize dependency

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ remoteDialerProxyVersion: 109.0.0+up0.7.0
 # NOTE: CAPI controller version has to be updated in scripts/package-env
 turtlesVersion: 109.0.0+up0.26.0
 cspAdapterMinVersion: 109.0.0+up9.0.0-rc.3
-defaultShellVersion: rancher/shell:v0.8.0-rc.1
+defaultShellVersion: rancher/shell:v0.8.0-rc.2
 fleetVersion: 110.0.0+up0.16.0-alpha.5
 defaultSccOperatorImage: rancher/scc-operator:v0.4.0-rc.1
 # NOTE: when updating this version, you will also need to update the hardcoded

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,7 +6,7 @@ const (
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "109.0.0+up9.0.0-rc.3"
 	DefaultSccOperatorImage       = "rancher/scc-operator:v0.4.0-rc.1"
-	DefaultShellVersion           = "rancher/shell:v0.8.0-rc.1"
+	DefaultShellVersion           = "rancher/shell:v0.8.0-rc.2"
 	FleetVersion                  = "110.0.0+up0.16.0-alpha.5"
 	RemoteDialerProxyVersion      = "109.0.0+up0.7.0"
 	TurtlesVersion                = "109.0.0+up0.26.0"

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -53,7 +53,6 @@ import (
 const (
 	// helmDataPath contains the files such as values.yaml for a given chart and tar of the chart.
 	helmDataPath = "/home/shell/helm"
-	helmRunPath  = "/home/shell/helm-run"
 )
 
 var (
@@ -71,73 +70,6 @@ var (
 	podOptionsScheme = runtime.NewScheme()
 	podOptionsCodec  = runtime.NewParameterCodec(podOptionsScheme)
 )
-
-var kustomization = `apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-transformers:
-- /home/shell/helm-run/transform%s.yaml
-resources:
-- /home/shell/helm-run/all.yaml`
-
-var transform = `apiVersion: builtin
-kind: LabelTransformer
-metadata:
-  name: common-labels
-labels:
-  io.cattle.field/appId: %s
-fieldSpecs:
-- path: metadata/labels
-  create: true
-- path: spec/selector
-  create: true
-  version: v1
-  kind: ReplicationController
-- path: spec/template/metadata/labels
-  create: true
-  version: v1
-  kind: ReplicationController
-- path: spec/selector/matchLabels
-  create: true
-  kind: Deployment
-- path: spec/template/metadata/labels
-  create: true
-  kind: Deployment
-- path: spec/selector/matchLabels
-  create: true
-  kind: ReplicaSet
-- path: spec/template/metadata/labels
-  create: true
-  kind: ReplicaSet
-- path: spec/selector/matchLabels
-  create: true
-  kind: DaemonSet
-- path: spec/template/metadata/labels
-  create: true
-  kind: DaemonSet
-- path: spec/selector/matchLabels
-  create: true
-  group: apps
-  kind: StatefulSet
-- path: spec/template/metadata/labels
-  create: true
-  group: apps
-  kind: StatefulSet
-- path: spec/volumeClaimTemplates[]/metadata/labels
-  create: true
-  group: apps
-  kind: StatefulSet
-- path: spec/template/metadata/labels
-  create: true
-  group: batch
-  kind: Job
-- path: spec/jobTemplate/metadata/labels
-  create: true
-  group: batch
-  kind: CronJob
-- path: spec/jobTemplate/spec/template/metadata/labels
-  create: true
-  group: batch
-  kind: CronJob`
 
 func init() {
 	v1internal.AddToScheme(podOptionsScheme)
@@ -486,7 +418,6 @@ type Command struct {
 	Chart            []byte        // content of the chart file
 	ReleaseName      string        // name of the release
 	ReleaseNamespace string        // namespace of the release
-	Kustomize        bool          // flag to inform if it should use kustomize.sh
 }
 
 type Commands []Command
@@ -545,11 +476,6 @@ func (c Command) Render(index int) (map[string][]byte, error) {
 		data[c.ChartFile] = c.Chart
 	}
 
-	if c.Kustomize {
-		data[fmt.Sprintf("kustomization%s.yaml", fileNumID)] = []byte(fmt.Sprintf(kustomization, fileNumID))
-		data[fmt.Sprintf("transform%s.yaml", fileNumID)] = []byte(fmt.Sprintf(transform, c.ReleaseName))
-	}
-
 	return data, nil
 }
 
@@ -597,13 +523,6 @@ func (c Command) renderArgs() ([]string, error) {
 	}
 
 	runPath := helmDataPath
-	if c.Kustomize {
-		// Run path when using kustomize.sh will be different. Original cannot be used
-		// because write permissions are necessary and the helmDataPath cannot be
-		// written to due to it having a SecretVolumeSource.
-		runPath = helmRunPath
-		args = append(args, "--post-renderer=/home/shell/kustomize.sh")
-	}
 
 	if len(c.Values) > 0 {
 		args = append(args, "--values="+filepath.Join(runPath, c.ValuesFile))
@@ -712,27 +631,9 @@ func addAnnotations(data []byte, annotations map[string]string) ([]byte, error) 
 	return yaml.Marshal(chartData)
 }
 
-// enableKustomize returns whether kustomize should be used. If the helm operation is
-// an upgrade and the migrated annotation is present, true will be returned.
-func (s *Operations) enableKustomize(annotations map[string]string, upgrade bool) bool {
-	if !upgrade {
-		return false
-	}
-
-	if len(annotations) == 0 {
-		return false
-	}
-
-	if annotations["apps.cattle.io/migrated"] != "true" {
-		return false
-	}
-
-	return true
-}
-
-// getChartCommand gets the chart based on the input, inject the annotations into it
-// and then creates and return a Command containing the name of the values file, name of the chart file, the chart data
-// and if the command should use kustomize.sh
+// getChartCommand gets the chart based on the input, inject the annotations
+// into it and then creates and return a Command containing the name of the
+// values file, name of the chart file and the chart data
 func (s *Operations) getChartCommand(namespace, name, chartName, chartVersion string, upgrade bool, annotations map[string]string, values map[string]interface{}) (Command, error) {
 	chart, err := s.contentManager.Chart(namespace, name, chartName, chartVersion, true)
 	if err != nil {
@@ -756,7 +657,6 @@ func (s *Operations) getChartCommand(namespace, name, chartName, chartVersion st
 		ValuesFile: valuesFileName,
 		ChartFile:  chartFileName,
 		Chart:      chartData,
-		Kustomize:  s.enableKustomize(annotations, upgrade),
 	}
 
 	if len(values) > 0 {
@@ -854,15 +754,7 @@ func (s *Operations) createOperation(ctx context.Context, user user.Info, status
 		return nil, err
 	}
 
-	var kustomize bool
-	for _, cmd := range cmds {
-		if !cmd.Kustomize {
-			continue
-		}
-		kustomize = true
-		break
-	}
-	pod, podOptions := s.createPod(secretData, kustomize, imageOverride, status.Tolerations)
+	pod, podOptions := s.createPod(secretData, imageOverride, status.Tolerations)
 	pod, err = s.Impersonator.CreatePod(ctx, user, pod, podOptions)
 	if err != nil {
 		return nil, err
@@ -1021,9 +913,8 @@ func (s *Operations) createNamespace(ctx context.Context, namespace, projectID s
 // createPod creates the struct of the pod for the operation to run in. It also mounts a secret with the secretdata provided.
 // If imageOverride is provided, it will override the default value of settings.FullShellImage.
 // The created pod has default tolerations and node selectors.
-// If the kustomize flag is true, the created pod is modified to be able to run the kustomize.sh script.
 // Returns a pod object and a pod options object representing the helm operation pod and it's options
-func (s *Operations) createPod(secretData map[string][]byte, kustomize bool, imageOverride string, tolerations []corev1.Toleration) (*corev1.Pod, *podimpersonation.PodOptions) {
+func (s *Operations) createPod(secretData map[string][]byte, imageOverride string, tolerations []corev1.Toleration) (*corev1.Pod, *podimpersonation.PodOptions) {
 	var (
 		f = false
 		t = true
@@ -1152,31 +1043,6 @@ func (s *Operations) createPod(secretData map[string][]byte, kustomize bool, ima
 		},
 	}
 
-	// if kustomize is false then helmDataPath is an acceptable path for helm to run. If it is true,
-	// files are copied from helmDataPath to helmRunPath. This is because the kustomize.sh script
-	// needs write permissions but volumes using a SecretVolumeSource are readOnly. This can not be
-	// changed with the readOnly field or the defaultMode field.
-	// See: https://github.com/kubernetes/kubernetes/issues/62099.
-	if kustomize {
-		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-			Name: "helm-run",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		})
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      "helm-run",
-			MountPath: helmRunPath,
-		})
-		pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
-			PostStart: &corev1.LifecycleHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/bin/sh", "-c", fmt.Sprintf("cp -r %s/. %s", helmDataPath, helmRunPath)},
-				},
-			},
-		}
-		pod.Spec.Containers[0].WorkingDir = helmRunPath
-	}
 	return pod, &podimpersonation.PodOptions{
 		SecretsToCreate: []*corev1.Secret{
 			secret,

--- a/pkg/catalogv2/helmop/operation_test.go
+++ b/pkg/catalogv2/helmop/operation_test.go
@@ -1,8 +1,6 @@
 package helmop
 
 import (
-	"fmt"
-	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
 	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"testing"
@@ -22,7 +20,6 @@ type createPodTestCase struct {
 	expected      *corev1.Pod
 	failMsg       string
 	secretData    map[string][]byte
-	kustomize     bool
 	imageOverride string
 	tolerations   []corev1.Toleration
 }
@@ -42,29 +39,10 @@ func Test_Render(t *testing.T) {
 			commands: Commands{
 				Command{
 					Operation:   "upgrade",
-					ChartFile:   "test-chart-v1.1.0.tgz",
-					Chart:       []byte("test-chart"),
-					Kustomize:   true,
-					ReleaseName: "test1",
-				},
-			},
-			expected: map[string][]byte{
-				"operation000":          []byte(strings.Join([]string{"upgrade", "--post-renderer=/home/shell/kustomize.sh", "test1", "/home/shell/helm-run/test-chart-v1.1.0.tgz"}, "\x00")),
-				"kustomization000.yaml": []byte(fmt.Sprintf(kustomization, "000")),
-				"transform000.yaml":     []byte(fmt.Sprintf(transform, "test1")),
-				"test-chart-v1.1.0.tgz": []byte("test-chart"),
-			},
-			failMsg: "kustomize enabled test case failed",
-		},
-		{
-			commands: Commands{
-				Command{
-					Operation:   "upgrade",
 					ValuesFile:  "values-test-chart-v1.1.0.yaml",
 					Values:      []byte("{\"a\":\"a\"}"),
 					ChartFile:   "test-chart-v1.1.0.tgz",
 					Chart:       []byte("test-chart"),
-					Kustomize:   false,
 					ReleaseName: "test2",
 				},
 			},
@@ -81,7 +59,6 @@ func Test_Render(t *testing.T) {
 					Operation:   "upgrade",
 					ChartFile:   "test-chart-v1.1.0.tgz",
 					Chart:       []byte("test-chart"),
-					Kustomize:   false,
 					ReleaseName: "test3",
 				},
 			},
@@ -97,7 +74,6 @@ func Test_Render(t *testing.T) {
 					Operation:   "install",
 					ChartFile:   "test-chart-v1.1.0.tgz",
 					Chart:       []byte("test-chart"),
-					Kustomize:   false,
 					ReleaseName: "test4",
 				},
 			},
@@ -113,7 +89,6 @@ func Test_Render(t *testing.T) {
 					Operation:   "uninstall",
 					ChartFile:   "test-chart-v1.1.0.tgz",
 					Chart:       []byte("test-chart"),
-					Kustomize:   false,
 					ReleaseName: "test5",
 				},
 			},
@@ -122,39 +97,6 @@ func Test_Render(t *testing.T) {
 				"test-chart-v1.1.0.tgz": []byte("test-chart"),
 			},
 			failMsg: "uninstall test case failed",
-		},
-		{
-			commands: Commands{
-				Command{
-					Operation:   "upgrade",
-					ChartFile:   "test-chart-v1.1.0.tgz",
-					Chart:       []byte("test-chart"),
-					Kustomize:   true,
-					ReleaseName: "test6",
-					ArgObjects: []interface{}{types.ChartInstallAction{
-						OperationTolerations: []corev1.Toleration{
-							{
-								Key:      "foo",
-								Operator: "equals",
-								Value:    "bar",
-								Effect:   "NoSchedule",
-							},
-							{
-								Key:      "foo2",
-								Operator: "equals",
-								Value:    "bar2",
-								Effect:   "NoSchedule",
-							}},
-					}},
-				},
-			},
-			expected: map[string][]byte{
-				"operation000":          []byte(strings.Join([]string{"upgrade", "--post-renderer=/home/shell/kustomize.sh", "test6", "/home/shell/helm-run/test-chart-v1.1.0.tgz"}, "\x00")),
-				"kustomization000.yaml": []byte(fmt.Sprintf(kustomization, "000")),
-				"transform000.yaml":     []byte(fmt.Sprintf(transform, "test6")),
-				"test-chart-v1.1.0.tgz": []byte("test-chart"),
-			},
-			failMsg: "operation toleration test case failed",
 		},
 	}
 
@@ -262,7 +204,7 @@ func Test_CreatePod(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		actual, _ := testCase.operation.createPod(testCase.secretData, testCase.kustomize, testCase.imageOverride, testCase.tolerations)
+		actual, _ := testCase.operation.createPod(testCase.secretData, testCase.imageOverride, testCase.tolerations)
 		asserts.ElementsMatch(testCase.expected.Spec.Tolerations, actual.Spec.Tolerations, testCase.failMsg)
 	}
 }


### PR DESCRIPTION
## Issue: #54676
 
## Problem

Kustomize functionality is tech debt and should be removed.
 
## Solution

Remove all the Kustomize functionality.

## Testing

## Engineering Testing

### Manual Testing

A simple test, like installing a chart from MAPS, should be enough because it uses the shell under the hood to do the installation. 

<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

Some unit tests to test this functionality were removed as well.

## QA Testing Considerations
 
### Regressions Considerations