### PR TITLE
fix(capr): honor agentEnvVars over global settings in node install script

### DIFF
--- a/pkg/capr/installer/installer.go
+++ b/pkg/capr/installer/installer.go
@@ -78,8 +78,11 @@ func LinuxInstallScript(ctx context.Context, token string, envVars []corev1.EnvV
 	if err != nil {
 		return nil, err
 	}
+
+	provided := providedEnvVars(envVars)
+
 	binaryURL := ""
-	if settings.SystemAgentVersion.Get() != "" {
+	if settings.SystemAgentVersion.Get() != "" && !provided["CATTLE_AGENT_BINARY_BASE_URL"] {
 		if settings.ServerURL.Get() != "" {
 			binaryURL = fmt.Sprintf("CATTLE_AGENT_BINARY_BASE_URL=\"%s/assets\"", settings.ServerURL.Get())
 		} else if defaultHost != "" {
@@ -92,21 +95,17 @@ func LinuxInstallScript(ctx context.Context, token string, envVars []corev1.EnvV
 	if v, ok := ctx.Value(tls.InternalAPI).(bool); ok && v {
 		ca = systemtemplate.InternalCAChecksum()
 	}
-	if ca != "" {
+	if ca != "" && !provided["CATTLE_CA_CHECKSUM"] {
 		ca = "CATTLE_CA_CHECKSUM=\"" + ca + "\""
+	} else {
+		ca = ""
 	}
 	if token != "" {
 		token = "CATTLE_ROLE_NONE=true\nCATTLE_TOKEN=\"" + token + "\""
 	}
 
 	// Merge the env vars with the AgentTLSModeStrict
-	found := false
-	for _, ev := range envVars {
-		if ev.Name == "STRICT_VERIFY" {
-			found = true // The user has specified `STRICT_VERIFY`, we should not attempt to overwrite it.
-		}
-	}
-	if !found {
+	if !provided["STRICT_VERIFY"] {
 		if settings.AgentTLSMode.Get() == settings.AgentTLSModeStrict {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  "STRICT_VERIFY",
@@ -132,7 +131,7 @@ func LinuxInstallScript(ctx context.Context, token string, envVars []corev1.EnvV
 		envVarBuf.WriteString(fmt.Sprintf("export %s=%s\n", envVar.Name, escapeShellValue(envVar.Value)))
 	}
 	server := ""
-	if settings.ServerURL.Get() != "" {
+	if settings.ServerURL.Get() != "" && !provided["CATTLE_SERVER"] {
 		server = fmt.Sprintf("CATTLE_SERVER=%s", settings.ServerURL.Get())
 	}
 	return []byte(fmt.Sprintf(`#!/usr/bin/env sh
@@ -146,6 +145,20 @@ func LinuxInstallScript(ctx context.Context, token string, envVars []corev1.EnvV
 `, envVarBuf.String(), binaryURL, server, ca, token, data)), nil
 }
 
+// providedEnvVars returns the set of env-var names with non-empty values supplied by the caller.
+// It is used to honor user-supplied agentEnvVars (e.g. CATTLE_SERVER, CATTLE_AGENT_BINARY_BASE_URL,
+// CATTLE_CA_CHECKSUM, STRICT_VERIFY) over values otherwise derived from global Rancher settings.
+func providedEnvVars(envVars []corev1.EnvVar) map[string]bool {
+	provided := make(map[string]bool, len(envVars))
+	for _, ev := range envVars {
+		if ev.Value == "" {
+			continue
+		}
+		provided[ev.Name] = true
+	}
+	return provided
+}
+
 func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.EnvVar, defaultHost, dataDir string) ([]byte, error) {
 	data, err := installScript(
 		settings.WinsAgentInstallScript,
@@ -154,8 +167,10 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 		return nil, err
 	}
 
+	provided := providedEnvVars(envVars)
+
 	binaryURL := ""
-	if settings.WinsAgentVersion.Get() != "" {
+	if settings.WinsAgentVersion.Get() != "" && !provided["CATTLE_AGENT_BINARY_BASE_URL"] {
 		if settings.ServerURL.Get() != "" {
 			binaryURL = capr.FormatWindowsEnvVar(corev1.EnvVar{
 				Name:  "CATTLE_AGENT_BINARY_BASE_URL",
@@ -185,11 +200,13 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 		ca = systemtemplate.InternalCAChecksum()
 	}
 
-	if ca != "" {
+	if ca != "" && !provided["CATTLE_CA_CHECKSUM"] {
 		ca = capr.FormatWindowsEnvVar(corev1.EnvVar{
 			Name:  "CATTLE_CA_CHECKSUM",
 			Value: ca,
 		}, false)
+	} else {
+		ca = ""
 	}
 
 	var tokenEnvVar, cattleRoleNone string
@@ -212,7 +229,7 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 		envVarBuf.WriteString(capr.FormatWindowsEnvVar(envVar, false) + "\n")
 	}
 	server := ""
-	if settings.ServerURL.Get() != "" {
+	if settings.ServerURL.Get() != "" && !provided["CATTLE_SERVER"] {
 		server = capr.FormatWindowsEnvVar(corev1.EnvVar{
 			Name:  "CATTLE_SERVER",
 			Value: settings.ServerURL.Get(),

--- a/pkg/capr/installer/installer_test.go
+++ b/pkg/capr/installer/installer_test.go
@@ -275,6 +275,10 @@ func TestInstaller_LinuxInstallScript_AgentEnvVarsPrecedence(t *testing.T) {
 			{Name: "CATTLE_SERVER", Value: overrideServer},
 			{Name: "CATTLE_AGENT_BINARY_BASE_URL", Value: overrideAssets},
 			{Name: "CATTLE_CA_CHECKSUM", Value: overrideCAChecksum},
+			// Non-CATTLE_ envvars must continue to render normally alongside
+			// the precedence-controlled CATTLE_* overrides.
+			{Name: "HTTP_PROXY", Value: "http://proxy.example.com:3128"},
+			{Name: "MyCustomVar", Value: "MyCustomValue"},
 		}, "", "/var/lib/rancher/rke2")
 	a.Nil(err)
 	a.NotNil(script)
@@ -290,6 +294,11 @@ func TestInstaller_LinuxInstallScript_AgentEnvVarsPrecedence(t *testing.T) {
 		"CATTLE_AGENT_BINARY_BASE_URL must be emitted once, with the user-provided value")
 	a.Equal(1, strings.Count(out, fmt.Sprintf("export CATTLE_CA_CHECKSUM='%s'", overrideCAChecksum)),
 		"CATTLE_CA_CHECKSUM must be emitted once, with the user-provided value")
+
+	// Non-CATTLE_ envvars must still pass through, rendered in the exported +
+	// single-quote escaped form alongside the precedence-controlled CATTLE_* overrides.
+	a.Contains(out, "export HTTP_PROXY='http://proxy.example.com:3128'")
+	a.Contains(out, "export MyCustomVar='MyCustomValue'")
 
 	// The values otherwise synthesized from global settings must not leak when the
 	// user has overridden them via agentEnvVars. The global server-url (and the binary
@@ -341,6 +350,10 @@ func TestInstaller_WindowsInstallScript_AgentEnvVarsPrecedence(t *testing.T) {
 			{Name: "CATTLE_SERVER", Value: overrideServer},
 			{Name: "CATTLE_AGENT_BINARY_BASE_URL", Value: overrideAssets},
 			{Name: "CATTLE_CA_CHECKSUM", Value: overrideCAChecksum},
+			// Non-CATTLE_ envvars must continue to render normally alongside
+			// the precedence-controlled CATTLE_* overrides.
+			{Name: "HTTP_PROXY", Value: "http://proxy.example.com:3128"},
+			{Name: "MyCustomVar", Value: "MyCustomValue"},
 		}, "", "/var/lib/rancher/rke2")
 	a.Nil(err)
 	a.NotNil(script)
@@ -356,6 +369,10 @@ func TestInstaller_WindowsInstallScript_AgentEnvVarsPrecedence(t *testing.T) {
 	a.Contains(out, fmt.Sprintf("$env:CATTLE_SERVER=\"%s\"", overrideServer))
 	a.Contains(out, fmt.Sprintf("$env:CATTLE_AGENT_BINARY_BASE_URL=\"%s\"", overrideAssets))
 	a.Contains(out, fmt.Sprintf("$env:CATTLE_CA_CHECKSUM=\"%s\"", overrideCAChecksum))
+
+	// Non-CATTLE_ envvars must still pass through.
+	a.Contains(out, "$env:HTTP_PROXY=\"http://proxy.example.com:3128\"")
+	a.Contains(out, "$env:MyCustomVar=\"MyCustomValue\"")
 
 	a.NotContains(out, "rancher.global.example.com",
 		"global server-url must not leak into the script when the user has overridden CATTLE_SERVER")

--- a/pkg/capr/installer/installer_test.go
+++ b/pkg/capr/installer/installer_test.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/rancher/rancher/pkg/capr"
@@ -252,4 +253,110 @@ func TestInstaller_LinuxInstallScript_ShellInjectionPrevention(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInstaller_LinuxInstallScript_AgentEnvVarsPrecedence verifies that user-supplied
+// agentEnvVars take precedence over values otherwise derived from the global server-url
+// setting. Without precedence, the bootstrap script duplicates these vars (user's first,
+// then global), and shell-script semantics make the global value win.
+func TestInstaller_LinuxInstallScript_AgentEnvVarsPrecedence(t *testing.T) {
+	a := assert.New(t)
+
+	a.Nil(settings.ServerURL.Set("https://rancher.global.example.com"))
+	a.Nil(settings.CACerts.Set("global-ca-cert-contents"))
+	a.Nil(settings.SystemAgentVersion.Set("v0.3.0"))
+
+	overrideServer := "https://rancher.override.example.com"
+	overrideAssets := overrideServer + "/assets"
+	overrideCAChecksum := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	script, err := LinuxInstallScript(context.TODO(), "test-token",
+		[]corev1.EnvVar{
+			{Name: "CATTLE_SERVER", Value: overrideServer},
+			{Name: "CATTLE_AGENT_BINARY_BASE_URL", Value: overrideAssets},
+			{Name: "CATTLE_CA_CHECKSUM", Value: overrideCAChecksum},
+		}, "", "/var/lib/rancher/rke2")
+	a.Nil(err)
+	a.NotNil(script)
+	out := string(script)
+
+	// Each user-supplied var is emitted exactly once, in the exported + single-quote
+	// escaped form used for agentEnvVars, with the user-provided value. We count the
+	// fully-formed export line (rather than a bare "CATTLE_SERVER=" substring) because
+	// the embedded install-script body itself references these names in its usage text.
+	a.Equal(1, strings.Count(out, fmt.Sprintf("export CATTLE_SERVER='%s'", overrideServer)),
+		"CATTLE_SERVER must be emitted once, with the user-provided value")
+	a.Equal(1, strings.Count(out, fmt.Sprintf("export CATTLE_AGENT_BINARY_BASE_URL='%s'", overrideAssets)),
+		"CATTLE_AGENT_BINARY_BASE_URL must be emitted once, with the user-provided value")
+	a.Equal(1, strings.Count(out, fmt.Sprintf("export CATTLE_CA_CHECKSUM='%s'", overrideCAChecksum)),
+		"CATTLE_CA_CHECKSUM must be emitted once, with the user-provided value")
+
+	// The values otherwise synthesized from global settings must not leak when the
+	// user has overridden them via agentEnvVars. The global server-url (and the binary
+	// base url derived from it) share the rancher.global host; the global CA checksum
+	// is derived from the global CACerts setting.
+	a.NotContains(out, "rancher.global.example.com",
+		"global server-url must not leak into the script when the user has overridden CATTLE_SERVER")
+	a.NotContains(out, fmt.Sprintf("CATTLE_CA_CHECKSUM=\"%s\"", systemtemplate.CAChecksum()),
+		"global CA checksum must not be emitted when the user has overridden CATTLE_CA_CHECKSUM")
+}
+
+// TestInstaller_LinuxInstallScript_FallbackToServerURL verifies that when the user
+// does not supply CATTLE_SERVER / CATTLE_AGENT_BINARY_BASE_URL / CATTLE_CA_CHECKSUM,
+// the script still falls back to values derived from global settings (existing behavior).
+func TestInstaller_LinuxInstallScript_FallbackToServerURL(t *testing.T) {
+	a := assert.New(t)
+
+	a.Nil(settings.ServerURL.Set("https://rancher.global.example.com"))
+	a.Nil(settings.CACerts.Set("global-ca-cert-contents"))
+	a.Nil(settings.SystemAgentVersion.Set("v0.3.0"))
+
+	caChecksum := systemtemplate.CAChecksum()
+
+	script, err := LinuxInstallScript(context.TODO(), "test-token", nil, "", "/var/lib/rancher/rke2")
+	a.Nil(err)
+	a.NotNil(script)
+	out := string(script)
+
+	a.Contains(out, "CATTLE_SERVER=https://rancher.global.example.com")
+	a.Contains(out, "CATTLE_AGENT_BINARY_BASE_URL=\"https://rancher.global.example.com/assets\"")
+	a.Contains(out, fmt.Sprintf("CATTLE_CA_CHECKSUM=\"%s\"", caChecksum))
+}
+
+// TestInstaller_WindowsInstallScript_AgentEnvVarsPrecedence verifies the same precedence
+// behavior for the Windows install script.
+func TestInstaller_WindowsInstallScript_AgentEnvVarsPrecedence(t *testing.T) {
+	a := assert.New(t)
+
+	a.Nil(settings.ServerURL.Set("https://rancher.global.example.com"))
+	a.Nil(settings.CACerts.Set("global-ca-cert-contents"))
+	a.Nil(settings.WinsAgentVersion.Set("v0.4.0"))
+
+	overrideServer := "https://rancher.override.example.com"
+	overrideAssets := overrideServer + "/assets"
+	overrideCAChecksum := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	script, err := WindowsInstallScript(context.TODO(), "test-token",
+		[]corev1.EnvVar{
+			{Name: "CATTLE_SERVER", Value: overrideServer},
+			{Name: "CATTLE_AGENT_BINARY_BASE_URL", Value: overrideAssets},
+			{Name: "CATTLE_CA_CHECKSUM", Value: overrideCAChecksum},
+		}, "", "/var/lib/rancher/rke2")
+	a.Nil(err)
+	a.NotNil(script)
+	out := string(script)
+
+	a.Equal(1, strings.Count(out, "$env:CATTLE_SERVER="),
+		"$env:CATTLE_SERVER must not be emitted twice (user value + global override)")
+	a.Equal(1, strings.Count(out, "$env:CATTLE_AGENT_BINARY_BASE_URL="),
+		"$env:CATTLE_AGENT_BINARY_BASE_URL must not be emitted twice")
+	a.Equal(1, strings.Count(out, "$env:CATTLE_CA_CHECKSUM="),
+		"$env:CATTLE_CA_CHECKSUM must not be emitted twice")
+
+	a.Contains(out, fmt.Sprintf("$env:CATTLE_SERVER=\"%s\"", overrideServer))
+	a.Contains(out, fmt.Sprintf("$env:CATTLE_AGENT_BINARY_BASE_URL=\"%s\"", overrideAssets))
+	a.Contains(out, fmt.Sprintf("$env:CATTLE_CA_CHECKSUM=\"%s\"", overrideCAChecksum))
+
+	a.NotContains(out, "rancher.global.example.com",
+		"global server-url must not leak into the script when the user has overridden CATTLE_SERVER")
 }


### PR DESCRIPTION
## Issue

Fixes #47386 

## Problem

When provisioning a downstream RKE2 cluster via `provisioning.cattle.io/v1 Cluster`, setting `spec.agentEnvVars` for `CATTLE_SERVER`, `CATTLE_AGENT_BINARY_BASE_URL`, or `CATTLE_CA_CHECKSUM` has no effect. The Linux/Windows install scripts written into the per-machine bootstrap secret emit the user-provided values, then **unconditionally append** values derived from the global `setting.management.cattle.io/server-url` and `CACerts` — and under shell-script semantics the later assignment wins, so user overrides are silently dropped.

This makes it impossible to direct a specific downstream cluster's nodes at a different Rancher hostname (e.g., one with a publicly-reachable DNS view or different cert) without changing the global `server-url` for the entire Rancher installation.

### Reproduction

1. Set the global `server-url` to e.g. `https://rancher.example.com`.
2. Stand up a second hostname (different DNS view / cert) pointing at the same Rancher backend, e.g. `https://rancher-public.example.com`.
3. Create a downstream RKE2 cluster:

```yaml
apiVersion: provisioning.cattle.io/v1
kind: Cluster
metadata:
  name: my-cluster
  namespace: fleet-default
spec:
  agentEnvVars:
    - name: CATTLE_SERVER
      value: https://rancher-public.example.com
    - name: CATTLE_AGENT_BINARY_BASE_URL
      value: https://rancher-public.example.com/assets
  # ...rkeConfig with a machine pool whose nodes can only resolve rancher-public.example.com
```

4. Decode the rendered bootstrap secret:

```sh
kubectl -n fleet-default get secret <cluster>-<pool>-<hash>-machine-bootstrap \
  -o jsonpath='{.data.value}' | base64 -d
```

Output today:

```sh
#!/usr/bin/env sh
CATTLE_SERVER="https://rancher-public.example.com"            # from agentEnvVars
CATTLE_AGENT_BINARY_BASE_URL="https://rancher-public.example.com/assets"
CATTLE_AGENT_BINARY_BASE_URL="https://rancher.example.com/assets"   # overwritten from server-url
CATTLE_SERVER=https://rancher.example.com                            # overwritten from server-url
CATTLE_CA_CHECKSUM="..."
CATTLE_TOKEN="..."
...
```

The node tries to reach the global URL, which is unreachable from its network, and provisioning hangs at `configuring bootstrap node(s) <node>: waiting for agent to check in and apply initial plan`.

### Root cause

[`pkg/capr/installer/installer.go` — `LinuxInstallScript`](https://github.com/rancher/rancher/blob/main/pkg/capr/installer/installer.go) renders user-provided `envVars` into a buffer first, then unconditionally appends synthesized `CATTLE_SERVER=` / `CATTLE_AGENT_BINARY_BASE_URL=` / `CATTLE_CA_CHECKSUM=` lines from global settings *after* that buffer:

```go
envVarBuf := &strings.Builder{}
for _, envVar := range envVars { /* writes user values */ }

server := ""
if settings.ServerURL.Get() != "" {
    server = fmt.Sprintf("CATTLE_SERVER=%s", settings.ServerURL.Get())  // wins via shell ordering
}
```

The analogous `WindowsInstallScript` has the same flaw.

## Solution

Treat `agentEnvVars` as the higher-precedence source: only emit the synthesized `CATTLE_SERVER` / `CATTLE_AGENT_BINARY_BASE_URL` / `CATTLE_CA_CHECKSUM` lines when the corresponding name was *not* supplied via `agentEnvVars` (with a non-empty value).

- A small helper `providedEnvVars(envVars)` returns the set of names with non-empty values supplied by the caller.
- Each fallback site (`binaryURL`, `ca`, `server`) checks the helper before emitting.
- The same precedence already applied to `STRICT_VERIFY` via an ad-hoc loop; that loop is folded into the shared helper.
- Applies symmetrically to `LinuxInstallScript` and `WindowsInstallScript`.

When the user does not override these vars, behavior is unchanged — global `server-url` / `CACerts` continue to populate the script as before.

## Testing

### Manual Testing

Reproduced the original failure on Rancher v2.13.3 against an RKE2 + DigitalOcean downstream cluster: setting `agentEnvVars` for `CATTLE_SERVER` and `CATTLE_AGENT_BINARY_BASE_URL` to a different hostname (with the same backend) had no effect; the rendered bootstrap secret showed both the user value and a later global-override line.

With this patch applied, the rendered bootstrap secret contains exactly one assignment per overridden var, with the user-supplied value, and no leak of the global `server-url` value.

### Engineering Testing

#### Manual Testing

In addition to the in-cluster reproduction above, the new unit tests exercise both the precedence path (user-supplied wins) and the fallback path (global setting still applies when the user does not override).

#### Automated Testing

* Test types added/modified:
    * Unit
* Coverage:
    * `TestInstaller_LinuxInstallScript_AgentEnvVarsPrecedence` — user-supplied `CATTLE_SERVER`, `CATTLE_AGENT_BINARY_BASE_URL`, and `CATTLE_CA_CHECKSUM` are not overwritten; each appears exactly once with the override value; the global `server-url` does not leak into the script.
    * `TestInstaller_LinuxInstallScript_FallbackToServerURL` — when no overrides are supplied, the script still derives all three vars from global settings (regression guard).
    * `TestInstaller_WindowsInstallScript_AgentEnvVarsPrecedence` — same precedence guarantees for the Windows install script.
    * Existing `TestInstaller_WindowsInstallScript` continues to cover the no-override Windows path.

## QA Testing Considerations

- Fresh install: provision an RKE2 downstream with no `agentEnvVars` — must behave exactly as before (uses global `server-url` / `CACerts`).
- Fresh install: provision an RKE2 downstream with `agentEnvVars` overriding `CATTLE_SERVER` and/or `CATTLE_AGENT_BINARY_BASE_URL` — node must check in via the override URL; rendered bootstrap secret must contain the override value once and no global-server-url assignment.
- Upgrade: existing downstream clusters that did **not** set `agentEnvVars` for these vars must reconcile with no change in the rendered script.
- Windows worker workflow if applicable in the test bed.

### Regressions Considerations

Risk is contained to `pkg/capr/installer/installer.go`. The change is gated on names actually appearing in `agentEnvVars`, so existing clusters that did not set these overrides see byte-identical output (modulo whitespace from the unchanged template).

One subtle behavior delta: an entry with empty `Value` (e.g. `agentEnvVars: [{name: STRICT_VERIFY, value: ""}]`) is now treated as "not provided" rather than "provided" for fallback-suppression purposes. The existing render loop already drops empty-value entries, so the previous behavior was to silently emit nothing for such an entry; the new behavior is to emit the global default. This brings empty-value handling in line with the `Value == ""` skip already present in the render loop and matches the documented intent of `agentEnvVars`.

Existing / newly added automated tests that provide evidence there are no regressions:
* `TestInstaller_LinuxInstallScript_FallbackToServerURL` — locks in the fallback path
* Existing `TestInstaller_WindowsInstallScript` — locks in the Windows fallback path