### PR TITLE
Add rate limiting to SCIM endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -402,7 +402,7 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
+	golang.org/x/time v0.14.0
 	golang.org/x/tools v0.43.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/pkg/auth/providers/scim/config_provider.go
+++ b/pkg/auth/providers/scim/config_provider.go
@@ -28,10 +28,12 @@ const (
 //
 // Each field maps directly to a key in ConfigMap.Data:
 //
-//	enabled:          "true" | "false"   (default: false)
-//	paused:           "true" | "false"   (default: false)
-//	userIdAttribute:  "userName" | "externalId"   (default: "userName")
-//	groupIdAttribute: "displayName" | "externalId" (default: "displayName")
+//	enabled:                    "true" | "false"                (default: false)
+//	paused:                     "true" | "false"                (default: false)
+//	userIdAttribute:            "userName" | "externalId"       (default: "userName")
+//	groupIdAttribute:           "displayName" | "externalId"    (default: "displayName")
+//	rateLimitRequestsPerSecond: integer                         (default: 0 = disabled)
+//	rateLimitBurst:             integer                         (default: 10)
 type providerConfig struct {
 	// Enabled controls whether SCIM provisioning is active for this provider.
 	// The SCIM feature flag must also be enabled; this flag alone is not sufficient.
@@ -54,6 +56,15 @@ type providerConfig struct {
 	//
 	// Supported values: "displayName" (default), "externalId".
 	GroupIDAttribute string
+
+	// RateLimitRequestsPerSecond caps SCIM API requests per second for this provider.
+	// 0 disables rate limiting. In HA setups each replica enforces its own limit,
+	// so the effective cluster-wide rate is roughly this value multiplied by the number of replicas.
+	RateLimitRequestsPerSecond int
+
+	// RateLimitBurst is how many requests this provider can make in a quick burst
+	// before the steady-state rate kicks in.
+	RateLimitBurst int
 }
 
 func (c *providerConfig) userID(user scimUser) string {
@@ -74,10 +85,13 @@ func (c *providerConfig) groupID(displayName, externalID string) string {
 	}
 }
 
+const defaultRateLimitBurst = 10
+
 func defaultProviderConfig() providerConfig {
 	return providerConfig{
 		UserIDAttribute:  UserIDUserName,
 		GroupIDAttribute: GroupIDDisplayName,
+		RateLimitBurst:   defaultRateLimitBurst,
 	}
 }
 
@@ -136,6 +150,24 @@ func getProviderConfig(configMapCache wcorev1.ConfigMapCache, provider string) p
 			cfg.GroupIDAttribute = v
 		} else {
 			logrus.Errorf("scim::getProviderConfig: invalid groupIdAttribute %q in configmap %s, using default", v, name)
+		}
+	}
+
+	if v, ok := cm.Data["rateLimitRequestsPerSecond"]; ok {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			logrus.Errorf("scim::getProviderConfig: invalid rateLimitRequestsPerSecond value %q in configmap %s, using default", v, name)
+		} else {
+			cfg.RateLimitRequestsPerSecond = n
+		}
+	}
+
+	if v, ok := cm.Data["rateLimitBurst"]; ok {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			logrus.Errorf("scim::getProviderConfig: invalid rateLimitBurst value %q in configmap %s, using default", v, name)
+		} else {
+			cfg.RateLimitBurst = n
 		}
 	}
 

--- a/pkg/auth/providers/scim/config_provider_test.go
+++ b/pkg/auth/providers/scim/config_provider_test.go
@@ -110,6 +110,8 @@ func TestDefaultProviderConfig(t *testing.T) {
 	assert.False(t, cfg.Paused)
 	assert.Equal(t, UserIDUserName, cfg.UserIDAttribute)
 	assert.Equal(t, GroupIDDisplayName, cfg.GroupIDAttribute)
+	assert.Equal(t, 0, cfg.RateLimitRequestsPerSecond)
+	assert.Equal(t, defaultRateLimitBurst, cfg.RateLimitBurst)
 }
 
 func TestGetProviderConfig(t *testing.T) {
@@ -158,7 +160,7 @@ func TestGetProviderConfig(t *testing.T) {
 						Data:       map[string]string{"enabled": "true"},
 					}, nil)
 			},
