### PR TITLE
fix: prevent panic on invalid AuditPolicy JSONPath redactions

### DIFF
--- a/pkg/auth/audit/utils.go
+++ b/pkg/auth/audit/utils.go
@@ -86,14 +86,30 @@ func matchesAny(s string, regexes []*regexp.Regexp) bool {
 func parsePaths(paths []string) ([]*jsonpath.JSONPath, error) {
 	compiled := make([]*jsonpath.JSONPath, len(paths))
 	for i, v := range paths {
-		jp, err := jsonpath.Parse(v)
+		jp, err := safeParseJSONPath(v)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse jsonpath: %w", err)
+			return nil, fmt.Errorf("failed to parse jsonpath %q: %w", v, err)
 		}
 		compiled[i] = jp
 	}
 
 	return compiled, nil
+}
+
+// safeParseJSONPath parses a JSONPath expression, recovering from any panic
+// in the underlying parser and returning it as an error. The upstream parser
+// can panic on malformed input such as unterminated subscripts (for example,
+// "$['testing'][5:"); converting the panic to an error allows the audit
+// policy controller to mark the policy invalid instead of crashing.
+func safeParseJSONPath(expr string) (jp *jsonpath.JSONPath, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			jp = nil
+			err = fmt.Errorf("invalid jsonpath expression: %v", r)
+		}
+	}()
+
+	return jsonpath.Parse(expr)
 }
 
 func pairMatches(v any, f func(string, any) bool) bool {

--- a/pkg/auth/audit/utils_test.go
+++ b/pkg/auth/audit/utils_test.go
@@ -168,3 +168,37 @@ func TestHasKey(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePathsInvalid(t *testing.T) {
+	cases := []struct {
+		Name string
+		Path string
+	}{
+		{
+			Name: "Unterminated Slice Subscript",
+			Path: "$['testing'][5:",
+		},
+		{
+			Name: "Unterminated Bracket",
+			Path: "$[",
+		},
+		{
+			Name: "Unterminated Quoted Key",
+			Path: "$['a",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			compiled, err := parsePaths([]string{tc.Path})
+			assert.Error(t, err)
+			assert.Nil(t, compiled)
+		})
+	}
+}
+
+func TestParsePathsValid(t *testing.T) {
+	compiled, err := parsePaths([]string{"$.foo.bar", "$['baz']"})
+	assert.NoError(t, err)
+	assert.Len(t, compiled, 2)
+}

--- a/pkg/auth/audit/writer_test.go
+++ b/pkg/auth/audit/writer_test.go
@@ -382,3 +382,29 @@ func TestCompressedZLib(t *testing.T) {
 
 	assert.Equal(t, expected, logs.logs)
 }
+
+// TestPolicyFromAuditPolicyMalformedPathDoesNotPanic is a regression test for
+// issue #54490: a malformed JSONPath such as "$['testing'][5:" used to panic
+// in the upstream parser. PolicyFromAuditPolicy must surface the failure as
+// a regular error so the caller (the audit policy controller / webhook) can
+// reject the policy instead of crashing.
+func TestPolicyFromAuditPolicyMalformedPathDoesNotPanic(t *testing.T) {
+	policy := &auditlogv1.AuditPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "panic-filter-test",
+		},
+		Spec: auditlogv1.AuditPolicySpec{
+			Enabled: true,
+			AdditionalRedactions: []auditlogv1.Redaction{
+				{
+					Paths: []string{"$['testing'][5:"},
+				},
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		_, err := PolicyFromAuditPolicy(policy)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/controllers/auditlog/auditpolicy/controller_test.go
+++ b/pkg/controllers/auditlog/auditpolicy/controller_test.go
@@ -207,7 +207,7 @@ func TestOnChange(t *testing.T) {
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: mockTimeFactory(),
 						Reason:             reasonPolicyIsInvalid,
-						Message:            "failed to create redactor: failed to parse paths: failed to parse jsonpath: paths must begin with the root object identifier: '$'",
+						Message:            "failed to create redactor: failed to parse paths: failed to parse jsonpath \".missing.root\": paths must begin with the root object identifier: '$'",
 					},
 				},
 			},


### PR DESCRIPTION
## Issue: #54490

## Problem
A misconfigured `AuditPolicy` whose `spec.additionalRedactions[].paths` contains a malformed JSONPath (for example `"$['testing'][5:"`) makes the upstream parser at `github.com/rancher/jsonpath/pkg.parseIndexRange` panic with `index out of range`. The panic propagates out of `PolicyFromAuditPolicy`, takes down the audit policy controller's `OnChange` handler, and is only caught by the framework's recovery in the rancher webhook. Net effect: the bad policy is silently rejected with a recovered panic in the logs instead of being reported back to the user.

## Solution
Wrap the call to `jsonpath.Parse` in `parsePaths` with a `recover()`. Any panic is converted into a regular `error`, which `PolicyFromAuditPolicy` already propagates up to the controller. The controller now marks the policy with `Reason=PolicyIsInvalid` and a clear `Message` instead of crashing. The error message is also improved to include the offending expression.

Changes:
- `pkg/auth/audit/utils.go`: new `safeParseJSONPath` helper that recovers parser panics; `parsePaths` quotes the offending expression in the error message.

## Testing
The repro from the issue (`additionalRedactions: [{paths: ["$['testing'][5:"]}]`) panicked deterministically with the previous code; with this change `PolicyFromAuditPolicy` returns an error and the controller surfaces it as a status condition.

## Engineering Testing
### Manual Testing
Verified that `jsonpath.Parse("$['testing'][5:")` panics on the current pinned version (`v0.0.0-20250620213443-ad24535cf0c1`) and that `safeParseJSONPath` returns an error for the same input. Other malformed inputs covered: `"$["`, `"$['a"`.

### Automated Testing
* Test types added/modified:
    * Unit
* `pkg/auth/audit/utils_test.go`: `TestParsePathsInvalid` covers three malformed inputs (including the issue's repro), `TestParsePathsValid` covers the happy path.
* `pkg/auth/audit/writer_test.go`: `TestPolicyFromAuditPolicyMalformedPathDoesNotPanic` is a regression test against the exact `AuditPolicy` from the bug report.
* `pkg/controllers/auditlog/auditpolicy/controller_test.go`: updated the existing `AddInvalidPolicyRedactorJSONPath` expected `Message` to match the improved error string.

Summary: `go test ./pkg/auth/audit/... ./pkg/controllers/auditlog/...` passes.

## QA Testing Considerations
Apply an `AuditPolicy` with `spec.additionalRedactions[0].paths: ["$['testing'][5:"]` and confirm the resource is accepted by the API but the controller marks it `Active=False, Reason=PolicyIsInvalid` with an error message naming the bad expression, and that the webhook does not log a recovered panic.

### Regressions Considerations
Low. The change is a defensive `recover` around a single parser call; valid JSONPaths take the same code path as before.

Existing / newly added automated tests that provide evidence there are no regressions:
* `TestParsePathsValid`, `TestPolicyRedactor`, `TestOnChange/AddInvalidPolicyRedactorJSONPath`