### PR TITLE
Don't overwrite AzureAD SLO fields

### DIFF
--- a/pkg/auth/providers/azure/azure_actions.go
+++ b/pkg/auth/providers/azure/azure_actions.go
@@ -144,10 +144,10 @@ func preserveStoredFields(stored, incoming *apiv3.AzureADConfig) {
 	if incoming.AllowedPrincipalIDs == nil {
 		incoming.AllowedPrincipalIDs = stored.AllowedPrincipalIDs
 	}
-	incoming.EndSessionEndpoint = stored.EndSessionEndpoint
+	if incoming.EndSessionEndpoint == "" {
+		incoming.EndSessionEndpoint = stored.EndSessionEndpoint
+	}
 	incoming.LogoutAllSupported = stored.LogoutAllSupported
-	incoming.LogoutAllEnabled = stored.LogoutAllEnabled
-	incoming.LogoutAllForced = stored.LogoutAllForced
 }
 
 // migrateNewFlowAnnotation ensures the proposed config has the GraphEndpointMigratedAnnotation set.

--- a/pkg/auth/providers/azure/azure_provider_test.go
+++ b/pkg/auth/providers/azure/azure_provider_test.go
@@ -408,23 +408,67 @@ func TestPreserveStoredFields(t *testing.T) {
 			want:     v3.AzureADConfig{},
 		},
 		{
-			name: "SLO fields always preserved from stored",
+			name: "LogoutAllSupported always from stored",
 			stored: v3.AzureADConfig{
 				AuthConfig: v3.AuthConfig{
 					LogoutAllSupported: true,
 				},
-				EndSessionEndpoint: "https://custom.gov/logout",
-				LogoutAllEnabled:   true,
-				LogoutAllForced:    true,
 			},
 			incoming: v3.AzureADConfig{},
 			want: v3.AzureADConfig{
 				AuthConfig: v3.AuthConfig{
 					LogoutAllSupported: true,
 				},
+			},
+		},
+		{
+			name:   "LogoutAllEnabled from incoming overrides stored false",
+			stored: v3.AzureADConfig{},
+			incoming: v3.AzureADConfig{
+				LogoutAllEnabled: true,
+			},
+			want: v3.AzureADConfig{
+				LogoutAllEnabled: true,
+			},
+		},
+		{
+			name: "LogoutAllEnabled from incoming overrides stored true",
+			stored: v3.AzureADConfig{
+				LogoutAllEnabled: true,
+			},
+			incoming: v3.AzureADConfig{},
+			want:     v3.AzureADConfig{},
+		},
+		{
+			name:   "LogoutAllForced from incoming overrides stored false",
+			stored: v3.AzureADConfig{},
+			incoming: v3.AzureADConfig{
+				LogoutAllForced: true,
+			},
+			want: v3.AzureADConfig{
+				LogoutAllForced: true,
+			},
+		},
+		{
+			name: "EndSessionEndpoint preserved when incoming is empty",
+			stored: v3.AzureADConfig{
 				EndSessionEndpoint: "https://custom.gov/logout",
-				LogoutAllEnabled:   true,
-				LogoutAllForced:    true,
+			},
+			incoming: v3.AzureADConfig{},
+			want: v3.AzureADConfig{
+				EndSessionEndpoint: "https://custom.gov/logout",
+			},
+		},
+		{
+			name: "EndSessionEndpoint from incoming used when non-empty",
+			stored: v3.AzureADConfig{
+				EndSessionEndpoint: "https://custom.gov/logout",
+			},
+			incoming: v3.AzureADConfig{
+				EndSessionEndpoint: "https://other.gov/logout",
+			},
+			want: v3.AzureADConfig{
+				EndSessionEndpoint: "https://other.gov/logout",
 			},
 		},
 		{

--- a/pkg/auth/providers/azure/azure_provider_test.go
+++ b/pkg/auth/providers/azure/azure_provider_test.go
@@ -408,7 +408,7 @@ func TestPreserveStoredFields(t *testing.T) {
 			want:     v3.AzureADConfig{},
 		},
 		{
-			name: "LogoutAllSupported always from stored",
+			name: "LogoutAllSupported preserved from stored",
 			stored: v3.AzureADConfig{
 				AuthConfig: v3.AuthConfig{
 					LogoutAllSupported: true,


### PR DESCRIPTION
## Issue: #55041 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

LogoutAllEnabled and LogoutAllForced fields were unconditionally copied from the stored config, so the values sent in the request were always discarded.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This change ensures that the values from the request are used with the exception of LogoutAllSupported that is not set by user.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests