### PR TITLE
Add nftables support with automatic iptables mode detection

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -296,7 +296,12 @@ COPY --from=rancher/k3s:v1.35.4-k3s1 \
     /bin/pigz \
     /bin/runc \
     /bin/which \
+    /bin/aux/iptables-apply \
+    /bin/aux/iptables-detect.sh \
+    /bin/aux/nft \
+    /bin/aux/xtables-set-mode.sh \
     /bin/aux/xtables-legacy-multi \
+    /bin/aux/xtables-nft-multi \
     /usr/bin/
 
 RUN ln -s /usr/bin/cni /usr/bin/bridge && \
@@ -311,14 +316,30 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
     ln -s /usr/bin/k3s /usr/bin/k3s-server && \
     ln -s /usr/bin/k3s /usr/bin/kubectl && \
     ln -s /usr/bin/pigz /usr/bin/unpigz && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-save && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-restore && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-translate && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-save && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-restore && \
-    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-translate
+    ln -s /usr/bin/iptables-detect.sh /usr/bin/ip6tables && \
+    ln -s /usr/bin/iptables-apply /usr/bin/ip6tables-apply && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-legacy && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-legacy-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-legacy-save && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/ip6tables-nft && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/ip6tables-nft-restore && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/ip6tables-nft-save && \
+    ln -s /usr/bin/iptables-detect.sh /usr/bin/ip6tables-restore && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/ip6tables-restore-translate && \
+    ln -s /usr/bin/iptables-detect.sh /usr/bin/ip6tables-save && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/ip6tables-translate && \
+    ln -s /usr/bin/iptables-detect.sh /usr/bin/iptables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-legacy && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-legacy-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-legacy-save && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/iptables-nft && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/iptables-nft-restore && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/iptables-nft-save && \
+    ln -s /usr/bin/iptables-detect.sh /usr/bin/iptables-restore && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/iptables-restore-translate && \
+    ln -s /usr/bin/iptables-detect.sh /usr/bin/iptables-save && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/iptables-translate && \
+    ln -s /usr/bin/xtables-nft-multi /usr/bin/xtables-monitor
 
 COPY --from=tini /usr/bin/tini /usr/bin/tini
 


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/54862

## Summary

This PR adds nftables support to fix failures when running Rancher in environments where legacy iptables kernel modules are not available.

## Problem

Rancher containers fail to start in environments using modern Linux kernels (6.17+) with legacy iptables disabled, such as:
- Alpine Linux 3.23+ with the `linux-virt` kernel
- Other distributions where `CONFIG_NETFILTER_XTABLES_LEGACY` is disabled

The failure occurs because kube-proxy attempts to use legacy iptables but encounters:
```
iptables is not available on this host : error listing chain "POSTROUTING" in table "nat": 
exit status 3: iptables v1.8.11 (legacy): can't initialize iptables table `nat': 
Table does not exist (do you need to insmod?)
```

## Root Cause

Starting with Linux kernel 6.17, the `CONFIG_NETFILTER_XTABLES_LEGACY` configuration option was introduced and defaults to disabled. Some distributions and kernel configurations explicitly disable this option, making legacy iptables modules (`ip_tables`, `iptable_nat`, etc.) unavailable.

For example, Alpine Linux's `linux-virt` kernel has:
```
CONFIG_NETFILTER_XTABLES=m
# CONFIG_NETFILTER_XTABLES_LEGACY is not set
```

(On alpine, I'm not sure if it's supposed to be disabled or not so I created this issue to confirm: https://gitlab.alpinelinux.org/alpine/aports/-/issues/18160)

## Solution

k3s already supports detecting the right iptables backend but we were missing those scripts so I'm just bringing them in.

## Related Issues

Addresses environments affected by:
- Linux kernel 6.17+ with `CONFIG_NETFILTER_XTABLES_LEGACY=n`
- Other minimal kernel configurations without legacy netfilter modules

## References

- [Dagger Issue: Linux kernel 6.17+ disabled legacy xtables](https://github.com/dagger/dagger/issues/11607)