### PR TITLE
Fix: IPv6-first dual-stack cluster

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -459,6 +459,7 @@ func getMachineNetworkInfo(secrets corecontrollers.SecretCache, entry *planEntry
 func updateConfigWithAddresses(config map[string]interface{}, info *machineNetworkInfo) {
 	nodeIPs := convert.ToStringSlice(config["node-ip"])
 	var toAdd []string
+	primaryNodeIPFamily := primaryAddressFamily(config)
 
 	switch info.DriverName {
 	case management.PodDriver:
@@ -492,7 +493,7 @@ func updateConfigWithAddresses(config map[string]interface{}, info *machineNetwo
 	if info.IPv6Address != "" && !slices.Contains(nodeIPs, info.IPv6Address) {
 		nodeIPs = append(nodeIPs, info.IPv6Address)
 	}
-
+	nodeIPs = reorderAddressesByFamily(nodeIPs, primaryNodeIPFamily)
 	config["node-ip"] = nodeIPs
 
 	// If a cloud provider is configured, it will manage the external IP.
@@ -513,8 +514,77 @@ func updateConfigWithAddresses(config map[string]interface{}, info *machineNetwo
 
 			nodeExternalIPs = append(nodeExternalIPs, ip)
 		}
+		nodeExternalIPs = reorderAddressesByFamily(nodeExternalIPs, primaryNodeIPFamily)
 		config["node-external-ip"] = nodeExternalIPs
 	}
+}
+
+// primaryAddressFamily inspects the "service-cidr" key in the provided config map and returns the IP address
+// family (4 or 6) of the first non-empty CIDR found. Values may be a comma-separated string or a slice of strings;
+// entries are iterated in order and the first parseable, non-empty CIDR determines the result.
+// Returns 0 if "service-cidr" is absent, empty, or if the first CIDR is not a valid network address.
+func primaryAddressFamily(config map[string]interface{}) int {
+	var firstCIDR string
+	for _, serviceCIDRValue := range convert.ToStringSlice(config["service-cidr"]) {
+		for _, serviceCIDR := range strings.Split(serviceCIDRValue, ",") {
+			serviceCIDR = strings.TrimSpace(serviceCIDR)
+			if serviceCIDR == "" {
+				continue
+			}
+			firstCIDR = serviceCIDR
+			break
+		}
+		if firstCIDR != "" {
+			break
+		}
+	}
+	if firstCIDR == "" {
+		return 0
+	}
+
+	_, parsedCIDR, err := net.ParseCIDR(firstCIDR)
+	if err != nil {
+		return 0
+	}
+	if parsedCIDR.IP.To4() != nil {
+		return 4
+	}
+	return 6
+}
+
+// reorderAddressesByFamily reorders the provided address slice so that addresses belonging to the primary IP family
+// (4 for IPv4, 6 for IPv6) are placed first, followed by addresses of the other IP family, and finally any values
+// that cannot be parsed as IP addresses (e.g. interface names). The relative order within each group is preserved.
+// The slice is returned unchanged when it contains fewer than two elements or when primaryFamily is 0.
+func reorderAddressesByFamily(addresses []string, primaryFamily int) []string {
+	if len(addresses) < 2 || primaryFamily == 0 {
+		return addresses
+	}
+
+	primary := make([]string, 0, len(addresses))
+	other := make([]string, 0, len(addresses))
+	nonIP := make([]string, 0, len(addresses))
+
+	for _, address := range addresses {
+		parsedIP := net.ParseIP(address)
+		if parsedIP == nil {
+			nonIP = append(nonIP, address)
+			continue
+		}
+
+		if primaryFamily == 4 && parsedIP.To4() != nil {
+			primary = append(primary, address)
+			continue
+		}
+		if primaryFamily == 6 && parsedIP.To4() == nil {
+			primary = append(primary, address)
+			continue
+		}
+
+		other = append(other, address)
+	}
+
+	return append(append(primary, other...), nonIP...)
 }
 
 // updateConfigWithAdvertiseAddresses sets the advertise-address and tls-san in the config

--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -520,36 +520,27 @@ func updateConfigWithAddresses(config map[string]interface{}, info *machineNetwo
 }
 
 // primaryAddressFamily inspects the "service-cidr" key in the provided config map and returns the IP address
-// family (4 or 6) of the first non-empty CIDR found. Values may be a comma-separated string or a slice of strings;
-// entries are iterated in order and the first parseable, non-empty CIDR determines the result.
-// Returns 0 if "service-cidr" is absent, empty, or if the first CIDR is not a valid network address.
+// family (4 or 6) of the first non-empty CIDR found;
+// returns 0 if "service-cidr" is absent, empty, or if the first non-empty CIDR is not a valid network address.
+// The service-cidr value should be a comma-separated string.
 func primaryAddressFamily(config map[string]interface{}) int {
-	var firstCIDR string
 	for _, serviceCIDRValue := range convert.ToStringSlice(config["service-cidr"]) {
 		for _, serviceCIDR := range strings.Split(serviceCIDRValue, ",") {
 			serviceCIDR = strings.TrimSpace(serviceCIDR)
 			if serviceCIDR == "" {
 				continue
 			}
-			firstCIDR = serviceCIDR
-			break
+			_, parsedCIDR, err := net.ParseCIDR(serviceCIDR)
+			if err != nil {
+				return 0
+			}
+			if parsedCIDR.IP.To4() != nil {
+				return 4
+			}
+			return 6
 		}
-		if firstCIDR != "" {
-			break
-		}
 	}
-	if firstCIDR == "" {
-		return 0
-	}
-
-	_, parsedCIDR, err := net.ParseCIDR(firstCIDR)
-	if err != nil {
-		return 0
-	}
-	if parsedCIDR.IP.To4() != nil {
-		return 4
-	}
-	return 6
+	return 0
 }
 
 // reorderAddressesByFamily reorders the provided address slice so that addresses belonging to the primary IP family

--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -17,6 +17,94 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPrimaryAddressFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]interface{}
+		expected int
+	}{
+		{
+			name:     "returns 0 when service-cidr is missing",
+			config:   map[string]interface{}{},
+			expected: 0,
+		},
+		{
+			name: "returns 4 for IPv4-first CIDR",
+			config: map[string]interface{}{
+				"service-cidr": "10.43.0.0/16,2001:db8:43::/112",
+			},
+			expected: 4,
+		},
+		{
+			name: "returns 6 for IPv6-first CIDR",
+			config: map[string]interface{}{
+				"service-cidr": "2001:db8:43::/112,10.43.0.0/16",
+			},
+			expected: 6,
+		},
+		{
+			name: "handles whitespace and multiple list entries",
+			config: map[string]interface{}{
+				"service-cidr": []string{"   ", "  2001:db8:43::/112  ,10.43.0.0/16"},
+			},
+			expected: 6,
+		},
+		{
+			name: "returns 0 for invalid first CIDR",
+			config: map[string]interface{}{
+				"service-cidr": "not-a-cidr,10.43.0.0/16",
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, primaryAddressFamily(tt.config))
+		})
+	}
+}
+
+func TestReorderAddressesByFamily(t *testing.T) {
+	tests := []struct {
+		name           string
+		addresses      []string
+		primaryFamily  int
+		expected       []string
+	}{
+		{
+			name:          "no-op when fewer than two addresses",
+			addresses:     []string{"10.0.0.1"},
+			primaryFamily: 4,
+			expected:      []string{"10.0.0.1"},
+		},
+		{
+			name:          "no-op when primary family is unset",
+			addresses:     []string{"2001:db8::1", "10.0.0.1"},
+			primaryFamily: 0,
+			expected:      []string{"2001:db8::1", "10.0.0.1"},
+		},
+		{
+			name:          "reorders IPv4 first and keeps group order stable",
+			addresses:     []string{"2001:db8::1", "10.0.0.1", "eth0", "10.0.0.2", "iface0", "2001:db8::2"},
+			primaryFamily: 4,
+			expected:      []string{"10.0.0.1", "10.0.0.2", "2001:db8::1", "2001:db8::2", "eth0", "iface0"},
+		},
+		{
+			name:          "reorders IPv6 first and keeps non-IP values at the end",
+			addresses:     []string{"10.0.0.2", "2001:db8::b", "eth0", "2001:db8::a", "10.0.0.1"},
+			primaryFamily: 6,
+			expected:      []string{"2001:db8::b", "2001:db8::a", "10.0.0.2", "10.0.0.1", "eth0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, reorderAddressesByFamily(tt.addresses, tt.primaryFamily))
+		})
+	}
+}
+
 func TestUpdateConfigWithAddresses(t *testing.T) {
 	tests := []struct {
 		name                    string
@@ -30,6 +118,7 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 			initialConfig: map[string]interface{}{
 				"node-ip":             []string{},
 				"node-external-ip":    []string{},
+				"service-cidr":        "10.43.0.0/16,2001:db8:43::/112",
 				"cloud-provider-name": "",
 			},
 			info: &machineNetworkInfo{
@@ -39,6 +128,23 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 				DriverName:        management.Amazonec2driver,
 			},
 			expectedNodeIPs:         []string{"10.0.0.5", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
+		},
+		{
+			name: "AWS dual-stack node with IPv6-first service-cidr",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"service-cidr":        "2001:db8:43::/112,10.43.0.0/16",
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.5"},
+				ExternalAddresses: []string{"1.2.3.4"},
+				IPv6Address:       "2001:db8::1",
+				DriverName:        management.Amazonec2driver,
+			},
+			expectedNodeIPs:         []string{"2001:db8::1", "10.0.0.5"},
 			expectedNodeExternalIPs: []string{"1.2.3.4"},
 		},
 		{
@@ -263,6 +369,38 @@ func TestUpdateConfigWithAddresses(t *testing.T) {
 			},
 			expectedNodeIPs:         []string{"10.0.0.5"},
 			expectedNodeExternalIPs: []string{"2001:db8::dead:beef"},
+		},
+		{
+			name: "node-external-ip is reordered to match IPv6-first service-cidr",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"service-cidr":        "2001:db8:43::/112,10.43.0.0/16",
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.5"},
+				ExternalAddresses: []string{"1.2.3.4", "2001:db8::dead:beef"},
+			},
+			expectedNodeIPs:         []string{"10.0.0.5"},
+			expectedNodeExternalIPs: []string{"2001:db8::dead:beef", "1.2.3.4"},
+		},
+		{
+			name: "invalid service-cidr preserves existing node-ip order",
+			initialConfig: map[string]interface{}{
+				"node-ip":             []string{},
+				"node-external-ip":    []string{},
+				"service-cidr":        "not-a-cidr,10.43.0.0/16",
+				"cloud-provider-name": "",
+			},
+			info: &machineNetworkInfo{
+				InternalAddresses: []string{"10.0.0.5"},
+				ExternalAddresses: []string{"1.2.3.4"},
+				IPv6Address:       "2001:db8::1",
+				DriverName:        management.Amazonec2driver,
+			},
+			expectedNodeIPs:         []string{"10.0.0.5", "2001:db8::1"},
+			expectedNodeExternalIPs: []string{"1.2.3.4"},
 		},
 		// Azure (and other drivers that only populate Driver.IPAddress with no PrivateIPAddress):
 		// node-ip and node-external-ip must both remain unset when there is no internal IP.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- https://github.com/rancher/rancher/issues/54944  

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When provisioning a downstream RKE2 cluster using the node driver with an **IPv6-first dual-stack** configuration, cluster creation fails due to a kube-apiserver validation error:

```text
service IP family "2001:cafe:43::/112" must match public address family "10.0.30.114"
```

The root cause is that Rancher populates `node-ip` and `node-external-ip` without preserving the IP family order defined in `service-cidr`.

In most cases, the generated node configuration looks like:

```json
"node-ip": [
  "10.0.30.114",
  "2600:1f13:290:5b01:606f:90de:7677:37f2"
]
```

However, when the cluster is configured with an IPv6-first service CIDR such as:

```yaml
service-cidr: 2001:cafe:43::/112,10.43.0.0/16
```

the kube-apiserver expects the primary node address to also be IPv6. Because the IPv4 address is listed first in `node-ip`, the kube-apiserver detects an IP family mismatch and fails validation for the primary service IP family, preventing the cluster from provisioning successfully.

See the code at https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/validation.go#L111-L128 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Order node-ip and node-external-ip to match the primary IP family of user-provided service-cidr, preventing kube-apiserver startup error: service IP family "X" must match public address family "Y". 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The changes are validated on the image built from the branch. 

Following the steps in the issue, Rancher is installed on a dual-stack k3s cluster. AWS node-driver is used to validate the following cases:
- IPv4-first dual-stack cluster
- IPv6-first dual-stack cluster
- IPv4 single-stack cluster 
- IPv6 single-stack cluster 



### Automated Testing

Unit tests are added for the new functions. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
1/ Node-driver cluster provisioning of the following cases
- IPv4-first dual-stack cluster
- IPv6-first dual-stack cluster
- IPv4 single-stack cluster 
- IPv6 single-stack cluster 

2/ Upgrading Rancher should not cause the re-provisioning of machines in the existing cluster or break the existing cluster 

 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 

Same areas as above

Existing / newly added automated tests that provide evidence there are no regressions:

n/a 