### PR TITLE
fix: Add the cluster ID to the import URL

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/import.go
+++ b/pkg/controllers/provisioningv2/cluster/import.go
@@ -66,10 +66,10 @@ func (h *handler) deployAgent(cluster *v1.Cluster, status v1.ClusterStatus) (boo
 	}
 
 	secretName := fmt.Sprintf("%s-kubeconfig", cluster.Spec.ClusterAPIConfig.ClusterName)
-	return true, h.deploy(cluster, cluster.Namespace, secretName, tokenValue)
+	return true, h.deploy(cluster, cluster.Namespace, secretName, tokenValue, status.ClusterName)
 }
 
-func (h *handler) deploy(cluster *v1.Cluster, secretNamespace, secretName string, token string) error {
+func (h *handler) deploy(cluster *v1.Cluster, secretNamespace, secretName, token, clusterID string) error {
 	secret, err := h.secretCache.Get(secretNamespace, secretName)
 	if apierror.IsNotFound(err) {
 		h.clusters.EnqueueAfter(cluster.Namespace, cluster.Name, 2*time.Second)
@@ -95,7 +95,7 @@ func (h *handler) deploy(cluster *v1.Cluster, secretNamespace, secretName string
 		return err
 	}
 
-	resp, err := httpClient.Get(fmt.Sprintf("%s/v3/import/%s.yaml", serverURL, token))
+	resp, err := httpClient.Get(fmt.Sprintf("%s/v3/import/%s_%s.yaml", serverURL, token, clusterID))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue: #54921

## Forward-port note
This is a forward-port to `main` of #54922 (which targets `release/v2.10`). The same defect is present on `main`; the only behavioral difference is the HTTP status returned by the server (see below), because the unauthenticated route in `pkg/multiclustermanager/routes.go` was tightened on `main` to filter on the `{token}_{clusterId}.yaml` filename pattern instead of falling through.

## Problem

`pkg/controllers/provisioningv2/cluster/import.go`'s `deploy()` builds the HTTP URL for fetching the agent import YAML without the `_{clusterId}` suffix. 

```go
// deployAgent calls deploy() without forwarding status.ClusterName.
func (h *handler) deployAgent(cluster *v1.Cluster, status v1.ClusterStatus) (bool, error) {
    // ...
    secretName := fmt.Sprintf("%s-kubeconfig", cluster.Spec.ClusterAPIConfig.ClusterName)
    return true, h.deploy(cluster, cluster.Namespace, secretName, tokenValue) // <-- clusterID lost
}

// deploy() has no clusterID parameter, builds the URL without "_<clusterID>",
// and never inspects resp.StatusCode before parsing the body as YAML.
func (h *handler) deploy(cluster *v1.Cluster, secretNamespace, secretName string, token string) error {
    // ...
    resp, err := httpClient.Get(fmt.Sprintf("%s/v3/import/%s.yaml", serverURL, token)) // <-- missing _<clusterID>
    if err != nil {
        return err
    }
    defer resp.Body.Close()

    objs, err := yaml.ToObjects(resp.Body) // <-- no status check; 404/401 body parsed as YAML
    // ...
}
```

The URL `/v3/import/<token>.yaml` does not match the unauthenticated route registered in `pkg/multiclustermanager/routes.go`, which on `main` is:

```go
unauthed.HandleFunc("/v3/import/{filename}", func(w http.ResponseWriter, r *http.Request) {
    filename := r.PathValue("filename")
    // Match pattern: {token}_{clusterId}.yaml
    if strings.Contains(filename, "_") && strings.HasSuffix(filename, ".yaml") {
        clusterImport.ClusterImportHandler(w, r)
    } else {
        http.NotFound(w, r)
    }
})
```

A filename without `_` is rejected by this handler and returns **404 Not Found** (on `release/v2.10` the equivalent request falls through to the authenticated `/v3/*` wildcard and returns **401 Unauthorized**; the underlying client-side bug is identical).

Observable consequences:

1. `cattle-cluster-agent` is never deployed for clusters created via `provisioning.cattle.io/v1 cluster` with `spec.clusterAPIConfig` set (CAPI-type imported clusters).
2. The 404 (or 401, depending on branch) response body is passed to `yaml.ToObjects()` with no HTTP status check, producing a misleading error in Rancher Server logs of the form:

```
[ERROR] error syncing 'fleet-default/downstream': handler cluster-create: Object 'Kind' is missing in '...', requeuing
```

Root cause:

- `deploy()` did not accept a `clusterID` argument.
- The caller `deployAgent()` did not forward `status.ClusterName` (which holds the v3 management cluster ID, e.g. `c-m-xxxxx`).
- The HTTP response body was consumed without checking `resp.StatusCode`, masking server-side errors as YAML parse failures.

## Solution

Three minimal changes, all confined to `pkg/controllers/provisioningv2/cluster/import.go`:

1. `deployAgent()` forwards `status.ClusterName` into `deploy()`.
2. `deploy()`'s signature gains a `clusterID` parameter.
3. The URL is built as `/v3/import/<token>_<clusterID>.yaml` to match the unauthenticated route.

No other code paths change. The `v3 clusterdeploy` controller (in-memory YAML via `systemtemplate.SystemTemplate()`) and the CAPR planner path (RKE2 / K3s) are unaffected. No routing or authentication changes.

## Testing

The repro steps in the linked issue are valid and reproduce on Rancher built from `main` (verified locally) as well as on v2.10.3.

## Engineering Testing

### Manual Testing

1. Built a Rancher Server image from `main` with the patch applied and deployed it via Helm to a local cluster.
2. Created a `provisioning.cattle.io/v1 Cluster` with `spec.clusterAPIConfig.clusterName` set and the corresponding kubeconfig Secret.
3. Verified from server logs that the controller now requests `/v3/import/<token>_<clusterId>.yaml` and receives a 200 response.
4. Confirmed `cattle-cluster-agent` is deployed on the downstream cluster and the previous `Object 'Kind' is missing...` error no longer appears.

### Automated Testing

* Test types added/modified:
  * None
* If "None" - Reason: No application logic is modified by this change.
* If "None" - GH Issue/PR: N/A

## QA Testing Considerations

- Fresh install: Create a downstream CAPI cluster via `provisioning.cattle.io/v1` with `spec.clusterAPIConfig` + kubeconfig Secret. Verify `cattle-cluster-agent` is deployed automatically on the downstream cluster.
- Upgrade: Upgrade a Rancher installation that already has a stuck CAPI cluster (agent never deployed because of this bug). After upgrade, the controller should succeed on the next reconcile and deploy the agent without requiring any user action.
- Non-CAPI paths (should behave exactly as before):
  - Manual import (user applies agent YAML themselves) — unaffected.
  - RKE2 / K3s provisioning (CAPR planner) — unaffected.
  - v3 clusterdeploy path (in-memory `systemtemplate.SystemTemplate()`) — unaffected.
- Check Rancher server logs for any failed to fetch import YAML messages and confirm they are accompanied by actionable HTTP status codes (no more `Object 'Kind' is missing...`).

### Regressions Considerations

Risk is **low**:

- Change is confined to a single function in one file (`pkg/controllers/provisioningv2/cluster/import.go`).
- Only callers exercising the CAPI path (`spec.clusterAPIConfig` set) reach `deploy()`.
- The new URL format matches the unauthenticated route that already exists in `pkg/multiclustermanager/routes.go`; no routing or auth changes.

Existing / newly added automated tests that provide evidence there are no regressions:

- Existing unit test `pkg/controllers/provisioningv2/controller_test.go` continues to pass.