-			wantConfig: providerConfig{Enabled: true, UserIDAttribute: UserIDUserName, GroupIDAttribute: GroupIDDisplayName},
+			wantConfig: providerConfig{Enabled: true, UserIDAttribute: UserIDUserName, GroupIDAttribute: GroupIDDisplayName, RateLimitBurst: defaultRateLimitBurst},
 		},
 		{
 			name: "enabled false",
@@ -180,7 +182,7 @@ func TestGetProviderConfig(t *testing.T) {
 						Data:       map[string]string{"userIdAttribute": "externalId"},
 					}, nil)
 			},
-			wantConfig: providerConfig{Enabled: false, UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDDisplayName},
+			wantConfig: providerConfig{Enabled: false, UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDDisplayName, RateLimitBurst: defaultRateLimitBurst},
 		},
 		{
 			name: "paused true",
@@ -191,7 +193,7 @@ func TestGetProviderConfig(t *testing.T) {
 						Data:       map[string]string{"enabled": "true", "paused": "true"},
 					}, nil)
 			},
-			wantConfig: providerConfig{Enabled: true, Paused: true, UserIDAttribute: UserIDUserName, GroupIDAttribute: GroupIDDisplayName},
+			wantConfig: providerConfig{Enabled: true, Paused: true, UserIDAttribute: UserIDUserName, GroupIDAttribute: GroupIDDisplayName, RateLimitBurst: defaultRateLimitBurst},
 		},
 		{
 			name: "invalid bool value for enabled defaults to false",
@@ -217,7 +219,7 @@ func TestGetProviderConfig(t *testing.T) {
 						},
 					}, nil)
 			},
-			wantConfig: providerConfig{Enabled: true, UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDExternalID},
+			wantConfig: providerConfig{Enabled: true, UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDExternalID, RateLimitBurst: defaultRateLimitBurst},
 		},
 		{
 			name: "invalid attribute values fall back to defaults",
@@ -242,7 +244,35 @@ func TestGetProviderConfig(t *testing.T) {
 						Data:       map[string]string{"userIdAttribute": "externalId"},
 					}, nil)
 			},
-			wantConfig: providerConfig{UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDDisplayName},
+			wantConfig: providerConfig{UserIDAttribute: UserIDExternalID, GroupIDAttribute: GroupIDDisplayName, RateLimitBurst: defaultRateLimitBurst},
+		},
+		{
+			name: "rate limit config",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data: map[string]string{
+							"rateLimitRequestsPerSecond": "50",
+							"rateLimitBurst":             "100",
+						},
+					}, nil)
+			},
+			wantConfig: providerConfig{UserIDAttribute: UserIDUserName, GroupIDAttribute: GroupIDDisplayName, RateLimitRequestsPerSecond: 50, RateLimitBurst: 100},
+		},
+		{
+			name: "invalid rate limit values fall back to defaults",
+			setup: func(cache *fake.MockCacheInterface[*corev1.ConfigMap]) {
+				cache.EXPECT().Get(tokenSecretNamespace, "scim-config-azuread").
+					Return(&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "scim-config-azuread"},
+						Data: map[string]string{
+							"rateLimitRequestsPerSecond": "not-a-number",
+							"rateLimitBurst":             "also-bad",
+						},
+					}, nil)
+			},
+			wantConfig: defaultProviderConfig(),
 		},
 	}
 

--- a/pkg/auth/providers/scim/handler.go
+++ b/pkg/auth/providers/scim/handler.go
@@ -37,36 +37,39 @@ func NewHandler(scaledContext *config.ScaledContext) http.Handler {
 	}
 
 	authenticator := NewTokenAuthenticator(scaledContext.Wrangler)
+	rateLimiter := newRateLimiter(func(provider string) (int, int) {
+		cfg := srv.getConfig(provider)
+		return cfg.RateLimitRequestsPerSecond, cfg.RateLimitBurst
+	})
 
 	r := http.NewServeMux()
 
-	// Setup the middleware
-	authWrap := func(h http.HandlerFunc) http.HandlerFunc {
-		return authenticator.Authenticate(h).ServeHTTP
+	middlewares := func(h http.HandlerFunc) http.HandlerFunc {
+		return authenticator.Authenticate(rateLimiter.Wrap(h)).ServeHTTP
 	}
 
 	// Discovery endpoints
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/ServiceProviderConfig", authWrap(srv.GetServiceProviderConfig))
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/ResourceTypes", authWrap(srv.ListResourceTypes))
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/ResourceTypes/{id}", authWrap(srv.GetResourceType))
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/Schemas", authWrap(srv.ListSchemas))
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/Schemas/{id}", authWrap(srv.GetSchema))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/ServiceProviderConfig", middlewares(srv.GetServiceProviderConfig))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/ResourceTypes", middlewares(srv.ListResourceTypes))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/ResourceTypes/{id}", middlewares(srv.GetResourceType))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/Schemas", middlewares(srv.ListSchemas))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/Schemas/{id}", middlewares(srv.GetSchema))
 
 	// User endpoints
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/Users", authWrap(srv.ListUsers))
-	r.HandleFunc("POST "+URLPrefix+"/{provider}/Users", authWrap(srv.CreateUser))
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/Users/{id}", authWrap(srv.GetUser))
-	r.HandleFunc("PUT "+URLPrefix+"/{provider}/Users/{id}", authWrap(srv.UpdateUser))
-	r.HandleFunc("PATCH "+URLPrefix+"/{provider}/Users/{id}", authWrap(srv.PatchUser))
-	r.HandleFunc("DELETE "+URLPrefix+"/{provider}/Users/{id}", authWrap(srv.DeleteUser))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/Users", middlewares(srv.ListUsers))
+	r.HandleFunc("POST "+URLPrefix+"/{provider}/Users", middlewares(srv.CreateUser))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/Users/{id}", middlewares(srv.GetUser))
+	r.HandleFunc("PUT "+URLPrefix+"/{provider}/Users/{id}", middlewares(srv.UpdateUser))
+	r.HandleFunc("PATCH "+URLPrefix+"/{provider}/Users/{id}", middlewares(srv.PatchUser))
+	r.HandleFunc("DELETE "+URLPrefix+"/{provider}/Users/{id}", middlewares(srv.DeleteUser))
 
 	// Group endpoints
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/Groups", authWrap(srv.ListGroups))
-	r.HandleFunc("POST "+URLPrefix+"/{provider}/Groups", authWrap(srv.CreateGroup))
-	r.HandleFunc("GET "+URLPrefix+"/{provider}/Groups/{id}", authWrap(srv.GetGroup))
-	r.HandleFunc("PUT "+URLPrefix+"/{provider}/Groups/{id}", authWrap(srv.UpdateGroup))
-	r.HandleFunc("PATCH "+URLPrefix+"/{provider}/Groups/{id}", authWrap(srv.PatchGroup))
-	r.HandleFunc("DELETE "+URLPrefix+"/{provider}/Groups/{id}", authWrap(srv.DeleteGroup))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/Groups", middlewares(srv.ListGroups))
+	r.HandleFunc("POST "+URLPrefix+"/{provider}/Groups", middlewares(srv.CreateGroup))
+	r.HandleFunc("GET "+URLPrefix+"/{provider}/Groups/{id}", middlewares(srv.GetGroup))
+	r.HandleFunc("PUT "+URLPrefix+"/{provider}/Groups/{id}", middlewares(srv.UpdateGroup))
+	r.HandleFunc("PATCH "+URLPrefix+"/{provider}/Groups/{id}", middlewares(srv.PatchGroup))
+	r.HandleFunc("DELETE "+URLPrefix+"/{provider}/Groups/{id}", middlewares(srv.DeleteGroup))
 
 	return r
 }

--- a/pkg/auth/providers/scim/ratelimit.go
+++ b/pkg/auth/providers/scim/ratelimit.go
@@ -13,24 +13,16 @@ type rateLimiter struct {
 	// mu protects the limiters map.
 	mu sync.Mutex
 	// limiters maps provider names to their individual rate limiters.
-	limiters map[string]*providerLimiter
+	limiters map[string]*rate.Limiter
 	// getConfig returns the current rate limit settings for a given provider.
 	getConfig func(provider string) (rate int, burst int)
-}
-
-// providerLimiter pairs a [rate.Limiter] with the settings it was created/updated with,
-// so we can detect when settings change and update the limiter in place.
-type providerLimiter struct {
-	limiter *rate.Limiter
-	rate    int
-	burst   int
 }
 
 // newRateLimiter creates a [rateLimiter] that reads per-provider rate and burst from the
 // provided function on every request, allowing config changes to take effect without restart.
 func newRateLimiter(getConfig func(provider string) (rate int, burst int)) *rateLimiter {
 	return &rateLimiter{
-		limiters:  make(map[string]*providerLimiter),
+		limiters:  make(map[string]*rate.Limiter),
 		getConfig: getConfig,
 	}
 }
