### PR TITLE
fix(oidc): fallback group claims to userinfo

### DIFF
--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -560,8 +560,38 @@ func (o *OpenIDCProvider) getUserInfoFromAuthCode(rw http.ResponseWriter, req *h
 	if err != nil {
 		return userInfo, oauth2Token, "", err
 	}
+	if err := mergeGroupsFromUserInfo(userInfo, claimInfo); err != nil {
+		return userInfo, oauth2Token, "", err
+	}
 
 	return userInfo, oauth2Token, rawIDToken, nil
+}
+
+func mergeGroupsFromUserInfo(userInfo *oidc.UserInfo, claimInfo *ClaimInfo) error {
+	if userInfo == nil || claimInfo == nil {
+		return nil
+	}
+
+	// Keep ID token/custom claim values authoritative and only use userinfo as fallback.
+	if claimInfo.Groups != nil && claimInfo.FullGroupPath != nil && claimInfo.Roles != nil {
+		return nil
+	}
+
+	var userInfoClaims ClaimInfo
+	if err := userInfo.Claims(&userInfoClaims); err != nil {
+		return err
+	}
+	if claimInfo.Groups == nil {
+		claimInfo.Groups = userInfoClaims.Groups
+	}
+	if claimInfo.FullGroupPath == nil {
+		claimInfo.FullGroupPath = userInfoClaims.FullGroupPath
+	}
+	if claimInfo.Roles == nil {
+		claimInfo.Roles = userInfoClaims.Roles
+	}
+
+	return nil
 }
 
 func (o *OpenIDCProvider) getClaimInfoFromToken(ctx context.Context, config *apiv3.OIDCConfig, token *oauth2.Token, userName string) (*ClaimInfo, error) {

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -150,7 +150,11 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				FullGroupPath: []string{"/admingroup"},
 				Roles:         []string{"adminrole"},
 			},
-			expectedClaimInfo: &ClaimInfo{},
+			expectedClaimInfo: &ClaimInfo{
+				Groups:        []string{"admingroup"},
+				FullGroupPath: []string{"/admingroup"},
+				Roles:         []string{"adminrole"},
+			},
 		},
 		"get groups with GroupsClaims": {
 			config: func(port string) *apiv3.OIDCConfig {
@@ -346,6 +350,61 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 			},
 			expectedClaimInfo: &ClaimInfo{
 				Email: "test.dev@example.com",
+			},
+		},
+		"custom groupsClaim takes precedence over userinfo groups": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.GroupsClaim = "custom:groups"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud":           "test",
+					"exp":           time.Now().Add(5 * time.Minute).Unix(), // expires in the future
+					"iss":           "http://localhost:" + port,
+					"custom:groups": []string{"id-token-group"},
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				assert.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute), // expires in the future
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				"groups": ["userinfo-group"],
+				"full_group_path": ["/userinfo-group"],
+				"roles": ["userinfo-role"]
+              }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject:       "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:        []string{"userinfo-group"},
+				FullGroupPath: []string{"/userinfo-group"},
+				Roles:         []string{"userinfo-role"},
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Groups:        []string{"id-token-group"},
+				FullGroupPath: []string{"/userinfo-group"},
+				Roles:         []string{"userinfo-role"},
 			},
 		},
 	}


### PR DESCRIPTION
Populate groups/full_group_path/roles from userinfo when missing in ID token claims, while preserving ID token custom-claim precedence.

Fixes #54963

This was done entirely by GPT. Feel free to take it, or roll your own implementation, I just wanted to point out that the fix in this branch seems to work for our case, with a custom OIDC provider.

## Issue: #54963
 
## Problem

The problem in our case was that OIDC groups would not show up in the UI, nor in the Kube token, except for the very first time an account logs in. Afterwards (logout & log back in), the groups were gone from both the Rancher UI and the corresponding Kubernetes token.
 
## Solution

This change attempts to do a merge, taking groups coming from the userinfo endpoint, but preferring the ID token values on conflict.
 
## Testing

There is an added test case, but I also rolled this out in our on-prem cluster and it seems to be working fine (built from this branch).

## Engineering Testing
### Manual Testing

Sign in with an OIDC user, check if it is e.g. possible to assign a member to a group, or a global role, using the dropdown (group names should be populated). Sign out & back in, it should still work.

`kubectl auth whoami` should also include the groups.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Populate OIDC groups from userinfo endpoint

## QA Testing Considerations

See the Manual Testing section above
 
### Regressions Considerations

What I did not check is how this change interacts with a list of groups also being present in the ID token. In our case groups are only present in the userinfo payload.

Existing / newly added automated tests that provide evidence there are no regressions:

See the updated unit tests.