### PR TITLE
AzureAD: preserve stored config fields during testAndApply

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -460,9 +460,9 @@ type AzureADConfig struct {
 	RancherURL            string `json:"rancherUrl,omitempty" norman:"required,notnullable"`
 	GroupMembershipFilter string `json:"groupMembershipFilter,omitempty"`
 
-	// LogoutEndpoint overrides the Azure AD end_session_endpoint used for SSO logout.
+	// EndSessionEndpoint overrides the Azure AD end_session_endpoint used for SSO logout.
 	// If empty, defaults to {Endpoint}/{TenantID}/oauth2/v2.0/logout.
-	LogoutEndpoint string `json:"logoutEndpoint,omitempty"`
+	EndSessionEndpoint string `json:"endSessionEndpoint,omitempty"`
 
 	// LogoutAllEnabled enables SSO logout (RP-Initiated Logout) for this provider.
 	// Can be set only if AuthConfig.LogoutAllSupported is true.

--- a/pkg/auth/providers/azure/azure_actions.go
+++ b/pkg/auth/providers/azure/azure_actions.go
@@ -90,7 +90,8 @@ func (ap *Provider) testAndApply(request *types.APIContext) error {
 		logrus.Errorf("Failed to fetch Azure AD Config from Kubernetes: %v", err)
 		return httperror.NewAPIError(httperror.ServerError, "failed to fetch Azure AD Config from Kubernetes")
 	}
-	migrateNewFlowAnnotation(currentConfig, azureADConfig)
+	migrateNewFlowAnnotation(azureADConfig)
+	preserveStoredFields(currentConfig, azureADConfig)
 
 	azureLogin := &apiv3.AzureADLogin{
 		Code: azureADConfigApplyInput.Code,
@@ -133,9 +134,25 @@ func (ap *Provider) testAndApply(request *types.APIContext) error {
 	return ap.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerToken, 0, "Token via Azure Configuration", request)
 }
 
-// Check the current auth config and make sure that the proposed one submitted through the API has up-to-date annotations.
-// Rancher relies on GraphEndpointMigratedAnnotation to choose the right authentication flow and Graph API.
-func migrateNewFlowAnnotation(current, proposed *apiv3.AzureADConfig) {
+func preserveStoredFields(stored, incoming *apiv3.AzureADConfig) {
+	if stored.Enabled {
+		incoming.Enabled = true
+	}
+	if incoming.AccessMode == "" {
+		incoming.AccessMode = stored.AccessMode
+	}
+	if incoming.AllowedPrincipalIDs == nil {
+		incoming.AllowedPrincipalIDs = stored.AllowedPrincipalIDs
+	}
+	incoming.LogoutAllSupported = stored.LogoutAllSupported
+	incoming.LogoutEndpoint = stored.LogoutEndpoint
+	incoming.LogoutAllEnabled = stored.LogoutAllEnabled
+	incoming.LogoutAllForced = stored.LogoutAllForced
+}
+
+// migrateNewFlowAnnotation ensures the proposed config has the GraphEndpointMigratedAnnotation set.
+// Rancher relies on this annotation to choose the right authentication flow and Graph API.
+func migrateNewFlowAnnotation(proposed *apiv3.AzureADConfig) {
 	// This covers the case where admins upgrade Rancher to v2.6.7+ without having used Azure AD as the auth provider.
 	// In 2.6.7+, whether Azure AD is later registered or not, Rancher on startup creates the annotation on the template auth config.
 	// But in the case where the auth config had been created on Rancher startup prior to v2.6.7, the annotation would be missing.

--- a/pkg/auth/providers/azure/azure_actions.go
+++ b/pkg/auth/providers/azure/azure_actions.go
@@ -144,8 +144,8 @@ func preserveStoredFields(stored, incoming *apiv3.AzureADConfig) {
 	if incoming.AllowedPrincipalIDs == nil {
 		incoming.AllowedPrincipalIDs = stored.AllowedPrincipalIDs
 	}
+	incoming.EndSessionEndpoint = stored.EndSessionEndpoint
 	incoming.LogoutAllSupported = stored.LogoutAllSupported
-	incoming.LogoutEndpoint = stored.LogoutEndpoint
 	incoming.LogoutAllEnabled = stored.LogoutAllEnabled
 	incoming.LogoutAllForced = stored.LogoutAllForced
 }

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -86,7 +86,7 @@ func (ap *Provider) LogoutAll(w http.ResponseWriter, r *http.Request, token acce
 		return fmt.Errorf("azure AD [logout-all]: provider not configured for SSO logout")
 	}
 
-	endSessionEndpoint := cfg.LogoutEndpoint
+	endSessionEndpoint := cfg.EndSessionEndpoint
 	if endSessionEndpoint == "" {
 		endSessionEndpoint, err = url.JoinPath(cfg.Endpoint, cfg.TenantID, "/oauth2/v2.0/logout")
 		if err != nil {

--- a/pkg/auth/providers/azure/azure_provider_test.go
+++ b/pkg/auth/providers/azure/azure_provider_test.go
@@ -338,68 +338,172 @@ func TestMigrateNewFlowAnnotation(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		current            *v3.AzureADConfig
 		proposed           *v3.AzureADConfig
 		annotationExpected bool
 	}{
 		{
-			name: "new setup on Rancher v2.6.7+ after an upgrade from previous version",
-			current: &v3.AzureADConfig{
-				AuthConfig: v3.AuthConfig{
-					Enabled: false,
-				},
-				GraphEndpoint: "https://graph.microsoft.com",
-			},
+			name:               "nil annotations gets annotation set",
 			proposed:           &v3.AzureADConfig{},
 			annotationExpected: true,
 		},
 		{
-			name: "new setup on Rancher v2.6.7+",
-			current: &v3.AzureADConfig{
+			name: "existing annotations preserved and annotation set",
+			proposed: &v3.AzureADConfig{
 				AuthConfig: v3.AuthConfig{
-					Enabled: false,
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							GraphEndpointMigratedAnnotation: "true",
+							"other": "value",
 						},
 					},
 				},
-				GraphEndpoint: "https://graph.microsoft.com",
 			},
-			proposed:           &v3.AzureADConfig{},
-			annotationExpected: true,
-		},
-		{
-			name: "reconfigure existing new setup",
-			current: &v3.AzureADConfig{
-				AuthConfig: v3.AuthConfig{
-					Enabled: true,
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							GraphEndpointMigratedAnnotation: "true",
-						},
-					},
-				},
-				GraphEndpoint: "https://graph.microsoft.com",
-			},
-			proposed:           &v3.AzureADConfig{},
 			annotationExpected: true,
 		},
 	}
 
-	for i := range tests {
-		test := tests[i]
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			migrateNewFlowAnnotation(test.current, test.proposed)
+			migrateNewFlowAnnotation(test.proposed)
 			_, hasAnnotation := test.proposed.Annotations[GraphEndpointMigratedAnnotation]
-			if test.annotationExpected && !hasAnnotation {
-				assert.Fail(t, "expected annotation on the processed config, but did not find one")
-			}
-			if !test.annotationExpected && hasAnnotation {
-				assert.Fail(t, "did not expect the annotation on the processed config, but found one")
-			}
+			assert.Equal(t, test.annotationExpected, hasAnnotation)
+		})
+	}
+}
+
+func TestPreserveStoredFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		stored   v3.AzureADConfig
+		incoming v3.AzureADConfig
+		want     v3.AzureADConfig
+	}{
+		{
+			name: "stored Enabled true survives incoming false",
+			stored: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{Enabled: true},
+			},
+			incoming: v3.AzureADConfig{},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{Enabled: true},
+			},
+		},
+		{
+			name:   "stored Enabled false allows incoming true",
+			stored: v3.AzureADConfig{},
+			incoming: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{Enabled: true},
+			},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{Enabled: true},
+			},
+		},
+		{
+			name:     "both Enabled false stays false",
+			stored:   v3.AzureADConfig{},
+			incoming: v3.AzureADConfig{},
+			want:     v3.AzureADConfig{},
+		},
+		{
+			name: "SLO fields always preserved from stored",
+			stored: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					LogoutAllSupported: true,
+				},
+				LogoutEndpoint:   "https://custom.gov/logout",
+				LogoutAllEnabled: true,
+				LogoutAllForced:  true,
+			},
+			incoming: v3.AzureADConfig{},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					LogoutAllSupported: true,
+				},
+				LogoutEndpoint:   "https://custom.gov/logout",
+				LogoutAllEnabled: true,
+				LogoutAllForced:  true,
+			},
+		},
+		{
+			name: "AccessMode preserved when incoming is empty",
+			stored: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{AccessMode: "restricted"},
+			},
+			incoming: v3.AzureADConfig{},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{AccessMode: "restricted"},
+			},
+		},
+		{
+			name: "AccessMode from incoming used when non-empty",
+			stored: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{AccessMode: "restricted"},
+			},
+			incoming: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{AccessMode: "unrestricted"},
+			},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{AccessMode: "unrestricted"},
+			},
+		},
+		{
+			name: "AllowedPrincipalIDs preserved when incoming is nil",
+			stored: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					AllowedPrincipalIDs: []string{"azuread_user://123"},
+				},
+			},
+			incoming: v3.AzureADConfig{},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					AllowedPrincipalIDs: []string{"azuread_user://123"},
+				},
+			},
+		},
+		{
+			name: "AllowedPrincipalIDs from incoming used when non-nil",
+			stored: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					AllowedPrincipalIDs: []string{"azuread_user://123"},
+				},
+			},
+			incoming: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					AllowedPrincipalIDs: []string{"azuread_user://456"},
+				},
+			},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					AllowedPrincipalIDs: []string{"azuread_user://456"},
+				},
+			},
+		},
+		{
+			name:   "zero-value stored does not corrupt incoming",
+			stored: v3.AzureADConfig{},
+			incoming: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					Enabled:    true,
+					AccessMode: "unrestricted",
+				},
+			},
+			want: v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					Enabled:    true,
+					AccessMode: "unrestricted",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			preserveStoredFields(&tt.stored, &tt.incoming)
+			assert.Equal(t, tt.want, tt.incoming)
 		})
 	}
 }

--- a/pkg/auth/providers/azure/azure_provider_test.go
+++ b/pkg/auth/providers/azure/azure_provider_test.go
@@ -413,18 +413,18 @@ func TestPreserveStoredFields(t *testing.T) {
 				AuthConfig: v3.AuthConfig{
 					LogoutAllSupported: true,
 				},
-				LogoutEndpoint:   "https://custom.gov/logout",
-				LogoutAllEnabled: true,
-				LogoutAllForced:  true,
+				EndSessionEndpoint: "https://custom.gov/logout",
+				LogoutAllEnabled:   true,
+				LogoutAllForced:    true,
 			},
 			incoming: v3.AzureADConfig{},
 			want: v3.AzureADConfig{
 				AuthConfig: v3.AuthConfig{
 					LogoutAllSupported: true,
 				},
-				LogoutEndpoint:   "https://custom.gov/logout",
-				LogoutAllEnabled: true,
-				LogoutAllForced:  true,
+				EndSessionEndpoint: "https://custom.gov/logout",
+				LogoutAllEnabled:   true,
+				LogoutAllForced:    true,
 			},
 		},
 		{
@@ -614,9 +614,9 @@ func TestLogoutAll(t *testing.T) {
 			},
 			wantURLAbsent: []string{"post_logout_redirect_uri"},
 		},
