### PR TITLE
Forwarded Headers Modifier for external TLS

### DIFF
--- a/chart/templates/ingate/httproute.yaml
+++ b/chart/templates/ingate/httproute.yaml
@@ -24,6 +24,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if eq (include "rancher.useExternalTls" .) "true" }}
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Forwarded-Proto
+            value: https
+          - name: X-Forwarded-Host
+            value: {{ .Values.hostname }}
+      {{- end }}
       backendRefs:
         - name: {{ include "rancher.fullname" . }}
           port: {{ ternary 443 80 .Values.service.disableHTTP }}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54788
 
## Problem
When networkExposure is of type Gateway and TLS are externally terminated (e.g. Nginx external Load Balancer), the automatically generated HTTPRoute cannot override X-forwarded-Port header.
These X-Forwarded headers are necessary even when external LB cannot provide them:
https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/configure-layer-7-nginx-load-balancer#3-configure-load-balancer
 
## Solution
Set the necessaries X-Forwarded headers.
 
## Testing

## Engineering Testing
### Manual Testing
I managed to make the application work by overriding the HTTPRoute with the missing HeaderModifier:
```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: rancher-http-route
  namespace: cattle-system
spec:
  parentRefs:
  - name: rancher-gateway
    namespace: cattle-system
    sectionName: rancher-http
  hostnames:
  - "rancher.example.com"
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    filters:
    - type: RequestHeaderModifier
      requestHeaderModifier:
        set:
        - name: X-Forwarded-Proto
          value: https
        - name: X-Forwarded-Host
          value: rancher.example.com
    backendRefs:
    - name: rancher
      port: 80
```

### Automated Testing
* Test types added/modified:
    * None
* Reason: manual verification with same code (see manuals)
* GH Issue/PR: [_LINK TO GH ISSUE/PR TO ADD TESTS_](https://github.com/rancher/rancher/issues/54788)

Summary: _TODO_

## QA Testing Considerations

 
### Regressions Considerations
Alternatively HTTPRoute filters could be generally passed from Rancher Helm Chart (thought for this case I'll stick to the external termination use).
I avoid this to minimize external HTTPRoute filters injections.