### PR TITLE
Fix handling non-transient errors for Cognito provider

### DIFF
--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -220,7 +220,7 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 			principalID = ""
 		}
 
-		// If there is no principalID for the provider, there is no reason to go through the refetch process
+		// If there is no principalID for the provider, there is no reason to go through the refetch process.
 		if principalID != "" {
 			secret := ""
 			hasPerUserSecrets, err := providers.ProviderHasPerUserSecrets(providerName)
@@ -238,7 +238,7 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 				}
 			}
 
-			// SAML cannot refresh, so we do restore the existing principals.
+			// For providers that don't support refresh (like SAML), we restore the existing principals.
 			if providers.UnrefreshableProviders[providerName] {
 				existingPrincipals := attribs.GroupPrincipals[providerName].Items
 				if existingPrincipals != nil {

--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
@@ -128,11 +127,6 @@ func (g *GenOIDCProvider) TransformToAuthProvider(authConfig map[string]any) (ma
 	p[publicclient.GenericOIDCProviderFieldScopes] = authConfig["scope"]
 
 	return p, nil
-}
-
-// RefetchGroupPrincipals is not implemented for OIDC.
-func (g *GenOIDCProvider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {
-	return nil, errors.New("Not implemented")
 }
 
 // groupToPrincipal takes a bare group name and turns it into a apiv3.Principal group object by filling-in other fields

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -154,7 +154,6 @@ func Configure(ctx context.Context, mgmt *config.ScaledContext) {
 	p = cognito.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[cognito.Name] = true
 	providersWithSecrets[cognito.Name] = true
-	UnrefreshableProviders[cognito.Name] = true
 	Providers[cognito.Name] = p
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a user was deleted or signed out from Cognito, the auth provider refresh never detected the error. The refresh silently restored stale principals instead of flagging the failure and stopping requeue.

Cognito shares its refresh logic with other OIDC providers, which already handle this correctly. But two things blocked it from running: a "not implemented" override hid the working code, and a configuration flag told the refresher to skip Cognito entirely.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Both were removed so that existing error detection now applies to Cognito as well.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests