### PR TITLE
[main] Allow editing `proxyendpoints` through steve

### DIFF
--- a/pkg/api/steve/disallow/disallow.go
+++ b/pkg/api/steve/disallow/disallow.go
@@ -20,6 +20,7 @@ var (
 		"podsecurityadmissionconfigurationtemplates": true,
 		"projects":                                   true,
 		"projectroletemplatebindings":                true,
+		"proxyendpoints":                             true,
 		"oidcclients":                                true,
 		"users":                                      true,
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54827
 
## Problem
 
When adding support for `management.cattle.io.proxyendpoints` in Rancher, `pkg/api/steve/disallow/disallow.go` was not updated with the new resource. By default, `disallow.go` will block several API methods for resources in the `management.cattle.io` and `project.cattle.io` groups. My understanding is that this was initially implemented to ensure that [existing Norman API endpoints](https://github.com/HarrisonWAffel/rancher/commit/ac734e57b3b8873f9e43be842058bb4e7ae67104) which handle resources in those groups were used instead of Steve. There isn't a competing norman handler for `proxyendpoints`, so this restriction doesn't apply. This change follows a similar pattern for other resources that have had retroactive steve access granted ([one](https://github.com/HarrisonWAffel/rancher/commit/3e12a6a835526a5bebdf3f07840f329db197a690), [two](https://github.com/HarrisonWAffel/rancher/commit/51144e322bdebc5dff3fc2ea5e3378d3dcd14f0e))

## Solution

Add an entry to the allow list to stop blocking `PUT`, `POST`, `PATCH`, and `DELETE` operations in Steve for `proxyendpoints`
 
## Testing

+ Deploy Rancher without this change, and navigate to `/v1/schemas/management.cattle.io.proxyendpoint`. The `resourceMethods` listed should show `blocked` for several methods (e.g. `blocked-PUT`)
+ Create a standard user without the `Manage Rancher Proxy` role. Navigate to `/v1/schemas/management.cattle.io.proxyendpoint` and ensure that a `404` is returned.
+ Add the `Manage Rancher Proxy` role to that standard user, and ensure that a `404` is no longer returned, and that the the `resourceMethods` show `blocked` methods.
+ Update Rancher to a version with this fix, and as an admin navigate to `/v1/schemas/management.cattle.io.proxyendpoint`. Ensure that the `resourceMethods` no longer show `blocked` methods.
+ Repeat the same steps for a **_new_** standard user. Ensure that a `404` is returned when the role is not granted, and that methods are not blocked when the role is added.

## Engineering Testing
### Manual Testing

I did the above locally in my IDE. 

### Automated Testing
n/a

## QA Testing Considerations

 
### Regressions Considerations
N/A, there is nothing relying on the existing steve endpoint for `proxyendpoints`.