### PR TITLE
[v2.11] Patch update csp-adapter

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 webhookVersion: 106.0.9+up0.7.9
 remoteDialerProxyVersion: 106.0.0+up0.4.4
 provisioningCAPIVersion: 106.0.0+up0.7.0
-cspAdapterMinVersion: 106.0.0+up6.0.0
+cspAdapterMinVersion: 106.0.1+up6.0.1
 defaultShellVersion: rancher/shell:v0.4.2
 fleetVersion: 106.1.12+up0.12.14

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,7 +3,7 @@
 package buildconfig
 
 const (
-	CspAdapterMinVersion     = "106.0.0+up6.0.0"
+	CspAdapterMinVersion     = "106.0.1+up6.0.1"
 	DefaultShellVersion      = "rancher/shell:v0.4.2"
 	FleetVersion             = "106.1.12+up0.12.14"
 	ProvisioningCAPIVersion  = "106.0.0+up0.7.0"


### PR DESCRIPTION
## Issue: 
https://jira.suse.com/browse/SURE-11375

## Problem:
This patch update addresses CVE's related to bci-micro images.
The patch will generate new release artifacts with the proper fix of bumping the base image used to build csp-adapter. 

## Testing:

### Scenario 1 (fresh install):

- On an EKS cluster (k8s version 1.32), install locally built rancher with cspAdapterMinVersion: 106.0.1+up6.0.1.
- Validated the support config and licence entitlement functionality. 
- Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. 
- Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. 
- Scaled back up to 21 nodes, validated the out-of-compliance message popped up.