### PR TITLE
[roletemplate aggregation] Add an enqueuer for RTBs when the aggregation cluster role changes

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/register.go
+++ b/pkg/controllers/management/auth/roletemplates/register.go
@@ -8,6 +8,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/name"
@@ -18,10 +19,12 @@ import (
 )
 
 const (
-	prtbByUsernameIndex         = "auth.management.cattle.io/prtb-by-username"
-	crtbByUsernameIndex         = "auth.management.cattle.io/crtb-by-username"
-	rbByPRTBOwnerReferenceIndex = "auth.management.cattle.io/rb-by-prtb-owner-reference"
-	rbByCRTBOwnerReferenceIndex = "auth.management.cattle.io/rb-by-crtb-owner-reference"
+	prtbByUsernameIndex             = "auth.management.cattle.io/prtb-by-username"
+	crtbByUsernameIndex             = "auth.management.cattle.io/crtb-by-username"
+	rbByPRTBOwnerReferenceIndex     = "auth.management.cattle.io/rb-by-prtb-owner-reference"
+	rbByCRTBOwnerReferenceIndex     = "auth.management.cattle.io/rb-by-crtb-owner-reference"
+	getPRTBsByRoleTemplateNameIndex = "auth.management.cattle.io/prtb-by-roletemplate-name"
+	getCRTBsByRoleTemplateNameIndex = "auth.management.cattle.io/crtb-by-roletemplate-name"
 
 	roleTemplateChangeHandler = "mgmt-roletemplate-change-handler"
 	roleTemplateRemoveHandler = "mgmt-roletemplate-remove-handler"
@@ -29,10 +32,12 @@ const (
 	crtbChangeHandler        = "mgmt-crtb-change-handler"
 	crtbRemoveHandler        = "mgmt-crtb-remove-handler"
 	crtbRoleTemplateEnqueuer = "cluster-crtb-roletemplate-enqueuer"
+	crtbClusterRoleEnqueuer  = "cluster-crtb-clusterrole-enqueuer"
 
 	prtbChangeHandler        = "mgmt-prtb-change-handler"
 	prtbRemoveHandler        = "mgmt-prtb-remove-handler"
 	prtbRoleTemplateEnqueuer = "cluster-prtb-roletemplate-enqueuer"
+	prtbClusterRoleEnqueuer  = "cluster-prtb-clusterrole-enqueuer"
 )
 
 func RegisterIndexers(wranglerContext *wrangler.Context) {
@@ -40,6 +45,8 @@ func RegisterIndexers(wranglerContext *wrangler.Context) {
 	wranglerContext.Mgmt.ProjectRoleTemplateBinding().Cache().AddIndexer(prtbByUsernameIndex, getPRTBByUsername)
 	wranglerContext.RBAC.RoleBinding().Cache().AddIndexer(rbByPRTBOwnerReferenceIndex, getRBByPRTBOwnerReference)
 	wranglerContext.RBAC.RoleBinding().Cache().AddIndexer(rbByCRTBOwnerReferenceIndex, getRBByCRTBOwnerReference)
+	wranglerContext.Mgmt.ProjectRoleTemplateBinding().Cache().AddIndexer(getPRTBsByRoleTemplateNameIndex, getPRTBByRoleTemplateName)
+	wranglerContext.Mgmt.ClusterRoleTemplateBinding().Cache().AddIndexer(getCRTBsByRoleTemplateNameIndex, getCRTBByRoleTemplateName)
 }
 
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
@@ -64,6 +71,8 @@ func Register(ctx context.Context, management *config.ManagementContext, cluster
 	}
 	relatedresource.Watch(ctx, crtbRoleTemplateEnqueuer, roletemplateEnqueuer.roletemplateEnqueueCRTBs, management.Wrangler.Mgmt.ClusterRoleTemplateBinding(), management.Wrangler.Mgmt.RoleTemplate())
 	relatedresource.Watch(ctx, prtbRoleTemplateEnqueuer, roletemplateEnqueuer.roletemplateEnqueuePRTBs, management.Wrangler.Mgmt.ProjectRoleTemplateBinding(), management.Wrangler.Mgmt.RoleTemplate())
+	relatedresource.Watch(ctx, crtbClusterRoleEnqueuer, roletemplateEnqueuer.clusterRoleEnqueueCRTBs, management.Wrangler.Mgmt.ClusterRoleTemplateBinding(), management.Wrangler.RBAC.ClusterRole())
+	relatedresource.Watch(ctx, prtbClusterRoleEnqueuer, roletemplateEnqueuer.clusterRoleEnqueuePRTBs, management.Wrangler.Mgmt.ProjectRoleTemplateBinding(), management.Wrangler.RBAC.ClusterRole())
 }
 
 type roletemplateEnqueuer struct {
@@ -71,6 +80,64 @@ type roletemplateEnqueuer struct {
 	crtbCache    mgmtv3.ClusterRoleTemplateBindingCache
 	projectCache mgmtv3.ProjectCache
 	prtbCache    mgmtv3.ProjectRoleTemplateBindingCache
+}
+
+// clusterRoleEnqueue extracts the owner from an aggregation ClusterRole and calls lookupKeys to resolve the related resource keys.
+func clusterRoleEnqueue(obj runtime.Object, lookupKeys func(owner string) ([]relatedresource.Key, error)) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	clusterRole, ok := obj.(*rbacv1.ClusterRole)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert object %T to *ClusterRole", obj)
+	}
+
+	// If it's not an aggregation cluster role, ignore it
+	if clusterRole.AggregationRule == nil {
+		return nil, nil
+	}
+
+	if owner, ok := clusterRole.Labels[rbac.ClusterRoleOwnerLabel]; ok {
+		return lookupKeys(owner)
+	}
+
+	return nil, nil
+}
+
+// clusterRoleEnqueuePRTBs enqueues PRTBs when the aggregation ClusterRole owned by the PRTB is changed.
+func (r *roletemplateEnqueuer) clusterRoleEnqueuePRTBs(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	return clusterRoleEnqueue(obj, func(owner string) ([]relatedresource.Key, error) {
+		prtbs, err := r.prtbCache.GetByIndex(getPRTBsByRoleTemplateNameIndex, owner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list PRTBs: %w", err)
+		}
+		var keys []relatedresource.Key
+		for _, prtb := range prtbs {
+			keys = append(keys, relatedresource.Key{
+				Name:      prtb.Name,
+				Namespace: prtb.Namespace,
+			})
+		}
+		return keys, nil
+	})
+}
+
+// clusterRoleEnqueueCRTBs enqueues CRTBs when the aggregation ClusterRole owned by the CRTB is changed.
+func (r *roletemplateEnqueuer) clusterRoleEnqueueCRTBs(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	return clusterRoleEnqueue(obj, func(owner string) ([]relatedresource.Key, error) {
+		crtbs, err := r.crtbCache.GetByIndex(getCRTBsByRoleTemplateNameIndex, owner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list CRTBs: %w", err)
+		}
+		var keys []relatedresource.Key
+		for _, crtb := range crtbs {
+			keys = append(keys, relatedresource.Key{
+				Name:      crtb.Name,
+				Namespace: crtb.Namespace,
+			})
+		}
+		return keys, nil
+	})
 }
 
 // roletemplateEnqueuePRTBs enqueues PRTBs that reference the changed RoleTemplate.
