### PR TITLE
feat: add support for skipSchemaValidation in Helm operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/rancher/rancher/pkg/plan v0.0.0-20260428222332-2696373f4152
 	github.com/rancher/remotedialer v0.6.1
 	github.com/rancher/remotedialer-proxy v0.8.0-rc.5
-	github.com/rancher/shepherd v0.0.0-20260602170443-db6955599de5
+	github.com/rancher/shepherd v0.0.0-20260602172829-e4b85e4732d5
 	github.com/rancher/steve v0.9.12
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8
 	github.com/rancher/wrangler/v3 v3.7.0

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/rancher/remotedialer-proxy v0.8.0-rc.5 h1:22cdanfJa8OeBhbiZVixgnQOWmU
 github.com/rancher/remotedialer-proxy v0.8.0-rc.5/go.mod h1:UbCeDnl3rtedAEvBp1PJc3itP26jSm3SYbaEw5SqKVw=
 github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHRkGaJ5v0=
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
-github.com/rancher/shepherd v0.0.0-20260602170443-db6955599de5 h1:RnqrzSOR45jW0wDsbh/4EZ43aRJf2kClJ3aEvG74NYA=
-github.com/rancher/shepherd v0.0.0-20260602170443-db6955599de5/go.mod h1:s0+3Z0LuHCQIBKJ2tsvd5HULR55MTOslcpzFMt7xmnE=
+github.com/rancher/shepherd v0.0.0-20260602172829-e4b85e4732d5 h1:vSX77PC/zY6P9VKruIVv8zd7XXC49/+eB3bWoFdmemU=
+github.com/rancher/shepherd v0.0.0-20260602172829-e4b85e4732d5/go.mod h1:s0+3Z0LuHCQIBKJ2tsvd5HULR55MTOslcpzFMt7xmnE=
 github.com/rancher/steve v0.9.12 h1:i/jtndyK9a+P8JzIqq3l5pEWV4QlkQQKezG/vtdoehU=
 github.com/rancher/steve v0.9.12/go.mod h1:9zO5/VrBX43g1uB9L0CPJtZa1ObhezWrr791l/k9pHA=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=

--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -40,6 +40,7 @@ type ChartInstallAction struct {
 	Wait                     bool                `json:"wait,omitempty"`
 	DisableHooks             bool                `json:"noHooks,omitempty"`
 	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	SkipSchemaValidation     bool                `json:"skipSchemaValidation,omitempty"`
 	Namespace                string              `json:"namespace,omitempty"`
 	ProjectID                string              `json:"projectId,omitempty"`
 	OperationTolerations     []corev1.Toleration `json:"operationTolerations,omitempty"`
@@ -72,6 +73,7 @@ type ChartUpgradeAction struct {
 	Wait                     bool                `json:"wait,omitempty"`
 	DisableHooks             bool                `json:"noHooks,omitempty"`
 	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	SkipSchemaValidation     bool                `json:"skipSchemaValidation,omitempty"`
 	Force                    bool                `json:"force,omitempty"`
 	TakeOwnership            bool                `json:"takeOwnership,omitempty"`
 	MaxHistory               int                 `json:"historyMax,omitempty"`

--- a/pkg/catalogv2/helmop/operation_test.go
+++ b/pkg/catalogv2/helmop/operation_test.go
@@ -100,6 +100,26 @@ func Test_Render(t *testing.T) {
 			},
 			failMsg: "uninstall test case failed",
 		},
+		{
+			commands: Commands{
+				Command{
+					Operation:   "install",
+					ChartFile:   "test-chart-v1.1.0.tgz",
+					Chart:       []byte("test-chart"),
+					ReleaseName: "test6",
+					ArgObjects: []interface{}{
+						map[string]interface{}{
+							"skipSchemaValidation": true,
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"operation000":          []byte(strings.Join([]string{"install", "--skip-schema-validation=true", "test6", "/home/shell/helm/test-chart-v1.1.0.tgz"}, "\x00")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "skip schema validation test case failed",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/v2/integration/catalogv2/charts_test.go
+++ b/tests/v2/integration/catalogv2/charts_test.go
@@ -733,6 +733,116 @@ func (w *ChartsTest) TestUninstallChartWithCustomTolerationOnTaintedCPNode() {
 	w.updateTaintOnNode(ctx, taint, taints.RemoveTaint)
 }
 
+// TestInstallChartWithSkipSchemaValidation tests the installation of a chart with skipSchemaValidation enabled
+func (w *ChartsTest) TestInstallChartWithSkipSchemaValidation() {
+	ctx := context.Background()
+
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		SkipSchemaValidation:     true,
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(ctx, metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	w.Require().Contains(op.Status.Command, "--skip-schema-validation=true")
+
+	//uninstall chart
+	w.Require().NoError(w.catalogClient.UninstallChart("rancher-aks-operator-crd", namespace.System, &types.ChartUninstallAction{
+		DisableHooks: false,
+		Timeout:      &metav1.Duration{Duration: 60 * time.Second},
+	}))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusUninstalled, "rancher-aks-operator-crd", 1))
+}
+
+// TestUpgradeChartWithSkipSchemaValidation tests the upgrade of a chart with skipSchemaValidation enabled
+func (w *ChartsTest) TestUpgradeChartWithSkipSchemaValidation() {
+	ctx := context.Background()
+
+	// Install initial version of the chart
+	w.Require().NoError(w.catalogClient.InstallChart(&types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		Charts: []types.ChartInstall{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 0))
+
+	// Upgrade the chart with SkipSchemaValidation set to true
+	w.Require().NoError(w.catalogClient.UpgradeChart(&types.ChartUpgradeAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 60 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace.System,
+		DisableOpenAPIValidation: false,
+		SkipSchemaValidation:     true,
+		Charts: []types.ChartUpgrade{{
+			ChartName:   "rancher-aks-operator-crd",
+			Version:     "104.0.2+up1.9.0",
+			ReleaseName: "rancher-aks-operator-crd",
+			Description: "rancher aks operator crd upgrade",
+		}},
+	}, "charts-small-fork"))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusDeployed, "rancher-aks-operator-crd", 1))
+
+	operationList, err := w.catalogClient.Operations(namespace.System).List(ctx, metav1.ListOptions{})
+	w.Require().NoError(err)
+	sort.Slice(operationList.Items, func(i, j int) bool {
+		return !operationList.Items[i].CreationTimestamp.Before(&operationList.Items[j].CreationTimestamp)
+	})
+
+	var op rv1.Operation
+	for _, item := range operationList.Items {
+		if item.Status.Release == "rancher-aks-operator-crd" {
+			op = item
+			break
+		}
+	}
+
+	w.Require().Contains(op.Status.Command, "--skip-schema-validation=true")
+
+	//uninstall chart
+	w.Require().NoError(w.catalogClient.UninstallChart("rancher-aks-operator-crd", namespace.System, &types.ChartUninstallAction{
+		DisableHooks: false,
+		Timeout:      &metav1.Duration{Duration: 60 * time.Second},
+	}))
+
+	w.Require().NoError(w.waitForChart(rv1.StatusUninstalled, "rancher-aks-operator-crd", 2))
+}
+
 func (w *ChartsTest) waitForChart(status rv1.Status, name string, previousVersion int) error {
 	var app *rv1.App
 	err := kwait.Poll(500*time.Millisecond, 360*time.Second, func() (done bool, err error) {


### PR DESCRIPTION
This change adds the SkipSchemaValidation field to the ChartInstallAction and ChartUpgradeAction structs, allowing users to bypass Helm schema validation during app installation and upgrade. This is particularly useful in air-gapped environments.

Ref: https://github.com/rancher/terraform-provider-rancher2/issues/1959