-		"custom LogoutEndpoint overrides default": {
+		"custom EndSessionEndpoint overrides default": {
 			config: newAzureConfig("https://login.microsoftonline.com/", "tenant1", "app1", func(c *v3.AzureADConfig) {
-				c.LogoutEndpoint = "https://custom.gov/logout"
+				c.EndSessionEndpoint = "https://custom.gov/logout"
 			}),
 			finalRedirect: "https://example.com/logged-out",
 			wantURLContains: []string{

--- a/pkg/client/generated/management/v3/zz_generated_azure_adconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_azure_adconfig.go
@@ -12,6 +12,7 @@ const (
 	AzureADConfigFieldCreatorID             = "creatorId"
 	AzureADConfigFieldDeviceAuthEndpoint    = "deviceAuthEndpoint"
 	AzureADConfigFieldEnabled               = "enabled"
+	AzureADConfigFieldEndSessionEndpoint    = "endSessionEndpoint"
 	AzureADConfigFieldEndpoint              = "endpoint"
 	AzureADConfigFieldGraphEndpoint         = "graphEndpoint"
 	AzureADConfigFieldGroupMembershipFilter = "groupMembershipFilter"
@@ -19,7 +20,6 @@ const (
 	AzureADConfigFieldLogoutAllEnabled      = "logoutAllEnabled"
 	AzureADConfigFieldLogoutAllForced       = "logoutAllForced"
 	AzureADConfigFieldLogoutAllSupported    = "logoutAllSupported"
-	AzureADConfigFieldLogoutEndpoint        = "logoutEndpoint"
 	AzureADConfigFieldName                  = "name"
 	AzureADConfigFieldOwnerReferences       = "ownerReferences"
 	AzureADConfigFieldRancherURL            = "rancherUrl"
@@ -42,6 +42,7 @@ type AzureADConfig struct {
 	CreatorID             string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DeviceAuthEndpoint    string            `json:"deviceAuthEndpoint,omitempty" yaml:"deviceAuthEndpoint,omitempty"`
 	Enabled               bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EndSessionEndpoint    string            `json:"endSessionEndpoint,omitempty" yaml:"endSessionEndpoint,omitempty"`
 	Endpoint              string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	GraphEndpoint         string            `json:"graphEndpoint,omitempty" yaml:"graphEndpoint,omitempty"`
 	GroupMembershipFilter string            `json:"groupMembershipFilter,omitempty" yaml:"groupMembershipFilter,omitempty"`
@@ -49,7 +50,6 @@ type AzureADConfig struct {
 	LogoutAllEnabled      bool              `json:"logoutAllEnabled,omitempty" yaml:"logoutAllEnabled,omitempty"`
 	LogoutAllForced       bool              `json:"logoutAllForced,omitempty" yaml:"logoutAllForced,omitempty"`
 	LogoutAllSupported    bool              `json:"logoutAllSupported,omitempty" yaml:"logoutAllSupported,omitempty"`
-	LogoutEndpoint        string            `json:"logoutEndpoint,omitempty" yaml:"logoutEndpoint,omitempty"`
 	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
 	OwnerReferences       []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	RancherURL            string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`


### PR DESCRIPTION
## Issue: #54938 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

testAndApply was overwriting the entire AzureADConfig with data from the request body. Fields not included in the request (Enabled, SLO settings, etc.) were being reset to zero values, causing:

  - logoutEndpoint (now renamed to endSessionEndpoint) disappears after reconfiguration
  - enabled resets to false when testAndApply is called for an already-enabled provider
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Preserve fields from the stored config that testAndApply wasn't meant to change.
 
## Testing

- Unit-tests