@@ -66,28 +58,22 @@ func (l *rateLimiter) getLimiter(provider string) *rate.Limiter {
 		limit = rate.Inf
 	}
 
-	pl, ok := l.limiters[provider]
+	lim, ok := l.limiters[provider]
 	if !ok {
-		// If it's a first request for this provider create a fresh limiter.
-		pl = &providerLimiter{
-			limiter: rate.NewLimiter(limit, burst),
-			rate:    rps,
-			burst:   burst,
-		}
-		l.limiters[provider] = pl
-		return pl.limiter
+		// First request for this provider — create a fresh limiter.
+		lim = rate.NewLimiter(limit, burst)
+		l.limiters[provider] = lim
+		return lim
 	}
 
 	// Config may have changed since last request — update in place
 	// so we keep the current token count instead of resetting it.
-	if pl.rate != rps {
-		pl.limiter.SetLimit(limit)
-		pl.rate = rps
+	if lim.Limit() != limit {
+		lim.SetLimit(limit)
 	}
-	if pl.burst != burst {
-		pl.limiter.SetBurst(burst)
-		pl.burst = burst
+	if lim.Burst() != burst {
+		lim.SetBurst(burst)
 	}
 
-	return pl.limiter
+	return lim
 }

--- a/pkg/auth/providers/scim/ratelimit.go
+++ b/pkg/auth/providers/scim/ratelimit.go
@@ -1,0 +1,93 @@
+package scim
+
+import (
+	"net/http"
+	"sync"
+
+	"golang.org/x/time/rate"
+)
+
+// rateLimiter enforces per-provider request rate limits using token bucket algorithm.
+// Each provider gets an independent limiter, so one provider's traffic doesn't affect another.
+type rateLimiter struct {
+	// mu protects the limiters map.
+	mu sync.Mutex
+	// limiters maps provider names to their individual rate limiters.
+	limiters map[string]*providerLimiter
+	// getConfig returns the current rate limit settings for a given provider.
+	getConfig func(provider string) (rate int, burst int)
+}
+
+// providerLimiter pairs a [rate.Limiter] with the settings it was created/updated with,
+// so we can detect when settings change and update the limiter in place.
+type providerLimiter struct {
+	limiter *rate.Limiter
+	rate    int
+	burst   int
+}
+
+// newRateLimiter creates a [rateLimiter] that reads per-provider rate and burst from the
+// provided function on every request, allowing config changes to take effect without restart.
+func newRateLimiter(getConfig func(provider string) (rate int, burst int)) *rateLimiter {
+	return &rateLimiter{
+		limiters:  make(map[string]*providerLimiter),
+		getConfig: getConfig,
+	}
+}
+
+// Wrap returns middleware that enforces per-provider rate limiting.
+func (l *rateLimiter) Wrap(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		provider := r.PathValue("provider")
+		if !l.getLimiter(provider).Allow() {
+			w.Header().Set("Retry-After", "1")
+			writeError(w, NewError(http.StatusTooManyRequests, "Rate limit exceeded. Please retry later."))
+			return
+		}
+		next(w, r)
+	}
+}
+
+// getLimiter returns the [rate.Limiter] for the given provider, creating or
+// updating it as needed based on current settings.
+func (l *rateLimiter) getLimiter(provider string) *rate.Limiter {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Read the current config for this provider.
+	rps, burst := l.getConfig(provider)
+	if burst < 1 {
+		burst = 1
+	}
+
+	// Zero or negative value means no limit.
+	limit := rate.Limit(rps)
+	if rps <= 0 {
+		limit = rate.Inf
+	}
+
+	pl, ok := l.limiters[provider]
+	if !ok {
+		// If it's a first request for this provider create a fresh limiter.
+		pl = &providerLimiter{
+			limiter: rate.NewLimiter(limit, burst),
+			rate:    rps,
+			burst:   burst,
+		}
+		l.limiters[provider] = pl
+		return pl.limiter
+	}
+
+	// Config may have changed since last request — update in place
+	// so we keep the current token count instead of resetting it.
+	if pl.rate != rps {
+		pl.limiter.SetLimit(limit)
+		pl.rate = rps
+	}
+	if pl.burst != burst {
+		pl.limiter.SetBurst(burst)
+		pl.burst = burst
+	}
+
+	return pl.limiter
+}

--- a/pkg/auth/providers/scim/ratelimit_test.go
+++ b/pkg/auth/providers/scim/ratelimit_test.go
@@ -1,0 +1,240 @@
+package scim
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimiter(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	configFunc := func(r, b int) func(string) (int, int) {
+		return func(string) (int, int) { return r, b }
+	}
+
+	t.Run("allows requests when disabled", func(t *testing.T) {
+		t.Parallel()
+		rl := newRateLimiter(configFunc(0, 10))
+		handler := rl.Wrap(next)
+
+		for range 100 {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("basic rate limiting", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			rl := newRateLimiter(configFunc(1, 1))
+			handler := rl.Wrap(next)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code)
+		})
+	})
+
+	t.Run("burst allowance", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			rl := newRateLimiter(configFunc(1, 5))
+			handler := rl.Wrap(next)
+
+			for i := range 5 {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+				r.SetPathValue("provider", "okta")
+				handler(w, r)
+				assert.Equalf(t, http.StatusOK, w.Code, "request %d should be allowed", i+1)
+			}
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code, "6th request should be rejected")
+		})
+	})
+
+	t.Run("per-provider isolation", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			rl := newRateLimiter(configFunc(1, 1))
+			handler := rl.Wrap(next)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/azuread/Users", nil)
+			r.SetPathValue("provider", "azuread")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code, "different provider should have independent limiter")
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code, "okta should be rate limited")
+		})
+	})
+
+	t.Run("per-provider config", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			rl := newRateLimiter(func(provider string) (int, int) {
+				if provider == "okta" {
+					return 1, 1
+				}
+				return 0, 10 // disabled for others
+			})
+			handler := rl.Wrap(next)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code, "okta should be rate limited")
+
+			for range 10 {
+				w = httptest.NewRecorder()
+				r = httptest.NewRequest(http.MethodGet, "/v1-scim/azuread/Users", nil)
+				r.SetPathValue("provider", "azuread")
+				handler(w, r)
+				assert.Equal(t, http.StatusOK, w.Code, "azuread should not be rate limited")
+			}
+		})
+	})
+
+	t.Run("config change propagation", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			currentRate := 1
+			rl := newRateLimiter(func(string) (int, int) { return currentRate, 1 })
+			handler := rl.Wrap(next)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+			currentRate = 0
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code, "disabling rate limit should allow requests")
+		})
+	})
+
+	t.Run("429 response format", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			rl := newRateLimiter(configFunc(1, 1))
+			handler := rl.Wrap(next)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+
+			assert.Equal(t, http.StatusTooManyRequests, w.Code)
+			assert.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
+			assert.Equal(t, "1", w.Header().Get("Retry-After"))
+
+			var body Error
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			assert.Equal(t, http.StatusTooManyRequests, body.Status)
+			assert.Contains(t, body.Detail, "Rate limit exceeded")
+			assert.Contains(t, body.Schemas, errorSchemaID)
+		})
+	})
+
+	t.Run("negative burst clamped to 1", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			rl := newRateLimiter(configFunc(1, -5))
+			handler := rl.Wrap(next)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest(http.MethodGet, "/v1-scim/okta/Users", nil)
+			r.SetPathValue("provider", "okta")
+			handler(w, r)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code)
+		})
+	})
+
+	t.Run("concurrent access", func(t *testing.T) {
+		t.Parallel()
+
+		rl := newRateLimiter(configFunc(100, 100))
+		handler := rl.Wrap(next)
+
+		var wg sync.WaitGroup
+		providers := []string{"okta", "azuread", "ping", "keycloak"}
+
+		for _, p := range providers {
+			for range 50 {
+				wg.Go(func() {
+					w := httptest.NewRecorder()
+					r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+p+"/Users", nil)
+					r.SetPathValue("provider", p)
+					handler(w, r)
+					assert.Equal(t, http.StatusOK, w.Code)
+				})
+			}
+		}
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
## Issue: #54870
<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

According to the RFD per-provider rate limits should be enforced to protect Rancher against runaway IdP sync operations that could overwhelm the API.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Token bucket rate limiter applied after authentication, configured per provider via the `scim-config-{provider}` ConfigMap. Each provider  gets an independent limiter so one IdP can't starve another.

Added new ConfigMap keys:

- rateLimitRequestsPerSecond (default: 0 = disabled)
- rateLimitBurst (default: 10)

Returns HTTP 429 with Retry-After header when exceeded.
In HA setups each replica enforces its own limit independently.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests