### PR TITLE
[release/v2.14] temporarily use k8s 1.34 version of autoscaler in order to not require new chart version

### DIFF
--- a/pkg/controllers/capr/autoscaler/fleet.go
+++ b/pkg/controllers/capr/autoscaler/fleet.go
@@ -24,7 +24,8 @@ import (
 // NOTE: When updating the chart version in build.yaml you will need to update this mapping
 // if adding support for a new minor k8s version
 var imageTagVersions = map[int]string{
-	35: "1.35.0-4.1",
+	// using 1.34 version for 1.35 temporarily - in order to not reqiure a new chart version
+	35: "1.34.0-3.4",
 	34: "1.34.0-3.4",
 	33: "1.33.0-3.3",
 	32: "1.32.3-1.5",


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54755

The v1.35 version of the autoscaler pod actually requires some changes to the rbac of the service account (included in the new chart version 9.56.1). 

Since this is a last minute change - the safer option is just to use the 1.34 version of the autoscaler image since it should "just work" and is already validated. This will buy us some time to properly pull in the new chart + autoscaler image for the next release. 


## Testing notes

ensured autoscaling was working manually:

```
I0424 01:55:55.514299       1 klogx.go:87] 154 other pods are also unschedulable
I0424 01:55:55.832637       1 waste.go:56] Expanding Node Group MachineDeployment/fleet-default/jacob-load-test-pool2 would waste 0.00% CPU, 48.42% Memory, 24.21% Blended
I0424 01:55:55.832784       1 orchestrator.go:185] Best option to resize: MachineDeployment/fleet-default/jacob-load-test-pool2
I0424 01:55:55.832871       1 orchestrator.go:189] Estimated 4 nodes needed in MachineDeployment/fleet-default/jacob-load-test-pool2
I0424 01:55:55.833026       1 orchestrator.go:261] Final scale-up plan: [{MachineDeployment/fleet-default/jacob-load-test-pool2 1->5 (max: 5)}]
I0424 01:55:55.833235       1 executor.go:164] Scale-up: setting group MachineDeployment/fleet-default/jacob-load-test-pool2 size to 5
```

<img width="577" height="167" alt="image" src="https://github.com/user-attachments/assets/6b1988e6-1c40-40d4-bc8b-31fd33c8a527" />
