### PR TITLE
Support OCI Helm charts in rancher-save/load-images scripts

### DIFF
--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -728,7 +728,7 @@ fi
 if $use_helm_for_charts; then
     chart_count=$(ls ./rancher-oci-charts/*.tgz 2>/dev/null | wc -l)
     echo ""
-    echo "OCI Helm charts saved in ./rancher-oci-charts/ (${chart_count} files). Reused on next runs and by rancher-load-images.sh. Remove with: rm -rf ./rancher-oci-charts"
+    echo "OCI Helm charts saved in ./rancher-oci-charts/ (${chart_count} files). Used by rancher-load-images.sh. Remove with: rm -rf ./rancher-oci-charts"
 fi
 `
 	linuxMirrorScript = "#!/bin/sh\nset -e -x\n\n"

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -640,7 +640,7 @@ while IFS= read -r i; do
     i="${source_registry}${i}"
     if $use_helm_for_charts && is_oci_helm_chart "${i}"; then
         chart_version="${i#*:}"
-        if helm pull "oci://${i%:*}" --version "${chart_version//_/+}" -d ./rancher-oci-charts > /dev/null 2>&1; then
+        if helm pull "oci://${i%:*}" --version "${chart_version//_/+}" -d ./rancher-oci-charts 2>&1; then
             echo "Helm chart pull success: ${i}"
         else
             echo "Helm chart pull failed: ${i}"

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -423,16 +423,14 @@ if $has_oci_charts; then
             use_helm_for_charts=true
         else
             echo "====================================================================="
-            echo "ERROR: ${list} contains OCI Helm charts but this host cannot push"
-            echo "them. Docker is not using the containerd snapshotter and the helm"
-            echo "CLI is not installed."
+            echo "ERROR: List contains non-image OCI artifacts, which are not supported"
+            echo "by docker's legacy storage drivers. You must take action in order to continue."
             echo ""
-            echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
-            echo "    1. Edit /etc/docker/daemon.json to include:"
-            echo "         { \"features\": { \"containerd-snapshotter\": true } }"
-            echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
+            echo "Preferred: configure docker to use the containerd image store"
+            echo "    https://docs.docker.com/engine/storage/containerd/#enable-containerd-image-store-on-docker-engine
+            echo "    NOTE: Switching image stores hides all images and containers currently present in the original docker image store."
             echo ""
-            echo "  WORKAROUND (alternative): install the helm CLI:"
+            echo "Alternative: install the helm CLI:"
             echo "    https://helm.sh/docs/intro/install/"
             echo "====================================================================="
             exit 1
@@ -617,16 +615,14 @@ if $has_oci_charts; then
             use_helm_for_charts=true
         else
             echo "====================================================================="
-            echo "ERROR: ${list} contains OCI Helm charts but this host cannot pull"
-            echo "them. Docker is not using the containerd snapshotter and the helm"
-            echo "CLI is not installed."
+            echo "ERROR: List contains non-image OCI artifacts, which are not supported"
+            echo "by docker's legacy storage drivers. You must take action in order to continue."
             echo ""
-            echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
-            echo "    1. Edit /etc/docker/daemon.json to include:"
-            echo "         { \"features\": { \"containerd-snapshotter\": true } }"
-            echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
+            echo "Preferred: configure docker to use the containerd image store"
+            echo "    https://docs.docker.com/engine/storage/containerd/#enable-containerd-image-store-on-docker-engine
+            echo "    NOTE: Switching image stores hides all images and containers currently present in the original docker image store."
             echo ""
-            echo "  WORKAROUND (alternative): install the helm CLI:"
+            echo "Alternative: install the helm CLI:"
             echo "    https://helm.sh/docs/intro/install/"
             echo "====================================================================="
             exit 1

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -521,8 +521,11 @@ if $use_helm_for_charts; then
         chart_ns="${chart_repo%/*}"
         chart_file="./rancher-oci-charts/${chart_name}-${chart_ver_oci//_/+}.tgz"
         if [ ! -f "${chart_file}" ]; then
-            echo "Helm chart file not found, skipping: ${chart_file}"
-            continue
+            echo "ERROR: Chart file missing: ${chart_file}"
+            echo "Expected location: ./rancher-oci-charts/"
+            echo "Ensure rancher-save-images.sh completed successfully and"
+            echo "rancher-oci-charts/ directory was transferred to this host."
+            exit 1
         fi
         echo "Helm chart push: ${chart_file} -> oci://${target_oci_base}/${chart_ns}"
         helm push "${chart_file}" "oci://${target_oci_base}/${chart_ns}" "${helm_push_args[@]}"
@@ -669,6 +672,12 @@ done < "${list}"
 
 echo "Creating ${images} with $(echo ${pulled} | wc -w | tr -d '[:space:]') images"
 docker save $(echo ${pulled}) | gzip --stdout > ${images}
+
+if $use_helm_for_charts; then
+    chart_count=$(ls ./rancher-oci-charts/*.tgz 2>/dev/null | wc -l)
+    echo ""
+    echo "OCI Helm charts saved in ./rancher-oci-charts/ (${chart_count} files). Reused on next runs and by rancher-load-images.sh. Remove with: rm -rf ./rancher-oci-charts"
+fi
 `
 	linuxMirrorScript = "#!/bin/sh\nset -e -x\n\n"
 	windowsLoadScript = `$ErrorActionPreference = 'Stop'

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -398,8 +398,17 @@ helm_available () {
     command -v helm >/dev/null 2>&1
 }
 
+helm_oci_ga () {
+    local v major minor
+    v=$(helm version --short 2>/dev/null | sed -n 's/^v\([0-9.]*\).*/\1/p')
+    [ -z "$v" ] && return 1
+    major=${v%%.*}
+    minor=${v#*.}; minor=${minor%%.*}
+    [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 8 ]; }
+}
+
 is_oci_helm_chart () {
-    [[ "$1" == *"/rancher/charts/"* || "$1" == "rancher/charts/"* ]]
+    [[ "$1" == *"rancher/charts/"* ]]
 }
 
 # Preflight: rancher-images.txt now ships OCI Helm chart entries that
@@ -419,6 +428,20 @@ use_helm_for_charts=false
 if $has_oci_charts; then
     if ! docker_uses_containerd_snapshotter; then
         if helm_available; then
+            if ! helm_oci_ga; then
+                echo "====================================================================="
+                echo "ERROR: helm CLI is older than v3.8.0; OCI chart support requires helm 3.8.0+ (GA)."
+                echo ""
+                echo "Please upgrade helm to v3.8.0 or later:"
+                echo "    https://helm.sh/docs/intro/install/"
+                echo ""
+                echo "For reference, older versions need HELM_EXPERIMENTAL_OCI=1 and are not supported here:"
+                echo "    v3.7.2 - last pre-GA (OCI works only with HELM_EXPERIMENTAL_OCI=1)"
+                echo "    v3.6.3 - older experimental-OCI"
+                echo "    v3.4.2 - OCI very limited"
+                echo "====================================================================="
+                exit 1
+            fi
             echo "WARNING: Docker is not using the containerd snapshotter; falling back to helm CLI for OCI Helm charts."
             use_helm_for_charts=true
         else
@@ -595,8 +618,17 @@ helm_available () {
     command -v helm >/dev/null 2>&1
 }
 
+helm_oci_ga () {
+    local v major minor
+    v=$(helm version --short 2>/dev/null | sed -n 's/^v\([0-9.]*\).*/\1/p')
+    [ -z "$v" ] && return 1
+    major=${v%%.*}
+    minor=${v#*.}; minor=${minor%%.*}
+    [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 8 ]; }
+}
+
 is_oci_helm_chart () {
-    [[ "$1" == *"/rancher/charts/"* || "$1" == "rancher/charts/"* ]]
+    [[ "$1" == *"rancher/charts/"* ]]
 }
 
 # Preflight: rancher-images.txt now ships OCI Helm chart entries that
@@ -616,6 +648,20 @@ use_helm_for_charts=false
 if $has_oci_charts; then
     if ! docker_uses_containerd_snapshotter; then
         if helm_available; then
+            if ! helm_oci_ga; then
+                echo "====================================================================="
+                echo "ERROR: helm CLI is older than v3.8.0; OCI chart support requires helm 3.8.0+ (GA)."
+                echo ""
+                echo "Please upgrade helm to v3.8.0 or later:"
+                echo "    https://helm.sh/docs/intro/install/"
+                echo ""
+                echo "For reference, older versions need HELM_EXPERIMENTAL_OCI=1 and are not supported here:"
+                echo "    v3.7.2 - last pre-GA (OCI works only with HELM_EXPERIMENTAL_OCI=1)"
+                echo "    v3.6.3 - older experimental-OCI"
+                echo "    v3.4.2 - OCI very limited"
+                echo "====================================================================="
+                exit 1
+            fi
             echo "WARNING: Docker is not using the containerd snapshotter; falling back to helm CLI for OCI Helm charts."
             use_helm_for_charts=true
         else

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -648,9 +648,9 @@ while IFS= read -r i; do
         echo "Pulling chart: ${i}..."
         helm_error=$(helm pull "oci://${i%:*}" --version "${chart_version//_/+}" -d ./rancher-oci-charts 2>&1)
         if [ $? -eq 0 ]; then
-            echo "✓ Chart pull success: ${i}"
+            echo "Chart pull success: ${i}"
         else
-            echo "✗ Chart pull FAILED: ${i}"
+            echo "Chart pull FAILED: ${i}"
             echo "Error output:"
             echo "${helm_error}"
             echo ""
@@ -672,8 +672,12 @@ while IFS= read -r i; do
     fi
 done < "${list}"
 
-echo "Creating ${images} with $(echo ${pulled} | wc -w | tr -d '[:space:]') images"
-docker save $(echo ${pulled}) | gzip --stdout > ${images}
+if [ -n "${pulled}" ]; then
+    echo "Creating ${images} with $(echo ${pulled} | wc -w | tr -d '[:space:]') images"
+    docker save $(echo ${pulled}) | gzip --stdout > ${images}
+else
+    echo "No docker images pulled; skipping ${images}."
+fi
 
 if $use_helm_for_charts; then
     chart_count=$(ls ./rancher-oci-charts/*.tgz 2>/dev/null | wc -l)

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -509,7 +509,9 @@ done
 if $use_helm_for_charts; then
     target_oci_base="${target_registry%/}"
     helm_push_args=()
-    if [[ "${target_oci_base}" == localhost* || "${target_oci_base}" == 127.0.0.1* ]]; then
+    target_host="${target_oci_base#http://}"
+    target_host="${target_host#https://}"
+    if [[ "${target_host}" == localhost* || "${target_host}" == 127.0.0.1* || "${target_host}" == 0.0.0.0* ]]; then
         helm_push_args+=("--plain-http")
     fi
     for i in "${linux_images[@]}"; do

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -640,10 +640,18 @@ while IFS= read -r i; do
     i="${source_registry}${i}"
     if $use_helm_for_charts && is_oci_helm_chart "${i}"; then
         chart_version="${i#*:}"
-        if helm pull "oci://${i%:*}" --version "${chart_version//_/+}" -d ./rancher-oci-charts 2>&1; then
-            echo "Helm chart pull success: ${i}"
+        echo "Pulling chart: ${i}..."
+        helm_error=$(helm pull "oci://${i%:*}" --version "${chart_version//_/+}" -d ./rancher-oci-charts 2>&1)
+        if [ $? -eq 0 ]; then
+            echo "✓ Chart pull success: ${i}"
         else
-            echo "Helm chart pull failed: ${i}"
+            echo "✗ Chart pull FAILED: ${i}"
+            echo "Error output:"
+            echo "${helm_error}"
+            echo ""
+            echo "ERROR: OCI Helm charts are required for Prime functionality."
+            echo "Cannot proceed with incomplete artifact set."
+            exit 1
         fi
         continue
     fi

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -577,29 +577,48 @@ while IFS= read -r i; do
     fi
 done < "${list}"
 
+use_helm_for_charts=false
 if $has_oci_charts; then
-    if ! docker_uses_containerd_snapshotter && ! helm_available; then
-        echo "====================================================================="
-        echo "ERROR: ${list} contains OCI Helm charts but this host cannot pull"
-        echo "them. Docker is not using the containerd snapshotter and the helm"
-        echo "CLI is not installed."
-        echo ""
-        echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
-        echo "    1. Edit /etc/docker/daemon.json to include:"
-        echo "         { \"features\": { \"containerd-snapshotter\": true } }"
-        echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
-        echo ""
-        echo "  WORKAROUND (alternative): install the helm CLI:"
-        echo "    https://helm.sh/docs/intro/install/"
-        echo "====================================================================="
-        exit 1
+    if ! docker_uses_containerd_snapshotter; then
+        if helm_available; then
+            echo "WARNING: Docker is not using the containerd snapshotter; falling back to helm CLI for OCI Helm charts."
+            use_helm_for_charts=true
+        else
+            echo "====================================================================="
+            echo "ERROR: ${list} contains OCI Helm charts but this host cannot pull"
+            echo "them. Docker is not using the containerd snapshotter and the helm"
+            echo "CLI is not installed."
+            echo ""
+            echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
+            echo "    1. Edit /etc/docker/daemon.json to include:"
+            echo "         { \"features\": { \"containerd-snapshotter\": true } }"
+            echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
+            echo ""
+            echo "  WORKAROUND (alternative): install the helm CLI:"
+            echo "    https://helm.sh/docs/intro/install/"
+            echo "====================================================================="
+            exit 1
+        fi
     fi
+fi
+
+if $use_helm_for_charts; then
+    mkdir -p ./rancher-oci-charts
 fi
 
 pulled=""
 while IFS= read -r i; do
     [ -z "${i}" ] && continue
     i="${source_registry}${i}"
+    if $use_helm_for_charts && is_oci_helm_chart "${i}"; then
+        chart_version="${i#*:}"
+        if helm pull "oci://${i%:*}" --version "${chart_version//_/+}" -d ./rancher-oci-charts > /dev/null 2>&1; then
+            echo "Helm chart pull success: ${i}"
+        else
+            echo "Helm chart pull failed: ${i}"
+        fi
+        continue
+    fi
     if docker pull "${i}" > /dev/null 2>&1; then
         echo "Image pull success: ${i}"
         pulled="${pulled} ${i}"

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -390,6 +390,50 @@ if [ ! -z "${source_registry}" ]; then
     source_registry="${source_registry}/"
 fi
 
+docker_uses_containerd_snapshotter () {
+    docker info 2>/dev/null | grep -qi "containerd.snapshotter"
+}
+
+helm_available () {
+    command -v helm >/dev/null 2>&1
+}
+
+is_oci_helm_chart () {
+    [[ "$1" == *"/rancher/charts/"* || "$1" == "rancher/charts/"* ]]
+}
+
+# Preflight: rancher-images.txt now ships OCI Helm chart entries that
+# 'docker push' cannot handle unless the daemon uses the containerd
+# snapshotter. If the host has neither the snapshotter nor the helm CLI, fail
+# fast with a clear message instead of producing cryptic media-type errors.
+has_oci_charts=false
+while IFS= read -r i; do
+    [ -z "${i}" ] && continue
+    if is_oci_helm_chart "${i}"; then
+        has_oci_charts=true
+        break
+    fi
+done < "${list}"
+
+if $has_oci_charts; then
+    if ! docker_uses_containerd_snapshotter && ! helm_available; then
+        echo "====================================================================="
+        echo "ERROR: ${list} contains OCI Helm charts but this host cannot push"
+        echo "them. Docker is not using the containerd snapshotter and the helm"
+        echo "CLI is not installed."
+        echo ""
+        echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
+        echo "    1. Edit /etc/docker/daemon.json to include:"
+        echo "         { \"features\": { \"containerd-snapshotter\": true } }"
+        echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
+        echo ""
+        echo "  WORKAROUND (alternative): install the helm CLI:"
+        echo "    https://helm.sh/docs/intro/install/"
+        echo "====================================================================="
+        exit 1
+    fi
+fi
+
 docker load --input ${images}
 
 linux_images=()
@@ -506,6 +550,50 @@ fi
 source_registry="${source_registry%/}"
 if [ ! -z "${source_registry}" ]; then
     source_registry="${source_registry}/"
+fi
+
+docker_uses_containerd_snapshotter () {
+    docker info 2>/dev/null | grep -qi "containerd.snapshotter"
+}
+
+helm_available () {
+    command -v helm >/dev/null 2>&1
+}
+
+is_oci_helm_chart () {
+    [[ "$1" == *"/rancher/charts/"* || "$1" == "rancher/charts/"* ]]
+}
+
+# Preflight: rancher-images.txt now ships OCI Helm chart entries that
+# 'docker pull' cannot handle unless the daemon uses the containerd
+# snapshotter. If the host has neither the snapshotter nor the helm CLI, fail
+# fast with a clear message instead of producing cryptic media-type errors.
+has_oci_charts=false
+while IFS= read -r i; do
+    [ -z "${i}" ] && continue
+    if is_oci_helm_chart "${i}"; then
+        has_oci_charts=true
+        break
+    fi
+done < "${list}"
+
+if $has_oci_charts; then
+    if ! docker_uses_containerd_snapshotter && ! helm_available; then
+        echo "====================================================================="
+        echo "ERROR: ${list} contains OCI Helm charts but this host cannot pull"
+        echo "them. Docker is not using the containerd snapshotter and the helm"
+        echo "CLI is not installed."
+        echo ""
+        echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
+        echo "    1. Edit /etc/docker/daemon.json to include:"
+        echo "         { \"features\": { \"containerd-snapshotter\": true } }"
+        echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
+        echo ""
+        echo "  WORKAROUND (alternative): install the helm CLI:"
+        echo "    https://helm.sh/docs/intro/install/"
+        echo "====================================================================="
+        exit 1
+    fi
 fi
 
 pulled=""

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -415,22 +415,28 @@ while IFS= read -r i; do
     fi
 done < "${list}"
 
+use_helm_for_charts=false
 if $has_oci_charts; then
-    if ! docker_uses_containerd_snapshotter && ! helm_available; then
-        echo "====================================================================="
-        echo "ERROR: ${list} contains OCI Helm charts but this host cannot push"
-        echo "them. Docker is not using the containerd snapshotter and the helm"
-        echo "CLI is not installed."
-        echo ""
-        echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
-        echo "    1. Edit /etc/docker/daemon.json to include:"
-        echo "         { \"features\": { \"containerd-snapshotter\": true } }"
-        echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
-        echo ""
-        echo "  WORKAROUND (alternative): install the helm CLI:"
-        echo "    https://helm.sh/docs/intro/install/"
-        echo "====================================================================="
-        exit 1
+    if ! docker_uses_containerd_snapshotter; then
+        if helm_available; then
+            echo "WARNING: Docker is not using the containerd snapshotter; falling back to helm CLI for OCI Helm charts."
+            use_helm_for_charts=true
+        else
+            echo "====================================================================="
+            echo "ERROR: ${list} contains OCI Helm charts but this host cannot push"
+            echo "them. Docker is not using the containerd snapshotter and the helm"
+            echo "CLI is not installed."
+            echo ""
+            echo "  WORKAROUND (preferred): enable Docker's containerd snapshotter:"
+            echo "    1. Edit /etc/docker/daemon.json to include:"
+            echo "         { \"features\": { \"containerd-snapshotter\": true } }"
+            echo "    2. Run: systemctl daemon-reload && systemctl restart docker"
+            echo ""
+            echo "  WORKAROUND (alternative): install the helm CLI:"
+            echo "    https://helm.sh/docs/intro/install/"
+            echo "====================================================================="
+            exit 1
+        fi
     fi
 fi
 
@@ -475,6 +481,9 @@ fi
 arch_list+=("linux-amd64")
 for i in "${linux_images[@]}"; do
     [ -z "${i}" ] && continue
+    if $use_helm_for_charts && is_oci_helm_chart "${i}"; then
+        continue
+    fi
     arch_suffix=""
     use_manifest=false
     if [[ (-n "${windows_image_list}") && " ${windows_images[@]}" =~ " ${i}" ]]; then
@@ -498,6 +507,29 @@ for i in "${linux_images[@]}"; do
         push_manifest "${image_name}"
     fi
 done
+
+if $use_helm_for_charts; then
+    target_oci_base="${target_registry%/}"
+    helm_push_args=()
+    if [[ "${target_oci_base}" == localhost* || "${target_oci_base}" == 127.0.0.1* ]]; then
+        helm_push_args+=("--plain-http")
+    fi
+    for i in "${linux_images[@]}"; do
+        [ -z "${i}" ] && continue
+        is_oci_helm_chart "${i}" || continue
+        chart_repo="${i%:*}"
+        chart_ver_oci="${i#*:}"
+        chart_name="${chart_repo##*/}"
+        chart_ns="${chart_repo%/*}"
+        chart_file="./rancher-oci-charts/${chart_name}-${chart_ver_oci//_/+}.tgz"
+        if [ ! -f "${chart_file}" ]; then
+            echo "Helm chart file not found, skipping: ${chart_file}"
+            continue
+        fi
+        echo "Helm chart push: ${chart_file} -> oci://${target_oci_base}/${chart_ns}"
+        helm push "${chart_file}" "oci://${target_oci_base}/${chart_ns}" "${helm_push_args[@]}"
+    done
+fi
 `
 	linuxSaveScript = `#!/bin/bash
 list="rancher-images.txt"


### PR DESCRIPTION
## Issue: #55068
 
## Problem
When executing the rancher-save-images.sh script it will fail if docker daemon is using overlay2

```
May 14 11:03:55 omarchy dockerd[1043949]: time="2026-05-14T11:03:55.489867235-03:00" level=error msg="Not continuing with pull after error" error="unsupported media type application/vnd.cncf.helm.config.v1+json"
```


```
./rancher-save-images.sh
Image pull success: rancher/aks-operator:v1.14.1
Image pull success: rancher/compliance-operator:v1.4.1
Image pull success: rancher/turtles:v0.26.1
Image pull failed: rancher/charts/rancher-ali-operator-crd:108.1.0_up1.13.1
Image pull failed: rancher/charts/rancher-ali-operator:108.1.0_up1.13.1
Image pull failed: rancher/charts/rancher-turtles-providers:108.0.2_up0.25.2
Creating rancher-images.tar.gz with 3 images
```
 
## Solution

The scripts detect OCI Helm chart entries in rancher-images.txt and pick one of three paths: 
(1) Docker with the containerd snapshotter handles charts and images uniformly via docker pull/push; 
(2) Docker on overlay2 with the helm CLI installed falls back to helm pull (writing .tgz files into ./rancher-oci-charts/) on save and helm push on load, while regular images still go through Docker; 
(3) Docker on overlay2 with no helm exits immediately with both workarounds, replacing the cryptic unsupported media type failure.

After a save run with the helm fallback active, the working directory will
  look like:
  ├── rancher-images.tar.gz                                  # docker container images (no charts)
  └── rancher-oci-charts/                                    # OCI Helm charts pulled via the helm CLI fallback
      ├── rancher-ali-operator-crd-108.1.0+up1.13.1.tgz
      ├── rancher-ali-operator-108.1.0+up1.13.1.tgz
      └── rancher-turtles-providers-108.0.2+up0.25.2.tgz

This can be discussed further if we want only one tarball or multiple is fine.
Other point of discussion is if we let the unsecure flag detection for testing in local environments, as helm does not comes with this as default (https://github.com/helm/helm/issues/6324).
 
## Testing
1. Create your local registry
2. ./rancher-save-images.sh --image-list rancher-images.txt --source-registry registry.rancher.com
3. ./rancher-load-images.sh \
    --images rancher-images.tar.gz \
    --image-list rancher-images.txt \
    --registry localhost:5000 \
    --source-registry registry.rancher.com