@@ -187,6 +254,26 @@ func getRBByCRTBOwnerReference(rb *rbacv1.RoleBinding) ([]string, error) {
 				return []string{ownerRef.Name}, nil
 			}
 		}
+	}
+	return []string{}, nil
+}
+
+func getPRTBByRoleTemplateName(prtb *v3.ProjectRoleTemplateBinding) ([]string, error) {
+	if prtb == nil {
+		return []string{}, nil
+	}
+	if prtb.RoleTemplateName != "" {
+		return []string{prtb.RoleTemplateName}, nil
+	}
+	return []string{}, nil
+}
+
+func getCRTBByRoleTemplateName(crtb *v3.ClusterRoleTemplateBinding) ([]string, error) {
+	if crtb == nil {
+		return []string{}, nil
+	}
+	if crtb.RoleTemplateName != "" {
+		return []string{crtb.RoleTemplateName}, nil
 	}
 	return []string{}, nil
 }

--- a/pkg/controllers/management/auth/roletemplates/register.go
+++ b/pkg/controllers/management/auth/roletemplates/register.go
@@ -19,12 +19,12 @@ import (
 )
 
 const (
-	prtbByUsernameIndex             = "auth.management.cattle.io/prtb-by-username"
-	crtbByUsernameIndex             = "auth.management.cattle.io/crtb-by-username"
-	rbByPRTBOwnerReferenceIndex     = "auth.management.cattle.io/rb-by-prtb-owner-reference"
-	rbByCRTBOwnerReferenceIndex     = "auth.management.cattle.io/rb-by-crtb-owner-reference"
-	getPRTBsByRoleTemplateNameIndex = "auth.management.cattle.io/prtb-by-roletemplate-name"
-	getCRTBsByRoleTemplateNameIndex = "auth.management.cattle.io/crtb-by-roletemplate-name"
+	prtbByUsernameIndex         = "auth.management.cattle.io/prtb-by-username"
+	crtbByUsernameIndex         = "auth.management.cattle.io/crtb-by-username"
+	rbByPRTBOwnerReferenceIndex = "auth.management.cattle.io/rb-by-prtb-owner-reference"
+	rbByCRTBOwnerReferenceIndex = "auth.management.cattle.io/rb-by-crtb-owner-reference"
+	prtbByRoleTemplateNameIndex = "auth.management.cattle.io/prtb-by-roletemplate-name"
+	crtbByRoleTemplateNameIndex = "auth.management.cattle.io/crtb-by-roletemplate-name"
 
 	roleTemplateChangeHandler = "mgmt-roletemplate-change-handler"
 	roleTemplateRemoveHandler = "mgmt-roletemplate-remove-handler"
@@ -45,8 +45,8 @@ func RegisterIndexers(wranglerContext *wrangler.Context) {
 	wranglerContext.Mgmt.ProjectRoleTemplateBinding().Cache().AddIndexer(prtbByUsernameIndex, getPRTBByUsername)
 	wranglerContext.RBAC.RoleBinding().Cache().AddIndexer(rbByPRTBOwnerReferenceIndex, getRBByPRTBOwnerReference)
 	wranglerContext.RBAC.RoleBinding().Cache().AddIndexer(rbByCRTBOwnerReferenceIndex, getRBByCRTBOwnerReference)
-	wranglerContext.Mgmt.ProjectRoleTemplateBinding().Cache().AddIndexer(getPRTBsByRoleTemplateNameIndex, getPRTBByRoleTemplateName)
-	wranglerContext.Mgmt.ClusterRoleTemplateBinding().Cache().AddIndexer(getCRTBsByRoleTemplateNameIndex, getCRTBByRoleTemplateName)
+	wranglerContext.Mgmt.ProjectRoleTemplateBinding().Cache().AddIndexer(prtbByRoleTemplateNameIndex, getPRTBByRoleTemplateName)
+	wranglerContext.Mgmt.ClusterRoleTemplateBinding().Cache().AddIndexer(crtbByRoleTemplateNameIndex, getCRTBByRoleTemplateName)
 }
 
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
@@ -107,9 +107,9 @@ func clusterRoleEnqueue(obj runtime.Object, lookupKeys func(owner string) ([]rel
 // clusterRoleEnqueuePRTBs enqueues PRTBs when the aggregation ClusterRole owned by the PRTB is changed.
 func (r *roletemplateEnqueuer) clusterRoleEnqueuePRTBs(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
 	return clusterRoleEnqueue(obj, func(owner string) ([]relatedresource.Key, error) {
-		prtbs, err := r.prtbCache.GetByIndex(getPRTBsByRoleTemplateNameIndex, owner)
+		prtbs, err := r.prtbCache.GetByIndex(prtbByRoleTemplateNameIndex, owner)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list PRTBs: %w", err)
+			return nil, fmt.Errorf("failed to list PRTBs for role template %s: %w", owner, err)
 		}
 		var keys []relatedresource.Key
 		for _, prtb := range prtbs {
@@ -125,9 +125,9 @@ func (r *roletemplateEnqueuer) clusterRoleEnqueuePRTBs(_, _ string, obj runtime.
 // clusterRoleEnqueueCRTBs enqueues CRTBs when the aggregation ClusterRole owned by the CRTB is changed.
 func (r *roletemplateEnqueuer) clusterRoleEnqueueCRTBs(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
 	return clusterRoleEnqueue(obj, func(owner string) ([]relatedresource.Key, error) {
-		crtbs, err := r.crtbCache.GetByIndex(getCRTBsByRoleTemplateNameIndex, owner)
+		crtbs, err := r.crtbCache.GetByIndex(crtbByRoleTemplateNameIndex, owner)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list CRTBs: %w", err)
+			return nil, fmt.Errorf("failed to list CRTBs for role template %s: %w", owner, err)
 		}
 		var keys []relatedresource.Key
 		for _, crtb := range crtbs {

--- a/pkg/controllers/management/auth/roletemplates/register_test.go
+++ b/pkg/controllers/management/auth/roletemplates/register_test.go
@@ -401,7 +401,7 @@ func TestClusterRoleEnqueuePRTBs(t *testing.T) {
 			obj:  aggregationClusterRole,
 			prtbCache: func(ctrl *gomock.Controller) mgmtv3.ProjectRoleTemplateBindingCache {
 				m := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
-				m.EXPECT().GetByIndex(getPRTBsByRoleTemplateNameIndex, "rt-1").Return([]*v3.ProjectRoleTemplateBinding{projectRoleTemplateBinding}, nil)
+				m.EXPECT().GetByIndex(prtbByRoleTemplateNameIndex, "rt-1").Return([]*v3.ProjectRoleTemplateBinding{projectRoleTemplateBinding}, nil)
 				return m
 			},
 			want: []relatedresource.Key{
@@ -413,7 +413,7 @@ func TestClusterRoleEnqueuePRTBs(t *testing.T) {
 			obj:  aggregationClusterRole,
 			prtbCache: func(ctrl *gomock.Controller) mgmtv3.ProjectRoleTemplateBindingCache {
 				m := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
-				m.EXPECT().GetByIndex(getPRTBsByRoleTemplateNameIndex, "rt-1").Return(nil, errors.New("prtb cache error"))
+				m.EXPECT().GetByIndex(prtbByRoleTemplateNameIndex, "rt-1").Return(nil, errors.New("prtb cache error"))
 				return m
 			},
 			wantErr: true,
@@ -427,8 +427,6 @@ func TestClusterRoleEnqueuePRTBs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			r := &roletemplateEnqueuer{}
 			if tt.prtbCache != nil {
 				r.prtbCache = tt.prtbCache(ctrl)
@@ -470,7 +468,7 @@ func TestClusterRoleEnqueueCRTBs(t *testing.T) {
 			obj:  aggregationClusterRole,
 			crtbCache: func(ctrl *gomock.Controller) mgmtv3.ClusterRoleTemplateBindingCache {
 				m := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
-				m.EXPECT().GetByIndex(getCRTBsByRoleTemplateNameIndex, "rt-1").Return([]*v3.ClusterRoleTemplateBinding{clusterRoleTemplateBinding}, nil)
+				m.EXPECT().GetByIndex(crtbByRoleTemplateNameIndex, "rt-1").Return([]*v3.ClusterRoleTemplateBinding{clusterRoleTemplateBinding}, nil)
 				return m
 			},
 			want: []relatedresource.Key{
@@ -482,7 +480,7 @@ func TestClusterRoleEnqueueCRTBs(t *testing.T) {
 			obj:  aggregationClusterRole,
 			crtbCache: func(ctrl *gomock.Controller) mgmtv3.ClusterRoleTemplateBindingCache {
 				m := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
-				m.EXPECT().GetByIndex(getCRTBsByRoleTemplateNameIndex, "rt-1").Return(nil, errors.New("crtb cache error"))
+				m.EXPECT().GetByIndex(crtbByRoleTemplateNameIndex, "rt-1").Return(nil, errors.New("crtb cache error"))
 				return m
 			},
 			wantErr: true,
@@ -496,8 +494,6 @@ func TestClusterRoleEnqueueCRTBs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			r := &roletemplateEnqueuer{}
 			if tt.crtbCache != nil {
 				r.crtbCache = tt.crtbCache(ctrl)

--- a/pkg/controllers/management/auth/roletemplates/register_test.go
+++ b/pkg/controllers/management/auth/roletemplates/register_test.go
@@ -6,11 +6,13 @@ import (
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -278,6 +280,309 @@ func TestRoletemplateEnqueuePRTBs(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClusterRoleEnqueue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		obj        runtime.Object
+		lookupKeys func(owner string) ([]relatedresource.Key, error)
+		want       []relatedresource.Key
+		wantErr    bool
+	}{
+		{
+			name: "valid aggregation cluster role with owner label",
+			obj: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cr-1",
+					Labels: map[string]string{
+						rbac.ClusterRoleOwnerLabel: "rt-1",
+					},
+				},
+				AggregationRule: &rbacv1.AggregationRule{},
+			},
+			lookupKeys: func(owner string) ([]relatedresource.Key, error) {
+				return []relatedresource.Key{{Name: "binding-1", Namespace: "ns-1"}}, nil
+			},
+			want: []relatedresource.Key{{Name: "binding-1", Namespace: "ns-1"}},
+		},
+		{
+			name: "lookupKeys returns error",
+			obj: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cr-1",
+					Labels: map[string]string{
+						rbac.ClusterRoleOwnerLabel: "rt-1",
+					},
+				},
+				AggregationRule: &rbacv1.AggregationRule{},
+			},
+			lookupKeys: func(owner string) ([]relatedresource.Key, error) {
+				return nil, errors.New("lookup error")
+			},
+			wantErr: true,
+		},
+		{
+			name: "cluster role without aggregation rule",
+			obj: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cr-1",
+					Labels: map[string]string{
+						rbac.ClusterRoleOwnerLabel: "rt-1",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "aggregation cluster role without owner label",
+			obj: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cr-1",
+				},
+				AggregationRule: &rbacv1.AggregationRule{},
+			},
+			want: nil,
+		},
+		{
+			name: "nil object",
+			obj:  nil,
+			want: nil,
+		},
+		{
+			name:    "non-ClusterRole object",
+			obj:     roletemplate,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := clusterRoleEnqueue(tt.obj, tt.lookupKeys)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClusterRoleEnqueuePRTBs(t *testing.T) {
+	t.Parallel()
+
+	aggregationClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cr-1",
+			Labels: map[string]string{
+				rbac.ClusterRoleOwnerLabel: "rt-1",
+			},
+		},
+		AggregationRule: &rbacv1.AggregationRule{},
+	}
+
+	tests := []struct {
+		name      string
+		obj       runtime.Object
+		prtbCache func(ctrl *gomock.Controller) mgmtv3.ProjectRoleTemplateBindingCache
+		want      []relatedresource.Key
+		wantErr   bool
+	}{
+		{
+			name: "valid aggregation cluster role returns PRTBs",
+			obj:  aggregationClusterRole,
+			prtbCache: func(ctrl *gomock.Controller) mgmtv3.ProjectRoleTemplateBindingCache {
+				m := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
+				m.EXPECT().GetByIndex(getPRTBsByRoleTemplateNameIndex, "rt-1").Return([]*v3.ProjectRoleTemplateBinding{projectRoleTemplateBinding}, nil)
+				return m
+			},
+			want: []relatedresource.Key{
+				{Name: "prtb-1", Namespace: "p-1"},
+			},
+		},
+		{
+			name: "prtb cache returns error",
+			obj:  aggregationClusterRole,
+			prtbCache: func(ctrl *gomock.Controller) mgmtv3.ProjectRoleTemplateBindingCache {
+				m := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
+				m.EXPECT().GetByIndex(getPRTBsByRoleTemplateNameIndex, "rt-1").Return(nil, errors.New("prtb cache error"))
+				return m
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil object",
+			obj:  nil,
+			want: nil,
+		},
+	}
+	ctrl := gomock.NewController(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &roletemplateEnqueuer{}
+			if tt.prtbCache != nil {
+				r.prtbCache = tt.prtbCache(ctrl)
+			}
+
+			got, err := r.clusterRoleEnqueuePRTBs("", "", tt.obj)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClusterRoleEnqueueCRTBs(t *testing.T) {
+	t.Parallel()
+
+	aggregationClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cr-1",
+			Labels: map[string]string{
+				rbac.ClusterRoleOwnerLabel: "rt-1",
+			},
+		},
+		AggregationRule: &rbacv1.AggregationRule{},
+	}
+
+	tests := []struct {
+		name      string
+		obj       runtime.Object
+		crtbCache func(ctrl *gomock.Controller) mgmtv3.ClusterRoleTemplateBindingCache
+		want      []relatedresource.Key
+		wantErr   bool
+	}{
+		{
+			name: "valid aggregation cluster role returns CRTBs",
+			obj:  aggregationClusterRole,
+			crtbCache: func(ctrl *gomock.Controller) mgmtv3.ClusterRoleTemplateBindingCache {
+				m := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+				m.EXPECT().GetByIndex(getCRTBsByRoleTemplateNameIndex, "rt-1").Return([]*v3.ClusterRoleTemplateBinding{clusterRoleTemplateBinding}, nil)
+				return m
+			},
+			want: []relatedresource.Key{
+				{Name: "crtb-1", Namespace: "c-1"},
+			},
+		},
+		{
+			name: "crtb cache returns error",
+			obj:  aggregationClusterRole,
+			crtbCache: func(ctrl *gomock.Controller) mgmtv3.ClusterRoleTemplateBindingCache {
+				m := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+				m.EXPECT().GetByIndex(getCRTBsByRoleTemplateNameIndex, "rt-1").Return(nil, errors.New("crtb cache error"))
+				return m
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil object",
+			obj:  nil,
+			want: nil,
+		},
+	}
+	ctrl := gomock.NewController(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &roletemplateEnqueuer{}
+			if tt.crtbCache != nil {
+				r.crtbCache = tt.crtbCache(ctrl)
+			}
+
+			got, err := r.clusterRoleEnqueueCRTBs("", "", tt.obj)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetPRTBByRoleTemplateName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		prtb *v3.ProjectRoleTemplateBinding
+		want []string
+	}{
+		{
+			name: "prtb with role template name",
+			prtb: &v3.ProjectRoleTemplateBinding{
+				RoleTemplateName: "rt-1",
+			},
+			want: []string{"rt-1"},
+		},
+		{
+			name: "prtb with empty role template name",
+			prtb: &v3.ProjectRoleTemplateBinding{},
+			want: []string{},
+		},
+		{
+			name: "nil prtb",
+			prtb: nil,
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getPRTBByRoleTemplateName(tt.prtb)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetCRTBByRoleTemplateName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		crtb *v3.ClusterRoleTemplateBinding
+		want []string
+	}{
+		{
+			name: "crtb with role template name",
+			crtb: &v3.ClusterRoleTemplateBinding{
+				RoleTemplateName: "rt-1",
+			},
+			want: []string{"rt-1"},
+		},
+		{
+			name: "crtb with empty role template name",
+			crtb: &v3.ClusterRoleTemplateBinding{},
+			want: []string{},
+		},
+		{
+			name: "nil crtb",
+			crtb: nil,
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getCRTBByRoleTemplateName(tt.crtb)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/53591
 
## Problem
When removing inherited permissions, users were still able to create and edit namespaces within a project.

The reason was that the bindings responsible for providing namespace create/edit access are assigned based on the values found in the aggregated cluster role. However, when the cluster role was updated (by removing an inherited RoleTemplate), the CRTB/PRTB would not reconcile and leave all the bindings from the older cluster role.

If you forced the CRTB/PRTB to reconcile, it would then have the correct permissions.
 
## Solution
When the aggregated cluster role gets updated, we trigger the controller for CRTBs and PRTBs. That way they are guaranteed to have the most up to date information.
 
## Testing

## Engineering Testing
### Manual Testing
Using the reproduction steps in the issue, I'm able to see the permissions get added/removed immediately as they should

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: Added unit tests for the new indexers and enqueue functions.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_