### PR TITLE
Ensure local-user-passwords are stored without MCM

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,7 +223,6 @@ func initLogs(c *cli.Context, cfg rancher.Options) {
 
 func run(cli *cli.Context, cfg rancher.Options) error {
 	logrus.Infof("Rancher version %s is starting", version.FriendlyVersion())
-	logrus.Infof("Rancher arguments %+v", cfg)
 	ctx := signals.SetupSignalContext()
 
 	if cfg.AddLocal != "true" && cfg.AddLocal != "auto" {
@@ -235,6 +234,8 @@ func run(cli *cli.Context, cfg rancher.Options) error {
 		return err
 	}
 	cfg.Embedded = embedded
+	cfg.LocalUserPasswordsNamespace = true
+	logrus.Infof("Rancher arguments %+v", cfg)
 
 	os.Unsetenv("KUBECONFIG")
 

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -111,6 +111,10 @@ type Options struct {
 	ClusterRegistry                string
 	AggregationRegistrationTimeout time.Duration
 	RancherNamespaceOptions        string
+
+	// LocalUserPasswordsNamespace should be set to true if the namespace for
+	// storing user passwords should be created.
+	LocalUserPasswordsNamespace bool
 }
 
 type Rancher struct {
@@ -445,7 +449,7 @@ func getSQLCacheGCValues(wranglerContext *wrangler.Context) (time.Duration, int)
 }
 
 func (r *Rancher) Start(ctx context.Context) error {
-	if features.MCM.Enabled() {
+	if r.opts.LocalUserPasswordsNamespace {
 		// ensure namespace for storing local users password is created
 		if _, err := r.Wrangler.Core.Namespace().Create(&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: pbkdf2.LocalUserPasswordsNamespace},


### PR DESCRIPTION
## Issue: #55134 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Harvester disables MCM in Rancher and the fix to not create the local-user-passwords namespace caused problems because the decision on whether or not to create the namespace was predicated on this.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This changes the logic for local-user-passwords to only create them if explicitly configured to do so, and the main rancher binary enables this.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_


```
$ kubectl get features | grep multi-cluster && k get namespaces | grep passwords
multi-cluster-management                         <no value>     false     Multi-cluster provisioning and management of Kubernetes clusters.
cattle-local-user-passwords   Active   76s
 ```

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_