### PR TITLE
Set the advertise-address based on primary ip family

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -578,8 +578,8 @@ func reorderAddressesByFamily(addresses []string, primaryFamily int) []string {
 	return append(append(primary, other...), nonIP...)
 }
 
-// updateConfigWithAdvertiseAddresses sets the advertise-address and tls-san in the config
-// if the non-worker node has different internal and external IPs.
+// updateConfigWithAdvertiseAddresses sets advertise-address and tls-san in the config
+// for non-worker nodes when the configured node-ip and node-external-ip values differ.
 // It reads node-ip and node-external-ip from the config (already ordered by preferred IP family)
 // and uses the first node-ip value as the advertise-address.
 func updateConfigWithAdvertiseAddresses(config map[string]interface{}, info *machineNetworkInfo) {

--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -580,19 +580,23 @@ func reorderAddressesByFamily(addresses []string, primaryFamily int) []string {
 
 // updateConfigWithAdvertiseAddresses sets the advertise-address and tls-san in the config
 // if the non-worker node has different internal and external IPs.
+// It reads node-ip and node-external-ip from the config (already ordered by preferred IP family)
+// and uses the first node-ip value as the advertise-address.
 func updateConfigWithAdvertiseAddresses(config map[string]interface{}, info *machineNetworkInfo) {
-	if isOnlyWorker(info.Entry) || len(info.InternalAddresses) == 0 || len(info.ExternalAddresses) == 0 {
+	nodeIPs := convert.ToStringSlice(config["node-ip"])
+	nodeExternalIPs := convert.ToStringSlice(config["node-external-ip"])
+	if isOnlyWorker(info.Entry) || len(nodeIPs) == 0 || len(nodeExternalIPs) == 0 {
 		return
 	}
-	internalAddresses := slices.Clone(info.InternalAddresses)
-	externalAddresses := slices.Clone(info.ExternalAddresses)
+	internalAddresses := slices.Clone(nodeIPs)
+	externalAddresses := slices.Clone(nodeExternalIPs)
 	slices.Sort(internalAddresses)
 	slices.Sort(externalAddresses)
 	if !slices.Equal(internalAddresses, externalAddresses) {
-		config["advertise-address"] = info.InternalAddresses[0]
+		config["advertise-address"] = nodeIPs[0]
 
 		tlsSan := convert.ToStringSlice(config["tls-san"])
-		for _, ip := range info.ExternalAddresses {
+		for _, ip := range nodeExternalIPs {
 			if !slices.Contains(tlsSan, ip) {
 				tlsSan = append(tlsSan, ip)
 			}

--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -525,139 +525,125 @@ func TestUpdateConfigWithAdvertiseAddresses(t *testing.T) {
 		expectedConfig map[string]interface{}
 	}{
 		{
-			name:          "control-plane node with different internal and external IPs",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"10.0.0.1"},
-				ExternalAddresses: []string{"192.168.1.1"},
-				Entry:             controlPlaneEntry,
+			name: "control-plane node with different node-ip and node-external-ip",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"10.0.0.1"},
+				"node-external-ip": []string{"192.168.1.1"},
 			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
 			expectAddrSet:  true,
 			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.1", "tls-san": []string{"192.168.1.1"}},
 		},
 		{
-			name:          "control-plane node with same internal and external IPs",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"192.168.1.1"},
-				ExternalAddresses: []string{"192.168.1.1"},
-				Entry:             controlPlaneEntry,
+			name: "control-plane node with same node-ip and node-external-ip",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"192.168.1.1"},
+				"node-external-ip": []string{"192.168.1.1"},
 			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{"node-ip": []string{"192.168.1.1"}, "node-external-ip": []string{"192.168.1.1"}},
+		},
+		{
+			name: "control-plane node with same set of node-ip and node-external-ip in different order",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"192.168.1.1", "192.168.1.2"},
+				"node-external-ip": []string{"192.168.1.2", "192.168.1.1"},
+			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{"node-ip": []string{"192.168.1.1", "192.168.1.2"}, "node-external-ip": []string{"192.168.1.2", "192.168.1.1"}},
+		},
+		{
+			name: "control-plane node with empty node-ip returns early",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{},
+				"node-external-ip": []string{"192.168.1.1"},
+			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{"node-ip": []string{}, "node-external-ip": []string{"192.168.1.1"}},
+		},
+		{
+			name: "control-plane node with empty node-external-ip returns early",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"10.0.0.1"},
+				"node-external-ip": []string{},
+			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
+			expectAddrSet:  false,
+			expectedConfig: map[string]interface{}{"node-ip": []string{"10.0.0.1"}, "node-external-ip": []string{}},
+		},
+		{
+			name:           "control-plane node with absent node-ip returns early",
+			initialConfig:  map[string]interface{}{},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
 			expectAddrSet:  false,
 			expectedConfig: map[string]interface{}{},
 		},
 		{
-			name:          "control-plane node with same set of internal and external IPs",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"192.168.1.1", "192.168.1.2"},
-				ExternalAddresses: []string{"192.168.1.2", "192.168.1.1"},
-				Entry:             controlPlaneEntry,
+			name: "worker-only node should be skipped",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"10.0.0.1"},
+				"node-external-ip": []string{"192.168.1.1"},
 			},
