### PR TITLE
Change multiple steps in different workflows to use our CI image

### DIFF
--- a/.github/actions/rancher-chart/build/action.yml
+++ b/.github/actions/rancher-chart/build/action.yml
@@ -3,10 +3,9 @@ description: "Install dependencies, pull files and build the Rancher chart"
 runs:
   using: "composite"
   steps:
-    # git is assumed to be installed because it is a requirement to run from the same repo
     - name: install dependencies
       shell: bash
-      run: zypper install -y jq awk aws-cli
+      run: zypper install -y aws-cli
     - name: Setup Tag Env Variables
       uses: ./.github/actions/setup-tag-env
     - id: env
@@ -14,19 +13,9 @@ runs:
       uses: ./.github/actions/setup-build-env
     - name: Install Helm dependencies
       env:
-        HELM_URL: https://get.helm.sh/helm-${{ steps.env.outputs.HELM_VERSION }}-linux-amd64.tar.gz
-        HELM_HASH: ${{ steps.env.outputs.HELM_HASH_amd64 }}
         HELM_UNITTEST_VERSION: ${{ steps.env.outputs.HELM_UNITTEST_VERSION }}
       shell: bash
       run: |
-        set -ex
-        curl "${HELM_URL}" --output /tmp/helm.tar.gz && \
-        echo "${HELM_HASH}  /tmp/helm.tar.gz" | sha256sum -c - && \
-        tar xvzf /tmp/helm.tar.gz --strip-components=1 -C /tmp/ && \
-        mv /tmp/helm /usr/bin/helm_v3 && \
-        chmod +x /usr/bin/helm_v3 && \
-        rm -f /tmp/helm.tar.gz
-
         helm_v3 plugin install https://github.com/helm-unittest/helm-unittest.git --version ${HELM_UNITTEST_VERSION};
     - name: Build
       shell: bash

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -83,7 +83,7 @@ jobs:
   build-publish-chart:
     needs: [push-images]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: registry.suse.com/bci/bci-base:15.7
+    container: ghcr.io/rancher/ci-image/go1.26
     permissions:
       contents: read
       id-token: write
@@ -94,11 +94,6 @@ jobs:
     env:
       ARCH: amd64
     steps:
-      - name: install dependencies
-        shell: bash
-        run: zypper install -y git
-      - name: Git safe directory
-        run: git config --global --add safe.directory "$PWD"
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,15 +22,10 @@ jobs:
     uses: ./.github/workflows/unit-test.yml
   build-chart:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: registry.suse.com/bci/bci-base:15.7
+    container: ghcr.io/rancher/ci-image/go1.26
     permissions:
       contents: read
     steps:
-      - name: install dependencies
-        shell: bash
-        run: zypper install -y git
-      - name: Git safe directory
-        run: git config --global --add safe.directory "$PWD"
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -85,7 +85,7 @@ jobs:
   build-publish-chart:
     needs: [push-images]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: registry.suse.com/bci/bci-base:15.7
+    container: ghcr.io/rancher/ci-image/go1.26
     permissions:
       contents: read
       id-token: write
@@ -97,11 +97,6 @@ jobs:
       ARCH: amd64
       REGISTRY: "" # remove to set the registry at systemDefaultRegistry on the chart
     steps:
-      - name: install dependencies
-        shell: bash
-        run: zypper install -y git
-      - name: Git safe directory
-        run: git config --global --add safe.directory "$PWD"
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/rcs-release.yml
+++ b/.github/workflows/rcs-release.yml
@@ -88,7 +88,7 @@ jobs:
   build-publish-chart:
     needs: [push-images]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: registry.suse.com/bci/bci-base:latest
+    container: ghcr.io/rancher/ci-image/go1.26
     permissions:
       contents: read
       id-token: write
@@ -99,11 +99,6 @@ jobs:
     env:
       ARCH: amd64
     steps:
-      - name: install dependencies
-        shell: bash
-        run: zypper install -y git
-      - name: Git safe directory
-        run: git config --global --add safe.directory "$PWD"
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
   build-publish-chart:
     needs: [push-images]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: registry.suse.com/bci/bci-base:15.7
+    container: ghcr.io/rancher/ci-image/go1.26
     permissions:
       contents: read
       id-token: write
@@ -98,11 +98,6 @@ jobs:
       ARCH: amd64
       REGISTRY: "" # remove to set the registry at systemDefaultRegistry on the chart
     steps:
-      - name: install dependencies
-        shell: bash
-        run: zypper install -y git
-      - name: Git safe directory
-        run: git config --global --add safe.directory "$PWD"
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
This change is a bit bigger. It touches multiple steps in workflows to migrate from bci-base to our CI image, removes multiple `zypper in` and `git safe` lines and one Helm checksum validation. It keeps only one `zypper in aws-cli` that isn't in the base image.