### PR TITLE
[v2.13] Mark GitHubApp provider as not using per-user secrets

### DIFF
--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -85,7 +85,6 @@ func Configure(ctx context.Context, mgmt *config.ScaledContext) {
 
 	p = githubapp.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[githubapp.Name] = true
-	providersWithSecrets[githubapp.Name] = true
 	Providers[githubapp.Name] = p
 
 	p = azure.Configure(mgmt, userMGR, tokenMGR)


### PR DESCRIPTION
Backport of #55156