### PR TITLE
Fix a panic when creating cluster-scoped ext.Tokens for kubeconfigs

### DIFF
--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -136,7 +136,7 @@ type Store struct {
 
 // New creates a new instance of [Store].
 func New(mcmEnabled bool, wranglerContext *wrangler.Context, authorizer authorizer.Authorizer) *Store {
-	extTokenStore := exttokens.NewSystemFromWrangler(wranglerContext)
+	extTokenStore := exttokens.NewSystemFromWrangler(wranglerContext, authorizer)
 	store := &Store{
 		mcmEnabled:      mcmEnabled,
 		configMapCache:  wranglerContext.Core.ConfigMap().Cache(),

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -182,7 +182,12 @@ func New(
 
 // NewSystemFromWrangler is a convenience function for creating a system token
 // store. It initializes the returned store from the provided wrangler context.
-func NewSystemFromWrangler(wranglerContext *wrangler.Context) *SystemStore {
+// An optional authorizer can be provided for cluster-scoped token authorization.
+func NewSystemFromWrangler(wranglerContext *wrangler.Context, authz ...authorizer.Authorizer) *SystemStore {
+	var authorizer authorizer.Authorizer
+	if len(authz) > 0 {
+		authorizer = authz[0]
+	}
 	return NewSystem(
 		wranglerContext.Core.Namespace(),
 		wranglerContext.Core.Namespace().Cache(),
@@ -193,6 +198,7 @@ func NewSystemFromWrangler(wranglerContext *wrangler.Context) *SystemStore {
 		NewTimeHandler(),
 		NewHashHandler(),
 		NewAuthHandler(),
+		authorizer,
 	)
 }
 
@@ -200,6 +206,7 @@ func NewSystemFromWrangler(wranglerContext *wrangler.Context) *SystemStore {
 // accessors to all the other controllers the store requires for proper
 // function. Note that it is recommended to use the NewSystemFromWrangler
 // convenience function instead.
+// An optional authorizer can be provided as the last argument for cluster-scoped token authorization.
 func NewSystem(
 	namespaceClient v1.NamespaceClient,
 	namespaceCache v1.NamespaceCache,
@@ -210,8 +217,14 @@ func NewSystem(
 	timer timeHandler,
 	hasher hashHandler,
 	auth authHandler,
+	authz ...authorizer.Authorizer,
 ) *SystemStore {
+	var authorizer authorizer.Authorizer
+	if len(authz) > 0 {
+		authorizer = authz[0]
+	}
 	tokenStore := SystemStore{
+		authorizer:      authorizer,
 		namespaceClient: namespaceClient,
 		namespaceCache:  namespaceCache,
 		secretClient:    secretClient,
@@ -673,7 +686,10 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 				token.Spec.ClusterName, err))
 		}
 
-		// Verify that user is authorized to access cluster
+		if t.authorizer == nil {
+			return nil, apierrors.NewInternalError(fmt.Errorf("authorizer is required for cluster-scoped tokens"))
+		}
+
 		decision, _, err := t.authorizer.Authorize(ctx, &authorizer.AttributesRecord{
 			User:            userInfo,
 			Verb:            "get",

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
@@ -1405,6 +1406,116 @@ func TestStoreCreate(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, test.rtok, tok)
+			}
+		})
+	}
+}
+
+func TestSystemStoreCreateClusterScoped(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		authorizer authorizer.Authorizer
+		cluster    *v3.Cluster
+		clusterErr error
+		err        string
+	}{
+		{
+			name:       "nil authorizer returns error",
+			authorizer: nil,
+			cluster:    &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-m-test"}},
+			err:        "authorizer is required for cluster-scoped tokens",
+		},
+		{
+			name:       "cluster not found",
+			authorizer: nil,
+			clusterErr: apierrors.NewNotFound(GVR.GroupResource(), "c-m-missing"),
+			err:        "cluster c-m-missing not found",
+		},
+		{
+			name: "authorizer denies access",
+			authorizer: authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionDeny, "denied", nil
+			}),
+			cluster: &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-m-test"}},
+			err:     "is not allowed to access cluster",
+		},
+		{
+			name: "authorizer allows access",
+			authorizer: authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			}),
+			cluster: &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-m-test"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			secrets.EXPECT().Cache().Return(scache)
+
+			users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+			ucache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+			users.EXPECT().Cache().Return(ucache)
+
+			nsCache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+			nsCache.EXPECT().Get(TokenNamespace).AnyTimes()
+
+			tcache := fake.NewMockNonNamespacedCacheInterface[*v3.Token](ctrl)
+			ccache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](ctrl)
+
+			timer := NewMocktimeHandler(ctrl)
+			hasher := NewMockhashHandler(ctrl)
+			auth := NewMockauthHandler(ctrl)
+
+			store := NewSystem(nil, nsCache, secrets, users, tcache, ccache, timer, hasher, auth, test.authorizer)
+
+			ucache.EXPECT().Get("world").Return(&v3.User{Enabled: ptr.To(true)}, nil)
+
+			auth.EXPECT().SessionID(gomock.Any()).Return("session-token", nil)
+			tcache.EXPECT().Get("session-token").Return(&v3.Token{
+				AuthProvider: "local",
+				UserPrincipal: v3.Principal{
+					ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
+				},
+			}, nil)
+
+			if test.clusterErr != nil {
+				ccache.EXPECT().Get("c-m-missing").Return(nil, test.clusterErr)
+			} else {
+				ccache.EXPECT().Get(test.cluster.Name).Return(test.cluster, nil)
+			}
+
+			if test.err == "" {
+				hasher.EXPECT().MakeAndHashSecret().Return("secretval", "hashval", nil)
+				timer.EXPECT().Now().Return("fake-now")
+
+				secrets.EXPECT().Create(gomock.Any()).Return(&properSecret, nil)
+			}
+
+			token := &ext.Token{
+				Spec: ext.TokenSpec{
+					UserID:      "world",
+					ClusterName: "c-m-test",
+				},
+			}
+			if test.clusterErr != nil {
+				token.Spec.ClusterName = "c-m-missing"
+			}
+
+			userInfo := &mockUser{name: "world"}
+			_, err := store.Create(context.Background(), GVR.GroupResource(), token, &metav1.CreateOptions{}, userInfo)
+
+			if test.err != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Issue: #55117 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The system token store panicked when creating cluster-scoped tokens because its constructor never accepted an authorizer. When a kubeconfig was requested for an ACE-enabled cluster with token generation on, the store tried to authorize cluster access through the nil authorizer.

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added an optional authorizer parameter to the system store constructors and a nil guard that returns an explicit error instead of panicking. The kubeconfig store now passes its authorizer through.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests