### PR TITLE
Fix agent deployment customisation reconciliation for nil to value field transitions 

### DIFF
--- a/pkg/cluster/agent_customization.go
+++ b/pkg/cluster/agent_customization.go
@@ -180,17 +180,9 @@ func AgentDeploymentCustomizationChanged(cluster *v3.Cluster) bool {
 		return affinitiesDiffer || tolerationsDiffer || resourcesDiffer
 	}
 
-	if specCustomization.AppendTolerations != nil && statusCustomization.AppendTolerations != nil {
-		tolerationsDiffer = !reflect.DeepEqual(specCustomization.AppendTolerations, statusCustomization.AppendTolerations)
-	}
-
-	if specCustomization.OverrideAffinity != nil && statusCustomization.OverrideAffinity != nil {
-		affinitiesDiffer = !reflect.DeepEqual(specCustomization.OverrideAffinity, statusCustomization.OverrideAffinity)
-	}
-
-	if specCustomization.OverrideResourceRequirements != nil && statusCustomization.OverrideResourceRequirements != nil {
-		resourcesDiffer = !reflect.DeepEqual(specCustomization.OverrideResourceRequirements, statusCustomization.OverrideResourceRequirements)
-	}
+	tolerationsDiffer = !reflect.DeepEqual(specCustomization.AppendTolerations, statusCustomization.AppendTolerations)
+	affinitiesDiffer = !reflect.DeepEqual(specCustomization.OverrideAffinity, statusCustomization.OverrideAffinity)
+	resourcesDiffer = !reflect.DeepEqual(specCustomization.OverrideResourceRequirements, statusCustomization.OverrideResourceRequirements)
 
 	return affinitiesDiffer || tolerationsDiffer || resourcesDiffer
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->  https://github.com/rancher/rancher/issues/54904

<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
When updating an imported cluster with cluster_agent_deployment_customization, Rancher fails to reconcile and redeploy the downstream cattle-cluster-agent when adding a new nested customisation field to an already-existing customisation object.
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
Currently, AgentDeploymentCustomizationChanged() function only compares nested customisation fields when both spec ad status values are non-nil... so remove nil-gated field comparison and rely on tolerationDiffer
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
tested the steps mentioned in the issue

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_