### PR TITLE
Mark GitHubApp provider as not using per-user secrets

### DIFF
--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -85,7 +85,6 @@ func Configure(ctx context.Context, mgmt *config.ScaledContext) {
 
 	p = githubapp.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[githubapp.Name] = true
-	providersWithSecrets[githubapp.Name] = true
 	Providers[githubapp.Name] = p
 
 	p = azure.Configure(mgmt, userMGR, tokenMGR)


### PR DESCRIPTION
## Issue: N/A <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The GitHubApp provider was registered as having per-user secrets, but it authenticates to the GitHub API using the App's own private key — a service-level credential stored in the AuthConfig, not a per-user token. Because no user secret is ever created during login, the provider refresh always failed to find one and silently skipped the refresh entirely. Group memberships were only updated on login.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Removed the per-user secret registration for the GitHubApp provider so the provider refresh proceeds with re-fetching group principals.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

N/A