### PR TITLE
[v2.13] Match project owner RBAC with aggregation version

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -329,7 +329,7 @@ func (m *manager) createMembershipRole(resourceType, roleName string, makeOwner 
 	}
 
 	if makeOwner {
-		rules[0].Verbs = []string{"*"}
+		rules[0].Verbs = []string{"get", "update", "delete", "patch", "create", "list", "watch", "deletecollection"}
 	} else {
 		rules[0].Verbs = []string{"get"}
 	}


### PR DESCRIPTION
Follow up after https://github.com/rancher/rancher/pull/55066
 
## Problem
In the linked PR, I changed the RBAC of project owner to explicitly set verbs. When I backported I changed just the RoleTemplate Aggregation Feature code, not the regular path. In 2.14 both were merged into common logic, but in 2.13 and earlier they are separate.
 
## Solution
Add the explicit verbs to the `manager.go` `createMembershipRole` function.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_