### PR TITLE
Fix rcs-release GHA workflow

### DIFF
--- a/.github/actions/images-files/generate/action.yml
+++ b/.github/actions/images-files/generate/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: install dependencies
       shell: bash
-      run: zypper install -y jq awk
+      run: zypper install -y aws-cli jq awk
     - name: Setup Environment Variables
       uses: ./.github/actions/setup-tag-env
     - id: env

--- a/.github/workflows/rcs-release.yml
+++ b/.github/workflows/rcs-release.yml
@@ -4,7 +4,8 @@ on:
     tags:
       - "v*-rcs*"
 
-permissions: {}
+permissions:
+  contents: read
 
 env:
   COMMIT: ${{ github.sha }}


### PR DESCRIPTION
## Issue: N/A <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

RCS Release GHA workflows was failing with
```
Invalid workflow file: .github/workflows/rcs-release.yml#L18
The workflow is not valid. .github/workflows/rcs-release.yml (Line: 18, Col: 3): Error calling workflow '.github/workflows/unit-test.yml@66b1c6e43d02cc44e7800c61d5724f64cb217e1c'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```
and subsequently `create-image-files` was failing with
```
Run ./.github/actions/images-files/generate
Run zypper install -y jq awk
/home/runner/_work/_temp/f0000c1a-b89a-4e5a-b5e6-d1e9df2bc955.sh: line 1: zypper: command not found
Error: Process completed with exit code 127.
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Set permissions on workflow level and make sure aws cli is installed.
 
