### PR TITLE
Fix handling non-transient errors in LDAP/AD

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -132,6 +132,9 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 
 	result, err := lConn.Search(search)
 	if err != nil {
+		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == 32 {
+			return nil, &common.NonTransientError{Err: apierror.NewAPIError(validation.NotFound, fmt.Sprintf("%s not found", dn))}
+		}
 		return nil, err
 	}
 

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -132,7 +132,7 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 
 	result, err := lConn.Search(search)
 	if err != nil {
-		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == 32 {
+		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == ldapv3.LDAPResultNoSuchObject {
 			return nil, &common.NonTransientError{Err: apierror.NewAPIError(validation.NotFound, fmt.Sprintf("%s not found", dn))}
 		}
 		return nil, err
@@ -390,7 +390,7 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 
 	result, err := lConn.Search(search)
 	if err != nil {
-		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == 32 {
+		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == ldapv3.LDAPResultNoSuchObject {
 			return nil, &common.NonTransientError{Err: apierror.NewAPIError(validation.NotFound, fmt.Sprintf("%s not found", distinguishedName))}
 		}
 		return nil, apierror.WrapAPIError(errors.Wrapf(err, "server returned error for search %v %v: %v", search.BaseDN, filter, err), validation.ServerError, "Internal server error")

--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers/common"

--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers/common"

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -551,7 +551,10 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 
 	result, err := lConn.Search(searchRequest)
 	if err != nil {
-		return nil, errors.New("no access")
+		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == 32 {
+			return nil, &common.NonTransientError{Err: httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("%s not found", distinguishedName))}
+		}
+		return nil, fmt.Errorf("ldap search error for %s: %w", distinguishedName, err)
 	}
 
 	if nEntries := len(result.Entries); nEntries < 1 {

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -338,7 +338,7 @@ func (p *ldapProvider) getPrincipal(distinguishedName string, scope string, conf
 
 	result, err := lConn.Search(search)
 	if err != nil {
-		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == 32 {
+		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == ldapv3.LDAPResultNoSuchObject {
 			return nil, &common.NonTransientError{Err: httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("%s not found", distinguishedName))}
 		}
 		return nil, httperror.WrapAPIError(errors.Wrapf(err, "server returned error for search %s %s: %v", search.BaseDN, filter, err), httperror.ServerError, "Internal server error")
@@ -551,7 +551,7 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 
 	result, err := lConn.Search(searchRequest)
 	if err != nil {
-		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == 32 {
+		if ldapErr, ok := err.(*ldapv3.Error); ok && ldapErr.ResultCode == ldapv3.LDAPResultNoSuchObject {
 			return nil, &common.NonTransientError{Err: httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("%s not found", distinguishedName))}
 		}
 		return nil, fmt.Errorf("ldap search error for %s: %w", distinguishedName, err)


### PR DESCRIPTION
## Issue: #49932 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
LDAP's RefetchGroupPrincipals returned a generic "no access" error for all search failures, including when a user was deleted (LDAP result code 32). The provider refresh treated "no access" as "user gone" and immediately deleted login tokens, logging the user out — but never applied the non-transient error annotation since the error wasn't wrapped as NonTransientError. 
The same issue existed in Active Directory's RefetchGroupPrincipals. AD didn't cause logout (the raw error hit the safe errorConfirmingLogins path), but the annotation was never applied either.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Now it's detected and wrapped the same way getPrincipal already does, so the controller annotates the UserAttribute and stops requeuing. Other LDAP errors (network issues, timeouts) now return a proper wrapped error instead of the "no access", so transient failures no longer cause immediate logout.
- Fixed the same way for AD.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
