### PR TITLE
Set kubeconfig-id label on tokens created by kubeconfigs

### DIFF
--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -466,7 +466,7 @@ func (s *Store) Create(
 	err = func() error { // Deliberately use an anonymous function to capture the status and error conditions.
 		// Generate a shared token for the default and non-ACE clusters.
 		if !dryRun && generateToken && needsSharedToken {
-			extToken := s.buildExtToken(userInfo.GetName(), authToken, ttlMilliseconds, "")
+			extToken := s.buildExtToken(userInfo.GetName(), authToken, ttlMilliseconds, "", kubeConfigID)
 			sharedToken, err := s.tokenMgr.CreateToken(ctx, extToken, userInfo)
 			if err != nil {
 				conditions = append(conditions, metav1.Condition{
@@ -557,7 +557,7 @@ func (s *Store) Create(
 
 			// Generate a cluster-scoped token for the ACE cluster.
 			if !dryRun && generateToken {
-				extToken := s.buildExtToken(userInfo.GetName(), authToken, ttlMilliseconds, cluster.Name)
+				extToken := s.buildExtToken(userInfo.GetName(), authToken, ttlMilliseconds, cluster.Name, kubeConfigID)
 				clusterToken, err := s.tokenMgr.CreateToken(ctx, extToken, userInfo)
 				if err != nil {
 					conditions = append(conditions, metav1.Condition{
@@ -864,8 +864,13 @@ func first(values []string) string {
 }
 
 // buildExtToken builds an [ext.Token] for a kubeconfig token.
-func (s *Store) buildExtToken(userName string, authToken accessor.TokenAccessor, ttl int64, clusterID string) *ext.Token {
+func (s *Store) buildExtToken(userName string, authToken accessor.TokenAccessor, ttl int64, clusterID, kubeConfigID string) *ext.Token {
 	return &ext.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				tokens.TokenKubeconfigIDLabel: kubeConfigID,
+			},
+		},
 		Spec: ext.TokenSpec{
 			UserID:        userName,
 			UserPrincipal: toExtTokenPrincipal(authToken.GetUserPrincipal()),

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -428,7 +428,12 @@ func TestStoreCreate(t *testing.T) {
 			return configMap, nil
 		}).Times(1)
 
-		tokenManager := &fakeTokenManager{} // Subtest specific instance.
+		var createdTokens []*ext.Token
+		tokenManager := &fakeTokenManager{}
+		tokenManager.createTokenFunc = func(ctx context.Context, token *ext.Token, userInfo k8suser.Info) (*ext.Token, error) {
+			createdTokens = append(createdTokens, token.DeepCopy())
+			return tokenManager.generate(token)
+		}
 
 		store := &Store{
 			mcmEnabled:          true,
@@ -546,6 +551,11 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, tokenManager.sharedTokenKeys[0], config.AuthInfos[defaultClusterName].Token)
 		require.Len(t, tokenManager.clusterTokenKeys, 1)
 		assert.Equal(t, tokenManager.clusterTokenKeys[0], config.AuthInfos["downstream2"].Token)
+
+		require.Len(t, createdTokens, 2)
+		for _, tok := range createdTokens {
+			assert.Equal(t, created.Name, tok.Labels["authn.management.cattle.io/kubeconfig-id"])
+		}
 
 		assert.Equal(t, "downstream1", config.CurrentContext)
 	})


### PR DESCRIPTION
## Issue: #55118 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a kubeconfig generates backing tokens, the token was missing the kubeconfig-id label that links it back to the originating kubeconfig. This was a regression from the migration to ext tokens.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The token builder now carries the kubeconfig ID through and sets it as a label on each created token.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests