### PR TITLE
SCIM: Support URN-prefixed attribute paths in PATCH and filter operations

### DIFF
--- a/pkg/auth/providers/scim/filter.go
+++ b/pkg/auth/providers/scim/filter.go
@@ -74,6 +74,13 @@ func ParseFilter(filter string) (*Filter, error) {
 	attr := tokens[0]
 	opStr := strings.ToLower(tokens[1])
 
+	// Strip URN prefix if present (RFC 7644 section 3.10).
+	strippedAttr, _, err := stripSchemaURN(attr, "")
+	if err != nil {
+		return nil, fmt.Errorf("invalid attribute name %q: %w", attr, err)
+	}
+	attr = strippedAttr
+
 	// Validate attribute name.
 	if !isValidAttributeName(attr) {
 		return nil, fmt.Errorf("invalid attribute name %q", attr)
@@ -240,6 +247,38 @@ func tokenize(filter string) ([]string, error) {
 	}
 
 	return tokens, nil
+}
+
+// knownResourceSchemaURNs maps schema URN prefixes to their resource type.
+// Only resource schemas are valid as attribute path prefixes per RFC 7644 section 3.10.
+var knownResourceSchemaURNs = map[string]string{
+	userSchemaID:  userResource,
+	groupSchemaID: groupResource,
+}
+
+// stripSchemaURN removes a recognized schema URN prefix from an attribute path
+// per RFC 7644 section 3.10. If path has no URN prefix, it is returned unchanged.
+// If expectedResourceType is non-empty, the URN's resource type must match it.
+func stripSchemaURN(path, expectedResourceType string) (string, string, error) {
+	if !strings.HasPrefix(path, "urn:") {
+		return path, "", nil
+	}
+
+	for urn, resourceType := range knownResourceSchemaURNs {
+		prefix := urn + ":"
+		if strings.HasPrefix(path, prefix) {
+			attrPath := path[len(prefix):]
+			if attrPath == "" {
+				return "", "", fmt.Errorf("missing attribute name after schema URN prefix")
+			}
+			if expectedResourceType != "" && !strings.EqualFold(resourceType, expectedResourceType) {
+				return "", "", fmt.Errorf("schema URN %q does not match resource type %q", urn, expectedResourceType)
+			}
+			return attrPath, resourceType, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("unrecognized schema URN prefix in attribute path %q", path)
 }
 
 // isValidAttributeName checks if the attribute name is valid per SCIM spec.

--- a/pkg/auth/providers/scim/filter_test.go
+++ b/pkg/auth/providers/scim/filter_test.go
@@ -241,6 +241,41 @@ func TestParseFilter(t *testing.T) {
 			wantErr:     true,
 			errContains: "invalid attribute name",
 		},
+
+		// URN-prefixed attributes
+		{
+			name:   "URN-prefixed user attribute",
+			filter: `urn:ietf:params:scim:schemas:core:2.0:User:userName eq "john.doe"`,
+			want: &Filter{
+				Attribute: "userName",
+				Operator:  opEqual,
+				Value:     "john.doe",
+			},
+		},
+		{
+			name:   "URN-prefixed group attribute",
+			filter: `urn:ietf:params:scim:schemas:core:2.0:Group:displayName eq "Engineering"`,
+			want: &Filter{
+				Attribute: "displayName",
+				Operator:  opEqual,
+				Value:     "Engineering",
+			},
+		},
+		{
+			name:   "URN-prefixed attribute with pr operator",
+			filter: `urn:ietf:params:scim:schemas:core:2.0:User:externalId pr`,
+			want: &Filter{
+				Attribute: "externalId",
+				Operator:  opPresent,
+				Value:     "",
+			},
+		},
+		{
+			name:        "unknown URN prefix in filter",
+			filter:      `urn:custom:schema:attr eq "value"`,
+			wantErr:     true,
+			errContains: "unrecognized schema URN",
+		},
 	}
 
 	for _, tt := range tests {
@@ -255,6 +290,117 @@ func TestParseFilter(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStripSchemaURN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		path                 string
+		expectedResourceType string
+		wantAttrPath         string
+		wantResourceType     string
+		wantErr              bool
+		errContains          string
+	}{
+		{
+			name:         "bare attribute",
+			path:         "userName",
+			wantAttrPath: "userName",
+		},
+		{
+			name:         "bare nested attribute",
+			path:         "name.familyName",
+			wantAttrPath: "name.familyName",
+		},
+		{
+			name:             "user URN prefix",
+			path:             "urn:ietf:params:scim:schemas:core:2.0:User:userName",
+			wantAttrPath:     "userName",
+			wantResourceType: "User",
+		},
+		{
+			name:             "group URN prefix",
+			path:             "urn:ietf:params:scim:schemas:core:2.0:Group:displayName",
+			wantAttrPath:     "displayName",
+			wantResourceType: "Group",
+		},
+		{
+			name:                 "user URN matching resource type",
+			path:                 "urn:ietf:params:scim:schemas:core:2.0:User:active",
+			expectedResourceType: "User",
+			wantAttrPath:         "active",
+			wantResourceType:     "User",
+		},
+		{
+			name:                 "user URN mismatched resource type",
+			path:                 "urn:ietf:params:scim:schemas:core:2.0:User:userName",
+			expectedResourceType: "Group",
+			wantErr:              true,
+			errContains:          "does not match",
+		},
+		{
+			name:                 "group URN mismatched resource type",
+			path:                 "urn:ietf:params:scim:schemas:core:2.0:Group:displayName",
+			expectedResourceType: "User",
+			wantErr:              true,
+			errContains:          "does not match",
+		},
+		{
+			name:        "unknown URN prefix",
+			path:        "urn:ietf:params:scim:schemas:extension:custom:2.0:Foo:bar",
+			wantErr:     true,
+			errContains: "unrecognized schema URN",
+		},
+		{
+			name:             "URN with complex path",
+			path:             "urn:ietf:params:scim:schemas:core:2.0:User:emails[primary eq true].value",
+			wantAttrPath:     "emails[primary eq true].value",
+			wantResourceType: "User",
+		},
+		{
+			name:             "URN with members filter path",
+			path:             `urn:ietf:params:scim:schemas:core:2.0:Group:members[value eq "u-123"]`,
+			wantAttrPath:     `members[value eq "u-123"]`,
+			wantResourceType: "Group",
+		},
+		{
+			name:         "empty path",
+			path:         "",
+			wantAttrPath: "",
+		},
+		{
+			name:        "URN prefix with no attribute",
+			path:        "urn:ietf:params:scim:schemas:core:2.0:User:",
+			wantErr:     true,
+			errContains: "missing attribute name",
+		},
+		{
+			name:        "malformed urn prefix",
+			path:        "urn:bogus",
+			wantErr:     true,
+			errContains: "unrecognized schema URN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attrPath, resourceType, err := stripSchemaURN(tt.path, tt.expectedResourceType)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.ErrorContains(t, err, tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAttrPath, attrPath)
+			assert.Equal(t, tt.wantResourceType, resourceType)
 		})
 	}
 }

--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -447,9 +447,11 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 	group = group.DeepCopy()
 	cfg := s.getConfig(provider)
 
-	var shouldUpdateGroup bool
-	var membersToAdd []scimMember
-	var membersToRemove []string
+	var (
+		shouldUpdateGroup bool
+		membersToAdd      []scimMember
+		membersToRemove   []string
+	)
 
 	for _, op := range payload.Operations {
 		switch strings.ToLower(op.Op) {
@@ -465,8 +467,12 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 				shouldUpdateGroup = true
 			}
 		case "add":
-			// Add members to group
-			if strings.ToLower(op.Path) != "members" {
+			addPath, _, err := stripSchemaURN(op.Path, groupResource)
+			if err != nil {
+				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid path %q: %s", op.Path, err)))
+				return
+			}
+			if strings.ToLower(addPath) != "members" {
 				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Unsupported add path: %s", op.Path)))
 				return
 			}
@@ -504,14 +510,16 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		case "remove":
-			// Remove members from group
-			if !strings.HasPrefix(strings.ToLower(op.Path), "members[") {
+			removePath, _, err := stripSchemaURN(op.Path, groupResource)
+			if err != nil {
+				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid path %q: %s", op.Path, err)))
+				return
+			}
+			if !strings.HasPrefix(strings.ToLower(removePath), "members[") {
 				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Unsupported remove path: %s", op.Path)))
 				return
 			}
-			// Format: members[value eq "user-id"]
-			// Extract user-id from the filter
-			if userID := extractMemberValueFromPath(op.Path); userID != "" {
+			if userID := extractMemberValueFromPath(removePath); userID != "" {
 				membersToRemove = append(membersToRemove, userID)
 			} else {
 				writeError(w, NewError(http.StatusBadRequest, "Invalid member removal path format"))
@@ -1006,8 +1014,13 @@ func applyReplaceGroup(group *v3.Group, op patchOp, cfg providerConfig) (bool, e
 		return updated, nil
 	}
 
+	path, _, err := stripSchemaURN(op.Path, groupResource)
+	if err != nil {
+		return false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid path %q: %s", op.Path, err))
+	}
+
 	var updated bool
-	switch strings.ToLower(op.Path) {
+	switch strings.ToLower(path) {
 	case "displayname":
 		if cfg.GroupIDAttribute != GroupIDExternalID {
 			return false, NewError(http.StatusBadRequest, "displayName cannot be changed when it is used as the group principal identifier")

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -571,6 +571,28 @@ func TestApplyReplaceGroup(t *testing.T) {
 		require.Error(t, err)
 		assert.False(t, updated)
 	})
+
+	t.Run("URN-prefixed externalId", func(t *testing.T) {
+		group := &v3.Group{ExternalID: "old-id"}
+		op := patchOp{Op: "replace", Path: "urn:ietf:params:scim:schemas:core:2.0:Group:externalId", Value: "new-id"}
+
+		updated, err := applyReplaceGroup(group, op, cfg)
+
+		require.NoError(t, err)
+		assert.True(t, updated)
+		assert.Equal(t, "new-id", group.ExternalID)
+	})
+
+	t.Run("URN-prefixed wrong resource type", func(t *testing.T) {
+		group := &v3.Group{}
+		op := patchOp{Op: "replace", Path: "urn:ietf:params:scim:schemas:core:2.0:User:userName", Value: "test"}
+
+		updated, err := applyReplaceGroup(group, op, cfg)
+
+		require.Error(t, err)
+		assert.False(t, updated)
+		assert.Contains(t, err.Error(), "does not match")
+	})
 }
 
 func TestExtractMemberValueFromPath(t *testing.T) {
@@ -967,6 +989,221 @@ func TestPatchGroup(t *testing.T) {
 		err = json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.Equal(t, "new-external-id", resp["externalId"])
+	})
+
+	t.Run("URN-prefixed replace externalId", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			ExternalID:  "old-external-id",
+			Provider:    provider,
+		}
+		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		groupCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		updatedGroup := existingGroup.DeepCopy()
+		updatedGroup.ExternalID = "new-external-id"
+		groupClient := fake.NewMockNonNamespacedClientInterface[*v3.Group, *v3.GroupList](ctrl)
+		groupClient.EXPECT().Update(gomock.Any()).Return(updatedGroup, nil)
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
+
+		srv := &SCIMServer{
+			groups:      groupClient,
+			groupsCache: groupCache,
+			userCache:   userCache,
+			getConfig:   testDefaultGetConfig,
+		}
+
+		payload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":    "replace",
+					"path":  "urn:ietf:params:scim:schemas:core:2.0:Group:externalId",
+					"value": "new-external-id",
+				},
+			},
+		}
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+
+		srv.PatchGroup(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err = json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "new-external-id", resp["externalId"])
+	})
+
+	t.Run("URN-prefixed add members", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			Provider:    provider,
+		}
+		groupCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		userCache.EXPECT().Get("u-mo773yttt4").Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
+		}, nil).Times(2)
+		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "u-mo773yttt4"},
+			GroupPrincipals: map[string]v3.Principals{provider: {Items: []v3.Principal{}}},
+		}, nil)
+		userAttrClient.EXPECT().Update(gomock.Any()).Return(&v3.UserAttribute{}, nil)
+
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{
+			{ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"}},
+		}, nil)
+		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
+			GroupPrincipals: map[string]v3.Principals{
+				provider: {Items: []v3.Principal{{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"}}},
+			},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {"username": {"john.doe"}},
+			},
+		}, nil)
+
+		srv := &SCIMServer{
+			groupsCache:        groupCache,
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		payload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":   "add",
+					"path": "urn:ietf:params:scim:schemas:core:2.0:Group:members",
+					"value": []map[string]any{
+						{"value": "u-mo773yttt4", "display": "john.doe"},
+					},
+				},
+			},
+		}
+		body, _ := json.Marshal(payload)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+
+		srv.PatchGroup(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("URN-prefixed remove member", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			Provider:    provider,
+		}
+		groupCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		userCache.EXPECT().Get("u-mo773yttt4").Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
+		}, nil)
+		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
+			GroupPrincipals: map[string]v3.Principals{
+				provider: {Items: []v3.Principal{{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"}}},
+			},
+		}, nil)
+		userAttrClient.EXPECT().Update(gomock.Any()).Return(&v3.UserAttribute{}, nil)
+
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
+
+		srv := &SCIMServer{
+			groupsCache:        groupCache,
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		payload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":   "remove",
+					"path": `urn:ietf:params:scim:schemas:core:2.0:Group:members[value eq "u-mo773yttt4"]`,
+				},
+			},
+		}
+		body, _ := json.Marshal(payload)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+
+		srv.PatchGroup(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("URN-prefixed path with wrong resource type returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			Provider:    provider,
+		}
+		groupCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		srv := &SCIMServer{
+			groupsCache: groupCache,
+			getConfig:   testDefaultGetConfig,
+		}
+
+		payload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":    "replace",
+					"path":  "urn:ietf:params:scim:schemas:core:2.0:User:userName",
+					"value": "test",
+				},
+			},
+		}
+		body, _ := json.Marshal(payload)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+
+		srv.PatchGroup(w, r)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }
 

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -701,8 +701,13 @@ func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op p
 		return shouldUpdateAttr, shouldUpdateUser, nil
 	}
 
