### PR TITLE
Support rejection of operations on local users when the local auth provider is marked disabled

### DIFF
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -224,6 +224,13 @@ var (
 		false,
 		true,
 	)
+	HideLocalAuthProvider = newFeature(
+		"hide-local-auth-provider",
+		"Hide the local auth provider when one or more external auth providers are active",
+		false,
+		true,
+		true,
+	)
 )
 
 func ListEnabled() []string {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#46078 
 
## Problem

See issue
 
## Solution

An additional setting `disable-local-auth-provider` is added to the system, with a default value of `false`.
IOW local auth provider is enabled.

This setting is queried by the webhook (see PR https://github.com/rancher/webhook/pull/1410).
When it is set the webhook performs additional checks and rejects operations on users linked to the local auth provider.
See the referenced PR for details on that.
 
## Testing
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_