### PR TITLE
fix(auth): pass OIDC scopes to redirect URL

### DIFF
--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -122,7 +122,11 @@ func (g *GenOIDCProvider) TransformToAuthProvider(authConfig map[string]any) (ma
 
 	if authConfig["acrValue"] != nil {
 		redirectURL := p[publicclient.GenericOIDCProviderFieldRedirectURL].(string)
-		p[publicclient.GenericOIDCProviderFieldRedirectURL] = redirectURL + fmt.Sprintf("&acr_values=%s", authConfig["acrValue"])
+		separator := "&"
+		if !strings.Contains(redirectURL, "?") {
+			separator = "?"
+		}
+		p[publicclient.GenericOIDCProviderFieldRedirectURL] = redirectURL + fmt.Sprintf("%sacr_values=%s", separator, authConfig["acrValue"])
 	}
 
 	p[publicclient.GenericOIDCProviderFieldScopes] = authConfig["scope"]

--- a/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
@@ -331,7 +331,7 @@ func TestGenOIDCProvider_TransformToAuthProvider(t *testing.T) {
 			},
 			expected: map[string]any{
 				"id":                 "genericoidc",
-				"redirectUrl":        "https://ranchertest.io/auth?client_id=client123&response_type=code&redirect_uri=https://example.com/callback",
+				"redirectUrl":        "https://ranchertest.io/auth?client_id=client123&response_type=code&redirect_uri=https://example.com/callback&scope=openid+profile+email",
 				"scopes":             "openid profile email",
 				"logoutAllSupported": false,
 				"logoutAllEnabled":   false,
@@ -351,7 +351,7 @@ func TestGenOIDCProvider_TransformToAuthProvider(t *testing.T) {
 			},
 			expected: map[string]any{
 				"id":                 "genericoidc",
-				"redirectUrl":        "https://ranchertest.io/auth?client_id=client123&response_type=code&redirect_uri=https://example.com/callback&acr_values=testing",
+				"redirectUrl":        "https://ranchertest.io/auth?client_id=client123&response_type=code&redirect_uri=https://example.com/callback&scope=openid+profile+email&acr_values=testing",
 				"scopes":             "openid profile email",
 				"logoutAllSupported": false,
 				"logoutAllEnabled":   false,

--- a/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
@@ -358,6 +358,55 @@ func TestGenOIDCProvider_TransformToAuthProvider(t *testing.T) {
 				"logoutAllForced":    false,
 			},
 		},
+		{
+			name: "Test with PKCE Redirection (API Host provided)",
+			authConfig: map[string]any{
+				"metadata":       map[string]any{"name": "genericoidc"},
+				"rancherApiHost": "https://rancher.example.com",
+				"scope":          "openid profile email",
+			},
+			expected: map[string]any{
+				"id":                 "genericoidc",
+				"redirectUrl":        "https://rancher.example.com/v1-oidc/genericoidc?scope=openid+profile+email",
+				"scopes":             "openid profile email",
+				"logoutAllSupported": false,
+				"logoutAllEnabled":   false,
+				"logoutAllForced":    false,
+			},
+		},
+		{
+			name: "Test with PKCE Redirection and acrValue but no scope",
+			authConfig: map[string]any{
+				"metadata":       map[string]any{"name": "genericoidc"},
+				"rancherApiHost": "https://rancher.example.com",
+				"acrValue":       "testing",
+			},
+			expected: map[string]any{
+				"id":                 "genericoidc",
+				"redirectUrl":        "https://rancher.example.com/v1-oidc/genericoidc?acr_values=testing",
+				"scopes":             nil,
+				"logoutAllSupported": false,
+				"logoutAllEnabled":   false,
+				"logoutAllForced":    false,
+			},
+		},
+		{
+			name: "Test with PKCE Redirection, acrValue and scope",
+			authConfig: map[string]any{
+				"metadata":       map[string]any{"name": "genericoidc"},
+				"rancherApiHost": "https://rancher.example.com",
+				"scope":          "openid profile email",
+				"acrValue":       "testing",
+			},
+			expected: map[string]any{
+				"id":                 "genericoidc",
+				"redirectUrl":        "https://rancher.example.com/v1-oidc/genericoidc?scope=openid+profile+email&acr_values=testing",
+				"scopes":             "openid profile email",
+				"logoutAllSupported": false,
+				"logoutAllEnabled":   false,
+				"logoutAllForced":    false,
+			},
+		},
 	}
 
 	provider := &GenOIDCProvider{

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -257,21 +257,35 @@ func GetOIDCRedirectionURL(config map[string]any, pkceVerifier string, values ur
 func (o *OpenIDCProvider) getRedirectURL(authConfig map[string]any) (string, error) {
 	name := authConfig["metadata"].(map[string]any)["name"].(string)
 	rancherAPIHost, ok := authConfig[client.GenericOIDCConfigFieldRancherAPIHost].(string)
+	
+	scopes, _ := authConfig["scope"].(string)
+
 	// No API Host - no PKCE Redirection.
 	if !ok {
 		logrus.Debugf("OpenIDCProvider: No API Host - no PKCE Redirection")
 		authURL, _ := FetchAuthURL(authConfig)
-		return fmt.Sprintf(
+		redirectURL := fmt.Sprintf(
 			"%s?client_id=%s&response_type=code&redirect_uri=%s",
 			authURL,
 			authConfig["clientId"],
 			authConfig["rancherUrl"],
-		), nil
+		)
+		if scopes != "" {
+			redirectURL = fmt.Sprintf("%s&scope=%s", redirectURL, url.QueryEscape(scopes))
+		}
+		return redirectURL, nil
 
 	}
 
 	// This redirects via the handler in pkg/auth/handler
-	return url.JoinPath(rancherAPIHost, "v1-oidc", name)
+	redirectURL, err := url.JoinPath(rancherAPIHost, "v1-oidc", name)
+	if err != nil {
+		return "", err
+	}
+	if scopes != "" {
+		redirectURL = fmt.Sprintf("%s?scope=%s", redirectURL, url.QueryEscape(scopes))
+	}
+	return redirectURL, nil
 }
 
 func (o *OpenIDCProvider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {


### PR DESCRIPTION
Fixes #47905.

Previously, custom scopes configured in the generic OIDC or Keycloak auth provider were ignored when generating the redirect URL. This ensures the scopes are properly appended as query parameters so the UI can utilize them.

## Issue: 
#47905

## Problem
1. When generating redirect URLs in `pkg/auth/providers/oidc/oidc_provider.go` via `getRedirectURL()`, the configured `scope` query parameter was not appended to the redirect URL, causing custom scopes to be ignored.
2. In `pkg/auth/providers/genericoidc/genericoidc_provider.go`, `acr_values` was unconditionally appended with `&acr_values=...`. If the base redirect URL generated by the parent OIDC provider did not contain a `?` (which happens when no scopes are provided in the PKCE flow), appending `&acr_values` resulted in an invalid URL structure (e.g., `https://.../v1-oidc/genericoidc&acr_values=testing` instead of `https://.../v1-oidc/genericoidc?acr_values=testing`).

## Solution
1. **OIDC Provider (`pkg/auth/providers/oidc/oidc_provider.go`)**:
   - Updated `getRedirectURL()` to fetch the `scope` from the auth config.
   - For non-PKCE flows: Properly URL-escapes and appends the `scope` as a query parameter (using `&scope=...`).
   - For PKCE flows (when `rancherApiHost` is configured): Safely appends `scope` to the generated `/v1-oidc/{name}` URL as `?scope=...` using `url.QueryEscape`.
2. **Generic OIDC Provider (`pkg/auth/providers/genericoidc/genericoidc_provider.go`)**:
   - Dynamically determines whether to use `?` or `&` when appending `acr_values` by checking if the base URL already contains a `?`.
3. **Tests (`pkg/auth/providers/genericoidc/genericoidc_provider_test.go`)**:
   - Added robust unit test cases covering PKCE redirection under all combinations of custom scopes and ACR values.

## Testing

### Engineering Testing
#### Manual Testing
Verified that redirect URLs are correctly formed for all combinations:
- With scopes `openid profile email` and PKCE: redirects to `/v1-oidc/genericoidc?scope=openid+profile+email`
- With both scopes and ACR value: redirects to `/v1-oidc/genericoidc?scope=openid+profile+email&acr_values=testing`
- With only ACR value: redirects to `/v1-oidc/genericoidc?acr_values=testing`

#### Automated Testing
* Test types added/modified:
  * Unit
* Summary: Added new unit tests in `pkg/auth/providers/genericoidc/genericoidc_provider_test.go` (`TestGenOIDCProvider_TransformToAuthProvider`) to verify that the redirect URLs are properly formatted for PKCE redirection under combinations of custom scopes and ACR values.

## QA Testing Considerations
Verify that Keycloak OIDC and generic OIDC providers correctly pass configured custom scopes to the IDP during the login redirect flow.

### Regressions Considerations
None. Existing login flows for OIDC providers are preserved. The logic checks for the existence of custom scopes / ACR values before modifying the URL.

Existing / newly added automated tests that provide evidence there are no regressions:
- New unit tests in `pkg/auth/providers/genericoidc/genericoidc_provider_test.go`
- Existing tests in `pkg/auth/providers/oidc/oidc_provider_test.go`