### PR TITLE
[main] Private Registry Support for Imported & Hosted clusters

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -56,12 +56,7 @@ func main() {
 
 	initFeatures()
 
-	// The cleanup is only performed by the cattle-cluster-agent,
-	// in whose template the CATTLE_CREDENTIAL_NAME environment variable is set
-	if os.Getenv("CATTLE_CREDENTIAL_NAME") != "" {
-		logrus.Infof("starting cattle-credential-cleanup goroutine in the background")
-		go clean.UnusedCattleCredentials()
-	}
+	runCleanup(ctx)
 
 	if os.Getenv("CLUSTER_CLEANUP") == "true" {
 		err = clean.Cluster()
@@ -93,6 +88,25 @@ func getParams() (map[string]interface{}, error) {
 
 func getTokenAndURL() (string, string, error) {
 	return cluster.TokenAndURL()
+}
+
+func runCleanup(ctx context.Context) {
+	// The cleanup is only performed by the cattle-cluster-agent,
+	// in whose template the CATTLE_CREDENTIAL_NAME environment variable is set
+	if os.Getenv("CATTLE_CREDENTIAL_NAME") != "" {
+		logrus.Infof("starting cattle-credential-cleanup goroutine in the background")
+		go clean.UnusedCattleCredentials()
+	}
+
+	if os.Getenv("CATTLE_AGENT_PULL_SECRETS") != "" {
+		// Run once on startup to make sure that there are no lingering pull secrets in the cattle-system namespace
+		go func() {
+			err := clean.UnusedPullSecrets(ctx)
+			if err != nil {
+				logrus.Errorf("failed to remove unused pull secrets: %v", err)
+			}
+		}()
+	}
 }
 
 func isConnect() bool {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -96,16 +96,8 @@ func runCleanup(ctx context.Context) {
 	if os.Getenv("CATTLE_CREDENTIAL_NAME") != "" {
 		logrus.Infof("starting cattle-credential-cleanup goroutine in the background")
 		go clean.UnusedCattleCredentials()
-	}
-
-	if os.Getenv("CATTLE_AGENT_PULL_SECRETS") != "" {
 		// Run once on startup to make sure that there are no lingering pull secrets in the cattle-system namespace
-		go func() {
-			err := clean.UnusedPullSecrets(ctx)
-			if err != nil {
-				logrus.Errorf("failed to remove unused pull secrets: %v", err)
-			}
-		}()
+		go clean.UnusedPullSecrets(ctx)
 	}
 }
 

--- a/pkg/agent/clean/cluster.go
+++ b/pkg/agent/clean/cluster.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/management/usercontrollers"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
 	"github.com/rancher/rancher/pkg/monitoring"
@@ -148,6 +149,11 @@ func Cluster() error {
 	rErr := cleanupRoles(client)
 	if len(rErr) > 0 {
 		errors = append(errors, rErr...)
+	}
+
+	sErr := cleanUpImagePullSecrets(client)
+	if len(sErr) > 0 {
+		errors = append(errors, sErr...)
 	}
 
 	if len(errors) > 0 {
@@ -325,6 +331,27 @@ func cleanupClusterRoles(client *kubernetes.Clientset) []error {
 		logrus.Infof("Deleting clusterRole: %v", cr.Name)
 		if !dryRun {
 			err = client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func cleanUpImagePullSecrets(client *kubernetes.Clientset) []error {
+	logrus.Info("Starting cleanup of imagePullSecrets")
+	s, err := client.CoreV1().Secrets("").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: cluster.CopiedPullSecretLabel + "=true",
+	})
+	if err != nil {
+		return []error{err}
+	}
+	var errs []error
+	for _, secret := range s.Items {
+		logrus.Infof("Deleting secret: %v", secret.Name)
+		if !dryRun {
+			err = client.CoreV1().Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/pkg/agent/clean/cluster.go
+++ b/pkg/agent/clean/cluster.go
@@ -349,7 +349,7 @@ func cleanUpImagePullSecrets(client *kubernetes.Clientset) []error {
 	}
 	var errs []error
 	for _, secret := range s.Items {
-		logrus.Infof("Deleting secret: %v", secret.Name)
+		logrus.Infof("Deleting secret %q in namespace %q", secret.Name, secret.Namespace)
 		if !dryRun {
 			err = client.CoreV1().Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
 			if err != nil {

--- a/pkg/agent/clean/credentials.go
+++ b/pkg/agent/clean/credentials.go
@@ -3,14 +3,64 @@ package clean
 import (
 	"context"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// UnusedPullSecrets removes rancher managed image pull secrets
+// from the cattle-system namespace that are no longer used by the cattle-cluster-agent.
+// This can occur in imported or hosted clusters, when either the cluster or global pull secret
+// configuration is changed after initial provisioning.
+func UnusedPullSecrets(ctx context.Context) error {
+	client, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+
+	k8s, err := kubernetes.NewForConfig(client)
+	if err != nil {
+		return err
+	}
+	secret := k8s.CoreV1().Secrets("cattle-system")
+	copiedPullSecrets, err := secret.List(ctx, metav1.ListOptions{
+		LabelSelector: "management.cattle.io/cattle-cluster-agent-pull-secret=true",
+	})
+	if err != nil {
+		return err
+	}
+
+	configuredPullSecrets := strings.Split(os.Getenv("CATTLE_AGENT_PULL_SECRETS"), ",")
+
+	var secretsToRemove []corev1.Secret
+	for _, pullSecret := range copiedPullSecrets.Items {
+		if !slices.Contains(configuredPullSecrets, pullSecret.Name) {
+			secretsToRemove = append(secretsToRemove, pullSecret)
+		}
+	}
+
+	if len(secretsToRemove) == 0 {
+		return nil
+	}
+
+	logrus.Infof("removing %d unused pull secrets", len(secretsToRemove))
+	for _, pullSecret := range secretsToRemove {
+		err = secret.Delete(ctx, pullSecret.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		logrus.Infof("removed unused pull secret %q", pullSecret.Name)
+	}
+
+	logrus.Infof("removed %d unused pull secrets", len(secretsToRemove))
+	return nil
+}
 
 // UnusedCattleCredentials removes all of the cattle-credentials that aren't being used by the current pod on a ticker. Meant to be run from a goroutine so it doesn't stop the parent execution
 func UnusedCattleCredentials() {
@@ -24,7 +74,10 @@ func UnusedCattleCredentials() {
 	}
 }
 
-// removeUnusedCattleCredentials goes through all the secrets in the cattle-system namespace and removes any that are not being used by the current pod and are older than an hour. This prevents any leftover tokens from being left in the cluster on rotation. The main reason we wait an hour is just in case the deployment is updated and/or flapping it won't nuke the secret unless it's been unused for a little while.
+// removeUnusedCattleCredentials goes through all the secrets in the cattle-system namespace and removes any that are
+// not being used by the current pod and are older than an hour. This prevents any leftover tokens from being left
+// in the cluster on rotation. The main reason we wait an hour is just in case the deployment is updated and/or
+// flapping it won't nuke the secret unless it's been unused for a little while.
 func removeUnusedCattleCredentials(ctx context.Context) error {
 	client, err := rest.InClusterConfig()
 	if err != nil {

--- a/pkg/agent/clean/credentials.go
+++ b/pkg/agent/clean/credentials.go
@@ -18,22 +18,25 @@ import (
 // from the cattle-system namespace that are no longer used by the cattle-cluster-agent.
 // This can occur in imported or hosted clusters, when either the cluster or global pull secret
 // configuration is changed after initial provisioning.
-func UnusedPullSecrets(ctx context.Context) error {
+func UnusedPullSecrets(ctx context.Context) {
 	client, err := rest.InClusterConfig()
 	if err != nil {
-		return err
+		logrus.Errorf("Error getting in cluster config: %v", err)
+		return
 	}
 
 	k8s, err := kubernetes.NewForConfig(client)
 	if err != nil {
-		return err
+		logrus.Errorf("Error getting kubernetes client: %v", err)
+		return
 	}
 	secret := k8s.CoreV1().Secrets("cattle-system")
 	copiedPullSecrets, err := secret.List(ctx, metav1.ListOptions{
 		LabelSelector: "management.cattle.io/cattle-cluster-agent-pull-secret=true",
 	})
 	if err != nil {
-		return err
+		logrus.Errorf("Error listing cattle-cluster-agent-pull-secrets: %v", err)
+		return
 	}
 
 	configuredPullSecrets := strings.Split(os.Getenv("CATTLE_AGENT_PULL_SECRETS"), ",")
@@ -46,20 +49,20 @@ func UnusedPullSecrets(ctx context.Context) error {
 	}
 
 	if len(secretsToRemove) == 0 {
-		return nil
+		return
 	}
 
 	logrus.Infof("removing %d unused pull secrets", len(secretsToRemove))
 	for _, pullSecret := range secretsToRemove {
 		err = secret.Delete(ctx, pullSecret.Name, metav1.DeleteOptions{})
 		if err != nil {
-			return err
+			logrus.Errorf("Error deleting pull secret: %v", err)
+			continue
 		}
 		logrus.Infof("removed unused pull secret %q", pullSecret.Name)
 	}
 
 	logrus.Infof("removed %d unused pull secrets", len(secretsToRemove))
-	return nil
 }
 
 // UnusedCattleCredentials removes all of the cattle-credentials that aren't being used by the current pod on a ticker. Meant to be run from a goroutine so it doesn't stop the parent execution

--- a/pkg/agent/rancher/rancher.go
+++ b/pkg/agent/rancher/rancher.go
@@ -81,7 +81,7 @@ func (h *handler) startRancher() {
 		HTTPSListenPort:         443,
 		Features:                os.Getenv("CATTLE_FEATURES"),
 		AddLocal:                "true",
-		ClusterRegistry:         os.Getenv("CATTLE_CLUSTER_REGISTRY"),
+		ClusterRegistry:         os.Getenv("CATTLE_SYSTEM_DEFAULT_REGISTRY"),
 		RancherNamespaceOptions: os.Getenv("RANCHER_NAMESPACE_OPTIONS"),
 	})
 	if err != nil {

--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -14,6 +14,7 @@ import (
 	schema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemtemplate"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -61,8 +62,22 @@ func (ch *ClusterImport) ClusterImportHandler(resp http.ResponseWriter, req *htt
 	}
 
 	agentImage := image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
-	if err = systemtemplate.SystemTemplate(resp, agentImage, authImage, "", token, url,
-		false, cluster, nil, nil, ch.SecretLister, false, namespace.GetMutator()); err != nil {
+	ops := &systemtemplate.TemplateOps{
+		AgentImage:     agentImage,
+		AuthImage:      authImage,
+		Namespace:      "",
+		Token:          token,
+		URL:            url,
+		IsPreBootstrap: false,
+		Cluster:        cluster,
+		AgentFeatures:  nil,
+		Taints:         nil,
+		SecretLister:   ch.SecretLister,
+		PcExists:       false,
+		Mutator:        namespace.GetMutator(),
+	}
+	if err = systemtemplate.SystemTemplate(resp, ops); err != nil {
+		logrus.Errorf("[cluster-registration-tokens] failed to generate template: %v", err)
 		resp.WriteHeader(500)
 		resp.Write([]byte(err.Error()))
 	}

--- a/pkg/api/steve/clusters/shell.go
+++ b/pkg/api/steve/clusters/shell.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/steve/pkg/podimpersonation"
 	"github.com/rancher/steve/pkg/stores/proxy"
@@ -118,7 +119,8 @@ func (s *shell) createPod(imageOverride string) *v1.Pod {
 	if imageName == "" {
 		imageName = settings.FullShellImage()
 	}
-	return &v1.Pod{
+
+	p := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "dashboard-shell-",
 			Namespace:    s.namespace,
@@ -237,4 +239,10 @@ func (s *shell) createPod(imageOverride string) *v1.Pod {
 			},
 		},
 	}
+
+	if registry, _ := cluster.GetPrivateRegistry(nil); registry != nil {
+		p.Spec.ImagePullSecrets = registry.PullSecretsAsObjectReferences()
+	}
+
+	return p
 }

--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -157,7 +157,7 @@ func addRoleConfig(config map[string]interface{}, controlPlane *rkev1.RKEControl
 		config["disable-etcd"] = true
 	}
 
-	if pr := image.GetPrivateRepoURLFromControlPlane(controlPlane); pr != "" && !isOnlyWorker(entry) {
+	if pr, _ := image.GetPrivateRepoURLFromControlPlane(controlPlane); pr != "" && !isOnlyWorker(entry) {
 		config["system-default-registry"] = pr
 	}
 

--- a/pkg/capr/planner/defaultplan.go
+++ b/pkg/capr/planner/defaultplan.go
@@ -5,12 +5,14 @@ import (
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/cluster"
 )
 
 // commonNodePlan returns a "default" node plan with the corresponding registry configuration.
 // It will append to the node plan passed in through options.
 func (p *Planner) commonNodePlan(controlPlane *rkev1.RKEControlPlane, np plan.NodePlan) (plan.NodePlan, registries, error) {
-	if controlPlane.Spec.Registries == nil {
+	globalRegistry, _ := cluster.GetPrivateRegistry(nil)
+	if controlPlane.Spec.Registries == nil && globalRegistry == nil {
 		return np, registries{}, nil
 	}
 

--- a/pkg/capr/planner/registry.go
+++ b/pkg/capr/planner/registry.go
@@ -9,6 +9,10 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/cluster"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/provisioningv2/image"
+	"github.com/rancher/rancher/pkg/settings"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -21,7 +25,13 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 		err     error
 	)
 
+	GSDR := settings.SystemDefaultRegistry.Get()
+	foundExistingGSDRConfiguration := false
+
 	for registryName, config := range controlPlane.Spec.Registries.Configs {
+		if registryName == GSDR {
+			foundExistingGSDRConfiguration = true
+		}
 		registryConfig := &registryConfig{}
 		if config.InsecureSkipVerify || config.TLSSecretName != "" || len(config.CABundle) > 0 {
 			registryConfig.TLS = &tlsConfig{
@@ -62,19 +72,79 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 			if err != nil {
 				return data, err
 			}
-			if secret.Type != rkev1.AuthConfigSecretType && secret.Type != corev1.SecretTypeBasicAuth {
-				return data, fmt.Errorf("secret [%s] must be of type [%s] or [%s]",
-					config.AuthConfigSecretName, rkev1.AuthConfigSecretType, corev1.SecretTypeBasicAuth)
+
+			if secret.Type != rkev1.AuthConfigSecretType && secret.Type != corev1.SecretTypeBasicAuth && secret.Type != corev1.SecretTypeDockerConfigJson {
+				return data, fmt.Errorf("secret [%s] must be of type [%s] or [%s] or [%s]",
+					config.AuthConfigSecretName, rkev1.AuthConfigSecretType, corev1.SecretTypeBasicAuth, corev1.SecretTypeDockerConfigJson)
 			}
+
+			if secret.Data == nil {
+				return data, fmt.Errorf("secret [%s] has nil data", config.AuthConfigSecretName)
+			}
+
+			username := string(secret.Data[rkev1.UsernameAuthConfigSecretKey])
+			password := string(secret.Data[rkev1.PasswordAuthConfigSecretKey])
+			auth := string(secret.Data[rkev1.AuthAuthConfigSecretKey])
+			identityToken := string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey])
+
+			// need to pull out the username, password, auth, from the .dockerconfigjson key
+			if secret.Type == corev1.SecretTypeDockerConfigJson {
+				username, password, auth, err = cluster.UnwrapDockerConfigJson(registryName, secret.Data)
+				if err != nil {
+					return data, err
+				}
+			}
+
 			registryConfig.Auth = &authConfig{
-				Username:      string(secret.Data[rkev1.UsernameAuthConfigSecretKey]),
-				Password:      string(secret.Data[rkev1.PasswordAuthConfigSecretKey]),
-				Auth:          string(secret.Data[rkev1.AuthAuthConfigSecretKey]),
-				IdentityToken: string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]),
+				Username:      username,
+				Password:      password,
+				Auth:          auth,
+				IdentityToken: identityToken,
 			}
 		}
 
 		configs[registryName] = registryConfig
+	}
+
+	// if a GSDR is defined and the user has not already configured
+	// authentication for that hostname, we need to fall back to the global configuration.
+	_, UsingGSDRDefault := image.GetPrivateRepoURLFromControlPlane(controlPlane)
+	if GSDR != "" && UsingGSDRDefault && !foundExistingGSDRConfiguration {
+		// we can only use the first pull secret set globally, since
+		// provisioned clusters have a 1-to-1 mapping of hostnames to secrets.
+		// Due to the format of registries.yaml, it's not possible to specify more than
+		// one set of credentials per hostname.
+		registry, _ := cluster.GetPrivateRegistry(nil)
+		if registry != nil && len(registry.PullSecrets) > 0 {
+			globalSecret := registry.PullSecretNamesAsSlice()[0]
+			secret, err := p.secretCache.Get(namespaces.System, globalSecret)
+			if err != nil {
+				return data, err
+			}
+
+			if secret.Type != corev1.SecretTypeDockerConfigJson {
+				return data, fmt.Errorf("global secret [%s] must be of type [%s]",
+					globalSecret, corev1.SecretTypeDockerConfigJson)
+			}
+
+			if secret.Data == nil {
+				return data, fmt.Errorf("global secret [%s] has nil data", globalSecret)
+			}
+
+			username, password, _, err := cluster.UnwrapDockerConfigJson(GSDR, secret.Data)
+			if err != nil {
+				return data, err
+			}
+
+			registryConfig := &registryConfig{}
+			registryConfig.Auth = &authConfig{
+				Username:      username,
+				Password:      password,
+				IdentityToken: string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]),
+			}
+
+			configs[GSDR] = registryConfig
+		}
 	}
 
 	data.registriesFileRaw, err = json.Marshal(map[string]interface{}{

--- a/pkg/capr/planner/registry.go
+++ b/pkg/capr/planner/registry.go
@@ -133,12 +133,12 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 					logrus.Debugf("[planner] skipping global pull secret %q: nil data", secretName)
 					continue
 				}
-				username, password, _, err := cluster.UnwrapDockerConfigJson(GSDR, secret.Data)
+				username, password, auth, err := cluster.UnwrapDockerConfigJson(GSDR, secret.Data)
 				if err != nil {
 					logrus.Debugf("[planner] skipping global pull secret %q: does not contain credentials for registry %q: %v", secretName, GSDR, err)
 					continue
 				}
-				if username == "" && password == "" && string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]) == "" {
+				if username == "" && password == "" && auth == "" && string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]) == "" {
 					logrus.Debugf("[planner] skipping global pull secret %q: no credentials found for registry %q", secretName, GSDR)
 					continue
 				}
@@ -146,6 +146,7 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 				registryConfig.Auth = &authConfig{
 					Username:      username,
 					Password:      password,
+					Auth:          auth,
 					IdentityToken: string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]),
 				}
 				configs[GSDR] = registryConfig

--- a/pkg/capr/planner/registry.go
+++ b/pkg/capr/planner/registry.go
@@ -13,6 +13,7 @@ import (
 	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -110,40 +111,50 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 	// authentication for that hostname, we need to fall back to the global configuration.
 	_, UsingGSDRDefault := image.GetPrivateRepoURLFromControlPlane(controlPlane)
 	if GSDR != "" && UsingGSDRDefault && !foundExistingGSDRConfiguration {
-		// we can only use the first pull secret set globally, since
-		// provisioned clusters have a 1-to-1 mapping of hostnames to secrets.
-		// Due to the format of registries.yaml, it's not possible to specify more than
-		// one set of credentials per hostname.
+		// since provisioned clusters have a 1-to-1 mapping of hostnames to secrets (
+		// due to the format of registries.yaml), it's not possible to specify more than
+		// one set of credentials per hostname. We iterate across all pull secrets
+		// until we find the first valid entry for the given registry host. If we don't find any,
+		// it's assumed that the URL is unauthenticated, and registres.yaml is left empty.
 		registry, _ := cluster.GetPrivateRegistry(nil)
 		if registry != nil && len(registry.PullSecrets) > 0 {
-			globalSecret := registry.PullSecretNamesAsSlice()[0]
-			secret, err := p.secretCache.Get(namespaces.System, globalSecret)
-			if err != nil {
-				return data, err
+			var foundCredentials bool
+			for _, secretName := range registry.PullSecretNamesAsSlice() {
+				secret, err := p.secretCache.Get(namespaces.System, secretName)
+				if err != nil {
+					logrus.Debugf("[planner] skipping global pull secret %q for registry %q: failed to fetch: %v", secretName, GSDR, err)
+					continue
+				}
+				if secret.Type != corev1.SecretTypeDockerConfigJson {
+					logrus.Debugf("[planner] skipping global pull secret %q: expected type %q, got %q", secretName, corev1.SecretTypeDockerConfigJson, secret.Type)
+					continue
+				}
+				if secret.Data == nil {
+					logrus.Debugf("[planner] skipping global pull secret %q: nil data", secretName)
+					continue
+				}
+				username, password, _, err := cluster.UnwrapDockerConfigJson(GSDR, secret.Data)
+				if err != nil {
+					logrus.Debugf("[planner] skipping global pull secret %q: does not contain credentials for registry %q: %v", secretName, GSDR, err)
+					continue
+				}
+				if username == "" && password == "" && string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]) == "" {
+					logrus.Debugf("[planner] skipping global pull secret %q: no credentials found for registry %q", secretName, GSDR)
+					continue
+				}
+				registryConfig := &registryConfig{}
+				registryConfig.Auth = &authConfig{
+					Username:      username,
+					Password:      password,
+					IdentityToken: string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]),
+				}
+				configs[GSDR] = registryConfig
+				foundCredentials = true
+				break
 			}
-
-			if secret.Type != corev1.SecretTypeDockerConfigJson {
-				return data, fmt.Errorf("global secret [%s] must be of type [%s]",
-					globalSecret, corev1.SecretTypeDockerConfigJson)
+			if !foundCredentials {
+				logrus.Warnf("[planner] no global pull secret contained credentials for registry %q. registries.yaml will be unpopulated.", GSDR)
 			}
-
-			if secret.Data == nil {
-				return data, fmt.Errorf("global secret [%s] has nil data", globalSecret)
-			}
-
-			username, password, _, err := cluster.UnwrapDockerConfigJson(GSDR, secret.Data)
-			if err != nil {
-				return data, err
-			}
-
-			registryConfig := &registryConfig{}
-			registryConfig.Auth = &authConfig{
-				Username:      username,
-				Password:      password,
-				IdentityToken: string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey]),
-			}
-
-			configs[GSDR] = registryConfig
 		}
 	}
 

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -25,6 +25,7 @@ import (
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/catalogv2/content"
+	"github.com/rancher/rancher/pkg/cluster"
 	catalogcontrollers "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/rbac"
@@ -1041,6 +1042,11 @@ func (s *Operations) createPod(secretData map[string][]byte, imageOverride strin
 				},
 			},
 		},
+	}
+
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry != nil && len(registry.PullSecrets) > 0 {
+		pod.Spec.ImagePullSecrets = registry.PullSecretsAsObjectReferences()
 	}
 
 	return pod, &podimpersonation.PodOptions{

--- a/pkg/catalogv2/helmop/operation_test.go
+++ b/pkg/catalogv2/helmop/operation_test.go
@@ -1,9 +1,11 @@
 package helmop
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"testing"
+
+	"github.com/rancher/rancher/pkg/settings"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -209,6 +211,38 @@ func Test_CreatePod(t *testing.T) {
 	}
 }
 
+func Test_CreatePod_ImagePullSecrets(t *testing.T) {
+	asserts := assert.New(t)
+
+	// Set up global registry with pull secrets
+	withSettings(t, "registry.example.com", "pull-secret-a,pull-secret-b")
+
+	operation := Operations{
+		namespace: "test-ns",
+	}
+
+	actual, _ := operation.createPod(nil, "", nil)
+	expectedPullSecrets := []corev1.LocalObjectReference{
+		{Name: "pull-secret-a"},
+		{Name: "pull-secret-b"},
+	}
+	asserts.Equal(expectedPullSecrets, actual.Spec.ImagePullSecrets, "Pod should have imagePullSecrets when global registry pull secrets are configured")
+}
+
+func Test_CreatePod_NoImagePullSecrets(t *testing.T) {
+	asserts := assert.New(t)
+
+	// Ensure no registry is configured
+	withSettings(t, "", "")
+
+	operation := Operations{
+		namespace: "test-ns",
+	}
+
+	actual, _ := operation.createPod(nil, "", nil)
+	asserts.Nil(actual.Spec.ImagePullSecrets, "Pod should not have imagePullSecrets when no global registry is configured")
+}
+
 func Test_mergeTolerations(t *testing.T) {
 	asserts := assert.New(t)
 	testCases := []mergeTolerationsTestCase{
@@ -268,4 +302,15 @@ func Test_mergeTolerations(t *testing.T) {
 		resp := mergeTolerations(t.tolerations, t.newTolerations)
 		asserts.ElementsMatch(resp, t.expected, t.name)
 	}
+}
+
+func withSettings(t *testing.T, sdr, pullSecrets string) {
+	curSdr := settings.SystemDefaultRegistry.Get()
+	curSdrPull := settings.SystemDefaultRegistryPullSecrets.Get()
+	settings.SystemDefaultRegistry.Set(sdr)
+	settings.SystemDefaultRegistryPullSecrets.Set(pullSecrets)
+	t.Cleanup(func() {
+		settings.SystemDefaultRegistry.Set(curSdr)
+		settings.SystemDefaultRegistryPullSecrets.Set(curSdrPull)
+	})
 }

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -218,7 +218,7 @@ func generateProvisionedClusterDockerConfig(cluster *v3.Cluster, secretLister v1
 func generateImportedClusterDockerConfig(cluster *v3.Cluster, secretLister v1.SecretLister, registry *PrivateRegistry) (string, []AgentPullSecret, error) {
 	clusterSystemDefaultURL := registry.URL
 	// Only generate credentials for imported or hosted clusters.
-	if !MgmtNameRegexp.MatchString(cluster.Name) {
+	if cluster == nil || !MgmtNameRegexp.MatchString(cluster.Name) {
 		return clusterSystemDefaultURL, nil, nil
 	}
 

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/wrangler/v3/pkg/name"
 	kcorev1 "k8s.io/api/core/v1"
 )
 
@@ -186,6 +187,13 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 	return "", nil, nil
 }
 
+// GeneratePullSecretName accepts an image pull secret name and returns a new name that
+// is generated and managed by Rancher. This is done to help avoid trampling user defined
+// secrets in downstream environments.
+func GeneratePullSecretName(secretName string) string {
+	return name.SafeConcatName(secretName, "rancher-managed-pull-secret")
+}
+
 func generateProvisionedClusterDockerConfig(cluster *v3.Cluster, secretLister v1.SecretLister) (string, []AgentPullSecret, error) {
 	v2ProvRegistryURL := cluster.GetSecret(v3.ClusterPrivateRegistryURL)
 
@@ -240,7 +248,7 @@ func generateImportedClusterDockerConfig(cluster *v3.Cluster, secretLister v1.Se
 		}
 
 		pullSecrets = append(pullSecrets, AgentPullSecret{
-			Name:             sec.Name,
+			Name:             GeneratePullSecretName(sec.Name),
 			DockerConfigJSON: base64.StdEncoding.EncodeToString(configJson),
 		})
 	}

--- a/pkg/cluster/private_registry_docker_config.go
+++ b/pkg/cluster/private_registry_docker_config.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -12,16 +11,16 @@ import (
 	"k8s.io/kubernetes/pkg/credentialprovider"
 )
 
-var (
-	ErrSecretDataNil            = errors.New("secret data is nil")
-	ErrAuthKeyNotFound          = errors.New("secret 'rke.cattle.io/auth-config' does not have expected 'auth' key")
-	ErrAuthMalformed            = errors.New("secret 'rke.cattle.io/auth-config' does not have 'auth' value in expected username:password format")
-	ErrUsernameNotFound         = errors.New("secret 'kubernetes.io/basic-auth' has no 'username' field")
-	ErrPasswordNotFound         = errors.New("secret 'kubernetes.io/basic-auth' has no 'password' field")
-	ErrDockerConfigKeyNotFound  = errors.New("secret 'kubernetes.io/dockerconfigjson' has no '.dockerconfigjson' field")
-	ErrUnsupportedSecretType    = errors.New("unsupported secret type")
-	ErrDockerConfigJsonNotFound = errors.New(".dockerconfigjson not found in secret")
-	ErrRegistryHostnameNotFound = errors.New("registry hostname not found in secret")
+const (
+	ErrSecretDataNil            = "pull secret %q for registry %q has nil data"
+	ErrAuthKeyNotFound          = "pull secret %q for registry %q of type 'rke.cattle.io/auth-config' is missing the 'auth' key"
+	ErrAuthMalformed            = "pull secret %q for registry %q of type 'rke.cattle.io/auth-config' has malformed 'auth' value: expected username:password format"
+	ErrUsernameNotFound         = "pull secret %q for registry %q of type 'kubernetes.io/basic-auth' is missing the 'username' field"
+	ErrPasswordNotFound         = "pull secret %q for registry %q of type 'kubernetes.io/basic-auth' is missing the 'password' field"
+	ErrDockerConfigKeyNotFound  = "pull secret %q for registry %q of type 'kubernetes.io/dockerconfigjson' is missing the '.dockerconfigjson' field"
+	ErrUnsupportedSecretType    = "pull secret %q for registry %q has unsupported type %q"
+	ErrDockerConfigJsonNotFound = "pull secret for registry %q is missing the '.dockerconfigjson' key"
+	ErrRegistryHostnameNotFound = "registry hostname %q not found in pull secret"
 )
 
 // ConvertToDockerConfigJson converts various types of secrets into a proper .dockerconfigjson format. Specifically, rke.cattle.io/auth-config, kubernetes.io/basic-auth,
@@ -30,41 +29,41 @@ func ConvertToDockerConfigJson(registryHost string, secret *kcorev1.Secret) ([]b
 	switch secret.Type {
 	case v1.AuthConfigSecretType:
 		if secret.Data == nil {
-			return nil, fmt.Errorf("'rke.cattle.io/auth-config': %w", ErrSecretDataNil)
+			return nil, fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
 		}
 		auth, ok := secret.Data["auth"]
 		if !ok {
-			return nil, ErrAuthKeyNotFound
+			return nil, fmt.Errorf(ErrAuthKeyNotFound, secret.Name, registryHost)
 		}
 		username, password, found := strings.Cut(string(auth), ":")
 		if !found {
-			return nil, ErrAuthMalformed
+			return nil, fmt.Errorf(ErrAuthMalformed, secret.Name, registryHost)
 		}
 		return BuildDockerConfigJson(registryHost, username, password)
 	case kcorev1.SecretTypeBasicAuth:
 		if secret.Data == nil {
-			return nil, fmt.Errorf("'kubernetes.io/basic-auth': %w", ErrSecretDataNil)
+			return nil, fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
 		}
 		username, ok := secret.Data["username"]
 		if !ok {
-			return nil, ErrUsernameNotFound
+			return nil, fmt.Errorf(ErrUsernameNotFound, secret.Name, registryHost)
 		}
 		password, ok := secret.Data["password"]
 		if !ok {
-			return nil, ErrPasswordNotFound
+			return nil, fmt.Errorf(ErrPasswordNotFound, secret.Name, registryHost)
 		}
 		return BuildDockerConfigJson(registryHost, string(username), string(password))
 	case kcorev1.SecretTypeDockerConfigJson:
 		if secret.Data == nil {
-			return nil, fmt.Errorf("'kubernetes.io/dockerconfigjson': %w", ErrSecretDataNil)
+			return nil, fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
 		}
 		cfg, ok := secret.Data[kcorev1.DockerConfigJsonKey]
 		if !ok {
-			return nil, ErrDockerConfigKeyNotFound
+			return nil, fmt.Errorf(ErrDockerConfigKeyNotFound, secret.Name, registryHost)
 		}
 		return cfg, nil
 	default:
-		return nil, fmt.Errorf("%w: %s", ErrUnsupportedSecretType, secret.Type)
+		return nil, fmt.Errorf(ErrUnsupportedSecretType, secret.Name, registryHost, secret.Type)
 	}
 }
 
@@ -85,7 +84,7 @@ func BuildDockerConfigJson(registryHostname, username, password string) ([]byte,
 func UnwrapDockerConfigJson(registryHostname string, configJson map[string][]byte) (username string, password string, auth string, err error) {
 	credJson, ok := configJson[kcorev1.DockerConfigJsonKey]
 	if !ok {
-		return "", "", "", ErrDockerConfigJsonNotFound
+		return "", "", "", fmt.Errorf(ErrDockerConfigJsonNotFound, registryHostname)
 	}
 
 	var cred credentialprovider.DockerConfigJSON
@@ -96,7 +95,7 @@ func UnwrapDockerConfigJson(registryHostname string, configJson map[string][]byt
 
 	entry, ok := cred.Auths[registryHostname]
 	if !ok {
-		return "", "", "", ErrRegistryHostnameNotFound
+		return "", "", "", fmt.Errorf(ErrRegistryHostnameNotFound, registryHostname)
 	}
 
 	auth = fmt.Sprintf("%s:%s", entry.Username, entry.Password)

--- a/pkg/cluster/private_registry_docker_config_test.go
+++ b/pkg/cluster/private_registry_docker_config_test.go
@@ -3,12 +3,14 @@ package cluster
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	v1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 )
 
@@ -25,41 +27,53 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		secret      *corev1.Secret
-		expectedErr error
-		validate    func(t *testing.T, got []byte)
+		name           string
+		secret         *corev1.Secret
+		expectedErrMsg string
+		validate       func(t *testing.T, got []byte)
 	}{
 		{
 			name: "rke auth-config: valid",
 			secret: &corev1.Secret{
-				Type: v1.AuthConfigSecretType,
-				Data: map[string][]byte{"auth": []byte("myuser:mypass")},
+				ObjectMeta: metav1.ObjectMeta{Name: "auth-secret"},
+				Type:       v1.AuthConfigSecretType,
+				Data:       map[string][]byte{"auth": []byte("myuser:mypass")},
 			},
 			validate: func(t *testing.T, got []byte) {
 				assert.JSONEq(t, string(buildExpectedDockerConfigJSON("myuser", "mypass")), string(got))
 			},
 		},
 		{
+			name: "rke auth-config: nil data",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "auth-secret"},
+				Type:       v1.AuthConfigSecretType,
+			},
+			expectedErrMsg: fmt.Sprintf(ErrSecretDataNil, "auth-secret", host),
+		},
+		{
 			name: "rke auth-config: missing auth key",
 			secret: &corev1.Secret{
-				Type: v1.AuthConfigSecretType,
-				Data: map[string][]byte{},
+				ObjectMeta: metav1.ObjectMeta{Name: "auth-secret"},
+				Type:       v1.AuthConfigSecretType,
+				Data:       map[string][]byte{},
 			},
-			expectedErr: ErrAuthKeyNotFound,
+			expectedErrMsg: fmt.Sprintf(ErrAuthKeyNotFound, "auth-secret", host),
 		},
 		{
 			name: "rke auth-config: malformed auth value (no colon delimiter)",
 			secret: &corev1.Secret{
-				Type: v1.AuthConfigSecretType,
-				Data: map[string][]byte{"auth": []byte("myusermypass")},
+				ObjectMeta: metav1.ObjectMeta{Name: "auth-secret"},
+				Type:       v1.AuthConfigSecretType,
+				Data:       map[string][]byte{"auth": []byte("myusermypass")},
 			},
-			expectedErr: ErrAuthMalformed,
+			expectedErrMsg: fmt.Sprintf(ErrAuthMalformed, "auth-secret", host),
 		},
 		{
 			name: "basic-auth: valid",
 			secret: &corev1.Secret{
-				Type: corev1.SecretTypeBasicAuth,
+				ObjectMeta: metav1.ObjectMeta{Name: "basic-secret"},
+				Type:       corev1.SecretTypeBasicAuth,
 				Data: map[string][]byte{
 					"username": []byte("myuser"),
 					"password": []byte("mypass"),
@@ -70,25 +84,36 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 			},
 		},
 		{
+			name: "basic-auth: nil data",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "basic-secret"},
+				Type:       corev1.SecretTypeBasicAuth,
+			},
+			expectedErrMsg: fmt.Sprintf(ErrSecretDataNil, "basic-secret", host),
+		},
+		{
 			name: "basic-auth: missing username",
 			secret: &corev1.Secret{
-				Type: corev1.SecretTypeBasicAuth,
-				Data: map[string][]byte{"password": []byte("mypass")},
+				ObjectMeta: metav1.ObjectMeta{Name: "basic-secret"},
+				Type:       corev1.SecretTypeBasicAuth,
+				Data:       map[string][]byte{"password": []byte("mypass")},
 			},
-			expectedErr: ErrUsernameNotFound,
+			expectedErrMsg: fmt.Sprintf(ErrUsernameNotFound, "basic-secret", host),
 		},
 		{
 			name: "basic-auth: missing password",
 			secret: &corev1.Secret{
-				Type: corev1.SecretTypeBasicAuth,
-				Data: map[string][]byte{"username": []byte("myuser")},
+				ObjectMeta: metav1.ObjectMeta{Name: "basic-secret"},
+				Type:       corev1.SecretTypeBasicAuth,
+				Data:       map[string][]byte{"username": []byte("myuser")},
 			},
-			expectedErr: ErrPasswordNotFound,
+			expectedErrMsg: fmt.Sprintf(ErrPasswordNotFound, "basic-secret", host),
 		},
 		{
 			name: "dockerconfigjson: valid passthrough",
 			secret: &corev1.Secret{
-				Type: corev1.SecretTypeDockerConfigJson,
+				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret"},
+				Type:       corev1.SecretTypeDockerConfigJson,
 				Data: map[string][]byte{
 					corev1.DockerConfigJsonKey: buildExpectedDockerConfigJSON("myuser", "mypass"),
 				},
@@ -98,20 +123,30 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 			},
 		},
 		{
+			name: "dockerconfigjson: nil data",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret"},
+				Type:       corev1.SecretTypeDockerConfigJson,
+			},
+			expectedErrMsg: fmt.Sprintf(ErrSecretDataNil, "docker-secret", host),
+		},
+		{
 			name: "dockerconfigjson: missing key",
 			secret: &corev1.Secret{
-				Type: corev1.SecretTypeDockerConfigJson,
-				Data: map[string][]byte{},
+				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret"},
+				Type:       corev1.SecretTypeDockerConfigJson,
+				Data:       map[string][]byte{},
 			},
-			expectedErr: ErrDockerConfigKeyNotFound,
+			expectedErrMsg: fmt.Sprintf(ErrDockerConfigKeyNotFound, "docker-secret", host),
 		},
 		{
 			name: "unsupported secret type",
 			secret: &corev1.Secret{
-				Type: "some.other/type",
-				Data: map[string][]byte{},
+				ObjectMeta: metav1.ObjectMeta{Name: "other-secret"},
+				Type:       "some.other/type",
+				Data:       map[string][]byte{},
 			},
-			expectedErr: ErrUnsupportedSecretType,
+			expectedErrMsg: fmt.Sprintf(ErrUnsupportedSecretType, "other-secret", host, "some.other/type"),
 		},
 	}
 
@@ -120,8 +155,8 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ConvertToDockerConfigJson(host, tt.secret)
-			if tt.expectedErr != nil {
-				assert.ErrorIs(t, err, tt.expectedErr)
+			if tt.expectedErrMsg != "" {
+				assert.ErrorContains(t, err, tt.expectedErrMsg)
 				assert.Nil(t, got)
 				return
 			}
@@ -196,9 +231,7 @@ func TestUnwrapDockerConfigJson(t *testing.T) {
 		expectedUsername string
 		expectedPassword string
 		expectedAuth     string
-		expectedErr      error
-		// errContains is used instead of expectedErr when the error format may vary (e.g. stdlib errors).
-		errContains string
+		expectedErrMsg   string
 	}{
 		{
 			name:             "valid config with matching hostname",
@@ -209,22 +242,22 @@ func TestUnwrapDockerConfigJson(t *testing.T) {
 			expectedAuth:     base64.StdEncoding.EncodeToString([]byte("myuser:mypass")),
 		},
 		{
-			name:        "missing .dockerconfigjson key",
-			host:        host,
-			data:        map[string][]byte{},
-			expectedErr: ErrDockerConfigJsonNotFound,
+			name:           "missing .dockerconfigjson key",
+			host:           host,
+			data:           map[string][]byte{},
+			expectedErrMsg: fmt.Sprintf(ErrDockerConfigJsonNotFound, host),
 		},
 		{
-			name:        "invalid JSON",
-			host:        host,
-			data:        map[string][]byte{corev1.DockerConfigJsonKey: []byte("not-json")},
-			errContains: "invalid character",
+			name:           "invalid JSON",
+			host:           host,
+			data:           map[string][]byte{corev1.DockerConfigJsonKey: []byte("not-json")},
+			expectedErrMsg: "invalid character",
 		},
 		{
-			name:        "hostname not found in auths",
-			host:        "other.registry.example.com",
-			data:        makeConfigJSON(host, "myuser", "mypass"),
-			expectedErr: ErrRegistryHostnameNotFound,
+			name:           "hostname not found in auths",
+			host:           "other.registry.example.com",
+			data:           makeConfigJSON(host, "myuser", "mypass"),
+			expectedErrMsg: fmt.Sprintf(ErrRegistryHostnameNotFound, "other.registry.example.com"),
 		},
 	}
 
@@ -233,12 +266,8 @@ func TestUnwrapDockerConfigJson(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			username, password, auth, err := UnwrapDockerConfigJson(tt.host, tt.data)
-			if tt.expectedErr != nil {
-				assert.ErrorIs(t, err, tt.expectedErr)
-				return
-			}
-			if tt.errContains != "" {
-				assert.ErrorContains(t, err, tt.errContains)
+			if tt.expectedErrMsg != "" {
+				assert.ErrorContains(t, err, tt.expectedErrMsg)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -233,7 +233,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			expectedURL: registryURL,
 			expectedPullSecrets: func(t *testing.T) []AgentPullSecret {
 				return []AgentPullSecret{{
-					Name:             "imported-secret",
+					Name:             "imported-secret-rancher-managed-pull-secret",
 					DockerConfigJSON: dockerConfigForCreds(t, "importuser", "importpass"),
 				}}
 			},

--- a/pkg/controllers/capr/machineprovision/args.go
+++ b/pkg/controllers/capr/machineprovision/args.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/management/drivers/nodedriver"
 	"github.com/rancher/wrangler/v3/pkg/data"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
@@ -62,6 +63,7 @@ type driverArgs struct {
 
 	DriverName          string
 	ImageName           string
+	ImagePullSecrets    []corev1.LocalObjectReference
 	CapiMachineName     string
 	MachineName         string
 	MachineNamespace    string
@@ -176,6 +178,12 @@ func (h *handler) getArgsEnvAndStatus(infra *infraObject, args map[string]any, d
 
 	cmd = append(cmd, instanceName)
 
+	var pullSecrets []corev1.LocalObjectReference
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry != nil && len(registry.PullSecrets) > 0 {
+		pullSecrets = registry.PullSecretsAsObjectReferences()
+	}
+
 	return driverArgs{
 		DriverName:          driver,
 		CapiMachineName:     machineName,
@@ -184,6 +192,7 @@ func (h *handler) getArgsEnvAndStatus(infra *infraObject, args map[string]any, d
 		MachineGVK:          infra.obj.GetObjectKind().GroupVersionKind(),
 		ImageName:           settings.PrefixPrivateRegistry(settings.MachineProvisionImage.Get()),
 		ImagePullPolicy:     settings.GetMachineProvisionImagePullPolicy(),
+		ImagePullSecrets:    pullSecrets,
 		EnvSecret:           envSecret,
 		FilesSecret:         filesSecret,
 		CertsSecret:         certsSecret,

--- a/pkg/controllers/capr/machineprovision/template.go
+++ b/pkg/controllers/capr/machineprovision/template.go
@@ -241,6 +241,10 @@ func objects(ready bool, args driverArgs) []runtime.Object {
 		},
 	}
 
+	if len(args.ImagePullSecrets) > 0 {
+		job.Spec.Template.Spec.ImagePullSecrets = args.ImagePullSecrets
+	}
+
 	return []runtime.Object{
 		args.EnvSecret,
 		secret,

--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/dashboard/hostedcluster"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/kubernetesprovider"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/mcmagent"
+	"github.com/rancher/rancher/pkg/controllers/dashboard/privateregistry"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/scaleavailable"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/systemcharts"
 	"github.com/rancher/rancher/pkg/controllers/management/clusterconnected"
@@ -53,6 +54,9 @@ func Register(ctx context.Context, clients *wrangler.Context, embedded bool, reg
 		hostedcluster.Register(ctx, clients)
 		// Automatically enable / disable built-in ProxyEndpoints via settings
 		proxysettings.Register(ctx, clients)
+		// Automatically handle global private registry pull secrets
+		// in the local and downstream imported / hosted clusters.
+		privateregistry.Register(ctx, clients)
 	}
 
 	if features.Fleet.Enabled() {

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
 	"github.com/rancher/rancher/pkg/features"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
@@ -37,12 +38,13 @@ var (
 	}
 
 	watchedSettings = map[string]struct{}{
-		settings.ServerURL.Name:             {},
-		settings.CACerts.Name:               {},
-		settings.SystemDefaultRegistry.Name: {},
-		settings.FleetMinVersion.Name:       {},
-		settings.FleetVersion.Name:          {},
-		settings.AgentTLSMode.Name:          {},
+		settings.ServerURL.Name:                        {},
+		settings.CACerts.Name:                          {},
+		settings.SystemDefaultRegistry.Name:            {},
+		settings.SystemDefaultRegistryPullSecrets.Name: {},
+		settings.FleetMinVersion.Name:                  {},
+		settings.FleetVersion.Name:                     {},
+		settings.AgentTLSMode.Name:                     {},
 	}
 )
 
@@ -71,7 +73,7 @@ type handler struct {
 	chartsConfig chart.RancherConfigGetter
 }
 
-func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error) {
+func (h *handler) onSetting(_ string, setting *v3.Setting) (*v3.Setting, error) {
 	if setting == nil {
 		return nil, nil
 	}
@@ -111,6 +113,13 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 		},
 	}
+
+	var pullSecrets []string
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry != nil {
+		pullSecrets = registry.PullSecretNamesAsSlice()
+	}
+	systemGlobalRegistry["cattle"].(map[string]interface{})["imagePullSecrets"] = pullSecrets
 
 	fleetChartValues := map[string]interface{}{
 		"agentTLSMode": settings.AgentTLSMode.Get(),

--- a/pkg/controllers/dashboard/fleetcharts/controller_test.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller_test.go
@@ -59,6 +59,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -112,6 +113,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -169,6 +171,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -226,6 +229,7 @@ bootstrap:
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -270,9 +274,73 @@ bootstrap:
 				return manager
 			},
 		},
+		{
+			name: "installation with global pull secrets",
+			newManager: func(ctrl *gomock.Controller) chart.Manager {
+				settings.ConfigMapName.Set("pass")
+				settings.FleetMinVersion.Set("")
+				settings.SystemDefaultRegistry.Set("registry.example.com")
+				settings.SystemDefaultRegistryPullSecrets.Set("pull-secret-a,pull-secret-b")
+
+				manager := fake.NewMockManager(ctrl)
+				expectedValues := map[string]interface{}{
+					"agentTLSMode": settings.AgentTLSMode.Get(),
+					"apiServerURL": settings.ServerURL.Get(),
+					"apiServerCA":  settings.CACerts.Get(),
+					"global": map[string]interface{}{
+						"cattle": map[string]interface{}{
+							"systemDefaultRegistry": "registry.example.com",
+							"imagePullSecrets":      []string{"pull-secret-a", "pull-secret-b"},
+						},
+					},
+					"bootstrap": map[string]interface{}{
+						"enabled":        false,
+						"agentNamespace": fleetconst.ReleaseLocalNamespace,
+					},
+					"gitops": map[string]interface{}{
+						"enabled": features.Gitops.Enabled(),
+					},
+					"priorityClassName": priorityClassName,
+				}
+
+				exactVersion := "0.7.0"
+				settings.FleetVersion.Set(exactVersion)
+
+				var b bool
+				manager.EXPECT().Ensure(
+					fleetconst.ReleaseNamespace,
+					fleetconst.CRDChartName,
+					fleetconst.CRDChartName,
+					exactVersion,
+					"",
+					nil,
+					gomock.AssignableToTypeOf(b),
+					"",
+				).Return(nil).Times(len(stgs))
+				manager.EXPECT().Ensure(
+					fleetconst.ReleaseNamespace,
+					fleetconst.ChartName,
+					fleetconst.ChartName,
+					exactVersion,
+					"",
+					expectedValues,
+					gomock.AssignableToTypeOf(b),
+					"",
+				).Return(nil).Times(len(stgs))
+
+				manager.EXPECT().Uninstall(fleetconst.ReleaseLegacyNamespace, fleetconst.ChartName).Return(nil).Times(len(stgs))
+				return manager
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			initialSDR := settings.SystemDefaultRegistry.Get()
+			initialSDRPull := settings.SystemDefaultRegistryPullSecrets.Get()
+			t.Cleanup(func() {
+				settings.SystemDefaultRegistry.Set(initialSDR)
+				settings.SystemDefaultRegistryPullSecrets.Set(initialSDRPull)
+			})
 			ctrl := gomock.NewController(t)
 			configCache := ctrlfake.NewMockCacheInterface[*v1.ConfigMap](ctrl)
 			configCache.EXPECT().

--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	cluster2 "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
 	controllerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -131,6 +132,13 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 		},
 	}
+
+	var pullSecrets []string
+	registry, _ := cluster2.GetPrivateRegistry(nil)
+	if registry != nil {
+		pullSecrets = registry.PullSecretNamesAsSlice()
+	}
+	systemGlobalRegistry["cattle"].(map[string]interface{})["imagePullSecrets"] = pullSecrets
 
 	additionalCA, err := getAdditionalCA(h.secretsCache)
 	if err != nil {

--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -8,6 +8,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	cluster2 "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
+	catalogcontrollers "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	controllerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
@@ -20,6 +21,11 @@ import (
 )
 
 const priorityClassKey = "priorityClassName"
+
+type operatorChart struct {
+	charts  []chart.Definition
+	version func() string
+}
 
 var (
 	AksCrdChart = chart.Definition{
@@ -52,6 +58,21 @@ var (
 		ReleaseName:      "rancher-gke-operator",
 		ChartName:        "rancher-gke-operator",
 	}
+
+	operatorChartMap = map[string]operatorChart{
+		"aks": {
+			charts:  []chart.Definition{AksCrdChart, AksChart},
+			version: settings.AksOperatorVersion.Get,
+		},
+		"gke": {
+			charts:  []chart.Definition{GkeCrdChart, GkeChart},
+			version: settings.GkeOperatorVersion.Get,
+		},
+		"eks": {
+			charts:  []chart.Definition{EksCrdChart, EksChart},
+			version: settings.EksOperatorVersion.Get,
+		},
+	}
 )
 
 type handler struct {
@@ -59,6 +80,7 @@ type handler struct {
 	projectCache controllerv3.ProjectCache
 	secretsCache v1.SecretCache
 	chartsConfig chart.RancherConfigGetter
+	apps         catalogcontrollers.AppController
 }
 
 func Register(ctx context.Context, wContext *wrangler.Context) {
@@ -67,82 +89,93 @@ func Register(ctx context.Context, wContext *wrangler.Context) {
 		projectCache: wContext.Mgmt.Project().Cache(),
 		secretsCache: wContext.Core.Secret().Cache(),
 		chartsConfig: chart.RancherConfigGetter{ConfigCache: wContext.Core.ConfigMap().Cache()},
+		apps:         wContext.Catalog.App(),
 	}
 
 	wContext.Mgmt.Cluster().OnChange(ctx, "cluster-provisioning-operator", h.onClusterChange)
 	wContext.Core.Secret().OnChange(ctx, "watch-helm-release", h.onSecretChange)
+	wContext.Mgmt.Setting().OnChange(ctx, "hosted-operator-redeploy", h.onSettingsChange)
 }
 
-func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, error) {
+func (h handler) onClusterChange(_ string, cluster *v3.Cluster) (*v3.Cluster, error) {
 	if cluster == nil {
 		return cluster, nil
 	}
-
 	skipChartInstallation := strings.EqualFold(settings.SkipHostedClusterChartInstallation.Get(), "true")
 	if skipChartInstallation {
 		logrus.Warn("Skipping installation of hosted cluster charts, 'skip-hosted-cluster-chart-installation' is set to true")
 		return cluster, nil
 	}
-
-	var toInstallCrdChart, toInstallChart *chart.Definition
-	var toInstallCrdChartVersion, toInstallChartVersion string
-	toInstallCrdChartVersion = ""
-	toInstallChartVersion = ""
-	if cluster.Spec.AKSConfig != nil {
-		toInstallCrdChart = &AksCrdChart
-		toInstallChart = &AksChart
-		if aksOperatorVersion := settings.AksOperatorVersion.Get(); aksOperatorVersion != "" {
-			toInstallCrdChartVersion = aksOperatorVersion
-			toInstallChartVersion = aksOperatorVersion
+	switch {
+	case cluster.Spec.AKSConfig != nil:
+		operator := operatorChartMap["aks"]
+		err := h.ensureChart(&operator.charts[0], &operator.charts[1], operator.version())
+		if err != nil {
+			return cluster, err
 		}
-	} else if cluster.Spec.EKSConfig != nil {
-		toInstallCrdChart = &EksCrdChart
-		toInstallChart = &EksChart
-		if eksOperatorVersion := settings.EksOperatorVersion.Get(); eksOperatorVersion != "" {
-			toInstallCrdChartVersion = eksOperatorVersion
-			toInstallChartVersion = eksOperatorVersion
+	case cluster.Spec.EKSConfig != nil:
+		operator := operatorChartMap["eks"]
+		err := h.ensureChart(&operator.charts[0], &operator.charts[1], operator.version())
+		if err != nil {
+			return cluster, err
 		}
-	} else if cluster.Spec.GKEConfig != nil {
-		toInstallCrdChart = &GkeCrdChart
-		toInstallChart = &GkeChart
-		if gkeOperatorVersion := settings.GkeOperatorVersion.Get(); gkeOperatorVersion != "" {
-			toInstallCrdChartVersion = gkeOperatorVersion
-			toInstallChartVersion = gkeOperatorVersion
+	case cluster.Spec.GKEConfig != nil:
+		operator := operatorChartMap["gke"]
+		err := h.ensureChart(&operator.charts[0], &operator.charts[1], operator.version())
+		if err != nil {
+			return cluster, err
 		}
-	}
-
-	if toInstallCrdChart == nil || toInstallChart == nil {
+	default:
 		return cluster, nil
 	}
+	return cluster, nil
+}
 
-	if err := h.manager.Ensure(
-		toInstallCrdChart.ReleaseNamespace,
-		toInstallCrdChart.ChartName,
-		toInstallCrdChart.ReleaseName,
-		toInstallCrdChartVersion,
-		"",
-		nil,
-		true,
-		""); err != nil {
-		return cluster, err
+func (h handler) onSettingsChange(_ string, setting *v3.Setting) (*v3.Setting, error) {
+	if setting == nil || (setting.Name != settings.SystemDefaultRegistryPullSecrets.Name && setting.Name != settings.SystemDefaultRegistry.Name) {
+		return setting, nil
 	}
-
-	systemGlobalRegistry := map[string]interface{}{
-		"cattle": map[string]interface{}{
-			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
-		},
+	skipChartInstallation := strings.EqualFold(settings.SkipHostedClusterChartInstallation.Get(), "true")
+	if skipChartInstallation {
+		logrus.Warn("Skipping installation of hosted cluster charts, 'skip-hosted-cluster-chart-installation' is set to true")
+		return setting, nil
 	}
+	// Ensure that previously installed operators are updated with the latest configuration.
+	for provider, operator := range operatorChartMap {
+		_, err := h.apps.Cache().Get(operator.charts[1].ReleaseNamespace, operator.charts[1].ReleaseName)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		// update the chart with the latest registry configuration
+		err = h.ensureChart(&operator.charts[0], &operator.charts[1], operator.version())
+		if err != nil {
+			return nil, err
+		}
+		logrus.Infof("Successfully redeployed %s operator chart due to change in registry settings", provider)
+	}
+	return setting, nil
+}
 
+func (h handler) ensureChart(toInstallCrdChart, toInstallChart *chart.Definition, chartVersion string) error {
 	var pullSecrets []string
 	registry, _ := cluster2.GetPrivateRegistry(nil)
 	if registry != nil {
 		pullSecrets = registry.PullSecretNamesAsSlice()
 	}
-	systemGlobalRegistry["cattle"].(map[string]interface{})["imagePullSecrets"] = pullSecrets
+
+	systemGlobalRegistry := map[string]interface{}{
+		"cattle": map[string]interface{}{
+			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+			"imagePullSecrets":      pullSecrets,
+		},
+	}
 
 	additionalCA, err := getAdditionalCA(h.secretsCache)
 	if err != nil {
-		return cluster, err
+		return err
 	}
 
 	chartValues := map[string]interface{}{
@@ -152,31 +185,44 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 		"noProxy":              os.Getenv("NO_PROXY"),
 		"additionalTrustedCAs": additionalCA != nil,
 	}
+
 	// add priority class value
 	if priorityClassName, err := h.chartsConfig.GetGlobalValue(chart.PriorityClassKey); err != nil {
 		if !chart.IsNotFoundError(err) {
-			logrus.Warnf("Failed to get rancher priorityClassName for 'rancher-webhook': %s", err.Error())
+			logrus.Warnf("Failed to get rancher priorityClassName for '%q': %v", toInstallChart.ChartName, err)
 		}
 	} else {
 		chartValues[priorityClassKey] = priorityClassName
 	}
 
 	if err := h.manager.Ensure(
+		toInstallCrdChart.ReleaseNamespace,
+		toInstallCrdChart.ChartName,
+		toInstallCrdChart.ReleaseName,
+		chartVersion,
+		"",
+		nil,
+		true,
+		""); err != nil {
+		return err
+	}
+
+	if err := h.manager.Ensure(
 		toInstallChart.ReleaseNamespace,
 		toInstallChart.ChartName,
 		toInstallChart.ReleaseName,
-		toInstallChartVersion,
+		chartVersion,
 		"",
 		chartValues,
 		true,
 		""); err != nil {
-		return cluster, err
+		return err
 	}
 
-	return cluster, nil
+	return nil
 }
 
-// check helm release secrets for aks/eks/gke operator chart, if it has been uninstalled, then remove it in m.manager.desiredChart
+// check helm release secrets for aks/eks/gke operator chart, if it has been uninstalled, then remove it in h.manager.desiredChart
 // so that we don't automatically redeploy it unless there is an AKS/EKS/GKE cluster triggering it
 func (h handler) onSecretChange(key string, obj *corev1.Secret) (*corev1.Secret, error) {
 	if obj == nil {

--- a/pkg/controllers/dashboard/hostedcluster/controller_test.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller_test.go
@@ -43,6 +43,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"httpProxy":            os.Getenv("HTTP_PROXY"),
@@ -91,6 +92,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"httpProxy":            os.Getenv("HTTP_PROXY"),
@@ -137,6 +139,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"httpProxy":            os.Getenv("HTTP_PROXY"),
@@ -174,9 +177,67 @@ func Test_handler_onClusterChange(t *testing.T) {
 				return manager
 			},
 		},
+		{
+			name: "installation with global pull secrets",
+			cluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					AKSConfig: &aksv1.AKSClusterConfigSpec{},
+				},
+			},
+			newManager: func(ctrl *gomock.Controller) chart.Manager {
+				settings.ConfigMapName.Set("pass")
+				settings.AksOperatorVersion.Set("")
+				settings.SystemDefaultRegistry.Set("registry.example.com")
+				settings.SystemDefaultRegistryPullSecrets.Set("pull-secret-a,pull-secret-b")
+
+				manager := chartsfake.NewMockManager(ctrl)
+				expectedValues := map[string]interface{}{
+					"global": map[string]interface{}{
+						"cattle": map[string]interface{}{
+							"systemDefaultRegistry": "registry.example.com",
+							"imagePullSecrets":      []string{"pull-secret-a", "pull-secret-b"},
+						},
+					},
+					"httpProxy":            os.Getenv("HTTP_PROXY"),
+					"httpsProxy":           os.Getenv("HTTPS_PROXY"),
+					"noProxy":              os.Getenv("NO_PROXY"),
+					"additionalTrustedCAs": false,
+					"priorityClassName":    priorityClassName,
+				}
+				var b bool
+				manager.EXPECT().Ensure(
+					AksCrdChart.ReleaseNamespace,
+					AksCrdChart.ReleaseName,
+					AksCrdChart.ChartName,
+					settings.AksOperatorVersion.Get(),
+					"",
+					nil,
+					gomock.AssignableToTypeOf(b),
+					"",
+				).Return(nil)
+				manager.EXPECT().Ensure(
+					AksChart.ReleaseNamespace,
+					AksChart.ReleaseName,
+					AksChart.ChartName,
+					settings.AksOperatorVersion.Get(),
+					"",
+					expectedValues,
+					gomock.AssignableToTypeOf(b),
+					"",
+				).Return(nil)
+
+				return manager
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			initialSDR := settings.SystemDefaultRegistry.Get()
+			initialSDRPull := settings.SystemDefaultRegistryPullSecrets.Get()
+			t.Cleanup(func() {
+				settings.SystemDefaultRegistry.Set(initialSDR)
+				settings.SystemDefaultRegistryPullSecrets.Set(initialSDRPull)
+			})
 			ctrl := gomock.NewController(t)
 			h := newHandler(ctrl)
 			h.manager = tt.newManager(ctrl)

--- a/pkg/controllers/dashboard/hostedcluster/controller_test.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller_test.go
@@ -7,26 +7,56 @@ import (
 	"testing"
 
 	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
 	chartsfake "github.com/rancher/rancher/pkg/controllers/dashboard/chart/fake"
+	catalogcontrollers "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var priorityClassName = "rancher-critical"
+var (
+	priorityClassName = "rancher-critical"
+	errTest           = fmt.Errorf("test error")
+	errNotFound       = apierrors.NewNotFound(schema.GroupResource{}, "")
+)
 
 func Test_handler_onClusterChange(t *testing.T) {
 
 	tests := []struct {
 		name       string
 		cluster    *v3.Cluster
-		newManager func(ctrl *gomock.Controller) chart.Manager
+		newManager func(t *testing.T, ctrl *gomock.Controller) chart.Manager
 		wantErr    bool
 	}{
+		{
+			name:    "nil cluster returns early",
+			cluster: nil,
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				return chartsfake.NewMockManager(ctrl)
+			},
+		},
+		{
+			name: "skip installation when SkipHostedClusterChartInstallation is true",
+			cluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					AKSConfig: &aksv1.AKSClusterConfigSpec{},
+				},
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				t.Setenv("CATTLE_SKIP_HOSTED_CLUSTER_CHART_INSTALLATION", "true")
+				settings.SkipHostedClusterChartInstallation.Set("true")
+				t.Cleanup(func() { settings.SkipHostedClusterChartInstallation.Set("") })
+				return chartsfake.NewMockManager(ctrl)
+			},
+		},
 		{
 			name: "normal installation",
 			cluster: &v3.Cluster{
@@ -34,7 +64,13 @@ func Test_handler_onClusterChange(t *testing.T) {
 					AKSConfig: &aksv1.AKSClusterConfigSpec{},
 				},
 			},
-			newManager: func(ctrl *gomock.Controller) chart.Manager {
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				initialAksOperatorVersion := settings.AksOperatorVersion.Get()
+				t.Cleanup(func() {
+					settings.ConfigMapName.Set(initialConfigMapName)
+					settings.AksOperatorVersion.Set(initialAksOperatorVersion)
+				})
 				settings.ConfigMapName.Set("pass")
 				settings.AksOperatorVersion.Set("")
 
@@ -84,7 +120,13 @@ func Test_handler_onClusterChange(t *testing.T) {
 					AKSConfig: &aksv1.AKSClusterConfigSpec{},
 				},
 			},
-			newManager: func(ctrl *gomock.Controller) chart.Manager {
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				initialAksOperatorVersion := settings.AksOperatorVersion.Get()
+				t.Cleanup(func() {
+					settings.ConfigMapName.Set(initialConfigMapName)
+					settings.AksOperatorVersion.Set(initialAksOperatorVersion)
+				})
 				settings.ConfigMapName.Set("error")
 				settings.AksOperatorVersion.Set("")
 				manager := chartsfake.NewMockManager(ctrl)
@@ -132,7 +174,13 @@ func Test_handler_onClusterChange(t *testing.T) {
 					AKSConfig: &aksv1.AKSClusterConfigSpec{},
 				},
 			},
-			newManager: func(ctrl *gomock.Controller) chart.Manager {
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				initialAksOperatorVersion := settings.AksOperatorVersion.Get()
+				t.Cleanup(func() {
+					settings.ConfigMapName.Set(initialConfigMapName)
+					settings.AksOperatorVersion.Set(initialAksOperatorVersion)
+				})
 				settings.ConfigMapName.Set("pass")
 				manager := chartsfake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
@@ -184,7 +232,13 @@ func Test_handler_onClusterChange(t *testing.T) {
 					AKSConfig: &aksv1.AKSClusterConfigSpec{},
 				},
 			},
-			newManager: func(ctrl *gomock.Controller) chart.Manager {
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				initialAksOperatorVersion := settings.AksOperatorVersion.Get()
+				t.Cleanup(func() {
+					settings.ConfigMapName.Set(initialConfigMapName)
+					settings.AksOperatorVersion.Set(initialAksOperatorVersion)
+				})
 				settings.ConfigMapName.Set("pass")
 				settings.AksOperatorVersion.Set("")
 				settings.SystemDefaultRegistry.Set("registry.example.com")
@@ -229,6 +283,89 @@ func Test_handler_onClusterChange(t *testing.T) {
 				return manager
 			},
 		},
+		{
+			name: "cluster with no provider config does nothing",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "plain-cluster"},
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				return chartsfake.NewMockManager(ctrl) // no Ensure calls expected
+			},
+		},
+		{
+			name: "crd chart ensure failure returns error",
+			cluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					AKSConfig: &aksv1.AKSClusterConfigSpec{},
+				},
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				initialAksOperatorVersion := settings.AksOperatorVersion.Get()
+				t.Cleanup(func() {
+					settings.ConfigMapName.Set(initialConfigMapName)
+					settings.AksOperatorVersion.Set(initialAksOperatorVersion)
+				})
+				settings.ConfigMapName.Set("pass")
+				settings.AksOperatorVersion.Set("")
+
+				manager := chartsfake.NewMockManager(ctrl)
+				var b bool
+				manager.EXPECT().Ensure(
+					AksCrdChart.ReleaseNamespace,
+					AksCrdChart.ReleaseName,
+					AksCrdChart.ChartName,
+					gomock.Any(),
+					"",
+					nil,
+					gomock.AssignableToTypeOf(b),
+					"",
+				).Return(errTest)
+
+				return manager
+			},
+			wantErr: true,
+		},
+		{
+			name: "operator chart ensure failure returns error",
+			cluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					AKSConfig: &aksv1.AKSClusterConfigSpec{},
+				},
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				initialAksOperatorVersion := settings.AksOperatorVersion.Get()
+				t.Cleanup(func() {
+					settings.ConfigMapName.Set(initialConfigMapName)
+					settings.AksOperatorVersion.Set(initialAksOperatorVersion)
+				})
+				settings.ConfigMapName.Set("pass")
+				settings.AksOperatorVersion.Set("")
+
+				manager := chartsfake.NewMockManager(ctrl)
+				var b bool
+				manager.EXPECT().Ensure(
+					AksCrdChart.ReleaseNamespace,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.AssignableToTypeOf(b),
+					"",
+				).Return(nil)
+				manager.EXPECT().Ensure(
+					AksChart.ReleaseNamespace,
+					AksChart.ReleaseName,
+					AksChart.ChartName,
+					gomock.Any(),
+					"",
+					gomock.Any(),
+					gomock.AssignableToTypeOf(b),
+					"",
+				).Return(errTest)
+
+				return manager
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -240,7 +377,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 			})
 			ctrl := gomock.NewController(t)
 			h := newHandler(ctrl)
-			h.manager = tt.newManager(ctrl)
+			h.manager = tt.newManager(t, ctrl)
 			got, err := h.onClusterChange("", tt.cluster)
 			if tt.wantErr {
 				assert.Error(t, err, "handler.onRepo() error = %v, wantErr %v", err, tt.wantErr)
@@ -254,9 +391,281 @@ func Test_handler_onClusterChange(t *testing.T) {
 	}
 }
 
+func Test_handler_onSettingsChange(t *testing.T) {
+	installedApp := &catalogv1.App{ObjectMeta: metav1.ObjectMeta{Name: "operator", Namespace: "cattle-system"}}
+
+	tests := []struct {
+		name       string
+		setting    *v3.Setting
+		setupApps  func(*gomock.Controller) catalogcontrollers.AppController
+		newManager func(t *testing.T, ctrl *gomock.Controller) chart.Manager
+		wantErr    bool
+	}{
+		{
+			name:    "nil setting returns early",
+			setting: nil,
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				return fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				return chartsfake.NewMockManager(ctrl)
+			},
+		},
+		{
+			name:    "unrelated setting name returns early",
+			setting: &v3.Setting{ObjectMeta: metav1.ObjectMeta{Name: "some-other-setting"}},
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				return fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				return chartsfake.NewMockManager(ctrl)
+			},
+		},
+		{
+			name:    "no operators installed, no charts redeployed",
+			setting: &v3.Setting{ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistry.Name}},
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				appsCtrl := fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+				appsCache := fake.NewMockCacheInterface[*catalogv1.App](ctrl)
+				appsCtrl.EXPECT().Cache().Return(appsCache).AnyTimes()
+				appsCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, errNotFound).AnyTimes()
+				return appsCtrl
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				return chartsfake.NewMockManager(ctrl) // no Ensure calls expected
+			},
+		},
+		{
+			name:    "app cache error returns error",
+			setting: &v3.Setting{ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistry.Name}},
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				appsCtrl := fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+				appsCache := fake.NewMockCacheInterface[*catalogv1.App](ctrl)
+				appsCtrl.EXPECT().Cache().Return(appsCache).AnyTimes()
+				// One provider's Get returns a non-NotFound error; others return NotFound.
+				appsCache.EXPECT().Get("cattle-system", "rancher-aks-operator").Return(nil, errTest).AnyTimes()
+				appsCache.EXPECT().Get("cattle-system", "rancher-eks-operator").Return(nil, errNotFound).AnyTimes()
+				appsCache.EXPECT().Get("cattle-system", "rancher-gke-operator").Return(nil, errNotFound).AnyTimes()
+				return appsCtrl
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				return chartsfake.NewMockManager(ctrl)
+			},
+			wantErr: true,
+		},
+		{
+			name:    "aks operator installed, SystemDefaultRegistry change triggers redeploy",
+			setting: &v3.Setting{ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistry.Name}},
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				appsCtrl := fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+				appsCache := fake.NewMockCacheInterface[*catalogv1.App](ctrl)
+				appsCtrl.EXPECT().Cache().Return(appsCache).AnyTimes()
+				appsCache.EXPECT().Get("cattle-system", "rancher-aks-operator").Return(installedApp, nil)
+				appsCache.EXPECT().Get("cattle-system", "rancher-eks-operator").Return(nil, errNotFound)
+				appsCache.EXPECT().Get("cattle-system", "rancher-gke-operator").Return(nil, errNotFound)
+				return appsCtrl
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				t.Cleanup(func() { settings.ConfigMapName.Set(initialConfigMapName) })
+				settings.ConfigMapName.Set("pass")
+				manager := chartsfake.NewMockManager(ctrl)
+				var b bool
+				// AKS CRD chart
+				manager.EXPECT().Ensure(
+					AksCrdChart.ReleaseNamespace, AksCrdChart.ReleaseName, AksCrdChart.ChartName,
+					gomock.Any(), "", nil, gomock.AssignableToTypeOf(b), "",
+				).Return(nil)
+				// AKS operator chart
+				manager.EXPECT().Ensure(
+					AksChart.ReleaseNamespace, AksChart.ReleaseName, AksChart.ChartName,
+					gomock.Any(), "", gomock.Any(), gomock.AssignableToTypeOf(b), "",
+				).Return(nil)
+				return manager
+			},
+		},
+		{
+			name:    "aks operator installed, SystemDefaultRegistryPullSecrets change triggers redeploy",
+			setting: &v3.Setting{ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name}},
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				appsCtrl := fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+				appsCache := fake.NewMockCacheInterface[*catalogv1.App](ctrl)
+				appsCtrl.EXPECT().Cache().Return(appsCache).AnyTimes()
+				appsCache.EXPECT().Get("cattle-system", "rancher-aks-operator").Return(installedApp, nil)
+				appsCache.EXPECT().Get("cattle-system", "rancher-eks-operator").Return(nil, errNotFound)
+				appsCache.EXPECT().Get("cattle-system", "rancher-gke-operator").Return(nil, errNotFound)
+				return appsCtrl
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				t.Cleanup(func() { settings.ConfigMapName.Set(initialConfigMapName) })
+				settings.ConfigMapName.Set("pass")
+				manager := chartsfake.NewMockManager(ctrl)
+				var b bool
+				manager.EXPECT().Ensure(
+					AksCrdChart.ReleaseNamespace, AksCrdChart.ReleaseName, AksCrdChart.ChartName,
+					gomock.Any(), "", nil, gomock.AssignableToTypeOf(b), "",
+				).Return(nil)
+				manager.EXPECT().Ensure(
+					AksChart.ReleaseNamespace, AksChart.ReleaseName, AksChart.ChartName,
+					gomock.Any(), "", gomock.Any(), gomock.AssignableToTypeOf(b), "",
+				).Return(nil)
+				return manager
+			},
+		},
+		{
+			name:    "operator installed but ensureChart fails, returns error",
+			setting: &v3.Setting{ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistry.Name}},
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				appsCtrl := fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+				appsCache := fake.NewMockCacheInterface[*catalogv1.App](ctrl)
+				appsCtrl.EXPECT().Cache().Return(appsCache).AnyTimes()
+				// All three may try to install; make all return an installed app so any attempt will fail.
+				appsCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(installedApp, nil).AnyTimes()
+				return appsCtrl
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				t.Cleanup(func() { settings.ConfigMapName.Set(initialConfigMapName) })
+				settings.ConfigMapName.Set("pass")
+				manager := chartsfake.NewMockManager(ctrl)
+				// The first Ensure call for any provider returns an error.
+				manager.EXPECT().Ensure(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errTest).AnyTimes()
+				return manager
+			},
+			wantErr: true,
+		},
+		{
+			name:    "orphaned operator (no cluster) is still redeployed on settings change",
+			setting: &v3.Setting{ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistry.Name}},
+			setupApps: func(ctrl *gomock.Controller) catalogcontrollers.AppController {
+				// App exists in the cluster even though there is no v3.Cluster object using it.
+				appsCtrl := fake.NewMockControllerInterface[*catalogv1.App, *catalogv1.AppList](ctrl)
+				appsCache := fake.NewMockCacheInterface[*catalogv1.App](ctrl)
+				appsCtrl.EXPECT().Cache().Return(appsCache).AnyTimes()
+				appsCache.EXPECT().Get("cattle-system", "rancher-aks-operator").Return(installedApp, nil)
+				appsCache.EXPECT().Get("cattle-system", "rancher-eks-operator").Return(nil, errNotFound)
+				appsCache.EXPECT().Get("cattle-system", "rancher-gke-operator").Return(nil, errNotFound)
+				return appsCtrl
+			},
+			newManager: func(t *testing.T, ctrl *gomock.Controller) chart.Manager {
+				initialConfigMapName := settings.ConfigMapName.Get()
+				t.Cleanup(func() { settings.ConfigMapName.Set(initialConfigMapName) })
+				settings.ConfigMapName.Set("pass")
+				manager := chartsfake.NewMockManager(ctrl)
+				var b bool
+				manager.EXPECT().Ensure(
+					AksCrdChart.ReleaseNamespace, AksCrdChart.ReleaseName, AksCrdChart.ChartName,
+					gomock.Any(), "", nil, gomock.AssignableToTypeOf(b), "",
+				).Return(nil)
+				manager.EXPECT().Ensure(
+					AksChart.ReleaseNamespace, AksChart.ReleaseName, AksChart.ChartName,
+					gomock.Any(), "", gomock.Any(), gomock.AssignableToTypeOf(b), "",
+				).Return(nil)
+				return manager
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			secretsCache := fake.NewMockCacheInterface[*v1.Secret](ctrl)
+			secretsCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			configCache := fake.NewMockCacheInterface[*v1.ConfigMap](ctrl)
+			configCache.EXPECT().Get(gomock.Any(), "pass").Return(&v1.ConfigMap{Data: map[string]string{"priorityClassName": priorityClassName}}, nil).AnyTimes()
+			configCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
+
+			h := &handler{
+				secretsCache: secretsCache,
+				chartsConfig: chart.RancherConfigGetter{ConfigCache: configCache},
+				manager:      tt.newManager(t, ctrl),
+				apps:         tt.setupApps(ctrl),
+			}
+
+			result, err := h.onSettingsChange("", tt.setting)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.setting, result)
+		})
+	}
+}
+
+func Test_handler_onSecretChange(t *testing.T) {
+	tests := []struct {
+		name         string
+		key          string
+		obj          *v1.Secret
+		expectRemove bool
+		removeNS     string
+		removeName   string
+	}{
+		{
+			name:         "non-nil secret, no remove",
+			key:          "cattle-system/sh.helm.release.v1.rancher-aks-operator.v1",
+			obj:          &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sh.helm.release.v1.rancher-aks-operator.v1", Namespace: "cattle-system"}},
+			expectRemove: false,
+		},
+		{
+			name:         "nil secret with wrong namespace, no remove",
+			key:          "other-namespace/sh.helm.release.v1.rancher-aks-operator.v1",
+			obj:          nil,
+			expectRemove: false,
+		},
+		{
+			name:         "nil secret in cattle-system but name has wrong segment count, no remove",
+			key:          "cattle-system/sh.helm.release.rancher-aks-operator.v1",
+			obj:          nil,
+			expectRemove: false,
+		},
+		{
+			name:         "nil secret, cattle-system, aks operator release name, triggers remove",
+			key:          "cattle-system/sh.helm.release.v1.rancher-aks-operator.v1",
+			obj:          nil,
+			expectRemove: true,
+			removeNS:     "cattle-system",
+			removeName:   "rancher-aks-operator",
+		},
+		{
+			name:         "nil secret, cattle-system, aks crd release name, triggers remove",
+			key:          "cattle-system/sh.helm.release.v1.rancher-aks-operator-crd.v1",
+			obj:          nil,
+			expectRemove: true,
+			removeNS:     "cattle-system",
+			removeName:   "rancher-aks-operator-crd",
+		},
+		{
+			name:         "nil secret, cattle-system, non-operator release name, no remove",
+			key:          "cattle-system/sh.helm.release.v1.some-other-chart.v1",
+			obj:          nil,
+			expectRemove: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			manager := chartsfake.NewMockManager(ctrl)
+			if tt.expectRemove {
+				manager.EXPECT().Remove(tt.removeNS, tt.removeName)
+			}
+			h := &handler{manager: manager}
+
+			result, err := h.onSecretChange(tt.key, tt.obj)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.obj, result)
+		})
+	}
+}
+
 func newHandler(ctrl *gomock.Controller) *handler {
 	secretsCache := fake.NewMockCacheInterface[*v1.Secret](ctrl)
-	secretsCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil)
+	secretsCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	configCache := fake.NewMockCacheInterface[*v1.ConfigMap](ctrl)
 	configCache.EXPECT().Get(gomock.Any(), "pass").Return(&v1.ConfigMap{Data: map[string]string{"priorityClassName": priorityClassName}}, nil).AnyTimes()
 	configCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()

--- a/pkg/controllers/dashboard/privateregistry/controller.go
+++ b/pkg/controllers/dashboard/privateregistry/controller.go
@@ -1,0 +1,455 @@
+package privateregistry
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	util "github.com/rancher/rancher/pkg/cluster"
+	"github.com/rancher/rancher/pkg/controllers/managementuser/secret"
+	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	provisioningv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/project"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/wrangler"
+	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/v3/pkg/relatedresource"
+	"github.com/sirupsen/logrus"
+	kcorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type handler struct {
+	settings                 mgmtcontrollers.SettingController
+	secrets                  corecontrollers.SecretController
+	secretCache              corecontrollers.SecretCache
+	project                  mgmtcontrollers.ProjectController
+	projectCache             mgmtcontrollers.ProjectCache
+	mgmtCluster              mgmtcontrollers.ClusterController
+	mgmtClusterCache         mgmtcontrollers.ClusterCache
+	provisioningClusterCache provisioningv1.ClusterCache
+}
+
+const clusterToSysProjIndex = "mgmt-system-project"
+
+func Register(ctx context.Context, wContext *wrangler.Context) {
+	h := &handler{
+		settings:                 wContext.Mgmt.Setting(),
+		secrets:                  wContext.Core.Secret(),
+		secretCache:              wContext.Core.Secret().Cache(),
+		project:                  wContext.Mgmt.Project(),
+		projectCache:             wContext.Mgmt.Project().Cache(),
+		mgmtCluster:              wContext.Mgmt.Cluster(),
+		mgmtClusterCache:         wContext.Mgmt.Cluster().Cache(),
+		provisioningClusterCache: wContext.Provisioning.Cluster().Cache(),
+	}
+
+	// maps cluster names to their system projects
+	h.projectCache.AddIndexer(clusterToSysProjIndex, func(obj *v3.Project) ([]string, error) {
+		if obj != nil && obj.Labels != nil && obj.ObjectMeta.Labels[project.SystemProjectLabelKey] == "true" {
+			if obj.Spec.ClusterName == "" {
+				return nil, fmt.Errorf("[private-registry] system project has empty cluster name")
+			}
+			return []string{obj.Spec.ClusterName}, nil
+		}
+		return []string{}, nil
+	})
+
+	h.settings.OnChange(ctx, "sync-source-secrets", h.labelSourceGlobalRegistryPullSecret)
+	h.mgmtCluster.OnChange(ctx, "manage-system-project-pull-secret-label", h.labelSystemProject)
+	h.mgmtCluster.OnChange(ctx, "manage-pss-downstream-clusters", h.manageImportedAndHostedClusterPSS)
+
+	// enqueue any v3 cluster which relies on the global configuration to ensure that in place updates to global pull secrets are promptly applied to downstream clusters.
+	relatedresource.WatchClusterScoped(ctx, "sync-cluster-global-pull-secret-contents", func(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
+		sec, ok := obj.(*kcorev1.Secret)
+		if !ok {
+			logrus.Errorf("[private-registry] failed to convert to secret")
+			return nil, nil
+		}
+		if sec.Labels == nil || sec.Labels[util.SourcePullSecretLabel] != "true" {
+			return nil, nil
+		}
+
+		configuredPullSecrets := activeGlobalPullSecrets()
+		if !configuredPullSecrets.Has(sec.Name) {
+			return nil, nil
+		}
+
+		return findV3ClustersUsingGlobalPullSecrets(h.mgmtClusterCache)
+	}, wContext.Mgmt.Cluster(), wContext.Core.Secret())
+
+	// enqueue any v3 cluster which relies on the global configuration to ensure that setting changes are promptly applied to downstream clusters
+	relatedresource.WatchClusterScoped(ctx, "sync-cluster-global-pull-secret-settings", func(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
+		if name != settings.SystemDefaultRegistryPullSecrets.Name && name != settings.SystemDefaultRegistry.Name {
+			return nil, nil
+		}
+		return findV3ClustersUsingGlobalPullSecrets(h.mgmtClusterCache)
+	}, wContext.Mgmt.Cluster(), wContext.Mgmt.Setting())
+}
+
+// labelSystemProject manages the 'management.cattle.io/use-global-private-registry-pull-secret' label
+// on system projects associated with imported or hosted clusters which rely on the global system default
+// registry pull secrets. This label is referenced in the project scoped secrets implementation to
+// ensure that the globally defined pull secrets are properly copied into the relevant namespaces in
+// the local cluster and downstream imported and hosted clusters.
+func (h *handler) labelSystemProject(_ string, cluster *v3.Cluster) (*v3.Cluster, error) {
+	if cluster == nil {
+		return cluster, nil
+	}
+
+	logrus.Tracef("[private-registry] syncing system project label for cluster %q", cluster.Name)
+	if (!v3.ClusterConditionSystemProjectCreated.IsTrue(cluster) || !v3.ClusterConditionAgentDeployed.IsTrue(cluster)) && cluster.Name != "local" {
+		logrus.Debugf("[private-registry] cluster %q not ready (systemProjectCreated=%v, agentDeployed=%v), skipping",
+			cluster.Name,
+			v3.ClusterConditionSystemProjectCreated.IsTrue(cluster),
+			v3.ClusterConditionAgentDeployed.IsTrue(cluster))
+		return cluster, nil
+	}
+
+	// Don't do this for provisioned clusters, the creds will be passed via prov2 and the system-agent.
+	if !util.MgmtNameRegexp.MatchString(cluster.Name) {
+		logrus.Debugf("[private-registry] cluster %q is provisioned, not imported/hosted; skipping system project label management", cluster.Name)
+		return cluster, nil
+	}
+
+	sysProj, err := h.getSystemProjectForCluster(cluster.Name)
+	if err != nil {
+		logrus.Errorf("[private-registry] failed to get system project for cluster %q: %v", cluster.Name, err)
+		return cluster, err
+	}
+
+	usesGlobalSecrets := sysProj.Labels != nil && sysProj.Labels[secret.NeedsGlobalPrivateRegistryPullSecret] == "true"
+	registry, isGlobalDefault := util.GetPrivateRegistry(cluster)
+
+	logrus.Tracef("[private-registry] cluster %q: isGlobalDefault=%v, usesGlobalSecrets=%v, registryNil=%v",
+		cluster.Name, isGlobalDefault, usesGlobalSecrets, registry == nil)
+
+	shouldUseGlobalSecrets := isGlobalDefault && registry != nil && len(registry.PullSecrets) > 0
+
+	if usesGlobalSecrets && !shouldUseGlobalSecrets {
+		logrus.Debugf("[private-registry] removing global pull secret label from system project %q for cluster %q", sysProj.Name, cluster.Name)
+		sysProj = sysProj.DeepCopy()
+		delete(sysProj.Labels, secret.NeedsGlobalPrivateRegistryPullSecret)
+		_, err = h.project.Update(sysProj)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to remove global pull secret label from system project %q for cluster %q: %v", sysProj.Name, cluster.Name, err)
+			return cluster, err
+		}
+		return cluster, nil
+	}
+
+	if !usesGlobalSecrets && shouldUseGlobalSecrets {
+		logrus.Debugf("[private-registry] adding global pull secret label to system project %q for cluster %q", sysProj.Name, cluster.Name)
+		sysProj = sysProj.DeepCopy()
+		if sysProj.Labels == nil {
+			sysProj.Labels = map[string]string{}
+		}
+		sysProj.Labels[secret.NeedsGlobalPrivateRegistryPullSecret] = "true"
+		_, err = h.project.Update(sysProj)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to add global pull secret label to system project %q for cluster %q: %v", sysProj.Name, cluster.Name, err)
+			return cluster, err
+		}
+	}
+
+	return cluster, nil
+}
+
+// labelSourceGlobalRegistryPullSecret handles the labeling and unlabeling of global system default registry pull secrets.
+// The label is used by other controls to synchronize the contents of the source pull secret to PSS copies in downstream clusters and
+// system project namespaces in the local cluster.
+func (h *handler) labelSourceGlobalRegistryPullSecret(_ string, setting *v3.Setting) (*v3.Setting, error) {
+	if setting == nil || setting.Name != settings.SystemDefaultRegistryPullSecrets.Name {
+		return setting, nil
+	}
+
+	logrus.Tracef("[private-registry] syncing global registry pull secret labels for setting %q", setting.Name)
+
+	existingGlobalPullSecrets, err := h.secretCache.List(namespaces.System, labels.SelectorFromSet(map[string]string{
+		util.SourcePullSecretLabel: "true",
+	}))
+	if err != nil {
+		logrus.Errorf("[private-registry] failed to list labeled source pull secrets in namespace %q: %v", namespaces.System, err)
+		return setting, err
+	}
+
+	existingSecretsSet := sets.New[string]()
+	for _, s := range existingGlobalPullSecrets {
+		existingSecretsSet.Insert(s.Name)
+	}
+	logrus.Debugf("[private-registry] found %d existing labeled pull secret(s): %v", existingSecretsSet.Len(), existingSecretsSet.UnsortedList())
+
+	specifiedSecretsSet := activeGlobalPullSecrets()
+
+	logrus.Debugf("[private-registry] setting specifies %d pull secret(s): %v", specifiedSecretsSet.Len(), specifiedSecretsSet.UnsortedList())
+
+	toRemove := existingSecretsSet.Difference(specifiedSecretsSet).UnsortedList()
+	if len(toRemove) > 0 {
+		logrus.Debugf("[private-registry] removing source label from %d secret(s): %v", len(toRemove), toRemove)
+	}
+
+	for _, s := range toRemove {
+		sec, err := h.secretCache.Get(namespaces.System, s)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to get secret %q in namespace %q: %v", s, namespaces.System, err)
+			return setting, err
+		}
+		sec = sec.DeepCopy()
+		delete(sec.Labels, util.SourcePullSecretLabel)
+		delete(sec.Annotations, secret.PSSIgnoreNamespacesAnnotation)
+		logrus.Tracef("[private-registry] removing source label and PSS annotation from secret %q", s)
+		_, err = h.secrets.Update(sec)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to update secret %q in namespace %q: %v", s, namespaces.System, err)
+			return setting, err
+		}
+	}
+
+	toLabel := specifiedSecretsSet.Difference(existingSecretsSet).UnsortedList()
+	if len(toLabel) > 0 {
+		logrus.Debugf("[private-registry] applying source label to %d secret(s): %v", len(toLabel), toLabel)
+	}
+
+	for _, s := range toLabel {
+		sec, err := h.secretCache.Get(namespaces.System, s)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to get secret %q in namespace %q: %v", s, namespaces.System, err)
+			return setting, err
+		}
+		sec = sec.DeepCopy()
+		if sec.Labels == nil {
+			sec.Labels = map[string]string{}
+		}
+		sec.Labels[util.SourcePullSecretLabel] = "true"
+		if sec.Annotations == nil {
+			sec.Annotations = map[string]string{}
+		}
+		sec.Annotations[secret.PSSIgnoreNamespacesAnnotation] = strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ",")
+		logrus.Tracef("[private-registry] applying source label and PSS annotation to secret %q", s)
+		_, err = h.secrets.Update(sec)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to update secret %q in namespace %q: %v", s, namespaces.System, err)
+			return setting, err
+		}
+	}
+
+	return setting, nil
+}
+
+// manageImportedAndHostedClusterPSS handles the synchronization of source image pull secrets and project scoped secrets
+// for downstream imported and hosted clusters only. This handler specifically focuses on clusters which define an override,
+// and ignores clusters that rely on the global configuration. Imported / Hosted clusters which rely on the GSDR will
+// receive their pull secrets via alternative system project pull secret propagation logic incorporated in the PSS implementation.
+func (h *handler) manageImportedAndHostedClusterPSS(_ string, cluster *v3.Cluster) (*v3.Cluster, error) {
+	if cluster == nil || cluster.Name == "local" {
+		return cluster, nil
+	}
+
+	logrus.Tracef("[private-registry] managing PSS for cluster %q", cluster.Name)
+
+	// don't use pull secrets if we're working with a provisioned cluster, credentials
+	// will be configured at the container runtime level.
+	if !util.MgmtNameRegexp.MatchString(cluster.Name) {
+		logrus.Debugf("[private-registry] cluster %q is provisioned, not imported/hosted; skipping PSS management", cluster.Name)
+		return cluster, nil
+	}
+
+	if !v3.ClusterConditionSystemProjectCreated.IsTrue(cluster) || !v3.ClusterConditionAgentDeployed.IsTrue(cluster) {
+		logrus.Debugf("[private-registry] cluster %q not ready (systemProjectCreated=%v, agentDeployed=%v), skipping",
+			cluster.Name,
+			v3.ClusterConditionSystemProjectCreated.IsTrue(cluster),
+			v3.ClusterConditionAgentDeployed.IsTrue(cluster))
+		return cluster, nil
+	}
+
+	sysProj, err := h.getSystemProjectForCluster(cluster.Name)
+	if err != nil {
+		logrus.Errorf("[private-registry] failed to get system project for cluster %q: %v", cluster.Name, err)
+		return cluster, err
+	}
+
+	backingNamespace := sysProj.GetProjectBackingNamespace()
+	logrus.Tracef("[private-registry] using backing namespace %q for cluster %q", backingNamespace, cluster.Name)
+
+	// gather all PSS's for this specific cluster in its system projects backing namespace
+	createdPSS, err := h.secretCache.List(backingNamespace, labels.SelectorFromSet(map[string]string{
+		util.CopiedPullSecretLabel: "true",
+	}))
+	if err != nil {
+		logrus.Errorf("[private-registry] failed to list copied PSS(s) in backing namespace %q for cluster %q: %v", backingNamespace, cluster.Name, err)
+		return cluster, err
+	}
+
+	privateRegistry, isGlobalDefault := util.GetPrivateRegistry(cluster)
+	if (privateRegistry == nil || isGlobalDefault) && len(createdPSS) == 0 {
+		logrus.Debugf("[private-registry] no applicable cluster-level pull secrets for cluster %q (isGlobalDefault=%v), skipping", cluster.Name, isGlobalDefault)
+		return cluster, nil
+	}
+
+	var configuredPullSecrets []kcorev1.SecretReference
+	if privateRegistry != nil {
+		configuredPullSecrets = privateRegistry.PullSecrets
+	}
+
+	// This finds the secrets that are specified
+	// on the cluster and creates a slice of all the secrets
+	// which currently exist.
+	var sourceAuthSecrets []*kcorev1.Secret
+	for _, ds := range configuredPullSecrets {
+		s, err := h.secretCache.Get(ds.Namespace, ds.Name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				logrus.Warnf("[private-registry] pull secret %q/%q defined on cluster %q not found, skipping", ds.Namespace, ds.Name, cluster.Name)
+				continue
+			}
+			logrus.Errorf("[private-registry] failed to get pull secret %q/%q for cluster %q: %v", ds.Namespace, ds.Name, cluster.Name, err)
+			return cluster, err
+		}
+		logrus.Tracef("[private-registry] resolved source pull secret %q/%q for cluster %q", ds.Namespace, ds.Name, cluster.Name)
+		sourceAuthSecrets = append(sourceAuthSecrets, s)
+	}
+	logrus.Debugf("[private-registry] resolved %d source pull secrets and found %d existing PSS(s) for cluster %q", len(sourceAuthSecrets), len(createdPSS), cluster.Name)
+
+	// Delete any PSS's that were created for secrets no longer specified on the cluster object.
+	for _, pss := range createdPSS {
+		if slices.ContainsFunc(sourceAuthSecrets, func(s *kcorev1.Secret) bool { return s.Name == pss.Name }) {
+			continue
+		}
+		logrus.Debugf("[private-registry] deleting stale PSS %q from namespace %q", pss.Name, backingNamespace)
+		err = h.secrets.Delete(pss.Namespace, pss.Name, &metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			logrus.Errorf("[private-registry] failed to delete stale PSS %q from namespace %q: %v", pss.Name, backingNamespace, err)
+			return cluster, err
+		}
+	}
+
+	if isGlobalDefault || privateRegistry == nil {
+		return cluster, nil
+	}
+
+	// Create any missing PSS's
+	for _, sourcePullSecret := range sourceAuthSecrets {
+		data, err := util.ConvertToDockerConfigJson(privateRegistry.URL, sourcePullSecret)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to convert pull secret %q to docker config for cluster %q: %v", sourcePullSecret.Name, cluster.Name, err)
+			continue
+		}
+
+		existingSecret := findSecretByName(createdPSS, sourcePullSecret.Name)
+		if existingSecret == nil {
+			logrus.Debugf("[private-registry] creating PSS %q in namespace %q for cluster %q", sourcePullSecret.Name, backingNamespace, cluster.Name)
+			pss := buildPSS(sysProj, backingNamespace, sourcePullSecret.Name, data)
+			_, err = h.secrets.Create(pss)
+			if err != nil && !errors.IsAlreadyExists(err) {
+				logrus.Errorf("[private-registry] failed to create PSS %q in namespace %q: %v", sourcePullSecret.Name, backingNamespace, err)
+				return cluster, err
+			}
+			continue
+		}
+
+		existingData := existingSecret.Data[kcorev1.DockerConfigJsonKey]
+		if bytes.Equal(existingData, data) {
+			logrus.Tracef("[private-registry] PSS %q in namespace %q is up to date", sourcePullSecret.Name, backingNamespace)
+			continue
+		}
+
+		logrus.Debugf("[private-registry] updating PSS %q in namespace %q for cluster %q", sourcePullSecret.Name, backingNamespace, cluster.Name)
+		existingSecret = existingSecret.DeepCopy()
+		existingSecret.Data[kcorev1.DockerConfigJsonKey] = data
+		_, err = h.secrets.Update(existingSecret)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to update PSS %q in namespace %q: %v", sourcePullSecret.Name, backingNamespace, err)
+			return cluster, err
+		}
+	}
+
+	return cluster, nil
+}
+
+func (h *handler) getSystemProjectForCluster(clusterName string) (*v3.Project, error) {
+	logrus.Tracef("[private-registry] looking up system project for cluster %q", clusterName)
+	clusterSystemProj, err := h.projectCache.GetByIndex(clusterToSysProjIndex, clusterName)
+	if err != nil {
+		logrus.Errorf("[private-registry] failed to look up system project for cluster %q: %v", clusterName, err)
+		return nil, err
+	}
+	if clusterSystemProj == nil || len(clusterSystemProj) == 0 {
+		logrus.Tracef("[private-registry] no system project found for cluster %q", clusterName)
+		return nil, fmt.Errorf("no system project found for cluster %q", clusterName)
+	}
+	localSystemProj := clusterSystemProj[0]
+	logrus.Tracef("[private-registry] found system project %q for cluster %q", localSystemProj.Name, clusterName)
+	return localSystemProj, nil
+}
+
+func buildPSS(proj *v3.Project, systemProjectBackingNamespace, name string, dockerconfigjson []byte) *kcorev1.Secret {
+	pss := &kcorev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: systemProjectBackingNamespace,
+			Annotations: map[string]string{
+				secret.PSSIgnoreNamespacesAnnotation: strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","),
+			},
+			Labels: map[string]string{
+				util.CopiedPullSecretLabel:                    "true",
+				secret.ProjectScopedSecretLabel:               proj.Name,
+				"management.cattle.io/registry-scoped-secret": "true",
+			},
+		},
+		Data: map[string][]byte{
+			kcorev1.DockerConfigJsonKey: dockerconfigjson,
+		},
+		Type: kcorev1.SecretTypeDockerConfigJson,
+	}
+
+	return pss
+}
+
+// findSecretByName returns the first secret in the slice whose name matches the given name, or nil if not found.
+func findSecretByName(secrets []*kcorev1.Secret, name string) *kcorev1.Secret {
+	for _, s := range secrets {
+		if s.Name == name {
+			return s
+		}
+	}
+	return nil
+}
+
+func findV3ClustersUsingGlobalPullSecrets(clusterCache mgmtcontrollers.ClusterCache) ([]relatedresource.Key, error) {
+	clusters, err := clusterCache.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	var clusterNames []relatedresource.Key
+	for _, cluster := range clusters {
+		_, isGlobalDefault := util.GetPrivateRegistry(cluster)
+		if !isGlobalDefault {
+			continue
+		}
+		if util.MgmtNameRegexp.MatchString(cluster.Name) {
+			clusterNames = append(clusterNames, relatedresource.Key{
+				Name: cluster.Name,
+			})
+		}
+	}
+	return clusterNames, nil
+}
+
+func activeGlobalPullSecrets() sets.Set[string] {
+	specifiedSecretsSet := sets.New[string]()
+	registry, _ := util.GetPrivateRegistry(nil)
+	if registry != nil {
+		for _, p := range registry.PullSecrets {
+			specifiedSecretsSet.Insert(p.Name)
+		}
+	}
+	return specifiedSecretsSet
+}

--- a/pkg/controllers/dashboard/privateregistry/controller.go
+++ b/pkg/controllers/dashboard/privateregistry/controller.go
@@ -30,12 +30,12 @@ import (
 )
 
 type handler struct {
-	secrets               corecontrollers.SecretController
-	secretCache           corecontrollers.SecretCache
-	project               mgmtcontrollers.ProjectController
-	projectCache          mgmtcontrollers.ProjectCache
-	mgmtClusterCache      mgmtcontrollers.ClusterCache
-	mgmtClusterController mgmtcontrollers.ClusterController
+	secrets          corecontrollers.SecretController
+	secretCache      corecontrollers.SecretCache
+	projects         mgmtcontrollers.ProjectController
+	projectCache     mgmtcontrollers.ProjectCache
+	mgmtClusters     mgmtcontrollers.ClusterController
+	mgmtClusterCache mgmtcontrollers.ClusterCache
 }
 
 const (
@@ -43,21 +43,24 @@ const (
 	clusterEnqueueBatchSize     = 10
 	clusterEnqueueDelay         = 2 * time.Second
 	clusterEnqueueJitterCeiling = 750 // milliseconds
+	// registrySecretUIHint is a label used by the UI to conditionally render special
+	// fields specific to registry credentials when viewed in the UI.
+	registrySecretUIHint = "management.cattle.io/registry-scoped-secret"
 )
 
 func Register(ctx context.Context, wContext *wrangler.Context) {
 	h := &handler{
-		secrets:               wContext.Core.Secret(),
-		secretCache:           wContext.Core.Secret().Cache(),
-		project:               wContext.Mgmt.Project(),
-		projectCache:          wContext.Mgmt.Project().Cache(),
-		mgmtClusterCache:      wContext.Mgmt.Cluster().Cache(),
-		mgmtClusterController: wContext.Mgmt.Cluster(),
+		secrets:          wContext.Core.Secret(),
+		secretCache:      wContext.Core.Secret().Cache(),
+		projects:         wContext.Mgmt.Project(),
+		projectCache:     wContext.Mgmt.Project().Cache(),
+		mgmtClusters:     wContext.Mgmt.Cluster(),
+		mgmtClusterCache: wContext.Mgmt.Cluster().Cache(),
 	}
 
 	// maps cluster names to their system projects
 	h.projectCache.AddIndexer(clusterToSysProjIndex, func(obj *v3.Project) ([]string, error) {
-		if obj != nil && obj.Labels != nil && obj.ObjectMeta.Labels[project.SystemProjectLabelKey] == "true" {
+		if obj != nil && obj.Labels != nil && obj.Labels[project.SystemProjectLabelKey] == "true" {
 			if obj.Spec.ClusterName == "" {
 				return nil, fmt.Errorf("[private-registry] system project has empty cluster name")
 			}
@@ -95,18 +98,18 @@ func (h *handler) labelSystemProject(_ string, cluster *v3.Cluster) (*v3.Cluster
 		return cluster, nil
 	}
 
+	// Don't do this for provisioned clusters, the creds will be passed via prov2 and the system-agent.
+	if !util.MgmtNameRegexp.MatchString(cluster.Name) {
+		logrus.Tracef("[private-registry] cluster %q is provisioned, not imported/hosted; skipping system project label management", cluster.Name)
+		return cluster, nil
+	}
+
 	logrus.Tracef("[private-registry] syncing system project label for cluster %q", cluster.Name)
 	if !v3.ClusterConditionSystemProjectCreated.IsTrue(cluster) || !v3.ClusterConditionAgentDeployed.IsTrue(cluster) {
 		logrus.Debugf("[private-registry] cluster %q not ready (systemProjectCreated=%v, agentDeployed=%v), skipping",
 			cluster.Name,
 			v3.ClusterConditionSystemProjectCreated.IsTrue(cluster),
 			v3.ClusterConditionAgentDeployed.IsTrue(cluster))
-		return cluster, nil
-	}
-
-	// Don't do this for provisioned clusters, the creds will be passed via prov2 and the system-agent.
-	if !util.MgmtNameRegexp.MatchString(cluster.Name) {
-		logrus.Debugf("[private-registry] cluster %q is provisioned, not imported/hosted; skipping system project label management", cluster.Name)
 		return cluster, nil
 	}
 
@@ -128,7 +131,7 @@ func (h *handler) labelSystemProject(_ string, cluster *v3.Cluster) (*v3.Cluster
 		logrus.Debugf("[private-registry] removing global pull secret label from system project %q for cluster %q", sysProj.Name, cluster.Name)
 		sysProj = sysProj.DeepCopy()
 		delete(sysProj.Labels, secret.NeedsGlobalPrivateRegistryPullSecret)
-		_, err = h.project.Update(sysProj)
+		_, err = h.projects.Update(sysProj)
 		if err != nil {
 			logrus.Errorf("[private-registry] failed to remove global pull secret label from system project %q for cluster %q: %v", sysProj.Name, cluster.Name, err)
 			return cluster, err
@@ -143,7 +146,7 @@ func (h *handler) labelSystemProject(_ string, cluster *v3.Cluster) (*v3.Cluster
 			sysProj.Labels = map[string]string{}
 		}
 		sysProj.Labels[secret.NeedsGlobalPrivateRegistryPullSecret] = "true"
-		_, err = h.project.Update(sysProj)
+		_, err = h.projects.Update(sysProj)
 		if err != nil {
 			logrus.Errorf("[private-registry] failed to add global pull secret label to system project %q for cluster %q: %v", sysProj.Name, cluster.Name, err)
 			return cluster, err
@@ -237,13 +240,7 @@ func (h *handler) labelConfiguredSourceGlobalRegistryPullSecrets(_ string, setti
 // labelSourceGlobalRegistryPullSecret ensures that the secrets defined in the SystemDefaultRegistryPullSecrets global setting
 // always have the correct SourcePullSecretLabel label and PSS namespace ignore label values.
 func (h *handler) labelSourceGlobalRegistryPullSecret(_ string, s *kcorev1.Secret) (*corev1.Secret, error) {
-	if s == nil {
-		return s, nil
-	}
-	if s.Namespace != namespaces.System {
-		return s, nil
-	}
-	if s.Data == nil {
+	if s == nil || s.DeletionTimestamp != nil || s.Namespace != namespaces.System || s.Data == nil {
 		return s, nil
 	}
 
@@ -385,7 +382,6 @@ func (h *handler) manageClusterSpecificPSS(_ string, cluster *v3.Cluster) (*v3.C
 			return cluster, err
 		}
 
-		// Compute the name the PSS will use in the backing namespace.
 		pssName := sourcePullSecret.Name
 		if cluster.Name != "local" {
 			pssName = util.GeneratePullSecretName(pssName)
@@ -419,6 +415,7 @@ func (h *handler) manageClusterSpecificPSS(_ string, cluster *v3.Cluster) (*v3.C
 				existing.Data = map[string][]byte{}
 			}
 			existing.Labels[util.CopiedPullSecretLabel] = "true"
+			existing.Labels[registrySecretUIHint] = "true"
 			existing.Data[kcorev1.DockerConfigJsonKey] = data
 			logrus.Debugf("[private-registry] adopting existing PSS %q in namespace %q for cluster %q", pssName, backingNamespace, cluster.Name)
 			_, err = h.secrets.Update(existing)
@@ -433,8 +430,9 @@ func (h *handler) manageClusterSpecificPSS(_ string, cluster *v3.Cluster) (*v3.C
 			existingSecret.Data = map[string][]byte{}
 		}
 
+		registrySecretValue, isRegistrySecret := existingSecret.Labels[registrySecretUIHint]
 		existingData := existingSecret.Data[kcorev1.DockerConfigJsonKey]
-		if bytes.Equal(existingData, data) {
+		if bytes.Equal(existingData, data) && isRegistrySecret && registrySecretValue == "true" {
 			logrus.Tracef("[private-registry] PSS %q in namespace %q is up to date", pssName, backingNamespace)
 			continue
 		}
@@ -442,6 +440,7 @@ func (h *handler) manageClusterSpecificPSS(_ string, cluster *v3.Cluster) (*v3.C
 		logrus.Debugf("[private-registry] updating PSS %q in namespace %q for cluster %q", pssName, backingNamespace, cluster.Name)
 		existingSecret = existingSecret.DeepCopy()
 		existingSecret.Data[kcorev1.DockerConfigJsonKey] = data
+		existingSecret.Labels[registrySecretUIHint] = "true"
 		_, err = h.secrets.Update(existingSecret)
 		if err != nil {
 			logrus.Errorf("[private-registry] failed to update PSS %q in namespace %q: %v", pssName, backingNamespace, err)
@@ -473,7 +472,7 @@ func (h *handler) syncClusterOnGlobalPullSecretChange(_ string, _ string, obj ru
 	if err != nil {
 		return nil, err
 	}
-	enqueueStaggered(clusters, h.mgmtClusterController)
+	enqueueStaggered(clusters, h.mgmtClusters)
 	return nil, nil
 }
 
@@ -488,7 +487,7 @@ func (h *handler) syncClusterOnGlobalRegistrySettingChange(_ string, name string
 	if err != nil {
 		return nil, err
 	}
-	enqueueStaggered(clusters, h.mgmtClusterController)
+	enqueueStaggered(clusters, h.mgmtClusters)
 	return nil, nil
 }
 
@@ -517,9 +516,9 @@ func buildPSS(proj *v3.Project, systemProjectBackingNamespace, name string, dock
 				secret.PSSIgnoreNamespacesAnnotation: strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","),
 			},
 			Labels: map[string]string{
-				util.CopiedPullSecretLabel:                    "true",
-				secret.ProjectScopedSecretLabel:               proj.Name,
-				"management.cattle.io/registry-scoped-secret": "true",
+				util.CopiedPullSecretLabel:      "true",
+				secret.ProjectScopedSecretLabel: proj.Name,
+				registrySecretUIHint:            "true",
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/controllers/dashboard/privateregistry/controller.go
+++ b/pkg/controllers/dashboard/privateregistry/controller.go
@@ -4,14 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"slices"
 	"strings"
+	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/secret"
 	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
-	provisioningv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
+	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/settings"
@@ -28,28 +30,29 @@ import (
 )
 
 type handler struct {
-	settings                 mgmtcontrollers.SettingController
-	secrets                  corecontrollers.SecretController
-	secretCache              corecontrollers.SecretCache
-	project                  mgmtcontrollers.ProjectController
-	projectCache             mgmtcontrollers.ProjectCache
-	mgmtCluster              mgmtcontrollers.ClusterController
-	mgmtClusterCache         mgmtcontrollers.ClusterCache
-	provisioningClusterCache provisioningv1.ClusterCache
+	secrets               corecontrollers.SecretController
+	secretCache           corecontrollers.SecretCache
+	project               mgmtcontrollers.ProjectController
+	projectCache          mgmtcontrollers.ProjectCache
+	mgmtClusterCache      mgmtcontrollers.ClusterCache
+	mgmtClusterController mgmtcontrollers.ClusterController
 }
 
-const clusterToSysProjIndex = "mgmt-system-project"
+const (
+	clusterToSysProjIndex       = "mgmt-system-project"
+	clusterEnqueueBatchSize     = 10
+	clusterEnqueueDelay         = 2 * time.Second
+	clusterEnqueueJitterCeiling = 750 // milliseconds
+)
 
 func Register(ctx context.Context, wContext *wrangler.Context) {
 	h := &handler{
-		settings:                 wContext.Mgmt.Setting(),
-		secrets:                  wContext.Core.Secret(),
-		secretCache:              wContext.Core.Secret().Cache(),
-		project:                  wContext.Mgmt.Project(),
-		projectCache:             wContext.Mgmt.Project().Cache(),
-		mgmtCluster:              wContext.Mgmt.Cluster(),
-		mgmtClusterCache:         wContext.Mgmt.Cluster().Cache(),
-		provisioningClusterCache: wContext.Provisioning.Cluster().Cache(),
+		secrets:               wContext.Core.Secret(),
+		secretCache:           wContext.Core.Secret().Cache(),
+		project:               wContext.Mgmt.Project(),
+		projectCache:          wContext.Mgmt.Project().Cache(),
+		mgmtClusterCache:      wContext.Mgmt.Cluster().Cache(),
+		mgmtClusterController: wContext.Mgmt.Cluster(),
 	}
 
 	// maps cluster names to their system projects
@@ -63,50 +66,37 @@ func Register(ctx context.Context, wContext *wrangler.Context) {
 		return []string{}, nil
 	})
 
-	h.settings.OnChange(ctx, "sync-source-secrets", h.labelSourceGlobalRegistryPullSecret)
-	h.mgmtCluster.OnChange(ctx, "manage-system-project-pull-secret-label", h.labelSystemProject)
-	h.mgmtCluster.OnChange(ctx, "manage-pss-downstream-clusters", h.manageImportedAndHostedClusterPSS)
+	// Updates source pull secrets in the cattle-system namespace when the global settings change
+	wContext.Mgmt.Setting().OnChange(ctx, "sync-source-secrets", h.labelConfiguredSourceGlobalRegistryPullSecrets)
+
+	// Labels the system project of imported or hosted clusters to request image pull secrets
+	wContext.Mgmt.Cluster().OnChange(ctx, "manage-configured-system-project-pull-secret-label", h.labelSystemProject)
+
+	// Creates PSS copies of the cluster level pull secrets configured for imported and hosted clusters.
+	wContext.Mgmt.Cluster().OnChange(ctx, "manage-pss-downstream-clusters", h.manageClusterSpecificPSS)
+
+	// Ensures that secrets configured in the global settings always have the source pull secret label.
+	wContext.Core.Secret().OnChange(ctx, "manage-configured-system-project-pull-secret-label", h.labelSourceGlobalRegistryPullSecret)
 
 	// enqueue any v3 cluster which relies on the global configuration to ensure that in place updates to global pull secrets are promptly applied to downstream clusters.
-	relatedresource.WatchClusterScoped(ctx, "sync-cluster-global-pull-secret-contents", func(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
-		sec, ok := obj.(*kcorev1.Secret)
-		if !ok {
-			logrus.Errorf("[private-registry] failed to convert to secret")
-			return nil, nil
-		}
-		if sec.Labels == nil || sec.Labels[util.SourcePullSecretLabel] != "true" {
-			return nil, nil
-		}
-
-		configuredPullSecrets := activeGlobalPullSecrets()
-		if !configuredPullSecrets.Has(sec.Name) {
-			return nil, nil
-		}
-
-		return findV3ClustersUsingGlobalPullSecrets(h.mgmtClusterCache)
-	}, wContext.Mgmt.Cluster(), wContext.Core.Secret())
+	relatedresource.WatchClusterScoped(ctx, "sync-cluster-global-pull-secret-contents", h.syncClusterOnGlobalPullSecretChange, wContext.Mgmt.Cluster(), wContext.Core.Secret())
 
 	// enqueue any v3 cluster which relies on the global configuration to ensure that setting changes are promptly applied to downstream clusters
-	relatedresource.WatchClusterScoped(ctx, "sync-cluster-global-pull-secret-settings", func(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
-		if name != settings.SystemDefaultRegistryPullSecrets.Name && name != settings.SystemDefaultRegistry.Name {
-			return nil, nil
-		}
-		return findV3ClustersUsingGlobalPullSecrets(h.mgmtClusterCache)
-	}, wContext.Mgmt.Cluster(), wContext.Mgmt.Setting())
+	relatedresource.WatchClusterScoped(ctx, "sync-cluster-global-pull-secret-settings", h.syncClusterOnGlobalRegistrySettingChange, wContext.Mgmt.Cluster(), wContext.Mgmt.Setting())
 }
 
 // labelSystemProject manages the 'management.cattle.io/use-global-private-registry-pull-secret' label
 // on system projects associated with imported or hosted clusters which rely on the global system default
 // registry pull secrets. This label is referenced in the project scoped secrets implementation to
 // ensure that the globally defined pull secrets are properly copied into the relevant namespaces in
-// the local cluster and downstream imported and hosted clusters.
+// downstream imported and hosted clusters.
 func (h *handler) labelSystemProject(_ string, cluster *v3.Cluster) (*v3.Cluster, error) {
-	if cluster == nil {
+	if cluster == nil || cluster.Name == "local" {
 		return cluster, nil
 	}
 
 	logrus.Tracef("[private-registry] syncing system project label for cluster %q", cluster.Name)
-	if (!v3.ClusterConditionSystemProjectCreated.IsTrue(cluster) || !v3.ClusterConditionAgentDeployed.IsTrue(cluster)) && cluster.Name != "local" {
+	if !v3.ClusterConditionSystemProjectCreated.IsTrue(cluster) || !v3.ClusterConditionAgentDeployed.IsTrue(cluster) {
 		logrus.Debugf("[private-registry] cluster %q not ready (systemProjectCreated=%v, agentDeployed=%v), skipping",
 			cluster.Name,
 			v3.ClusterConditionSystemProjectCreated.IsTrue(cluster),
@@ -163,11 +153,11 @@ func (h *handler) labelSystemProject(_ string, cluster *v3.Cluster) (*v3.Cluster
 	return cluster, nil
 }
 
-// labelSourceGlobalRegistryPullSecret handles the labeling and unlabeling of global system default registry pull secrets.
-// The label is used by other controls to synchronize the contents of the source pull secret to PSS copies in downstream clusters and
-// system project namespaces in the local cluster.
-func (h *handler) labelSourceGlobalRegistryPullSecret(_ string, setting *v3.Setting) (*v3.Setting, error) {
-	if setting == nil || setting.Name != settings.SystemDefaultRegistryPullSecrets.Name {
+// labelConfiguredSourceGlobalRegistryPullSecrets handles the labeling and unlabeling of global system default registry pull secrets whenever the
+// global settings change. The label is used by other controllers to synchronize the contents of the source pull secret to PSS copies
+// in downstream clusters and system project namespaces in the local cluster.
+func (h *handler) labelConfiguredSourceGlobalRegistryPullSecrets(_ string, setting *v3.Setting) (*v3.Setting, error) {
+	if setting == nil || (setting.Name != settings.SystemDefaultRegistryPullSecrets.Name && setting.Name != settings.SystemDefaultRegistry.Name) {
 		return setting, nil
 	}
 
@@ -244,12 +234,58 @@ func (h *handler) labelSourceGlobalRegistryPullSecret(_ string, setting *v3.Sett
 	return setting, nil
 }
 
-// manageImportedAndHostedClusterPSS handles the synchronization of source image pull secrets and project scoped secrets
-// for downstream imported and hosted clusters only. This handler specifically focuses on clusters which define an override,
-// and ignores clusters that rely on the global configuration. Imported / Hosted clusters which rely on the GSDR will
-// receive their pull secrets via alternative system project pull secret propagation logic incorporated in the PSS implementation.
-func (h *handler) manageImportedAndHostedClusterPSS(_ string, cluster *v3.Cluster) (*v3.Cluster, error) {
-	if cluster == nil || cluster.Name == "local" {
+// labelSourceGlobalRegistryPullSecret ensures that the secrets defined in the SystemDefaultRegistryPullSecrets global setting
+// always have the correct SourcePullSecretLabel label and PSS namespace ignore label values.
+func (h *handler) labelSourceGlobalRegistryPullSecret(_ string, s *kcorev1.Secret) (*corev1.Secret, error) {
+	if s == nil {
+		return s, nil
+	}
+	if s.Namespace != namespaces.System {
+		return s, nil
+	}
+	if s.Data == nil {
+		return s, nil
+	}
+
+	activePullSecrets := activeGlobalPullSecrets()
+	if !activePullSecrets.Has(s.Name) {
+		return s, nil
+	}
+
+	sps, hasSps := s.Labels[util.SourcePullSecretLabel]
+	ins, hasIns := s.Annotations[secret.PSSIgnoreNamespacesAnnotation]
+	expectedIns := strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ",")
+	if !hasSps || sps != "true" || !hasIns || ins == "" || ins != expectedIns {
+		s = s.DeepCopy()
+		if s.Labels == nil {
+			s.Labels = map[string]string{}
+		}
+		if s.Annotations == nil {
+			s.Annotations = map[string]string{}
+		}
+		if !hasSps || sps != "true" {
+			s.Labels[util.SourcePullSecretLabel] = "true"
+		}
+		if !hasIns || ins == "" || ins != expectedIns {
+			s.Annotations[secret.PSSIgnoreNamespacesAnnotation] = expectedIns
+		}
+		_, err := h.secrets.Update(s)
+		if err != nil {
+			logrus.Errorf("[private-registry] failed to label secret %q as source pull secret: %v", s.Name, err)
+			return s, err
+		}
+	}
+
+	return s, nil
+}
+
+// manageClusterSpecificPSS handles the synchronization of source image pull secrets and project scoped secrets
+// for downstream imported and hosted clusters, as well as the local cluster. This handler specifically
+// focuses on clusters which define an override, and ignores clusters that rely on the global configuration,
+// with an exception for the local cluster. Imported / Hosted clusters which rely on the GSDR will receive
+// their pull secrets via alternative system project pull secret propagation logic incorporated in the PSS implementation.
+func (h *handler) manageClusterSpecificPSS(_ string, cluster *v3.Cluster) (*v3.Cluster, error) {
+	if cluster == nil {
 		return cluster, nil
 	}
 
@@ -262,7 +298,7 @@ func (h *handler) manageImportedAndHostedClusterPSS(_ string, cluster *v3.Cluste
 		return cluster, nil
 	}
 
-	if !v3.ClusterConditionSystemProjectCreated.IsTrue(cluster) || !v3.ClusterConditionAgentDeployed.IsTrue(cluster) {
+	if cluster.Name != "local" && (!v3.ClusterConditionSystemProjectCreated.IsTrue(cluster) || !v3.ClusterConditionAgentDeployed.IsTrue(cluster)) {
 		logrus.Debugf("[private-registry] cluster %q not ready (systemProjectCreated=%v, agentDeployed=%v), skipping",
 			cluster.Name,
 			v3.ClusterConditionSystemProjectCreated.IsTrue(cluster),
@@ -289,7 +325,7 @@ func (h *handler) manageImportedAndHostedClusterPSS(_ string, cluster *v3.Cluste
 	}
 
 	privateRegistry, isGlobalDefault := util.GetPrivateRegistry(cluster)
-	if (privateRegistry == nil || isGlobalDefault) && len(createdPSS) == 0 {
+	if cluster.Name != "local" && (privateRegistry == nil || isGlobalDefault) && len(createdPSS) == 0 {
 		logrus.Debugf("[private-registry] no applicable cluster-level pull secrets for cluster %q (isGlobalDefault=%v), skipping", cluster.Name, isGlobalDefault)
 		return cluster, nil
 	}
@@ -320,7 +356,13 @@ func (h *handler) manageImportedAndHostedClusterPSS(_ string, cluster *v3.Cluste
 
 	// Delete any PSS's that were created for secrets no longer specified on the cluster object.
 	for _, pss := range createdPSS {
-		if slices.ContainsFunc(sourceAuthSecrets, func(s *kcorev1.Secret) bool { return s.Name == pss.Name }) {
+		if slices.ContainsFunc(sourceAuthSecrets, func(s *kcorev1.Secret) bool {
+			expectedName := s.Name
+			if cluster.Name != "local" {
+				expectedName = util.GeneratePullSecretName(s.Name)
+			}
+			return expectedName == pss.Name
+		}) {
 			continue
 		}
 		logrus.Debugf("[private-registry] deleting stale PSS %q from namespace %q", pss.Name, backingNamespace)
@@ -331,7 +373,7 @@ func (h *handler) manageImportedAndHostedClusterPSS(_ string, cluster *v3.Cluste
 		}
 	}
 
-	if isGlobalDefault || privateRegistry == nil {
+	if (cluster.Name != "local" && isGlobalDefault) || privateRegistry == nil {
 		return cluster, nil
 	}
 
@@ -340,38 +382,114 @@ func (h *handler) manageImportedAndHostedClusterPSS(_ string, cluster *v3.Cluste
 		data, err := util.ConvertToDockerConfigJson(privateRegistry.URL, sourcePullSecret)
 		if err != nil {
 			logrus.Errorf("[private-registry] failed to convert pull secret %q to docker config for cluster %q: %v", sourcePullSecret.Name, cluster.Name, err)
-			continue
+			return cluster, err
 		}
 
-		existingSecret := findSecretByName(createdPSS, sourcePullSecret.Name)
+		// Compute the name the PSS will use in the backing namespace.
+		pssName := sourcePullSecret.Name
+		if cluster.Name != "local" {
+			pssName = util.GeneratePullSecretName(pssName)
+		}
+
+		existingSecret := findSecretByName(createdPSS, pssName)
 		if existingSecret == nil {
-			logrus.Debugf("[private-registry] creating PSS %q in namespace %q for cluster %q", sourcePullSecret.Name, backingNamespace, cluster.Name)
-			pss := buildPSS(sysProj, backingNamespace, sourcePullSecret.Name, data)
-			_, err = h.secrets.Create(pss)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				logrus.Errorf("[private-registry] failed to create PSS %q in namespace %q: %v", sourcePullSecret.Name, backingNamespace, err)
+			logrus.Debugf("[private-registry] creating PSS %q in namespace %q for cluster %q", pssName, backingNamespace, cluster.Name)
+			pss := buildPSS(sysProj, backingNamespace, pssName, data)
+			_, err := h.secrets.Create(pss)
+			if err == nil {
+				continue
+			}
+			if !errors.IsAlreadyExists(err) {
+				logrus.Errorf("[private-registry] failed to create PSS %q in namespace %q: %v", pssName, backingNamespace, err)
+				return cluster, err
+			}
+			// adopt the pull secret if it already exists but does not have
+			// the expected label. We fetch from cache to avoid relying on the
+			// potentially nil return value from Create on conflict.
+			existing, err := h.secretCache.Get(backingNamespace, pssName)
+			if err != nil {
+				logrus.Errorf("[private-registry] failed to get existing PSS %q in namespace %q for adoption: %v", pssName, backingNamespace, err)
+				return cluster, err
+			}
+			existing = existing.DeepCopy()
+			if existing.Labels == nil {
+				existing.Labels = map[string]string{}
+			}
+			if existing.Data == nil {
+				existing.Data = map[string][]byte{}
+			}
+			existing.Labels[util.CopiedPullSecretLabel] = "true"
+			existing.Data[kcorev1.DockerConfigJsonKey] = data
+			logrus.Debugf("[private-registry] adopting existing PSS %q in namespace %q for cluster %q", pssName, backingNamespace, cluster.Name)
+			_, err = h.secrets.Update(existing)
+			if err != nil {
+				logrus.Errorf("[private-registry] failed to update adopted PSS %q in namespace %q: %v", pssName, backingNamespace, err)
 				return cluster, err
 			}
 			continue
 		}
 
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
 		existingData := existingSecret.Data[kcorev1.DockerConfigJsonKey]
 		if bytes.Equal(existingData, data) {
-			logrus.Tracef("[private-registry] PSS %q in namespace %q is up to date", sourcePullSecret.Name, backingNamespace)
+			logrus.Tracef("[private-registry] PSS %q in namespace %q is up to date", pssName, backingNamespace)
 			continue
 		}
 
-		logrus.Debugf("[private-registry] updating PSS %q in namespace %q for cluster %q", sourcePullSecret.Name, backingNamespace, cluster.Name)
+		logrus.Debugf("[private-registry] updating PSS %q in namespace %q for cluster %q", pssName, backingNamespace, cluster.Name)
 		existingSecret = existingSecret.DeepCopy()
 		existingSecret.Data[kcorev1.DockerConfigJsonKey] = data
 		_, err = h.secrets.Update(existingSecret)
 		if err != nil {
-			logrus.Errorf("[private-registry] failed to update PSS %q in namespace %q: %v", sourcePullSecret.Name, backingNamespace, err)
+			logrus.Errorf("[private-registry] failed to update PSS %q in namespace %q: %v", pssName, backingNamespace, err)
 			return cluster, err
 		}
 	}
 
 	return cluster, nil
+}
+
+// syncClusterOnGlobalPullSecretChange re-enqueues all imported/hosted/local clusters that rely on the
+// global registry configuration whenever a source pull secret in cattle-system is updated.
+func (h *handler) syncClusterOnGlobalPullSecretChange(_ string, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	sec, ok := obj.(*kcorev1.Secret)
+	if !ok {
+		logrus.Errorf("[private-registry] failed to convert to secret")
+		return nil, nil
+	}
+	if sec.Labels == nil || sec.Labels[util.SourcePullSecretLabel] != "true" {
+		return nil, nil
+	}
+
+	configuredPullSecrets := activeGlobalPullSecrets()
+	if !configuredPullSecrets.Has(sec.Name) {
+		return nil, nil
+	}
+
+	clusters, err := findV3ClustersUsingGlobalPullSecrets(h.mgmtClusterCache)
+	if err != nil {
+		return nil, err
+	}
+	enqueueStaggered(clusters, h.mgmtClusterController)
+	return nil, nil
+}
+
+// syncClusterOnGlobalRegistrySettingChange re-enqueues all imported/hosted/local clusters that rely on
+// the global registry configuration whenever the SystemDefaultRegistry or SystemDefaultRegistryPullSecrets
+// settings are updated.
+func (h *handler) syncClusterOnGlobalRegistrySettingChange(_ string, name string, _ runtime.Object) ([]relatedresource.Key, error) {
+	if name != settings.SystemDefaultRegistryPullSecrets.Name && name != settings.SystemDefaultRegistry.Name {
+		return nil, nil
+	}
+	clusters, err := findV3ClustersUsingGlobalPullSecrets(h.mgmtClusterCache)
+	if err != nil {
+		return nil, err
+	}
+	enqueueStaggered(clusters, h.mgmtClusterController)
+	return nil, nil
 }
 
 func (h *handler) getSystemProjectForCluster(clusterName string) (*v3.Project, error) {
@@ -381,7 +499,7 @@ func (h *handler) getSystemProjectForCluster(clusterName string) (*v3.Project, e
 		logrus.Errorf("[private-registry] failed to look up system project for cluster %q: %v", clusterName, err)
 		return nil, err
 	}
-	if clusterSystemProj == nil || len(clusterSystemProj) == 0 {
+	if len(clusterSystemProj) == 0 {
 		logrus.Tracef("[private-registry] no system project found for cluster %q", clusterName)
 		return nil, fmt.Errorf("no system project found for cluster %q", clusterName)
 	}
@@ -423,22 +541,18 @@ func findSecretByName(secrets []*kcorev1.Secret, name string) *kcorev1.Secret {
 	return nil
 }
 
-func findV3ClustersUsingGlobalPullSecrets(clusterCache mgmtcontrollers.ClusterCache) ([]relatedresource.Key, error) {
+func findV3ClustersUsingGlobalPullSecrets(clusterCache mgmtcontrollers.ClusterCache) ([]string, error) {
 	clusters, err := clusterCache.List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
-	var clusterNames []relatedresource.Key
+	var clusterNames []string
 	for _, cluster := range clusters {
 		_, isGlobalDefault := util.GetPrivateRegistry(cluster)
 		if !isGlobalDefault {
 			continue
 		}
-		if util.MgmtNameRegexp.MatchString(cluster.Name) {
-			clusterNames = append(clusterNames, relatedresource.Key{
-				Name: cluster.Name,
-			})
-		}
+		clusterNames = append(clusterNames, cluster.Name)
 	}
 	return clusterNames, nil
 }
@@ -452,4 +566,16 @@ func activeGlobalPullSecrets() sets.Set[string] {
 		}
 	}
 	return specifiedSecretsSet
+}
+
+// enqueueStaggered enqueues the given cluster names with a staggered delay to avoid thundering herd issues.
+// Clusters are enqueued in batches of 10 with a base delay of 2 seconds between batches, plus a random jitter
+// of up to 750 milliseconds.
+func enqueueStaggered(clusterNames []string, clusterController mgmtcontrollers.ClusterController) {
+	for i, cluster := range clusterNames {
+		batchIndex := i / clusterEnqueueBatchSize
+		jitter := time.Duration(rand.IntN(clusterEnqueueJitterCeiling)) * time.Millisecond
+		delay := time.Duration(batchIndex)*(clusterEnqueueDelay) + jitter
+		clusterController.EnqueueAfter(cluster, delay)
+	}
 }

--- a/pkg/controllers/dashboard/privateregistry/controller_test.go
+++ b/pkg/controllers/dashboard/privateregistry/controller_test.go
@@ -1,0 +1,1114 @@
+package privateregistry
+
+import (
+	"fmt"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/cluster"
+	"github.com/rancher/rancher/pkg/controllers/managementuser/secret"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/project"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	errDefault  = fmt.Errorf("error")
+	errNotFound = apierrors.NewNotFound(schema.GroupResource{}, "")
+)
+
+func readyCluster(name string, importedCfg *v3.ImportedConfig) *v3.Cluster {
+	return &v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v3.ClusterSpec{
+			ImportedConfig:     importedCfg,
+			FleetWorkspaceName: "fleet-default",
+		},
+		Status: v3.ClusterStatus{
+			Conditions: []v3.ClusterCondition{
+				{Type: "SystemProjectCreated", Status: corev1.ConditionTrue},
+				{Type: "AgentDeployed", Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func systemProject(clusterName, projectName string, extraLabels map[string]string) *v3.Project {
+	l := map[string]string{
+		project.SystemProjectLabelKey: "true",
+	}
+	for k, v := range extraLabels {
+		l[k] = v
+	}
+	return &v3.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: projectName, Labels: l},
+		Spec:       v3.ProjectSpec{ClusterName: clusterName},
+		Status:     v3.ProjectStatus{BackingNamespace: clusterName + "-" + projectName},
+	}
+}
+
+func withSettings(t *testing.T, registryURL, pullSecrets string) {
+	t.Helper()
+	origRegistry := settings.SystemDefaultRegistry.Get()
+	origPullSecrets := settings.SystemDefaultRegistryPullSecrets.Get()
+	t.Cleanup(func() {
+		settings.SystemDefaultRegistry.Set(origRegistry)
+		settings.SystemDefaultRegistryPullSecrets.Set(origPullSecrets)
+	})
+	settings.SystemDefaultRegistry.Set(registryURL)
+	settings.SystemDefaultRegistryPullSecrets.Set(pullSecrets)
+}
+
+func Test_handler_labelSystemProject(t *testing.T) {
+	tests := []struct {
+		name               string
+		cluster            *v3.Cluster
+		registryURL        string
+		pullSecrets        string
+		setupProjectCache  func(*fake.MockCacheInterface[*v3.Project])
+		setupProjectClient func(*fake.MockControllerInterface[*v3.Project, *v3.ProjectList])
+		wantErr            bool
+	}{
+		{
+			name:    "nil cluster",
+			cluster: nil,
+		},
+		{
+			name: "cluster not ready, not local",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c-abcde"},
+			},
+		},
+		{
+			name:        "local cluster skips readiness check, adds label when global registry configured",
+			cluster:     &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "local").Return([]*v3.Project{
+					systemProject("local", "p-system", nil),
+				}, nil)
+			},
+			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *v3.Project) (*v3.Project, error) {
+					assert.Equal(t, "true", p.Labels[secret.NeedsGlobalPrivateRegistryPullSecret])
+					return p, nil
+				})
+			},
+		},
+		{
+			name:    "provisioned cluster skipped, name does not match MgmtNameRegexp",
+			cluster: readyCluster("c-m-123", nil),
+		},
+		{
+			name:        "no system project found despite cluster condition, error returned",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return(nil, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "error getting system project for cluster, err returned",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "global registry with pull secrets configured, label added to system project",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					systemProject("c-abcde", "p-system", nil),
+				}, nil)
+			},
+			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *v3.Project) (*v3.Project, error) {
+					assert.Equal(t, "true", p.Labels[secret.NeedsGlobalPrivateRegistryPullSecret])
+					return p, nil
+				})
+			},
+		},
+		{
+			name:        "global registry with pull secrets, label already present, no update",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					systemProject("c-abcde", "p-system", map[string]string{
+						secret.NeedsGlobalPrivateRegistryPullSecret: "true",
+					}),
+				}, nil)
+			},
+		},
+		{
+			name:        "global registry configuration removed, label removed from system project",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "",
+			pullSecrets: "",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					systemProject("c-abcde", "p-system", map[string]string{
+						secret.NeedsGlobalPrivateRegistryPullSecret: "true",
+					}),
+				}, nil)
+			},
+			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *v3.Project) (*v3.Project, error) {
+					_, exists := p.Labels[secret.NeedsGlobalPrivateRegistryPullSecret]
+					assert.False(t, exists)
+					return p, nil
+				})
+			},
+		},
+		{
+			name: "cluster-level registry overrides global, label removed from system project",
+			cluster: readyCluster("c-abcde", &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			registryURL: "global-registry.example.com",
+			pullSecrets: "global-pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					systemProject("c-abcde", "p-system", map[string]string{
+						secret.NeedsGlobalPrivateRegistryPullSecret: "true",
+					}),
+				}, nil)
+			},
+			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *v3.Project) (*v3.Project, error) {
+					_, exists := p.Labels[secret.NeedsGlobalPrivateRegistryPullSecret]
+					assert.False(t, exists)
+					return p, nil
+				})
+			},
+		},
+		{
+			name:        "global registry with no pull secrets, label not added",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					systemProject("c-abcde", "p-system", nil),
+				}, nil)
+			},
+		},
+		{
+			name:        "error updating project on label add",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					systemProject("c-abcde", "p-system", nil),
+				}, nil)
+			},
+			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
+				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "error updating project on label remove",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "",
+			pullSecrets: "",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					systemProject("c-abcde", "p-system", map[string]string{
+						secret.NeedsGlobalPrivateRegistryPullSecret: "true",
+					}),
+				}, nil)
+			},
+			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
+				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "system project has nil labels, global registry configured, label added without panic",
+			cluster:     readyCluster("c-abcde", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				// project with nil Labels
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "p-system"},
+						Spec:       v3.ProjectSpec{ClusterName: "c-abcde"},
+						Status:     v3.ProjectStatus{BackingNamespace: "c-abcde-p-system"},
+					},
+				}, nil)
+			},
+			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *v3.Project) (*v3.Project, error) {
+					assert.NotNil(t, p.Labels)
+					assert.Equal(t, "true", p.Labels[secret.NeedsGlobalPrivateRegistryPullSecret])
+					return p, nil
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
+			if tt.setupProjectCache != nil {
+				tt.setupProjectCache(projectCache)
+			}
+			projectClient := fake.NewMockControllerInterface[*v3.Project, *v3.ProjectList](ctrl)
+			if tt.setupProjectClient != nil {
+				tt.setupProjectClient(projectClient)
+			}
+
+			h := &handler{
+				projectCache: projectCache,
+				project:      projectClient,
+			}
+
+			result, err := h.labelSystemProject("", tt.cluster)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.cluster != nil {
+				assert.Equal(t, tt.cluster, result)
+			}
+		})
+	}
+}
+
+func Test_handler_labelSourceGlobalRegistryPullSecret(t *testing.T) {
+	tests := []struct {
+		name              string
+		setting           *v3.Setting
+		registryURL       string
+		pullSecrets       string
+		setupSecretCache  func(*fake.MockCacheInterface[*corev1.Secret])
+		setupSecretClient func(*fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
+		wantNil           bool
+		wantErr           bool
+	}{
+		{
+			name:    "nil setting",
+			setting: nil,
+		},
+		{
+			name: "wrong setting name",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-other-setting"},
+			},
+		},
+		{
+			name: "no existing labeled secrets and no specified secrets",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			registryURL: "",
+			pullSecrets: "",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{}, nil)
+			},
+		},
+		{
+			name: "error listing existing labeled secrets",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "new secret specified, label added",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "new-secret",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get(namespaces.System, "new-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-secret", Namespace: namespaces.System},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					assert.NotEmpty(t, s.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "existing secret removed from setting, label and annotation removed",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "old-secret",
+							Namespace: namespaces.System,
+							Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+							Annotations: map[string]string{
+								secret.PSSIgnoreNamespacesAnnotation: "cattle-system",
+							},
+						},
+					},
+				}, nil)
+				f.EXPECT().Get(namespaces.System, "old-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-secret",
+						Namespace: namespaces.System,
+						Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+						Annotations: map[string]string{
+							secret.PSSIgnoreNamespacesAnnotation: "cattle-system",
+						},
+					},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					_, hasSource := s.Labels[cluster.SourcePullSecretLabel]
+					assert.False(t, hasSource)
+					_, hasPSS := s.Annotations[secret.PSSIgnoreNamespacesAnnotation]
+					assert.False(t, hasPSS)
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "secret replaced",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "new-secret",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "old-secret",
+							Namespace: namespaces.System,
+							Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+				f.EXPECT().Get(namespaces.System, "old-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-secret",
+						Namespace: namespaces.System,
+						Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+					},
+				}, nil)
+				f.EXPECT().Get(namespaces.System, "new-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-secret", Namespace: namespaces.System},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				// remove old
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "old-secret", s.Name)
+					_, hasSource := s.Labels[cluster.SourcePullSecretLabel]
+					_, hasAnno := s.Annotations[secret.PSSIgnoreNamespacesAnnotation]
+					assert.False(t, hasSource)
+					assert.False(t, hasAnno)
+					return s, nil
+				})
+				// add new
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "new-secret", s.Name)
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					assert.NotEmpty(t, s.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "error getting secret during removal",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			pullSecrets: "",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: namespaces.System, Labels: map[string]string{cluster.SourcePullSecretLabel: "true"}}},
+				}, nil)
+				f.EXPECT().Get(namespaces.System, "secret").Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error getting secret during labeling",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "missing-secret",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get(namespaces.System, "missing-secret").Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "secret already labeled and still specified, no update needed",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "existing-secret",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "existing-secret",
+							Namespace: namespaces.System,
+							Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+				// secret is in both existing and specified sets, so neither toRemove nor toLabel
+				// no Get or Update should be called
+			},
+		},
+		{
+			name: "error updating secret during label removal",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			pullSecrets: "",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "old-secret",
+							Namespace: namespaces.System,
+							Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+				f.EXPECT().Get(namespaces.System, "old-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-secret",
+						Namespace: namespaces.System,
+						Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+					},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error updating secret during label addition",
+			setting: &v3.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SystemDefaultRegistryPullSecrets.Name},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "new-secret",
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(namespaces.System, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get(namespaces.System, "new-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-secret", Namespace: namespaces.System},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			if tt.setupSecretCache != nil {
+				tt.setupSecretCache(secretCache)
+			}
+			secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			if tt.setupSecretClient != nil {
+				tt.setupSecretClient(secretClient)
+			}
+
+			h := &handler{
+				secretCache: secretCache,
+				secrets:     secretClient,
+			}
+
+			result, err := h.labelSourceGlobalRegistryPullSecret("", tt.setting)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.setting != nil && !tt.wantNil {
+				assert.Equal(t, tt.setting, result)
+			}
+		})
+	}
+}
+
+func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
+	const (
+		testCluster   = "c-abcde"
+		testProject   = "p-system"
+		testBackingNS = testCluster + "-" + testProject
+	)
+
+	var (
+		existingData = []byte(`{"auths":{"cluster-registry.example.com":{"auth":""}}}`)
+		updatedData  = []byte(`{"auths":{"cluster-registry-2.example.com":{"auth":""}}}`)
+	)
+
+	tests := []struct {
+		name              string
+		cluster           *v3.Cluster
+		registryURL       string
+		pullSecrets       string
+		setupProjectCache func(*fake.MockCacheInterface[*v3.Project])
+		setupSecretCache  func(*fake.MockCacheInterface[*corev1.Secret])
+		setupSecretClient func(*fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
+		wantErr           bool
+	}{
+		{
+			name:    "nil cluster",
+			cluster: nil,
+		},
+		{
+			name:    "local cluster skipped",
+			cluster: &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+		},
+		{
+			name:        "no private registry configured",
+			cluster:     readyCluster(testCluster, nil),
+			registryURL: "",
+			pullSecrets: "",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+			},
+		},
+		{
+			name:        "provisioned cluster skipped",
+			cluster:     readyCluster("c-m-abc", nil),
+			registryURL: "my-registry.example.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "cluster not ready",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: testCluster},
+				Spec: v3.ClusterSpec{
+					ImportedConfig: &v3.ImportedConfig{
+						PrivateRegistryURL:         "cluster-registry.example.com",
+						PrivateRegistryPullSecrets: []string{"cluster-secret"},
+					},
+					FleetWorkspaceName: "fleet-default",
+				},
+			},
+		},
+		{
+			name: "cluster-level registry, no system project found",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return(nil, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name: "cluster-level registry, no existing PSS and no pull secrets to create",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL: "cluster-registry.example.com",
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+			},
+		},
+		{
+			name: "cluster-level registry, source secret found, PSS created",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "cluster-secret", s.Name)
+					assert.Equal(t, testBackingNS, s.Namespace)
+					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
+					assert.Equal(t, testProject, s.Labels["management.cattle.io/project-scoped-secret"])
+					assert.Equal(t, "true", s.Labels["management.cattle.io/registry-scoped-secret"])
+					assert.Equal(t, corev1.SecretTypeDockerConfigJson, s.Type)
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "cluster-level registry, PSS already exists and is up to date, no update needed",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				existingData := []byte(`{"auths":{"cluster-registry.example.com":{"auth":""}}}`)
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cluster-secret",
+							Namespace: testBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+						Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+					},
+				}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+			},
+			// setupSecretClient: no client calls expected.
+		},
+		{
+			name: "cluster-level registry, PSS already exists but is out of date, update needed",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cluster-secret",
+							Namespace: testBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+						Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+					},
+				}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: updatedData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, p.Data[corev1.DockerConfigJsonKey], updatedData)
+					return p, nil
+				})
+			},
+		},
+		{
+			name: "stale PSS deleted when source secret removed from cluster spec",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL: "cluster-registry.example.com",
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "stale-secret",
+							Namespace: testBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Delete(testBackingNS, "stale-secret", &metav1.DeleteOptions{}).Return(nil)
+			},
+		},
+		{
+			name: "source secret not found, skipped",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"missing-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "missing-secret").Return(nil, errNotFound)
+			},
+		},
+		{
+			name:        "global default registry configured, PSS creation skipped after unused secret cleanup",
+			cluster:     readyCluster(testCluster, nil),
+			registryURL: "global-registry.example.com",
+			pullSecrets: "global-pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "stale-from-old-cluster-config",
+							Namespace: testBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+				f.EXPECT().Get(namespaces.System, "global-pull-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "global-pull-secret", Namespace: namespaces.System},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Delete(testBackingNS, "stale-from-old-cluster-config", &metav1.DeleteOptions{}).Return(nil)
+			},
+		},
+		{
+			name: "error listing existing PSS",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error getting system project from cache",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL: "cluster-registry.example.com",
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error getting source pull secret (non-not-found error)",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"error-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "error-secret").Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error deleting stale PSS",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL: "cluster-registry.example.com",
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "stale-secret",
+							Namespace: testBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Delete(testBackingNS, "stale-secret", &metav1.DeleteOptions{}).Return(errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error creating new PSS",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error updating existing out-of-date PSS",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cluster-secret",
+							Namespace: testBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+						Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+					},
+				}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: updatedData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "global registry with pull secrets, no existing PSS, early return",
+			cluster:     readyCluster(testCluster, nil),
+			registryURL: "global-registry.example.com",
+			pullSecrets: "global-pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
+			if tt.setupProjectCache != nil {
+				tt.setupProjectCache(projectCache)
+			}
+			secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			if tt.setupSecretCache != nil {
+				tt.setupSecretCache(secretCache)
+			}
+			secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			if tt.setupSecretClient != nil {
+				tt.setupSecretClient(secretClient)
+			}
+
+			h := &handler{
+				projectCache: projectCache,
+				secretCache:  secretCache,
+				secrets:      secretClient,
+			}
+
+			result, err := h.manageImportedAndHostedClusterPSS("", tt.cluster)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.cluster != nil {
+				assert.Equal(t, tt.cluster, result)
+			}
+		})
+	}
+}
+
+func Test_handler_getSystemProjectForCluster(t *testing.T) {
+	tests := []struct {
+		name              string
+		clusterName       string
+		setupProjectCache func(*fake.MockCacheInterface[*v3.Project])
+		wantProject       *v3.Project
+		wantErr           bool
+	}{
+		{
+			name:        "project found",
+			clusterName: "c-abcde",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					{ObjectMeta: metav1.ObjectMeta{Name: "p-system"}},
+				}, nil)
+			},
+			wantProject: &v3.Project{ObjectMeta: metav1.ObjectMeta{Name: "p-system"}},
+			wantErr:     false,
+		},
+		{
+			name:        "no project found, error returned",
+			clusterName: "c-abcde",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return(nil, nil)
+			},
+			wantProject: nil,
+			wantErr:     true,
+		},
+		{
+			name:        "no project found, empty slice, error returned",
+			clusterName: "c-abcde",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{}, nil)
+			},
+			wantProject: nil,
+			wantErr:     true,
+		},
+		{
+			name:        "error returned from indexer",
+			clusterName: "c-abcde",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return(nil, errDefault)
+			},
+			wantProject: nil,
+			wantErr:     true,
+		},
+		{
+			name:        "multiple system projects, only returns first",
+			clusterName: "c-abcde",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "c-abcde").Return([]*v3.Project{
+					{ObjectMeta: metav1.ObjectMeta{Name: "p-first"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "p-second"}},
+				}, nil)
+			},
+			wantProject: &v3.Project{ObjectMeta: metav1.ObjectMeta{Name: "p-first"}},
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
+			if tt.setupProjectCache != nil {
+				tt.setupProjectCache(projectCache)
+			}
+			h := &handler{projectCache: projectCache}
+
+			project, err := h.getSystemProjectForCluster(tt.clusterName)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantProject, project)
+		})
+	}
+}
+
+func Test_buildPSS(t *testing.T) {
+	proj := &v3.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-system"},
+	}
+	data := []byte(`{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}`)
+
+	pss := buildPSS(proj, "c-abcde-p-system", "my-pull-secret", data)
+
+	assert.Equal(t, "my-pull-secret", pss.Name)
+	assert.Equal(t, "c-abcde-p-system", pss.Namespace)
+	assert.Equal(t, corev1.SecretTypeDockerConfigJson, pss.Type)
+	assert.Equal(t, data, pss.Data[corev1.DockerConfigJsonKey])
+	assert.Equal(t, "true", pss.Labels[cluster.CopiedPullSecretLabel])
+	assert.Equal(t, "p-system", pss.Labels["management.cattle.io/project-scoped-secret"])
+	assert.Equal(t, "true", pss.Labels["management.cattle.io/registry-scoped-secret"])
+	assert.NotEmpty(t, pss.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+}

--- a/pkg/controllers/dashboard/privateregistry/controller_test.go
+++ b/pkg/controllers/dashboard/privateregistry/controller_test.go
@@ -277,7 +277,7 @@ func Test_handler_labelSystemProject(t *testing.T) {
 
 			h := &handler{
 				projectCache: projectCache,
-				project:      projectClient,
+				projects:     projectClient,
 			}
 
 			result, err := h.labelSystemProject("", tt.cluster)
@@ -811,7 +811,10 @@ func Test_handler_manageClusterSpecificPSS(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      cluster.GeneratePullSecretName("cluster-secret"),
 							Namespace: testBackingNS,
-							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+							Labels: map[string]string{
+								cluster.CopiedPullSecretLabel: "true",
+								registrySecretUIHint:          "true",
+							},
 						},
 						Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
 					},
@@ -855,6 +858,83 @@ func Test_handler_manageClusterSpecificPSS(t *testing.T) {
 			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *corev1.Secret) (*corev1.Secret, error) {
 					assert.Equal(t, p.Data[corev1.DockerConfigJsonKey], updatedData)
+					assert.Equal(t, "true", p.Labels[registrySecretUIHint])
+					return p, nil
+				})
+			},
+		},
+		{
+			name: "cluster-level registry, PSS data up to date but registrySecretUIHint label absent, update triggered to add label",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      cluster.GeneratePullSecretName("cluster-secret"),
+							Namespace: testBackingNS,
+							// registrySecretUIHint label is intentionally absent
+							Labels: map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+						Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+					},
+				}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", p.Labels[registrySecretUIHint])
+					assert.Equal(t, existingData, p.Data[corev1.DockerConfigJsonKey])
+					return p, nil
+				})
+			},
+		},
+		{
+			name: "cluster-level registry, PSS data up to date but registrySecretUIHint label is wrong value, update triggered to correct label",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      cluster.GeneratePullSecretName("cluster-secret"),
+							Namespace: testBackingNS,
+							Labels: map[string]string{
+								cluster.CopiedPullSecretLabel: "true",
+								registrySecretUIHint:          "false",
+							},
+						},
+						Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+					},
+				}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", p.Labels[registrySecretUIHint])
+					assert.Equal(t, existingData, p.Data[corev1.DockerConfigJsonKey])
 					return p, nil
 				})
 			},
@@ -1856,7 +1936,7 @@ func Test_handler_syncClusterOnGlobalPullSecretChange(t *testing.T) {
 				tt.setupController(clusterController)
 			}
 
-			h := &handler{mgmtClusterCache: clusterCache, mgmtClusterController: clusterController}
+			h := &handler{mgmtClusterCache: clusterCache, mgmtClusters: clusterController}
 			keys, err := h.syncClusterOnGlobalPullSecretChange("", "", tt.obj)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -1928,7 +2008,7 @@ func Test_handler_syncClusterOnGlobalRegistrySettingChange(t *testing.T) {
 				tt.setupController(clusterController)
 			}
 
-			h := &handler{mgmtClusterCache: clusterCache, mgmtClusterController: clusterController}
+			h := &handler{mgmtClusterCache: clusterCache, mgmtClusters: clusterController}
 			keys, err := h.syncClusterOnGlobalRegistrySettingChange("", tt.settingName, nil)
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/controllers/dashboard/privateregistry/controller_test.go
+++ b/pkg/controllers/dashboard/privateregistry/controller_test.go
@@ -2,7 +2,9 @@ package privateregistry
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/cluster"
@@ -16,12 +18,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
-	errDefault  = fmt.Errorf("error")
-	errNotFound = apierrors.NewNotFound(schema.GroupResource{}, "")
+	errDefault       = fmt.Errorf("error")
+	errNotFound      = apierrors.NewNotFound(schema.GroupResource{}, "")
+	errAlreadyExists = apierrors.NewAlreadyExists(schema.GroupResource{Resource: "secrets"}, "")
 )
 
 func readyCluster(name string, importedCfg *v3.ImportedConfig) *v3.Cluster {
@@ -87,21 +91,10 @@ func Test_handler_labelSystemProject(t *testing.T) {
 			},
 		},
 		{
-			name:        "local cluster skips readiness check, adds label when global registry configured",
+			name:        "local cluster skipped entirely",
 			cluster:     &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
 			registryURL: "my-registry.example.com",
 			pullSecrets: "pull-secret",
-			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
-				f.EXPECT().GetByIndex(clusterToSysProjIndex, "local").Return([]*v3.Project{
-					systemProject("local", "p-system", nil),
-				}, nil)
-			},
-			setupProjectClient: func(f *fake.MockControllerInterface[*v3.Project, *v3.ProjectList]) {
-				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(p *v3.Project) (*v3.Project, error) {
-					assert.Equal(t, "true", p.Labels[secret.NeedsGlobalPrivateRegistryPullSecret])
-					return p, nil
-				})
-			},
 		},
 		{
 			name:    "provisioned cluster skipped, name does not match MgmtNameRegexp",
@@ -567,7 +560,7 @@ func Test_handler_labelSourceGlobalRegistryPullSecret(t *testing.T) {
 				secrets:     secretClient,
 			}
 
-			result, err := h.labelSourceGlobalRegistryPullSecret("", tt.setting)
+			result, err := h.labelConfiguredSourceGlobalRegistryPullSecrets("", tt.setting)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -580,11 +573,14 @@ func Test_handler_labelSourceGlobalRegistryPullSecret(t *testing.T) {
 	}
 }
 
-func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
+func Test_handler_manageClusterSpecificPSS(t *testing.T) {
 	const (
 		testCluster   = "c-abcde"
 		testProject   = "p-system"
 		testBackingNS = testCluster + "-" + testProject
+
+		localProject   = "p-l8l4n"
+		localBackingNS = "local-" + localProject
 	)
 
 	var (
@@ -607,8 +603,106 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 			cluster: nil,
 		},
 		{
-			name:    "local cluster skipped",
-			cluster: &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			name:        "local cluster skips readiness check, uses global registry, PSS created in system project",
+			cluster:     &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			registryURL: "global-registry.example.com",
+			pullSecrets: "global-pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "local").Return([]*v3.Project{
+					systemProject("local", localProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(localBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get(namespaces.System, "global-pull-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "global-pull-secret", Namespace: namespaces.System},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "global-pull-secret", s.Name)
+					assert.Equal(t, localBackingNS, s.Namespace)
+					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
+					return s, nil
+				})
+			},
+		},
+		{
+			name:        "local cluster, no registry configured, no PSS, early return",
+			cluster:     &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			registryURL: "",
+			pullSecrets: "",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "local").Return([]*v3.Project{
+					systemProject("local", localProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(localBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+			},
+		},
+		{
+			name:        "local cluster, no registry configured, stale PSS cleaned up",
+			cluster:     &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			registryURL: "",
+			pullSecrets: "",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "local").Return([]*v3.Project{
+					systemProject("local", localProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(localBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "stale-pss",
+							Namespace: localBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Delete(localBackingNS, "stale-pss", &metav1.DeleteOptions{}).Return(nil)
+			},
+		},
+		{
+			name:        "local cluster, global registry, stale PSS from old config cleaned up, new PSS created",
+			cluster:     &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}},
+			registryURL: "global-registry.example.com",
+			pullSecrets: "global-pull-secret",
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, "local").Return([]*v3.Project{
+					systemProject("local", localProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(localBackingNS, gomock.Any()).Return([]*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "old-cluster-secret",
+							Namespace: localBackingNS,
+							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
+						},
+					},
+				}, nil)
+				f.EXPECT().Get(namespaces.System, "global-pull-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "global-pull-secret", Namespace: namespaces.System},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`)},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Delete(localBackingNS, "old-cluster-secret", &metav1.DeleteOptions{}).Return(nil)
+				f.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "global-pull-secret", s.Name)
+					assert.Equal(t, localBackingNS, s.Namespace)
+					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
+					return s, nil
+				})
+			},
 		},
 		{
 			name:        "no private registry configured",
@@ -689,7 +783,7 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 			},
 			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				f.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
-					assert.Equal(t, "cluster-secret", s.Name)
+					assert.Equal(t, cluster.GeneratePullSecretName("cluster-secret"), s.Name)
 					assert.Equal(t, testBackingNS, s.Namespace)
 					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
 					assert.Equal(t, testProject, s.Labels["management.cattle.io/project-scoped-secret"])
@@ -715,7 +809,7 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "cluster-secret",
+							Name:      cluster.GeneratePullSecretName("cluster-secret"),
 							Namespace: testBackingNS,
 							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 						},
@@ -745,7 +839,7 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "cluster-secret",
+							Name:      cluster.GeneratePullSecretName("cluster-secret"),
 							Namespace: testBackingNS,
 							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 						},
@@ -944,7 +1038,7 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "cluster-secret",
+							Name:      cluster.GeneratePullSecretName("cluster-secret"),
 							Namespace: testBackingNS,
 							Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 						},
@@ -958,6 +1052,210 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 				}, nil)
 			},
 			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "PSS already exists without label, adopted, label and data persisted even when data matches",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				// List returns empty: the unlabeled secret is invisible to the label selector
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				// source secret in fleet-default
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+				// fetch for adoption uses generated name
+				f.EXPECT().Get(testBackingNS, cluster.GeneratePullSecretName("cluster-secret")).Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cluster.GeneratePullSecretName("cluster-secret"),
+						Namespace: testBackingNS,
+					},
+					Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).Return(nil, errAlreadyExists)
+				// Update must always be called to persist the label, even when data is unchanged
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, cluster.GeneratePullSecretName("cluster-secret"), s.Name)
+					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
+					assert.Equal(t, existingData, s.Data[corev1.DockerConfigJsonKey])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "PSS already exists without label, adopted, data differs, label and new data persisted",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: updatedData},
+				}, nil)
+				f.EXPECT().Get(testBackingNS, cluster.GeneratePullSecretName("cluster-secret")).Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cluster.GeneratePullSecretName("cluster-secret"),
+						Namespace: testBackingNS,
+					},
+					Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).Return(nil, errAlreadyExists)
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, cluster.GeneratePullSecretName("cluster-secret"), s.Name)
+					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
+					assert.Equal(t, updatedData, s.Data[corev1.DockerConfigJsonKey])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "PSS already exists without label, adopted, nil labels initialised",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+				// existing secret has nil labels, fetched by generated name
+				f.EXPECT().Get(testBackingNS, cluster.GeneratePullSecretName("cluster-secret")).Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cluster.GeneratePullSecretName("cluster-secret"),
+						Namespace: testBackingNS,
+						Labels:    nil,
+					},
+					Data: map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).Return(nil, errAlreadyExists)
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.NotNil(t, s.Labels)
+					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "PSS already exists without label, adopted, nil data initialised",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+				// existing secret has nil Data, fetched by generated name
+				f.EXPECT().Get(testBackingNS, cluster.GeneratePullSecretName("cluster-secret")).Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cluster.GeneratePullSecretName("cluster-secret"),
+						Namespace: testBackingNS,
+					},
+					Data: nil,
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).Return(nil, errAlreadyExists)
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.NotNil(t, s.Data)
+					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
+					assert.Equal(t, existingData, s.Data[corev1.DockerConfigJsonKey])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "error fetching existing secret during adoption",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+				f.EXPECT().Get(testBackingNS, cluster.GeneratePullSecretName("cluster-secret")).Return(nil, errDefault)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).Return(nil, errAlreadyExists)
+			},
+			wantErr: true,
+		},
+		{
+			name: "error updating secret during adoption",
+			cluster: readyCluster(testCluster, &v3.ImportedConfig{
+				PrivateRegistryURL:         "cluster-registry.example.com",
+				PrivateRegistryPullSecrets: []string{"cluster-secret"},
+			}),
+			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
+				f.EXPECT().GetByIndex(clusterToSysProjIndex, testCluster).Return([]*v3.Project{
+					systemProject(testCluster, testProject, nil),
+				}, nil)
+			},
+			setupSecretCache: func(f *fake.MockCacheInterface[*corev1.Secret]) {
+				f.EXPECT().List(testBackingNS, gomock.Any()).Return([]*corev1.Secret{}, nil)
+				f.EXPECT().Get("fleet-default", "cluster-secret").Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "fleet-default"},
+					Type:       corev1.SecretTypeDockerConfigJson,
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+				f.EXPECT().Get(testBackingNS, cluster.GeneratePullSecretName("cluster-secret")).Return(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: cluster.GeneratePullSecretName("cluster-secret"), Namespace: testBackingNS},
+					Data:       map[string][]byte{corev1.DockerConfigJsonKey: existingData},
+				}, nil)
+			},
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Create(gomock.Any()).Return(nil, errAlreadyExists)
 				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
 			},
 			wantErr: true,
@@ -1002,7 +1300,7 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 				secrets:      secretClient,
 			}
 
-			result, err := h.manageImportedAndHostedClusterPSS("", tt.cluster)
+			result, err := h.manageClusterSpecificPSS("", tt.cluster)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -1010,6 +1308,241 @@ func Test_handler_manageImportedAndHostedClusterPSS(t *testing.T) {
 			}
 			if tt.cluster != nil {
 				assert.Equal(t, tt.cluster, result)
+			}
+		})
+	}
+}
+
+func Test_handler_labelSourceGlobalRegistryPullSecretOnChange(t *testing.T) {
+	tests := []struct {
+		name              string
+		secret            *corev1.Secret
+		registryURL       string
+		pullSecrets       string
+		setupSecretClient func(*fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
+		wantErr           bool
+	}{
+		{
+			name:   "nil secret returns nil",
+			secret: nil,
+		},
+		{
+			name: "secret in wrong namespace skipped",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: "default"},
+				Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "secret with nil data skipped",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: namespaces.System},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "secret not in active pull secrets skipped",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: namespaces.System},
+				Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "secret already correctly labeled and annotated, no update",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret",
+					Namespace: namespaces.System,
+					Labels: map[string]string{
+						cluster.SourcePullSecretLabel: "true",
+					},
+					Annotations: map[string]string{
+						secret.PSSIgnoreNamespacesAnnotation: strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","),
+					},
+				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "secret missing source label, label and annotation added",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: namespaces.System},
+				Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					assert.Equal(t, strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","), s.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "secret with empty source label, label and stale annotation corrected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret",
+					Namespace: namespaces.System,
+					Labels:    map[string]string{cluster.SourcePullSecretLabel: ""},
+					Annotations: map[string]string{
+						secret.PSSIgnoreNamespacesAnnotation: "cattle-system",
+					},
+				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					assert.Equal(t, strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","), s.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "source label explicitly false, label set to true",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret",
+					Namespace: namespaces.System,
+					Labels:    map[string]string{cluster.SourcePullSecretLabel: "false"},
+					Annotations: map[string]string{
+						secret.PSSIgnoreNamespacesAnnotation: strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","),
+					},
+				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "stale annotation value triggers annotation update",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret",
+					Namespace: namespaces.System,
+					Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+					Annotations: map[string]string{
+						secret.PSSIgnoreNamespacesAnnotation: "cattle-system",
+					},
+				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					assert.Equal(t, strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","), s.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "secret has source label but missing annotation, annotation added",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret",
+					Namespace: namespaces.System,
+					Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					assert.NotEmpty(t, s.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "secret has source label but empty annotation, annotation set",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret",
+					Namespace: namespaces.System,
+					Labels:    map[string]string{cluster.SourcePullSecretLabel: "true"},
+					Annotations: map[string]string{
+						secret.PSSIgnoreNamespacesAnnotation: "",
+					},
+				},
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+					assert.Equal(t, "true", s.Labels[cluster.SourcePullSecretLabel])
+					assert.Equal(t, strings.Join(settings.SystemNamespacesIgnoringPullSecrets, ","), s.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+					return s, nil
+				})
+			},
+		},
+		{
+			name: "no pull secrets configured, secret skipped",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: namespaces.System},
+				Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "",
+			pullSecrets: "",
+		},
+		{
+			name: "error on update returns error",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: namespaces.System},
+				Data:       map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{}`)},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupSecretClient: func(f *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				f.EXPECT().Update(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			if tt.setupSecretClient != nil {
+				tt.setupSecretClient(secretClient)
+			}
+
+			h := &handler{
+				secrets: secretClient,
+			}
+
+			result, err := h.labelSourceGlobalRegistryPullSecret("", tt.secret)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.secret != nil {
+				assert.NotNil(t, result)
 			}
 		})
 	}
@@ -1111,4 +1644,441 @@ func Test_buildPSS(t *testing.T) {
 	assert.Equal(t, "p-system", pss.Labels["management.cattle.io/project-scoped-secret"])
 	assert.Equal(t, "true", pss.Labels["management.cattle.io/registry-scoped-secret"])
 	assert.NotEmpty(t, pss.Annotations[secret.PSSIgnoreNamespacesAnnotation])
+}
+
+func Test_findV3ClustersUsingGlobalPullSecrets(t *testing.T) {
+	// A cluster with no ImportedConfig URL will have isGlobalDefault=true.
+	globalCluster := func(name string) *v3.Cluster {
+		return &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	}
+	// A cluster with an ImportedConfig URL will have isGlobalDefault=false.
+	overrideCluster := func(name string) *v3.Cluster {
+		return &v3.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: v3.ClusterSpec{
+				ImportedConfig:     &v3.ImportedConfig{PrivateRegistryURL: "cluster-registry.example.com"},
+				FleetWorkspaceName: "fleet-default",
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		setupCache func(*fake.MockNonNamespacedCacheInterface[*v3.Cluster])
+		wantNames  []string
+		wantErr    bool
+	}{
+		{
+			name: "error listing clusters returns error",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty cluster list returns nil",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{}, nil)
+			},
+			wantNames: nil,
+		},
+		{
+			name: "clusters with cluster-level registry override are excluded",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{
+					overrideCluster("c-abcde"),
+				}, nil)
+			},
+			wantNames: nil,
+		},
+		{
+			name: "provisioned clusters using global default are included",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{
+					globalCluster("c-m-abc12"),
+				}, nil)
+			},
+			wantNames: []string{"c-m-abc12"},
+		},
+		{
+			name: "imported cluster using global default is included",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{
+					globalCluster("c-abcde"),
+				}, nil)
+			},
+			wantNames: []string{"c-abcde"},
+		},
+		{
+			name: "local cluster using global default is included",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{
+					globalCluster("local"),
+				}, nil)
+			},
+			wantNames: []string{"local"},
+		},
+		{
+			name: "mix: all clusters using global default are returned, only cluster-level overrides are excluded",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{
+					globalCluster("local"),
+					globalCluster("c-abcde"),
+					overrideCluster("c-fghij"), // cluster-level override → excluded
+					globalCluster("c-m-abc12"), // provisioned name, global default → included
+				}, nil)
+			},
+			wantNames: []string{"local", "c-abcde", "c-m-abc12"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			clusterCache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](ctrl)
+			tt.setupCache(clusterCache)
+
+			names, err := findV3ClustersUsingGlobalPullSecrets(clusterCache)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.ElementsMatch(t, tt.wantNames, names)
+		})
+	}
+}
+
+func Test_handler_syncClusterOnGlobalPullSecretChange(t *testing.T) {
+	importedCluster := &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-abcde"}}
+
+	tests := []struct {
+		name            string
+		obj             runtime.Object
+		registryURL     string
+		pullSecrets     string
+		setupCache      func(*fake.MockNonNamespacedCacheInterface[*v3.Cluster])
+		setupController func(*fake.MockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList])
+		wantErr         bool
+	}{
+		{
+			name: "nil object returns nil, nothing enqueued",
+			obj:  nil,
+		},
+		{
+			name: "non-secret object returns nil, nothing enqueued",
+			obj:  &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-abcde"}},
+		},
+		{
+			name:        "secret with nil labels returns nil, nothing enqueued",
+			obj:         &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"}},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "secret with source label not true returns nil, nothing enqueued",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pull-secret",
+					Labels: map[string]string{cluster.SourcePullSecretLabel: "false"},
+				},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "source secret not in configured pull secrets returns nil, nothing enqueued",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "other-secret",
+					Labels: map[string]string{cluster.SourcePullSecretLabel: "true"},
+				},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+		},
+		{
+			name: "no pull secrets configured, secret not active, nothing enqueued",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pull-secret",
+					Labels: map[string]string{cluster.SourcePullSecretLabel: "true"},
+				},
+			},
+			registryURL: "",
+			pullSecrets: "",
+		},
+		{
+			name: "valid source secret triggers staggered enqueue of affected clusters",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pull-secret",
+					Labels: map[string]string{cluster.SourcePullSecretLabel: "true"},
+				},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{importedCluster}, nil)
+			},
+			setupController: func(f *fake.MockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList]) {
+				f.EXPECT().EnqueueAfter("c-abcde", gomock.Any())
+			},
+		},
+		{
+			name: "valid source secret, cluster cache error propagated, nothing enqueued",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pull-secret",
+					Labels: map[string]string{cluster.SourcePullSecretLabel: "true"},
+				},
+			},
+			registryURL: "registry.com",
+			pullSecrets: "pull-secret",
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			clusterCache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](ctrl)
+			if tt.setupCache != nil {
+				tt.setupCache(clusterCache)
+			}
+			clusterController := fake.NewMockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList](ctrl)
+			if tt.setupController != nil {
+				tt.setupController(clusterController)
+			}
+
+			h := &handler{mgmtClusterCache: clusterCache, mgmtClusterController: clusterController}
+			keys, err := h.syncClusterOnGlobalPullSecretChange("", "", tt.obj)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			// The handler now always returns nil — cluster re-enqueue is done via EnqueueAfter.
+			assert.Nil(t, keys)
+		})
+	}
+}
+
+func Test_handler_syncClusterOnGlobalRegistrySettingChange(t *testing.T) {
+	importedCluster := &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-abcde"}}
+	localCluster := &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}}
+
+	tests := []struct {
+		name            string
+		settingName     string
+		setupCache      func(*fake.MockNonNamespacedCacheInterface[*v3.Cluster])
+		setupController func(*fake.MockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList])
+		wantErr         bool
+	}{
+		{
+			name:        "unrelated setting name returns nil, nothing enqueued",
+			settingName: "some-other-setting",
+		},
+		{
+			name:        "SystemDefaultRegistryPullSecrets triggers staggered enqueue of affected clusters",
+			settingName: settings.SystemDefaultRegistryPullSecrets.Name,
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{importedCluster, localCluster}, nil)
+			},
+			setupController: func(f *fake.MockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList]) {
+				f.EXPECT().EnqueueAfter("c-abcde", gomock.Any())
+				f.EXPECT().EnqueueAfter("local", gomock.Any())
+			},
+		},
+		{
+			name:        "SystemDefaultRegistry triggers staggered enqueue of affected clusters",
+			settingName: settings.SystemDefaultRegistry.Name,
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return([]*v3.Cluster{importedCluster}, nil)
+			},
+			setupController: func(f *fake.MockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList]) {
+				f.EXPECT().EnqueueAfter("c-abcde", gomock.Any())
+			},
+		},
+		{
+			name:        "cluster cache error propagated, nothing enqueued",
+			settingName: settings.SystemDefaultRegistryPullSecrets.Name,
+			setupCache: func(f *fake.MockNonNamespacedCacheInterface[*v3.Cluster]) {
+				f.EXPECT().List(gomock.Any()).Return(nil, errDefault)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			clusterCache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](ctrl)
+			if tt.setupCache != nil {
+				tt.setupCache(clusterCache)
+			}
+			clusterController := fake.NewMockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList](ctrl)
+			if tt.setupController != nil {
+				tt.setupController(clusterController)
+			}
+
+			h := &handler{mgmtClusterCache: clusterCache, mgmtClusterController: clusterController}
+			keys, err := h.syncClusterOnGlobalRegistrySettingChange("", tt.settingName, nil)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			// The handler now always returns nil — cluster re-enqueue is done via EnqueueAfter.
+			assert.Nil(t, keys)
+		})
+	}
+}
+
+func Test_enqueueStaggered(t *testing.T) {
+	type enqueueCall struct {
+		name  string
+		delay time.Duration
+	}
+
+	// clusterNames builds a slice ["c-0", "c-1", ..., "c-(n-1)"].
+	clusterNames := func(n int) []string {
+		names := make([]string, n)
+		for i := range names {
+			names[i] = fmt.Sprintf("c-%d", i)
+		}
+		return names
+	}
+
+	tests := []struct {
+		name         string
+		input        []string
+		verifyDelays func(t *testing.T, calls []enqueueCall)
+	}{
+		{
+			name:  "empty list enqueues nothing",
+			input: nil,
+			verifyDelays: func(t *testing.T, calls []enqueueCall) {
+				assert.Empty(t, calls)
+			},
+		},
+		{
+			name:  "single cluster receives first-batch delay (< 2s + jitter ceiling)",
+			input: []string{"c-abcde"},
+			verifyDelays: func(t *testing.T, calls []enqueueCall) {
+				assert.Len(t, calls, 1)
+				assert.Equal(t, "c-abcde", calls[0].name)
+				// batchIndex=0: delay = 0*clusterEnqueueDelay + jitter, jitter in [0, 750ms)
+				assert.GreaterOrEqual(t, calls[0].delay, time.Duration(0))
+				assert.Less(t, calls[0].delay, time.Duration(clusterEnqueueJitterCeiling)*time.Millisecond)
+			},
+		},
+		{
+			name:  "all ten clusters in first batch receive delay below 2s",
+			input: clusterNames(10),
+			verifyDelays: func(t *testing.T, calls []enqueueCall) {
+				assert.Len(t, calls, 10)
+				names := make([]string, len(calls))
+				for i, c := range calls {
+					names[i] = c.name
+				}
+				assert.ElementsMatch(t, clusterNames(10), names)
+				for _, c := range calls {
+					// batchIndex=0 for all: delay in [0, 750ms)
+					assert.GreaterOrEqual(t, c.delay, time.Duration(0))
+					assert.Less(t, c.delay, time.Duration(clusterEnqueueJitterCeiling)*time.Millisecond)
+				}
+			},
+		},
+		{
+			name:  "eleventh cluster falls into second batch with delay >= 2s",
+			input: clusterNames(11),
+			verifyDelays: func(t *testing.T, calls []enqueueCall) {
+				assert.Len(t, calls, 11)
+				byName := make(map[string]time.Duration, len(calls))
+				for _, c := range calls {
+					byName[c.name] = c.delay
+				}
+				// First batch (c-0 through c-9): batchIndex=0, delay in [0, 750ms)
+				for i := 0; i < 10; i++ {
+					d := byName[fmt.Sprintf("c-%d", i)]
+					assert.GreaterOrEqual(t, d, time.Duration(0), "c-%d should have non-negative delay", i)
+					assert.Less(t, d, time.Duration(clusterEnqueueJitterCeiling)*time.Millisecond, "c-%d should be in batch 0", i)
+				}
+				// Second batch (c-10): batchIndex=1, delay in [2s, 2s+750ms)
+				d := byName["c-10"]
+				assert.GreaterOrEqual(t, d, clusterEnqueueDelay, "c-10 should be in batch 1")
+				assert.Less(t, d, clusterEnqueueDelay+time.Duration(clusterEnqueueJitterCeiling)*time.Millisecond, "c-10 should be in batch 1")
+			},
+		},
+		{
+			name:  "twenty-one clusters span three batches with correct delay ranges",
+			input: clusterNames(21),
+			verifyDelays: func(t *testing.T, calls []enqueueCall) {
+				assert.Len(t, calls, 21)
+				byName := make(map[string]time.Duration, len(calls))
+				for _, c := range calls {
+					byName[c.name] = c.delay
+				}
+				jitterCeiling := time.Duration(clusterEnqueueJitterCeiling) * time.Millisecond
+				// Batch 0 (c-0 to c-9): delay in [0, 750ms)
+				for i := 0; i < 10; i++ {
+					d := byName[fmt.Sprintf("c-%d", i)]
+					assert.GreaterOrEqual(t, d, time.Duration(0), "c-%d should be in batch 0", i)
+					assert.Less(t, d, jitterCeiling, "c-%d should be in batch 0", i)
+				}
+				// Batch 1 (c-10 to c-19): delay in [2s, 2s+750ms)
+				for i := 10; i < 20; i++ {
+					d := byName[fmt.Sprintf("c-%d", i)]
+					assert.GreaterOrEqual(t, d, clusterEnqueueDelay, "c-%d should be in batch 1", i)
+					assert.Less(t, d, clusterEnqueueDelay+jitterCeiling, "c-%d should be in batch 1", i)
+				}
+				// Batch 2 (c-20): delay in [4s, 4s+750ms)
+				d := byName["c-20"]
+				assert.GreaterOrEqual(t, d, 2*clusterEnqueueDelay, "c-20 should be in batch 2")
+				assert.Less(t, d, 2*clusterEnqueueDelay+jitterCeiling, "c-20 should be in batch 2")
+			},
+		},
+		{
+			name:  "cluster names are preserved exactly as passed",
+			input: []string{"local", "c-abcde", "c-m-abc12"},
+			verifyDelays: func(t *testing.T, calls []enqueueCall) {
+				assert.Len(t, calls, 3)
+				names := make([]string, len(calls))
+				for i, c := range calls {
+					names[i] = c.name
+				}
+				assert.ElementsMatch(t, []string{"local", "c-abcde", "c-m-abc12"}, names)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			clusterController := fake.NewMockNonNamespacedControllerInterface[*v3.Cluster, *v3.ClusterList](ctrl)
+
+			var calls []enqueueCall
+			if len(tt.input) > 0 {
+				clusterController.EXPECT().
+					EnqueueAfter(gomock.Any(), gomock.Any()).
+					Do(func(name string, delay time.Duration) {
+						calls = append(calls, enqueueCall{name: name, delay: delay})
+					}).
+					Times(len(tt.input))
+			}
+
+			enqueueStaggered(tt.input, clusterController)
+
+			if tt.verifyDelays != nil {
+				tt.verifyDelays(t, calls)
+			}
+		})
+	}
 }

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -10,6 +10,7 @@ import (
 
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
 	"github.com/rancher/rancher/pkg/controllers/management/importedclusterversionmanagement"
 	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
@@ -54,6 +55,14 @@ var (
 		chart.RemoteDialerProxyChartName: "rancher/remotedialer-proxy",
 		chart.TurtlesChartName:           "rancher/turtles",
 	}
+	// topLevelImagePullSecrets tracks the system charts that do not
+	// use the standard 'global.cattle.imagePullSecrets' field to accept pull
+	// secret references. Any chart listed in this map will have to subsequently
+	// set up the image pull secrets in the chart specific Values function.
+	topLevelImagePullSecrets = map[string]struct{}{
+		chart.RemoteDialerProxyChartName: {},
+		chart.TurtlesChartName:           {},
+	}
 	watchedSettings = map[string]struct{}{
 		settings.RancherWebhookVersion.Name:               {},
 		settings.RancherTurtlesVersion.Name:               {},
@@ -61,6 +70,7 @@ var (
 		settings.ShellImage.Name:                          {},
 		settings.SystemUpgradeControllerChartVersion.Name: {},
 		settings.ImportedClusterVersionManagement.Name:    {},
+		settings.SystemDefaultRegistryPullSecrets.Name:    {},
 	}
 	managedPlanSelector = labels.Set(map[string]string{k3sbasedupgrade.RancherManagedPlan: "true"}).AsSelector()
 )
@@ -85,6 +95,7 @@ func Register(ctx context.Context, wContext *wrangler.Context, registryOverride 
 	}
 
 	wContext.Catalog.ClusterRepo().OnChange(ctx, "bootstrap-charts", h.onRepo)
+
 	relatedresource.WatchClusterScoped(ctx, "bootstrap-charts", relatedFeatures, wContext.Catalog.ClusterRepo(), wContext.Mgmt.Feature())
 
 	relatedresource.WatchClusterScoped(ctx, "bootstrap-settings-charts", relatedSettings, wContext.Catalog.ClusterRepo(), wContext.Mgmt.Setting())
@@ -121,71 +132,103 @@ type handler struct {
 	registryOverride               string
 }
 
-func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.ClusterRepo, error) {
+func (h *handler) onRepo(_ string, repo *catalog.ClusterRepo) (*catalog.ClusterRepo, error) {
 	if repo == nil || repo.Name != repoName {
 		return repo, nil
 	}
 
-	systemGlobalRegistry := map[string]interface{}{
-		"cattle": map[string]interface{}{
-			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
-		},
-	}
+	systemDefaultRegistry := settings.SystemDefaultRegistry.Get()
+	var helmOpInstallImageOverride string
 	if h.registryOverride != "" {
-		// if we have a specific image override, don't set the system default registry
-		// don't need to check for type assert since we just created this above
-		registryMap := systemGlobalRegistry["cattle"].(map[string]interface{})
-		registryMap["systemDefaultRegistry"] = ""
-		systemGlobalRegistry["cattle"] = registryMap
+		// if we have a specific image override, don't set the system default registry. This will be the case when
+		// these controllers are running in the downstream cattle-cluster-agent.
+		systemDefaultRegistry = ""
+		logrus.Tracef("[system-charts] registryOverride=%q set; systemDefaultRegistry cleared for per-chart image override", h.registryOverride)
+		helmOpInstallImageOverride = h.registryOverride + "/" + settings.ShellImage.Get()
+		logrus.Tracef("[system-charts] helmOpInstallImageOverride=%q", helmOpInstallImageOverride)
 	}
-	for _, chartDef := range h.getChartsToInstall() {
+
+	chartsToInstall := h.getChartsToInstall()
+	logrus.Debugf("[system-charts] evaluating %d chart definition(s)", len(chartsToInstall))
+
+	for _, chartDef := range chartsToInstall {
+		logrus.Tracef("[system-charts] processing chart %q (namespace=%q, release=%q, uninstall=%v)", chartDef.ChartName, chartDef.ReleaseNamespace, chartDef.ReleaseName, chartDef.Uninstall)
+
 		if chartDef.Uninstall {
+			logrus.Debugf("[system-charts] uninstalling chart %q (removeNamespace=%v)", chartDef.ChartName, chartDef.RemoveNamespace)
 			// it is important to remove the chart from the desired chart list
 			h.manager.Remove(chartDef.ReleaseNamespace, chartDef.ChartName)
 			if err := h.manager.Uninstall(chartDef.ReleaseNamespace, chartDef.ChartName); err != nil {
+				logrus.Errorf("[system-charts] failed to uninstall chart %q: %v", chartDef.ChartName, err)
 				return repo, err
 			}
 			if chartDef.RemoveNamespace {
+				logrus.Debugf("[system-charts] deleting namespace %q for chart %q", chartDef.ReleaseNamespace, chartDef.ChartName)
 				if err := h.namespaces.Delete(chartDef.ReleaseNamespace, nil); err != nil && !errors.IsNotFound(err) {
+					logrus.Errorf("[system-charts] failed to delete namespace %q: %v", chartDef.ReleaseNamespace, err)
 					return repo, err
 				}
 			}
 			continue
 		}
+
 		if chartDef.Enabled != nil && !chartDef.Enabled() {
+			logrus.Tracef("[system-charts] chart %q is disabled, skipping", chartDef.ChartName)
 			continue
 		}
 
 		values := map[string]interface{}{
-			"global": systemGlobalRegistry,
+			"global": map[string]interface{}{
+				"cattle": map[string]interface{}{
+					"systemDefaultRegistry": systemDefaultRegistry,
+				},
+			},
 		}
-		var installImageOverride string
-		if h.registryOverride != "" {
-			imageSettings, ok := values["image"].(map[string]interface{})
-			if !ok {
-				imageSettings = map[string]interface{}{}
-			}
-			if image, ok := primaryImages[chartDef.ChartName]; ok {
+
+		if _, ok := topLevelImagePullSecrets[chartDef.ChartName]; !ok {
+			global := values["global"].(map[string]interface{})
+			cattle := global["cattle"].(map[string]interface{})
+			h.setImagePullSecrets(cattle, false)
+		}
+
+		if image, ok := primaryImages[chartDef.ChartName]; ok {
+			imageSettings := map[string]interface{}{}
+			if h.registryOverride != "" {
 				imageSettings["repository"] = h.registryOverride + "/" + image
-				values["image"] = imageSettings
+			} else {
+				// If we do not have a registry override, ensure we are passing the plain repository and image name.
+				// Due to how the chart patching logic works, this is required to properly handle the case where a
+				// private registry is no longer configured at the cluster or global level. If we do not explicitly
+				// define this field, the old value (which points to the previously defined private registry) will always
+				// be used.
+				imageSettings["repository"] = image
 			}
-			installImageOverride = h.registryOverride + "/" + settings.ShellImage.Get()
+			logrus.Debugf("[system-charts] overriding image repository for chart %q to %q", chartDef.ChartName, imageSettings["repository"])
+			values["image"] = imageSettings
 		}
+
 		if chartDef.Values != nil {
-			for k, v := range chartDef.Values() {
+			chartSpecificValues := chartDef.Values()
+			logrus.Tracef("[system-charts] merging %d chart-specific value(s) for chart %q", len(chartSpecificValues), chartDef.ChartName)
+			for k, v := range chartSpecificValues {
 				values[k] = v
 			}
 		}
+
 		// webhook needs to be able to adopt the MutatingWebhookConfiguration which originally wasn't a part of the
 		// chart definition, but is now part of the chart definition
 		minVersion := chartDef.MinVersionSetting.Get()
 		exactVersion := chartDef.ExactVersionSetting.Get()
 		takeOwnership := chartDef.ChartName == chart.WebhookChartName
-		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, chartDef.ReleaseName, minVersion, exactVersion, values, takeOwnership, installImageOverride); err != nil {
+		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, chartDef.ReleaseName, minVersion, exactVersion, values, takeOwnership, helmOpInstallImageOverride); err != nil {
+			logrus.Errorf("[system-charts] failed to ensure chart %q: %v", chartDef.ChartName, err)
 			return repo, err
 		}
+
+		logrus.Debugf("[system-charts] ensured chart %q in namespace %q", chartDef.ChartName, chartDef.ReleaseNamespace)
 	}
 
+	logrus.Tracef("[system-charts] reconciliation complete for repo %q", repoName)
 	return repo, nil
 }
 
@@ -200,6 +243,9 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				values := map[string]interface{}{}
 				// add priority class value
 				h.setPriorityClass(values, chart.RemoteDialerProxyChartName)
+				// add image pull secrets, RDP uses local object references at
+				// the top level.
+				h.setImagePullSecrets(values, true)
 				return values
 			},
 			Enabled: func() bool {
@@ -263,6 +309,9 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 						},
 					},
 				}
+				// add image pull secrets, turtles uses string references at
+				// the top level.
+				h.setImagePullSecrets(values, false)
 				// add priority class value
 				h.setPriorityClass(values, chart.TurtlesChartName)
 				// get custom values for rancher-turtles
@@ -292,19 +341,28 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				values := map[string]interface{}{}
 				// add priority class value
 				h.setPriorityClass(values, chart.SystemUpgradeControllerChartName)
-				// override the image registries because the structure of the values in this chart differs from the expected structure
+
+				// override the image registries because the structure of the values
+				// in this chart differs from the expected structure. Ensure that
+				// we always set the image repository so that the current private
+				// registry configuration is always respected.
+				sucRepository := "rancher/system-upgrade-controller"
+				kubectlRepository := "rancher/kuberlr-kubectl"
 				if h.registryOverride != "" {
-					values["systemUpgradeController"] = map[string]interface{}{
-						"image": map[string]interface{}{
-							"repository": fmt.Sprintf("%s/%s", h.registryOverride, "rancher/system-upgrade-controller"),
-						},
-					}
-					values["kubectl"] = map[string]interface{}{
-						"image": map[string]interface{}{
-							"repository": fmt.Sprintf("%s/%s", h.registryOverride, "rancher/kuberlr-kubectl"),
-						},
-					}
+					sucRepository = fmt.Sprintf("%s/%s", h.registryOverride, "rancher/system-upgrade-controller")
+					kubectlRepository = fmt.Sprintf("%s/%s", h.registryOverride, "rancher/kuberlr-kubectl")
 				}
+				values["systemUpgradeController"] = map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository": sucRepository,
+					},
+				}
+				values["kubectl"] = map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository": kubectlRepository,
+					},
+				}
+
 				// get custom values for system-upgrade-controller
 				configMapValues := h.getChartValues(chart.SystemUpgradeControllerChartName)
 				return data.MergeMaps(values, configMapValues)
@@ -314,7 +372,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				suc, err := h.deploymentCache.Get(namespace.System, sucDeploymentName)
 				if err != nil && !errors.IsNotFound(err) {
 					toEnable = false
-					logrus.Warnf("[systemcharts] failed to get the deployment %s/%s: %s", namespace.System, sucDeploymentName, err.Error())
+					logrus.Warnf("[system-charts] failed to get deployment %q/%q: %v", namespace.System, sucDeploymentName, err)
 				}
 				if suc != nil {
 					// The missing annotation suggests that either the legacy Fleet bundle in the node-driver RKE2/K3s cluster,
@@ -335,7 +393,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 					// Rancher has direct access to the mgmt v3 cluster and the ImportedClusterVersionManagement setting
 					cluster, err := h.clusterCache.Get("local")
 					if err != nil {
-						logrus.Warnf("[systemcharts] failed to get the local cluster: %v", err)
+						logrus.Warnf("[system-charts] failed to get local cluster: %v", err)
 					}
 					if cluster != nil && (cluster.Status.Driver == v3.ClusterDriverRke2 || cluster.Status.Driver == v3.ClusterDriverK3s) {
 						versionManagementEnabled = importedclusterversionmanagement.Enabled(cluster)
@@ -344,14 +402,14 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				if isInHarvesterLocal() {
 					cluster, err := h.clusterCache.Get("local")
 					if err != nil {
-						logrus.Warnf("[systemcharts] failed to get the local cluster: %v", err)
+						logrus.Warnf("[system-charts] failed to get local cluster: %v", err)
 					}
 					if cluster != nil && cluster.Status.Provider == "harvester" && cluster.Status.Driver == v3.ClusterDriverImported {
 						versionManagementEnabled = importedclusterversionmanagement.Enabled(cluster)
 					}
 				}
 				toInstall := versionManagementEnabled && toEnable
-				logrus.Debugf("[systemcharts] install system-upgrade-controller: %t (versionManagementEnabled: %t && toEnable: %t)",
+				logrus.Debugf("[system-charts] install system-upgrade-controller: %v (versionManagementEnabled=%v, toEnable=%v)",
 					toInstall, versionManagementEnabled, toEnable)
 				return toInstall
 			},
@@ -361,7 +419,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				// The removal of the plans is handled in the k3sbasedupgrade package.
 				plans, err := h.planCache.List(namespace.System, managedPlanSelector)
 				if err != nil {
-					logrus.Warnf("[systemcharts] failed to list plans: %v", err)
+					logrus.Warnf("[system-charts] failed to list plans: %v", err)
 				}
 				if len(plans) == 0 {
 					noManagedPlan = true
@@ -378,7 +436,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 					// Rancher has direct access to the mgmt v3 cluster and the ImportedClusterVersionManagement setting
 					cluster, err := h.clusterCache.Get("local")
 					if err != nil {
-						logrus.Warnf("[systemcharts] failed to get the local cluster: %v", err)
+						logrus.Warnf("[system-charts] failed to get local cluster: %v", err)
 					}
 					if cluster != nil && (cluster.Status.Driver == v3.ClusterDriverRke2 || cluster.Status.Driver == v3.ClusterDriverK3s) {
 						versionManagementEnabled = importedclusterversionmanagement.Enabled(cluster)
@@ -387,15 +445,15 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				if isInHarvesterLocal() {
 					cluster, err := h.clusterCache.Get("local")
 					if err != nil {
-						logrus.Warnf("[systemcharts] failed to get the local cluster: %v", err)
+						logrus.Warnf("[system-charts] failed to get local cluster: %v", err)
 					}
 					if cluster != nil && cluster.Status.Provider == "harvester" && cluster.Status.Driver == v3.ClusterDriverImported {
 						versionManagementEnabled = importedclusterversionmanagement.Enabled(cluster)
 					}
 				}
 				toUninstall := !versionManagementEnabled && noManagedPlan
-				logrus.Debugf("[systemcharts] uninstall system-upgrade-controller: %t (!versionManagementEnabled: %t && noManagedPlan: %t)",
-					toUninstall, !versionManagementEnabled, noManagedPlan)
+				logrus.Debugf("[system-charts] uninstall system-upgrade-controller: %v (versionManagementEnabled=%v, noManagedPlan=%v)",
+					toUninstall, versionManagementEnabled, noManagedPlan)
 				return toUninstall
 			}(),
 		},
@@ -415,7 +473,7 @@ func (h *handler) onDeployment(_ string, d *k8sappsv1.Deployment) (*k8sappsv1.De
 	}
 
 	index := slices.Index(d.Finalizers, legacyAppFinalizer)
-	logrus.Infof("[systemcharts] found deployment %s/%s with index of target finalzier = %d", d.Namespace, d.Name, index)
+	logrus.Tracef("[system-charts] deployment %q/%q: legacy finalizer index=%d", d.Namespace, d.Name, index)
 	if (d.DeletionTimestamp != nil && index == -1) || (d.DeletionTimestamp == nil && index >= 0) {
 		return d, nil
 	}
@@ -442,7 +500,7 @@ func (h *handler) onDeployment(_ string, d *k8sappsv1.Deployment) (*k8sappsv1.De
 		}); err != nil {
 			return nil, fmt.Errorf("failed to update deployment %s/%s: %w", d.Namespace, d.Name, err)
 		}
-		logrus.Infof("[systemcharts] enqueue %s", repoName)
+		logrus.Debugf("[system-charts] enqueuing %q to reconcile after legacy SUC deployment cleanup", repoName)
 		h.clusterRepo.EnqueueAfter(repoName, 2*time.Second)
 
 	case d.DeletionTimestamp == nil && index == -1:
@@ -479,7 +537,7 @@ func (h *handler) onPlan(_ string, plan *upgradev1.Plan) (*upgradev1.Plan, error
 		return plan, nil
 	}
 	index := slices.Index(plan.Finalizers, managedPlanFinalizer)
-	logrus.Debugf("[systemcharts] found plan %s/%s with index of target finalzier = %d", plan.Namespace, plan.Name, index)
+	logrus.Tracef("[system-charts] plan %q/%q: managed-plan finalizer index=%d", plan.Namespace, plan.Name, index)
 	if (plan.DeletionTimestamp != nil && index == -1) || (plan.DeletionTimestamp == nil && index >= 0) {
 		return plan, nil
 	}
@@ -502,7 +560,7 @@ func (h *handler) onPlan(_ string, plan *upgradev1.Plan) (*upgradev1.Plan, error
 		if err != nil {
 			return nil, err
 		}
-		logrus.Infof("[systemcharts] enqueue %s", repoName)
+		logrus.Debugf("[system-charts] enqueuing %q to reconcile after managed plan deletion", repoName)
 		h.clusterRepo.EnqueueAfter(repoName, 2*time.Second)
 	}
 	if plan.DeletionTimestamp == nil && index == -1 {
@@ -527,7 +585,7 @@ func (h *handler) onPlan(_ string, plan *upgradev1.Plan) (*upgradev1.Plan, error
 	return plan, nil
 }
 
-// OnCluster enqueues the rancher-charts ClusterRepo to the controller's processing queue when the local cluster is updated.
+// onCluster enqueues the rancher-charts ClusterRepo to the controller's processing queue when the local cluster is updated.
 // It ensures the timely installation or uninstallation of the system-upgrade-controller app in the local cluster
 // when the "rancher.io/imported-cluster-version-management" annotation is changed.
 func (h *handler) onCluster(_ string, obj *v3.Cluster) (*v3.Cluster, error) {
@@ -547,7 +605,24 @@ func (h *handler) setPriorityClass(values map[string]interface{}, chartName stri
 	if err == nil {
 		values[chart.PriorityClassKey] = priorityClassName
 	} else if !chart.IsNotFoundError(err) {
-		logrus.Warnf("[systemcharts] Failed to get rancher %s for %s: %s", chart.PriorityClassKey, chartName, err.Error())
+		logrus.Warnf("[system-charts] failed to get %s for chart %q: %v", chart.PriorityClassKey, chartName, err)
+	}
+}
+
+func (h *handler) setImagePullSecrets(values map[string]interface{}, useObjectReferences bool) {
+	var pullSecretsAsStrings []string
+	var pullSecretsAsObjectReferences []kcorev1.LocalObjectReference
+
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry != nil {
+		pullSecretsAsObjectReferences = registry.PullSecretsAsObjectReferences()
+		pullSecretsAsStrings = registry.PullSecretNamesAsSlice()
+	}
+
+	if useObjectReferences {
+		values["imagePullSecrets"] = pullSecretsAsObjectReferences
+	} else {
+		values["imagePullSecrets"] = pullSecretsAsStrings
 	}
 }
 
@@ -555,7 +630,7 @@ func (h *handler) setPriorityClass(values map[string]interface{}, chartName stri
 func (h *handler) getChartValues(chartName string) map[string]interface{} {
 	configMapValues, err := h.chartsConfig.GetChartValues(chartName)
 	if err != nil && !chart.IsNotFoundError(err) {
-		logrus.Warnf("[systemcharts] Failed to get chart values for %s: %s", chartName, err.Error())
+		logrus.Warnf("[system-charts] failed to get chart values for chart %q: %v", chartName, err)
 	}
 	return configMapValues
 }
@@ -594,7 +669,7 @@ func isInHarvesterLocal() bool {
 	// the multi-cluster-management and multi-cluster-management-agent features are disabled,
 	// and the Harvester feature is enabled.
 	if !features.MCMAgent.Enabled() && !features.MCM.Enabled() && features.Harvester.Enabled() {
-		logrus.Debugf("Rancher is embedded and running in the Harvester local cluster.")
+		logrus.Debugf("[system-charts] Rancher is embedded in the Harvester local cluster")
 		return true
 	}
 	return false

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -149,7 +149,7 @@ func (h *handler) onRepo(_ string, repo *catalog.ClusterRepo) (*catalog.ClusterR
 	}
 
 	chartsToInstall := h.getChartsToInstall()
-	logrus.Debugf("[system-charts] evaluating %d chart definition(s)", len(chartsToInstall))
+	logrus.Tracef("[system-charts] evaluating %d chart definition(s)", len(chartsToInstall))
 
 	for _, chartDef := range chartsToInstall {
 		logrus.Tracef("[system-charts] processing chart %q (namespace=%q, release=%q, uninstall=%v)", chartDef.ChartName, chartDef.ReleaseNamespace, chartDef.ReleaseName, chartDef.Uninstall)
@@ -560,7 +560,7 @@ func (h *handler) onPlan(_ string, plan *upgradev1.Plan) (*upgradev1.Plan, error
 		if err != nil {
 			return nil, err
 		}
-		logrus.Debugf("[system-charts] enqueuing %q to reconcile after managed plan deletion", repoName)
+		logrus.Infof("[system-charts] enqueuing %q to reconcile after managed plan deletion", repoName)
 		h.clusterRepo.EnqueueAfter(repoName, 2*time.Second)
 	}
 	if plan.DeletionTimestamp == nil && index == -1 {

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -43,15 +43,17 @@ var (
 			chart.WebhookChartName: testYAML,
 		},
 	}
-	emptyConfig                            = &v1.ConfigMap{}
-	originalWebhookVersion                 = settings.RancherWebhookVersion.Get()
-	originalSUCVersion                     = settings.SystemUpgradeControllerChartVersion.Get()
-	originalImportedVersionManagement      = settings.ImportedClusterVersionManagement.Get()
-	originalMCM                            = features.MCM.Enabled()
-	originalMCMAgent                       = features.MCMAgent.Enabled()
-	originalManagedSystemUpgradeController = features.ManagedSystemUpgradeController.Enabled()
-	originalTurtles                        = features.Turtles.Enabled()
-	sucDeployment                          = &appsv1.Deployment{
+	emptyConfig                              = &v1.ConfigMap{}
+	originalWebhookVersion                   = settings.RancherWebhookVersion.Get()
+	originalSUCVersion                       = settings.SystemUpgradeControllerChartVersion.Get()
+	originalImportedVersionManagement        = settings.ImportedClusterVersionManagement.Get()
+	originalSystemDefaultRegistry            = settings.SystemDefaultRegistry.Get()
+	originalSystemDefaultRegistryPullSecrets = settings.SystemDefaultRegistryPullSecrets.Get()
+	originalMCM                              = features.MCM.Enabled()
+	originalMCMAgent                         = features.MCMAgent.Enabled()
+	originalManagedSystemUpgradeController   = features.ManagedSystemUpgradeController.Enabled()
+	originalTurtles                          = features.Turtles.Enabled()
+	sucDeployment                            = &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
@@ -171,7 +173,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -198,6 +204,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.TurtlesNamespace,
@@ -216,6 +226,17 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
+						},
+					},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/system-upgrade-controller",
+						},
+					},
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/kuberlr-kubectl",
 						},
 					},
 				}
@@ -265,7 +286,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -292,6 +317,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.TurtlesNamespace,
@@ -310,6 +339,17 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
+						},
+					},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/system-upgrade-controller",
+						},
+					},
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/kuberlr-kubectl",
 						},
 					},
 				}
@@ -359,7 +399,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -385,6 +429,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -436,7 +484,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -462,6 +514,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -513,7 +569,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -539,6 +599,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -589,7 +653,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -615,6 +683,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -666,7 +738,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -693,6 +769,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.TurtlesNamespace,
@@ -711,6 +791,17 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
+						},
+					},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/system-upgrade-controller",
+						},
+					},
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/kuberlr-kubectl",
 						},
 					},
 				}
@@ -732,6 +823,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]v1.LocalObjectReference)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/remotedialer-proxy",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -779,7 +874,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -806,6 +905,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.TurtlesNamespace,
@@ -825,6 +928,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]v1.LocalObjectReference)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/remotedialer-proxy",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -877,7 +984,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -904,6 +1015,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.TurtlesNamespace,
@@ -923,6 +1038,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]v1.LocalObjectReference)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/remotedialer-proxy",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -975,7 +1094,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -1001,6 +1124,10 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -1050,7 +1177,11 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
 						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -1076,6 +1207,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.TurtlesNamespace,
@@ -1093,6 +1228,17 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"imagePullSecrets":      ([]string)(nil),
+						},
+					},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/system-upgrade-controller",
+						},
+					},
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/kuberlr-kubectl",
 						},
 					},
 				}
@@ -1113,6 +1259,154 @@ func Test_ChartInstallation(t *testing.T) {
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
+					},
+					"imagePullSecrets": ([]v1.LocalObjectReference)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/remotedialer-proxy",
+					},
+				}
+				mocks.manager.EXPECT().Ensure(
+					namespace.System,
+					chart.RemoteDialerProxyChartName,
+					chart.RemoteDialerProxyChartName,
+					"",
+					"2.0.0",
+					expectedRDPValues,
+					gomock.AssignableToTypeOf(false),
+					"",
+				).Return(nil)
+
+				// rancher-operator
+				mocks.manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
+				mocks.manager.EXPECT().Remove(operatorNamespace, "rancher-operator")
+
+				// rancher-provisioning-capi
+				mocks.namespaceCtrl.EXPECT().Delete(provisioningCapiNamespace, nil).Return(nil)
+				mocks.manager.EXPECT().Uninstall(provisioningCapiNamespace, "rancher-provisioning-capi").Return(nil)
+				mocks.manager.EXPECT().Remove(provisioningCapiNamespace, "rancher-provisioning-capi")
+			},
+		},
+		{
+			name: "installation with global pull secrets",
+			setup: func(mocks testMocks) {
+				_ = settings.SystemDefaultRegistry.Set("registry.example.com")
+				_ = settings.SystemDefaultRegistryPullSecrets.Set("pull-secret-a,pull-secret-b")
+
+				mocks.namespaceCtrl.EXPECT().Delete(operatorNamespace, nil).Return(nil)
+				mocks.configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(priorityConfig, nil).Times(7)
+				mocks.deploymentCache.EXPECT().Get(namespace.System, sucDeploymentName).Return(sucDeployment, nil).Times(1)
+				mocks.clusterCache.EXPECT().Get("local").Return(localCuster, nil).Times(2)
+				mocks.planCache.EXPECT().List(namespace.System, managedPlanSelector).Return(nil, nil).Times(1)
+				_ = settings.RancherWebhookVersion.Set("2.0.0")
+				_ = settings.RancherTurtlesVersion.Set("2.0.0")
+				_ = settings.SystemUpgradeControllerChartVersion.Set("2.0.0")
+				_ = settings.RemoteDialerProxyVersion.Set("2.0.0")
+				_ = os.Setenv("CATTLE_SUC_APP_NAME_OVERRIDE", "")
+
+				pullSecrets := []string{"pull-secret-a", "pull-secret-b"}
+
+				// rancher-webhook: global.cattle.imagePullSecrets set; no top-level imagePullSecrets
+				expectedWebhookValues := map[string]interface{}{
+					"priorityClassName": priorityClassName,
+					"capi":              nil,
+					"mcm": map[string]interface{}{
+						"enabled": features.MCM.Enabled(),
+					},
+					"global": map[string]interface{}{
+						"cattle": map[string]interface{}{
+							"systemDefaultRegistry": "registry.example.com",
+							"imagePullSecrets":      pullSecrets,
+						},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
+					},
+				}
+				mocks.manager.EXPECT().Ensure(
+					namespace.System,
+					chart.WebhookChartName,
+					chart.WebhookChartName,
+					"",
+					"2.0.0",
+					expectedWebhookValues,
+					gomock.AssignableToTypeOf(false),
+					"",
+				).Return(nil)
+
+				// rancher-turtles: global.cattle.imagePullSecrets set; top-level imagePullSecrets as []string
+				expectedTurtlesValues := map[string]interface{}{
+					"priorityClassName": priorityClassName,
+					"features": map[string]interface{}{
+						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+					"global": map[string]interface{}{
+						"cattle": map[string]interface{}{
+							"systemDefaultRegistry": "registry.example.com",
+						},
+					},
+					"imagePullSecrets": pullSecrets,
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
+				}
+				mocks.manager.EXPECT().Ensure(
+					namespace.TurtlesNamespace,
+					chart.TurtlesChartName,
+					chart.TurtlesChartName,
+					"",
+					"2.0.0",
+					expectedTurtlesValues,
+					gomock.AssignableToTypeOf(false),
+					"",
+				).Return(nil)
+
+				// system-upgrade-controller: global.cattle.imagePullSecrets set; no top-level imagePullSecrets
+				expectedSUCValues := map[string]interface{}{
+					"priorityClassName": priorityClassName,
+					"global": map[string]interface{}{
+						"cattle": map[string]interface{}{
+							"systemDefaultRegistry": "registry.example.com",
+							"imagePullSecrets":      pullSecrets,
+						},
+					},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/system-upgrade-controller",
+						},
+					},
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/kuberlr-kubectl",
+						},
+					},
+				}
+				mocks.manager.EXPECT().Ensure(
+					namespace.System,
+					chart.SystemUpgradeControllerChartName,
+					chart.SystemUpgradeControllerChartName,
+					"",
+					"2.0.0",
+					expectedSUCValues,
+					gomock.AssignableToTypeOf(false),
+					"",
+				).Return(nil)
+
+				// remotedialer-proxy: global.cattle.imagePullSecrets set; top-level imagePullSecrets as []v1.LocalObjectReference
+				expectedRDPValues := map[string]interface{}{
+					"priorityClassName": priorityClassName,
+					"global": map[string]interface{}{
+						"cattle": map[string]interface{}{
+							"systemDefaultRegistry": "registry.example.com",
+						},
+					},
+					"imagePullSecrets": []v1.LocalObjectReference{
+						{Name: "pull-secret-a"},
+						{Name: "pull-secret-b"},
+					},
+					"image": map[string]interface{}{
+						"repository": "rancher/remotedialer-proxy",
 					},
 				}
 				mocks.manager.EXPECT().Ensure(
@@ -1159,6 +1453,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": "",
+							"imagePullSecrets":      ([]string)(nil),
 						},
 					},
 					"image": map[string]interface{}{
@@ -1188,6 +1483,7 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": "",
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
 					"image": map[string]interface{}{
 						"repository": "rancher-test.io/rancher/turtles",
 					},
@@ -1208,6 +1504,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": "",
+							"imagePullSecrets":      ([]string)(nil),
 						}},
 					"systemUpgradeController": map[string]interface{}{
 						"image": map[string]interface{}{
@@ -1241,6 +1538,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"image": map[string]interface{}{
 						"repository": "rancher-test.io/rancher/remotedialer-proxy",
 					},
+					"imagePullSecrets": ([]v1.LocalObjectReference)(nil),
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.System,
@@ -1287,6 +1585,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 						},
 					},
+					"imagePullSecrets": ([]v1.LocalObjectReference)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/remotedialer-proxy",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.System,
@@ -1308,6 +1610,9 @@ func Test_ChartInstallation(t *testing.T) {
 					},
 					"global": "",
 					"newKey": "newValue",
+					"image": map[string]interface{}{
+						"repository": "rancher/rancher-webhook",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.System,
@@ -1342,6 +1647,10 @@ func Test_ChartInstallation(t *testing.T) {
 							"systemDefaultRegistry": "",
 						},
 					},
+					"imagePullSecrets": ([]string)(nil),
+					"image": map[string]interface{}{
+						"repository": "rancher/turtles",
+					},
 				}
 				mocks.manager.EXPECT().Ensure(
 					namespace.TurtlesNamespace,
@@ -1360,6 +1669,17 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": "",
+							"imagePullSecrets":      ([]string)(nil),
+						},
+					},
+					"systemUpgradeController": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/system-upgrade-controller",
+						},
+					},
+					"kubectl": map[string]interface{}{
+						"image": map[string]interface{}{
+							"repository": "rancher/kuberlr-kubectl",
 						},
 					},
 				}
@@ -1383,6 +1703,8 @@ func Test_ChartInstallation(t *testing.T) {
 			_ = settings.RancherWebhookVersion.Set(originalWebhookVersion)
 			_ = settings.SystemUpgradeControllerChartVersion.Set(originalSUCVersion)
 			_ = settings.ImportedClusterVersionManagement.Set(originalImportedVersionManagement)
+			_ = settings.SystemDefaultRegistry.Set(originalSystemDefaultRegistry)
+			_ = settings.SystemDefaultRegistryPullSecrets.Set(originalSystemDefaultRegistryPullSecrets)
 			features.MCM.Set(originalMCM)
 			features.MCMAgent.Set(originalMCMAgent)
 			features.ManagedSystemUpgradeController.Set(originalManagedSystemUpgradeController)
@@ -1450,7 +1772,10 @@ func Test_TurtlesInstallation(t *testing.T) {
 		"capi":              nil,
 		"mcm":               map[string]interface{}{"enabled": features.MCM.Enabled()},
 		"global": map[string]interface{}{
-			"cattle": map[string]interface{}{"systemDefaultRegistry": settings.SystemDefaultRegistry.Get()},
+			"cattle": map[string]interface{}{"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(), "imagePullSecrets": ([]string)(nil)},
+		},
+		"image": map[string]interface{}{
+			"repository": "rancher/rancher-webhook",
 		},
 	}
 	expectedTurtlesValues := map[string]interface{}{
@@ -1461,7 +1786,13 @@ func Test_TurtlesInstallation(t *testing.T) {
 			},
 		},
 		"global": map[string]interface{}{
-			"cattle": map[string]interface{}{"systemDefaultRegistry": settings.SystemDefaultRegistry.Get()},
+			"cattle": map[string]interface{}{
+				"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+			},
+		},
+		"imagePullSecrets": ([]string)(nil),
+		"image": map[string]interface{}{
+			"repository": "rancher/turtles",
 		},
 	}
 	gomock.InOrder(
@@ -1520,7 +1851,13 @@ func Test_TurtlesWinsWhenBothEnabled(t *testing.T) {
 			},
 		},
 		"global": map[string]interface{}{
-			"cattle": map[string]interface{}{"systemDefaultRegistry": settings.SystemDefaultRegistry.Get()},
+			"cattle": map[string]interface{}{
+				"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+			},
+		},
+		"imagePullSecrets": ([]string)(nil),
+		"image": map[string]interface{}{
+			"repository": "rancher/turtles",
 		},
 	}
 	gomock.InOrder(
@@ -1674,6 +2011,13 @@ func Test_relatedSettings(t *testing.T) {
 			name: "shell image",
 			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
 				Name: settings.ShellImage.Name,
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "system default registry pull secrets",
+			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
+				Name: settings.SystemDefaultRegistryPullSecrets.Name,
 			}},
 			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
 		},

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -3,6 +3,8 @@ package clusterdeploy
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -130,6 +132,7 @@ func (cd *clusterDeploy) sync(key string, cluster *apimgmtv3.Cluster) (runtime.O
 		toUpdate.Status.AuthImage = modified.Status.AuthImage
 		toUpdate.Status.AppliedAgentEnvVars = modified.Status.AppliedAgentEnvVars
 		toUpdate.Status.AppliedClusterAgentDeploymentCustomization = modified.Status.AppliedClusterAgentDeploymentCustomization
+		toUpdate.Status.AppliedClusterAgentImagePullSecretsHash = modified.Status.AppliedClusterAgentImagePullSecretsHash
 		// Copy conditions this controller owns
 		util.CopyCondition(apimgmtv3.ClusterConditionAgentDeployed, modified, toUpdate)
 		util.CopyCondition(apimgmtv3.ClusterConditionSystemAccountCreated, modified, toUpdate)
@@ -418,6 +421,40 @@ func (cd *clusterDeploy) ensurePriorityClass(cluster *apimgmtv3.Cluster, kubeCon
 	return false, fmt.Errorf("clusterDeploy: error encountered querying downstream priority class: %w", err)
 }
 
+// manageImagePullSecretHash generates a hash of the image pull secrets configured
+// on the cluster and compares it to the hash stored in the cluster status. A change
+// in the hash indicates when one or more secrets used by the cluster need to be copied
+// downstream to stay up to date with the version in the local cluster.
+// The value is generated using the secrets name, namespace, and the observed resource version.
+func (cd *clusterDeploy) manageImagePullSecretHash(cluster *apimgmtv3.Cluster) (string, bool, error) {
+	registry, _ := util.GetPrivateRegistry(cluster)
+	if registry == nil || len(registry.PullSecrets) == 0 {
+		return "", cluster.Status.AppliedClusterAgentImagePullSecretsHash != "", nil
+	}
+
+	var secretReferences []string
+	for _, pullSecret := range registry.PullSecrets {
+		s, err := cd.secretLister.Get(pullSecret.Namespace, pullSecret.Name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Errorf("clusterDeploy: manageImagePullSecretHash: failed to retrieve secret [%s]: %v", pullSecret.Name, err)
+				continue
+			}
+			return "", false, err
+		}
+		secretReferences = append(secretReferences, fmt.Sprintf("%s:%s=%s", s.Namespace, s.Name, s.ResourceVersion))
+	}
+
+	hashBytes := sha256.Sum256([]byte(strings.Join(secretReferences, ",")))
+	hash := hex.EncodeToString(hashBytes[:])
+	if hash != cluster.Status.AppliedClusterAgentImagePullSecretsHash {
+		logrus.Infof("clusterDeploy: manageImagePullSecretHash: returning true due to secret resource version hash change")
+		return hash, true, nil
+	}
+
+	return hash, false, nil
+}
+
 func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 	if cluster.Spec.Internal {
 		return nil
@@ -440,8 +477,13 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 		return err
 	}
 
+	pullSecretHash, hashChanged, err := cd.manageImagePullSecretHash(cluster)
+	if err != nil {
+		return err
+	}
+
 	shouldRedeployAgent := redeployAgent(cluster, desiredAgent, desiredAuth, desiredFeatures, desiredTaints)
-	agentManifestChanged := shouldRedeployAgent || pcDeleted || pcCreated
+	agentManifestChanged := shouldRedeployAgent || pcDeleted || pcCreated || hashChanged
 	if !agentManifestChanged && !pcChanged {
 		return nil
 	}
@@ -544,6 +586,7 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 	}
 
 	cluster.Status.AppliedAgentEnvVars = append(settings.DefaultAgentSettingsAsEnvVars(), cluster.Spec.AgentEnvVars...)
+	cluster.Status.AppliedClusterAgentImagePullSecretsHash = pullSecretHash
 
 	util.UpdateAppliedAgentDeploymentCustomization(cluster)
 
@@ -584,11 +627,23 @@ func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authIma
 		return nil, fmt.Errorf("waiting for server-url setting to be set")
 	}
 
-	buf := &bytes.Buffer{}
-	err = systemtemplate.SystemTemplate(buf, agentImage, authImage, cluster.Name,
-		token, url, capr.PreBootstrap(cluster), cluster, features,
-		taints, cd.secretLister, priorityClassExists, namespace.GetMutator())
+	ops := &systemtemplate.TemplateOps{
+		AgentImage:     agentImage,
+		AuthImage:      authImage,
+		Namespace:      cluster.Name,
+		Token:          token,
+		URL:            url,
+		IsPreBootstrap: capr.PreBootstrap(cluster),
+		Cluster:        cluster,
+		AgentFeatures:  features,
+		Taints:         taints,
+		SecretLister:   cd.secretLister,
+		PcExists:       priorityClassExists,
+		Mutator:        namespace.GetMutator(),
+	}
 
+	buf := &bytes.Buffer{}
+	err = systemtemplate.SystemTemplate(buf, ops)
 	return buf.Bytes(), err
 }
 

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -427,10 +427,14 @@ func (cd *clusterDeploy) ensurePriorityClass(cluster *apimgmtv3.Cluster, kubeCon
 // downstream to stay up to date with the version in the local cluster.
 // The value is generated using the secrets name, namespace, and the observed resource version.
 func (cd *clusterDeploy) manageImagePullSecretHash(cluster *apimgmtv3.Cluster) (string, bool, error) {
+	if !util.MgmtNameRegexp.MatchString(cluster.Name) {
+		return "", cluster.Status.AppliedClusterAgentImagePullSecretsHash != "", nil
+	}
+
 	registry, _ := util.GetPrivateRegistry(cluster)
 	// since provisioned clusters don't use pull secrets we don't need to track the hash. This also helps
 	// reduce unneeded agent redeployments.
-	if registry == nil || len(registry.PullSecrets) == 0 || !util.MgmtNameRegexp.MatchString(cluster.Name) {
+	if registry == nil || len(registry.PullSecrets) == 0 {
 		return "", cluster.Status.AppliedClusterAgentImagePullSecretsHash != "", nil
 	}
 
@@ -447,7 +451,7 @@ func (cd *clusterDeploy) manageImagePullSecretHash(cluster *apimgmtv3.Cluster) (
 	hashBytes := sha256.Sum256([]byte(strings.Join(secretReferences, ",")))
 	hash := hex.EncodeToString(hashBytes[:])
 	if hash != cluster.Status.AppliedClusterAgentImagePullSecretsHash {
-		logrus.Infof("clusterDeploy: manageImagePullSecretHash: returning true due to secret resource version hash change")
+		logrus.Debugf("clusterDeploy: manageImagePullSecretHash: returning true due to secret resource version hash change")
 		return hash, true, nil
 	}
 

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -428,7 +428,9 @@ func (cd *clusterDeploy) ensurePriorityClass(cluster *apimgmtv3.Cluster, kubeCon
 // The value is generated using the secrets name, namespace, and the observed resource version.
 func (cd *clusterDeploy) manageImagePullSecretHash(cluster *apimgmtv3.Cluster) (string, bool, error) {
 	registry, _ := util.GetPrivateRegistry(cluster)
-	if registry == nil || len(registry.PullSecrets) == 0 {
+	// since provisioned clusters don't use pull secrets we don't need to track the hash. This also helps
+	// reduce unneeded agent redeployments.
+	if registry == nil || len(registry.PullSecrets) == 0 || !util.MgmtNameRegexp.MatchString(cluster.Name) {
 		return "", cluster.Status.AppliedClusterAgentImagePullSecretsHash != "", nil
 	}
 
@@ -436,10 +438,7 @@ func (cd *clusterDeploy) manageImagePullSecretHash(cluster *apimgmtv3.Cluster) (
 	for _, pullSecret := range registry.PullSecrets {
 		s, err := cd.secretLister.Get(pullSecret.Namespace, pullSecret.Name)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logrus.Errorf("clusterDeploy: manageImagePullSecretHash: failed to retrieve secret [%s]: %v", pullSecret.Name, err)
-				continue
-			}
+			logrus.Errorf("clusterDeploy: manageImagePullSecretHash: failed to retrieve secret [%s]: %v", pullSecret.Name, err)
 			return "", false, err
 		}
 		secretReferences = append(secretReferences, fmt.Sprintf("%s:%s=%s", s.Namespace, s.Name, s.ResourceVersion))

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -1,17 +1,22 @@
 package usercontrollers
 
 import (
+	"bytes"
 	"context"
 	"time"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/management/imported"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
+	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/sirupsen/logrus"
 	batchV1 "k8s.io/api/batch/v1"
 	coreV1 "k8s.io/api/core/v1"
@@ -166,7 +171,13 @@ func (c *ClusterLifecycleCleanup) cleanupImportedCluster(cluster *v3.Cluster) er
 		return err
 	}
 
-	job, err := c.createCleanupJob(userContext, sa.Name)
+	// create cleanup image pull secret
+	secrets, err := c.createCleanupImagePullSecrets(userContext, cluster)
+	if err != nil {
+		return err
+	}
+
+	job, err := c.createCleanupJob(userContext, sa.Name, secrets)
 	if err != nil {
 		return err
 	}
@@ -180,8 +191,13 @@ func (c *ClusterLifecycleCleanup) cleanupImportedCluster(cluster *v3.Cluster) er
 		},
 	}
 
-	// These resouces need the ownerReference added so they get cleaned up after
+	// These resources need the ownerReference added so they get cleaned up after
 	// the job deletes itself.
+
+	err = c.updateClusterImagePullSecretsOwner(userContext, secrets, or)
+	if err != nil {
+		return err
+	}
 
 	err = c.updateClusterRoleOwner(userContext, role, or)
 	if err != nil {
@@ -217,6 +233,12 @@ func (c *ClusterLifecycleCleanup) createCleanupClusterRole(userContext *config.U
 			Verbs:     []string{"list", "get", "delete"},
 			APIGroups: []string{"rbac.authorization.k8s.io"},
 			Resources: []string{"roles", "rolebindings", "clusterroles", "clusterrolebindings"},
+		},
+		// This is needed to remove any image pull secrets that were added to various namespaces by Rancher
+		{
+			Verbs:     []string{"list", "delete"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
 		},
 		// The job is going to delete itself after running to trigger ownerReference
 		// cleanup of the clusterRole, serviceAccount and clusterRoleBinding
@@ -257,6 +279,69 @@ func (c *ClusterLifecycleCleanup) createCleanupServiceAccount(userContext *confi
 	return userContext.K8sClient.CoreV1().ServiceAccounts("default").Create(context.TODO(), &serviceAccount, metav1.CreateOptions{})
 }
 
+func (c *ClusterLifecycleCleanup) createCleanupImagePullSecrets(userContext *config.UserContext, cluster *v3.Cluster) ([]*corev1.Secret, error) {
+	registry, _ := util.GetPrivateRegistry(cluster)
+	if registry == nil {
+		return nil, nil
+	}
+
+	var copiedSecrets []*corev1.Secret
+	for _, sec := range registry.PullSecrets {
+		existingPullSec, err := userContext.K8sClient.CoreV1().Secrets(namespaces.System).Get(c.ctx, sec.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Warnf("image pull secret %s/%s was not found, skipping copy", sec.Namespace, sec.Name)
+				continue
+			}
+			return nil, err
+		}
+
+		data, err := util.ConvertToDockerConfigJson(registry.URL, existingPullSec)
+		if err != nil {
+			return nil, err
+		}
+
+		defaultPullSecretName := name.SafeConcatName("cattle-cleanup", sec.Name, cluster.Name)
+
+		s := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultPullSecretName,
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				coreV1.DockerConfigJsonKey: data,
+			},
+			Type: "kubernetes.io/dockerconfigjson",
+		}
+
+		defPull, err := userContext.K8sClient.CoreV1().Secrets("default").Get(c.ctx, defaultPullSecretName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				defPull, err = userContext.K8sClient.CoreV1().Secrets("default").Create(c.ctx, &s, metav1.CreateOptions{})
+				if err != nil {
+					return nil, err
+				}
+				copiedSecrets = append(copiedSecrets, defPull)
+				continue
+			}
+			return nil, err
+		}
+
+		if !bytes.Equal(defPull.Data[coreV1.DockerConfigJsonKey], data) {
+			defPull = defPull.DeepCopy()
+			defPull.Data[coreV1.DockerConfigJsonKey] = data
+			_, err = userContext.K8sClient.CoreV1().Secrets("default").Update(c.ctx, defPull, metav1.UpdateOptions{})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		copiedSecrets = append(copiedSecrets, defPull)
+	}
+
+	return copiedSecrets, nil
+}
+
 func (c *ClusterLifecycleCleanup) createCleanupClusterRoleBinding(
 	userContext *config.UserContext,
 	role, sa string,
@@ -283,7 +368,7 @@ func (c *ClusterLifecycleCleanup) createCleanupClusterRoleBinding(
 	return userContext.K8sClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), &clusterRoleBinding, metav1.CreateOptions{})
 }
 
-func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserContext, sa string) (*batchV1.Job, error) {
+func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserContext, sa string, secrets []*corev1.Secret) (*batchV1.Job, error) {
 	meta := metav1.ObjectMeta{
 		GenerateName: "cattle-cleanup-",
 		Namespace:    "default",
@@ -322,6 +407,11 @@ func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserConte
 			},
 		},
 	}
+
+	for _, secret := range secrets {
+		job.Spec.Template.Spec.ImagePullSecrets = append(job.Spec.Template.Spec.ImagePullSecrets, coreV1.LocalObjectReference{Name: secret.Name})
+	}
+
 	return userContext.K8sClient.BatchV1().Jobs("default").Create(context.TODO(), &job, metav1.CreateOptions{})
 }
 
@@ -360,6 +450,25 @@ func (c *ClusterLifecycleCleanup) updateServiceAccountOwner(
 		_, err = userContext.K8sClient.CoreV1().ServiceAccounts("default").Update(context.TODO(), sa, metav1.UpdateOptions{})
 		if err != nil {
 			return err
+		}
+		return nil
+	})
+}
+
+func (c *ClusterLifecycleCleanup) updateClusterImagePullSecretsOwner(userContext *config.UserContext, secrets []*corev1.Secret, or []metav1.OwnerReference) error {
+	return tryUpdate(func() error {
+		for _, s := range secrets {
+			existing, err := userContext.K8sClient.CoreV1().Secrets(s.Namespace).Get(c.ctx, s.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			existing.OwnerReferences = or
+
+			_, err = userContext.K8sClient.CoreV1().Secrets(s.Namespace).Update(c.ctx, existing, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -59,8 +59,9 @@ and de-registering k8s controllers, on cluster.remove
 */
 func RegisterEarly(ctx context.Context, management *config.ManagementContext, manager *clustermanager.Manager) {
 	lifecycle := &ClusterLifecycleCleanup{
-		Manager: manager,
-		ctx:     ctx,
+		Manager:  manager,
+		mgmtCore: management.Core,
+		ctx:      ctx,
 	}
 
 	clusterClient := management.Management.Clusters("")
@@ -68,8 +69,9 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, ma
 }
 
 type ClusterLifecycleCleanup struct {
-	Manager *clustermanager.Manager
-	ctx     context.Context
+	Manager  *clustermanager.Manager
+	mgmtCore corev1.Interface
+	ctx      context.Context
 }
 
 func (c *ClusterLifecycleCleanup) Create(obj *v3.Cluster) (runtime.Object, error) {
@@ -285,18 +287,22 @@ func (c *ClusterLifecycleCleanup) createCleanupServiceAccount(userContext *confi
 }
 
 func (c *ClusterLifecycleCleanup) createCleanupImagePullSecrets(userContext *config.UserContext, cluster *v3.Cluster) ([]*corev1.Secret, error) {
-	registry, _ := util.GetPrivateRegistry(cluster)
+	registry, isGlobal := util.GetPrivateRegistry(cluster)
 	if registry == nil {
 		return nil, nil
 	}
 
+	ns := namespaces.System
+	if !isGlobal {
+		ns = "fleet-default"
+	}
+
 	var copiedSecrets []*corev1.Secret
 	for _, sec := range registry.PullSecrets {
-		downstreamPullSecretName := util.GeneratePullSecretName(sec.Name)
-		existingPullSec, err := userContext.K8sClient.CoreV1().Secrets(namespaces.System).Get(c.ctx, downstreamPullSecretName, metav1.GetOptions{})
+		existingPullSec, err := c.mgmtCore.Secrets(ns).Get(sec.Name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				logrus.Warnf("image pull secret %s/%s was not found, skipping copy", sec.Namespace, downstreamPullSecretName)
+				logrus.Warnf("image pull secret %s/%s was not found, skipping copy", sec.Namespace, sec.Name)
 				continue
 			}
 			return nil, err
@@ -307,7 +313,7 @@ func (c *ClusterLifecycleCleanup) createCleanupImagePullSecrets(userContext *con
 			return nil, err
 		}
 
-		defaultPullSecretName := name.SafeConcatName("cattle-cleanup", downstreamPullSecretName, cluster.Name)
+		defaultPullSecretName := name.SafeConcatName("cattle-cleanup", util.GeneratePullSecretName(sec.Name), cluster.Name)
 
 		s := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -3,6 +3,7 @@ package usercontrollers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"time"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -177,8 +178,12 @@ func (c *ClusterLifecycleCleanup) cleanupImportedCluster(cluster *v3.Cluster) er
 		return err
 	}
 
-	job, err := c.createCleanupJob(userContext, sa.Name, secrets)
+	job, err := c.createCleanupJob(userContext, cluster, sa.Name, secrets)
 	if err != nil {
+		cleanupErr := c.cleanupImagePullSecrets(userContext, secrets)
+		if cleanupErr != nil {
+			return errors.Join(err, cleanupErr)
+		}
 		return err
 	}
 
@@ -287,10 +292,11 @@ func (c *ClusterLifecycleCleanup) createCleanupImagePullSecrets(userContext *con
 
 	var copiedSecrets []*corev1.Secret
 	for _, sec := range registry.PullSecrets {
-		existingPullSec, err := userContext.K8sClient.CoreV1().Secrets(namespaces.System).Get(c.ctx, sec.Name, metav1.GetOptions{})
+		downstreamPullSecretName := util.GeneratePullSecretName(sec.Name)
+		existingPullSec, err := userContext.K8sClient.CoreV1().Secrets(namespaces.System).Get(c.ctx, downstreamPullSecretName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				logrus.Warnf("image pull secret %s/%s was not found, skipping copy", sec.Namespace, sec.Name)
+				logrus.Warnf("image pull secret %s/%s was not found, skipping copy", sec.Namespace, downstreamPullSecretName)
 				continue
 			}
 			return nil, err
@@ -301,7 +307,7 @@ func (c *ClusterLifecycleCleanup) createCleanupImagePullSecrets(userContext *con
 			return nil, err
 		}
 
-		defaultPullSecretName := name.SafeConcatName("cattle-cleanup", sec.Name, cluster.Name)
+		defaultPullSecretName := name.SafeConcatName("cattle-cleanup", downstreamPullSecretName, cluster.Name)
 
 		s := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -329,6 +335,9 @@ func (c *ClusterLifecycleCleanup) createCleanupImagePullSecrets(userContext *con
 
 		if !bytes.Equal(defPull.Data[coreV1.DockerConfigJsonKey], data) {
 			defPull = defPull.DeepCopy()
+			if defPull.Data == nil {
+				defPull.Data = make(map[string][]byte)
+			}
 			defPull.Data[coreV1.DockerConfigJsonKey] = data
 			_, err = userContext.K8sClient.CoreV1().Secrets("default").Update(c.ctx, defPull, metav1.UpdateOptions{})
 			if err != nil {
@@ -368,7 +377,7 @@ func (c *ClusterLifecycleCleanup) createCleanupClusterRoleBinding(
 	return userContext.K8sClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), &clusterRoleBinding, metav1.CreateOptions{})
 }
 
-func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserContext, sa string, secrets []*corev1.Secret) (*batchV1.Job, error) {
+func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserContext, cluster *v3.Cluster, sa string, secrets []*corev1.Secret) (*batchV1.Job, error) {
 	meta := metav1.ObjectMeta{
 		GenerateName: "cattle-cleanup-",
 		Namespace:    "default",
@@ -384,7 +393,7 @@ func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserConte
 					Containers: []coreV1.Container{
 						coreV1.Container{
 							Name:  "cleanup-agent",
-							Image: image.Resolve(settings.AgentImage.Get()),
+							Image: image.ResolveWithCluster(settings.AgentImage.Get(), cluster),
 							Env: []coreV1.EnvVar{
 								coreV1.EnvVar{
 									Name:  "CLUSTER_CLEANUP",
@@ -492,6 +501,18 @@ func (c *ClusterLifecycleCleanup) updateClusterRoleBindingOwner(
 		}
 		return nil
 	})
+}
+
+func (c *ClusterLifecycleCleanup) cleanupImagePullSecrets(userContext *config.UserContext, secrets []*corev1.Secret) error {
+	for _, secret := range secrets {
+		if secret == nil {
+			continue
+		}
+		if deleteErr := userContext.K8sClient.CoreV1().Secrets("default").Delete(c.ctx, secret.Name, metav1.DeleteOptions{}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+			logrus.WithError(deleteErr).Warnf("failed to delete cleanup image pull secret %s/%s after cleanup job creation failed", coreV1.NamespaceDefault, secret.Name)
+		}
+	}
+	return nil
 }
 
 func cleanupNamespaces(client kubernetes.Interface) error {

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets.go
@@ -13,6 +13,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/cluster"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -40,9 +41,9 @@ const (
 	projectIDLabel                = "field.cattle.io/projectId"
 	ProjectScopedSecretLabel      = "management.cattle.io/project-scoped-secret"
 	pssCopyAnnotation             = "management.cattle.io/project-scoped-secret-copy"
-	pssIgnoreNamespacesAnnotation = "management.cattle.io/project-scoped-secret-ignore-namespaces"
+	PSSIgnoreNamespacesAnnotation = "management.cattle.io/project-scoped-secret-ignore-namespaces"
 
-	needsGlobalPrivateRegistryPullSecret = "management.cattle.io/use-global-private-registry-pull-secret"
+	NeedsGlobalPrivateRegistryPullSecret = "management.cattle.io/use-global-private-registry-pull-secret"
 )
 
 // previous controller label, annotations and finalizer
@@ -358,7 +359,7 @@ func (n *namespaceHandler) getNamespacesFromGlobalPullSecret(secret *corev1.Secr
 // that have opted in to the global private registry pull secret.
 func (n *namespaceHandler) getNamespacesForGlobalPullSecretProjects() ([]*corev1.Namespace, error) {
 	projects, err := n.projectCache.List(n.clusterName, labels.SelectorFromSet(map[string]string{
-		needsGlobalPrivateRegistryPullSecret: "true",
+		NeedsGlobalPrivateRegistryPullSecret: "true",
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list projects which need global private registry pull secret: %w", err)
@@ -478,22 +479,22 @@ func areSecretsSame(s1, s2 *corev1.Secret) bool {
 		reflect.DeepEqual(s1.Labels, s2.Labels)
 }
 
-func isSystemProject(project *v3.Project) bool {
-	if project.Labels == nil {
+func isSystemProject(proj *v3.Project) bool {
+	if proj.Labels == nil {
 		return false
 	}
-	return project.Labels["authz.management.cattle.io/system-project"] == "true"
+	return proj.Labels[project.SystemProjectLabelKey] == "true"
 }
 
 func usesGlobalSecrets(project *v3.Project) bool {
 	if project.Labels == nil {
 		return false
 	}
-	return project.Labels[needsGlobalPrivateRegistryPullSecret] == "true"
+	return project.Labels[NeedsGlobalPrivateRegistryPullSecret] == "true"
 }
 
 func secretIgnoresNamespace(annos map[string]string, namespace string) bool {
-	v, ok := annos[pssIgnoreNamespacesAnnotation]
+	v, ok := annos[PSSIgnoreNamespacesAnnotation]
 	if !ok {
 		return false
 	}

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets.go
@@ -418,7 +418,7 @@ func (n *namespaceHandler) getNamespacesFromSecret(secret *corev1.Secret) ([]*co
 }
 
 // getGlobalPullSecrets retrieves the pull secrets specified in the SystemDefaultRegistryPullSecrets setting
-// and returns copies of those secrets which have been relabeled to indicate that they are not source secrets.
+// and returns copies of those secrets which have been relabeled and renamed to indicate that they are not source secrets.
 // The returned secrets can be safely synchronized into project namespaces without impacting future list operations for
 // source secrets. Secrets that are not of type kubernetes.io/dockerconfigjson are silently skipped
 // rather than causing an error, as we don't want a single misconfigured secret to block reconciliation of
@@ -450,6 +450,9 @@ func (n *namespaceHandler) getGlobalPullSecrets() ([]*corev1.Secret, error) {
 		}
 		delete(secretCopy.Labels, cluster.SourcePullSecretLabel)
 		secretCopy.Labels[cluster.CopiedPullSecretLabel] = "true"
+
+		// rename the downstream secret to help avoid trampling user defined secrets.
+		secretCopy.Name = cluster.GeneratePullSecretName(secretCopy.Name)
 		pullSecrets = append(pullSecrets, secretCopy)
 	}
 	return pullSecrets, nil

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets_pull_secrets_test.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets_pull_secrets_test.go
@@ -80,7 +80,7 @@ func Test_usesGlobalSecrets(t *testing.T) {
 			name: "label set to true",
 			project: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{needsGlobalPrivateRegistryPullSecret: "true"},
+					Labels: map[string]string{NeedsGlobalPrivateRegistryPullSecret: "true"},
 				},
 			},
 			want: true,
@@ -89,7 +89,7 @@ func Test_usesGlobalSecrets(t *testing.T) {
 			name: "label set to other value",
 			project: &v3.Project{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{needsGlobalPrivateRegistryPullSecret: "false"},
+					Labels: map[string]string{NeedsGlobalPrivateRegistryPullSecret: "false"},
 				},
 			},
 			want: false,
@@ -116,7 +116,7 @@ func Test_usesGlobalSecrets(t *testing.T) {
 func Test_namespaceHandler_getNamespacesFromGlobalPullSecret(t *testing.T) {
 	systemProjectLabels := map[string]string{
 		"authz.management.cattle.io/system-project": "true",
-		needsGlobalPrivateRegistryPullSecret:        "true",
+		NeedsGlobalPrivateRegistryPullSecret:        "true",
 	}
 
 	tests := []struct {
@@ -198,7 +198,7 @@ func Test_namespaceHandler_getNamespacesFromGlobalPullSecret(t *testing.T) {
 			},
 			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
 				f.EXPECT().List("c-abc", gomock.Any()).Return([]*v3.Project{
-					{ObjectMeta: metav1.ObjectMeta{Name: "p-abc", Labels: map[string]string{needsGlobalPrivateRegistryPullSecret: "true"}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "p-abc", Labels: map[string]string{NeedsGlobalPrivateRegistryPullSecret: "true"}}},
 				}, nil)
 			},
 			want: nil,
@@ -318,7 +318,7 @@ func Test_namespaceHandler_secretEnqueueNamespace(t *testing.T) {
 							Name: "p-system",
 							Labels: map[string]string{
 								"authz.management.cattle.io/system-project": "true",
-								needsGlobalPrivateRegistryPullSecret:        "true",
+								NeedsGlobalPrivateRegistryPullSecret:        "true",
 							},
 						},
 					},
@@ -347,7 +347,7 @@ func Test_namespaceHandler_secretEnqueueNamespace(t *testing.T) {
 							Name: "p-system",
 							Labels: map[string]string{
 								"authz.management.cattle.io/system-project": "true",
-								needsGlobalPrivateRegistryPullSecret:        "true",
+								NeedsGlobalPrivateRegistryPullSecret:        "true",
 							},
 						},
 					},
@@ -355,7 +355,7 @@ func Test_namespaceHandler_secretEnqueueNamespace(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "n-system",
 							Labels: map[string]string{
-								needsGlobalPrivateRegistryPullSecret: "true",
+								NeedsGlobalPrivateRegistryPullSecret: "true",
 							},
 						},
 					},
@@ -401,7 +401,7 @@ func Test_namespaceHandler_secretEnqueueNamespace(t *testing.T) {
 func Test_namespaceHandler_onSettingEnqueueNamespace(t *testing.T) {
 	systemProjectLabels := map[string]string{
 		"authz.management.cattle.io/system-project": "true",
-		needsGlobalPrivateRegistryPullSecret:        "true",
+		NeedsGlobalPrivateRegistryPullSecret:        "true",
 	}
 
 	tests := []struct {
@@ -447,7 +447,7 @@ func Test_namespaceHandler_onSettingEnqueueNamespace(t *testing.T) {
 			},
 			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
 				f.EXPECT().List("c-abc", gomock.Any()).Return([]*v3.Project{
-					{ObjectMeta: metav1.ObjectMeta{Name: "p-user", Labels: map[string]string{needsGlobalPrivateRegistryPullSecret: "true"}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "p-user", Labels: map[string]string{NeedsGlobalPrivateRegistryPullSecret: "true"}}},
 				}, nil)
 			},
 			wantKeys: []relatedresource.Key{},
@@ -523,7 +523,7 @@ func Test_namespaceHandler_onSettingEnqueueNamespace(t *testing.T) {
 			},
 			setupProjectCache: func(f *fake.MockCacheInterface[*v3.Project]) {
 				f.EXPECT().List("c-abc", gomock.Any()).Return([]*v3.Project{
-					{ObjectMeta: metav1.ObjectMeta{Name: "p-user", Labels: map[string]string{needsGlobalPrivateRegistryPullSecret: "true"}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "p-user", Labels: map[string]string{NeedsGlobalPrivateRegistryPullSecret: "true"}}},
 				}, nil)
 			},
 			wantKeys: []relatedresource.Key{},
@@ -620,7 +620,7 @@ func Test_namespaceHandler_onSettingEnqueueNamespace(t *testing.T) {
 func Test_namespaceHandler_onSystemProjectEnqueueNamespace(t *testing.T) {
 	systemProjectLabels := map[string]string{
 		"authz.management.cattle.io/system-project": "true",
-		needsGlobalPrivateRegistryPullSecret:        "true",
+		NeedsGlobalPrivateRegistryPullSecret:        "true",
 	}
 
 	tests := []struct {
@@ -928,16 +928,7 @@ func Test_namespaceHandler_getGlobalPullSecrets(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set the settings for the test — when provider is nil, Set modifies the default in the settings map.
-			origRegistry := settings.SystemDefaultRegistry.Get()
-			origPullSecrets := settings.SystemDefaultRegistryPullSecrets.Get()
-			t.Cleanup(func() {
-				settings.SystemDefaultRegistry.Set(origRegistry)
-				settings.SystemDefaultRegistryPullSecrets.Set(origPullSecrets)
-			})
-			settings.SystemDefaultRegistry.Set(tt.registryURL)
-			settings.SystemDefaultRegistryPullSecrets.Set(tt.pullSecretNames)
-
+			withSettings(t, tt.registryURL, tt.pullSecretNames)
 			managementSecretCacheMock := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
 			if tt.setupManagementCache != nil {
 				tt.setupManagementCache(managementSecretCacheMock)
@@ -969,7 +960,7 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 
 	systemProjectLabels := map[string]string{
 		"authz.management.cattle.io/system-project": "true",
-		needsGlobalPrivateRegistryPullSecret:        "true",
+		NeedsGlobalPrivateRegistryPullSecret:        "true",
 	}
 
 	tests := []struct {
@@ -1047,7 +1038,7 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 						Name: testProjectName,
 						Labels: map[string]string{
 							"authz.management.cattle.io/system-project": "true",
-							// needsGlobalPrivateRegistryPullSecret is NOT set
+							// NeedsGlobalPrivateRegistryPullSecret is NOT set
 						},
 					},
 					Spec:   v3.ProjectSpec{ClusterName: testClusterName},
@@ -1197,14 +1188,7 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			origRegistry := settings.SystemDefaultRegistry.Get()
-			origPullSecrets := settings.SystemDefaultRegistryPullSecrets.Get()
-			t.Cleanup(func() {
-				settings.SystemDefaultRegistry.Set(origRegistry)
-				settings.SystemDefaultRegistryPullSecrets.Set(origPullSecrets)
-			})
-			settings.SystemDefaultRegistry.Set(tt.registryURL)
-			settings.SystemDefaultRegistryPullSecrets.Set(tt.pullSecretNames)
+			withSettings(t, tt.registryURL, tt.pullSecretNames)
 
 			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
 			if tt.setupProjectCache != nil {
@@ -1241,4 +1225,15 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func withSettings(t *testing.T, sdr, pullSecrets string) {
+	curSdr := settings.SystemDefaultRegistry.Get()
+	curSdrPull := settings.SystemDefaultRegistryPullSecrets.Get()
+	settings.SystemDefaultRegistry.Set(sdr)
+	settings.SystemDefaultRegistryPullSecrets.Set(pullSecrets)
+	t.Cleanup(func() {
+		settings.SystemDefaultRegistry.Set(curSdr)
+		settings.SystemDefaultRegistryPullSecrets.Set(curSdrPull)
+	})
 }

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets_pull_secrets_test.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets_pull_secrets_test.go
@@ -787,7 +787,7 @@ func Test_namespaceHandler_getGlobalPullSecrets(t *testing.T) {
 			want: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pull-secret-1",
+						Name:      "pull-secret-1-rancher-managed-pull-secret",
 						Namespace: "cattle-system",
 						Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 					},
@@ -839,7 +839,7 @@ func Test_namespaceHandler_getGlobalPullSecrets(t *testing.T) {
 			want: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "valid-secret",
+						Name:      "valid-secret-rancher-managed-pull-secret",
 						Namespace: "cattle-system",
 						Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 					},
@@ -873,7 +873,7 @@ func Test_namespaceHandler_getGlobalPullSecrets(t *testing.T) {
 			want: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pull-secret-1",
+						Name:      "pull-secret-1-rancher-managed-pull-secret",
 						Namespace: "cattle-system",
 						Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 					},
@@ -881,7 +881,7 @@ func Test_namespaceHandler_getGlobalPullSecrets(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pull-secret-2",
+						Name:      "pull-secret-2-rancher-managed-pull-secret",
 						Namespace: "cattle-system",
 						Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 					},
@@ -915,7 +915,7 @@ func Test_namespaceHandler_getGlobalPullSecrets(t *testing.T) {
 			want: []*corev1.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "exists",
+						Name:      "exists-rancher-managed-pull-secret",
 						Namespace: "cattle-system",
 						Labels:    map[string]string{cluster.CopiedPullSecretLabel: "true"},
 					},
@@ -1006,9 +1006,9 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 				}, nil)
 			},
 			setupSecretClient: func(f *fake.MockClientInterface[*corev1.Secret, *corev1.SecretList]) {
-				f.EXPECT().Get(testNamespace, "global-pull-secret", gomock.Any()).Return(nil, errNotFound)
+				f.EXPECT().Get(testNamespace, "global-pull-secret-rancher-managed-pull-secret", gomock.Any()).Return(nil, errNotFound)
 				f.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
-					assert.Equal(t, "global-pull-secret", s.Name)
+					assert.Equal(t, "global-pull-secret-rancher-managed-pull-secret", s.Name)
 					assert.Equal(t, testNamespace, s.Namespace)
 					assert.Equal(t, "true", s.Annotations[pssCopyAnnotation])
 					assert.Equal(t, "true", s.Labels[cluster.CopiedPullSecretLabel])
@@ -1017,7 +1017,7 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 				f.EXPECT().List(testNamespace, metav1.ListOptions{LabelSelector: ProjectScopedSecretLabel}).Return(&corev1.SecretList{Items: []corev1.Secret{}}, nil)
 				f.EXPECT().List(testNamespace, metav1.ListOptions{LabelSelector: cluster.CopiedPullSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
-						{ObjectMeta: metav1.ObjectMeta{Name: "global-pull-secret", Namespace: testNamespace}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "global-pull-secret-rancher-managed-pull-secret", Namespace: testNamespace}},
 					},
 				}, nil)
 			},
@@ -1106,9 +1106,9 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 					return s, nil
 				})
 				// CreateOrUpdateNamespacedResource for global pull secret
-				f.EXPECT().Get(testNamespace, "global-pull-secret", gomock.Any()).Return(nil, errNotFound)
+				f.EXPECT().Get(testNamespace, "global-pull-secret-rancher-managed-pull-secret", gomock.Any()).Return(nil, errNotFound)
 				f.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
-					assert.Equal(t, "global-pull-secret", s.Name)
+					assert.Equal(t, "global-pull-secret-rancher-managed-pull-secret", s.Name)
 					assert.Equal(t, testNamespace, s.Namespace)
 					return s, nil
 				})
@@ -1120,7 +1120,7 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 				}, nil)
 				f.EXPECT().List(testNamespace, metav1.ListOptions{LabelSelector: cluster.CopiedPullSecretLabel}).Return(&corev1.SecretList{
 					Items: []corev1.Secret{
-						{ObjectMeta: metav1.ObjectMeta{Name: "global-pull-secret", Namespace: testNamespace}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "global-pull-secret-rancher-managed-pull-secret", Namespace: testNamespace}},
 					},
 				}, nil)
 			},

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -506,7 +506,7 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.DesiredAuthImage = image.ResolveWithCluster(settings.AuthImage.Get(), cluster)
 
 	spec.ClusterSecrets.PrivateRegistrySecret = image.GetPrivateRepoSecretFromCluster(cluster)
-	spec.ClusterSecrets.PrivateRegistryURL = image.GetPrivateRepoURLFromCluster(cluster)
+	spec.ClusterSecrets.PrivateRegistryURL, _ = image.GetPrivateRepoURLFromCluster(cluster)
 
 	spec.AgentEnvVars = nil
 	for _, env := range cluster.Spec.AgentEnvVars {

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -82,7 +82,8 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 			// cluster for the cluster level registry.
 			return mgmtcluster.GetPrivateRegistryURL(mgmtCluster)
 		}
-		return image.GetPrivateRepoURLFromCluster(cluster)
+		url, _ := image.GetPrivateRepoURLFromCluster(cluster)
+		return url
 	}
 
 	rocontrollers.RegisterClusterGeneratingHandler(ctx,

--- a/pkg/controllers/provisioningv2/machineconfigcleanup/controller.go
+++ b/pkg/controllers/provisioningv2/machineconfigcleanup/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	v3apis "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/controllers/capr/dynamicschema"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/fleet"
@@ -241,6 +242,11 @@ func cleanupObjects(token string) []runtime.Object {
 				},
 			},
 		},
+	}
+
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry != nil {
+		cronJob.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = registry.PullSecretsAsObjectReferences()
 	}
 
 	return []runtime.Object{

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -15,10 +15,11 @@ const (
 const (
 	SystemImageVersionAnnotation = "field.cattle.io/systemImageVersion"
 	ProjectIDAnnotation          = "field.cattle.io/projectId"
+	SystemProjectLabelKey        = "authz.management.cattle.io/system-project"
 )
 
 var (
-	SystemProjectLabel = map[string]string{"authz.management.cattle.io/system-project": "true"}
+	SystemProjectLabel = map[string]string{SystemProjectLabelKey: "true"}
 )
 
 func GetSystemProject(clusterName string, projectLister mgmtv3.ProjectLister) (*mgmtv3.Project, error) {

--- a/pkg/provisioningv2/image/resolve.go
+++ b/pkg/provisioningv2/image/resolve.go
@@ -11,7 +11,8 @@ import (
 )
 
 func ResolveWithControlPlane(image string, cp *rkev1.RKEControlPlane) string {
-	return resolve(GetPrivateRepoURLFromControlPlane(cp), image)
+	csdr, _ := GetPrivateRepoURLFromControlPlane(cp)
+	return resolve(csdr, image)
 }
 
 func ResolveWithCluster(image string, cluster *v1.Cluster) string {
@@ -33,9 +34,23 @@ func resolve(reg, image string) string {
 // GetPrivateRepoSecretFromCluster returns the name of the secret containing the credentials for the cluster level system-default-registry.
 func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) string {
 	if cluster != nil && cluster.Spec.RKEConfig != nil && cluster.Spec.RKEConfig.Registries != nil {
-		return cluster.Spec.RKEConfig.Registries.Configs[GetPrivateRepoURLFromCluster(cluster)].AuthConfigSecretName
+		config, ok := cluster.Spec.RKEConfig.Registries.Configs[GetPrivateRepoURLFromCluster(cluster)]
+		if ok {
+			return config.AuthConfigSecretName
+		}
 	}
-	return "" // don't return settings.SystemDefaultRegistry.Get() as the global system-default-registry requires no auth
+
+	// fall back to the GSDR if configured, but only return the first pull secret. Due to the format of the containerd registry authentication file
+	// only one credential can be configured per hostname.
+	globalPullSecrets := settings.SystemDefaultRegistryPullSecrets.Get()
+	if globalPullSecrets != "" {
+		firstEntry := strings.TrimSpace(strings.Split(globalPullSecrets, ",")[0])
+		if firstEntry != "" {
+			return firstEntry
+		}
+	}
+
+	return ""
 }
 
 // GetPrivateRepoURLFromCluster returns the system-default-registry URL from either the clusters
@@ -43,7 +58,8 @@ func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) string {
 // If no cluster level system-default-registry is configured, it will return the global system-default-registry.
 func GetPrivateRepoURLFromCluster(cluster *v1.Cluster) string {
 	if cluster != nil && cluster.Spec.RKEConfig != nil {
-		return getPrivateRepoURL(cluster.Spec.RKEConfig.MachineGlobalConfig, cluster.Spec.RKEConfig.MachineSelectorConfig)
+		url, _ := getPrivateRepoURL(cluster.Spec.RKEConfig.MachineGlobalConfig, cluster.Spec.RKEConfig.MachineSelectorConfig)
+		return url
 	}
 
 	return settings.SystemDefaultRegistry.Get()
@@ -51,31 +67,34 @@ func GetPrivateRepoURLFromCluster(cluster *v1.Cluster) string {
 
 // GetPrivateRepoURLFromControlPlane returns the system-default-registry URL from either the control planes
 // machineGlobalConfig, or one of its machineSelectorConfig's which has no label selectors.
-// If no cluster level system-default-registry is configured, it will return the global system-default-registry.
-func GetPrivateRepoURLFromControlPlane(cp *rkev1.RKEControlPlane) string {
+// If no cluster level system-default-registry is configured, it will return the global system-default-registry and a boolean
+// indicating that the value was pulled from the global configuration.
+func GetPrivateRepoURLFromControlPlane(cp *rkev1.RKEControlPlane) (string, bool) {
 	if cp != nil {
 		return getPrivateRepoURL(cp.Spec.MachineGlobalConfig, cp.Spec.MachineSelectorConfig)
 	}
 
-	return settings.SystemDefaultRegistry.Get()
+	return settings.SystemDefaultRegistry.Get(), true
 }
 
-func getPrivateRepoURL(machineGlobalConfig rkev1.GenericMap, machineSelectorConfig []rkev1.RKESystemConfig) string {
+// getPrivateRepoURL retrieves the configured system-default-registry URL from either the machineGlobalConfig or machineSelectorConfig (in that order),
+// and returns the URL along with a boolean indicating whether the returned URL is from the global configuration.
+func getPrivateRepoURL(machineGlobalConfig rkev1.GenericMap, machineSelectorConfig []rkev1.RKESystemConfig) (string, bool) {
 	for key, val := range machineGlobalConfig.Data {
 		if val, ok := val.(string); ok && key == "system-default-registry" {
-			return val
+			return val, false
 		}
 	}
 
 	for _, config := range machineSelectorConfig {
 		if registryVal, ok := config.Config.Data["system-default-registry"]; config.MachineLabelSelector == nil && ok {
 			if registry, ok := registryVal.(string); ok {
-				return registry
+				return registry, false
 			}
 		}
 	}
 
-	return settings.SystemDefaultRegistry.Get()
+	return settings.SystemDefaultRegistry.Get(), true
 }
 
 func GetDesiredAgentImage(cp *rkev1.RKEControlPlane, mgmtCluster *v3.Cluster) string {

--- a/pkg/provisioningv2/image/resolve.go
+++ b/pkg/provisioningv2/image/resolve.go
@@ -11,12 +11,13 @@ import (
 )
 
 func ResolveWithControlPlane(image string, cp *rkev1.RKEControlPlane) string {
-	csdr, _ := GetPrivateRepoURLFromControlPlane(cp)
-	return resolve(csdr, image)
+	url, _ := GetPrivateRepoURLFromControlPlane(cp)
+	return resolve(url, image)
 }
 
 func ResolveWithCluster(image string, cluster *v1.Cluster) string {
-	return resolve(GetPrivateRepoURLFromCluster(cluster), image)
+	url, _ := GetPrivateRepoURLFromCluster(cluster)
+	return resolve(url, image)
 }
 
 func resolve(reg, image string) string {
@@ -33,8 +34,9 @@ func resolve(reg, image string) string {
 
 // GetPrivateRepoSecretFromCluster returns the name of the secret containing the credentials for the cluster level system-default-registry.
 func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) string {
+	url, isGlobalDefault := GetPrivateRepoURLFromCluster(cluster)
 	if cluster != nil && cluster.Spec.RKEConfig != nil && cluster.Spec.RKEConfig.Registries != nil {
-		config, ok := cluster.Spec.RKEConfig.Registries.Configs[GetPrivateRepoURLFromCluster(cluster)]
+		config, ok := cluster.Spec.RKEConfig.Registries.Configs[url]
 		if ok {
 			return config.AuthConfigSecretName
 		}
@@ -43,10 +45,12 @@ func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) string {
 	// fall back to the GSDR if configured, but only return the first pull secret. Due to the format of the containerd registry authentication file
 	// only one credential can be configured per hostname.
 	globalPullSecrets := settings.SystemDefaultRegistryPullSecrets.Get()
-	if globalPullSecrets != "" {
-		firstEntry := strings.TrimSpace(strings.Split(globalPullSecrets, ",")[0])
-		if firstEntry != "" {
-			return firstEntry
+	if isGlobalDefault && globalPullSecrets != "" {
+		for _, entry := range strings.Split(globalPullSecrets, ",") {
+			secret := strings.TrimSpace(entry)
+			if secret != "" {
+				return secret
+			}
 		}
 	}
 
@@ -56,13 +60,12 @@ func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) string {
 // GetPrivateRepoURLFromCluster returns the system-default-registry URL from either the clusters
 // machineGlobalConfig, or one of its machineSelectorConfig's which has no label selectors.
 // If no cluster level system-default-registry is configured, it will return the global system-default-registry.
-func GetPrivateRepoURLFromCluster(cluster *v1.Cluster) string {
+func GetPrivateRepoURLFromCluster(cluster *v1.Cluster) (string, bool) {
 	if cluster != nil && cluster.Spec.RKEConfig != nil {
-		url, _ := getPrivateRepoURL(cluster.Spec.RKEConfig.MachineGlobalConfig, cluster.Spec.RKEConfig.MachineSelectorConfig)
-		return url
+		return getPrivateRepoURL(cluster.Spec.RKEConfig.MachineGlobalConfig, cluster.Spec.RKEConfig.MachineSelectorConfig)
 	}
 
-	return settings.SystemDefaultRegistry.Get()
+	return settings.SystemDefaultRegistry.Get(), true
 }
 
 // GetPrivateRepoURLFromControlPlane returns the system-default-registry URL from either the control planes

--- a/pkg/provisioningv2/image/resolve_test.go
+++ b/pkg/provisioningv2/image/resolve_test.go
@@ -1,0 +1,668 @@
+package image
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestResolveWithControlPlane(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		cp       *rkev1.RKEControlPlane
+		global   string
+		expected string
+	}{
+		{
+			name:  "nil control plane falls back to global registry",
+			image: "rancher/rancher-agent:v2.15.0",
+			cp:    nil,
+			// global is set via withGlobalRegistry below
+			global:   "global.registry.io",
+			expected: "global.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+		{
+			name:  "control plane with machineGlobalConfig registry",
+			image: "rancher/rancher-agent:v2.15.0",
+			cp: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					ClusterConfiguration: rkev1.ClusterConfiguration{
+						MachineGlobalConfig: rkev1.GenericMap{
+							Data: map[string]any{
+								"system-default-registry": "cp.registry.io",
+							},
+						},
+					},
+				},
+			},
+			expected: "cp.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+		{
+			name:  "control plane with machineSelectorConfig registry",
+			image: "rancher/rancher-agent:v2.15.0",
+			cp: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					ClusterConfiguration: rkev1.ClusterConfiguration{
+						MachineSelectorConfig: []rkev1.RKESystemConfig{
+							{
+								MachineLabelSelector: nil,
+								Config: rkev1.GenericMap{
+									Data: map[string]any{
+										"system-default-registry": "selector.registry.io",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "selector.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+		{
+			name:  "control plane with no registry and no global falls back to unmodified image",
+			image: "rancher/rancher-agent:v2.15.0",
+			cp: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{},
+			},
+			global:   "",
+			expected: "rancher/rancher-agent:v2.15.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withGlobalRegistry(t, tt.global)
+			got := ResolveWithControlPlane(tt.image, tt.cp)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestResolveWithCluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		cluster  *v1.Cluster
+		global   string
+		expected string
+	}{
+		{
+			name:     "nil cluster falls back to global registry",
+			image:    "rancher/rancher-agent:v2.15.0",
+			cluster:  nil,
+			global:   "global.registry.io",
+			expected: "global.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+		{
+			name:  "cluster with machineGlobalConfig registry",
+			image: "rancher/rancher-agent:v2.15.0",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineGlobalConfig: rkev1.GenericMap{
+								Data: map[string]any{
+									"system-default-registry": "cluster.registry.io",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "cluster.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+		{
+			name:  "nil RKEConfig falls back to global registry",
+			image: "rancher/rancher-agent:v2.15.0",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: nil,
+				},
+			},
+			global:   "global.registry.io",
+			expected: "global.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withGlobalRegistry(t, tt.global)
+			got := ResolveWithCluster(tt.image, tt.cluster)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetPrivateRepoURLFromCluster(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     *v1.Cluster
+		global      string
+		expectedURL string
+	}{
+		{
+			name:        "nil cluster returns global registry",
+			cluster:     nil,
+			global:      "global.registry.io",
+			expectedURL: "global.registry.io",
+		},
+		{
+			name: "cluster with nil RKEConfig returns global registry",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{RKEConfig: nil},
+			},
+			global:      "global.registry.io",
+			expectedURL: "global.registry.io",
+		},
+		{
+			name: "cluster with machineGlobalConfig registry returns cluster registry",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineGlobalConfig: rkev1.GenericMap{
+								Data: map[string]any{
+									"system-default-registry": "cluster.registry.io",
+								},
+							},
+						},
+					},
+				},
+			},
+			global:      "global.registry.io",
+			expectedURL: "cluster.registry.io",
+		},
+		{
+			name: "cluster with machineSelectorConfig (nil selector) returns that registry",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineSelectorConfig: []rkev1.RKESystemConfig{
+								{
+									MachineLabelSelector: nil,
+									Config: rkev1.GenericMap{
+										Data: map[string]any{
+											"system-default-registry": "selector.registry.io",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			global:      "global.registry.io",
+			expectedURL: "selector.registry.io",
+		},
+		{
+			name: "machineSelectorConfig with non-nil label selector is skipped, falls back to global",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineSelectorConfig: []rkev1.RKESystemConfig{
+								{
+									MachineLabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"role": "worker"},
+									},
+									Config: rkev1.GenericMap{
+										Data: map[string]any{
+											"system-default-registry": "worker.registry.io",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			global:      "global.registry.io",
+			expectedURL: "global.registry.io",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withGlobalRegistry(t, tt.global)
+			got := GetPrivateRepoURLFromCluster(tt.cluster)
+			assert.Equal(t, tt.expectedURL, got)
+		})
+	}
+}
+
+func TestGetPrivateRepoURLFromControlPlane(t *testing.T) {
+	tests := []struct {
+		name           string
+		cp             *rkev1.RKEControlPlane
+		global         string
+		expectedURL    string
+		expectedGlobal bool
+	}{
+		{
+			name:           "nil control plane returns global registry with isGlobal=true",
+			cp:             nil,
+			global:         "global.registry.io",
+			expectedURL:    "global.registry.io",
+			expectedGlobal: true,
+		},
+		{
+			name: "control plane with machineGlobalConfig registry returns it with isGlobal=false",
+			cp: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					ClusterConfiguration: rkev1.ClusterConfiguration{
+						MachineGlobalConfig: rkev1.GenericMap{
+							Data: map[string]any{
+								"system-default-registry": "cp.registry.io",
+							},
+						},
+					},
+				},
+			},
+			global:         "global.registry.io",
+			expectedURL:    "cp.registry.io",
+			expectedGlobal: false,
+		},
+		{
+			name: "control plane with no registry returns global with isGlobal=true",
+			cp: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{},
+			},
+			global:         "global.registry.io",
+			expectedURL:    "global.registry.io",
+			expectedGlobal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withGlobalRegistry(t, tt.global)
+			gotURL, gotGlobal := GetPrivateRepoURLFromControlPlane(tt.cp)
+			assert.Equal(t, tt.expectedURL, gotURL)
+			assert.Equal(t, tt.expectedGlobal, gotGlobal)
+		})
+	}
+}
+
+func TestGetPrivateRepoSecretFromCluster(t *testing.T) {
+	const clusterRegistry = "cluster.registry.io"
+
+	tests := []struct {
+		name           string
+		cluster        *v1.Cluster
+		globalSecrets  string
+		expectedSecret string
+	}{
+		{
+			name:           "nil cluster with no global pull secrets returns empty string",
+			cluster:        nil,
+			globalSecrets:  "",
+			expectedSecret: "",
+		},
+		{
+			name:           "nil cluster with global pull secrets returns first secret",
+			cluster:        nil,
+			globalSecrets:  "global-secret,other-secret",
+			expectedSecret: "global-secret",
+		},
+		{
+			name:           "nil cluster with global pull secrets trims whitespace",
+			cluster:        nil,
+			globalSecrets:  "  trimmed-secret  , other-secret",
+			expectedSecret: "trimmed-secret",
+		},
+		{
+			name: "cluster with matching registry config returns its auth secret",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineGlobalConfig: rkev1.GenericMap{
+								Data: map[string]any{
+									"system-default-registry": clusterRegistry,
+								},
+							},
+							Registries: &rkev1.Registry{
+								Configs: map[string]rkev1.RegistryConfig{
+									clusterRegistry: {
+										AuthConfigSecretName: "my-cluster-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			globalSecrets:  "global-secret",
+			expectedSecret: "my-cluster-secret",
+		},
+		{
+			name: "cluster with registries but no matching key falls back to global pull secrets",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineGlobalConfig: rkev1.GenericMap{
+								Data: map[string]any{
+									"system-default-registry": clusterRegistry,
+								},
+							},
+							Registries: &rkev1.Registry{
+								Configs: map[string]rkev1.RegistryConfig{
+									"other.registry.io": {
+										AuthConfigSecretName: "other-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			globalSecrets:  "global-secret",
+			expectedSecret: "global-secret",
+		},
+		{
+			name: "cluster with nil registries falls back to global pull secrets",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineGlobalConfig: rkev1.GenericMap{
+								Data: map[string]any{
+									"system-default-registry": clusterRegistry,
+								},
+							},
+							Registries: nil,
+						},
+					},
+				},
+			},
+			globalSecrets:  "global-secret",
+			expectedSecret: "global-secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withGlobalPullSecrets(t, tt.globalSecrets)
+			got := GetPrivateRepoSecretFromCluster(tt.cluster)
+			assert.Equal(t, tt.expectedSecret, got)
+		})
+	}
+}
+
+func TestGetDesiredAgentImage(t *testing.T) {
+	const agentImageDefault = "rancher/rancher-agent:v2.15.0"
+
+	tests := []struct {
+		name        string
+		cp          *rkev1.RKEControlPlane
+		mgmtCluster *v3.Cluster
+		agentImage  string
+		global      string
+		expected    string
+	}{
+		{
+			name: "AgentImageOverride takes highest priority",
+			cp:   nil,
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						DesiredAgentImage:  "desired-image:v1",
+						AgentImageOverride: "override-image:v1",
+					},
+				},
+			},
+			expected: "override-image:v1",
+		},
+		{
+			name: "DesiredAgentImage is used when AgentImageOverride is empty",
+			cp:   nil,
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						DesiredAgentImage: "desired-image:v1",
+					},
+				},
+			},
+			expected: "desired-image:v1",
+		},
+		{
+			name:       "empty DesiredAgentImage resolves from settings",
+			cp:         nil,
+			agentImage: agentImageDefault,
+			global:     "",
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{},
+				},
+			},
+			expected: agentImageDefault,
+		},
+		{
+			name:       "\"fixed\" DesiredAgentImage resolves from settings",
+			cp:         nil,
+			agentImage: agentImageDefault,
+			global:     "",
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						DesiredAgentImage: "fixed",
+					},
+				},
+			},
+			expected: agentImageDefault,
+		},
+		{
+			name:       "empty DesiredAgentImage with global registry resolves and prefixes image",
+			cp:         nil,
+			agentImage: "rancher/rancher-agent:v2.15.0",
+			global:     "my.registry.io",
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{},
+				},
+			},
+			expected: "my.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+		{
+			name:       "control plane registry takes precedence over global",
+			agentImage: "rancher/rancher-agent:v2.15.0",
+			global:     "global.registry.io",
+			cp: &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					ClusterConfiguration: rkev1.ClusterConfiguration{
+						MachineGlobalConfig: rkev1.GenericMap{
+							Data: map[string]any{
+								"system-default-registry": "cp.registry.io",
+							},
+						},
+					},
+				},
+			},
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{},
+				},
+			},
+			expected: "cp.registry.io/rancher/rancher-agent:v2.15.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withGlobalRegistry(t, tt.global)
+			if tt.agentImage != "" {
+				withAgentImage(t, tt.agentImage)
+			}
+			got := GetDesiredAgentImage(tt.cp, tt.mgmtCluster)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetDesiredAuthImage(t *testing.T) {
+	const authImageDefault = "rancher/kube-api-auth:v0.2.2"
+
+	tests := []struct {
+		name        string
+		cp          *rkev1.RKEControlPlane
+		mgmtCluster *v3.Cluster
+		authImage   string
+		global      string
+		expected    string
+	}{
+		{
+			name: "LocalClusterAuthEndpoint disabled returns empty string",
+			cp:   nil,
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						LocalClusterAuthEndpoint: v3.LocalClusterAuthEndpoint{
+							Enabled: false,
+						},
+						DesiredAuthImage: "some-image:v1",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "LocalClusterAuthEndpoint enabled returns DesiredAuthImage",
+			cp:   nil,
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						LocalClusterAuthEndpoint: v3.LocalClusterAuthEndpoint{
+							Enabled: true,
+						},
+						DesiredAuthImage: "desired-auth-image:v1",
+					},
+				},
+			},
+			expected: "desired-auth-image:v1",
+		},
+		{
+			name:      "LocalClusterAuthEndpoint enabled, empty DesiredAuthImage resolves from settings",
+			cp:        nil,
+			authImage: authImageDefault,
+			global:    "",
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						LocalClusterAuthEndpoint: v3.LocalClusterAuthEndpoint{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			expected: authImageDefault,
+		},
+		{
+			name:      "LocalClusterAuthEndpoint enabled, \"fixed\" DesiredAuthImage resolves from settings",
+			cp:        nil,
+			authImage: authImageDefault,
+			global:    "",
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						LocalClusterAuthEndpoint: v3.LocalClusterAuthEndpoint{
+							Enabled: true,
+						},
+						DesiredAuthImage: "fixed",
+					},
+				},
+			},
+			expected: authImageDefault,
+		},
+		{
+			name:      "LocalClusterAuthEndpoint enabled, global registry prefixes resolved image",
+			cp:        nil,
+			authImage: "rancher/kube-api-auth:v0.2.2",
+			global:    "my.registry.io",
+			mgmtCluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						LocalClusterAuthEndpoint: v3.LocalClusterAuthEndpoint{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			expected: "my.registry.io/rancher/kube-api-auth:v0.2.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withGlobalRegistry(t, tt.global)
+			if tt.authImage != "" {
+				withAuthImage(t, tt.authImage)
+			}
+			got := GetDesiredAuthImage(tt.cp, tt.mgmtCluster)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// withGlobalRegistry sets the global SystemDefaultRegistry setting for the
+// duration of the test and restores the original value on cleanup.
+func withGlobalRegistry(t *testing.T, reg string) {
+	t.Helper()
+	orig := settings.SystemDefaultRegistry.Get()
+	if err := settings.SystemDefaultRegistry.Set(reg); err != nil {
+		t.Fatalf("failed to set SystemDefaultRegistry: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := settings.SystemDefaultRegistry.Set(orig); err != nil {
+			t.Logf("failed to restore SystemDefaultRegistry: %v", err)
+		}
+	})
+}
+
+// withGlobalPullSecrets sets the global SystemDefaultRegistryPullSecrets
+// setting for the duration of the test and restores the original value on cleanup.
+func withGlobalPullSecrets(t *testing.T, secrets string) {
+	t.Helper()
+	orig := settings.SystemDefaultRegistryPullSecrets.Get()
+	if err := settings.SystemDefaultRegistryPullSecrets.Set(secrets); err != nil {
+		t.Fatalf("failed to set SystemDefaultRegistryPullSecrets: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := settings.SystemDefaultRegistryPullSecrets.Set(orig); err != nil {
+			t.Logf("failed to restore SystemDefaultRegistryPullSecrets: %v", err)
+		}
+	})
+}
+
+func withAgentImage(t *testing.T, img string) {
+	t.Helper()
+	orig := settings.AgentImage.Get()
+	if err := settings.AgentImage.Set(img); err != nil {
+		t.Fatalf("failed to set AgentImage: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := settings.AgentImage.Set(orig); err != nil {
+			t.Logf("failed to restore AgentImage: %v", err)
+		}
+	})
+}
+
+func withAuthImage(t *testing.T, img string) {
+	t.Helper()
+	orig := settings.AuthImage.Get()
+	if err := settings.AuthImage.Set(img); err != nil {
+		t.Fatalf("failed to set AuthImage: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := settings.AuthImage.Set(orig); err != nil {
+			t.Logf("failed to restore AuthImage: %v", err)
+		}
+	})
+}

--- a/pkg/provisioningv2/image/resolve_test.go
+++ b/pkg/provisioningv2/image/resolve_test.go
@@ -231,7 +231,7 @@ func TestGetPrivateRepoURLFromCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			withGlobalRegistry(t, tt.global)
-			got := GetPrivateRepoURLFromCluster(tt.cluster)
+			got, _ := GetPrivateRepoURLFromCluster(tt.cluster)
 			assert.Equal(t, tt.expectedURL, got)
 		})
 	}
@@ -291,31 +291,57 @@ func TestGetPrivateRepoURLFromControlPlane(t *testing.T) {
 }
 
 func TestGetPrivateRepoSecretFromCluster(t *testing.T) {
-	const clusterRegistry = "cluster.registry.io"
+	const (
+		clusterRegistry = "cluster.registry.io"
+		globalRegistry  = "global.registry.io"
+	)
 
 	tests := []struct {
 		name           string
 		cluster        *v1.Cluster
+		globalRegistry string
 		globalSecrets  string
 		expectedSecret string
 	}{
 		{
 			name:           "nil cluster with no global pull secrets returns empty string",
 			cluster:        nil,
+			globalRegistry: globalRegistry,
 			globalSecrets:  "",
 			expectedSecret: "",
 		},
 		{
 			name:           "nil cluster with global pull secrets returns first secret",
 			cluster:        nil,
+			globalRegistry: globalRegistry,
 			globalSecrets:  "global-secret,other-secret",
 			expectedSecret: "global-secret",
 		},
 		{
 			name:           "nil cluster with global pull secrets trims whitespace",
 			cluster:        nil,
+			globalRegistry: globalRegistry,
 			globalSecrets:  "  trimmed-secret  , other-secret",
 			expectedSecret: "trimmed-secret",
+		},
+		{
+			name: "cluster SDR explicitly set to same hostname as global SDR, does not use global pull secrets",
+			cluster: &v1.Cluster{
+				Spec: v1.ClusterSpec{
+					RKEConfig: &v1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							MachineGlobalConfig: rkev1.GenericMap{
+								Data: map[string]any{
+									"system-default-registry": globalRegistry,
+								},
+							},
+						},
+					},
+				},
+			},
+			globalRegistry: globalRegistry,
+			globalSecrets:  "global-secret",
+			expectedSecret: "",
 		},
 		{
 			name: "cluster with matching registry config returns its auth secret",
@@ -339,11 +365,15 @@ func TestGetPrivateRepoSecretFromCluster(t *testing.T) {
 					},
 				},
 			},
+			globalRegistry: globalRegistry,
 			globalSecrets:  "global-secret",
 			expectedSecret: "my-cluster-secret",
 		},
+		// The next two cases confirm that when a cluster defines its own SDR (different
+		// from the global), global pull secrets are never used, even if the cluster has
+		// no matching registry config entry of its own.
 		{
-			name: "cluster with registries but no matching key falls back to global pull secrets",
+			name: "cluster SDR differs from global SDR with unmatched registry config does not use global pull secrets",
 			cluster: &v1.Cluster{
 				Spec: v1.ClusterSpec{
 					RKEConfig: &v1.RKEConfig{
@@ -364,11 +394,12 @@ func TestGetPrivateRepoSecretFromCluster(t *testing.T) {
 					},
 				},
 			},
+			globalRegistry: globalRegistry,
 			globalSecrets:  "global-secret",
-			expectedSecret: "global-secret",
+			expectedSecret: "",
 		},
 		{
-			name: "cluster with nil registries falls back to global pull secrets",
+			name: "cluster SDR differs from global SDR with nil registries does not use global pull secrets",
 			cluster: &v1.Cluster{
 				Spec: v1.ClusterSpec{
 					RKEConfig: &v1.RKEConfig{
@@ -383,13 +414,22 @@ func TestGetPrivateRepoSecretFromCluster(t *testing.T) {
 					},
 				},
 			},
+			globalRegistry: globalRegistry,
 			globalSecrets:  "global-secret",
+			expectedSecret: "",
+		},
+		{
+			name:           "global SDR is malformed, get first valid entry",
+			cluster:        &v1.Cluster{},
+			globalRegistry: globalRegistry,
+			globalSecrets:  ", global-secret",
 			expectedSecret: "global-secret",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			withGlobalRegistry(t, tt.globalRegistry)
 			withGlobalPullSecrets(t, tt.globalSecrets)
 			got := GetPrivateRepoSecretFromCluster(tt.cluster)
 			assert.Equal(t, tt.expectedSecret, got)

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -66,6 +66,16 @@ var (
 	}
 
 	AgentImage          = NewSetting("agent-image", "rancher/rancher-agent:head")
+	SystemNamespacesIgnoringPullSecrets = []string{
+		"cattle-system",
+		"cattle-global-data",
+		"cattle-local-user-passwords",
+		"cattle-tokens",
+		"cattle-oidc-codes",
+		"cattle-oidc-client-secrets",
+		"cattle-impersonation-system",
+	}
+
 	AgentRolloutTimeout = NewSetting("agent-rollout-timeout", "300s")
 	// AgentTLSMode is translated to the environment variable STRICT_VERIFY when rendering the cluster/node agent manifests and should not be specified as a default agent setting as it has no direct effect on the agent itself.
 	AgentTLSMode                        = NewSetting("agent-tls-mode", AgentTLSModeStrict).WithDefaultOnUpgrade(AgentTLSModeSystemStore)

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -56,6 +56,14 @@ type clusterAgentContext struct {
 	PodDisruptionBudget   string
 	SUCAppNameOverride    string
 	NamespaceOptions      namespace.Mutator
+	// AgentDeploymentPullSecrets are pull secrets that are used exclusively for
+	// the cluster agent deployment
+	AgentDeploymentPullSecrets []util.AgentPullSecret
+	// SystemDefaultPullSecrets are secret references passed to the cluster
+	// agent as environment variables, later used to deploy system charts with the
+	// correct pull secret configuration.
+	SystemDefaultPullSecrets []util.AgentPullSecret
+	AllPullSecrets           []util.AgentPullSecret
 }
 
 type priorityClassContext struct {
@@ -135,26 +143,52 @@ func PodDisruptionBudgetTemplate(cluster *apimgmtv3.Cluster) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url string, isPreBootstrap bool,
-	cluster *apimgmtv3.Cluster, agentFeatures map[string]bool, taints []corev1.Taint,
-	secretLister v1.SecretLister, pcExists bool, mutator namespace.Mutator) error {
+type TemplateOps struct {
+	AgentImage     string
+	AuthImage      string
+	Namespace      string
+	Token          string
+	URL            string
+	IsPreBootstrap bool
+	Cluster        *apimgmtv3.Cluster
+	AgentFeatures  map[string]bool
+	Taints         []corev1.Taint
+	SecretLister   v1.SecretLister
+	PcExists       bool
+	Mutator        namespace.Mutator
+}
+
+func SystemTemplate(resp io.Writer, ops *TemplateOps) error {
 	var tolerations, agentEnvVars, agentAppendTolerations, agentAffinity, agentResourceRequirements string
-	d := sha256.Sum256([]byte(fmt.Sprintf("%s.%s.%s", url, token, namespace)))
+	d := sha256.Sum256([]byte(fmt.Sprintf("%s.%s.%s", ops.URL, ops.Token, ops.Namespace)))
 	tokenKey := hex.EncodeToString(d[:])[:10]
 
-	if authImage == "fixed" {
-		authImage = settings.AuthImage.Get()
+	if ops.AuthImage == "fixed" {
+		ops.AuthImage = settings.AuthImage.Get()
 	}
 
-	registryURL, registryConfig, err := util.GeneratePrivateRegistryEncodedDockerConfig(cluster, secretLister)
+	var registryURL string
+	var err error
+	var registryConfigs, agentDeploymentPullSecrets, systemDefaultPullSecrets []util.AgentPullSecret
+
+	registryURL, registryConfigs, err = util.GeneratePrivateRegistryEncodedDockerConfig(ops.Cluster, ops.SecretLister)
 	if err != nil {
-		logrus.Errorf("[system-template] failed to generate registry config when deploying cattle cluster agent for cluster %s: %v", cluster.Name, err)
 		return err
 	}
 
-	if taints != nil {
-		tolerationList := make([]corev1.Toleration, 0, len(taints))
-		for _, taint := range taints {
+	// ensure the cluster agent can always be pulled, regardless of cluster type.
+	agentDeploymentPullSecrets = registryConfigs
+
+	// only set the _system default_ pull secrets for imported or hosted clusters, which are identified by the legacy cluster naming convention (c-xxxxx).
+	// Provisioned and custom clusters (identified by c-m-xxxxx) will use the underlying containerd configuration set at the node level
+	// to authenticate pulls, so deploying image pull secrets in those environments is unnecessary.
+	if util.MgmtNameRegexp.MatchString(ops.Cluster.Name) {
+		systemDefaultPullSecrets = registryConfigs
+	}
+
+	if ops.Taints != nil {
+		tolerationList := make([]corev1.Toleration, 0, len(ops.Taints))
+		for _, taint := range ops.Taints {
 			toleration := corev1.Toleration{
 				Key:    taint.Key,
 				Effect: taint.Effect,
@@ -173,8 +207,8 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 	}
 
 	envVars := settings.DefaultAgentSettingsAsEnvVars()
-	if cluster != nil {
-		envVars = append(envVars, cluster.Spec.AgentEnvVars...)
+	if ops.Cluster != nil {
+		envVars = append(envVars, ops.Cluster.Spec.AgentEnvVars...)
 	}
 
 	// Merge the env vars with the AgentTLSModeStrict
@@ -200,14 +234,14 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 
 	agentEnvVars = toYAML(envVars)
 
-	if appendTolerations := util.GetClusterAgentTolerations(cluster); appendTolerations != nil {
+	if appendTolerations := util.GetClusterAgentTolerations(ops.Cluster); appendTolerations != nil {
 		agentAppendTolerations = toYAML(appendTolerations)
 		if agentAppendTolerations == "" {
 			return fmt.Errorf("error converting agent append tolerations to YAML")
 		}
 	}
 
-	affinity, err := util.GetClusterAgentAffinity(cluster)
+	affinity, err := util.GetClusterAgentAffinity(ops.Cluster)
 	if err != nil {
 		return err
 	}
@@ -216,61 +250,58 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 		return fmt.Errorf("error converting agent affinity to YAML")
 	}
 
-	if resourceRequirements := util.GetClusterAgentResourceRequirements(cluster); resourceRequirements != nil {
+	if resourceRequirements := util.GetClusterAgentResourceRequirements(ops.Cluster); resourceRequirements != nil {
 		agentResourceRequirements = toYAML(resourceRequirements)
 		if agentResourceRequirements == "" {
 			return fmt.Errorf("error converting agent resource requirements to YAML")
 		}
 	}
 
-	pcEnabled, pdbEnabled := util.AgentSchedulingCustomizationEnabled(cluster)
+	pcEnabled, pdbEnabled := util.AgentSchedulingCustomizationEnabled(ops.Cluster)
 
 	var pdb string
 	if pdbEnabled {
-		pdbYaml, err := PodDisruptionBudgetTemplate(cluster)
+		pdbYaml, err := PodDisruptionBudgetTemplate(ops.Cluster)
 		if err != nil {
 			return err
 		}
 		pdb = string(pdbYaml)
 	}
 
-	rcfg := ""
-	if len(registryConfig) > 0 {
-		rcfg = registryConfig[0].DockerConfigJSON
-	}
-
 	context := &clusterAgentContext{
-		Features:              toFeatureString(agentFeatures),
-		CAChecksum:            CAChecksum(),
-		AgentImage:            agentImage,
-		AgentEnvVars:          agentEnvVars,
-		AuthImage:             authImage,
-		TokenKey:              tokenKey,
-		Token:                 base64.StdEncoding.EncodeToString([]byte(token)),
-		URL:                   base64.StdEncoding.EncodeToString([]byte(url)),
-		Namespace:             base64.StdEncoding.EncodeToString([]byte(namespace)),
-		URLPlain:              url,
-		IsPreBootstrap:        isPreBootstrap,
-		PrivateRegistryConfig: rcfg,
-		Tolerations:           tolerations,
-		AppendTolerations:     agentAppendTolerations,
-		Affinity:              agentAffinity,
-		ResourceRequirements:  agentResourceRequirements,
-		ClusterRegistry:       registryURL,
-		PodDisruptionBudget:   pdb,
-		EnablePriorityClass:   pcExists && pcEnabled,
+		Features:                   toFeatureString(ops.AgentFeatures),
+		CAChecksum:                 CAChecksum(),
+		AgentImage:                 ops.AgentImage,
+		AgentEnvVars:               agentEnvVars,
+		AuthImage:                  ops.AuthImage,
+		TokenKey:                   tokenKey,
+		Token:                      base64.StdEncoding.EncodeToString([]byte(ops.Token)),
+		URL:                        base64.StdEncoding.EncodeToString([]byte(ops.URL)),
+		Namespace:                  base64.StdEncoding.EncodeToString([]byte(ops.Namespace)),
+		URLPlain:                   ops.URL,
+		IsPreBootstrap:             ops.IsPreBootstrap,
+		Tolerations:                tolerations,
+		AppendTolerations:          agentAppendTolerations,
+		Affinity:                   agentAffinity,
+		ResourceRequirements:       agentResourceRequirements,
+		ClusterRegistry:            registryURL,
+		PodDisruptionBudget:        pdb,
+		EnablePriorityClass:        ops.PcExists && pcEnabled,
+		SystemDefaultPullSecrets:   systemDefaultPullSecrets,
+		AgentDeploymentPullSecrets: agentDeploymentPullSecrets,
+		AllPullSecrets:             registryConfigs,
 		SUCAppNameOverride: func() string {
 			// Set the field to ensure backward compatibility in the case of node-driver RKE2/K3s cluster
-			if cluster.Status.Driver == apimgmtv3.ClusterDriverImported &&
-				(cluster.Status.Provider == apimgmtv3.ClusterDriverRke2 || cluster.Status.Provider == apimgmtv3.ClusterDriverK3s) {
-				if cluster.Spec.DisplayName != "" {
+			if ops.Cluster.Status.Driver == apimgmtv3.ClusterDriverImported &&
+				(ops.Cluster.Status.Provider == apimgmtv3.ClusterDriverRke2 || ops.Cluster.Status.Provider == apimgmtv3.ClusterDriverK3s) {
+				if ops.Cluster.Spec.DisplayName != "" {
 					return capr.SafeConcatName(capr.MaxHelmReleaseNameLength, "mcc",
-						capr.SafeConcatName(48, cluster.Spec.DisplayName, "managed", "system-upgrade-controller"))
+						capr.SafeConcatName(48, ops.Cluster.Spec.DisplayName, "managed", "system-upgrade-controller"))
 				}
 			}
 			return ""
 		}(),
-		NamespaceOptions: mutator,
+		NamespaceOptions: ops.Mutator,
 	}
 
 	return t.Execute(resp, context)
@@ -302,13 +333,24 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 }
 
 func ForCluster(cluster *apimgmtv3.Cluster, token string, taints []corev1.Taint, secretLister v1.SecretLister) ([]byte, error) {
-
 	status := util.GetAgentSchedulingCustomizationStatus(cluster)
 	pcExists := status != nil && status.PriorityClass != nil
 
 	buf := &bytes.Buffer{}
-	err := SystemTemplate(buf, GetDesiredAgentImage(cluster), GetDesiredAuthImage(cluster),
-		cluster.Name, token, settings.ServerURL.Get(), capr.PreBootstrap(cluster), cluster, GetDesiredFeatures(cluster), taints, secretLister, pcExists, namespace.GetMutator())
+	err := SystemTemplate(buf, &TemplateOps{
+		AgentImage:     GetDesiredAgentImage(cluster),
+		AuthImage:      GetDesiredAuthImage(cluster),
+		Namespace:      cluster.Name,
+		Token:          token,
+		URL:            settings.ServerURL.Get(),
+		IsPreBootstrap: capr.PreBootstrap(cluster),
+		Cluster:        cluster,
+		AgentFeatures:  GetDesiredFeatures(cluster),
+		Taints:         taints,
+		SecretLister:   secretLister,
+		PcExists:       pcExists,
+		Mutator:        namespace.GetMutator(),
+	})
 	return buf.Bytes(), err
 }
 

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -35,27 +35,26 @@ var (
 )
 
 type clusterAgentContext struct {
-	Features              string
-	CAChecksum            string
-	AgentImage            string
-	AgentEnvVars          string
-	AuthImage             string
-	TokenKey              string
-	Token                 string
-	URL                   string
-	Namespace             string
-	URLPlain              string
-	IsPreBootstrap        bool
-	PrivateRegistryConfig string
-	Tolerations           string
-	AppendTolerations     string
-	Affinity              string
-	ResourceRequirements  string
-	ClusterRegistry       string
-	EnablePriorityClass   bool
-	PodDisruptionBudget   string
-	SUCAppNameOverride    string
-	NamespaceOptions      namespace.Mutator
+	Features             string
+	CAChecksum           string
+	AgentImage           string
+	AgentEnvVars         string
+	AuthImage            string
+	TokenKey             string
+	Token                string
+	URL                  string
+	Namespace            string
+	URLPlain             string
+	IsPreBootstrap       bool
+	Tolerations          string
+	AppendTolerations    string
+	Affinity             string
+	ResourceRequirements string
+	ClusterRegistry      string
+	EnablePriorityClass  bool
+	PodDisruptionBudget  string
+	SUCAppNameOverride   string
+	NamespaceOptions     namespace.Mutator
 	// AgentDeploymentPullSecrets are pull secrets that are used exclusively for
 	// the cluster agent deployment
 	AgentDeploymentPullSecrets []util.AgentPullSecret

--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -25,14 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	mockSecrets = make(map[string]*corev1.Secret)
-)
-
-func resetMockSecrets() {
-	mockSecrets = make(map[string]*corev1.Secret)
-}
-
 func TestSystemTemplate_systemtemplate(t *testing.T) {
 	mockSecrets := map[string]*corev1.Secret{}
 	secretLister := &corefakes.SecretListerMock{
@@ -72,6 +64,8 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 		expectedServiceAccountHashes      map[string]string
 		expectedSecretHashes              map[string]string
 		expectedPodDisruptionBudgetHashes map[string]string
+
+		expectedError string
 	}{
 		{
 			name: "test-provisioned-import",
@@ -101,7 +95,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "026d73c819a0667fbbd50ca10a4f4215624f5c3d448a1324b24c5f9f8ae99cb3",
+				"cattle-cluster-agent": "917545cb236474fcbacbe58048b0b993d92e260854936215c5aa661dad17f06c",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -155,7 +149,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "0ced645edfc4a11bdbf1731fc97ea76c69d5da0f691a395293df4cc6b6ce9e8c",
+				"cattle-cluster-agent": "3fefd2c1c90a1888872aaf2c99b8c4af7181cb2112314a594db06f41cdead797",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -212,7 +206,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "04e8f9817b3d89a8b7302329bc4447fa70eb43d19051f4bc068bd47e26fa4e61",
+				"cattle-cluster-agent": "dfc98011fee111f2cba26a355d77eb1609897fad08c326c1757daf41beeaefa2",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -260,7 +254,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 			token:      "some-dummy-token",
 			agentImage: "my/agent:image",
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "b4ffce8a1fc601ce95f599332de597de478a2244fc6bac3b7dc6204416dfb550",
+				"cattle-cluster-agent": "6eb9e03bd66e38218593431cb9eac446fb08ab2de2837ef5b45ec15f7da9c16e",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -308,8 +302,9 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					"baz": "quz",
 				},
 			},
+			agentImage: "my/agent:image",
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "5bbbf41e0dcb41ed586e26899d0de6eb474c7d6c309cfac9355a3ee4651b6b3d",
+				"cattle-cluster-agent": "2abd36961d049a71c24b475f381997df367516ab6e40c7b26c483527cbdbb0aa",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -355,8 +350,9 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 				Labels: map[string]string{},
 			},
+			agentImage: "my/agent:image",
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "c7193972923103ae418b609b0fae682322ea9b3b59b00e9a526561d388b2c500",
+				"cattle-cluster-agent": "5e54284182cee355941d12c9436e5dfa757ae0c83f626c91554a48c99fe1e672",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -396,13 +392,15 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			mutator: namespace.Mutator{
-				Enabled: true,
+				Enabled:     true,
+				Annotations: map[string]string{},
 				Labels: map[string]string{
 					"baz": "quz",
 				},
 			},
+			agentImage: "my/agent:image",
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "098ff7fd84702264e219dd843e1e39a73b09535beb08f13c5922e285e5b189cf",
+				"cattle-cluster-agent": "29191730aae7f756a32b6dc3a8be8e7b035fff627065569c5c7970aeece98967",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -426,11 +424,262 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				"cattle-credentials-5ec1f7e700": "38a97eb12e58ccc7ab0b07c8730e0c61fe71f8197aa98ac509431ff265cb2861",
 			},
 		},
+		{
+			name: "imported cluster with pull secrets renders imagePullSecrets and secret resources",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-abc12", // matches MgmtNameRegexp
+				},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName: "test-imported-pull-secrets",
+					ImportedConfig: &apimgmtv3.ImportedConfig{
+						PrivateRegistryURL:         "my-registry.example.com",
+						PrivateRegistryPullSecrets: []string{"my-pull-secret"},
+					},
+				},
+				Status: apimgmtv3.ClusterStatus{
+					Driver:   "imported",
+					Provider: "rke2",
+				},
+			},
+			agentImage: "rancher/rancher-agent:v2.8.0",
+			token:      "test-token",
+			url:        "https://rancher.example.com",
+			secrets: map[string]*corev1.Secret{
+				"fleet-default:my-pull-secret": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fleet-default",
+						Name:      "my-pull-secret",
+					},
+					Type: corev1.SecretTypeBasicAuth,
+					Data: map[string][]byte{
+						"username": []byte("testuser"),
+						"password": []byte("testpass"),
+					},
+				},
+			},
+			expectedDeploymentHashes: map[string]string{
+				"cattle-cluster-agent": "fd5589102bdb6941ee7ec3488e014ca2d290551eda5bc9620fcd1de14f3e775e",
+			},
+			expectedDaemonSetHashes: map[string]string{},
+			expectedClusterRoleHashes: map[string]string{
+				"proxy-clusterrole-kubeapiserver": "0b1d7f692252b3f498855fa24f669499ba1c061d0ae0eab0db2bb570bc25e63c",
+				"cattle-admin":                    "d2b6b43774ce046f3e4e157b94167d6be596d697c3c9411d4ef4d6f29c2d5fde",
+			},
+			expectedClusterRoleBindingHashes: map[string]string{
+				"proxy-role-binding-kubernetes-master": "8e33b2e67243b5a87012489fcd12b4e805c6b6b3c3c2bb4063eee04ca7bc372e",
+				"cattle-admin-binding":                 "d646e3b685d8f931a11f4938e4c95a97151286fa391ef03898e6d44f6827cf16",
+			},
+			expectedNamespaceHashes: map[string]string{
+				"cattle-system": "53b1582048d8703999612a3b41f7301b4136e8dd3041d57e9a59c97e76dfa564",
+			},
+			expectedServiceHashes: map[string]string{
+				"cattle-cluster-agent": "03b629bf7287d1a70f31fdf138ea5ec38201040e757b21a808ea0d413e27d65f",
+			},
+			expectedServiceAccountHashes: map[string]string{
+				"cattle": "ba41ec07896a1e2d2319c0ca1405c81faf4ad4c7c0a3c183909860531863202b",
+			},
+			expectedSecretHashes: map[string]string{
+				"cattle-credentials-a15c1b308a": "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
+				"my-pull-secret":                "61985305208c14eb725a4a32dd8c31ae7963ff54212d7b700ae8c7a619cc3e57",
+			},
+		},
+		{
+			name: "provisioned cluster name does not get system default pull secrets env var",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-m-abc12", // does NOT match MgmtNameRegexp
+				},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName: "test-prov-no-system-secrets",
+					ImportedConfig: &apimgmtv3.ImportedConfig{
+						PrivateRegistryURL:         "my-registry.example.com",
+						PrivateRegistryPullSecrets: []string{"my-pull-secret"},
+					},
+				},
+			},
+			agentImage: "rancher-agent:v2.8.0",
+			token:      "test-token",
+			url:        "https://rancher.example.com",
+			secrets: map[string]*corev1.Secret{
+				"fleet-default:my-pull-secret": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fleet-default",
+						Name:      "my-pull-secret",
+					},
+					Type: corev1.SecretTypeBasicAuth,
+					Data: map[string][]byte{
+						"username": []byte("testuser"),
+						"password": []byte("testpass"),
+					},
+				},
+			},
+			expectedDeploymentHashes: map[string]string{
+				"cattle-cluster-agent": "41aff69d267c73e0f1fc8b7c39e2d99b4e95f55d0256546d3c76d040fa79413b",
+			},
+			expectedDaemonSetHashes: map[string]string{},
+			expectedClusterRoleHashes: map[string]string{
+				"proxy-clusterrole-kubeapiserver": "0b1d7f692252b3f498855fa24f669499ba1c061d0ae0eab0db2bb570bc25e63c",
+				"cattle-admin":                    "d2b6b43774ce046f3e4e157b94167d6be596d697c3c9411d4ef4d6f29c2d5fde",
+			},
+			expectedClusterRoleBindingHashes: map[string]string{
+				"proxy-role-binding-kubernetes-master": "8e33b2e67243b5a87012489fcd12b4e805c6b6b3c3c2bb4063eee04ca7bc372e",
+				"cattle-admin-binding":                 "d646e3b685d8f931a11f4938e4c95a97151286fa391ef03898e6d44f6827cf16",
+			},
+			expectedNamespaceHashes: map[string]string{
+				"cattle-system": "53b1582048d8703999612a3b41f7301b4136e8dd3041d57e9a59c97e76dfa564",
+			},
+			expectedServiceHashes: map[string]string{
+				"cattle-cluster-agent": "03b629bf7287d1a70f31fdf138ea5ec38201040e757b21a808ea0d413e27d65f",
+			},
+			expectedServiceAccountHashes: map[string]string{
+				"cattle": "ba41ec07896a1e2d2319c0ca1405c81faf4ad4c7c0a3c183909860531863202b",
+			},
+			expectedSecretHashes: map[string]string{
+				"cattle-credentials-a15c1b308a": "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
+			},
+		},
+		{
+			name: "imported cluster with multiple pull secrets",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-xyz99", // matches MgmtNameRegexp
+				},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName: "test-multi-secrets",
+					ImportedConfig: &apimgmtv3.ImportedConfig{
+						PrivateRegistryURL:         "my-registry.example.com",
+						PrivateRegistryPullSecrets: []string{"secret-one", "secret-two"},
+					},
+				},
+				Status: apimgmtv3.ClusterStatus{
+					Driver:   "imported",
+					Provider: "rke2",
+				},
+			},
+			agentImage: "rancher-agent:v2.8.0",
+			token:      "test-token",
+			url:        "https://rancher.example.com",
+			secrets: map[string]*corev1.Secret{
+				"fleet-default:secret-one": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fleet-default",
+						Name:      "secret-one",
+					},
+					Type: corev1.SecretTypeBasicAuth,
+					Data: map[string][]byte{
+						"username": []byte("user1"),
+						"password": []byte("pass1"),
+					},
+				},
+				"fleet-default:secret-two": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fleet-default",
+						Name:      "secret-two",
+					},
+					Type: corev1.SecretTypeBasicAuth,
+					Data: map[string][]byte{
+						"username": []byte("user2"),
+						"password": []byte("pass2"),
+					},
+				},
+			},
+			expectedDeploymentHashes: map[string]string{
+				"cattle-cluster-agent": "b51bb5eefa28f4575463418dd583c98d9de920966a1acb87bb9f50d073bb844d",
+			},
+			expectedDaemonSetHashes: map[string]string{},
+			expectedClusterRoleHashes: map[string]string{
+				"proxy-clusterrole-kubeapiserver": "0b1d7f692252b3f498855fa24f669499ba1c061d0ae0eab0db2bb570bc25e63c",
+				"cattle-admin":                    "d2b6b43774ce046f3e4e157b94167d6be596d697c3c9411d4ef4d6f29c2d5fde",
+			},
+			expectedClusterRoleBindingHashes: map[string]string{
+				"proxy-role-binding-kubernetes-master": "8e33b2e67243b5a87012489fcd12b4e805c6b6b3c3c2bb4063eee04ca7bc372e",
+				"cattle-admin-binding":                 "d646e3b685d8f931a11f4938e4c95a97151286fa391ef03898e6d44f6827cf16",
+			},
+			expectedNamespaceHashes: map[string]string{
+				"cattle-system": "53b1582048d8703999612a3b41f7301b4136e8dd3041d57e9a59c97e76dfa564",
+			},
+			expectedServiceHashes: map[string]string{
+				"cattle-cluster-agent": "03b629bf7287d1a70f31fdf138ea5ec38201040e757b21a808ea0d413e27d65f",
+			},
+			expectedServiceAccountHashes: map[string]string{
+				"cattle": "ba41ec07896a1e2d2319c0ca1405c81faf4ad4c7c0a3c183909860531863202b",
+			},
+			expectedSecretHashes: map[string]string{
+				"cattle-credentials-a15c1b308a": "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
+				"secret-one":                    "ec0ab5854406c5dc00c68a85944219623a18a81f26731c55f321dec6b31e6fcc",
+				"secret-two":                    "799af6afbcfcc7698b8ac8f282f49cc51bd4b775454bc28d902e9217416196d5",
+			},
+		},
+		{
+			name: "pull secret lookup failure returns error",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-abc12",
+				},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName: "test-secret-failure",
+					ImportedConfig: &apimgmtv3.ImportedConfig{
+						PrivateRegistryURL:         "my-registry.example.com",
+						PrivateRegistryPullSecrets: []string{"nonexistent-secret"},
+					},
+				},
+				Status: apimgmtv3.ClusterStatus{
+					Driver:   "imported",
+					Provider: "rke2",
+				},
+			},
+			agentImage:    "my-registry.example.com/rancher/rancher-agent:v2.8.0",
+			token:         "test-token",
+			url:           "https://rancher.example.com",
+			expectedError: "\"fleet-default:nonexistent-secret\" not found",
+		},
+		{
+			name: "pre-bootstrap renders bootstrap deployment with hostNetwork",
+			cluster: &apimgmtv3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-preboot"},
+				Spec: apimgmtv3.ClusterSpec{
+					DisplayName:    "test-preboot",
+					ImportedConfig: &apimgmtv3.ImportedConfig{},
+				},
+				Status: apimgmtv3.ClusterStatus{
+					Driver:   "imported",
+					Provider: "rke2",
+				},
+			},
+			agentImage:     "rancher/rancher-agent:v2.8.0",
+			token:          "test-token",
+			url:            "https://rancher.example.com",
+			isPreBootstrap: true,
+			expectedDeploymentHashes: map[string]string{
+				"cattle-cluster-agent-bootstrap": "7050b599b7fce1af3ce6a5165118ba749d3415b2e623d40477f46f8999c3d5a6",
+			},
+			expectedDaemonSetHashes: map[string]string{},
+			expectedClusterRoleHashes: map[string]string{
+				"proxy-clusterrole-kubeapiserver": "0b1d7f692252b3f498855fa24f669499ba1c061d0ae0eab0db2bb570bc25e63c",
+				"cattle-admin":                    "d2b6b43774ce046f3e4e157b94167d6be596d697c3c9411d4ef4d6f29c2d5fde",
+			},
+			expectedClusterRoleBindingHashes: map[string]string{
+				"proxy-role-binding-kubernetes-master": "8e33b2e67243b5a87012489fcd12b4e805c6b6b3c3c2bb4063eee04ca7bc372e",
+				"cattle-admin-binding":                 "d646e3b685d8f931a11f4938e4c95a97151286fa391ef03898e6d44f6827cf16",
+			},
+			expectedNamespaceHashes: map[string]string{
+				"cattle-system": "53b1582048d8703999612a3b41f7301b4136e8dd3041d57e9a59c97e76dfa564",
+			},
+			expectedServiceHashes: map[string]string{
+				"cattle-cluster-agent": "03b629bf7287d1a70f31fdf138ea5ec38201040e757b21a808ea0d413e27d65f",
+			},
+			expectedServiceAccountHashes: map[string]string{
+				"cattle": "ba41ec07896a1e2d2319c0ca1405c81faf4ad4c7c0a3c183909860531863202b",
+			},
+			expectedSecretHashes: map[string]string{
+				"cattle-credentials-a15c1b308a": "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer resetMockSecrets()
 
 			mockSecrets = tt.secrets
 			var b bytes.Buffer
@@ -438,9 +687,29 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				tt.agentImage = image.ResolveWithCluster(tt.agentImage, tt.cluster)
 			}
 
-			err := SystemTemplate(&b, tt.agentImage, tt.authImage, tt.namespace, tt.token, tt.url, tt.isPreBootstrap, tt.cluster, tt.features, tt.taints, secretLister, tt.pcExists, tt.mutator)
+			err := SystemTemplate(&b, &TemplateOps{
+				AgentImage:     tt.agentImage,
+				AuthImage:      tt.authImage,
+				Namespace:      tt.namespace,
+				Token:          tt.token,
+				URL:            tt.url,
+				IsPreBootstrap: tt.isPreBootstrap,
+				Cluster:        tt.cluster,
+				AgentFeatures:  tt.features,
+				Taints:         tt.taints,
+				SecretLister:   secretLister,
+				PcExists:       tt.pcExists,
+				Mutator:        tt.mutator,
+			})
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
 			assert.NoError(t, err)
 
+			// Hash-based assertions
 			decoder := scheme.Codecs.UniversalDeserializer()
 			for _, r := range strings.Split(b.String(), "---") {
 				if len(r) == 0 {
@@ -462,63 +731,90 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedDeploymentHashes[deployment.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, deployment.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, deployment.Name, getHash(b))
+					if tt.expectedDeploymentHashes != nil {
+						assert.Equal(t, tt.expectedDeploymentHashes[deployment.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, deployment.Name))
+					}
 				case "ClusterRole":
 					clusterrole := obj.(*rbacv1.ClusterRole)
 					b, err := json.Marshal(clusterrole)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedClusterRoleHashes[clusterrole.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, clusterrole.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, clusterrole.Name, getHash(b))
+					if tt.expectedClusterRoleHashes != nil {
+						assert.Equal(t, tt.expectedClusterRoleHashes[clusterrole.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, clusterrole.Name))
+					}
 				case "ClusterRoleBinding":
 					crb := obj.(*rbacv1.ClusterRoleBinding)
 					b, err := json.Marshal(crb)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedClusterRoleBindingHashes[crb.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, crb.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, crb.Name, getHash(b))
+					if tt.expectedClusterRoleBindingHashes != nil {
+						assert.Equal(t, tt.expectedClusterRoleBindingHashes[crb.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, crb.Name))
+					}
 				case "Namespace":
 					ns := obj.(*corev1.Namespace)
 					b, err := json.Marshal(ns)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedNamespaceHashes[ns.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, ns.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, ns.Name, getHash(b))
+					if tt.expectedNamespaceHashes != nil {
+						assert.Equal(t, tt.expectedNamespaceHashes[ns.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, ns.Name))
+					}
 				case "DaemonSet":
 					ds := obj.(*appsv1.DaemonSet)
 					b, err := json.Marshal(ds)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedDaemonSetHashes[ds.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, ds.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, ds.Name, getHash(b))
+					if tt.expectedDaemonSetHashes != nil {
+						assert.Equal(t, tt.expectedDaemonSetHashes[ds.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, ds.Name))
+					}
 				case "Service":
 					svc := obj.(*corev1.Service)
 					b, err := json.Marshal(svc)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedServiceHashes[svc.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, svc.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, svc.Name, getHash(b))
+					if tt.expectedServiceHashes != nil {
+						assert.Equal(t, tt.expectedServiceHashes[svc.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, svc.Name))
+					}
 				case "ServiceAccount":
 					svcacct := obj.(*corev1.ServiceAccount)
 					b, err := json.Marshal(svcacct)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedServiceAccountHashes[svcacct.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, svcacct.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, svcacct.Name, getHash(b))
+					if tt.expectedServiceAccountHashes != nil {
+						assert.Equal(t, tt.expectedServiceAccountHashes[svcacct.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, svcacct.Name))
+					}
 				case "Secret":
 					secret := obj.(*corev1.Secret)
 					b, err := json.Marshal(secret)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedSecretHashes[secret.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, secret.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, secret.Name, getHash(b))
+					if tt.expectedSecretHashes != nil {
+						assert.Equal(t, tt.expectedSecretHashes[secret.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, secret.Name))
+					}
 				case "PodDisruptionBudget":
 					pdb := obj.(*policyv1.PodDisruptionBudget)
 					b, err := json.Marshal(pdb)
 					if err != nil {
 						assert.FailNow(t, err.Error())
 					}
-					assert.Equal(t, tt.expectedPodDisruptionBudgetHashes[pdb.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, pdb.Name))
+					t.Logf("Hash %s/%s: %s", groupVersionKind.Kind, pdb.Name, getHash(b))
+					if tt.expectedPodDisruptionBudgetHashes != nil {
+						assert.Equal(t, tt.expectedPodDisruptionBudgetHashes[pdb.Name], getHash(b), fmt.Sprintf("%s/%s", groupVersionKind.Kind, pdb.Name))
+					}
 				default:
 					assert.FailNow(t, fmt.Sprintf("unexpected Kind for GVK: %s", groupVersionKind.String()))
 				}

--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -459,7 +459,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "fd5589102bdb6941ee7ec3488e014ca2d290551eda5bc9620fcd1de14f3e775e",
+				"cattle-cluster-agent": "cd6af455643df366219d5cd6f09b923ea34ce8ae676ae9f5761a61dac72fe906",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -480,8 +480,8 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				"cattle": "ba41ec07896a1e2d2319c0ca1405c81faf4ad4c7c0a3c183909860531863202b",
 			},
 			expectedSecretHashes: map[string]string{
-				"cattle-credentials-a15c1b308a": "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
-				"my-pull-secret":                "61985305208c14eb725a4a32dd8c31ae7963ff54212d7b700ae8c7a619cc3e57",
+				"cattle-credentials-a15c1b308a":              "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
+				"my-pull-secret-rancher-managed-pull-secret": "2df73d5a6af032f3ac7014a342b7f8e36a2ddc6431be33f5ffe03964fa17f8fc",
 			},
 		},
 		{
@@ -494,7 +494,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					DisplayName: "test-prov-no-system-secrets",
 					ImportedConfig: &apimgmtv3.ImportedConfig{
 						PrivateRegistryURL:         "my-registry.example.com",
-						PrivateRegistryPullSecrets: []string{"my-pull-secret"},
+						PrivateRegistryPullSecrets: []string{"my-pull-secret-rancher-managed-pull-secret"},
 					},
 				},
 			},
@@ -502,10 +502,10 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 			token:      "test-token",
 			url:        "https://rancher.example.com",
 			secrets: map[string]*corev1.Secret{
-				"fleet-default:my-pull-secret": {
+				"fleet-default:my-pull-secret-rancher-managed-pull-secret": {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "fleet-default",
-						Name:      "my-pull-secret",
+						Name:      "my-pull-secret-rancher-managed-pull-secret",
 					},
 					Type: corev1.SecretTypeBasicAuth,
 					Data: map[string][]byte{
@@ -585,7 +585,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			expectedDeploymentHashes: map[string]string{
-				"cattle-cluster-agent": "b51bb5eefa28f4575463418dd583c98d9de920966a1acb87bb9f50d073bb844d",
+				"cattle-cluster-agent": "71b6caef327667e09762e6ed504feba21e54fb06a7517cf1220e13517786318a",
 			},
 			expectedDaemonSetHashes: map[string]string{},
 			expectedClusterRoleHashes: map[string]string{
@@ -606,9 +606,9 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				"cattle": "ba41ec07896a1e2d2319c0ca1405c81faf4ad4c7c0a3c183909860531863202b",
 			},
 			expectedSecretHashes: map[string]string{
-				"cattle-credentials-a15c1b308a": "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
-				"secret-one":                    "ec0ab5854406c5dc00c68a85944219623a18a81f26731c55f321dec6b31e6fcc",
-				"secret-two":                    "799af6afbcfcc7698b8ac8f282f49cc51bd4b775454bc28d902e9217416196d5",
+				"cattle-credentials-a15c1b308a":          "e5b7eedd320bfd99546203b85a24d29b6be73e506053ac39065fd42ebb217b86",
+				"secret-one-rancher-managed-pull-secret": "d4e2a71ad3344fd5487e36c6f9987bdad155e42e75675f0af39f9b03027203a1",
+				"secret-two-rancher-managed-pull-secret": "a8b13caa20117d26374c99ffbc3dbc4b9a62d9b58c4040b43ae11596c1fe7b0c",
 			},
 		},
 		{

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -89,15 +89,17 @@ data:
 
 ---
 
-{{- if .PrivateRegistryConfig}}
+{{- range .AllPullSecrets}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cattle-private-registry
+  name: {{.Name}}
   namespace: cattle-system
+  labels:
+    management.cattle.io/cattle-cluster-agent-pull-secret: "true"
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: "{{.PrivateRegistryConfig}}"
+  .dockerconfigjson: "{{.DockerConfigJSON}}"
 
 ---
 {{- end }}
@@ -205,7 +207,7 @@ spec:
             value: "true"
           - name: CATTLE_K8S_MANAGED
             value: "true"
-          - name: CATTLE_CLUSTER_REGISTRY
+          - name: CATTLE_SYSTEM_DEFAULT_REGISTRY
             value: "{{.ClusterRegistry}}"
           - name: CATTLE_CREDENTIAL_NAME
             value: cattle-credentials-{{.TokenKey}}
@@ -218,6 +220,14 @@ spec:
           {{- if .IsPreBootstrap }}
           # since we're on the host network, talk to the apiserver over localhost
           {{- end }}
+          {{- if .SystemDefaultPullSecrets}}
+          - name: CATTLE_SYSTEM_DEFAULT_REGISTRY_PULL_SECRETS
+            value: "{{range $i, $s := .SystemDefaultPullSecrets}}{{if $i}},{{end}}{{$s.Name}}{{end}}"
+          {{- end }}
+          {{- if .AgentDeploymentPullSecrets }}
+          - name: CATTLE_AGENT_PULL_SECRETS
+            value: "{{range $i, $s := .AgentDeploymentPullSecrets}}{{if $i}},{{end}}{{$s.Name}}{{end}}"
+          {{- end }}
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}
       {{- end }}
@@ -226,9 +236,11 @@ spec:
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
-      {{- if .PrivateRegistryConfig}}
+      {{- if .AgentDeploymentPullSecrets}}
       imagePullSecrets:
-      - name: cattle-private-registry
+      {{- range .AgentDeploymentPullSecrets}}
+      - name: {{.Name}}
+      {{- end }}
       {{- end }}
       {{- if .IsPreBootstrap }}
       # use hostNetwork since the CNI (and coreDNS) is not up yet
@@ -296,10 +308,12 @@ spec:
         volumeMounts:
         - name: k8s-ssl
           mountPath: /etc/kubernetes
-      {{- if .PrivateRegistryConfig}}
+      {{- if .AgentDeploymentPullSecrets}}
       imagePullSecrets:
-      - name: cattle-private-registry
-      {{- end }}
+      {{- range .AgentDeploymentPullSecrets}}
+      - name: {{.Name}}
+      {{- end}}
+      {{- end}}
       volumes:
       - name: k8s-ssl
         hostPath:

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -93,7 +93,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{.Name}}
+  name: "{{.Name}}"
   namespace: cattle-system
   labels:
     management.cattle.io/cattle-cluster-agent-pull-secret: "true"
@@ -239,7 +239,7 @@ spec:
       {{- if .AgentDeploymentPullSecrets}}
       imagePullSecrets:
       {{- range .AgentDeploymentPullSecrets}}
-      - name: {{.Name}}
+      - name: "{{.Name}}"
       {{- end }}
       {{- end }}
       {{- if .IsPreBootstrap }}
@@ -311,7 +311,7 @@ spec:
       {{- if .AgentDeploymentPullSecrets}}
       imagePullSecrets:
       {{- range .AgentDeploymentPullSecrets}}
-      - name: {{.Name}}
+      - name: "{{.Name}}"
       {{- end}}
       {{- end}}
       volumes:


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54180

## Problem

Rancher does not support authenticated system default registries in the local cluster or certain downstream cluster types  (imported generic clusters, and hosted clusters with are either imported or provisioned through Rancher). This is a problem for users in air-gapped environments which enforce the use of authenticated private registries, and is a feature gap between provisioned clusters.
 
## Solution

This PR implements support for authenticated registries for the above mentioned cluster types, and expands the configuration options offered at the cluster level to allow for cluster level registry overrides in imported and hosted clusters. These changes also update how system charts are deployed so that they will automatically leverage the managed image pull secrets. This PR builds off of the work done in https://github.com/rancher/rancher/pull/54890


This is a large PR, to help reviewers I want to call out some of the most impactful changes (in order of impact / importance)

+ A new set of registry related controllers were implemented to automatically propagate pull secrets configured globally and on a per cluster level downstream. This is the largest amount of net-new code, and does most of the heavily lifting for the feature (`pkg/controllers/dashboard/privateregistry/controller.go`).
+ The system charts controller has been refactored to automatically define pull secrets when deploying charts in both the local and downstream clusters (`pkg/controllers/dashboard/systemcharts/controller.go`). 
+ The controller responsible for deploying the AKS/EKS/GKE operators has been refactored so that those charts will be redeployed when the global settings change (`pkg/controllers/dashboard/hostedcluster/controller.go`)
+ The cluster agent templating and deployment process has been updated to properly deploy image pull secrets on initial registration / provisioning, and will automatically redeploy those pull secrets when they change (`pkg/controllers/management/clusterdeploy/clusterdeploy.go`, `pkg/systemtemplate/import.go`). 
    + Those secrets are also periodically cleaned up on cluster redeployment, or imported cluster deregistration (`pkg/agent/clean/cluster.go`, `pkg/controllers/management/usercontrollers/controller.go`)
+ CAPR has been updated to properly deploy the globally defined pull secrets when no cluster level override is defined (`pkg/capr/planner/registry.go`)

To support those core changes a number of other smaller changes have been made, happy to explain them 1on1 if more context is needed. To help reduce the number of changes and make reviewing _slightly_ easier, this PR does **not** implement the following

+ Cluster auto-scaler support
+ automatic configuration of optional rancher managed charts (monitoring/logging, etc.) installed by users.

We will handle those changes in the next PR for this feature. There will also be some other minor changes required once image pull secret support within fleet and its chart are implemented.
 
## Testing

## Engineering Testing
### Manual Testing

Testing all of this is pretty complicated, and covering each required step is more detailed than what can be covered in a single PR description. 

At a high level, I've tested this by 

+ Standing up an authenticated private registry
+ Creating one cluster of each type
    + Node Driver provisioned, KEv2 provisioned (GKE), Custom cluster, Imported rke2 standalone cluster, imported hosted cluster (GKE)
+ Updating the `SystemDefaultRegistry` and `SystemDefaultRegistryPullSecrets` global settings to point to my authenticated registry and one or more pull secrets in the `cattle-system` namespace
+ Checking across the local and all provisioned clusters that the cattle-cluster is deployed properly, system charts are deployed properly, and any relevant node level changes are made (i.e. `registries.yaml` genereation for provisioned clusters)
+ Ensuring that subsequent changes to the global settings are replicated across all clusters, and that the global configuration can be removed
+ Testing cluster level overrides for each cluster type, ensuring the downstream environment is properly configured

### Automated Testing
Summary: lots of unit tests

## QA Testing Considerations

We'll need to do a detailed sync up to come up with the best test plan for this change, since it's pretty involved.

### Regressions Considerations
+ We need to ensure that the system-charts controller still works as expected
+ We need to ensure that the CAPR changes have not broken existing cluster level registry behavior (I haven't seen any issues so far) 


Existing / newly added automated tests that provide evidence there are no regressions:

Lots of unit tests. 