+			info:           &machineNetworkInfo{Entry: workerEntry},
 			expectAddrSet:  false,
-			expectedConfig: map[string]interface{}{},
+			expectedConfig: map[string]interface{}{"node-ip": []string{"10.0.0.1"}, "node-external-ip": []string{"192.168.1.1"}},
 		},
 		{
-			name:          "control-plane node with no internal IP",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{},
-				ExternalAddresses: []string{"192.168.1.1"},
-				Entry:             controlPlaneEntry,
+			name: "control-plane node with multiple different IPs uses first node-ip",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"10.0.0.2", "10.0.0.1"},
+				"node-external-ip": []string{"192.168.1.2", "192.168.1.1"},
 			},
-			expectAddrSet:  false,
-			expectedConfig: map[string]interface{}{},
-		},
-		{
-			name:          "control-plane node with no external IP",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"10.0.0.1"},
-				ExternalAddresses: []string{},
-				Entry:             controlPlaneEntry,
-			},
-			expectAddrSet:  false,
-			expectedConfig: map[string]interface{}{},
-		},
-		{
-			name:          "control-plane node with no internal or external IPs",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{},
-				ExternalAddresses: []string{},
-				Entry:             controlPlaneEntry,
-			},
-			expectAddrSet:  false,
-			expectedConfig: map[string]interface{}{},
-		},
-		{
-			name:          "worker-only node should be skipped",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"10.0.0.1"},
-				ExternalAddresses: []string{"192.168.1.1"},
-				Entry:             workerEntry,
-			},
-			expectAddrSet:  false,
-			expectedConfig: map[string]interface{}{},
-		},
-		{
-			name:          "control-plane node with multiple different IPs",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"10.0.0.2", "10.0.0.1"},
-				ExternalAddresses: []string{"192.168.1.2", "192.168.1.1"},
-				Entry:             controlPlaneEntry,
-			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
 			expectAddrSet:  true,
 			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.2", "tls-san": []string{"192.168.1.2", "192.168.1.1"}},
 		},
 		{
-			name:          "control-plane node with different internal and external interface names",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"eth0"},
-				ExternalAddresses: []string{"eth1"},
-				Entry:             controlPlaneEntry,
+			name: "control-plane node with interface names uses first node-ip",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"eth0"},
+				"node-external-ip": []string{"eth1"},
 			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
 			expectAddrSet:  true,
 			expectedConfig: map[string]interface{}{"advertise-address": "eth0", "tls-san": []string{"eth1"}},
 		},
 		{
-			name:          "control-plane node with same internal and external interface names",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"eth0"},
-				ExternalAddresses: []string{"eth0"},
-				Entry:             controlPlaneEntry,
-			},
-			expectAddrSet:  false,
-			expectedConfig: map[string]interface{}{},
-		},
-		{
-			name:          "control-plane node with mixed different ip and interface name",
-			initialConfig: map[string]interface{}{},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"eth0"},
-				ExternalAddresses: []string{"192.168.1.1"},
-				Entry:             controlPlaneEntry,
-			},
-			expectAddrSet:  true,
-			expectedConfig: map[string]interface{}{"advertise-address": "eth0", "tls-san": []string{"192.168.1.1"}},
-		},
-		{
-			name: "control-plane node with pre-existing tls-san",
+			name: "control-plane node with pre-existing tls-san appends node-external-ip",
 			initialConfig: map[string]interface{}{
-				"tls-san": []string{"existing-san", "192.168.1.1"},
+				"node-ip":          []string{"10.0.0.1"},
+				"node-external-ip": []string{"192.168.1.1", "192.168.1.2"},
+				"tls-san":          []string{"existing-san", "192.168.1.1"},
 			},
-			info: &machineNetworkInfo{
-				InternalAddresses: []string{"10.0.0.1"},
-				ExternalAddresses: []string{"192.168.1.1", "192.168.1.2"},
-				Entry:             controlPlaneEntry,
-			},
+			info:          &machineNetworkInfo{Entry: controlPlaneEntry},
 			expectAddrSet: true,
-			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.1",
-				"tls-san": []string{"existing-san", "192.168.1.1", "192.168.1.2"}},
+			expectedConfig: map[string]interface{}{
+				"advertise-address": "10.0.0.1",
+				"tls-san":           []string{"existing-san", "192.168.1.1", "192.168.1.2"},
+			},
+		},
+		{
+			name: "IPv6-first node-ip uses first (IPv6) as advertise-address",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"2001:db8::1", "10.0.0.1"},
+				"node-external-ip": []string{"1.2.3.4"},
+			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "2001:db8::1", "tls-san": []string{"1.2.3.4"}},
+		},
+		{
+			name: "IPv4-first node-ip uses first (IPv4) as advertise-address",
+			initialConfig: map[string]interface{}{
+				"node-ip":          []string{"10.0.0.1", "2001:db8::1"},
+				"node-external-ip": []string{"1.2.3.4"},
+			},
+			info:           &machineNetworkInfo{Entry: controlPlaneEntry},
+			expectAddrSet:  true,
+			expectedConfig: map[string]interface{}{"advertise-address": "10.0.0.1", "tls-san": []string{"1.2.3.4"}},
 		},
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 - https://github.com/rancher/rancher/issues/54944

## Problem

This PR is a follow-up to https://github.com/rancher/rancher/pull/54977 and addresses an additional dual-stack networking scenario.

When a machine has a public IPv4 address, and private IPv4 + IPv6 addresses, and the cluster CIDR configuration is IPv6-first dual-stack, the `advertise-address` can be incorrectly derived from the machine’s private IPv4 address. This results in the kube-apiserver validation error:

```
service IP family "2001:cafe:43::/112" must match public address family "10.0.30.114"
```

This issue was not detected in the previous PR because the test environment did not assign a public IPv4 address to the EC2 instance. As a result, both `node-external-ip` and `advertise-address` were absent from the generated configuration, allowing cluster provisioning to succeed.

## Solution

This PR updates the `advertise-address` selection logic to derive the value from the already IP-family-ordered `node-ip` and `node-external-ip` lists. This ensures the selected advertise address aligns with the cluster’s primary IP family configuration and avoids mismatches during kube-apiserver validation.

## Testing

### Engineering Testing

The fix was validated using a container image built from this PR and deployed into a dual-stack K3s cluster. The following downstream cluster provisioning scenarios were tested:

* IPv4-first dual-stack service CIDR + machine with a public IPv4 address, and private IPv4 + IPv6 addresses
* IPv4-first dual-stack service CIDR + machine with private IPv4 + IPv6 addresses
* IPv6-first dual-stack service CIDR + machine with a public IPv4 address, and private IPv4 + IPv6 addresses
* IPv6-first dual-stack service CIDR + machine with private IPv4 + IPv6 addresses
 

### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

Unit tests are updated to cover the new cases.  


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
The above scenarios and normal cluster provisioning. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

The above scenarios and normal cluster provisioning.  
 