### PR TITLE
[backport 2.14] refactor how autoscaler controller handles mapping k8s version -> chart values for 1.35

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -6,7 +6,3 @@ cspAdapterMinVersion: 109.0.0+up9.0.0
 defaultShellVersion: rancher/shell:v0.7.0
 fleetVersion: 109.0.1+up0.15.1
 defaultSccOperatorImage: rancher/scc-operator:v0.4.0
-# NOTE: when updating this version, you will also need to update the hardcoded
-# k8s minor <-> image tag mapping in pkg/controllers/capr/autoscaler/fleet.go (imageTagVersions variable).
-# if adding support for a new k8s minor release (e.g. new rancher release)
-clusterAutoscalerChartVersion: 9.50.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,12 +3,11 @@
 package buildconfig
 
 const (
-	ClusterAutoscalerChartVersion = "9.50.1"
-	CspAdapterMinVersion          = "109.0.0+up9.0.0"
-	DefaultSccOperatorImage       = "rancher/scc-operator:v0.4.0"
-	DefaultShellVersion           = "rancher/shell:v0.7.0"
-	FleetVersion                  = "109.0.1+up0.15.1"
-	RemoteDialerProxyVersion      = "109.0.2+up0.7.2"
-	TurtlesVersion                = "109.0.2+up0.26.2-rc.0"
-	WebhookVersion                = "109.0.1+up0.10.4"
+	CspAdapterMinVersion     = "109.0.0+up9.0.0"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.4.0"
+	DefaultShellVersion      = "rancher/shell:v0.7.0"
+	FleetVersion             = "109.0.1+up0.15.1"
+	RemoteDialerProxyVersion = "109.0.2+up0.7.2"
+	TurtlesVersion           = "109.0.2+up0.26.2-rc.0"
+	WebhookVersion           = "109.0.1+up0.10.4"
 )

--- a/pkg/controllers/capr/autoscaler/fleet.go
+++ b/pkg/controllers/capr/autoscaler/fleet.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/docker/distribution/reference"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/rancher/rancher/pkg/buildconfig"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -18,18 +17,35 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 )
 
-// hardcoded k8s minor <-> image tag mapping, adding new versions here will automatically
-// rollout updates to all clusters on rancher upgrade (e.g. setting a new minor version)
-//
-// NOTE: When updating the chart version in build.yaml you will need to update this mapping
-// if adding support for a new minor k8s version
-var imageTagVersions = map[int]string{
-	// using 1.34 version for 1.35 temporarily - in order to not reqiure a new chart version
-	35: "1.34.0-3.4",
-	34: "1.34.0-3.4",
-	33: "1.33.0-3.3",
-	32: "1.32.3-1.5",
+type k8sToAutoscalerVersion struct {
+	imageTag     string
+	chartVersion string
 }
+
+// hardcoded k8s minor <-> imageTag tag + chartVersion version mapping, adding new versions here will automatically
+// rollout updates to all clusters on rancher upgrade (e.g. setting a new minor version for imageTag or chartVersion)
+var k8sVersionToAutoscalerChartVersions = map[int]*k8sToAutoscalerVersion{
+	35: {
+		imageTag:     "1.35.0-4.1",
+		chartVersion: "9.56.0",
+	},
+	34: {
+		imageTag:     "1.34.0-3.4",
+		chartVersion: "9.50.1",
+	},
+	33: {
+		imageTag:     "1.33.0-3.3",
+		chartVersion: "9.50.1",
+	},
+	32: {
+		imageTag:     "1.32.3-1.5",
+		chartVersion: "9.50.1",
+	},
+}
+
+// this is a default value - so we never actually fall back to what is in the chart. this ensures
+// that we're running a vetted image that exists in the prime registry
+var defaultChartVersionConfigs = k8sVersionToAutoscalerChartVersions[34]
 
 // ensureFleetHelmOp creates or updates a Helm operation for cluster autoscaler.
 // one key parameter here is the kubeconfigVersion which is legitimately just involved to
@@ -46,7 +62,7 @@ func (h *autoscalerHandler) ensureFleetHelmOp(cluster *capi.Cluster, kubeconfigV
 				DefaultNamespace: "kube-system",
 				Helm: &fleet.HelmOptions{
 					Chart:       getChartName(),
-					Version:     buildconfig.ClusterAutoscalerChartVersion,
+					Version:     h.chartVersionsForCluster(cluster).chartVersion,
 					Repo:        settings.ClusterAutoscalerChartRepository.Get(),
 					ReleaseName: "cluster-autoscaler",
 					Values: &fleet.GenericMap{
@@ -106,15 +122,22 @@ func (h *autoscalerHandler) ensureFleetHelmOp(cluster *capi.Cluster, kubeconfigV
 	return err
 }
 
-// resolveImageTagVersion returns the cluster-autoscaler image version for cluster autoscaler based on the Kubernetes minor version of the cluster.
-func (h *autoscalerHandler) resolveImageTagVersion(cluster *capi.Cluster) string {
-	minorVersion := h.getKubernetesMinorVersion(cluster)
-	version, exists := imageTagVersions[minorVersion]
-	if !exists || version == "" {
-		logrus.Debugf("[autoscaler] no chart version found for kubernetes minor version %d - latest version of cluster-autoscaler chart will be installed", minorVersion)
-		return ""
+func (h *autoscalerHandler) chartVersionsForCluster(cluster *capi.Cluster) *k8sToAutoscalerVersion {
+	v := h.getKubernetesMinorVersion(cluster)
+	versions, ok := k8sVersionToAutoscalerChartVersions[v]
+	if !ok {
+		logrus.Warnf(
+			"[autoscaler] no chart versions found for cluster %s/%s with kubernetes minor=%d, using default chartVersion=%s imageTag=%s",
+			cluster.Namespace,
+			cluster.Name,
+			v,
+			defaultChartVersionConfigs.chartVersion,
+			defaultChartVersionConfigs.imageTag,
+		)
+		return defaultChartVersionConfigs
 	}
-	return version
+
+	return versions
 }
 
 // getChartImageSettings returns a map of the image settings to pass to the chart, this is based on the kubernetes minor version
@@ -146,13 +169,12 @@ func (h *autoscalerHandler) getChartImageSettings(cluster *capi.Cluster) map[str
 		"registry":   registry,
 	}
 
-	// this handles if we don't have a specific validated tag for the given k8s version - fall back to
-	// the default helm chart tag OR whatever was set on the image (if present)
-	configuredTag := h.resolveImageTagVersion(cluster)
-	if configuredTag != "" {
-		imageSettings["tag"] = configuredTag
-	} else if isTagged { // tag defaults to latest if not set
+	// this handles if the image setting was set with a tag - we just use that
+	// instead of the hardcoded version for the k8s version
+	if isTagged {
 		imageSettings["tag"] = tag.Tag()
+	} else {
+		imageSettings["tag"] = h.chartVersionsForCluster(cluster).imageTag
 	}
 
 	return imageSettings

--- a/pkg/controllers/capr/autoscaler/fleet_test.go
+++ b/pkg/controllers/capr/autoscaler/fleet_test.go
@@ -7,7 +7,6 @@ import (
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	rke "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
-	"github.com/rancher/rancher/pkg/buildconfig"
 	"github.com/rancher/rancher/pkg/settings"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -221,7 +220,7 @@ func (s *autoscalerSuite) TestEnsureFleetHelmOp_HappyPath_NoUpdateNeeded() {
 					DefaultNamespace: "kube-system",
 					Helm: &fleet.HelmOptions{
 						Chart:       getChartName(),
-						Version:     buildconfig.ClusterAutoscalerChartVersion,
+						Version:     s.h.chartVersionsForCluster(cluster).chartVersion,
 						Repo:        settings.ClusterAutoscalerChartRepository.Get(),
 						ReleaseName: "cluster-autoscaler",
 						Values: &fleet.GenericMap{
@@ -269,21 +268,11 @@ func (s *autoscalerSuite) TestResolveImageTagVersion_HappyPath_KnownVersion() {
 
 	s.setupClientForControlPlane("rke.cattle.io/v1", "RKEControlPlane", "v1.34.0+k3s1", true)
 
-	result := s.h.resolveImageTagVersion(cluster)
-	s.Equal("1.34.0-3.4", result)
+	result := s.h.chartVersionsForCluster(cluster)
+	s.Equal("1.34.0-3.4", result.imageTag)
 }
 
 func (s *autoscalerSuite) TestResolveImageTagVersion_EdgeCase_UnknownVersion() {
-	// Temporarily modify the imageTagVersions map to test unknown version
-	originalMap := imageTagVersions
-	imageTagVersions = map[int]string{
-		99: "1.99.0-9.9", // Use a version that's not in the original map
-	}
-
-	defer func() {
-		imageTagVersions = originalMap // Restore original map
-	}()
-
 	cluster := &capi.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
@@ -291,8 +280,8 @@ func (s *autoscalerSuite) TestResolveImageTagVersion_EdgeCase_UnknownVersion() {
 		},
 	}
 
-	result := s.h.resolveImageTagVersion(cluster)
-	s.Equal("", result) // Should return empty string for unknown version
+	result := s.h.chartVersionsForCluster(cluster)
+	s.Equal(defaultChartVersionConfigs.imageTag, result.imageTag)
 }
 
 // Test cases for getChartImageSettings method

--- a/tests/v2prov/tests/autoscaler/autoscaling_provisioning_test.go
+++ b/tests/v2prov/tests/autoscaler/autoscaling_provisioning_test.go
@@ -1,0 +1,234 @@
+package autoscaler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/tests/v2prov/clients"
+	"github.com/rancher/rancher/tests/v2prov/cluster"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
+	"github.com/rancher/rancher/tests/v2prov/operations"
+	"github.com/rancher/rancher/tests/v2prov/wait"
+	"github.com/rancher/wrangler/v3/pkg/name"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+func Test_Autoscaling_Provisioning(t *testing.T) {
+	// this test only works if autoscaling is enabled and set up properly
+	if !features.ClusterAutoscaling.Enabled() {
+		t.Skip()
+	}
+
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		workerPoolConfig provisioningv1.RKEMachinePool
+		addLoad          bool
+	}{
+		{
+
+			// scale-up provisions a cluster with autoscaling enabled on the worker pool,
+			// deploys resource-intensive pods to the downstream cluster to trigger pending pods, and verifies the
+			// cluster-autoscaler adds new worker nodes.
+			name: "scale-up",
+			workerPoolConfig: provisioningv1.RKEMachinePool{
+				Name:               "scale-up-workers",
+				WorkerRole:         true,
+				Quantity:           &defaults.One,
+				AutoscalingMinSize: &defaults.One,
+				AutoscalingMaxSize: &defaults.Three,
+			},
+			addLoad: true,
+		},
+		{
+
+			// scale-down provisions a cluster with an oversized worker pool
+			// (Quantity=3 with min=1), then waits for the autoscaler to detect underutilization and scale
+			// the worker pool down. waits a maximum of 15 minutes to exceed the default 10-minute scale-down-unneeded-time.
+			name: "scale-down",
+			workerPoolConfig: provisioningv1.RKEMachinePool{
+				Name:               "scale-down-workers",
+				WorkerRole:         true,
+				Quantity:           &defaults.Three,
+				AutoscalingMinSize: &defaults.One,
+				AutoscalingMaxSize: &defaults.Three,
+			},
+			addLoad: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := clients.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
+
+			c, err := cluster.New(client, &provisioningv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "autoscaler-" + tt.name,
+				},
+				Spec: provisioningv1.ClusterSpec{
+					KubernetesVersion: defaults.SomeK8sVersion,
+					RKEConfig: &provisioningv1.RKEConfig{
+						MachinePools: []provisioningv1.RKEMachinePool{
+							{
+								Name:             "cp-etcd",
+								EtcdRole:         true,
+								ControlPlaneRole: true,
+								WorkerRole:       true,
+								Quantity:         &defaults.One,
+							},
+							tt.workerPoolConfig,
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			c, err = cluster.WaitForCreate(client, c)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			initialMachines, err := cluster.Machines(client, c)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			kc, err := operations.GetAndVerifyDownstreamClientset(client, c)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait for the cluster-autoscaler HelmOp to deploy successfully before creating load.
+			err = waitForAutoscalerDeployment(client, name.SafeConcatName("autoscaler", c.Namespace, c.Name), c.Namespace)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log("cluster-autoscaler deployment is ready")
+
+			if tt.addLoad {
+				deployLoadPods(t, kc)
+			}
+
+			err = waitForMachinePoolScaling(t, client, c, func(count int) bool {
+				// if we added load -> we're expecting machines to be added
+				if tt.addLoad {
+					return count > len(initialMachines.Items)
+				}
+
+				// otherwise, reduced
+				return count < len(initialMachines.Items)
+			}, 20*time.Minute)
+			if err != nil {
+				t.Fatalf("autoscaler did not scale in time: %v", err)
+			}
+
+			err = cluster.EnsureMinimalConflictsWithThreshold(client, c, cluster.SaneConflictMessageThreshold)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// waitForMachinePoolScaling polls the machine count for a cluster until the given condition
+// function returns true or the timeout expires.
+func waitForMachinePoolScaling(t *testing.T, client *clients.Clients, c *provisioningv1.Cluster, condition func(int) bool, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		machines, err := cluster.Machines(client, c)
+		if err != nil {
+			t.Logf("error listing machines: %v", err)
+		} else {
+			count := len(machines.Items)
+			t.Logf("current machine count: %d", count)
+			if condition(count) {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for machine count condition after %v", timeout)
+		}
+		time.Sleep(30 * time.Second)
+	}
+}
+
+// waitForAutoscalerDeployment waits for the appropriate downstream autoscaler helmop to be "Ready" before adding load to the cluster
+func waitForAutoscalerDeployment(client *clients.Clients, name, namespace string) error {
+	// watch helmops - once the expected name becomes ready return
+	return wait.Object(client.Ctx, client.Fleet.HelmOp().Watch, &fleet.HelmOp{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}, func(obj runtime.Object) (bool, error) {
+		helmop := obj.(*fleet.HelmOp)
+		if helmop.Status.Summary.DesiredReady == 0 {
+			return false, nil
+		}
+
+		return helmop.Status.Summary.Ready == helmop.Status.Summary.DesiredReady, nil
+	})
+}
+
+// deployLoadPods creates a deployment with resource-intensive pods in the downstream cluster.
+// The pods request enough resources that they cannot all fit on a single worker node, causing
+// some to enter Pending state and triggering the cluster-autoscaler to scale up.
+func deployLoadPods(t *testing.T, kc *kubernetes.Clientset) {
+	replicas := int32(1000)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "autoscaler-load-test",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "autoscaler-load-test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "autoscaler-load-test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "busybox",
+							Command: []string{"sleep", "infinity"},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := retry.OnError(defaults.DownstreamRetry, func(error) bool { return true }, func() error {
+		_, err := kc.AppsV1().Deployments("default").Create(context.TODO(), deploy, metav1.CreateOptions{})
+		return err
+	})
+	if err != nil {
+		t.Fatalf("failed to create load deployment: %v", err)
+	}
+	t.Log("deployed load pods to trigger autoscaler scale-up")
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54937

This is a backport of #54891 