### PR TITLE
check the Connected condition on mgmt cluster

### DIFF
--- a/pkg/controllers/capr/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagent.go
@@ -60,6 +60,7 @@ var (
 )
 
 type handler struct {
+	mgmtClusterCache          v3.ClusterCache
 	clusterRegistrationTokens v3.ClusterRegistrationTokenCache
 	bundles                   fleetcontrollers.BundleController
 	cluster                   provisioningcontrollers.ClusterController
@@ -70,6 +71,7 @@ type handler struct {
 
 func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	h := &handler{
+		mgmtClusterCache:          clients.Mgmt.Cluster().Cache(),
 		clusterRegistrationTokens: clients.Mgmt.ClusterRegistrationToken().Cache(),
 		bundles:                   clients.Fleet.Bundle(),
 		cluster:                   clients.Provisioning.Cluster(),
@@ -102,10 +104,20 @@ func (h *handler) InstallSystemAgentUpgrader(_ string, cluster *rancherv1.Cluste
 		logrus.Debugf("[managesystemagent] cluster %s/%s: the SystemUpgradeControllerChartVersion setting is not set, skip installing system-agent-upgrader", cluster.Namespace, cluster.Name)
 		return cluster, fmt.Errorf("[managesystemagent] cluster %s/%s: the SystemUpgradeControllerChartVersion setting is not set", cluster.Namespace, cluster.Name)
 	}
-	// Skip if Rancher does not have a connection to the cluster
-	if !clusterconnected.Connected.IsTrue(cluster) {
+
+	// Skip if Rancher does not have a connection to the cluster.
+	// The Connected condition lives on the management cluster object, not the provisioning cluster.
+	if cluster.Status.ClusterName == "" {
 		return cluster, nil
 	}
+	mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
+	if err != nil {
+		return nil, err
+	}
+	if !clusterconnected.Connected.IsTrue(mgmtCluster) {
+		return cluster, nil
+	}
+
 	// Skip if the cluster's kubeconfig is not populated
 	if cluster.Status.ClientSecretName == "" {
 		return cluster, nil
@@ -482,8 +494,16 @@ func (h *handler) UninstallFleetBasedApps(_ string, cluster *rancherv1.Cluster) 
 		return cluster, nil
 	}
 
-	// Skip if Rancher does not have a connection to the cluster
-	if !clusterconnected.Connected.IsTrue(cluster) {
+	// Skip if Rancher does not have a connection to the cluster.
+	// The Connected condition lives on the management cluster object, not the provisioning cluster.
+	if cluster.Status.ClusterName == "" {
+		return cluster, nil
+	}
+	mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
+	if err != nil {
+		return nil, err
+	}
+	if !clusterconnected.Connected.IsTrue(mgmtCluster) {
 		return cluster, nil
 	}
 

--- a/pkg/controllers/capr/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagent.go
@@ -112,7 +112,10 @@ func (h *handler) InstallSystemAgentUpgrader(_ string, cluster *rancherv1.Cluste
 	}
 	mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
 	if err != nil {
-		return nil, err
+		if errors.IsNotFound(err) {
+			return cluster, nil
+		}
+		return cluster, err
 	}
 	if !clusterconnected.Connected.IsTrue(mgmtCluster) {
 		return cluster, nil
@@ -501,7 +504,10 @@ func (h *handler) UninstallFleetBasedApps(_ string, cluster *rancherv1.Cluster) 
 	}
 	mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
 	if err != nil {
-		return nil, err
+		if errors.IsNotFound(err) {
+			return cluster, nil
+		}
+		return cluster, err
 	}
 	if !clusterconnected.Connected.IsTrue(mgmtCluster) {
 		return cluster, nil


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
- https://github.com/rancher/rancher/issues/55111 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
 
Because we no longer mirror the conditions from the mgmt cluster to the provisioning cluster (commit 052bb9402), it breaks the `InstallSystemAgentUpgrader` and `UninstallFleetBasedApps` functions, which check the Connected condition on the provisioning cluster. As a result, the system-agent-upgrader Plans are not delivered to the node-driver clusters. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Check the Connected condition on the associated mgmt cluster.  

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The fix is validated in the local development setup, and the Plans are created on the DS node-driver cluster as expected. 


### Automated Testing
 
none

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
The following two plans should be created on the node-driver cluster:
- system-agent-upgrader
- system-agent-upgrader-windows


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 
no 

Existing / newly added automated tests that provide evidence there are no regressions:
 
n/a