### PR TITLE
feat: support separate administration hostname for keycloak provider

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -731,7 +731,7 @@ type OIDCConfig struct {
 	// GroupsClaim is used instead of groups
 	GroupsClaim string `json:"groupsClaim,omitempty"`
 
-	// NameClaim is used instead instead of the name claim.
+	// NameClaim is used instead of the name claim.
 	NameClaim string `json:"nameClaim,omitempty"`
 
 	// EmailClaim is used instead of email
@@ -749,6 +749,11 @@ type OIDCConfig struct {
 	// client/secret rather than the user credentials if the underlying provider
 	// supports this.
 	ClientAuthenticatedSearch bool `json:"clientAuthenticatedSearch"`
+
+	// AdminEndpoint is used as a base url for all administration endpoints requests
+	// instead of the Issuer if the underlying provider is configured to expose it's
+	// administration endpoints on a separate hostname.
+	AdminEndpoint string `json:"adminEndpoint,omitempty"`
 }
 
 type OIDCTestOutput struct {

--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -40,9 +40,16 @@ type KeyCloakClient struct {
 
 func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, config *apiv3.OIDCConfig) ([]account, error) {
 	var accounts []account
-	sURL, err := getSearchURL(config.Issuer)
-	if err != nil {
-		return accounts, err
+	var sURL string
+	var err error
+
+	if config.AdminEndpoint != "" {
+		sURL = config.AdminEndpoint
+	} else {
+		sURL, err = getSearchURL(config.Issuer)
+		if err != nil {
+			return accounts, err
+		}
 	}
 	if principalType == "" || principalType == UserType {
 		var userAccounts []account
@@ -128,13 +135,19 @@ func getSubGroups(group Group) []Group {
 
 func (k *KeyCloakClient) getFromKeyCloakByID(principalID, principalType string, config *apiv3.OIDCConfig) (account, error) {
 	var searchResult account
+	var sURL string
+	var err error
 
 	if principalID == "" {
 		return searchResult, errors.Errorf("invalid id %v", principalID)
 	}
-	sURL, err := getSearchURL(config.Issuer)
-	if err != nil {
-		return searchResult, nil
+	if config.AdminEndpoint != "" {
+		sURL = config.AdminEndpoint
+	} else {
+		sURL, err = getSearchURL(config.Issuer)
+		if err != nil {
+			return searchResult, nil
+		}
 	}
 	// this will use the keycloak search endpoint with an id
 	if principalType == UserType {

--- a/pkg/client/generated/management/v3/zz_generated_cognito_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_cognito_config.go
@@ -4,6 +4,7 @@ const (
 	CognitoConfigType                           = "cognitoConfig"
 	CognitoConfigFieldAccessMode                = "accessMode"
 	CognitoConfigFieldAcrValue                  = "acrValue"
+	CognitoConfigFieldAdminEndpoint             = "adminEndpoint"
 	CognitoConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
 	CognitoConfigFieldAnnotations               = "annotations"
 	CognitoConfigFieldAuthEndpoint              = "authEndpoint"
@@ -43,6 +44,7 @@ const (
 type CognitoConfig struct {
 	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
 	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AdminEndpoint             string            `json:"adminEndpoint,omitempty" yaml:"adminEndpoint,omitempty"`
 	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_generic_oidcconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_generic_oidcconfig.go
@@ -4,6 +4,7 @@ const (
 	GenericOIDCConfigType                           = "genericOIDCConfig"
 	GenericOIDCConfigFieldAccessMode                = "accessMode"
 	GenericOIDCConfigFieldAcrValue                  = "acrValue"
+	GenericOIDCConfigFieldAdminEndpoint             = "adminEndpoint"
 	GenericOIDCConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
 	GenericOIDCConfigFieldAnnotations               = "annotations"
 	GenericOIDCConfigFieldAuthEndpoint              = "authEndpoint"
@@ -43,6 +44,7 @@ const (
 type GenericOIDCConfig struct {
 	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
 	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AdminEndpoint             string            `json:"adminEndpoint,omitempty" yaml:"adminEndpoint,omitempty"`
 	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
@@ -4,6 +4,7 @@ const (
 	KeyCloakOIDCConfigType                           = "keyCloakOIDCConfig"
 	KeyCloakOIDCConfigFieldAccessMode                = "accessMode"
 	KeyCloakOIDCConfigFieldAcrValue                  = "acrValue"
+	KeyCloakOIDCConfigFieldAdminEndpoint             = "adminEndpoint"
 	KeyCloakOIDCConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
 	KeyCloakOIDCConfigFieldAnnotations               = "annotations"
 	KeyCloakOIDCConfigFieldAuthEndpoint              = "authEndpoint"
@@ -43,6 +44,7 @@ const (
 type KeyCloakOIDCConfig struct {
 	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
 	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AdminEndpoint             string            `json:"adminEndpoint,omitempty" yaml:"adminEndpoint,omitempty"`
 	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_oidc_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_oidc_config.go
@@ -4,6 +4,7 @@ const (
 	OIDCConfigType                           = "oidcConfig"
 	OIDCConfigFieldAccessMode                = "accessMode"
 	OIDCConfigFieldAcrValue                  = "acrValue"
+	OIDCConfigFieldAdminEndpoint             = "adminEndpoint"
 	OIDCConfigFieldAllowedPrincipalIDs       = "allowedPrincipalIds"
 	OIDCConfigFieldAnnotations               = "annotations"
 	OIDCConfigFieldAuthEndpoint              = "authEndpoint"
@@ -43,6 +44,7 @@ const (
 type OIDCConfig struct {
 	AccessMode                string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
 	AcrValue                  string            `json:"acrValue,omitempty" yaml:"acrValue,omitempty"`
+	AdminEndpoint             string            `json:"adminEndpoint,omitempty" yaml:"adminEndpoint,omitempty"`
 	AllowedPrincipalIDs       []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations               map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AuthEndpoint              string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/53967
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When using Keycloak, it is considered a best practice to expose the Keycloak Administration REST API and Console on a different hostname or context-path than the one used for the public frontend URLs that are used e.g. by login flows, as stated in [Configuring Keycloak for production](https://www.keycloak.org/server/configuration-production#_exposing_the_keycloak_administration_apis_and_ui_on_a_different_hostname).

Currently if Keycloak is configured to expose its administration endpoints on a separate hostname, Keycloak OIDC functionality in Rancher that uses Keycloak [search](https://github.com/rancher/rancher/blob/v2.12.0/pkg/auth/providers/keycloakoidc/keycloak_client.go#L167) will always fail with the following error:
```
[keycloak oidc] <func>: received error unmarshalling search results, err: invalid character '<' looking for beginning of value
```
This happens because function `getSearchURL` currently uses `config.Issuer` for the Keycloak Administration REST API base URL, expecting the Administration REST API to be on the same hostname as the OIDC Issuer. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Introduce a new configuration option `AdminEndpoint` to store the base URL for the Keycloak Administration REST API and use this option for Keycloak Administration API requests instead of the Issuer if it is specified.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
1. Configure Keycloak behind a reverse proxy so that all Keycloak administration endpoints are exposed on a separate hostname `<keycloak-admin-hostname>`.
2. Configure the Keycloak OIDC provider in Rancher with the new `AdminEndpoint` option pointing to `https://<keycloak-admin-hostname>/admin/realms/<realm-name>` and the group search enabled.
3. Use Keycloak OIDC to login to Rancher with an account able to view Keycloak groups and users.
4. Confirm that the Keycloak group search allows searching and viewing Keycloak groups.
5. Confirm that no `keycloak oidc` errors are present in Runcher logs.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: -
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: https://github.com/rancher/rancher/issues/53967

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_