### PR TITLE
[roletemplate aggregation] Make sure to delete PRTBs/CRTBs when a user is deleted

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/crtb_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler.go
@@ -204,6 +204,8 @@ func (c *crtbHandler) reconcileSubject(binding *v3.ClusterRoleTemplateBinding, l
 		return binding, fmt.Errorf("ClusterRoleTemplateBinding %v has no subject", binding.Name)
 	}
 
+	needsUpdate := false
+
 	if binding.UserName == "" {
 		displayName := binding.Annotations["auth.cattle.io/principal-display-name"]
 		user, err := c.userMGR.EnsureUser(binding.UserPrincipalName, displayName)
@@ -213,7 +215,7 @@ func (c *crtbHandler) reconcileSubject(binding *v3.ClusterRoleTemplateBinding, l
 		}
 
 		binding.UserName = user.Name
-		c.s.AddCondition(localConditions, condition, subjectExists, nil)
+		needsUpdate = true
 	}
 
 	if binding.UserPrincipalName == "" {
@@ -225,10 +227,19 @@ func (c *crtbHandler) reconcileSubject(binding *v3.ClusterRoleTemplateBinding, l
 		for _, p := range u.PrincipalIDs {
 			if strings.HasSuffix(p, binding.UserName) {
 				binding.UserPrincipalName = p
+				needsUpdate = true
 				break
 			}
 		}
-		c.s.AddCondition(localConditions, condition, subjectExists, nil)
+	}
+
+	if needsUpdate {
+		updated, err := c.crtbClient.Update(binding)
+		if err != nil {
+			c.s.AddCondition(localConditions, condition, failedToCreateUser, err)
+			return binding, err
+		}
+		binding = updated
 	}
 
 	c.s.AddCondition(localConditions, condition, subjectExists, nil)

--- a/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/crtb_handler_test.go
@@ -28,6 +28,7 @@ func TestCRTBHandlerReconcileSubject(t *testing.T) {
 	type controllers struct {
 		userMGR        *userMocks.MockManager
 		userController *fake.MockNonNamespacedControllerInterface[*v3.User, *v3.UserList]
+		crtbController *fake.MockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList]
 	}
 	tests := []struct {
 		name             string
@@ -100,6 +101,9 @@ func TestCRTBHandlerReconcileSubject(t *testing.T) {
 				c.userMGR.EXPECT().EnsureUser("principal-name", "test-name").Return(&v3.User{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-user"},
 				}, nil)
+				c.crtbController.EXPECT().Update(gomock.Any()).DoAndReturn(func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					return crtb, nil
+				})
 			},
 			wantedCondition: &reducedCondition{
 				reason: subjectExists,
@@ -147,6 +151,9 @@ func TestCRTBHandlerReconcileSubject(t *testing.T) {
 				c.userController.EXPECT().Get("test-user", metav1.GetOptions{}).Return(&v3.User{
 					PrincipalIDs: []string{"principal/test-user"},
 				}, nil)
+				c.crtbController.EXPECT().Update(gomock.Any()).DoAndReturn(func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					return crtb, nil
+				})
 			},
 			wantedCondition: &reducedCondition{
 				reason: subjectExists,
@@ -183,6 +190,7 @@ func TestCRTBHandlerReconcileSubject(t *testing.T) {
 			controllers := controllers{
 				userMGR:        userMocks.NewMockManager(ctrl),
 				userController: fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl),
+				crtbController: fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl),
 			}
 
 			if tt.setupControllers != nil {
@@ -192,6 +200,7 @@ func TestCRTBHandlerReconcileSubject(t *testing.T) {
 				s:              status.NewStatus(),
 				userMGR:        controllers.userMGR,
 				userController: controllers.userController,
+				crtbClient:     controllers.crtbController,
 			}
 			localConditions := []metav1.Condition{}
 

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler.go
@@ -310,6 +310,8 @@ func (p *prtbHandler) reconcileSubject(binding *v3.ProjectRoleTemplateBinding) (
 		return nil, fmt.Errorf("binding %v has no subject", binding.Name)
 	}
 
+	needsUpdate := false
+
 	if binding.UserName == "" {
 		displayName := binding.Annotations["auth.cattle.io/principal-display-name"]
 		user, err := p.userMGR.EnsureUser(binding.UserPrincipalName, displayName)
@@ -318,6 +320,7 @@ func (p *prtbHandler) reconcileSubject(binding *v3.ProjectRoleTemplateBinding) (
 		}
 
 		binding.UserName = user.Name
+		needsUpdate = true
 	}
 
 	if binding.UserPrincipalName == "" {
@@ -328,9 +331,18 @@ func (p *prtbHandler) reconcileSubject(binding *v3.ProjectRoleTemplateBinding) (
 		for _, p := range u.PrincipalIDs {
 			if strings.HasSuffix(p, binding.UserName) {
 				binding.UserPrincipalName = p
+				needsUpdate = true
 				break
 			}
 		}
+	}
+
+	if needsUpdate {
+		updated, err := p.prtbClient.Update(binding)
+		if err != nil {
+			return binding, err
+		}
+		binding = updated
 	}
 
 	return binding, nil

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
@@ -18,13 +18,17 @@ import (
 
 func TestPRTBHandlerReconcileSubject(t *testing.T) {
 	t.Parallel()
+	type controllers struct {
+		userMGR        *userMocks.MockManager
+		userController *fake.MockNonNamespacedControllerInterface[*v3.User, *v3.UserList]
+		prtbController *fake.MockControllerInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList]
+	}
 	tests := []struct {
-		name                string
-		setupUserManager    func(*userMocks.MockManager)
-		setupUserController func(*fake.MockNonNamespacedControllerInterface[*v3.User, *v3.UserList])
-		binding             *v3.ProjectRoleTemplateBinding
-		want                *v3.ProjectRoleTemplateBinding
-		wantErr             bool
+		name             string
+		setupControllers func(controllers)
+		binding          *v3.ProjectRoleTemplateBinding
+		want             *v3.ProjectRoleTemplateBinding
+		wantErr          bool
 	}{
 		{
 			name: "prtb with a UserPrincipalName and Username is no-op",
@@ -74,10 +78,13 @@ func TestPRTBHandlerReconcileSubject(t *testing.T) {
 				UserName:          "",
 				UserPrincipalName: "test-principal",
 			},
-			setupUserManager: func(m *userMocks.MockManager) {
-				m.EXPECT().EnsureUser("test-principal", "display-name").Return(&v3.User{
+			setupControllers: func(c controllers) {
+				c.userMGR.EXPECT().EnsureUser("test-principal", "display-name").Return(&v3.User{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-user"},
 				}, nil)
+				c.prtbController.EXPECT().Update(gomock.Any()).DoAndReturn(func(prtb *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+					return prtb, nil
+				})
 			},
 			want: &v3.ProjectRoleTemplateBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -100,8 +107,8 @@ func TestPRTBHandlerReconcileSubject(t *testing.T) {
 				UserName:          "",
 				UserPrincipalName: "test-principal",
 			},
-			setupUserManager: func(m *userMocks.MockManager) {
-				m.EXPECT().EnsureUser("test-principal", "display-name").Return(nil, errDefault)
+			setupControllers: func(c controllers) {
+				c.userMGR.EXPECT().EnsureUser("test-principal", "display-name").Return(nil, errDefault)
 			},
 			want: &v3.ProjectRoleTemplateBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -120,10 +127,13 @@ func TestPRTBHandlerReconcileSubject(t *testing.T) {
 				UserName:          "test-user",
 				UserPrincipalName: "",
 			},
-			setupUserController: func(m *fake.MockNonNamespacedControllerInterface[*v3.User, *v3.UserList]) {
-				m.EXPECT().Get("test-user", metav1.GetOptions{}).Return(&v3.User{
+			setupControllers: func(c controllers) {
+				c.userController.EXPECT().Get("test-user", metav1.GetOptions{}).Return(&v3.User{
 					PrincipalIDs: []string{"principal-test-user"},
 				}, nil)
+				c.prtbController.EXPECT().Update(gomock.Any()).DoAndReturn(func(prtb *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+					return prtb, nil
+				})
 			},
 			want: &v3.ProjectRoleTemplateBinding{
 				UserName:          "test-user",
@@ -136,8 +146,8 @@ func TestPRTBHandlerReconcileSubject(t *testing.T) {
 				UserName:          "test-user",
 				UserPrincipalName: "",
 			},
-			setupUserController: func(m *fake.MockNonNamespacedControllerInterface[*v3.User, *v3.UserList]) {
-				m.EXPECT().Get("test-user", metav1.GetOptions{}).Return(nil, errDefault)
+			setupControllers: func(c controllers) {
+				c.userController.EXPECT().Get("test-user", metav1.GetOptions{}).Return(nil, errDefault)
 			},
 			want: &v3.ProjectRoleTemplateBinding{
 				UserName:          "test-user",
@@ -150,17 +160,18 @@ func TestPRTBHandlerReconcileSubject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			mockUserManager := userMocks.NewMockManager(ctrl)
-			mockUserController := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
-			if tt.setupUserManager != nil {
-				tt.setupUserManager(mockUserManager)
+			controllers := controllers{
+				userMGR:        userMocks.NewMockManager(ctrl),
+				userController: fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl),
+				prtbController: fake.NewMockControllerInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList](ctrl),
 			}
-			if tt.setupUserController != nil {
-				tt.setupUserController(mockUserController)
+			if tt.setupControllers != nil {
+				tt.setupControllers(controllers)
 			}
 			p := &prtbHandler{
-				userMGR:        mockUserManager,
-				userController: mockUserController,
+				userMGR:        controllers.userMGR,
+				userController: controllers.userController,
+				prtbClient:     controllers.prtbController,
 			}
 
 			got, err := p.reconcileSubject(tt.binding)
@@ -976,7 +987,6 @@ func TestPRTBHandlerHandleMigration(t *testing.T) {
 	}
 }
 
-
 func TestDeleteDuplicatePRTBs(t *testing.T) {
 	t.Parallel()
 
@@ -1176,7 +1186,7 @@ func TestDeleteDuplicatePRTBs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "prtb-2",
 						Namespace:         "ns",
-						CreationTimestamp:  now,
+						CreationTimestamp: now,
 						DeletionTimestamp: &now,
 					},
 					UserName:         "user1",
@@ -1263,4 +1273,3 @@ func TestDeleteDuplicatePRTBs(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54057
 
## Problem
When a user gets deleted, all of the RBAC assigned to them should be deleted. This includes PRTBs, CRTBs, GRBs and tokens. However, when deleting a user via the UI the CRTB was not being deleted.
 
## Solution
The issue was that when a PRTB or CRTB was created with just a `userprincipalname`, it would create a `username`, but never actually persisted that change to etcd. Because of that, the indexer would never add the CRTB/PRTB and when the user is deleted the function designed to delete PRTBs/CRTBs would not find any attached to the username.

Adding a step where we update if a `username` or `userprincipalname` gets created for the CRTB/PRTB marks the change and ensures it ends up in etcd.
 
## Testing
## Engineering Testing
### Manual Testing
Manually testing, I actually found that this was an issue with both PRTBs and CRTBs. If done via the UI, PRTBs are provided with a username so they don't encounter the bug. But if you create it with just a `userprincipalname` directly, this same bug can occur for PRTBs.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_