### PR TITLE
[Backport 2.14] Ensure local-user-passwords are stored when MCM is not enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,7 +217,6 @@ func initLogs(c *cli.Context, cfg rancher.Options) {
 
 func run(cli *cli.Context, cfg rancher.Options) error {
 	logrus.Infof("Rancher version %s is starting", version.FriendlyVersion())
-	logrus.Infof("Rancher arguments %+v", cfg)
 	ctx := signals.SetupSignalContext()
 
 	if cfg.AddLocal != "true" && cfg.AddLocal != "auto" {
@@ -229,6 +228,8 @@ func run(cli *cli.Context, cfg rancher.Options) error {
 		return err
 	}
 	cfg.Embedded = embedded
+	cfg.LocalUserPasswordsNamespace = true
+	logrus.Infof("Rancher arguments %+v", cfg)
 
 	os.Unsetenv("KUBECONFIG")
 

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -110,6 +110,10 @@ type Options struct {
 	ClusterRegistry                string
 	AggregationRegistrationTimeout time.Duration
 	RancherNamespaceOptions        string
+
+	// LocalUserPasswordsNamespace should be set to true if the namespace for
+	// storing user passwords should be created.
+	LocalUserPasswordsNamespace bool
 }
 
 type Rancher struct {
@@ -443,7 +447,7 @@ func getSQLCacheGCValues(wranglerContext *wrangler.Context) (time.Duration, int)
 }
 
 func (r *Rancher) Start(ctx context.Context) error {
-	if features.MCM.Enabled() {
+	if r.opts.LocalUserPasswordsNamespace {
 		// ensure namespace for storing local users password is created
 		if _, err := r.Wrangler.Core.Namespace().Create(&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: pbkdf2.LocalUserPasswordsNamespace},


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/55136 to v2.14