### PR TITLE
Fix intermittent clusterAuthToken sync failures

### DIFF
--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -154,6 +154,20 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 	_, err = h.clusterAuthToken.Update(clusterAuthToken)
 	if errors.IsNotFound(err) {
 		_, err = h.clusterAuthToken.Create(clusterAuthToken)
+		// Lister said NotFound but the API server says it exists — the
+		// lister cache was stale. Fetch the real object and update it so
+		// we don't silently accept stale field values.
+		if errors.IsAlreadyExists(err) {
+			existing, err := h.clusterAuthToken.Get(clusterAuthToken.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			existing.UserName = clusterAuthToken.UserName
+			existing.Enabled = clusterAuthToken.Enabled
+			existing.ExpiresAt = clusterAuthToken.ExpiresAt
+			_, err = h.clusterAuthToken.Update(existing)
+			return nil, err
+		}
 	}
 	return nil, err
 }
@@ -239,20 +253,28 @@ func (h *tokenHandler) createClusterAuthToken(token accessor.TokenAccessor, hash
 		}
 	}
 
-	// Now create the shadow token.
-	clusterAuthToken, err = h.clusterAuthToken.Create(clusterAuthToken)
-	if err == nil {
-		return nil
+	// Now create the shadow token. If it already exists (e.g. a previous
+	// attempt created it but setInitialized failed due to a resourceVersion
+	// conflict), update it rather than deleting. Deleting can cause
+	// a create-delete loop that blocks ACE authentication.
+	if _, err = h.clusterAuthToken.Create(clusterAuthToken); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+
+		existing, err := h.clusterAuthToken.Get(clusterAuthToken.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		existing.UserName = clusterAuthToken.UserName
+		existing.Enabled = clusterAuthToken.Enabled
+		existing.ExpiresAt = clusterAuthToken.ExpiresAt
+		if _, err = h.clusterAuthToken.Update(existing); err != nil {
+			return err
+		}
 	}
 
-	// Avoid leaving partially created resources.
-	if err := h.clusterAuthToken.Delete(clusterAuthToken.Name, &metav1.DeleteOptions{}); err != nil {
-		logrus.Errorf("failed to delete cluster auth token `%s` after creation failure: %v",
-			clusterAuthToken.Name, err)
-	}
-
-	// Report creation failure
-	return err
+	return nil
 }
 
 // Updated is called when a token is updated, and is responsible for creating/updating the corresponding
@@ -309,11 +331,8 @@ func (h *tokenHandler) Updated(token *managementv3.Token) (runtime.Object, error
 		username:  clusterAuthToken.UserName,
 	}
 
-	// if the token is hashed, compare its value to make sure the downstream has the latest hash
-	//
-	// BEWARE! for an unhashed token a comparison here is bogus. the downstream hash was
-	// made on creation and any hash we make here to compare with will be different from
-	// it due to the random salt!
+	// Only compare values if the token was hashed — for plaintext tokens the
+	// downstream copy was salted at creation time, so the two will never match.
 	if token.Annotations[tokens.TokenHashed] == "true" {
 		hashVersion, err := hashers.GetHashVersion(token.Token)
 		if err != nil {
@@ -355,6 +374,18 @@ func (h *tokenHandler) Updated(token *managementv3.Token) (runtime.Object, error
 	_, err = h.clusterAuthToken.Update(clusterAuthToken)
 	if errors.IsNotFound(err) {
 		_, err = h.clusterAuthToken.Create(clusterAuthToken)
+		// Same stale-lister recovery as in [ExtUpdated] above.
+		if errors.IsAlreadyExists(err) {
+			existing, err := h.clusterAuthToken.Get(clusterAuthToken.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			existing.UserName = clusterAuthToken.UserName
+			existing.Enabled = clusterAuthToken.Enabled
+			existing.ExpiresAt = clusterAuthToken.ExpiresAt
+			_, err = h.clusterAuthToken.Update(existing)
+			return nil, err
+		}
 	}
 
 	return nil, err

--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 	"sort"
 
+	clusterapiv3 "github.com/rancher/rancher/pkg/apis/cluster.cattle.io/v3"
 	extv1 "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
+	mgmtapiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/auth/tokens/hashers"
@@ -43,9 +45,23 @@ type tokenHandler struct {
 	clusterSecretLister        wcore.SecretCache
 }
 
+// validateToken rejects tokens missing a name or userID before they reach any
+// Kubernetes API call. Without this, an empty string triggers "resource name may
+// not be empty" errors that requeue forever and block sync for the entire cluster.
+func validateToken(name, userID string) error {
+	if name == "" || userID == "" {
+		logrus.Warnf("[%s] skipping token with empty name=%q or userID=%q", clusterAuthTokenController, name, userID)
+		return generic.ErrSkip
+	}
+	return nil
+}
+
 // extCreate is called when a given ext token is created, and is responsible for
 // updating/creating the ClusterAuthToken in the downstream cluster.
 func (h *tokenHandler) extCreate(token *extv1.Token) (*extv1.Token, error) {
+	if err := validateToken(token.GetName(), token.Spec.UserID); err != nil {
+		return token, err
+	}
 	logrus.Debugf("[%s] ext CREATE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.Spec.ClusterName)
 
 	_, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
@@ -75,6 +91,9 @@ func (h *tokenHandler) extCreate(token *extv1.Token) (*extv1.Token, error) {
 // ExtUpdated is called when a given ext token is modified, and is responsible
 // for updating/creating the ClusterAuthToken in a downstream cluster.
 func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
+	if err := validateToken(token.GetName(), token.Spec.UserID); err != nil {
+		return token, err
+	}
 	logrus.Debugf("[%s] ext UPDATE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.Spec.ClusterName)
 
 	clusterAuthToken, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
@@ -175,13 +194,19 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 // ExtRemove is called when a given ext token is deleted,
 // and removes the ClusterAuthToken in the downstream cluster.
 func (h *tokenHandler) ExtRemove(token *extv1.Token) (*extv1.Token, error) {
+	if err := validateToken(token.GetName(), token.GetUserID()); err != nil {
+		return token, err
+	}
 	logrus.Debugf("[%s] ext REMOVE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.Spec.ClusterName)
 
 	return nil, h.remove(token.GetName(), token.GetUserID(), extTokenUserClusterKey(token))
 }
 
 // Create is called when a given token is created, and is responsible for creating a ClusterAuthToken in a downstream cluster.
-func (h *tokenHandler) Create(token *managementv3.Token) (runtime.Object, error) {
+func (h *tokenHandler) Create(token *mgmtapiv3.Token) (runtime.Object, error) {
+	if err := validateToken(token.Name, token.UserID); err != nil {
+		return token, err
+	}
 	logrus.Debugf("[%s] v3 CREATE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.ClusterName)
 
 	_, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
@@ -279,7 +304,10 @@ func (h *tokenHandler) createClusterAuthToken(token accessor.TokenAccessor, hash
 
 // Updated is called when a token is updated, and is responsible for creating/updating the corresponding
 // ClusterAuthTokens in the downstream cluster.
-func (h *tokenHandler) Updated(token *managementv3.Token) (runtime.Object, error) {
+func (h *tokenHandler) Updated(token *mgmtapiv3.Token) (runtime.Object, error) {
+	if err := validateToken(token.Name, token.UserID); err != nil {
+		return token, err
+	}
 	logrus.Debugf("[%s] v3 UPDATE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.ClusterName)
 
 	clusterAuthToken, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
@@ -391,7 +419,10 @@ func (h *tokenHandler) Updated(token *managementv3.Token) (runtime.Object, error
 	return nil, err
 }
 
-func (h *tokenHandler) Remove(token *managementv3.Token) (runtime.Object, error) {
+func (h *tokenHandler) Remove(token *mgmtapiv3.Token) (runtime.Object, error) {
+	if err := validateToken(token.Name, token.UserID); err != nil {
+		return token, err
+	}
 	logrus.Debugf("[%s] v3 REMOVE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.ClusterName)
 
 	return nil, h.remove(token.GetName(), token.GetUserID(), tokenUserClusterKey(token))
@@ -428,7 +459,7 @@ func (h *tokenHandler) remove(name, userID, key string) error {
 
 	var lastName string
 	if len(tokens) == 1 {
-		lastName = tokens[0].(*managementv3.Token).Name
+		lastName = tokens[0].(*mgmtapiv3.Token).Name
 	} else if len(extTokens) == 1 {
 		lastName = extTokens[0].(*extv1.Token).Name
 	}
@@ -468,7 +499,7 @@ func (h *tokenHandler) updateClusterUserAttribute(userID string) error {
 
 	clusterUserAttribute, err := h.clusterUserAttributeLister.Get(h.namespace, userID)
 	if errors.IsNotFound(err) {
-		_, err = h.clusterUserAttribute.Create(&clusterv3.ClusterUserAttribute{
+		_, err = h.clusterUserAttribute.Create(&clusterapiv3.ClusterUserAttribute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: userID,
 			},

--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -103,6 +103,7 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 	if err != nil {
 		return nil, err
 	}
+	clusterAuthToken = clusterAuthToken.DeepCopy()
 
 	forced := false
 	clusterAuthTokenSecret, err := h.clusterSecretLister.Get(h.namespace, common.ClusterAuthTokenSecretName(token.Name))
@@ -117,6 +118,8 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 		forced = true
 		hashedValue := token.Status.Hash
 		clusterAuthTokenSecret = common.NewClusterAuthTokenSecret(h.namespace, token, hashedValue)
+	} else {
+		clusterAuthTokenSecret = clusterAuthTokenSecret.DeepCopy()
 	}
 
 	err = h.updateClusterUserAttribute(token.GetUserID())
@@ -181,6 +184,7 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 			if err != nil {
 				return nil, err
 			}
+			existing = existing.DeepCopy()
 			existing.UserName = clusterAuthToken.UserName
 			existing.Enabled = clusterAuthToken.Enabled
 			existing.ExpiresAt = clusterAuthToken.ExpiresAt
@@ -272,6 +276,7 @@ func (h *tokenHandler) createClusterAuthToken(token accessor.TokenAccessor, hash
 			logrus.Errorf("error migrating clusterAuthToken's secret %s: %s", clusterAuthTokenSecret.Name, err)
 			return err
 		}
+		existing = existing.DeepCopy()
 		existing.Data = clusterAuthTokenSecret.Data
 		if _, err = h.clusterSecret.Update(existing); err != nil {
 			return err
@@ -291,6 +296,7 @@ func (h *tokenHandler) createClusterAuthToken(token accessor.TokenAccessor, hash
 		if err != nil {
 			return err
 		}
+		existing = existing.DeepCopy()
 		existing.UserName = clusterAuthToken.UserName
 		existing.Enabled = clusterAuthToken.Enabled
 		existing.ExpiresAt = clusterAuthToken.ExpiresAt
@@ -317,6 +323,7 @@ func (h *tokenHandler) Updated(token *mgmtapiv3.Token) (runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
+	clusterAuthToken = clusterAuthToken.DeepCopy()
 
 	forced := false
 	clusterAuthTokenSecret, err := h.clusterSecretLister.Get(h.namespace, common.ClusterAuthTokenSecretName(token.Name))
@@ -340,6 +347,8 @@ func (h *tokenHandler) Updated(token *mgmtapiv3.Token) (runtime.Object, error) {
 		}
 
 		clusterAuthTokenSecret = common.NewClusterAuthTokenSecret(h.namespace, token, hashedValue)
+	} else {
+		clusterAuthTokenSecret = clusterAuthTokenSecret.DeepCopy()
 	}
 
 	err = h.updateClusterUserAttribute(token.GetUserID())
@@ -408,6 +417,7 @@ func (h *tokenHandler) Updated(token *mgmtapiv3.Token) (runtime.Object, error) {
 			if err != nil {
 				return nil, err
 			}
+			existing = existing.DeepCopy()
 			existing.UserName = clusterAuthToken.UserName
 			existing.Enabled = clusterAuthToken.Enabled
 			existing.ExpiresAt = clusterAuthToken.ExpiresAt

--- a/pkg/controllers/managementuser/clusterauthtoken/token_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	clusterv3 "github.com/rancher/rancher/pkg/apis/cluster.cattle.io/v3"
+	clusterapiv3 "github.com/rancher/rancher/pkg/apis/cluster.cattle.io/v3"
 	extv1 "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
+	mgmtapiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/auth/tokens/hashers"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3/fakes"
-	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
-	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	mgmtFakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
@@ -22,7 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -40,7 +39,7 @@ func TestExtCreate(t *testing.T) {
 		},
 		Spec: extv1.TokenSpec{
 			UserID:  userID,
-			Enabled: pointer.Bool(true),
+			Enabled: ptr.To(true),
 		},
 		Status: extv1.TokenStatus{
 			ExpiresAt: "10000000000",
@@ -48,7 +47,7 @@ func TestExtCreate(t *testing.T) {
 			Hash:      hashedTokenKey,
 		},
 	}
-	testAuthToken := &clusterv3.ClusterAuthToken{
+	testAuthToken := &clusterapiv3.ClusterAuthToken{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-token",
 		},
@@ -59,7 +58,7 @@ func TestExtCreate(t *testing.T) {
 		UserName:  userID,
 		Enabled:   true,
 	}
-	testAuthSecret := &v1.Secret{
+	testAuthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cat-test-token",
 		},
@@ -77,8 +76,8 @@ func TestExtCreate(t *testing.T) {
 		name  string
 		token *extv1.Token
 
-		existingClusterAuthToken  *clusterv3.ClusterAuthToken
-		existingClusterAuthSecret *v1.Secret
+		existingClusterAuthToken  *clusterapiv3.ClusterAuthToken
+		existingClusterAuthSecret *corev1.Secret
 		existingTokenError        error
 		tokenHashingEnabled       bool
 		updateAuthTokenErr        error
@@ -112,7 +111,7 @@ func TestExtCreate(t *testing.T) {
 		},
 		{
 			name:               "token disabled, create token",
-			token:              setExtTokenEnabled(testToken, pointer.BoolPtr(false)),
+			token:              setExtTokenEnabled(testToken, ptr.To(false)),
 			existingTokenError: authTokenNotFoundError,
 
 			wantClusterAuthToken: true,
@@ -173,6 +172,26 @@ func TestExtCreate(t *testing.T) {
 
 			wantError: true,
 		},
+		{
+			name: "empty userID, skip token",
+			token: &extv1.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-token"},
+				Spec:       extv1.TokenSpec{UserID: ""},
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
+		{
+			name: "empty name, skip token",
+			token: &extv1.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: ""},
+				Spec:       extv1.TokenSpec{UserID: userID},
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -225,17 +244,17 @@ func TestExtCreate(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	testToken := &managementv3.Token{
+	testToken := &mgmtapiv3.Token{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-token",
 		},
 		ExpiresAt: "10000000000",
 		UserID:    userID,
 		Token:     tokenKey,
-		Enabled:   pointer.Bool(true),
+		Enabled:   ptr.To(true),
 	}
 
-	testAuthToken := &clusterv3.ClusterAuthToken{
+	testAuthToken := &clusterapiv3.ClusterAuthToken{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-token",
 		},
@@ -246,7 +265,7 @@ func TestCreate(t *testing.T) {
 		UserName:  userID,
 		Enabled:   true,
 	}
-	testAuthSecret := &v1.Secret{
+	testAuthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cat-test-token",
 		},
@@ -261,10 +280,10 @@ func TestCreate(t *testing.T) {
 	authTokenNotFoundError := apierrors.NewNotFound(schema.GroupResource{Group: "cluster.cattle.io", Resource: "ClusterAuthToken"}, testToken.Name)
 	tests := []struct {
 		name  string
-		token *managementv3.Token
+		token *mgmtapiv3.Token
 
-		existingClusterAuthToken  *clusterv3.ClusterAuthToken
-		existingClusterAuthSecret *v1.Secret
+		existingClusterAuthToken  *clusterapiv3.ClusterAuthToken
+		existingClusterAuthSecret *corev1.Secret
 		existingTokenError        error
 		tokenHashingEnabled       bool
 		updateAuthTokenErr        error
@@ -307,7 +326,7 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			name:               "token disabled, create token",
-			token:              setTokenEnabled(testToken, pointer.BoolPtr(false)),
+			token:              setTokenEnabled(testToken, ptr.To(false)),
 			existingTokenError: authTokenNotFoundError,
 
 			wantClusterAuthToken: true,
@@ -376,6 +395,26 @@ func TestCreate(t *testing.T) {
 
 			wantError: true,
 		},
+		{
+			name: "empty userID, skip token",
+			token: &mgmtapiv3.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-token"},
+				UserID:     "",
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
+		{
+			name: "empty name, skip token",
+			token: &mgmtapiv3.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: ""},
+				UserID:     userID,
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -440,7 +479,7 @@ func TestExtUpdate(t *testing.T) {
 		},
 		Spec: extv1.TokenSpec{
 			UserID:  userID,
-			Enabled: pointer.Bool(true),
+			Enabled: ptr.To(true),
 		},
 		Status: extv1.TokenStatus{
 			ExpiresAt: "10000000000",
@@ -448,7 +487,7 @@ func TestExtUpdate(t *testing.T) {
 			Hash:      hashedTokenKey,
 		},
 	}
-	testAuthToken := &clusterv3.ClusterAuthToken{
+	testAuthToken := &clusterapiv3.ClusterAuthToken{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-token",
 		},
@@ -459,7 +498,7 @@ func TestExtUpdate(t *testing.T) {
 		UserName:  userID,
 		Enabled:   true,
 	}
-	testAuthSecret := &v1.Secret{
+	testAuthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cat-test-token",
 		},
@@ -480,8 +519,8 @@ func TestExtUpdate(t *testing.T) {
 		name  string
 		token *extv1.Token
 
-		existingClusterAuthToken  *clusterv3.ClusterAuthToken
-		existingClusterAuthSecret *v1.Secret
+		existingClusterAuthToken  *clusterapiv3.ClusterAuthToken
+		existingClusterAuthSecret *corev1.Secret
 		existingTokenError        error
 		tokenHashingEnabled       bool
 		updateAuthTokenErr        error
@@ -495,7 +534,7 @@ func TestExtUpdate(t *testing.T) {
 	}{
 		{
 			name:                      "token disabled, update token",
-			token:                     setExtTokenEnabled(testToken, pointer.Bool(false)),
+			token:                     setExtTokenEnabled(testToken, ptr.To(false)),
 			existingClusterAuthToken:  testAuthToken,
 			existingClusterAuthSecret: testAuthSecret,
 
@@ -624,6 +663,26 @@ func TestExtUpdate(t *testing.T) {
 			wantAuthTokenUpdate:  true,
 			wantAuthTokenEnabled: true,
 		},
+		{
+			name: "empty userID, skip token",
+			token: &extv1.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-token"},
+				Spec:       extv1.TokenSpec{UserID: ""},
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
+		{
+			name: "empty name, skip token",
+			token: &extv1.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: ""},
+				Spec:       extv1.TokenSpec{UserID: userID},
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -672,16 +731,16 @@ func TestExtUpdate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	testToken := &managementv3.Token{
+	testToken := &mgmtapiv3.Token{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-token",
 		},
 		ExpiresAt: "10000000000",
 		UserID:    userID,
 		Token:     tokenKey,
-		Enabled:   pointer.Bool(true),
+		Enabled:   ptr.To(true),
 	}
-	testAuthToken := &clusterv3.ClusterAuthToken{
+	testAuthToken := &clusterapiv3.ClusterAuthToken{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-token",
 		},
@@ -692,7 +751,7 @@ func TestUpdate(t *testing.T) {
 		UserName:  userID,
 		Enabled:   true,
 	}
-	testAuthSecret := &v1.Secret{
+	testAuthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cat-test-token",
 		},
@@ -710,10 +769,10 @@ func TestUpdate(t *testing.T) {
 	authTokenNotFoundError := apierrors.NewNotFound(schema.GroupResource{Group: "cluster.cattle.io", Resource: "ClusterAuthToken"}, testToken.Name)
 	tests := []struct {
 		name  string
-		token *managementv3.Token
+		token *mgmtapiv3.Token
 
-		existingClusterAuthToken  *clusterv3.ClusterAuthToken
-		existingClusterAuthSecret *v1.Secret
+		existingClusterAuthToken  *clusterapiv3.ClusterAuthToken
+		existingClusterAuthSecret *corev1.Secret
 		existingTokenError        error
 		tokenHashingEnabled       bool
 		updateAuthTokenErr        error
@@ -727,7 +786,7 @@ func TestUpdate(t *testing.T) {
 	}{
 		{
 			name:                      "token disabled, update token",
-			token:                     setTokenEnabled(testToken, pointer.Bool(false)),
+			token:                     setTokenEnabled(testToken, ptr.To(false)),
 			existingClusterAuthToken:  testAuthToken,
 			existingClusterAuthSecret: testAuthSecret,
 
@@ -865,6 +924,26 @@ func TestUpdate(t *testing.T) {
 			wantAuthTokenUpdate:  true,
 			wantAuthTokenEnabled: true,
 		},
+		{
+			name: "empty userID, skip token",
+			token: &mgmtapiv3.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-token"},
+				UserID:     "",
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
+		{
+			name: "empty name, skip token",
+			token: &mgmtapiv3.Token{
+				ObjectMeta: metav1.ObjectMeta{Name: ""},
+				UserID:     userID,
+			},
+
+			wantError:     true,
+			wantSkipError: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -921,7 +1000,7 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
-func hashToken(token *managementv3.Token, hashedToken string) *managementv3.Token {
+func hashToken(token *mgmtapiv3.Token, hashedToken string) *mgmtapiv3.Token {
 	newToken := token.DeepCopy()
 	newToken.Token = hashedToken
 	if newToken.Annotations == nil {
@@ -931,28 +1010,28 @@ func hashToken(token *managementv3.Token, hashedToken string) *managementv3.Toke
 	return newToken
 }
 
-func setTokenEnabled(token *managementv3.Token, enabled *bool) *managementv3.Token {
+func setTokenEnabled(token *mgmtapiv3.Token, enabled *bool) *mgmtapiv3.Token {
 	newToken := token.DeepCopy()
 	newToken.Enabled = enabled
 	return newToken
 }
 
-func setTokenExpiry(token *managementv3.Token, expiry string) *managementv3.Token {
+func setTokenExpiry(token *mgmtapiv3.Token, expiry string) *mgmtapiv3.Token {
 	newToken := token.DeepCopy()
 	newToken.ExpiresAt = expiry
 	return newToken
 }
 
-func setTokenUser(token *managementv3.Token, user string) *managementv3.Token {
+func setTokenUser(token *mgmtapiv3.Token, user string) *mgmtapiv3.Token {
 	newToken := token.DeepCopy()
 	newToken.UserID = user
 	return newToken
 }
 
 type testInput struct {
-	Token                     *managementv3.Token
-	ExistingClusterAuthToken  *clusterv3.ClusterAuthToken
-	ExistingClusterAuthSecret *v1.Secret
+	Token                     *mgmtapiv3.Token
+	ExistingClusterAuthToken  *clusterapiv3.ClusterAuthToken
+	ExistingClusterAuthSecret *corev1.Secret
 	ExistingTokenError        error
 	TokenHashingEnabled       bool
 	UpdateAuthTokenErr        error
@@ -963,7 +1042,7 @@ type testInput struct {
 func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 	ctrl := gomock.NewController(t)
 	mockLister := fakes.ClusterAuthTokenListerMock{}
-	mockLister.GetFunc = func(namespace, name string) (*clusterv3.ClusterAuthToken, error) {
+	mockLister.GetFunc = func(namespace, name string) (*clusterapiv3.ClusterAuthToken, error) {
 		return testInput.ExistingClusterAuthToken.DeepCopy(), testInput.ExistingTokenError
 	}
 	mockSecretLister := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
@@ -982,12 +1061,12 @@ func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 		return in1, testInput.UpdateAuthTokenErr
 	}).AnyTimes()
 
-	var modifiedToken *clusterv3.ClusterAuthToken
+	var modifiedToken *clusterapiv3.ClusterAuthToken
 	var isUpdated bool
 	var isDeleted bool
 	var updateCallCount int
 	mockAuthTokens := fakes.ClusterAuthTokenInterfaceMock{}
-	mockAuthTokens.UpdateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+	mockAuthTokens.UpdateFunc = func(in1 *clusterapiv3.ClusterAuthToken) (*clusterapiv3.ClusterAuthToken, error) {
 		updateCallCount++
 		isUpdated = true
 		modifiedToken = in1
@@ -996,7 +1075,7 @@ func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 		}
 		return in1, nil
 	}
-	mockAuthTokens.CreateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+	mockAuthTokens.CreateFunc = func(in1 *clusterapiv3.ClusterAuthToken) (*clusterapiv3.ClusterAuthToken, error) {
 		modifiedToken = in1
 		return in1, testInput.CreateAuthTokenErr
 	}
@@ -1004,11 +1083,11 @@ func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 		isDeleted = true
 		return nil
 	}
-	mockAuthTokens.GetFunc = func(name string, opts metav1.GetOptions) (*clusterv3.ClusterAuthToken, error) {
+	mockAuthTokens.GetFunc = func(name string, opts metav1.GetOptions) (*clusterapiv3.ClusterAuthToken, error) {
 		if testInput.ExistingClusterAuthToken != nil {
 			return testInput.ExistingClusterAuthToken.DeepCopy(), nil
 		}
-		return &clusterv3.ClusterAuthToken{
+		return &clusterapiv3.ClusterAuthToken{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			TypeMeta:   metav1.TypeMeta{Kind: "ClusterAuthToken"},
 		}, nil
@@ -1021,7 +1100,7 @@ func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: userID,
 			},
-			Enabled: pointer.BoolPtr(true),
+			Enabled: ptr.To(true),
 		}, nil
 	}
 	userAttributeLister := mgmtFakes.UserAttributeListerMock{}
@@ -1032,8 +1111,8 @@ func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 		}, nil
 	}
 	clusterUserAttributeLister := fakes.ClusterUserAttributeListerMock{}
-	clusterUserAttributeLister.GetFunc = func(namespace, name string) (*clusterv3.ClusterUserAttribute, error) {
-		return &clusterv3.ClusterUserAttribute{
+	clusterUserAttributeLister.GetFunc = func(namespace, name string) (*clusterapiv3.ClusterUserAttribute, error) {
+		return &clusterapiv3.ClusterUserAttribute{
 			LastRefresh:  "1000",
 			NeedsRefresh: false,
 			Enabled:      true,
@@ -1096,8 +1175,8 @@ func setExtTokenUser(token *extv1.Token, user string) *extv1.Token {
 
 type testExtInput struct {
 	Token                     *extv1.Token
-	ExistingClusterAuthToken  *clusterv3.ClusterAuthToken
-	ExistingClusterAuthSecret *v1.Secret
+	ExistingClusterAuthToken  *clusterapiv3.ClusterAuthToken
+	ExistingClusterAuthSecret *corev1.Secret
 	ExistingTokenError        error
 	TokenHashingEnabled       bool
 	UpdateAuthTokenErr        error
@@ -1106,8 +1185,8 @@ type testExtInput struct {
 }
 
 type testOutput struct {
-	ModifiedClusterAuthToken  *clusterv3.ClusterAuthToken
-	ModifiedClusterAuthSecret *v1.Secret
+	ModifiedClusterAuthToken  *clusterapiv3.ClusterAuthToken
+	ModifiedClusterAuthSecret *corev1.Secret
 	AuthTokenUpdated          bool
 	AuthTokenDeleted          bool
 	Error                     error
@@ -1116,7 +1195,7 @@ type testOutput struct {
 func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 	ctrl := gomock.NewController(t)
 	mockLister := fakes.ClusterAuthTokenListerMock{}
-	mockLister.GetFunc = func(namespace, name string) (*clusterv3.ClusterAuthToken, error) {
+	mockLister.GetFunc = func(namespace, name string) (*clusterapiv3.ClusterAuthToken, error) {
 		return testInput.ExistingClusterAuthToken.DeepCopy(), testInput.ExistingTokenError
 	}
 	mockSecretLister := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
@@ -1135,12 +1214,12 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 		return in1, testInput.UpdateAuthTokenErr
 	}).AnyTimes()
 
-	var modifiedToken *clusterv3.ClusterAuthToken
+	var modifiedToken *clusterapiv3.ClusterAuthToken
 	var isUpdated bool
 	var isDeleted bool
 	var updateCallCount int
 	mockAuthTokens := fakes.ClusterAuthTokenInterfaceMock{}
-	mockAuthTokens.UpdateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+	mockAuthTokens.UpdateFunc = func(in1 *clusterapiv3.ClusterAuthToken) (*clusterapiv3.ClusterAuthToken, error) {
 		updateCallCount++
 		isUpdated = true
 		modifiedToken = in1
@@ -1149,7 +1228,7 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 		}
 		return in1, nil
 	}
-	mockAuthTokens.CreateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+	mockAuthTokens.CreateFunc = func(in1 *clusterapiv3.ClusterAuthToken) (*clusterapiv3.ClusterAuthToken, error) {
 		modifiedToken = in1
 		return in1, testInput.CreateAuthTokenErr
 	}
@@ -1157,11 +1236,11 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 		isDeleted = true
 		return nil
 	}
-	mockAuthTokens.GetFunc = func(name string, opts metav1.GetOptions) (*clusterv3.ClusterAuthToken, error) {
+	mockAuthTokens.GetFunc = func(name string, opts metav1.GetOptions) (*clusterapiv3.ClusterAuthToken, error) {
 		if testInput.ExistingClusterAuthToken != nil {
 			return testInput.ExistingClusterAuthToken.DeepCopy(), nil
 		}
-		return &clusterv3.ClusterAuthToken{
+		return &clusterapiv3.ClusterAuthToken{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			TypeMeta:   metav1.TypeMeta{Kind: "ClusterAuthToken"},
 		}, nil
@@ -1174,7 +1253,7 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: userID,
 			},
-			Enabled: pointer.BoolPtr(true),
+			Enabled: ptr.To(true),
 		}, nil
 	}
 	userAttributeLister := mgmtFakes.UserAttributeListerMock{}
@@ -1185,8 +1264,8 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 		}, nil
 	}
 	clusterUserAttributeLister := fakes.ClusterUserAttributeListerMock{}
-	clusterUserAttributeLister.GetFunc = func(namespace, name string) (*clusterv3.ClusterUserAttribute, error) {
-		return &clusterv3.ClusterUserAttribute{
+	clusterUserAttributeLister.GetFunc = func(namespace, name string) (*clusterapiv3.ClusterUserAttribute, error) {
+		return &clusterapiv3.ClusterUserAttribute{
 			LastRefresh:  "1000",
 			NeedsRefresh: false,
 			Enabled:      true,

--- a/pkg/controllers/managementuser/clusterauthtoken/token_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token_test.go
@@ -155,7 +155,16 @@ func TestExtCreate(t *testing.T) {
 			wantError:            true,
 			wantClusterAuthToken: true,
 			wantAuthTokenEnabled: true,
-			wantAuthTokenDeleted: true,
+		},
+		{
+			name:               "create already exists, update instead",
+			token:              testToken,
+			existingTokenError: authTokenNotFoundError,
+			createAuthTokenErr: apierrors.NewAlreadyExists(schema.GroupResource{Group: "cluster.cattle.io", Resource: "ClusterAuthToken"}, testToken.Name),
+
+			wantClusterAuthToken: true,
+			wantAuthTokenEnabled: true,
+			wantAuthTokenUpdate:  true,
 		},
 		{
 			name:               "get current token error",
@@ -349,7 +358,16 @@ func TestCreate(t *testing.T) {
 			wantError:            true,
 			wantClusterAuthToken: true,
 			wantAuthTokenEnabled: true,
-			wantAuthTokenDeleted: true,
+		},
+		{
+			name:               "create already exists, update instead",
+			token:              testToken,
+			existingTokenError: authTokenNotFoundError,
+			createAuthTokenErr: apierrors.NewAlreadyExists(schema.GroupResource{Group: "cluster.cattle.io", Resource: "ClusterAuthToken"}, testToken.Name),
+
+			wantClusterAuthToken: true,
+			wantAuthTokenEnabled: true,
+			wantAuthTokenUpdate:  true,
 		},
 		{
 			name:               "get current token error",
@@ -594,6 +612,18 @@ func TestExtUpdate(t *testing.T) {
 			wantAuthTokenUpdate:  true,
 			wantAuthTokenEnabled: true,
 		},
+		{
+			name:                      "update auth token not found, create already exists, update instead",
+			token:                     setExtTokenUser(testToken, "new-user"),
+			existingClusterAuthToken:  testAuthToken,
+			existingClusterAuthSecret: testAuthSecret,
+			updateAuthTokenErr:        authTokenNotFoundError,
+			createAuthTokenErr:        apierrors.NewAlreadyExists(schema.GroupResource{Group: "cluster.cattle.io", Resource: "ClusterAuthToken"}, testToken.Name),
+
+			wantClusterAuthToken: true,
+			wantAuthTokenUpdate:  true,
+			wantAuthTokenEnabled: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -823,6 +853,18 @@ func TestUpdate(t *testing.T) {
 			wantAuthTokenUpdate:  true,
 			wantAuthTokenEnabled: true,
 		},
+		{
+			name:                      "update auth token not found, create already exists, update instead",
+			token:                     setTokenUser(testToken, "new-user"),
+			existingClusterAuthToken:  testAuthToken,
+			existingClusterAuthSecret: testAuthSecret,
+			updateAuthTokenErr:        authTokenNotFoundError,
+			createAuthTokenErr:        apierrors.NewAlreadyExists(schema.GroupResource{Group: "cluster.cattle.io", Resource: "ClusterAuthToken"}, testToken.Name),
+
+			wantClusterAuthToken: true,
+			wantAuthTokenUpdate:  true,
+			wantAuthTokenEnabled: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -943,11 +985,16 @@ func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 	var modifiedToken *clusterv3.ClusterAuthToken
 	var isUpdated bool
 	var isDeleted bool
+	var updateCallCount int
 	mockAuthTokens := fakes.ClusterAuthTokenInterfaceMock{}
 	mockAuthTokens.UpdateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+		updateCallCount++
 		isUpdated = true
 		modifiedToken = in1
-		return in1, testInput.UpdateAuthTokenErr
+		if updateCallCount == 1 {
+			return in1, testInput.UpdateAuthTokenErr
+		}
+		return in1, nil
 	}
 	mockAuthTokens.CreateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
 		modifiedToken = in1
@@ -956,6 +1003,15 @@ func runCreateUpdateTest(t *testing.T, testInput *testInput) *testOutput {
 	mockAuthTokens.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
 		isDeleted = true
 		return nil
+	}
+	mockAuthTokens.GetFunc = func(name string, opts metav1.GetOptions) (*clusterv3.ClusterAuthToken, error) {
+		if testInput.ExistingClusterAuthToken != nil {
+			return testInput.ExistingClusterAuthToken.DeepCopy(), nil
+		}
+		return &clusterv3.ClusterAuthToken{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterAuthToken"},
+		}, nil
 	}
 
 	// cluster userAttributes are also updated in these functions
@@ -1082,11 +1138,16 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 	var modifiedToken *clusterv3.ClusterAuthToken
 	var isUpdated bool
 	var isDeleted bool
+	var updateCallCount int
 	mockAuthTokens := fakes.ClusterAuthTokenInterfaceMock{}
 	mockAuthTokens.UpdateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+		updateCallCount++
 		isUpdated = true
 		modifiedToken = in1
-		return in1, testInput.UpdateAuthTokenErr
+		if updateCallCount == 1 {
+			return in1, testInput.UpdateAuthTokenErr
+		}
+		return in1, nil
 	}
 	mockAuthTokens.CreateFunc = func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
 		modifiedToken = in1
@@ -1095,6 +1156,15 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 	mockAuthTokens.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
 		isDeleted = true
 		return nil
+	}
+	mockAuthTokens.GetFunc = func(name string, opts metav1.GetOptions) (*clusterv3.ClusterAuthToken, error) {
+		if testInput.ExistingClusterAuthToken != nil {
+			return testInput.ExistingClusterAuthToken.DeepCopy(), nil
+		}
+		return &clusterv3.ClusterAuthToken{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterAuthToken"},
+		}, nil
 	}
 
 	// cluster userAttributes are also updated in these functions


### PR DESCRIPTION
## Issue: #53695 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

- When the downstream ClusterAuthToken Create call returned AlreadyExists (due to a stale lister cache after a resourceVersion conflict retry), createClusterAuthToken unconditionally deleted the existing valid resource. This caused a create-delete loop that blocked token sync and broke ACE authentication for affected clusters.
- There are reported "resource name may not be empty" errors that  cause the controller to spin.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Replace the destructive delete with a get-modify-update, mirroring the pattern already used for secrets. Apply the same handling in ExtUpdated and Updated where Create follows a NotFound Update — previously these silently accepted whatever existed without verifying field values.
- The real root cause is not clear but all request derive resource names from either token name or userID so we defensively reject tokens with empty name or userID for all handlers.

The "object missing name" errors in kube-api-auth are likely a side effect of the create-delete loop in the cat-token-controller. When the controller rapidly deletes and recreates ClusterAuthToken secrets, kube-api-auth's concurrent migration code can catch a secret mid-flight — if the GetNamespaced call returns an object in a bad state, then the subsequent Update fails because Norman's client sees an empty Name and rejects it with "object missing name."
The first fix stops the create-delete loop and hopefully eliminates the window where kube-api-auth can hit this race.
 
## Testing
- Unit tests