+	path, _, err := stripSchemaURN(op.Path, userResource)
+	if err != nil {
+		return false, false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid path %q: %s", op.Path, err))
+	}
+
 	var updateAttr, updateUser bool
-	switch strings.ToLower(op.Path) {
+	switch strings.ToLower(path) {
 	case "active":
 		active, err := boolFromValue(op.Value)
 		if err != nil {

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -2689,4 +2689,213 @@ func TestPatchUser(t *testing.T) {
 		srv.PatchUser(w, r)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 	})
+
+	t.Run("URN-prefixed path for active", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-12345"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+			assert.Equal(t, false, *u.Enabled)
+			return u, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			users:              userClient,
+			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:active", "value": false}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, false, resp["active"])
+	})
+
+	t.Run("URN-prefixed path for externalId", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"old-ext-id"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+			assert.Equal(t, "new-ext-id", first(attr.ExtraByProvider[provider]["externalid"]))
+			return attr, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:externalId", "value": "new-ext-id"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "new-ext-id", resp["externalId"])
+	})
+
+	t.Run("URN-prefixed path with wrong resource type returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-12345"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:Group:displayName", "value": "test"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("URN-prefixed path for emails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-12345"},
+					"email":      {"old@example.com"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+			assert.Equal(t, "new@example.com", first(attr.ExtraByProvider[provider]["email"]))
+			return attr, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:emails[primary eq true].value", "value": "new@example.com"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		emails, ok := resp["emails"].([]any)
+		require.True(t, ok)
+		require.Len(t, emails, 1)
+		emailMap := emails[0].(map[string]any)
+		assert.Equal(t, "new@example.com", emailMap["value"])
+	})
 }


### PR DESCRIPTION
## Issue: #54871 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Some IdPs (e.g. Entra ID) send fully qualified attribute paths like urn:ietf:params:scim:schemas:core:2.0:User:userName instead of just userName. This is valid per RFC 7644 3.10 and required when schema extensions are used.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add stripSchemaURN() to recognize and strip known schema URN prefixes (User, Group) before attribute matching. Integrated into filter parsing, user PATCH, and group PATCH (replace, add, remove). Unknown URNs and resource type mismatches (e.g. User URN on a Group endpoint) return 400 errors.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests