### PR TITLE
Add spec.IncludeDefaultEntry field to ext.Kubeconfig

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -254,6 +254,12 @@ type KubeconfigSpec struct {
 	// TTL is the time-to-live of the kubeconfig tokens, in seconds.
 	// +optional
 	TTL int64 `json:"ttl,omitempty"`
+	// IncludeDefaultEntry controls whether the default "rancher" cluster/user/context entry
+	// pointing directly to the Rancher server URL is included in the generated kubeconfig.
+	// When nil or true (the default), the entry is included for backward compatibility.
+	// When false, the entry is omitted.
+	// +optional
+	IncludeDefaultEntry *bool `json:"includeDefaultEntry,omitempty"`
 }
 
 // KubeconfigStatus defines the most recently observed status of the Kubeconfig.

--- a/pkg/apis/ext.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/ext.cattle.io/v1/zz_generated_deepcopy.go
@@ -195,6 +195,11 @@ func (in *KubeconfigSpec) DeepCopyInto(out *KubeconfigSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IncludeDefaultEntry != nil {
+		in, out := &in.IncludeDefaultEntry, &out.IncludeDefaultEntry
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -66,13 +66,14 @@ const (
 
 // List of fields that hold Kubeconfig data.
 const (
-	ClustersField         = "clusters"
-	CurrentContextField   = "current-context"
-	DescriptionField      = "description"
-	TTLField              = "ttl"
-	StatusConditionsField = "status-conditions"
-	StatusSummaryField    = "status-summary"
-	StatusTokensField     = "status-tokens"
+	ClustersField            = "clusters"
+	CurrentContextField      = "current-context"
+	DescriptionField         = "description"
+	TTLField                 = "ttl"
+	IncludeDefaultEntryField = "include-default-entry"
+	StatusConditionsField    = "status-conditions"
+	StatusSummaryField       = "status-summary"
+	StatusTokensField        = "status-tokens"
 )
 
 // List of statuses.
@@ -271,6 +272,10 @@ func (s *Store) Create(
 		return nil, apierrors.NewBadRequest("spec.clusters must be unique")
 	}
 
+	if !includeDefaultEntry(&kubeconfig.Spec) && len(kubeconfig.Spec.Clusters) == 0 {
+		return nil, apierrors.NewBadRequest("at least one cluster is required when includeDefaultEntry is false")
+	}
+
 	defaultTTL, err := s.getDefaultTTL()
 	if err != nil {
 		return nil, fmt.Errorf("error getting default token TTL: %w", err)
@@ -385,6 +390,18 @@ func (s *Store) Create(
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid currentContext %s", kubeconfig.Spec.CurrentContext))
 	}
 
+	includeDefault := includeDefaultEntry(&kubeconfig.Spec)
+
+	needsSharedToken := includeDefault
+	if !needsSharedToken {
+		for _, c := range clusters {
+			if !c.Spec.LocalClusterAuthEndpoint.Enabled {
+				needsSharedToken = true
+				break
+			}
+		}
+	}
+
 	dryRun := options != nil && len(options.DryRun) > 0
 	generateToken := s.shouldGenerateToken()
 
@@ -438,12 +455,17 @@ func (s *Store) Create(
 			CreationTimestamp: configMap.CreationTimestamp.Format(time.RFC3339),
 			TTL:               strconv.FormatInt(kubeconfig.Spec.TTL, 10),
 		},
-		CurrentContext: defaultClusterName,
+		CurrentContext: func() string {
+			if includeDefault {
+				return defaultClusterName
+			}
+			return ""
+		}(),
 	}
 
 	err = func() error { // Deliberately use an anonymous function to capture the status and error conditions.
 		// Generate a shared token for the default and non-ACE clusters.
-		if !dryRun && generateToken {
+		if !dryRun && generateToken && needsSharedToken {
 			extToken := s.buildExtToken(userInfo.GetName(), authToken, ttlMilliseconds, "")
 			sharedToken, err := s.tokenMgr.CreateToken(ctx, extToken, userInfo)
 			if err != nil {
@@ -475,24 +497,29 @@ func (s *Store) Create(
 			})
 		}
 
-		// The default entry that points to the Rancher URL.
-		// Even a base user without access to any cluster should be able to use a kubeconfig
-		// to interact with Rancher via Public API.
-		data.Clusters = append(data.Clusters, kconfig.Cluster{
-			Name:   defaultClusterName,
-			Server: "https://" + host,
-			Cert:   caCert,
-		})
-		data.Users = append(data.Users, kconfig.User{
-			Name:  defaultClusterName,
-			Token: sharedTokenKey,
-			Host:  host,
-		})
-		data.Contexts = append(data.Contexts, kconfig.Context{
-			Name:    defaultClusterName,
-			Cluster: defaultClusterName,
-			User:    defaultClusterName,
-		})
+		if includeDefault {
+			data.Clusters = append(data.Clusters, kconfig.Cluster{
+				Name:   defaultClusterName,
+				Server: "https://" + host,
+				Cert:   caCert,
+			})
+			data.Users = append(data.Users, kconfig.User{
+				Name:  defaultClusterName,
+				Token: sharedTokenKey,
+				Host:  host,
+			})
+			data.Contexts = append(data.Contexts, kconfig.Context{
+				Name:    defaultClusterName,
+				Cluster: defaultClusterName,
+				User:    defaultClusterName,
+			})
+		} else if needsSharedToken {
+			data.Users = append(data.Users, kconfig.User{
+				Name:  defaultClusterName,
+				Token: sharedTokenKey,
+				Host:  host,
+			})
+		}
 
 		for _, cluster := range clusters {
 			var tokenKey string
@@ -726,6 +753,10 @@ func (s *Store) toConfigMap(kubeconfig *ext.Kubeconfig) (*corev1.ConfigMap, erro
 	configMap.Data[DescriptionField] = kubeconfig.Spec.Description
 	configMap.Data[TTLField] = strconv.FormatInt(kubeconfig.Spec.TTL, 10)
 
+	if kubeconfig.Spec.IncludeDefaultEntry != nil {
+		configMap.Data[IncludeDefaultEntryField] = strconv.FormatBool(*kubeconfig.Spec.IncludeDefaultEntry)
+	}
+
 	// Note: Value should never be persisted!
 	configMap.Data[StatusSummaryField] = kubeconfig.Status.Summary
 	if len(kubeconfig.Status.Conditions) > 0 {
@@ -787,6 +818,14 @@ func (s *Store) fromConfigMap(configMap *corev1.ConfigMap) (*ext.Kubeconfig, err
 		}
 	}
 
+	if v, ok := configMap.Data[IncludeDefaultEntryField]; ok {
+		boolVal, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing includeDefaultEntry for %s: %w", configMap.Name, err)
+		}
+		kubeconfig.Spec.IncludeDefaultEntry = &boolVal
+	}
+
 	kubeconfig.Status.Summary = configMap.Data[StatusSummaryField]
 
 	if serialized := configMap.Data[StatusConditionsField]; serialized != "" {
@@ -810,6 +849,10 @@ func (s *Store) fromConfigMap(configMap *corev1.ConfigMap) (*ext.Kubeconfig, err
 	}
 
 	return kubeconfig, nil
+}
+
+func includeDefaultEntry(spec *ext.KubeconfigSpec) bool {
+	return spec.IncludeDefaultEntry == nil || *spec.IncludeDefaultEntry
 }
 
 // first returns the first element of a slice of strings, or an empty string if the slice is empty.
@@ -1413,6 +1456,9 @@ func (s *Store) Update(
 	if oldKubeconfig.Spec.TTL != newKubeconfig.Spec.TTL {
 		return nil, false, apierrors.NewBadRequest("spec.ttl is immutable")
 	}
+	if !reflect.DeepEqual(oldKubeconfig.Spec.IncludeDefaultEntry, newKubeconfig.Spec.IncludeDefaultEntry) {
+		return nil, false, apierrors.NewBadRequest("spec.includeDefaultEntry is immutable")
+	}
 
 	newKubeconfig.UID = oldKubeconfig.UID // Make sure UID is preserved.
 
@@ -1497,27 +1543,32 @@ var (
 
 	pathCMLabelKind = fieldpath.MakePathOrDie("metadata", "labels", KindLabel)
 
-	pathKConfigClustersField       = fieldpath.MakePathOrDie("spec", "clusters")
-	pathKConfigCurrentContextField = fieldpath.MakePathOrDie("spec", "currentContext")
-	pathKConfigDescriptionField    = fieldpath.MakePathOrDie("spec", "description")
-	pathKConfigTTLField            = fieldpath.MakePathOrDie("spec", "ttl")
+	pathKConfigClustersField            = fieldpath.MakePathOrDie("spec", "clusters")
+	pathKConfigCurrentContextField      = fieldpath.MakePathOrDie("spec", "currentContext")
+	pathKConfigDescriptionField         = fieldpath.MakePathOrDie("spec", "description")
+	pathKConfigTTLField                 = fieldpath.MakePathOrDie("spec", "ttl")
+	pathKConfigIncludeDefaultEntryField = fieldpath.MakePathOrDie("spec", "includeDefaultEntry")
+
+	pathCMIncludeDefaultEntryField = fieldpath.MakePathOrDie("data", "include-default-entry")
 
 	mapFromConfigMap = extcommon.MapSpec{
-		pathCMData.String():                  nil,
-		pathCMClustersField.String():         pathKConfigClustersField,
-		pathCMCurrentContextField.String():   pathKConfigCurrentContextField,
-		pathCMDescriptionField.String():      pathKConfigDescriptionField,
-		pathCMTTLField.String():              pathKConfigTTLField,
-		pathCMStatusConditionsField.String(): nil,
-		pathCMStatusSummaryField.String():    nil,
-		pathCMStatusTokensField.String():     nil,
-		pathCMLabelKind.String():             nil,
+		pathCMData.String():                     nil,
+		pathCMClustersField.String():            pathKConfigClustersField,
+		pathCMCurrentContextField.String():      pathKConfigCurrentContextField,
+		pathCMDescriptionField.String():         pathKConfigDescriptionField,
+		pathCMTTLField.String():                 pathKConfigTTLField,
+		pathCMIncludeDefaultEntryField.String(): pathKConfigIncludeDefaultEntryField,
+		pathCMStatusConditionsField.String():    nil,
+		pathCMStatusSummaryField.String():       nil,
+		pathCMStatusTokensField.String():        nil,
+		pathCMLabelKind.String():                nil,
 	}
 
 	mapFromKubeconfig = extcommon.MapSpec{
-		pathKConfigClustersField.String():       pathCMClustersField,
-		pathKConfigCurrentContextField.String(): pathCMCurrentContextField,
-		pathKConfigDescriptionField.String():    pathCMDescriptionField,
-		pathKConfigTTLField.String():            pathCMTTLField,
+		pathKConfigClustersField.String():            pathCMClustersField,
+		pathKConfigCurrentContextField.String():      pathCMCurrentContextField,
+		pathKConfigDescriptionField.String():         pathCMDescriptionField,
+		pathKConfigTTLField.String():                 pathCMTTLField,
+		pathKConfigIncludeDefaultEntryField.String(): pathCMIncludeDefaultEntryField,
 	}
 )

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -1186,6 +1186,308 @@ func TestStoreCreate(t *testing.T) {
 		assert.True(t, apierrors.IsBadRequest(err))
 		assert.Contains(t, err.Error(), "exceeds max ttl")
 	})
+	t.Run("exclude default entry with no clusters", func(t *testing.T) {
+		store := &Store{
+			authorizer:    commonAuthorizer,
+			userCache:     userCache,
+			tokenStore:    tokenStore,
+			tokenMgr:      tokenManager,
+			getDefaultTTL: getDefaultTTL,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				IncludeDefaultEntry: ptr.To(false),
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsBadRequest(err))
+		assert.Contains(t, err.Error(), "at least one cluster is required when includeDefaultEntry is false")
+	})
+	t.Run("exclude default entry with non-ACE clusters", func(t *testing.T) {
+		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		})
+
+		var configMap *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			configMap.CreationTimestamp = metav1.NewTime(time.Now())
+			configMap.Name = names.SimpleNameGenerator.GenerateName(configMap.GenerateName)
+			return configMap, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			return configMap, nil
+		}).Times(1)
+
+		tokenManager := &fakeTokenManager{}
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters:            []string{downstream1},
+				IncludeDefaultEntry: ptr.To(false),
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.NoError(t, err)
+
+		created := obj.(*ext.Kubeconfig)
+		assert.Equal(t, StatusSummaryComplete, created.Status.Summary)
+		assert.Equal(t, "false", configMap.Data[IncludeDefaultEntryField])
+
+		config, err := clientcmd.Load([]byte(created.Status.Value))
+		require.NoError(t, err)
+
+		require.Len(t, config.Clusters, 1)
+		assert.Contains(t, config.Clusters, "downstream1")
+		assert.NotContains(t, config.Clusters, defaultClusterName)
+
+		require.Len(t, config.Contexts, 1)
+		assert.Contains(t, config.Contexts, "downstream1")
+		assert.NotContains(t, config.Contexts, defaultClusterName)
+
+		require.Len(t, config.AuthInfos, 1)
+		assert.Contains(t, config.AuthInfos, defaultClusterName)
+
+		require.Len(t, tokenManager.sharedTokenKeys, 1)
+		assert.Equal(t, tokenManager.sharedTokenKeys[0], config.AuthInfos[defaultClusterName].Token)
+		require.Len(t, tokenManager.clusterTokenKeys, 0)
+
+		assert.Equal(t, "downstream1", config.CurrentContext)
+	})
+	t.Run("exclude default entry with ACE-only clusters", func(t *testing.T) {
+		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		})
+
+		var configMap *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			configMap.CreationTimestamp = metav1.NewTime(time.Now())
+			configMap.Name = names.SimpleNameGenerator.GenerateName(configMap.GenerateName)
+			return configMap, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			return configMap, nil
+		}).Times(1)
+
+		tokenManager := &fakeTokenManager{}
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters:            []string{downstream2},
+				IncludeDefaultEntry: ptr.To(false),
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.NoError(t, err)
+
+		created := obj.(*ext.Kubeconfig)
+		assert.Equal(t, StatusSummaryComplete, created.Status.Summary)
+
+		config, err := clientcmd.Load([]byte(created.Status.Value))
+		require.NoError(t, err)
+
+		assert.NotContains(t, config.Clusters, defaultClusterName)
+		assert.NotContains(t, config.Contexts, defaultClusterName)
+		assert.NotContains(t, config.AuthInfos, defaultClusterName)
+
+		require.Len(t, tokenManager.sharedTokenKeys, 0)
+		require.Len(t, tokenManager.clusterTokenKeys, 1)
+
+		assert.Equal(t, "downstream2-cp", config.CurrentContext)
+	})
+	t.Run("exclude default entry with mixed clusters", func(t *testing.T) {
+		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		})
+
+		var configMap *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			configMap.CreationTimestamp = metav1.NewTime(time.Now())
+			configMap.Name = names.SimpleNameGenerator.GenerateName(configMap.GenerateName)
+			return configMap, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			return configMap, nil
+		}).Times(1)
+
+		tokenManager := &fakeTokenManager{}
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters:            []string{downstream1, downstream2},
+				CurrentContext:      downstream1,
+				IncludeDefaultEntry: ptr.To(false),
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.NoError(t, err)
+
+		created := obj.(*ext.Kubeconfig)
+		assert.Equal(t, StatusSummaryComplete, created.Status.Summary)
+
+		config, err := clientcmd.Load([]byte(created.Status.Value))
+		require.NoError(t, err)
+
+		assert.NotContains(t, config.Clusters, defaultClusterName)
+		assert.NotContains(t, config.Contexts, defaultClusterName)
+
+		assert.Contains(t, config.AuthInfos, defaultClusterName)
+		require.Len(t, tokenManager.sharedTokenKeys, 1)
+		assert.Equal(t, tokenManager.sharedTokenKeys[0], config.AuthInfos[defaultClusterName].Token)
+		require.Len(t, tokenManager.clusterTokenKeys, 1)
+
+		assert.Equal(t, "downstream1", config.CurrentContext)
+	})
+	t.Run("include default entry explicitly", func(t *testing.T) {
+		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		})
+
+		var configMap *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			configMap.CreationTimestamp = metav1.NewTime(time.Now())
+			configMap.Name = names.SimpleNameGenerator.GenerateName(configMap.GenerateName)
+			return configMap, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			return configMap, nil
+		}).Times(1)
+
+		tokenManager := &fakeTokenManager{}
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters:            []string{downstream1},
+				IncludeDefaultEntry: ptr.To(true),
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.NoError(t, err)
+
+		created := obj.(*ext.Kubeconfig)
+		assert.Equal(t, StatusSummaryComplete, created.Status.Summary)
+		assert.Equal(t, "true", configMap.Data[IncludeDefaultEntryField])
+
+		config, err := clientcmd.Load([]byte(created.Status.Value))
+		require.NoError(t, err)
+
+		assert.Contains(t, config.Clusters, defaultClusterName)
+		assert.Contains(t, config.Contexts, defaultClusterName)
+		assert.Contains(t, config.AuthInfos, defaultClusterName)
+	})
 }
 
 func generateCAKeyAndCert() (*ecdsa.PrivateKey, string, error) {
@@ -2263,6 +2565,17 @@ func TestStoreUpdate(t *testing.T) {
 			assert.False(t, isCreated)
 			assert.True(t, apierrors.IsBadRequest(err))
 		})
+		t.Run("spec.includeDefaultEntry", func(t *testing.T) {
+			newKubeconfig := oldKubeconfig.DeepCopy()
+			newKubeconfig.Spec.IncludeDefaultEntry = ptr.To(false)
+			objInfo := &fakeUpdatedObjectInfo{obj: newKubeconfig}
+
+			kubeconfig, isCreated, err := store.Update(ctx, kubeconfigID, objInfo, nil, updateValidation, false, options)
+			require.Error(t, err)
+			assert.Nil(t, kubeconfig)
+			assert.False(t, isCreated)
+			assert.True(t, apierrors.IsBadRequest(err))
+		})
 	})
 	t.Run("dryRun", func(t *testing.T) {
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
@@ -2648,5 +2961,64 @@ func TestPrintKubeconfig(t *testing.T) {
 		require.Len(t, row.Cells, 8)
 		assert.Equal(t, unknownValue, row.Cells[3].(string))
 		assert.Equal(t, unknownValue, row.Cells[4].(string))
+	})
+}
+
+func TestIncludeDefaultEntryConfigMapRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := &Store{}
+
+	t.Run("nil round-trips as nil", func(t *testing.T) {
+		kc := &ext.Kubeconfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: ext.KubeconfigSpec{
+				TTL: 3600,
+			},
+		}
+
+		cm, err := store.toConfigMap(kc)
+		require.NoError(t, err)
+		assert.NotContains(t, cm.Data, IncludeDefaultEntryField)
+
+		result, err := store.fromConfigMap(cm)
+		require.NoError(t, err)
+		assert.Nil(t, result.Spec.IncludeDefaultEntry)
+	})
+	t.Run("false round-trips as false", func(t *testing.T) {
+		kc := &ext.Kubeconfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: ext.KubeconfigSpec{
+				TTL:                 3600,
+				IncludeDefaultEntry: ptr.To(false),
+			},
+		}
+
+		cm, err := store.toConfigMap(kc)
+		require.NoError(t, err)
+		assert.Equal(t, "false", cm.Data[IncludeDefaultEntryField])
+
+		result, err := store.fromConfigMap(cm)
+		require.NoError(t, err)
+		require.NotNil(t, result.Spec.IncludeDefaultEntry)
+		assert.False(t, *result.Spec.IncludeDefaultEntry)
+	})
+	t.Run("true round-trips as true", func(t *testing.T) {
+		kc := &ext.Kubeconfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: ext.KubeconfigSpec{
+				TTL:                 3600,
+				IncludeDefaultEntry: ptr.To(true),
+			},
+		}
+
+		cm, err := store.toConfigMap(kc)
+		require.NoError(t, err)
+		assert.Equal(t, "true", cm.Data[IncludeDefaultEntryField])
+
+		result, err := store.fromConfigMap(cm)
+		require.NoError(t, err)
+		require.NotNil(t, result.Spec.IncludeDefaultEntry)
+		assert.True(t, *result.Spec.IncludeDefaultEntry)
 	})
 }

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -1184,7 +1184,7 @@ func TestStoreCreate(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, obj)
 		assert.True(t, apierrors.IsBadRequest(err))
-		assert.Contains(t, err.Error(), "exceeds max ttl")
+		assert.ErrorContains(t, err, "exceeds max ttl")
 	})
 	t.Run("exclude default entry with no clusters", func(t *testing.T) {
 		store := &Store{
@@ -1211,7 +1211,7 @@ func TestStoreCreate(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, obj)
 		assert.True(t, apierrors.IsBadRequest(err))
-		assert.Contains(t, err.Error(), "at least one cluster is required when includeDefaultEntry is false")
+		assert.ErrorContains(t, err, "at least one cluster is required when includeDefaultEntry is false")
 	})
 	t.Run("exclude default entry with non-ACE clusters", func(t *testing.T) {
 		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -1285,7 +1285,7 @@ func TestStoreCreate(t *testing.T) {
 
 		require.Len(t, tokenManager.sharedTokenKeys, 1)
 		assert.Equal(t, tokenManager.sharedTokenKeys[0], config.AuthInfos[defaultClusterName].Token)
-		require.Len(t, tokenManager.clusterTokenKeys, 0)
+		require.Empty(t, tokenManager.clusterTokenKeys)
 
 		assert.Equal(t, "downstream1", config.CurrentContext)
 	})
@@ -1351,7 +1351,7 @@ func TestStoreCreate(t *testing.T) {
 		assert.NotContains(t, config.Contexts, defaultClusterName)
 		assert.NotContains(t, config.AuthInfos, defaultClusterName)
 
-		require.Len(t, tokenManager.sharedTokenKeys, 0)
+		require.Empty(t, tokenManager.sharedTokenKeys)
 		require.Len(t, tokenManager.clusterTokenKeys, 1)
 
 		assert.Equal(t, "downstream2-cp", config.CurrentContext)

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -419,6 +419,13 @@ func schema_pkg_apis_extcattleio_v1_KubeconfigSpec(ref common.ReferenceCallback)
 							Format:      "int64",
 						},
 					},
+					"includeDefaultEntry": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IncludeDefaultEntry controls whether the default \"rancher\" cluster/user/context entry pointing directly to the Rancher server URL is included in the generated kubeconfig. When nil or true (the default), the entry is included for backward compatibility. When false, the entry is omitted.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Issue: #55031 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Every generated kubeconfig unconditionally included a `rancher` default entry pointing directly to the Rancher server URL.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added an optional boolean field `spec.IncludeDefaultEntry` that defaults to `true` for backward compatibility. When set to `false`, the default cluster and context entries are omitted.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests