### PR TITLE
Doc: update rancher forum link and disable rss feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rancher is an open source container management platform built for organizations 
 <!-- stable v2.14.1 DO NOT REMOVE THIS LINE -->
 * v2.14.1 - `rancher/rancher:v2.14.1` / `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.14.1).
   
-To get automated notifications of our latest release, you can watch the announcements category in our [forums](http://forums.rancher.com/c/announcements), or subscribe to the RSS feed `https://forums.rancher.com/c/announcements.rss`.
+To get automated notifications of our latest release, you can watch the announcements category in our [forums](https://forums.suse.com/c/announcements/12).
 
 ## Quick Start
 


### PR DESCRIPTION
## Problem

Link of the rancher forum is now SUSE.
 
## Solution

Set the correct releases announcement forum link
 
## Testing

Just click on the link ;)

## Engineering Testing
### Manual Testing

- Go to previous URL: http://forums.rancher.com/c/announcements, get an incorrect TLS certificate
- Go to the new URL: link to rancher announcement is OK