### PR TITLE
Use patch instead of update for githubapp migration annotation

### DIFF
--- a/pkg/data/management/githubapp_refresh_users.go
+++ b/pkg/data/management/githubapp_refresh_users.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	"github.com/rancher/rancher/pkg/auth/providers/githubapp"
@@ -9,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const providerRefreshRequestedAnnotation = "auth.cattle.io/provider-refresh-requested"
@@ -21,7 +23,8 @@ const providerRefreshRequestedAnnotation = "auth.cattle.io/provider-refresh-requ
 func RefreshGitHubAppUsersOnce(ctx context.Context, authConfigs apisv3.AuthConfigClient) {
 	authConfig, err := authConfigs.Get(githubapp.Name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		return // Provider config is missing; nothing to do.
+		logrus.Debugf("refreshGitHubAppUsersOnce: AuthConfig %s not found, skipping", githubapp.Name)
+		return
 	}
 	if err != nil {
 		logrus.Errorf("refreshGitHubAppUsersOnce: getting AuthConfig: %v", err)
@@ -29,22 +32,34 @@ func RefreshGitHubAppUsersOnce(ctx context.Context, authConfigs apisv3.AuthConfi
 	}
 
 	if !authConfig.Enabled {
-		return // Provider is not enabled; nothing to do.
+		logrus.Debugf("refreshGitHubAppUsersOnce: provider %s is not enabled, skipping", githubapp.Name)
+		return
 	}
 
 	if authConfig.Annotations[providerRefreshRequestedAnnotation] == "true" {
-		return // Already ran.
+		logrus.Debugf("refreshGitHubAppUsersOnce: provider %s already refreshed, skipping", githubapp.Name)
+		return
 	}
 
+	logrus.Infof("refreshGitHubAppUsersOnce: triggering refresh for all users of provider %s", githubapp.Name)
 	providerrefresh.TriggerAllUserRefresh()
 
-	// Set the annotation so subsequent restarts skip it.
-	authConfig = authConfig.DeepCopy()
-	if authConfig.Annotations == nil {
-		authConfig.Annotations = map[string]string{}
+	// Use a JSON Merge Patch instead of a typed Update to set the
+	// annotation. AuthConfig objects store provider-specific fields not
+	// defined in the base v3.AuthConfig struct; a typed Update (PUT)
+	// would strip those fields and corrupt the stored configuration.
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				providerRefreshRequestedAnnotation: "true",
+			},
+		},
+	})
+	if err != nil {
+		logrus.Errorf("refreshGitHubAppUsersOnce: marshaling patch: %v", err)
+		return
 	}
-	authConfig.Annotations[providerRefreshRequestedAnnotation] = "true"
-	if _, err := authConfigs.Update(authConfig); err != nil {
-		logrus.Warnf("refreshGitHubAppUsersOnce: setting annotation: %v", err)
+	if _, err := authConfigs.Patch(githubapp.Name, types.MergePatchType, patch); err != nil {
+		logrus.Warnf("refreshGitHubAppUsersOnce: patching annotation: %v", err)
 	}
 }

--- a/pkg/data/management/githubapp_refresh_users_test.go
+++ b/pkg/data/management/githubapp_refresh_users_test.go
@@ -1,16 +1,19 @@
 package management
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestRefreshGitHubAppUsersOnce(t *testing.T) {
@@ -19,11 +22,10 @@ func TestRefreshGitHubAppUsersOnce(t *testing.T) {
 	notFound := k8serrors.NewNotFound(schema.GroupResource{Resource: "authconfigs"}, "githubapp")
 
 	tests := []struct {
-		name            string
-		authConfig      *v3.AuthConfig
-		getErr          error
-		wantUpdateCalls int
-		wantAnnotation  bool
+		name       string
+		authConfig *v3.AuthConfig
+		getErr     error
+		wantPatch  bool
 	}{
 		{
 			name:   "provider not configured",
@@ -49,7 +51,6 @@ func TestRefreshGitHubAppUsersOnce(t *testing.T) {
 				},
 				Enabled: true,
 			},
-			wantAnnotation: true,
 		},
 		{
 			name: "first run",
@@ -57,8 +58,7 @@ func TestRefreshGitHubAppUsersOnce(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "githubapp"},
 				Enabled:    true,
 			},
-			wantUpdateCalls: 1,
-			wantAnnotation:  true,
+			wantPatch: true,
 		},
 	}
 
@@ -71,23 +71,20 @@ func TestRefreshGitHubAppUsersOnce(t *testing.T) {
 			mock := fake.NewMockNonNamespacedClientInterface[*v3.AuthConfig, *v3.AuthConfigList](ctrl)
 			mock.EXPECT().Get("githubapp", metav1.GetOptions{}).Return(tt.authConfig, tt.getErr)
 
-			var updated *v3.AuthConfig
-			if tt.wantUpdateCalls > 0 {
-				mock.EXPECT().Update(gomock.Any()).DoAndReturn(func(cfg *v3.AuthConfig) (*v3.AuthConfig, error) {
-					updated = cfg
-					return cfg, nil
-				}).Times(tt.wantUpdateCalls)
+			if tt.wantPatch {
+				mock.EXPECT().Patch("githubapp", types.MergePatchType, gomock.Any()).DoAndReturn(
+					func(_ string, _ types.PatchType, data []byte, _ ...string) (*v3.AuthConfig, error) {
+						var payload map[string]any
+						require.NoError(t, json.Unmarshal(data, &payload))
+						metadata, _ := payload["metadata"].(map[string]any)
+						annotations, _ := metadata["annotations"].(map[string]any)
+						assert.Equal(t, "true", annotations[providerRefreshRequestedAnnotation])
+						return tt.authConfig, nil
+					},
+				)
 			}
 
 			RefreshGitHubAppUsersOnce(t.Context(), mock)
-
-			if tt.wantAnnotation {
-				source := updated
-				if source == nil {
-					source = tt.authConfig
-				}
-				assert.Equal(t, "true", source.Annotations[providerRefreshRequestedAnnotation])
-			}
 		})
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The one-time migration that refreshes GitHub App user group memberships after upgrade was not persisting its guard annotation. The function used a typed Update (PUT) on the AuthConfig, but AuthConfig objects store provider-specific fields that are not defined in the base type. A typed PUT would strip those fields, either corrupting the configuration or failing due to a concurrent update conflict with the auth config controller.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Switched to a JSON Merge Patch that only touches the annotation, preserving all other fields.

Added logging on every code path so the migration outcome is always visible in logs.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests