### PR TITLE
Revert temporary k3s downgrade for provisioning tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -127,11 +127,6 @@ if [ -z "${SOME_K8S_VERSION}" ]; then
   echo "Resolved ${DIST} to latest version ${SOME_K8S_VERSION}"
 fi
 
-if [ $SOME_K8S_VERSION = "v1.35.0+k3s3" ]; then
-  echo "WARNING: Downgrading k3s version v1.35.0+k3s3 to v1.35.0+k3s1 to skip temporary test problem"
-  export SOME_K8S_VERSION="v1.35.0+k3s1"
-fi
-
 if [ -z "${CATTLE_CHART_DEFAULT_URL}" ]; then
 # If `CATTLE_CHART_DEFAULT_URL` is not set, use the `https://github.com/rancher/charts` so GitHub is used instead of
 # the default `https://git.rancher.io/charts` to reduce the reliance and load on our Git mirror


### PR DESCRIPTION
Reverts #53713

This reverts commit 761888eef76121f4a419fa24a3c7cb28c2ec15ff.

3 months later, k3s version being detected is already newer (than the offending `v1.35.0+k3s3`) and no longer needs this workaround. Example from [recent CI run](https://github.com/rancher/rancher/actions/runs/25045964800/job/73368572633?pr=54161#step:9:668):
```
Starting rancher server for provisioning-tests using v1.35.3+k3s1
```