### PR TITLE
fix: detect primary IP family for peer ID in dual-stack clusters

### DIFF
--- a/pkg/tunnelserver/peermanager.go
+++ b/pkg/tunnelserver/peermanager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	gonet "net"
 	"os"
 	"strings"
 	"sync"
@@ -21,13 +22,13 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/net"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-func NewPeerManager(ctx context.Context, endpoints corecontrollers.EndpointsController, dialer *remotedialer.Server) (peermanager.PeerManager, error) {
-	return startPeerManager(ctx, endpoints, dialer)
+func NewPeerManager(ctx context.Context, endpoints corecontrollers.EndpointsController, services corecontrollers.ServiceController, dialer *remotedialer.Server) (peermanager.PeerManager, error) {
+	return startPeerManager(ctx, endpoints, services, dialer)
 }
 
 type peerManager struct {
@@ -84,7 +85,7 @@ func getTokenFromToken(ctx context.Context, tokenBytes []byte) ([]byte, error) {
 	return secret.Data[v1.ServiceAccountTokenKey], nil
 }
 
-func startPeerManager(ctx context.Context, endpoints corecontrollers.EndpointsController, server *remotedialer.Server) (peermanager.PeerManager, error) {
+func startPeerManager(ctx context.Context, endpoints corecontrollers.EndpointsController, services corecontrollers.ServiceController, server *remotedialer.Server) (peermanager.PeerManager, error) {
 	tokenBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if os.IsNotExist(err) || settings.Namespace.Get() == "" || settings.PeerServices.Get() == "" {
 		logrus.Infof("Running in single server mode, will not peer connections")
@@ -98,7 +99,12 @@ func startPeerManager(ctx context.Context, endpoints corecontrollers.EndpointsCo
 		return nil, err
 	}
 
-	ip, err := net.ChooseHostInterface()
+	primaryFamily := detectPrimaryIPFamily(services, settings.Namespace.Get(), settings.PeerServices.Get())
+	if primaryFamily != "" {
+		logrus.Infof("Detected primary IP family %s from peer service", primaryFamily)
+	}
+
+	ip, err := choosePeerIP(primaryFamily)
 	if err != nil {
 		return nil, errors.Wrap(err, "choosing interface IP")
 	}
@@ -230,4 +236,40 @@ func (p *peerManager) Leader() {
 
 	p.leader = true
 	p.notify()
+}
+
+// detectPrimaryIPFamily queries the Kubernetes Service for the peer service
+// to determine the primary IP address family used for Endpoints.
+// Returns v1.IPv6Protocol if the Service's primary IP family is IPv6,
+// v1.IPv4Protocol if IPv4, or empty string if detection fails.
+func detectPrimaryIPFamily(services corecontrollers.ServiceController, namespace string, peerServices string) v1.IPFamily {
+	for _, svc := range strings.Split(peerServices, ",") {
+		svcName := strings.TrimSpace(svc)
+		if svcName == "" {
+			continue
+		}
+		service, err := services.Get(namespace, svcName, metav1.GetOptions{})
+		if err != nil {
+			logrus.Debugf("Could not get service %s/%s to detect IP family: %v", namespace, svcName, err)
+			continue
+		}
+		if len(service.Spec.IPFamilies) > 0 {
+			return service.Spec.IPFamilies[0]
+		}
+	}
+	return ""
+}
+
+// choosePeerIP selects the local IP address to use as the peer ID.
+// If the primary family is IPv6, it attempts to resolve an IPv6 address.
+// Otherwise, it falls back to the default behavior (IPv4 preference).
+func choosePeerIP(family v1.IPFamily) (gonet.IP, error) {
+	if family == v1.IPv6Protocol {
+		ip, err := utilnet.ResolveBindAddress(gonet.IPv6unspecified)
+		if err == nil {
+			return ip, nil
+		}
+		logrus.Warnf("Failed to resolve IPv6 bind address, falling back to default: %v", err)
+	}
+	return utilnet.ChooseHostInterface()
 }

--- a/pkg/tunnelserver/peermanager_test.go
+++ b/pkg/tunnelserver/peermanager_test.go
@@ -1,0 +1,150 @@
+package tunnelserver
+
+import (
+	"fmt"
+	"testing"
+
+	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// fakeServiceController is a minimal mock that implements corecontrollers.ServiceController
+// with only the Get method returning useful results. The embedded interface satisfies
+// all other methods — they will panic if called, which is acceptable for focused unit tests.
+type fakeServiceController struct {
+	corecontrollers.ServiceController
+	services map[string]*v1.Service // key: "namespace/name"
+}
+
+func (f *fakeServiceController) Get(namespace, name string, options metav1.GetOptions) (*v1.Service, error) {
+	key := namespace + "/" + name
+	svc, ok := f.services[key]
+	if !ok {
+		return nil, fmt.Errorf("service %s not found", key)
+	}
+	return svc, nil
+}
+
+func TestDetectPrimaryIPFamily(t *testing.T) {
+	tests := []struct {
+		name         string
+		services     map[string]*v1.Service
+		namespace    string
+		peerServices string
+		expected     v1.IPFamily
+	}{
+		{
+			name: "IPv4 primary family in dual-stack",
+			services: map[string]*v1.Service{
+				"cattle-system/rancher": {
+					Spec: v1.ServiceSpec{
+						IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+					},
+				},
+			},
+			namespace:    "cattle-system",
+			peerServices: "rancher",
+			expected:     v1.IPv4Protocol,
+		},
+		{
+			name: "IPv6 primary family in dual-stack",
+			services: map[string]*v1.Service{
+				"cattle-system/rancher": {
+					Spec: v1.ServiceSpec{
+						IPFamilies: []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+					},
+				},
+			},
+			namespace:    "cattle-system",
+			peerServices: "rancher",
+			expected:     v1.IPv6Protocol,
+		},
+		{
+			name: "IPv6 single stack",
+			services: map[string]*v1.Service{
+				"cattle-system/rancher": {
+					Spec: v1.ServiceSpec{
+						IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+					},
+				},
+			},
+			namespace:    "cattle-system",
+			peerServices: "rancher",
+			expected:     v1.IPv6Protocol,
+		},
+		{
+			name: "IPv4 single stack",
+			services: map[string]*v1.Service{
+				"cattle-system/rancher": {
+					Spec: v1.ServiceSpec{
+						IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+					},
+				},
+			},
+			namespace:    "cattle-system",
+			peerServices: "rancher",
+			expected:     v1.IPv4Protocol,
+		},
+		{
+			name:         "service not found returns empty",
+			services:     map[string]*v1.Service{},
+			namespace:    "cattle-system",
+			peerServices: "rancher",
+			expected:     "",
+		},
+		{
+			name: "empty IPFamilies returns empty",
+			services: map[string]*v1.Service{
+				"cattle-system/rancher": {
+					Spec: v1.ServiceSpec{},
+				},
+			},
+			namespace:    "cattle-system",
+			peerServices: "rancher",
+			expected:     "",
+		},
+		{
+			name: "multiple peer services uses first available",
+			services: map[string]*v1.Service{
+				"cattle-system/rancher": {
+					Spec: v1.ServiceSpec{
+						IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+					},
+				},
+			},
+			namespace:    "cattle-system",
+			peerServices: "rancher,rancher-other",
+			expected:     v1.IPv6Protocol,
+		},
+		{
+			name: "first peer service missing falls through to second",
+			services: map[string]*v1.Service{
+				"cattle-system/rancher-other": {
+					Spec: v1.ServiceSpec{
+						IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+					},
+				},
+			},
+			namespace:    "cattle-system",
+			peerServices: "rancher,rancher-other",
+			expected:     v1.IPv6Protocol,
+		},
+		{
+			name:         "empty peer services string returns empty",
+			services:     map[string]*v1.Service{},
+			namespace:    "cattle-system",
+			peerServices: "",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeServiceController{services: tt.services}
+			result := detectPrimaryIPFamily(fake, tt.namespace, tt.peerServices)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -510,7 +510,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 
 	tunnelAuth := &tunnelserver.Authorizers{}
 	tunnelServer := remotedialer.New(tunnelAuth.Authorize, tunnelserver.ErrorWriter)
-	peerManager, err := tunnelserver.NewPeerManager(ctx, core.Core().V1().Endpoints(), tunnelServer)
+	peerManager, err := tunnelserver.NewPeerManager(ctx, core.Core().V1().Endpoints(), core.Core().V1().Service(), tunnelServer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- https://github.com/rancher/rancher/issues/50933
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Rancher returns errors when deploying into an IPv6-first dual-stack cluster, and Fleet is not installed. 

```
"Failed to connect to peer wss://[fd00:0:0:7::d]/v3/connect [local ID=10.7.0.13]: websocket: bad handshake"
```
 

## Root Cause

The bug is in [`pkg/tunnelserver/peermanager.go`](https://github.com/rancher/rancher/blob/53bb43f088ddbe5399198265a682f834efbd13cf/pkg/tunnelserver/peermanager.go) — specifically the mismatch between how the **local peer ID** is determined and how **peer addresses** are discovered from Kubernetes Endpoints.

### The problem flow:

1. **Line 101** — `net.ChooseHostInterface()` (from `k8s.io/apimachinery/pkg/util/net`) selects the local IP. In a dual-stack IPv6-first cluster, this typically returns the **IPv4** address (e.g., `10.7.0.13`), because the Go/k8s utility prefers IPv4.

2. **Line 108** — `server.PeerID` is set to that IPv4 address (`10.7.0.13`).

3. **Line 158-166** — In `addRemovePeers()`, the code iterates over Kubernetes Endpoint addresses. In an **IPv6-first** dual-stack cluster, these Endpoints contain **IPv6** addresses (e.g., `fd00:0:0:7::d`).

4. **Line 160** — The self-detection check `addr.IP == p.server.PeerID` compares the IPv6 endpoint address against the IPv4 PeerID. **They never match**, so:
   - `ready` stays `false` 
   - The local node's IPv6 address gets added as a **remote peer** instead of being recognized as self

5. **Line 174** — The peer manager tries to connect to `wss://[fd00:0:0:7::d]/v3/connect`, but the Rancher server may not be properly listening on that IPv6 address, resulting in `websocket: bad handshake`.

```go name=pkg/tunnelserver/peermanager.go url=https://github.com/rancher/rancher/blob/53bb43f088ddbe5399198265a682f834efbd13cf/pkg/tunnelserver/peermanager.go#L101-L108
	ip, err := net.ChooseHostInterface()
	if err != nil {
		return nil, errors.Wrap(err, "choosing interface IP")
	}

	logrus.Infof("Running in clustered mode with ID %s, monitoring endpoint %s/%s", ip, settings.Namespace.Get(), settings.PeerServices.Get())

	server.PeerID = ip.String()
```

### Why it only affects IPv6-first dual-stack

| Config | `ChooseHostInterface()` | Endpoint IPs | Match? |
|--------|------------------------|-------------|--------|
| IPv4 only | IPv4 | IPv4 | ✅ |
| IPv6 only | IPv6 | IPv6 | ✅ |
| Dual-stack IPv4-first | IPv4 | IPv4 | ✅ |
| **Dual-stack IPv6-first** | **IPv4** | **IPv6** | ❌ |

In IPv6-first mode, Kubernetes populates Endpoints with IPv6 addresses, but `ChooseHostInterface()` still returns IPv4 — creating the fatal mismatch.


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->


Query the Kubernetes peer Service's spec.ipFamilies to determine whether Endpoints use IPv4 or IPv6 addresses. 
When the primary family is IPv6, use ResolveBindAddress with IPv6 preference to select the local IPv6 address as the peer ID. This fixes peer self-identification failure in IPv6-first dual-stack clusters where ChooseHostInterface returns IPv4 but Endpoints contain IPv6 addresses.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The fix is validated by deploying the customized Rancher container built from the branch into an IPv6-first dual-stack k3s cluster. 

Rancher logs contain the following messages: 

```
2026/05/01 00:12:31 [INFO] Detected primary IP family IPv6 from peer service
2026/05/01 00:12:31 [INFO] Running in clustered mode with ID 2001:db8:42::26, monitoring endpoint cattle-system/rancher
```

### Automated Testing
 
Unit tests are added for the detectPrimaryIPFamily function. 


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
- The reported issue should be gone 
- The fleet and other components should be installed automatically as Rancher boots up 
- Rancher should work as expected 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

n/a 

Existing / newly added automated tests that provide evidence there are no regressions:
 
n/a