### PR TITLE
Propagate NonTransientError from RefetchGroupPrincipals in provider refresh

### DIFF
--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -1,6 +1,7 @@
 package providerrefresh
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -246,6 +247,14 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 			} else {
 				newGroupPrincipals, err = providers.RefetchGroupPrincipals(principalID, providerName, secret)
 				if err != nil {
+					// Non-transient errors (e.g. invalid_grant when the user's IdP session
+					// is revoked) must propagate to the controller so it can annotate the
+					// UserAttribute and stop requeuing. Without this, the loop continues
+					// to GetPrincipal which hits the same issue and keeps requeuing.
+					var nte *common.NonTransientError
+					if errors.As(err, &nte) {
+						return nil, err
+					}
 					// In the case that we cant access a server, we still want to continue refreshing, but
 					// we no longer want to disable derived tokens, or remove their login tokens for this provider.
 					if err.Error() != "no access" {

--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -686,6 +686,97 @@ func TestTriggerUserRefreshSkipsAnnotatedUser(t *testing.T) {
 		"Update should not be called for annotated user attribute")
 }
 
+func TestRefreshAttributesNonTransientError(t *testing.T) {
+	t.Parallel()
+
+	const providerName = "testoidc"
+
+	user := &apiv3.User{
+		ObjectMeta:   metav1.ObjectMeta{Name: "user-abcde"},
+		PrincipalIDs: []string{providerName + "_user://some-guid"},
+	}
+
+	attribs := &apiv3.UserAttribute{
+		ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+		GroupPrincipals: map[string]apiv3.Principals{},
+		ExtraByProvider: map[string]map[string][]string{},
+	}
+
+	loginToken := &apiv3.Token{
+		UserID:       "user-abcde",
+		IsDerived:    false,
+		AuthProvider: providerName,
+		UserPrincipal: apiv3.Principal{
+			ObjectMeta: metav1.ObjectMeta{Name: providerName + "_user://some-guid"},
+			Provider:   providerName,
+		},
+	}
+
+	providers.ProviderNames = map[string]bool{
+		providerName: true,
+	}
+	providers.Providers = map[string]common.AuthProvider{
+		providerName: &mockNonTransientProvider{},
+	}
+
+	ctrl := gomock.NewController(t)
+	secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+
+	users.EXPECT().Cache().Return(nil)
+	secrets.EXPECT().Cache().Return(scache)
+	scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+	tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+	var tokenDeleteCalled, tokenUpdateCalled bool
+	r := &refresher{
+		tokenLister: &fakes.TokenListerMock{
+			ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+				return []*apiv3.Token{loginToken}, nil
+			},
+		},
+		userLister: &fakes.UserListerMock{
+			GetFunc: func(_, _ string) (*apiv3.User, error) {
+				return user, nil
+			},
+		},
+		tokens: &fakes.TokenInterfaceMock{
+			DeleteFunc: func(_ string, _ *metav1.DeleteOptions) error {
+				tokenDeleteCalled = true
+				return nil
+			},
+		},
+		tokenMGR: tokens.NewMockedManager(tokenClient),
+		extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+			exttokens.NewTimeHandler(),
+			exttokens.NewHashHandler(),
+			exttokens.NewAuthHandler()),
+	}
+
+	got, err := r.refreshAttributes(attribs)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+
+	var nte *common.NonTransientError
+	assert.ErrorAs(t, err, &nte)
+	assert.False(t, tokenDeleteCalled, "tokens should not be deleted when NonTransientError is returned")
+	assert.False(t, tokenUpdateCalled, "tokens should not be updated when NonTransientError is returned")
+}
+
+type mockNonTransientProvider struct {
+	mockLocalProvider
+}
+
+func (p *mockNonTransientProvider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {
+	return nil, &common.NonTransientError{Err: fmt.Errorf("oauth2: invalid_grant: Session not active")}
+}
+
+func (p *mockNonTransientProvider) IsDisabledProvider() (bool, error) {
+	return false, nil
+}
+
 type mockLocalProvider struct {
 	canAccess   bool
 	disabled    bool

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -3,12 +3,12 @@ package keycloakoidc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
-	"github.com/pkg/errors"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
@@ -151,12 +151,12 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token accessor.T
 	var externalID string
 	parts := strings.SplitN(principalID, ":", 2)
 	if len(parts) != 2 {
-		return apiv3.Principal{}, errors.Errorf("invalid id %v", principalID)
+		return apiv3.Principal{}, fmt.Errorf("invalid id %v", principalID)
 	}
 	externalID = strings.TrimPrefix(parts[1], "//")
 	parts = strings.SplitN(parts[0], "_", 2)
 	if len(parts) != 2 {
-		return apiv3.Principal{}, errors.Errorf("invalid id %v", principalID)
+		return apiv3.Principal{}, fmt.Errorf("invalid id %v", principalID)
 	}
 	principalType := parts[1]
 	keyCloakClient, err := k.newClient(config, token)
@@ -212,6 +212,13 @@ func (k *keyCloakOIDCProvider) getRefreshAndUpdateToken(ctx context.Context, oau
 
 	reusedToken, err := oauth2.ReuseTokenSource(oauthToken, oauthConfig.TokenSource(ctx, oauthToken)).Token()
 	if err != nil {
+		// invalid_grant means the refresh token was revoked at the IdP (e.g. session
+		// deleted in Keycloak). This won't resolve on retry, so surface it as
+		// NonTransientError to stop the controller from requeuing.
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant" {
+			return oauthToken, &common.NonTransientError{Err: fmt.Errorf("setting up reusable token: %w", err)}
+		}
 		return oauthToken, fmt.Errorf("setting up reusable token: %w", err)
 	}
 

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider_test.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider_test.go
@@ -1,11 +1,13 @@
 package keycloakoidc
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -15,10 +17,12 @@ import (
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/oidc"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -218,4 +222,78 @@ func (m *fakeTokenManager) UpdateSecret(userID, provider, secret string) error {
 	}
 
 	return m.updateSecretFunc(userID, provider, secret)
+}
+
+func TestGetRefreshAndUpdateTokenInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		responseCode     int
+		responseBody     string
+		wantNonTransient bool
+	}{
+		{
+			name:             "invalid_grant returns NonTransientError",
+			responseCode:     http.StatusBadRequest,
+			responseBody:     `{"error":"invalid_grant","error_description":"Session not active"}`,
+			wantNonTransient: true,
+		},
+		{
+			name:             "server_error is not NonTransientError",
+			responseCode:     http.StatusInternalServerError,
+			responseBody:     `{"error":"server_error","error_description":"Internal error"}`,
+			wantNonTransient: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.responseCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			t.Cleanup(srv.Close)
+
+			k := &keyCloakOIDCProvider{}
+
+			storedToken, _ := json.Marshal(map[string]string{
+				"access_token":  "expired-token",
+				"refresh_token": "test-refresh-token",
+				"expiry":        time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+			})
+
+			token := &apiv3.Token{
+				UserID:       "test-user",
+				AuthProvider: Name,
+			}
+
+			tokenMgr := &fakeTokenManager{
+				getSecretFunc: func(userID, provider string, fallbackTokens []accessor.TokenAccessor) (string, error) {
+					return string(storedToken), nil
+				},
+			}
+			k.TokenMgr = tokenMgr
+
+			oauthConfig := oauth2.Config{
+				ClientID: "test-client",
+				Endpoint: oauth2.Endpoint{
+					TokenURL: srv.URL + "/token",
+				},
+			}
+
+			_, err := k.getRefreshAndUpdateToken(context.Background(), oauthConfig, token)
+			require.Error(t, err)
+
+			var nte *common.NonTransientError
+			if tt.wantNonTransient {
+				assert.ErrorAs(t, err, &nte)
+			} else {
+				assert.False(t, errors.As(err, &nte))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Issue: #49932 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When RefetchGroupPrincipals returns a NonTransientError (e.g. invalid_grant from Keycloak OIDC after a user's session is deleted), provider refresh was swallowing it - logging a warning and continuing the loop. The loop then hit GetPrincipal which encountered the same invalid token through a different code path that didn't wrap it as NonTransientError either, causing the controller to re-queue indefinitely instead of annotating the UserAttribute and halting.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Fix the issue by checking for NonTransientError before the existing transient error handling in refreshAttributes. Also wrap invalid_grant in keycloakoidc's getRefreshAndUpdateToken.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
- Unit tests