### PR TITLE
Replace integration tests with CI verification in push.yml

### DIFF
--- a/.github/scripts/verify-ci-on-commit.sh
+++ b/.github/scripts/verify-ci-on-commit.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies that CI passed on the pull request that merged COMMIT_SHA into
+# the target branch. Fails if no merged PR is found, since all commits to
+# main and release branches must arrive via a pull request.
+#
+# Required environment variables:
+#   COMMIT_SHA  - the commit to verify
+#   REPO        - the GitHub repository in "owner/repo" form
+#   GH_TOKEN    - a token with pull-requests:read and checks:read
+
+: "${COMMIT_SHA:?COMMIT_SHA is required}"
+: "${REPO:?REPO is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+echo "Verifying CI checks for commit ${COMMIT_SHA} in ${REPO}"
+
+PR_NUMBER=$(gh api \
+    "repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
+    --jq "[.[] | select(.merge_commit_sha == \"${COMMIT_SHA}\")] | first | .number // empty")
+
+if [[ -z "${PR_NUMBER:-}" ]]; then
+    echo "ERROR: no merged PR found for ${COMMIT_SHA}" >&2
+    exit 1
+fi
+
+echo "Found PR #${PR_NUMBER}, checking required CI..."
+gh pr checks "${PR_NUMBER}" --repo "${REPO}" --required

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,13 +53,25 @@ jobs:
           persist-credentials: false
       - name: setup and build
         uses: ./.github/actions/build-images/agent
-  integration-tests:
-    needs: [build-server, build-agent]
-    uses: ./.github/workflows/integration-tests.yml
+  verify-ci:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
+      checks: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      COMMIT_SHA: ${{ github.sha }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Verify CI passed on merged PR
+        run: ./.github/scripts/verify-ci-on-commit.sh
   push-images:
-    needs: [unit-tests, integration-tests]
+    needs: [unit-tests, build-server, build-agent, verify-ci]
     strategy:
       matrix:
         os: [linux]


### PR DESCRIPTION
The push workflow triggers only on merges to main and release branches, which are gated by required CI checks on the originating pull request. Re-running integration tests in the push workflow duplicates roughly 30 minutes of work that was already validated before merge.

Replace the `integration-tests` job with `verify-ci`, which finds the merged PR for the triggering commit using the GitHub API and checks that all required CI checks passed on it via `gh pr checks --required`. The check logic lives in `.github/scripts/verify-ci-on-commit.sh` so it can be shellchecked and tested locally. The approach mirrors what I have [implemented](https://github.com/rancher/fleet/pull/4908/changes/104271b6e18588633bc9f7e0c5f531439b36702d) in the Fleet project's release workflow.

`push-images` now explicitly lists `build-server` and `build-agent` in its `needs`, since the transitive dependency through `integration-tests` no longer exists.