### PR TITLE
LDAP Provider Client Fixes

### DIFF
--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -3,7 +3,6 @@ package ldap
 import (
 	"crypto/x509"
 	"fmt"
-	"reflect"
 	"strings"
 
 	ldapv3 "github.com/go-ldap/ldap/v3"
@@ -96,7 +95,7 @@ func (p *ldapProvider) loginUser(lConn ldapv3.Client, credentials *v3.BasicLogin
 	}
 
 	if len(opResult.Entries) < 1 {
-		return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.Unauthorized, "Cannot locate user information for "+searchOpRequest.Filter)
+		return v3.Principal{}, nil, apierror.NewAPIError(validation.Unauthorized, "Cannot locate user information for "+searchOpRequest.Filter)
 	}
 
 	userPrincipal, groupPrincipals, err := p.getPrincipalsFromSearchResult(result, opResult, config, lConn)
@@ -195,12 +194,12 @@ func (p *ldapProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult
 			ldap.SanitizeAttr(config.GroupObjectClass),
 		)
 		newGroupPrincipals, err := p.searchLdap(query, groupScope, config, lConn)
-		// Deduplicate groupprincipals get from userMemberAttribute
-		nonDupGroupPrincipals = ldap.FindNonDuplicateBetweenGroupPrincipals(newGroupPrincipals, groupPrincipals, nonDupGroupPrincipals)
-		groupPrincipals = append(groupPrincipals, nonDupGroupPrincipals...)
 		if err != nil {
 			return userPrincipal, groupPrincipals, err
 		}
+		// Deduplicate groupprincipals get from userMemberAttribute
+		nonDupGroupPrincipals = ldap.FindNonDuplicateBetweenGroupPrincipals(newGroupPrincipals, groupPrincipals, nonDupGroupPrincipals)
+		groupPrincipals = append(groupPrincipals, nonDupGroupPrincipals...)
 	}
 
 	if len(groupPrincipals) == 0 {
@@ -473,7 +472,7 @@ func (p *ldapProvider) searchLdap(query string, scope string, config *v3.LdapCon
 
 	results, err := lConn.SearchWithPaging(search, 1000)
 	if err != nil {
-		ldapErr, ok := reflect.ValueOf(err).Interface().(*ldapv3.Error)
+		ldapErr, ok := err.(*ldapv3.Error)
 		if ok && ldapErr.ResultCode != ldapv3.LDAPResultNoSuchObject {
 			return []v3.Principal{}, fmt.Errorf("ldap: error searching for query %s:, error: %w", query, err)
 		}
@@ -546,7 +545,7 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 
 	searchRequest := ldap.NewBaseObjectSearchRequest(
 		distinguishedName,
-		fmt.Sprintf("(%s=%s)", ObjectClass, config.UserObjectClass),
+		fmt.Sprintf("(%s=%s)", ObjectClass, ldap.SanitizeAttr(config.UserObjectClass)),
 		config.GetUserSearchAttributes(ObjectClass),
 	)
 
@@ -556,7 +555,7 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 	}
 
 	if nEntries := len(result.Entries); nEntries < 1 {
-		return nil, httperror.WrapAPIError(err, httperror.Unauthorized, "Cannot locate user information for "+searchRequest.Filter)
+		return nil, httperror.NewAPIError(httperror.Unauthorized, "Cannot locate user information for "+searchRequest.Filter)
 	} else if nEntries > 1 {
 		return nil, fmt.Errorf("ldap: user search found more than one result")
 	}
@@ -574,7 +573,7 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 	}
 
 	if len(opResult.Entries) < 1 {
-		return nil, httperror.WrapAPIError(err, httperror.Unauthorized, "Cannot locate user information for "+searchOpRequest.Filter)
+		return nil, httperror.NewAPIError(httperror.Unauthorized, "Cannot locate user information for "+searchOpRequest.Filter)
 	}
 
 	_, groupPrincipals, err := p.getPrincipalsFromSearchResult(result, opResult, config, lConn)

--- a/pkg/auth/providers/ldap/ldap_client_test.go
+++ b/pkg/auth/providers/ldap/ldap_client_test.go
@@ -569,3 +569,65 @@ func TestLDAPProviderLoginUser(t *testing.T) {
 		require.Equal(t, validation.Unauthorized, herr.Code)
 	})
 }
+
+func TestSearchLdapNoSuchObjectErrorIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	provider := &ldapProvider{
+		providerName: "openldap",
+		userScope:    "openldap_user",
+		groupScope:   "openldap_group",
+	}
+
+	config := &v3.LdapConfig{
+		LdapFields: v3.LdapFields{
+			ServiceAccountDistinguishedName: saDN,
+			ServiceAccountPassword:          saPassword,
+			UserObjectClass:                 userObjectClassName,
+			UserSearchBase:                  "ou=users,dc=foo,dc=bar",
+		},
+	}
+
+	ldapConn := &ldapFakes.FakeLdapConn{
+		SearchWithPagingFunc: func(searchRequest *ldapv3.SearchRequest, pagingSize uint32) (*ldapv3.SearchResult, error) {
+			// Return an empty result alongside the error so that the code can
+			// safely iterate over result.Entries after skipping the error.
+			return &ldapv3.SearchResult{}, ldapv3.NewError(ldapv3.LDAPResultNoSuchObject, fmt.Errorf("no such object"))
+		},
+	}
+
+	principals, err := provider.searchLdap("(objectClass=inetOrgPerson)", provider.userScope, config, ldapConn)
+
+	require.NoError(t, err, "LDAPResultNoSuchObject should be treated as empty results, not an error")
+	require.Empty(t, principals)
+}
+
+func TestSearchLdapOtherLDAPErrorIsPropagated(t *testing.T) {
+	t.Parallel()
+
+	provider := &ldapProvider{
+		providerName: "openldap",
+		userScope:    "openldap_user",
+		groupScope:   "openldap_group",
+	}
+
+	config := &v3.LdapConfig{
+		LdapFields: v3.LdapFields{
+			ServiceAccountDistinguishedName: saDN,
+			ServiceAccountPassword:          saPassword,
+			UserObjectClass:                 userObjectClassName,
+			UserSearchBase:                  "ou=users,dc=foo,dc=bar",
+		},
+	}
+
+	ldapConn := &ldapFakes.FakeLdapConn{
+		SearchWithPagingFunc: func(searchRequest *ldapv3.SearchRequest, pagingSize uint32) (*ldapv3.SearchResult, error) {
+			return nil, ldapv3.NewError(ldapv3.LDAPResultUnavailable, fmt.Errorf("service unavailable"))
+		},
+	}
+
+	principals, err := provider.searchLdap("(objectClass=inetOrgPerson)", provider.userScope, config, ldapConn)
+
+	require.Error(t, err, "non-NoSuchObject LDAP errors should be propagated to the caller")
+	require.Empty(t, principals)
+}

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -187,11 +187,12 @@ func (p *ldapProvider) SearchPrincipals(searchKey, principalType string, myToken
 	principals, err = p.searchPrincipals(searchKey, principalType, config, lConn)
 	if err == nil {
 		for _, principal := range principals {
-			if principal.PrincipalType == "user" {
+			switch principal.PrincipalType {
+			case "user":
 				if common.SamePrincipal(myToken.GetUserPrincipal(), principal) {
 					principal.Me = true
 				}
-			} else if principal.PrincipalType == "group" {
+			case "group":
 				if p.isMemberOf(myToken.GetGroupPrincipals(), principal) {
 					principal.MemberOf = true
 				}


### PR DESCRIPTION
In some cases WrapAPIError was being used when err was nil this has been changed to NewAPIError.

Missing ldap.SanitizeAttr in RefetchGroupPrincipals.