### PR TITLE
Move provider metadata to the AuthProvider interface

### DIFF
--- a/pkg/api/norman/customization/cluster/formatter_test.go
+++ b/pkg/api/norman/customization/cluster/formatter_test.go
@@ -14,7 +14,7 @@ import (
 // stubURLBuilder is a minimal implementation of types.URLBuilder for testing.
 type stubURLBuilder struct{}
 
-func (s *stubURLBuilder) Current() string { return "http://rancher.test" }
+func (s *stubURLBuilder) Current() string                                        { return "http://rancher.test" }
 func (s *stubURLBuilder) Collection(_ *types.Schema, _ *types.APIVersion) string { return "" }
 func (s *stubURLBuilder) CollectionAction(_ *types.Schema, _ *types.APIVersion, _ string) string {
 	return ""
@@ -22,25 +22,25 @@ func (s *stubURLBuilder) CollectionAction(_ *types.Schema, _ *types.APIVersion, 
 func (s *stubURLBuilder) SubContextCollection(_ *types.Schema, _ string, _ *types.Schema) string {
 	return ""
 }
-func (s *stubURLBuilder) SchemaLink(_ *types.Schema) string                        { return "" }
+func (s *stubURLBuilder) SchemaLink(_ *types.Schema) string { return "" }
 func (s *stubURLBuilder) ResourceLink(resource *types.RawResource) string {
 	return "http://rancher.test/v3/clusters/" + resource.ID
 }
 func (s *stubURLBuilder) Link(linkName string, resource *types.RawResource) string {
 	return "http://rancher.test/v3/clusters/" + resource.ID + "/" + linkName
 }
-func (s *stubURLBuilder) RelativeToRoot(path string) string            { return path }
-func (s *stubURLBuilder) Version(_ types.APIVersion) string            { return "" }
-func (s *stubURLBuilder) Marker(marker string) string                  { return marker }
-func (s *stubURLBuilder) ReverseSort(_ types.SortOrder) string         { return "" }
-func (s *stubURLBuilder) Sort(_ string) string                         { return "" }
-func (s *stubURLBuilder) SetSubContext(_ string)                        {}
+func (s *stubURLBuilder) RelativeToRoot(path string) string              { return path }
+func (s *stubURLBuilder) Version(_ types.APIVersion) string              { return "" }
+func (s *stubURLBuilder) Marker(marker string) string                    { return marker }
+func (s *stubURLBuilder) ReverseSort(_ types.SortOrder) string           { return "" }
+func (s *stubURLBuilder) Sort(_ string) string                           { return "" }
+func (s *stubURLBuilder) SetSubContext(_ string)                         {}
 func (s *stubURLBuilder) FilterLink(_ *types.Schema, _, _ string) string { return "" }
 func (s *stubURLBuilder) Action(action string, resource *types.RawResource) string {
 	return "http://rancher.test/v3/clusters/" + resource.ID + "?action=" + action
 }
-func (s *stubURLBuilder) ResourceLinkByID(_ *types.Schema, _ string) string         { return "" }
-func (s *stubURLBuilder) ActionLinkByID(_ *types.Schema, _, _ string) string        { return "" }
+func (s *stubURLBuilder) ResourceLinkByID(_ *types.Schema, _ string) string  { return "" }
+func (s *stubURLBuilder) ActionLinkByID(_ *types.Schema, _, _ string) string { return "" }
 
 func TestFormatter_ShellLink(t *testing.T) {
 	tests := []struct {

--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -208,6 +208,7 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 		// We have to find out if the user has a principal for the provider.
 		principalID := GetPrincipalIDForProvider(providerName, user)
 		var newGroupPrincipals []apiv3.Principal
+		canRefresh := true
 
 		providerDisabled, err := providers.IsDisabledProvider(providerName)
 		if err != nil {
@@ -223,7 +224,6 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 		// If there is no principalID for the provider, there is no reason to go through the refetch process
 		if principalID != "" {
 			secret := ""
-			canRefresh := true
 
 			if providers.ProviderUsesUserSecrets(providerName) {
 				secret, err = r.tokenMGR.GetSecret(user.Name, providerName, loginTokens[providerName])
@@ -300,23 +300,24 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 		// Update extras if either the user has an active login token, or an API token/kubeconfig token and is still active in the auth provider.
 		// If the user cannot access the auth provider, the derived tokens are deactivated below and should not be used to determine extra attributes.
 		if principalID != "" && (len(loginTokens[providerName]) > 0 || (len(derivedTokens[providerName]) > 0 && (canAccessProvider || errorConfirmingLogins))) {
-			// A user is 1:1 with its principal for a given provider, no need to get principals from tokens beyond the first one
-			var token accessor.TokenAccessor
-			if len(loginTokens[providerName]) > 0 {
-				token = loginTokens[providerName][0]
-			} else {
-				token = derivedTokens[providerName][0]
-			}
-			userPrincipal, err := providers.GetPrincipal(principalID, token)
-			if err != nil {
-				return nil, err
-			}
-			userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
-			if userExtraInfo != nil {
-				if attribs.ExtraByProvider == nil {
-					attribs.ExtraByProvider = make(map[string]map[string][]string)
+			if canRefresh {
+				var token accessor.TokenAccessor
+				if len(loginTokens[providerName]) > 0 {
+					token = loginTokens[providerName][0]
+				} else {
+					token = derivedTokens[providerName][0]
 				}
-				attribs.ExtraByProvider[providerName] = userExtraInfo
+				userPrincipal, err := providers.GetPrincipal(principalID, token)
+				if err != nil {
+					return nil, err
+				}
+				userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
+				if userExtraInfo != nil {
+					if attribs.ExtraByProvider == nil {
+						attribs.ExtraByProvider = make(map[string]map[string][]string)
+					}
+					attribs.ExtraByProvider[providerName] = userExtraInfo
+				}
 			}
 		}
 

--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -299,25 +299,23 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 
 		// Update extras if either the user has an active login token, or an API token/kubeconfig token and is still active in the auth provider.
 		// If the user cannot access the auth provider, the derived tokens are deactivated below and should not be used to determine extra attributes.
-		if principalID != "" && (len(loginTokens[providerName]) > 0 || (len(derivedTokens[providerName]) > 0 && (canAccessProvider || errorConfirmingLogins))) {
-			if canRefresh {
-				var token accessor.TokenAccessor
-				if len(loginTokens[providerName]) > 0 {
-					token = loginTokens[providerName][0]
-				} else {
-					token = derivedTokens[providerName][0]
+		if principalID != "" && canRefresh && (len(loginTokens[providerName]) > 0 || (len(derivedTokens[providerName]) > 0 && (canAccessProvider || errorConfirmingLogins))) {
+			var token accessor.TokenAccessor
+			if len(loginTokens[providerName]) > 0 {
+				token = loginTokens[providerName][0]
+			} else {
+				token = derivedTokens[providerName][0]
+			}
+			userPrincipal, err := providers.GetPrincipal(principalID, token)
+			if err != nil {
+				return nil, err
+			}
+			userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
+			if userExtraInfo != nil {
+				if attribs.ExtraByProvider == nil {
+					attribs.ExtraByProvider = make(map[string]map[string][]string)
 				}
-				userPrincipal, err := providers.GetPrincipal(principalID, token)
-				if err != nil {
-					return nil, err
-				}
-				userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
-				if userExtraInfo != nil {
-					if attribs.ExtraByProvider == nil {
-						attribs.ExtraByProvider = make(map[string]map[string][]string)
-					}
-					attribs.ExtraByProvider[providerName] = userExtraInfo
-				}
+				attribs.ExtraByProvider[providerName] = userExtraInfo
 			}
 		}
 

--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -156,7 +156,51 @@ func (r *refresher) triggerUserRefresh(userName string, force bool) {
 	}
 }
 
-func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAttribute, error) {
+func (r *refresher) deleteToken(token accessor.TokenAccessor) error {
+	switch token.(type) {
+	case *apiv3.Token:
+		return r.tokens.Delete(token.GetName(), &metav1.DeleteOptions{})
+	case *ext.Token:
+		return r.extTokenStore.Delete(token.GetName(), &metav1.DeleteOptions{})
+	default:
+		return fmt.Errorf("unable to delete token of unknown type %T", token)
+	}
+}
+
+func (r *refresher) disableToken(token accessor.TokenAccessor) error {
+	switch t := token.(type) {
+	case *apiv3.Token:
+		v3Token := t.DeepCopy()
+		v3Token.Enabled = ptr.To(false)
+		_, err := r.tokenMGR.UpdateToken(v3Token)
+		return err
+	case *ext.Token:
+		return r.extTokenStore.Disable(t.GetName())
+	default:
+		return fmt.Errorf("unable to disable token of unknown type %T", token)
+	}
+}
+
+func (r *refresher) deleteLoginTokens(providerName string, loginTokens map[string][]accessor.TokenAccessor) error {
+	for _, token := range loginTokens[providerName] {
+		if err := r.deleteToken(token); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// refreshAttributes re-evaluates a user's access across all configured auth
+// providers. For each provider it refreshes group memberships, checks whether
+// the user can still log in, and cleans up login tokens for providers that
+// rejected the user. If no provider confirms access and none had transient
+// errors, all derived (non-login) tokens are disabled. Transient errors are
+// treated conservatively: tokens are preserved to avoid locking out users due
+// to temporary IdP failures.
+func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*apiv3.UserAttribute, error) {
 	var (
 		derivedTokenList      []accessor.TokenAccessor
 		canLogInAtAll         bool
@@ -183,7 +227,6 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 		}
 	}
 
-	// List v3.Tokens.
 	tokenUserIDLabelSet := labels.Set(map[string]string{tokens.UserIDLabel: user.Name})
 	v3Tokens, err := r.tokenLister.List("", tokenUserIDLabelSet.AsSelector())
 	if err != nil {
@@ -194,7 +237,6 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 		assign(token)
 	}
 
-	// List ext.Tokens.
 	extTokens, err := r.extTokenStore.ListForUser(user.Name)
 	if err != nil {
 		return nil, fmt.Errorf("error listing ext tokens for user %s: %w", user.Name, err)
@@ -205,173 +247,176 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 	}
 
 	for _, providerName := range providers.ProviderNames() {
-		// We have to find out if the user has a principal for the provider.
-		principalID := GetPrincipalIDForProvider(providerName, user)
-		var newGroupPrincipals []apiv3.Principal
-		canRefresh := true
-
-		providerDisabled, err := providers.IsDisabledProvider(providerName)
+		canAccess, errConfirming, err := r.refreshProvider(attribs, providerName, user, loginTokens, derivedTokens, errorConfirmingLogins)
 		if err != nil {
-			logrus.Warnf("Unable to determine if provider %s was disabled, will assume that it isn't with error: %v", providerName, err)
-			// This is set as false by the return, but it's re-set here to be explicit/safe about the behavior.
-			providerDisabled = false
+			return nil, err
 		}
-		if providerDisabled {
-			// If this auth provider has been disabled, act as though the user lost access to this provider.
-			principalID = ""
+		if errConfirming {
+			errorConfirmingLogins = true
 		}
-
-		// If there is no principalID for the provider, there is no reason to go through the refetch process
-		if principalID != "" {
-			secret := ""
-
-			if providers.ProviderUsesUserSecrets(providerName) {
-				secret, err = r.tokenMGR.GetSecret(user.Name, providerName, loginTokens[providerName])
-				if apierrors.IsNotFound(err) {
-					canRefresh = false
-					errorConfirmingLogins = true
-				} else if err != nil {
-					return nil, err
-				}
-			}
-
-			if !providers.ProviderCanRefreshPrincipals(providerName) || !canRefresh {
-				existingPrincipals := attribs.GroupPrincipals[providerName].Items
-				if existingPrincipals != nil {
-					newGroupPrincipals = existingPrincipals
-				}
-			} else {
-				newGroupPrincipals, err = providers.RefetchGroupPrincipals(principalID, providerName, secret)
-				if err != nil {
-					// Non-transient errors (e.g. invalid_grant when the user's IdP session
-					// is revoked) must propagate to the controller so it can annotate the
-					// UserAttribute and stop requeuing. Without this, the loop continues
-					// to GetPrincipal which hits the same issue and keeps requeuing.
-					var nte *common.NonTransientError
-					if errors.As(err, &nte) {
-						return nil, err
-					}
-					// In the case that we cant access a server, we still want to continue refreshing, but
-					// we no longer want to disable derived tokens, or remove their login tokens for this provider.
-					if err.Error() != "no access" {
-						errorConfirmingLogins = true
-						logrus.Warnf(
-							"Error refreshing token principals for auth provider %s, userattribute %s, principal %s, skipping: %v",
-							providerName,
-							attribs.Name,
-							principalID,
-							err,
-						)
-						existingPrincipals := attribs.GroupPrincipals[providerName].Items
-						if existingPrincipals != nil {
-							newGroupPrincipals = existingPrincipals
-						}
-					} else {
-						// In the case that the user explicitly cannot login at all to this provider
-						// (e.g. they no longer exist) we pretend they have no principal with this provider
-						// so that their login tokens get blanked out
-						principalID = ""
-					}
-				}
-			}
-		}
-
-		if len(newGroupPrincipals) == 0 {
-			newGroupPrincipals = nil
-		}
-
-		attribs.GroupPrincipals[providerName] = apiv3.Principals{Items: newGroupPrincipals}
-
-		canAccessProvider := false
-
-		if principalID != "" && !errorConfirmingLogins {
-			// We want to verify that the user still has rancher access.
-			canStillAccess, err := providers.CanAccessWithGroupProviders(providerName, principalID, newGroupPrincipals)
-			if err != nil {
-				return nil, err
-			}
-
-			if canStillAccess {
-				canAccessProvider = true
-				canLogInAtAll = true
-			}
-		}
-
-		// Update extras if either the user has an active login token, or an API token/kubeconfig token and is still active in the auth provider.
-		// If the user cannot access the auth provider, the derived tokens are deactivated below and should not be used to determine extra attributes.
-		if principalID != "" && canRefresh && (len(loginTokens[providerName]) > 0 || (len(derivedTokens[providerName]) > 0 && (canAccessProvider || errorConfirmingLogins))) {
-			var token accessor.TokenAccessor
-			if len(loginTokens[providerName]) > 0 {
-				token = loginTokens[providerName][0]
-			} else {
-				token = derivedTokens[providerName][0]
-			}
-			userPrincipal, err := providers.GetPrincipal(principalID, token)
-			if err != nil {
-				return nil, err
-			}
-			userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
-			if userExtraInfo != nil {
-				if attribs.ExtraByProvider == nil {
-					attribs.ExtraByProvider = make(map[string]map[string][]string)
-				}
-				attribs.ExtraByProvider[providerName] = userExtraInfo
-			}
-		}
-
-		// If the user doesn't have access through this provider, we want to remove their
-		// login tokens for this provider
-		if !canAccessProvider && !errorConfirmingLogins {
-			for _, token := range loginTokens[providerName] {
-				var err error
-				switch token.(type) {
-				case *apiv3.Token:
-					err = r.tokens.Delete(token.GetName(), &metav1.DeleteOptions{})
-				case *ext.Token:
-					err = r.extTokenStore.Delete(token.GetName(), &metav1.DeleteOptions{})
-				default:
-					err = fmt.Errorf("unable to delete token of unknown type %T", token)
-				}
-				if err != nil {
-					if apierrors.IsNotFound(err) {
-						continue
-					}
-					return nil, err
-				}
-			}
+		if canAccess {
+			canLogInAtAll = true
 		}
 	}
 
-	// If they can still log in, or we failed to validate one of their logins, don't disable derived tokens
 	if canLogInAtAll || errorConfirmingLogins {
 		return attribs, nil
 	}
 
-	// User has been deactivated, disable their tokens.
 	for _, token := range derivedTokenList {
-		var err error
-		switch t := token.(type) {
-		case *apiv3.Token:
-			v3Token := t.DeepCopy()
-			v3Token.Enabled = ptr.To(false)
-			_, err = r.tokenMGR.UpdateToken(v3Token)
-		case *ext.Token:
-			err = r.extTokenStore.Disable(t.GetName())
-		default:
-			err = fmt.Errorf("unable to update token of unknown type %T", token)
-		}
-		if err != nil {
+		if err := r.disableToken(token); err != nil {
 			return nil, fmt.Errorf("error disabling token %s: %w", token.GetName(), err)
 		}
 	}
-	return attribs, err
+
+	return attribs, nil
 }
 
-func GetPrincipalIDForProvider(providerName string, user *v3.User) string {
+// refreshProvider refreshes a single provider's state within attribs.
+// It returns whether the user can access the provider and whether there was
+// an error confirming their login (which prevents token cleanup).
+func (r *refresher) refreshProvider(
+	attribs *apiv3.UserAttribute,
+	providerName string,
+	user *apiv3.User,
+	loginTokens, derivedTokens map[string][]accessor.TokenAccessor,
+	errorConfirmingLogins bool,
+) (canAccess bool, errConfirming bool, err error) {
+	principalID := GetPrincipalIDForProvider(providerName, user)
+
+	providerDisabled, err := providers.IsDisabledProvider(providerName)
+	if err != nil {
+		logrus.Warnf("Unable to determine if provider %s was disabled, will assume that it isn't with error: %v", providerName, err)
+		providerDisabled = false
+	}
+	if providerDisabled {
+		principalID = ""
+	}
+
+	if principalID == "" {
+		attribs.GroupPrincipals[providerName] = apiv3.Principals{}
+		if !errorConfirmingLogins {
+			if err := r.deleteLoginTokens(providerName, loginTokens); err != nil {
+				return false, false, err
+			}
+		}
+		return false, false, nil
+	}
+
+	newGroupPrincipals, canRefresh, errConfirming, principalID, err := r.refreshGroupPrincipals(attribs, providerName, user.Name, principalID, loginTokens)
+	if err != nil {
+		return false, false, err
+	}
+
+	if len(newGroupPrincipals) == 0 {
+		newGroupPrincipals = nil
+	}
+	attribs.GroupPrincipals[providerName] = apiv3.Principals{Items: newGroupPrincipals}
+
+	if principalID != "" && !errorConfirmingLogins && !errConfirming {
+		canStillAccess, err := providers.CanAccessWithGroupProviders(providerName, principalID, newGroupPrincipals)
+		if err != nil {
+			return false, false, err
+		}
+		canAccess = canStillAccess
+	}
+
+	if principalID != "" && canRefresh && (len(loginTokens[providerName]) > 0 || (len(derivedTokens[providerName]) > 0 && (canAccess || errorConfirmingLogins || errConfirming))) {
+		var token accessor.TokenAccessor
+		if len(loginTokens[providerName]) > 0 {
+			token = loginTokens[providerName][0]
+		} else {
+			token = derivedTokens[providerName][0]
+		}
+		userPrincipal, err := providers.GetPrincipal(principalID, token)
+		if err != nil {
+			return false, false, err
+		}
+		userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
+		if userExtraInfo != nil {
+			if attribs.ExtraByProvider == nil {
+				attribs.ExtraByProvider = make(map[string]map[string][]string)
+			}
+			attribs.ExtraByProvider[providerName] = userExtraInfo
+		}
+	}
+
+	if !canAccess && !errorConfirmingLogins && !errConfirming {
+		if err := r.deleteLoginTokens(providerName, loginTokens); err != nil {
+			return false, false, err
+		}
+	}
+
+	return canAccess, errConfirming, nil
+}
+
+// refreshGroupPrincipals fetches or preserves group principals for a provider.
+func (r *refresher) refreshGroupPrincipals(
+	attribs *apiv3.UserAttribute,
+	providerName string,
+	userName string,
+	principalID string,
+	loginTokens map[string][]accessor.TokenAccessor,
+) (groups []apiv3.Principal, canRefresh bool, errConfirming bool, updatedPrincipalID string, err error) {
+	canRefresh = true
+	updatedPrincipalID = principalID
+	secret := ""
+
+	if providers.ProviderUsesUserSecrets(providerName) {
+		secret, err = r.tokenMGR.GetSecret(userName, providerName, loginTokens[providerName])
+		if apierrors.IsNotFound(err) {
+			canRefresh = false
+			errConfirming = true
+		} else if err != nil {
+			return nil, false, false, principalID, err
+		}
+	}
+
+	if !providers.ProviderCanRefreshPrincipals(providerName) || !canRefresh {
+		existing := attribs.GroupPrincipals[providerName].Items
+		if existing != nil {
+			groups = existing
+		}
+		return groups, canRefresh, errConfirming, updatedPrincipalID, nil
+	}
+
+	groups, err = providers.RefetchGroupPrincipals(principalID, providerName, secret)
+	if err == nil {
+		return groups, canRefresh, errConfirming, updatedPrincipalID, nil
+	}
+
+	// Non-transient errors must propagate so the controller can annotate
+	// the UserAttribute and stop requeuing.
+	var nte *common.NonTransientError
+	if errors.As(err, &nte) {
+		return nil, false, false, principalID, err
+	}
+
+	if err.Error() != "no access" {
+		errConfirming = true
+		logrus.Warnf(
+			"Error refreshing token principals for auth provider %s, userattribute %s, principal %s, skipping: %v",
+			providerName, attribs.Name, principalID, err,
+		)
+		existing := attribs.GroupPrincipals[providerName].Items
+		if existing != nil {
+			groups = existing
+		}
+		return groups, canRefresh, errConfirming, updatedPrincipalID, nil
+	}
+
+	// User explicitly cannot log in (e.g. they no longer exist in the IdP).
+	// Blank their principal so login tokens get cleaned up.
+	updatedPrincipalID = ""
+	return nil, canRefresh, errConfirming, updatedPrincipalID, nil
+}
+
+func GetPrincipalIDForProvider(providerName string, user *apiv3.User) string {
 	prefix := providerName + "_user://"
 	if providerName == "local" {
 		prefix = "local://"
 	}
+
 	principalID := ""
 	for _, id := range user.PrincipalIDs {
 		if strings.HasPrefix(id, prefix) {
@@ -379,5 +424,6 @@ func GetPrincipalIDForProvider(providerName string, user *v3.User) string {
 			break
 		}
 	}
+
 	return principalID
 }

--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -204,7 +204,7 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 		assign(&token)
 	}
 
-	for providerName := range providers.ProviderNames {
+	for _, providerName := range providers.ProviderNames() {
 		// We have to find out if the user has a principal for the provider.
 		principalID := GetPrincipalIDForProvider(providerName, user)
 		var newGroupPrincipals []apiv3.Principal
@@ -223,23 +223,19 @@ func (r *refresher) refreshAttributes(attribs *apiv3.UserAttribute) (*v3.UserAtt
 		// If there is no principalID for the provider, there is no reason to go through the refetch process
 		if principalID != "" {
 			secret := ""
-			hasPerUserSecrets, err := providers.ProviderHasPerUserSecrets(providerName)
-			if err != nil {
-				return nil, err
-			}
-			if hasPerUserSecrets {
+			canRefresh := true
+
+			if providers.ProviderUsesUserSecrets(providerName) {
 				secret, err = r.tokenMGR.GetSecret(user.Name, providerName, loginTokens[providerName])
 				if apierrors.IsNotFound(err) {
-					// There is no secret so we can't refresh, just continue to the next attribute.
-					return attribs, nil
-				}
-				if err != nil {
+					canRefresh = false
+					errorConfirmingLogins = true
+				} else if err != nil {
 					return nil, err
 				}
 			}
 
-			// SAML cannot refresh, so we do restore the existing principals.
-			if providers.UnrefreshableProviders[providerName] {
+			if !providers.ProviderCanRefreshPrincipals(providerName) || !canRefresh {
 				existingPrincipals := attribs.GroupPrincipals[providerName].Items
 				if existingPrincipals != nil {
 					newGroupPrincipals = existingPrincipals

--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/local"
 	"github.com/rancher/rancher/pkg/auth/providers/saml"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	exttokens "github.com/rancher/rancher/pkg/ext/stores/tokens"
@@ -68,7 +69,7 @@ func TestRefreshAttributes(t *testing.T) {
 			"shibboleth": {},
 		},
 		ExtraByProvider: map[string]map[string][]string{
-			providers.LocalProvider: {
+			local.Name: {
 				common.UserAttributePrincipalID: {"local://user-abcde"},
 				common.UserAttributeUserName:    {"admin"},
 			},
@@ -92,13 +93,13 @@ func TestRefreshAttributes(t *testing.T) {
 	loginTokenLocal := apiv3.Token{
 		UserID:       "user-abcde",
 		IsDerived:    false,
-		AuthProvider: providers.LocalProvider,
+		AuthProvider: local.Name,
 		UserPrincipal: apiv3.Principal{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "local://user-abcde",
 			},
 			LoginName: "admin",
-			Provider:  providers.LocalProvider,
+			Provider:  local.Name,
 			ExtraInfo: map[string]string{
 				common.UserAttributePrincipalID: "local://user-abcde",
 				common.UserAttributeUserName:    "admin",
@@ -138,7 +139,7 @@ func TestRefreshAttributes(t *testing.T) {
 			Kind:   exttokens.IsLogin,
 			UserPrincipal: ext.TokenPrincipal{
 				Name:      "local://user-abcde",
-				Provider:  providers.LocalProvider,
+				Provider:  local.Name,
 				LoginName: "admin",
 				ExtraInfo: map[string]string{
 					common.UserAttributePrincipalID: "local://user-abcde",
@@ -490,23 +491,18 @@ func TestRefreshAttributes(t *testing.T) {
 		},
 	}
 
-	providers.ProviderNames = map[string]bool{
-		providers.LocalProvider: true,
-		saml.ShibbolethName:     true,
-	}
-
 	for _, tt := range tests {
 		tokenUpdateCalled = false
 		tokenDeleteCalled = false
 		t.Run(tt.name, func(t *testing.T) {
-			providers.Providers = map[string]common.AuthProvider{
-				providers.LocalProvider: &mockLocalProvider{
+			providers.SetProviders(map[string]common.AuthProvider{
+				local.Name: &mockLocalProvider{
 					canAccess:   tt.enabled,
 					disabled:    tt.providerDisabled,
 					disabledErr: tt.providerDisabledError,
 				},
 				saml.ShibbolethName: &mockShibbolethProvider{},
-			}
+			})
 
 			ctrl := gomock.NewController(t)
 			secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
@@ -712,12 +708,9 @@ func TestRefreshAttributesNonTransientError(t *testing.T) {
 		},
 	}
 
-	providers.ProviderNames = map[string]bool{
-		providerName: true,
-	}
-	providers.Providers = map[string]common.AuthProvider{
+	providers.SetProviders(map[string]common.AuthProvider{
 		providerName: &mockNonTransientProvider{},
-	}
+	})
 
 	ctrl := gomock.NewController(t)
 	secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
@@ -834,6 +827,9 @@ func (p *mockLocalProvider) GetUserExtraAttributes(userPrincipal apiv3.Principal
 	}
 }
 
+func (p *mockLocalProvider) UsesUserSecrets() bool      { return false }
+func (p *mockLocalProvider) CanRefreshPrincipals() bool { return true }
+
 func (p *mockLocalProvider) CleanupResources(*apiv3.AuthConfig) error {
 	return nil
 }
@@ -894,6 +890,109 @@ func (p *mockShibbolethProvider) GetUserExtraAttributes(userPrincipal apiv3.Prin
 	}
 }
 
+func (p *mockShibbolethProvider) UsesUserSecrets() bool      { return false }
+func (p *mockShibbolethProvider) CanRefreshPrincipals() bool { return false }
+
 func (p *mockShibbolethProvider) CleanupResources(*apiv3.AuthConfig) error {
 	return nil
+}
+
+type mockGitHubAppProvider struct {
+	mockLocalProvider
+	refetchCalled   bool
+	refetchSecret   string
+	groupPrincipals []apiv3.Principal
+}
+
+func (p *mockGitHubAppProvider) RefetchGroupPrincipals(principalID, secret string) ([]apiv3.Principal, error) {
+	p.refetchCalled = true
+	p.refetchSecret = secret
+	return p.groupPrincipals, nil
+}
+
+func (p *mockGitHubAppProvider) IsDisabledProvider() (bool, error) {
+	return false, nil
+}
+
+func TestRefreshAttributesNoPerUserSecrets(t *testing.T) {
+	const providerName = "githubapp"
+
+	user := &apiv3.User{
+		ObjectMeta:   metav1.ObjectMeta{Name: "user-ghapp"},
+		PrincipalIDs: []string{providerName + "_user://12345"},
+	}
+
+	attribs := &apiv3.UserAttribute{
+		ObjectMeta:      metav1.ObjectMeta{Name: "user-ghapp"},
+		GroupPrincipals: map[string]apiv3.Principals{},
+		ExtraByProvider: map[string]map[string][]string{},
+	}
+
+	loginToken := &apiv3.Token{
+		UserID:       "user-ghapp",
+		IsDerived:    false,
+		AuthProvider: providerName,
+		UserPrincipal: apiv3.Principal{
+			ObjectMeta: metav1.ObjectMeta{Name: providerName + "_user://12345"},
+			Provider:   providerName,
+			LoginName:  "testuser",
+			ExtraInfo: map[string]string{
+				common.UserAttributePrincipalID: providerName + "_user://12345",
+				common.UserAttributeUserName:    "testuser",
+			},
+		},
+	}
+
+	wantGroupPrincipals := []apiv3.Principal{
+		{
+			ObjectMeta:    metav1.ObjectMeta{Name: providerName + "_team://org:team1"},
+			PrincipalType: "group",
+			Provider:      providerName,
+		},
+	}
+
+	mockProvider := &mockGitHubAppProvider{
+		mockLocalProvider: mockLocalProvider{canAccess: true},
+		groupPrincipals:   wantGroupPrincipals,
+	}
+
+	providers.SetProviders(map[string]common.AuthProvider{
+		providerName: mockProvider,
+	})
+
+	ctrl := gomock.NewController(t)
+	secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+
+	users.EXPECT().Cache().Return(nil)
+	secrets.EXPECT().Cache().Return(scache)
+	scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+	tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+	r := &refresher{
+		tokenLister: &fakes.TokenListerMock{
+			ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+				return []*apiv3.Token{loginToken}, nil
+			},
+		},
+		userLister: &fakes.UserListerMock{
+			GetFunc: func(_, _ string) (*apiv3.User, error) {
+				return user, nil
+			},
+		},
+		tokens:   &fakes.TokenInterfaceMock{},
+		tokenMGR: tokens.NewMockedManager(tokenClient),
+		extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+			exttokens.NewTimeHandler(),
+			exttokens.NewHashHandler(),
+			exttokens.NewAuthHandler()),
+	}
+
+	got, err := r.refreshAttributes(attribs)
+	assert.NoError(t, err)
+	assert.True(t, mockProvider.refetchCalled, "RefetchGroupPrincipals should be called for providers without per-user secrets")
+	assert.Empty(t, mockProvider.refetchSecret, "secret should be empty for providers without per-user secrets")
+	assert.Equal(t, wantGroupPrincipals, got.GroupPrincipals[providerName].Items)
 }

--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -556,7 +557,7 @@ func TestRefreshAttributes(t *testing.T) {
 						return nil
 					},
 				},
-				tokenMGR: tokens.NewMockedManager(tokenClient),
+				tokenMGR: tokens.NewMockedManager(tokenClient, nil),
 				extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
 					exttokens.NewTimeHandler(),
 					exttokens.NewHashHandler(),
@@ -741,7 +742,7 @@ func TestRefreshAttributesNonTransientError(t *testing.T) {
 				return nil
 			},
 		},
-		tokenMGR: tokens.NewMockedManager(tokenClient),
+		tokenMGR: tokens.NewMockedManager(tokenClient, nil),
 		extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
 			exttokens.NewTimeHandler(),
 			exttokens.NewHashHandler(),
@@ -771,9 +772,11 @@ func (p *mockNonTransientProvider) IsDisabledProvider() (bool, error) {
 }
 
 type mockLocalProvider struct {
-	canAccess   bool
-	disabled    bool
-	disabledErr error
+	canAccess      bool
+	canAccessErr   error
+	getPrincipalFn func(string, accessor.TokenAccessor) (apiv3.Principal, error)
+	disabled       bool
+	disabledErr    error
 }
 
 func (p *mockLocalProvider) IsDisabledProvider() (bool, error) {
@@ -801,6 +804,9 @@ func (p *mockLocalProvider) SearchPrincipals(name, principalType string, myToken
 }
 
 func (p *mockLocalProvider) GetPrincipal(principalID string, token accessor.TokenAccessor) (apiv3.Principal, error) {
+	if p.getPrincipalFn != nil {
+		return p.getPrincipalFn(principalID, token)
+	}
 	return token.GetUserPrincipal(), nil
 }
 
@@ -817,7 +823,7 @@ func (p *mockLocalProvider) RefetchGroupPrincipals(principalID string, secret st
 }
 
 func (p *mockLocalProvider) CanAccessWithGroupProviders(userPrincipalID string, groups []apiv3.Principal) (bool, error) {
-	return p.canAccess, nil
+	return p.canAccess, p.canAccessErr
 }
 
 func (p *mockLocalProvider) GetUserExtraAttributes(userPrincipal apiv3.Principal) map[string][]string {
@@ -983,7 +989,7 @@ func TestRefreshAttributesNoPerUserSecrets(t *testing.T) {
 			},
 		},
 		tokens:   &fakes.TokenInterfaceMock{},
-		tokenMGR: tokens.NewMockedManager(tokenClient),
+		tokenMGR: tokens.NewMockedManager(tokenClient, nil),
 		extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
 			exttokens.NewTimeHandler(),
 			exttokens.NewHashHandler(),
@@ -995,4 +1001,831 @@ func TestRefreshAttributesNoPerUserSecrets(t *testing.T) {
 	assert.True(t, mockProvider.refetchCalled, "RefetchGroupPrincipals should be called for providers without per-user secrets")
 	assert.Empty(t, mockProvider.refetchSecret, "secret should be empty for providers without per-user secrets")
 	assert.Equal(t, wantGroupPrincipals, got.GroupPrincipals[providerName].Items)
+}
+
+type mockSecretProvider struct {
+	mockLocalProvider
+	refetchErr    error
+	refetchGroups []apiv3.Principal
+	refetchCalled bool
+}
+
+func (p *mockSecretProvider) UsesUserSecrets() bool      { return true }
+func (p *mockSecretProvider) CanRefreshPrincipals() bool { return true }
+
+func (p *mockSecretProvider) RefetchGroupPrincipals(principalID, secret string) ([]apiv3.Principal, error) {
+	p.refetchCalled = true
+	return p.refetchGroups, p.refetchErr
+}
+
+func (p *mockSecretProvider) IsDisabledProvider() (bool, error) {
+	return p.disabled, p.disabledErr
+}
+
+type mockRefetchErrorProvider struct {
+	mockLocalProvider
+	refetchErr error
+}
+
+func (p *mockRefetchErrorProvider) RefetchGroupPrincipals(principalID, secret string) ([]apiv3.Principal, error) {
+	return nil, p.refetchErr
+}
+
+func (p *mockRefetchErrorProvider) IsDisabledProvider() (bool, error) {
+	return false, nil
+}
+
+func TestRefreshAttributesEarlyErrors(t *testing.T) {
+	t.Run("user lister error", func(t *testing.T) {
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) {
+					return nil, fmt.Errorf("user lookup failed")
+				},
+			},
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.ErrorContains(t, err, "error getting user")
+	})
+
+	t.Run("token lister error", func(t *testing.T) {
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) {
+					return &apiv3.User{ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"}}, nil
+				},
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return nil, fmt.Errorf("token list failed")
+				},
+			},
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.ErrorContains(t, err, "error listing tokens")
+	})
+
+	t.Run("ext token list error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return(nil, fmt.Errorf("cache error")).AnyTimes()
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) {
+					return &apiv3.User{ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"}}, nil
+				},
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{}, nil
+				},
+			},
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.ErrorContains(t, err, "error listing ext tokens")
+	})
+}
+
+func TestRefreshAttributesPerUserSecrets(t *testing.T) {
+	const providerName = "github"
+
+	user := &apiv3.User{
+		ObjectMeta:   metav1.ObjectMeta{Name: "user-secret"},
+		PrincipalIDs: []string{providerName + "_user://12345"},
+	}
+
+	existingGroups := []apiv3.Principal{
+		{ObjectMeta: metav1.ObjectMeta{Name: providerName + "_team://org:existing"}},
+	}
+
+	t.Run("secret not found preserves state", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+		mgrSecretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		mgrSecretCache.EXPECT().
+			Get("cattle-system", "user-secret-secret").
+			Return(nil, apierrors.NewNotFound(corev1.Resource("secrets"), "user-secret-secret")).
+			AnyTimes()
+
+		mockProvider := &mockSecretProvider{
+			mockLocalProvider: mockLocalProvider{canAccess: true},
+		}
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: mockProvider,
+		})
+
+		derivedToken := &apiv3.Token{
+			UserID:       "user-secret",
+			IsDerived:    true,
+			AuthProvider: providerName,
+			UserPrincipal: apiv3.Principal{
+				ObjectMeta: metav1.ObjectMeta{Name: providerName + "_user://12345"},
+				Provider:   providerName,
+			},
+		}
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{derivedToken}, nil
+				},
+			},
+			tokens:   &fakes.TokenInterfaceMock{},
+			tokenMGR: tokens.NewMockedManager(tokenClient, mgrSecretCache),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-secret"},
+			GroupPrincipals: map[string]apiv3.Principals{
+				providerName: {Items: existingGroups},
+			},
+			ExtraByProvider: map[string]map[string][]string{
+				providerName: {"key": {"existing-value"}},
+			},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.NoError(t, err)
+		assert.False(t, mockProvider.refetchCalled, "RefetchGroupPrincipals should not be called when secret is missing")
+		assert.Equal(t, existingGroups, got.GroupPrincipals[providerName].Items, "existing group principals should be preserved")
+		assert.Equal(t, map[string][]string{"key": {"existing-value"}}, got.ExtraByProvider[providerName], "existing extra attributes should be preserved")
+	})
+
+	t.Run("secret hard error returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+		mgrSecretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		mgrSecretCache.EXPECT().
+			Get("cattle-system", "user-secret-secret").
+			Return(nil, fmt.Errorf("connection refused")).
+			AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockSecretProvider{
+				mockLocalProvider: mockLocalProvider{canAccess: true},
+			},
+		})
+
+		loginToken := &apiv3.Token{
+			UserID:       "user-secret",
+			IsDerived:    false,
+			AuthProvider: providerName,
+			UserPrincipal: apiv3.Principal{
+				ObjectMeta: metav1.ObjectMeta{Name: providerName + "_user://12345"},
+				Provider:   providerName,
+			},
+		}
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken}, nil
+				},
+			},
+			tokens:   &fakes.TokenInterfaceMock{},
+			tokenMGR: tokens.NewMockedManager(tokenClient, mgrSecretCache),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-secret"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.Error(t, err)
+	})
+}
+
+func TestRefreshAttributesRefetchErrors(t *testing.T) {
+	const providerName = "testprovider"
+
+	user := &apiv3.User{
+		ObjectMeta:   metav1.ObjectMeta{Name: "user-refetch"},
+		PrincipalIDs: []string{providerName + "_user://abc"},
+	}
+
+	existingGroups := []apiv3.Principal{
+		{ObjectMeta: metav1.ObjectMeta{Name: providerName + "_team://existing-group"}},
+	}
+
+	loginToken := &apiv3.Token{
+		UserID:       "user-refetch",
+		IsDerived:    false,
+		AuthProvider: providerName,
+		UserPrincipal: apiv3.Principal{
+			ObjectMeta: metav1.ObjectMeta{Name: providerName + "_user://abc"},
+			Provider:   providerName,
+			LoginName:  "testuser",
+			ExtraInfo: map[string]string{
+				common.UserAttributePrincipalID: providerName + "_user://abc",
+				common.UserAttributeUserName:    "testuser",
+			},
+		},
+	}
+
+	t.Run("transient error preserves groups", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockRefetchErrorProvider{
+				mockLocalProvider: mockLocalProvider{canAccess: true},
+				refetchErr:        fmt.Errorf("connection timeout"),
+			},
+		})
+
+		var tokenDeleteCalled bool
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken}, nil
+				},
+			},
+			tokens: &fakes.TokenInterfaceMock{
+				DeleteFunc: func(_ string, _ *metav1.DeleteOptions) error {
+					tokenDeleteCalled = true
+					return nil
+				},
+			},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-refetch"},
+			GroupPrincipals: map[string]apiv3.Principals{
+				providerName: {Items: existingGroups},
+			},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.NoError(t, err)
+		assert.Equal(t, existingGroups, got.GroupPrincipals[providerName].Items, "existing groups should be preserved on transient error")
+		assert.False(t, tokenDeleteCalled, "login tokens should not be deleted when errorConfirmingLogins is set")
+	})
+
+	t.Run("no access blanks principal and deletes tokens", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockRefetchErrorProvider{
+				mockLocalProvider: mockLocalProvider{canAccess: false},
+				refetchErr:        errors.New("no access"),
+			},
+		})
+
+		derivedToken := &apiv3.Token{
+			UserID:       "user-refetch",
+			IsDerived:    true,
+			AuthProvider: providerName,
+			UserPrincipal: apiv3.Principal{
+				ObjectMeta: metav1.ObjectMeta{Name: providerName + "_user://abc"},
+				Provider:   providerName,
+			},
+		}
+
+		var tokenDeleteCalled, tokenUpdateCalled bool
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken, derivedToken}, nil
+				},
+			},
+			tokens: &fakes.TokenInterfaceMock{
+				DeleteFunc: func(_ string, _ *metav1.DeleteOptions) error {
+					tokenDeleteCalled = true
+					return nil
+				},
+			},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		tokenClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(token *apiv3.Token) (*apiv3.Token, error) {
+			tokenUpdateCalled = true
+			return token.DeepCopy(), nil
+		}).AnyTimes()
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-refetch"},
+			GroupPrincipals: map[string]apiv3.Principals{
+				providerName: {Items: existingGroups},
+			},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.NoError(t, err)
+		assert.Nil(t, got.GroupPrincipals[providerName].Items, "group principals should be cleared on no access")
+		assert.True(t, tokenDeleteCalled, "login tokens should be deleted when user has no access")
+		assert.True(t, tokenUpdateCalled, "derived tokens should be disabled when user has no access")
+	})
+}
+
+func TestRefreshAttributesAccessAndPrincipalErrors(t *testing.T) {
+	const providerName = "testprovider"
+
+	user := &apiv3.User{
+		ObjectMeta:   metav1.ObjectMeta{Name: "user-err"},
+		PrincipalIDs: []string{providerName + "_user://abc"},
+	}
+
+	loginToken := &apiv3.Token{
+		UserID:       "user-err",
+		IsDerived:    false,
+		AuthProvider: providerName,
+		UserPrincipal: apiv3.Principal{
+			ObjectMeta: metav1.ObjectMeta{Name: providerName + "_user://abc"},
+			Provider:   providerName,
+			LoginName:  "testuser",
+			ExtraInfo: map[string]string{
+				common.UserAttributePrincipalID: providerName + "_user://abc",
+				common.UserAttributeUserName:    "testuser",
+			},
+		},
+	}
+
+	t.Run("can access error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockRefetchErrorProvider{
+				mockLocalProvider: mockLocalProvider{
+					canAccess:    false,
+					canAccessErr: fmt.Errorf("ldap connection failed"),
+				},
+				refetchErr: nil,
+			},
+		})
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken}, nil
+				},
+			},
+			tokens:   &fakes.TokenInterfaceMock{},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-err"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.Error(t, err)
+	})
+
+	t.Run("get principal error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockRefetchErrorProvider{
+				mockLocalProvider: mockLocalProvider{
+					canAccess: true,
+					getPrincipalFn: func(principalID string, token accessor.TokenAccessor) (apiv3.Principal, error) {
+						return apiv3.Principal{}, fmt.Errorf("principal fetch failed")
+					},
+				},
+			},
+			local.Name: &mockLocalProvider{
+				canAccess: true,
+				getPrincipalFn: func(principalID string, token accessor.TokenAccessor) (apiv3.Principal, error) {
+					return apiv3.Principal{}, fmt.Errorf("local fallback also failed")
+				},
+			},
+		})
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken}, nil
+				},
+			},
+			tokens:   &fakes.TokenInterfaceMock{},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-err"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.ErrorContains(t, err, "principal fetch failed")
+	})
+
+	t.Run("extra attributes with nil ExtraByProvider", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockRefetchErrorProvider{
+				mockLocalProvider: mockLocalProvider{canAccess: true},
+			},
+		})
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken}, nil
+				},
+			},
+			tokens:   &fakes.TokenInterfaceMock{},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-err"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.NoError(t, err)
+		assert.NotNil(t, got.ExtraByProvider, "ExtraByProvider should be initialized when nil")
+		assert.Contains(t, got.ExtraByProvider, providerName)
+	})
+
+	t.Run("login token delete not found is ignored", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockRefetchErrorProvider{
+				mockLocalProvider: mockLocalProvider{canAccess: false},
+			},
+		})
+
+		tokenClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(token *apiv3.Token) (*apiv3.Token, error) {
+			return token.DeepCopy(), nil
+		}).AnyTimes()
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken}, nil
+				},
+			},
+			tokens: &fakes.TokenInterfaceMock{
+				DeleteFunc: func(_ string, _ *metav1.DeleteOptions) error {
+					return apierrors.NewNotFound(corev1.Resource("tokens"), "token")
+				},
+			},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-err"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.NoError(t, err, "not-found errors during login token deletion should be ignored")
+		assert.NotNil(t, got)
+	})
+
+	t.Run("login token delete error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{}, nil).AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockRefetchErrorProvider{
+				mockLocalProvider: mockLocalProvider{canAccess: false},
+			},
+		})
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{loginToken}, nil
+				},
+			},
+			tokens: &fakes.TokenInterfaceMock{
+				DeleteFunc: func(_ string, _ *metav1.DeleteOptions) error {
+					return fmt.Errorf("delete failed")
+				},
+			},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-err"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.Error(t, err)
+	})
+}
+
+func TestRefreshAttributesExtTokenDisable(t *testing.T) {
+	const providerName = local.Name
+
+	user := &apiv3.User{
+		ObjectMeta:   metav1.ObjectMeta{Name: "user-ext"},
+		PrincipalIDs: []string{"local://user-ext"},
+	}
+
+	eDerivedToken := ext.Token{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-ext-derived"},
+		Spec: ext.TokenSpec{
+			UserID: "user-ext",
+			Kind:   "",
+			UserPrincipal: ext.TokenPrincipal{
+				Name:     "local://user-ext",
+				Provider: providerName,
+			},
+		},
+	}
+
+	principalBytes, _ := json.Marshal(eDerivedToken.Spec.UserPrincipal)
+	eDerivedSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "user-ext-derived",
+			Labels: map[string]string{tokens.UserIDLabel: "user-ext"},
+		},
+		Data: map[string][]byte{
+			exttokens.FieldEnabled:        []byte("true"),
+			exttokens.FieldHash:           []byte("somehash"),
+			exttokens.FieldKind:           []byte(""),
+			exttokens.FieldLastUpdateTime: []byte("13:00:05"),
+			exttokens.FieldPrincipal:      principalBytes,
+			exttokens.FieldTTL:            []byte("4000"),
+			exttokens.FieldUID:            []byte("uid-123"),
+			exttokens.FieldUserID:         []byte("user-ext"),
+		},
+	}
+
+	t.Run("ext derived tokens disabled on lost access", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{&eDerivedSecret}, nil).AnyTimes()
+		scache.EXPECT().Get("cattle-tokens", gomock.Any()).Return(&eDerivedSecret, nil).AnyTimes()
+
+		var patchCalled bool
+		secrets.EXPECT().
+			Patch("cattle-tokens", "user-ext-derived", ktypes.JSONPatchType, gomock.Any()).
+			DoAndReturn(func(ns, name string, pt ktypes.PatchType, patch []byte, subresources ...string) (*corev1.Secret, error) {
+				patchCalled = true
+				return nil, nil
+			}).
+			AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockLocalProvider{canAccess: false},
+		})
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{}, nil
+				},
+			},
+			tokens:   &fakes.TokenInterfaceMock{},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-ext"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		_, err := r.refreshAttributes(attribs)
+		assert.NoError(t, err)
+		assert.True(t, patchCalled, "ext derived token should be disabled via secret patch")
+	})
+
+	t.Run("disable token error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+		tokenClient := fake.NewMockNonNamespacedClientInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().List("cattle-tokens", gomock.Any()).Return([]*corev1.Secret{&eDerivedSecret}, nil).AnyTimes()
+		scache.EXPECT().Get("cattle-tokens", gomock.Any()).Return(&eDerivedSecret, nil).AnyTimes()
+
+		secrets.EXPECT().
+			Patch("cattle-tokens", gomock.Any(), ktypes.JSONPatchType, gomock.Any()).
+			Return(nil, fmt.Errorf("patch failed")).
+			AnyTimes()
+
+		providers.SetProviders(map[string]common.AuthProvider{
+			providerName: &mockLocalProvider{canAccess: false},
+		})
+
+		r := &refresher{
+			userLister: &fakes.UserListerMock{
+				GetFunc: func(_, _ string) (*apiv3.User, error) { return user, nil },
+			},
+			tokenLister: &fakes.TokenListerMock{
+				ListFunc: func(_ string, _ labels.Selector) ([]*apiv3.Token, error) {
+					return []*apiv3.Token{}, nil
+				},
+			},
+			tokens:   &fakes.TokenInterfaceMock{},
+			tokenMGR: tokens.NewMockedManager(tokenClient, nil),
+			extTokenStore: exttokens.NewSystem(nil, nil, secrets, users, nil, nil,
+				exttokens.NewTimeHandler(),
+				exttokens.NewHashHandler(),
+				exttokens.NewAuthHandler()),
+		}
+
+		attribs := &apiv3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "user-ext"},
+			GroupPrincipals: map[string]apiv3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}
+
+		got, err := r.refreshAttributes(attribs)
+		assert.Nil(t, got)
+		assert.ErrorContains(t, err, "error disabling token")
+	})
 }

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -149,6 +149,9 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 	return groupPrincipals, err
 }
 
+func (p *adProvider) UsesUserSecrets() bool       { return false }
+func (p *adProvider) CanRefreshPrincipals() bool { return true }
+
 func (p *adProvider) getPrincipalsFromSearchResult(lConn ldapv3.Client, config *v3.ActiveDirectoryConfig, result *ldapv3.SearchResult) (v3.Principal, []v3.Principal, error) {
 	var (
 		groupPrincipals       []v3.Principal

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -149,7 +149,7 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 	return groupPrincipals, err
 }
 
-func (p *adProvider) UsesUserSecrets() bool       { return false }
+func (p *adProvider) UsesUserSecrets() bool      { return false }
 func (p *adProvider) CanRefreshPrincipals() bool { return true }
 
 func (p *adProvider) getPrincipalsFromSearchResult(lConn ldapv3.Client, config *v3.ActiveDirectoryConfig, result *ldapv3.SearchResult) (v3.Principal, []v3.Principal, error) {

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -196,7 +196,7 @@ func (ap *Provider) RefetchGroupPrincipals(principalID, secret string) ([]apiv3.
 	return groupPrincipals, nil
 }
 
-func (ap *Provider) UsesUserSecrets() bool       { return false }
+func (ap *Provider) UsesUserSecrets() bool      { return false }
 func (ap *Provider) CanRefreshPrincipals() bool { return true }
 
 func (ap *Provider) SearchPrincipals(name, principalType string, token accessor.TokenAccessor) ([]apiv3.Principal, error) {

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -196,6 +196,9 @@ func (ap *Provider) RefetchGroupPrincipals(principalID, secret string) ([]apiv3.
 	return groupPrincipals, nil
 }
 
+func (ap *Provider) UsesUserSecrets() bool       { return false }
+func (ap *Provider) CanRefreshPrincipals() bool { return true }
+
 func (ap *Provider) SearchPrincipals(name, principalType string, token accessor.TokenAccessor) ([]apiv3.Principal, error) {
 	cfg, err := ap.GetAzureConfigK8s()
 	if err != nil {

--- a/pkg/auth/providers/common/provider.go
+++ b/pkg/auth/providers/common/provider.go
@@ -33,6 +33,14 @@ type AuthProvider interface {
 	GetPrincipal(principalID string, token accessor.TokenAccessor) (v3.Principal, error)
 	CustomizeSchema(schema *types.Schema)
 	TransformToAuthProvider(authConfig map[string]any) (map[string]any, error)
+	// UsesUserSecrets reports whether the provider stores per-user OAuth tokens
+	// in secrets. Providers that authenticate via service credentials (e.g. an
+	// App private key) return false.
+	UsesUserSecrets() bool
+	// CanRefreshPrincipals reports whether the provider supports refetching
+	// group principals at refresh time. Providers that return false will have
+	// their existing group principals preserved instead.
+	CanRefreshPrincipals() bool
 	RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error)
 	CanAccessWithGroupProviders(userPrincipalID string, groups []v3.Principal) (bool, error)
 	// GetUserExtraAttributes retrieves the extra attributes from the specified principal.

--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -135,6 +135,9 @@ func (g *GenOIDCProvider) RefetchGroupPrincipals(principalID string, secret stri
 	return nil, errors.New("Not implemented")
 }
 
+func (g *GenOIDCProvider) UsesUserSecrets() bool       { return false }
+func (g *GenOIDCProvider) CanRefreshPrincipals() bool { return false }
+
 // groupToPrincipal takes a bare group name and turns it into a apiv3.Principal group object by filling-in other fields
 // with basic provider information.
 func (g *GenOIDCProvider) groupToPrincipal(groupName string) apiv3.Principal {

--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -135,7 +135,7 @@ func (g *GenOIDCProvider) RefetchGroupPrincipals(principalID string, secret stri
 	return nil, errors.New("Not implemented")
 }
 
-func (g *GenOIDCProvider) UsesUserSecrets() bool       { return false }
+func (g *GenOIDCProvider) UsesUserSecrets() bool      { return false }
 func (g *GenOIDCProvider) CanRefreshPrincipals() bool { return false }
 
 // groupToPrincipal takes a bare group name and turns it into a apiv3.Principal group object by filling-in other fields

--- a/pkg/auth/providers/github/github_provider.go
+++ b/pkg/auth/providers/github/github_provider.go
@@ -272,7 +272,7 @@ func (g *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]
 	return groupPrincipals, nil
 }
 
-func (g *Provider) UsesUserSecrets() bool       { return true }
+func (g *Provider) UsesUserSecrets() bool      { return true }
 func (g *Provider) CanRefreshPrincipals() bool { return true }
 
 func (g *Provider) SearchPrincipals(searchKey, principalType string, token accessor.TokenAccessor) ([]apiv3.Principal, error) {

--- a/pkg/auth/providers/github/github_provider.go
+++ b/pkg/auth/providers/github/github_provider.go
@@ -272,6 +272,9 @@ func (g *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]
 	return groupPrincipals, nil
 }
 
+func (g *Provider) UsesUserSecrets() bool       { return true }
+func (g *Provider) CanRefreshPrincipals() bool { return true }
+
 func (g *Provider) SearchPrincipals(searchKey, principalType string, token accessor.TokenAccessor) ([]apiv3.Principal, error) {
 	var principals []apiv3.Principal
 	var err error

--- a/pkg/auth/providers/githubapp/githubapp_provider.go
+++ b/pkg/auth/providers/githubapp/githubapp_provider.go
@@ -196,7 +196,7 @@ func (g *Provider) RefetchGroupPrincipals(principalID string, _ string) ([]apiv3
 	return g.getGroupPrincipals(principalID, config)
 }
 
-func (g *Provider) UsesUserSecrets() bool       { return false }
+func (g *Provider) UsesUserSecrets() bool      { return false }
 func (g *Provider) CanRefreshPrincipals() bool { return true }
 
 func (g *Provider) getGroupPrincipals(principalID string, config *apiv3.GithubAppConfig) ([]apiv3.Principal, error) {

--- a/pkg/auth/providers/githubapp/githubapp_provider.go
+++ b/pkg/auth/providers/githubapp/githubapp_provider.go
@@ -196,6 +196,9 @@ func (g *Provider) RefetchGroupPrincipals(principalID string, _ string) ([]apiv3
 	return g.getGroupPrincipals(principalID, config)
 }
 
+func (g *Provider) UsesUserSecrets() bool       { return false }
+func (g *Provider) CanRefreshPrincipals() bool { return true }
+
 func (g *Provider) getGroupPrincipals(principalID string, config *apiv3.GithubAppConfig) ([]apiv3.Principal, error) {
 	_, id, err := parsePrincipalID(principalID)
 	if err != nil {

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -291,6 +291,9 @@ func (g *googleOauthProvider) RefetchGroupPrincipals(principalID string, secret 
 	return nested, nil
 }
 
+func (g *googleOauthProvider) UsesUserSecrets() bool       { return true }
+func (g *googleOauthProvider) CanRefreshPrincipals() bool { return true }
+
 func (g *googleOauthProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPrincipals []apiv3.Principal) (bool, error) {
 	config, err := g.getGoogleOAuthConfigCR()
 	if err != nil {

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -291,7 +291,7 @@ func (g *googleOauthProvider) RefetchGroupPrincipals(principalID string, secret 
 	return nested, nil
 }
 
-func (g *googleOauthProvider) UsesUserSecrets() bool       { return true }
+func (g *googleOauthProvider) UsesUserSecrets() bool      { return true }
 func (g *googleOauthProvider) CanRefreshPrincipals() bool { return true }
 
 func (g *googleOauthProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPrincipals []apiv3.Principal) (bool, error) {

--- a/pkg/auth/providers/googleoauth/goauth_provider_test.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider_test.go
@@ -15,8 +15,8 @@ func TestWrapGoogleNonTransient(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		err           error
+		name             string
+		err              error
 		wantNonTransient bool
 	}{
 		{

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -583,5 +583,5 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 	return groupPrincipals, nil
 }
 
-func (p *ldapProvider) UsesUserSecrets() bool       { return false }
+func (p *ldapProvider) UsesUserSecrets() bool      { return false }
 func (p *ldapProvider) CanRefreshPrincipals() bool { return true }

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -582,3 +582,6 @@ func (p *ldapProvider) RefetchGroupPrincipals(principalID string, secret string)
 	}
 	return groupPrincipals, nil
 }
+
+func (p *ldapProvider) UsesUserSecrets() bool       { return false }
+func (p *ldapProvider) CanRefreshPrincipals() bool { return true }

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -202,7 +202,7 @@ func (l *Provider) getGroupPrincipals(user *apiv3.User) ([]apiv3.Principal, erro
 	return groupPrincipals, nil
 }
 
-func (l *Provider) UsesUserSecrets() bool       { return false }
+func (l *Provider) UsesUserSecrets() bool      { return false }
 func (l *Provider) CanRefreshPrincipals() bool { return true }
 
 func (l *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -202,6 +202,9 @@ func (l *Provider) getGroupPrincipals(user *apiv3.User) ([]apiv3.Principal, erro
 	return groupPrincipals, nil
 }
 
+func (l *Provider) UsesUserSecrets() bool       { return false }
+func (l *Provider) CanRefreshPrincipals() bool { return true }
+
 func (l *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {
 	userID := strings.SplitN(principalID, "://", 2)[1]
 	user, err := l.userLister.Get("", userID)

--- a/pkg/auth/providers/mocks/provider.go
+++ b/pkg/auth/providers/mocks/provider.go
@@ -75,6 +75,20 @@ func (mr *MockAuthProviderMockRecorder) CanAccessWithGroupProviders(userPrincipa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanAccessWithGroupProviders", reflect.TypeOf((*MockAuthProvider)(nil).CanAccessWithGroupProviders), userPrincipalID, groups)
 }
 
+// CanRefreshPrincipals mocks base method.
+func (m *MockAuthProvider) CanRefreshPrincipals() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanRefreshPrincipals")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanRefreshPrincipals indicates an expected call of CanRefreshPrincipals.
+func (mr *MockAuthProviderMockRecorder) CanRefreshPrincipals() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanRefreshPrincipals", reflect.TypeOf((*MockAuthProvider)(nil).CanRefreshPrincipals))
+}
+
 // CustomizeSchema mocks base method.
 func (m *MockAuthProvider) CustomizeSchema(schema *types.Schema) {
 	m.ctrl.T.Helper()
@@ -216,4 +230,18 @@ func (m *MockAuthProvider) TransformToAuthProvider(authConfig map[string]any) (m
 func (mr *MockAuthProviderMockRecorder) TransformToAuthProvider(authConfig any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformToAuthProvider", reflect.TypeOf((*MockAuthProvider)(nil).TransformToAuthProvider), authConfig)
+}
+
+// UsesUserSecrets mocks base method.
+func (m *MockAuthProvider) UsesUserSecrets() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UsesUserSecrets")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// UsesUserSecrets indicates an expected call of UsesUserSecrets.
+func (mr *MockAuthProviderMockRecorder) UsesUserSecrets() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UsesUserSecrets", reflect.TypeOf((*MockAuthProvider)(nil).UsesUserSecrets))
 }

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -304,7 +304,7 @@ func (o *OpenIDCProvider) RefetchGroupPrincipals(principalID string, secret stri
 	return o.getGroupsFromClaimInfo(*claimInfo), nil
 }
 
-func (o *OpenIDCProvider) UsesUserSecrets() bool       { return true }
+func (o *OpenIDCProvider) UsesUserSecrets() bool      { return true }
 func (o *OpenIDCProvider) CanRefreshPrincipals() bool { return true }
 
 func (o *OpenIDCProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPrincipals []v3.Principal) (bool, error) {

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -304,6 +304,9 @@ func (o *OpenIDCProvider) RefetchGroupPrincipals(principalID string, secret stri
 	return o.getGroupsFromClaimInfo(*claimInfo), nil
 }
 
+func (o *OpenIDCProvider) UsesUserSecrets() bool       { return true }
+func (o *OpenIDCProvider) CanRefreshPrincipals() bool { return true }
+
 func (o *OpenIDCProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPrincipals []v3.Principal) (bool, error) {
 	config, err := o.GetConfig()
 	if err != nil {

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -3,7 +3,9 @@ package providers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 
@@ -242,12 +244,7 @@ func ProviderNames() []string {
 	mu.RLock()
 	defer mu.RUnlock()
 
-	names := make([]string, 0, len(providers))
-	for name := range providers {
-		names = append(names, name)
-	}
-
-	return names
+	return slices.Collect(maps.Keys(providers))
 }
 
 // SetProviders replaces the provider map. Intended for use in tests.

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -27,14 +27,16 @@ import (
 )
 
 var (
-	ProviderNames          = make(map[string]bool)
-	providersWithSecrets   = make(map[string]bool)
-	UnrefreshableProviders = make(map[string]bool)
-	Providers              = make(map[string]common.AuthProvider)
-	LocalProvider          = "local"
-	confMu                 sync.Mutex
+	// mu guards the [providers] map.
+	mu sync.RWMutex
+
+	// providers maps provider names to their AuthProvider implementations, populated by Configure.
+	providers = make(map[string]common.AuthProvider)
+
+	// userExtraAttributesMap defines which token ExtraInfo keys are propagated to UserAttributes.
 	userExtraAttributesMap = map[string]bool{common.UserAttributePrincipalID: true, common.UserAttributeUserName: true}
-	// Names of all SAML providers. Used to look up the provider based on the type.
+
+	// samlProviders lists all SAML provider names. Used to look up the provider based on the type.
 	samlProviders = map[string]bool{
 		saml.PingName:       true,
 		saml.ADFSName:       true,
@@ -44,16 +46,21 @@ var (
 	}
 )
 
+// IsSAMLProviderType reports whether the given auth config type belongs to a SAML provider.
 func IsSAMLProviderType(t string) bool {
 	return samlProviders[nameFromType(t)]
 }
 
+// GetProvider returns the registered AuthProvider for the given name or an error if not found.
 func GetProvider(providerName string) (common.AuthProvider, error) {
-	if provider, ok := Providers[providerName]; ok {
-		if provider != nil {
-			return provider, nil
-		}
+	mu.RLock()
+	provider, ok := providers[providerName]
+	mu.RUnlock()
+
+	if ok && provider != nil {
+		return provider, nil
 	}
+
 	return nil, fmt.Errorf("no such provider '%s'", providerName)
 }
 
@@ -61,102 +68,42 @@ func nameFromType(t string) string {
 	return strings.TrimSuffix(strings.TrimSuffix(strings.ToLower(t), "config"), "provider")
 }
 
+// GetProviderByType returns the registered AuthProvider whose name matches the given auth config type, or nil.
 func GetProviderByType(t string) common.AuthProvider {
-	return Providers[nameFromType(t)]
+	mu.RLock()
+	defer mu.RUnlock()
+
+	return providers[nameFromType(t)]
 }
 
+// Configure initializes all auth providers and registers them in the provider map.
 func Configure(ctx context.Context, mgmt *config.ScaledContext) {
-	confMu.Lock()
-	defer confMu.Unlock()
+	mu.Lock()
+	defer mu.Unlock()
 
 	userMGR := mgmt.UserManager
 	tokenMGR := tokens.NewManager(mgmt.Wrangler)
 
-	var p common.AuthProvider
-
-	p = local.Configure(ctx, mgmt, userMGR)
-	ProviderNames[local.Name] = true
-	Providers[local.Name] = p
-
-	p = github.Configure(mgmt, userMGR, tokenMGR)
-	ProviderNames[github.Name] = true
-	providersWithSecrets[github.Name] = true
-	Providers[github.Name] = p
-
-	p = githubapp.Configure(ctx, mgmt, userMGR, tokenMGR)
-	ProviderNames[githubapp.Name] = true
-	Providers[githubapp.Name] = p
-
-	p = azure.Configure(mgmt, userMGR, tokenMGR)
-	ProviderNames[azure.Name] = true
-	providersWithSecrets[azure.Name] = true
-	Providers[azure.Name] = p
-
-	p = activedirectory.Configure(mgmt, userMGR, tokenMGR)
-	ProviderNames[activedirectory.Name] = true
-	Providers[activedirectory.Name] = p
-
-	p = ldap.Configure(mgmt, userMGR, tokenMGR, ldap.OpenLdapName)
-	ProviderNames[ldap.OpenLdapName] = true
-	Providers[ldap.OpenLdapName] = p
-
-	p = ldap.Configure(mgmt, userMGR, tokenMGR, ldap.FreeIpaName)
-	ProviderNames[ldap.FreeIpaName] = true
-	Providers[ldap.FreeIpaName] = p
-
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.PingName)
-	ProviderNames[saml.PingName] = true
-	UnrefreshableProviders[saml.PingName] = true
-	Providers[saml.PingName] = p
-
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.ADFSName)
-	ProviderNames[saml.ADFSName] = true
-	UnrefreshableProviders[saml.ADFSName] = true
-	Providers[saml.ADFSName] = p
-
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.KeyCloakName)
-	ProviderNames[saml.KeyCloakName] = true
-	UnrefreshableProviders[saml.KeyCloakName] = true
-	Providers[saml.KeyCloakName] = p
-
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.OKTAName)
-	ProviderNames[saml.OKTAName] = true
-	UnrefreshableProviders[saml.OKTAName] = true
-	Providers[saml.OKTAName] = p
-
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.ShibbolethName)
-	ProviderNames[saml.ShibbolethName] = true
-	UnrefreshableProviders[saml.ShibbolethName] = false
-	Providers[saml.ShibbolethName] = p
-
-	p = googleoauth.Configure(mgmt, userMGR, tokenMGR)
-	ProviderNames[googleoauth.Name] = true
-	providersWithSecrets[googleoauth.Name] = true
-	Providers[googleoauth.Name] = p
-
-	p = oidc.Configure(ctx, mgmt, userMGR, tokenMGR)
-	ProviderNames[oidc.Name] = true
-	providersWithSecrets[oidc.Name] = true
-	Providers[oidc.Name] = p
-
-	p = keycloakoidc.Configure(ctx, mgmt, userMGR, tokenMGR)
-	ProviderNames[keycloakoidc.Name] = true
-	providersWithSecrets[keycloakoidc.Name] = true
-	Providers[keycloakoidc.Name] = p
-
-	p = genericoidc.Configure(ctx, mgmt, userMGR, tokenMGR)
-	ProviderNames[genericoidc.Name] = true
-	providersWithSecrets[genericoidc.Name] = true
-	UnrefreshableProviders[genericoidc.Name] = true
-	Providers[genericoidc.Name] = p
-
-	p = cognito.Configure(ctx, mgmt, userMGR, tokenMGR)
-	ProviderNames[cognito.Name] = true
-	providersWithSecrets[cognito.Name] = true
-	UnrefreshableProviders[cognito.Name] = true
-	Providers[cognito.Name] = p
+	providers[local.Name] = local.Configure(ctx, mgmt, userMGR)
+	providers[github.Name] = github.Configure(mgmt, userMGR, tokenMGR)
+	providers[githubapp.Name] = githubapp.Configure(ctx, mgmt, userMGR, tokenMGR)
+	providers[azure.Name] = azure.Configure(mgmt, userMGR, tokenMGR)
+	providers[activedirectory.Name] = activedirectory.Configure(mgmt, userMGR, tokenMGR)
+	providers[ldap.OpenLdapName] = ldap.Configure(mgmt, userMGR, tokenMGR, ldap.OpenLdapName)
+	providers[ldap.FreeIpaName] = ldap.Configure(mgmt, userMGR, tokenMGR, ldap.FreeIpaName)
+	providers[saml.PingName] = saml.Configure(mgmt, userMGR, tokenMGR, saml.PingName)
+	providers[saml.ADFSName] = saml.Configure(mgmt, userMGR, tokenMGR, saml.ADFSName)
+	providers[saml.KeyCloakName] = saml.Configure(mgmt, userMGR, tokenMGR, saml.KeyCloakName)
+	providers[saml.OKTAName] = saml.Configure(mgmt, userMGR, tokenMGR, saml.OKTAName)
+	providers[saml.ShibbolethName] = saml.Configure(mgmt, userMGR, tokenMGR, saml.ShibbolethName)
+	providers[googleoauth.Name] = googleoauth.Configure(mgmt, userMGR, tokenMGR)
+	providers[oidc.Name] = oidc.Configure(ctx, mgmt, userMGR, tokenMGR)
+	providers[keycloakoidc.Name] = keycloakoidc.Configure(ctx, mgmt, userMGR, tokenMGR)
+	providers[genericoidc.Name] = genericoidc.Configure(ctx, mgmt, userMGR, tokenMGR)
+	providers[cognito.Name] = cognito.Configure(ctx, mgmt, userMGR, tokenMGR)
 }
 
+// ProviderLogoutAll logs out the user from all sessions for the token's auth provider.
 func ProviderLogoutAll(w http.ResponseWriter, r *http.Request, token accessor.TokenAccessor) error {
 	apName := token.GetAuthProvider()
 	if apName == "" {
@@ -167,9 +114,11 @@ func ProviderLogoutAll(w http.ResponseWriter, r *http.Request, token accessor.To
 	if err != nil {
 		return err
 	}
+
 	return ap.LogoutAll(w, r, token)
 }
 
+// ProviderLogout logs out the current session for the token's auth provider.
 func ProviderLogout(w http.ResponseWriter, r *http.Request, token accessor.TokenAccessor) error {
 	apName := token.GetAuthProvider()
 	if apName == "" {
@@ -180,25 +129,38 @@ func ProviderLogout(w http.ResponseWriter, r *http.Request, token accessor.Token
 	if err != nil {
 		return err
 	}
+
 	return ap.Logout(w, r, token)
 }
 
+// IsValidUserExtraAttribute reports whether key is a recognized extra attribute for user propagation.
 func IsValidUserExtraAttribute(key string) bool {
 	if _, ok := userExtraAttributesMap[strings.ToLower(key)]; ok {
 		return true
 	}
+
 	return false
 }
 
+// AuthenticateUser delegates authentication to the named provider and returns the resulting principals.
 func AuthenticateUser(w http.ResponseWriter, req *http.Request, input any, providerName string) (apiv3.Principal, []apiv3.Principal, string, error) {
-	return Providers[providerName].AuthenticateUser(w, req, input)
+	mu.RLock()
+	p := providers[providerName]
+	mu.RUnlock()
+
+	return p.AuthenticateUser(w, req, input)
 }
 
+// GetPrincipal looks up a principal by ID using the token's auth provider, falling back to the local provider.
 func GetPrincipal(principalID string, myToken accessor.TokenAccessor) (apiv3.Principal, error) {
-	principal, err := Providers[myToken.GetAuthProvider()].GetPrincipal(principalID, myToken)
+	mu.RLock()
+	p := providers[myToken.GetAuthProvider()]
+	lp := providers[local.Name]
+	mu.RUnlock()
 
-	if err != nil && myToken.GetAuthProvider() != LocalProvider {
-		p2, e2 := Providers[LocalProvider].GetPrincipal(principalID, myToken)
+	principal, err := p.GetPrincipal(principalID, myToken)
+	if err != nil && myToken.GetAuthProvider() != local.Name {
+		p2, e2 := lp.GetPrincipal(principalID, myToken)
 		if e2 == nil {
 			return p2, nil
 		}
@@ -207,20 +169,26 @@ func GetPrincipal(principalID string, myToken accessor.TokenAccessor) (apiv3.Pri
 	return principal, err
 }
 
+// SearchPrincipals searches for principals by name using the token's auth provider, appending deduplicated local results.
 func SearchPrincipals(name, principalType string, myToken accessor.TokenAccessor) ([]apiv3.Principal, error) {
 	ap := myToken.GetAuthProvider()
 	if ap == "" {
 		return []apiv3.Principal{}, fmt.Errorf("[SearchPrincipals] no authProvider specified in token")
 	}
-	if Providers[ap] == nil {
+
+	mu.RLock()
+	p := providers[ap]
+	lp := providers[local.Name]
+	mu.RUnlock()
+
+	if p == nil {
 		return []apiv3.Principal{}, fmt.Errorf("[SearchPrincipals] authProvider %v not initialized", ap)
 	}
-	principals, err := Providers[ap].SearchPrincipals(name, principalType, myToken)
+	principals, err := p.SearchPrincipals(name, principalType, myToken)
 	if err != nil {
 		return principals, err
 	}
-	if ap != LocalProvider {
-		lp := Providers[LocalProvider]
+	if ap != local.Name {
 		if lpDedupe, _ := lp.(*local.Provider); lpDedupe != nil {
 			localPrincipals, err := lpDedupe.SearchPrincipalsDedupe(name, principalType, myToken, principals)
 			if err != nil {
@@ -232,27 +200,87 @@ func SearchPrincipals(name, principalType string, myToken accessor.TokenAccessor
 	return principals, err
 }
 
+// CanAccessWithGroupProviders checks whether the user or any of their group principals have access via the named provider.
 func CanAccessWithGroupProviders(providerName string, userPrincipalID string, groups []apiv3.Principal) (bool, error) {
-	return Providers[providerName].CanAccessWithGroupProviders(userPrincipalID, groups)
+	mu.RLock()
+	p := providers[providerName]
+	mu.RUnlock()
+
+	return p.CanAccessWithGroupProviders(userPrincipalID, groups)
 }
 
+// RefetchGroupPrincipals refreshes the group principals for the given user from the named provider.
 func RefetchGroupPrincipals(principalID string, providerName string, secret string) ([]apiv3.Principal, error) {
-	return Providers[providerName].RefetchGroupPrincipals(principalID, secret)
+	mu.RLock()
+	p := providers[providerName]
+	mu.RUnlock()
+
+	return p.RefetchGroupPrincipals(principalID, secret)
 }
 
+// GetUserExtraAttributes returns extra attributes for the user principal from the named provider.
 func GetUserExtraAttributes(providerName string, userPrincipal apiv3.Principal) map[string][]string {
-	return Providers[providerName].GetUserExtraAttributes(userPrincipal)
+	mu.RLock()
+	p := providers[providerName]
+	mu.RUnlock()
+
+	return p.GetUserExtraAttributes(userPrincipal)
 }
 
+// IsDisabledProvider reports whether the named provider is currently disabled.
 func IsDisabledProvider(providerName string) (bool, error) {
 	provider, err := GetProvider(providerName)
 	if err != nil {
 		return false, err
 	}
+
 	return provider.IsDisabledProvider()
 }
 
-// ProviderHasPerUserSecrets returns true if a given provider is known to use per-user auth tokens stored in secrets.
-func ProviderHasPerUserSecrets(providerName string) (bool, error) {
-	return providersWithSecrets[providerName], nil
+// ProviderNames returns the names of all registered providers.
+func ProviderNames() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	names := make([]string, 0, len(providers))
+	for name := range providers {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// SetProviders replaces the provider map. Intended for use in tests.
+func SetProviders(m map[string]common.AuthProvider) {
+	mu.Lock()
+	defer mu.Unlock()
+	if m == nil {
+		m = make(map[string]common.AuthProvider)
+	}
+
+	providers = m
+}
+
+// ProviderUsesUserSecrets reports whether the named provider stores per-user secrets for token refresh.
+func ProviderUsesUserSecrets(providerName string) bool {
+	mu.RLock()
+	p, ok := providers[providerName]
+	mu.RUnlock()
+	if ok {
+		return p.UsesUserSecrets()
+	}
+
+	return false
+}
+
+// ProviderCanRefreshPrincipals reports whether the named provider supports refreshing group principals.
+func ProviderCanRefreshPrincipals(providerName string) bool {
+	mu.RLock()
+	p, ok := providers[providerName]
+	mu.RUnlock()
+	if ok {
+		return p.CanRefreshPrincipals()
+	}
+
+	return false
 }

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"testing"
 
+	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/genericoidc"
 	"github.com/rancher/rancher/pkg/auth/providers/github"
 	"github.com/rancher/rancher/pkg/auth/providers/githubapp"
@@ -32,11 +33,12 @@ func TestIsSAMLProvider(t *testing.T) {
 }
 
 func TestProviderUsesUserSecrets(t *testing.T) {
-	t.Parallel()
-
-	providers[github.Name] = &github.Provider{}
-	providers[githubapp.Name] = &githubapp.Provider{}
-	providers[local.Name] = &local.Provider{}
+	SetProviders(map[string]common.AuthProvider{
+		github.Name:    &github.Provider{},
+		githubapp.Name: &githubapp.Provider{},
+		local.Name:     &local.Provider{},
+	})
+	defer SetProviders(nil)
 
 	assert.True(t, ProviderUsesUserSecrets(github.Name))
 	assert.False(t, ProviderUsesUserSecrets(githubapp.Name))
@@ -44,10 +46,11 @@ func TestProviderUsesUserSecrets(t *testing.T) {
 }
 
 func TestProviderCanRefreshPrincipals(t *testing.T) {
-	t.Parallel()
-
-	providers[github.Name] = &github.Provider{}
-	providers[genericoidc.Name] = &genericoidc.GenOIDCProvider{}
+	SetProviders(map[string]common.AuthProvider{
+		github.Name:      &github.Provider{},
+		genericoidc.Name: &genericoidc.GenOIDCProvider{},
+	})
+	defer SetProviders(nil)
 
 	assert.True(t, ProviderCanRefreshPrincipals(github.Name))
 	assert.False(t, ProviderCanRefreshPrincipals(genericoidc.Name))

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -1,133 +1,54 @@
 package providers
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/rancher/rancher/pkg/auth/providers/azure"
-	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/genericoidc"
 	"github.com/rancher/rancher/pkg/auth/providers/github"
+	"github.com/rancher/rancher/pkg/auth/providers/githubapp"
+	"github.com/rancher/rancher/pkg/auth/providers/local"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestIsSAMLProvider(t *testing.T) {
-	tests := []struct {
-		provider string
-		isSAML   bool
-	}{
-		{
-			provider: "pingProvider",
-			isSAML:   true,
-		},
-		{
-			provider: "adfsProvider",
-			isSAML:   true,
-		},
-		{
-			provider: "keyCloakProvider",
-			isSAML:   true,
-		},
-		{
-			provider: "oktaProvider",
-			isSAML:   true,
-		},
-		{
-			provider: "shibbolethProvider",
-			isSAML:   true,
-		},
-		{
-			provider: "githubProvider",
-			isSAML:   false,
-		},
-		{
-			provider: "localProvider",
-			isSAML:   false,
-		},
+	t.Parallel()
+
+	for _, name := range []string{
+		"ping", "pingConfig", "pingProvider",
+		"adfs", "adfsConfig", "adfsProvider",
+		"keycloak", "keycloakConfig", "keycloakProvider",
+		"okta", "oktaConfig", "oktaProvider",
+		"shibboleth", "shibbolethConfig", "shibbolethProvider",
+	} {
+		assert.True(t, IsSAMLProviderType(name), name)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.provider, func(t *testing.T) {
-			assert.Equal(t, tt.isSAML, IsSAMLProviderType(tt.provider))
-		})
+	for _, name := range []string{
+		"github", "githubConfig", "githubProvider",
+		"local", "localConfig", "localProvider",
+	} {
+		assert.False(t, IsSAMLProviderType(name), name)
 	}
 }
 
-func TestNewAzureADProviderDoesNotHavePerUserTokens(t *testing.T) {
-	t.Cleanup(cleanup)
-	newFlowCfg := map[string]any{
-		"metadata": map[string]any{
-			"name":        "azure",
-			"annotations": map[string]any{"auth.cattle.io/azuread-endpoint-migrated": "true"},
-		},
-		"enabled":       true,
-		"graphEndpoint": "https://graph.microsoft.com/",
-	}
+func TestProviderUsesUserSecrets(t *testing.T) {
+	t.Parallel()
 
-	getter := newMockUnstructuredGetter()
-	obj := mockUnstructured{content: newFlowCfg}
-	getter.objects[azure.Name] = &obj
-	Providers[azure.Name] = &azure.Provider{Retriever: getter}
+	providers[github.Name] = &github.Provider{}
+	providers[githubapp.Name] = &githubapp.Provider{}
+	providers[local.Name] = &local.Provider{}
 
-	hasPerUserSecrets, err := ProviderHasPerUserSecrets(azure.Name)
-
-	require.NoError(t, err)
-	assert.False(t, hasPerUserSecrets)
+	assert.True(t, ProviderUsesUserSecrets(github.Name))
+	assert.False(t, ProviderUsesUserSecrets(githubapp.Name))
+	assert.False(t, ProviderUsesUserSecrets(local.Name))
 }
 
-func TestProviderHasPerUserTokens(t *testing.T) {
-	t.Cleanup(cleanup)
-	hasPerUserSecrets, err := ProviderHasPerUserSecrets(github.Name)
+func TestProviderCanRefreshPrincipals(t *testing.T) {
+	t.Parallel()
 
-	require.NoError(t, err)
-	assert.False(t, hasPerUserSecrets)
+	providers[github.Name] = &github.Provider{}
+	providers[genericoidc.Name] = &genericoidc.GenOIDCProvider{}
 
-	providersWithSecrets[github.Name] = true
-	hasPerUserSecrets, err = ProviderHasPerUserSecrets(github.Name)
-
-	require.NoError(t, err)
-	assert.True(t, hasPerUserSecrets)
+	assert.True(t, ProviderCanRefreshPrincipals(github.Name))
+	assert.False(t, ProviderCanRefreshPrincipals(genericoidc.Name))
 }
-
-func cleanup() {
-	Providers = make(map[string]common.AuthProvider)
-	providersWithSecrets = make(map[string]bool)
-}
-
-type mockUnstructuredGetter struct {
-	objects    map[string]runtime.Object
-	errObjects map[string]error
-}
-
-func newMockUnstructuredGetter() *mockUnstructuredGetter {
-	return &mockUnstructuredGetter{
-		objects:    map[string]runtime.Object{},
-		errObjects: map[string]error{},
-	}
-}
-
-func (m *mockUnstructuredGetter) Get(name string, _ metav1.GetOptions) (runtime.Object, error) {
-	if obj, ok := m.objects[name]; ok {
-		return obj, nil
-	}
-	if err, ok := m.errObjects[name]; ok {
-		return nil, err
-	}
-	return nil, fmt.Errorf("object %s not found", name)
-}
-
-type mockUnstructured struct {
-	content map[string]any
-}
-
-func (m *mockUnstructured) NewEmptyInstance() runtime.Unstructured                 { return nil }
-func (m *mockUnstructured) UnstructuredContent() map[string]any                    { return m.content }
-func (m *mockUnstructured) SetUnstructuredContent(input map[string]any)            { m.content = input }
-func (m *mockUnstructured) IsList() bool                                           { return false }
-func (m *mockUnstructured) EachListItem(func(runtime.Object) error) error          { return nil }
-func (m *mockUnstructured) EachListItemWithAlloc(func(runtime.Object) error) error { return nil }
-func (m *mockUnstructured) GetObjectKind() schema.ObjectKind                       { return nil }
-func (m *mockUnstructured) DeepCopyObject() runtime.Object                         { return nil }

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -241,7 +241,12 @@ func (h *loginHandler) login(w http.ResponseWriter, r *http.Request, input login
 	if providers.IsSAMLProviderType(input.GetType()) {
 		// SAML's login flow is different. Unlike other providers it gets the logged in user's data
 		// via the POST from the identity provider on a separate endpoint.
-		err := saml.PerformSamlLogin(r, w, input.GetName(), input, providers.Providers[input.GetName()])
+		p, err := providers.GetProvider(input.GetName())
+		if err != nil {
+			util.ReturnAPIError(w, err)
+			return
+		}
+		err = saml.PerformSamlLogin(r, w, input.GetName(), input, p)
 		if err != nil {
 			if !util.IsAPIError(err) {
 				logrus.Errorf("login: Error performing SAML login: %s", err)

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -365,7 +365,7 @@ func (s *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]
 	return nil, errors.New("Not implemented")
 }
 
-func (s *Provider) UsesUserSecrets() bool       { return false }
+func (s *Provider) UsesUserSecrets() bool      { return false }
 func (s *Provider) CanRefreshPrincipals() bool { return s.name == ShibbolethName }
 
 // SearchPrincipals searches for a principal by name using LDAP if configured.

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -365,6 +365,9 @@ func (s *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]
 	return nil, errors.New("Not implemented")
 }
 
+func (s *Provider) UsesUserSecrets() bool       { return false }
+func (s *Provider) CanRefreshPrincipals() bool { return s.name == ShibbolethName }
+
 // SearchPrincipals searches for a principal by name using LDAP if configured.
 // Otherwise it returns a "fake" principal of a requested type with the name as the searchKey.
 // If the principalType is empty, both user and group principals are returned.

--- a/pkg/auth/providers/saml/saml_provider_test.go
+++ b/pkg/auth/providers/saml/saml_provider_test.go
@@ -462,6 +462,9 @@ func (p *mockLdapProvider) TransformToAuthProvider(authConfig map[string]any) (m
 	panic("TransformToAuthProvider Unimplemented!")
 }
 
+func (p *mockLdapProvider) UsesUserSecrets() bool       { return false }
+func (p *mockLdapProvider) CanRefreshPrincipals() bool { return true }
+
 func (p *mockLdapProvider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {
 	panic("RefetchGroupPrincipals Unimplemented!")
 }

--- a/pkg/auth/providers/saml/saml_provider_test.go
+++ b/pkg/auth/providers/saml/saml_provider_test.go
@@ -462,7 +462,7 @@ func (p *mockLdapProvider) TransformToAuthProvider(authConfig map[string]any) (m
 	panic("TransformToAuthProvider Unimplemented!")
 }
 
-func (p *mockLdapProvider) UsesUserSecrets() bool       { return false }
+func (p *mockLdapProvider) UsesUserSecrets() bool      { return false }
 func (p *mockLdapProvider) CanRefreshPrincipals() bool { return true }
 
 func (p *mockLdapProvider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -300,7 +300,7 @@ func TestSyncGroupMembers(t *testing.T) {
 
 		srv := &SCIMServer{
 			userCache: userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig: testDefaultGetConfig,
 		}
 
 		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{
@@ -322,7 +322,7 @@ func TestSyncGroupMembers(t *testing.T) {
 
 		srv := &SCIMServer{
 			userCache: userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig: testDefaultGetConfig,
 		}
 
 		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{
@@ -354,7 +354,7 @@ func TestSyncGroupMembers(t *testing.T) {
 
 		srv := &SCIMServer{
 			userCache: userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig: testDefaultGetConfig,
 		}
 
 		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{
@@ -703,7 +703,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -743,7 +744,7 @@ func TestPatchGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -762,7 +763,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -788,7 +790,7 @@ func TestPatchGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -807,7 +809,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -846,7 +849,7 @@ func TestPatchGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupCache,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -865,7 +868,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -930,7 +934,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -979,7 +984,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -1033,7 +1039,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -1106,7 +1113,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -1162,7 +1170,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -1199,7 +1208,8 @@ func TestPatchGroup(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 
 		srv.PatchGroup(w, r)
 
@@ -1479,7 +1489,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1603,7 +1613,7 @@ func TestCreateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1637,7 +1647,7 @@ func TestCreateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1704,7 +1714,7 @@ func TestCreateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1737,7 +1747,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1779,7 +1789,7 @@ func TestCreateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1823,7 +1833,7 @@ func TestCreateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1875,7 +1885,7 @@ func TestCreateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1921,7 +1931,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1967,7 +1977,7 @@ func TestCreateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			groups:      groupClient,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2037,7 +2047,8 @@ func TestGetGroup(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.GetGroup(w, r)
@@ -2076,11 +2087,12 @@ func TestGetGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID+"?excludedAttributes=members,other_attribute", nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.GetGroup(w, r)
@@ -2115,11 +2127,12 @@ func TestGetGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.GetGroup(w, r)
@@ -2144,11 +2157,12 @@ func TestGetGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.GetGroup(w, r)
@@ -2171,11 +2185,12 @@ func TestGetGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.GetGroup(w, r)
@@ -2206,11 +2221,12 @@ func TestGetGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.GetGroup(w, r)
@@ -2270,7 +2286,8 @@ func TestGetGroup(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.GetGroup(w, r)
@@ -2313,7 +2330,7 @@ func TestUpdateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2324,7 +2341,8 @@ func TestUpdateGroup(t *testing.T) {
 			"members": []
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2377,7 +2395,7 @@ func TestUpdateGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2388,7 +2406,8 @@ func TestUpdateGroup(t *testing.T) {
 			"members": []
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2441,7 +2460,8 @@ func TestUpdateGroup(t *testing.T) {
 			"members": []
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2479,7 +2499,8 @@ func TestUpdateGroup(t *testing.T) {
 			"members": []
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2546,7 +2567,8 @@ func TestUpdateGroup(t *testing.T) {
 			"members": [{"value": "u-user1", "display": "user1"}]
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2570,7 +2592,8 @@ func TestUpdateGroup(t *testing.T) {
 			"displayName": "Engineering"
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/grp-abc123", bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", "grp-abc123")
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", "grp-abc123")
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2588,7 +2611,8 @@ func TestUpdateGroup(t *testing.T) {
 
 		body := `not valid json`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/grp-abc123", bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", "grp-abc123")
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", "grp-abc123")
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2607,7 +2631,8 @@ func TestUpdateGroup(t *testing.T) {
 
 		body := `{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "id": "grp-abc123"}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/grp-abc123", bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", "grp-abc123")
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", "grp-abc123")
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2631,7 +2656,7 @@ func TestUpdateGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2640,7 +2665,8 @@ func TestUpdateGroup(t *testing.T) {
 			"displayName": "Engineering"
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2672,7 +2698,7 @@ func TestUpdateGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2683,7 +2709,8 @@ func TestUpdateGroup(t *testing.T) {
 			"members": [{"value": "u-user1", "display": "user1"}]
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2760,7 +2787,8 @@ func TestUpdateGroup(t *testing.T) {
 			"members": []
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateGroup(w, r)
@@ -2794,11 +2822,12 @@ func TestDeleteGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteGroup(w, r)
@@ -2862,7 +2891,8 @@ func TestDeleteGroup(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteGroup(w, r)
@@ -2879,11 +2909,12 @@ func TestDeleteGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteGroup(w, r)
@@ -2906,11 +2937,12 @@ func TestDeleteGroup(t *testing.T) {
 
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteGroup(w, r)
@@ -2941,11 +2973,12 @@ func TestDeleteGroup(t *testing.T) {
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteGroup(w, r)
@@ -2980,11 +3013,12 @@ func TestDeleteGroup(t *testing.T) {
 			groupsCache: groupsCache,
 			groups:      groupClient,
 			userCache:   userCache,
-			getConfig:          testDefaultGetConfig,
+			getConfig:   testDefaultGetConfig,
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Groups/"+groupID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", groupID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteGroup(w, r)

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -548,7 +548,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -607,7 +608,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -638,7 +640,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -669,7 +672,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -703,7 +707,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -1138,7 +1143,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1198,7 +1204,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1254,7 +1261,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": false
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1311,7 +1319,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1362,7 +1371,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1387,7 +1397,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1422,7 +1433,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1467,7 +1479,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": false
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1493,7 +1506,8 @@ func TestUpdateUser(t *testing.T) {
 
 		body := `not valid json`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1514,7 +1528,8 @@ func TestUpdateUser(t *testing.T) {
 
 		body := `{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"]}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1571,7 +1586,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1619,7 +1635,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": false
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1649,7 +1666,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1670,7 +1688,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1699,7 +1718,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1722,7 +1742,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1754,7 +1775,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1774,7 +1796,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1827,7 +1850,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -1890,7 +1914,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": "True"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -1944,7 +1969,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "externalId", "value": "new-ext-id"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -1999,7 +2025,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "emails[primary eq true].value", "value": "new@example.com"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2061,7 +2088,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "value": {"externalId": "new-ext-id", "active": false}}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2110,7 +2138,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "displayName", "value": "New Name"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2158,7 +2187,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "add", "path": "displayName", "value": "John Doe"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2206,7 +2236,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "add", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2262,7 +2293,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "userName", "value": "new.name"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2308,7 +2340,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "userName", "value": "new.name"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2351,7 +2384,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": true}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2375,7 +2409,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2402,7 +2437,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2444,7 +2480,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2485,7 +2522,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "remove", "path": "active"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2526,7 +2564,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "unsupportedPath", "value": "test"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2551,7 +2590,8 @@ func TestPatchUser(t *testing.T) {
 
 		body := `not valid json`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2592,7 +2632,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": "not-a-boolean"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2638,7 +2679,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "externalId", "value": "new-ext-id"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2683,7 +2725,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2732,7 +2775,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2786,7 +2830,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:externalId", "value": "new-ext-id"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2833,7 +2878,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:Group:displayName", "value": "test"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2883,7 +2929,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:emails[primary eq true].value", "value": "new@example.com"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)

--- a/pkg/auth/requests/authenticate_test.go
+++ b/pkg/auth/requests/authenticate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/local"
 	"github.com/rancher/rancher/pkg/auth/tokens/hashers"
 	"github.com/rancher/rancher/pkg/clusterrouter"
 	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
@@ -100,6 +101,9 @@ func (p *fakeProvider) TransformToAuthProvider(map[string]interface{}) (map[stri
 	panic("not implemented")
 }
 
+func (p *fakeProvider) UsesUserSecrets() bool      { return false }
+func (p *fakeProvider) CanRefreshPrincipals() bool { return true }
+
 func (p *fakeProvider) RefetchGroupPrincipals(_, _ string) ([]v3.Principal, error) {
 	panic("not implemented")
 }
@@ -125,17 +129,14 @@ func (p *fakeProvider) CleanupResources(*v3.AuthConfig) error {
 
 func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 	// This test cannot run in parallel.
-	existingProviders := providers.Providers
-	defer func() {
-		providers.Providers = existingProviders
-	}()
+	defer providers.SetProviders(nil)
 
 	fakeProvider := &fakeProvider{
 		name: "fake",
 	}
-	providers.Providers = map[string]common.AuthProvider{
+	providers.SetProviders(map[string]common.AuthProvider{
 		fakeProvider.name: fakeProvider,
-	}
+	})
 
 	now := time.Now()
 	userID := "u-abcdef"
@@ -207,7 +208,7 @@ func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 				common.UserAttributePrincipalID: {userPrincipalID},
 				common.UserAttributeUserName:    {user.Username},
 			},
-			providers.LocalProvider: {
+			local.Name: {
 				common.UserAttributePrincipalID: {"local://" + userID},
 				common.UserAttributeUserName:    {"local-user"},
 			},
@@ -636,17 +637,14 @@ func TestTokenAuthenticatorAuthenticate(t *testing.T) {
 }
 
 func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
-	existingProviders := providers.Providers
-	defer func() {
-		providers.Providers = existingProviders
-	}()
+	defer providers.SetProviders(nil)
 
 	fakeProvider := &fakeProvider{
 		name: "fake",
 	}
-	providers.Providers = map[string]common.AuthProvider{
+	providers.SetProviders(map[string]common.AuthProvider{
 		fakeProvider.name: fakeProvider,
-	}
+	})
 
 	now := time.Now()
 	userID := "u-abcdef"
@@ -738,7 +736,7 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 				common.UserAttributePrincipalID: {userPrincipalID},
 				common.UserAttributeUserName:    {user.Username},
 			},
-			providers.LocalProvider: {
+			local.Name: {
 				common.UserAttributePrincipalID: {"local://" + userID},
 				common.UserAttributeUserName:    {"local-user"},
 			},
@@ -1199,9 +1197,8 @@ func TestTokenAuthenticatorAuthenticateExtToken(t *testing.T) {
 func TestAuthenticateWithAccessTokenAndOIDCEnabled(t *testing.T) {
 	// This test cannot run in parallel.
 	existingServerURL := settings.ServerURL.Get()
-	existingProviders := providers.Providers
 	t.Cleanup(func() {
-		providers.Providers = existingProviders
+		providers.SetProviders(nil)
 		_ = settings.ServerURL.Set(existingServerURL)
 	})
 	_ = settings.ServerURL.Set("https://rancher.example.com")
@@ -1215,9 +1212,9 @@ func TestAuthenticateWithAccessTokenAndOIDCEnabled(t *testing.T) {
 	fakeProvider := &fakeProvider{
 		name: "fake",
 	}
-	providers.Providers = map[string]common.AuthProvider{
+	providers.SetProviders(map[string]common.AuthProvider{
 		fakeProvider.name: fakeProvider,
-	}
+	})
 
 	userID := "u-abcdef"
 	userPrincipalID := "fake_user://12345"
@@ -1301,7 +1298,7 @@ func TestAuthenticateWithAccessTokenAndOIDCEnabled(t *testing.T) {
 					common.UserAttributePrincipalID: {userPrincipalID},
 					common.UserAttributeUserName:    {user.Username},
 				},
-				providers.LocalProvider: {
+				local.Name: {
 					common.UserAttributePrincipalID: {"local://" + userID},
 					common.UserAttributeUserName:    {"local-user"},
 				},
@@ -1427,7 +1424,7 @@ func TestAuthenticateWithAccessTokenAndOIDCEnabled(t *testing.T) {
 					common.UserAttributePrincipalID: {userPrincipalID},
 					common.UserAttributeUserName:    {user.Username},
 				},
-				providers.LocalProvider: {
+				local.Name: {
 					common.UserAttributePrincipalID: {"local://" + userID},
 					common.UserAttributeUserName:    {"local-user"},
 				},
@@ -1486,9 +1483,8 @@ func TestAuthenticateWithAccessTokenAndOIDCEnabled(t *testing.T) {
 func TestAuthenticateWithAccessTokenAndOIDCDisabled(t *testing.T) {
 	// This test cannot run in parallel.
 	existingServerURL := settings.ServerURL.Get()
-	existingProviders := providers.Providers
 	t.Cleanup(func() {
-		providers.Providers = existingProviders
+		providers.SetProviders(nil)
 		_ = settings.ServerURL.Set(existingServerURL)
 	})
 	_ = settings.ServerURL.Set("https://rancher.example.com")
@@ -1502,9 +1498,9 @@ func TestAuthenticateWithAccessTokenAndOIDCDisabled(t *testing.T) {
 	fakeProvider := &fakeProvider{
 		name: "fake",
 	}
-	providers.Providers = map[string]common.AuthProvider{
+	providers.SetProviders(map[string]common.AuthProvider{
 		fakeProvider.name: fakeProvider,
-	}
+	})
 
 	userID := "u-abcdef"
 	userPrincipalID := "fake_user://12345"
@@ -1587,7 +1583,7 @@ func TestAuthenticateWithAccessTokenAndOIDCDisabled(t *testing.T) {
 				common.UserAttributePrincipalID: {userPrincipalID},
 				common.UserAttributeUserName:    {user.Username},
 			},
-			providers.LocalProvider: {
+			local.Name: {
 				common.UserAttributePrincipalID: {"local://" + userID},
 				common.UserAttributeUserName:    {"local-user"},
 			},

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -500,7 +500,11 @@ func (m *Manager) UpdateSecret(userID, provider, secret string) error {
 	return err
 }
 
-// PerUserCacheProviders is a set of provider names for which the token manager creates a per-user login token.
+// PerUserCacheProviders is a set of provider names for which the token manager
+// creates and stores a per-user OAuth secret during login. The read-side
+// equivalent is AuthProvider.UsesUserSecrets(); these two must agree on which
+// providers use per-user secrets. They are maintained separately because the
+// tokens package cannot import providers (circular dependency).
 var PerUserCacheProviders = []string{"github", "azuread", "googleoauth", "oidc", "keycloakoidc"}
 
 func (m *Manager) NewLoginToken(userID string, userPrincipal apiv3.Principal, groupPrincipals []apiv3.Principal, providerToken string, ttl int64, description string) (*apiv3.Token, string, error) {

--- a/pkg/auth/tokens/test_utils.go
+++ b/pkg/auth/tokens/test_utils.go
@@ -2,11 +2,13 @@ package tokens
 
 import (
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	ctrlv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 )
 
 // NewMockedManager returns a token manager with mocked clients to be used in other packages' tests.
-func NewMockedManager(tokens v3.TokenClient) *Manager { // add other clients, indexers, listers as needed
+func NewMockedManager(tokens v3.TokenClient, secretCache ctrlv1.SecretCache) *Manager {
 	return &Manager{
-		tokens: tokens,
+		tokens:      tokens,
+		secretCache: secretCache,
 	}
 }

--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -67,10 +67,10 @@ func TestPrimaryAddressFamily(t *testing.T) {
 
 func TestReorderAddressesByFamily(t *testing.T) {
 	tests := []struct {
-		name           string
-		addresses      []string
-		primaryFamily  int
-		expected       []string
+		name          string
+		addresses     []string
+		primaryFamily int
+		expected      []string
 	}{
 		{
 			name:          "no-op when fewer than two addresses",

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -635,4 +635,3 @@ func TestPrivateRegistryPullSecretsAsObjectReferences(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -28,11 +28,11 @@ import (
 )
 
 var (
-	errTest                     = fmt.Errorf("test error")
-	priorityClassName           = "rancher-critical"
-	operatorNamespace           = "rancher-operator-system"
-	provisioningCapiNamespace   = "cattle-provisioning-capi-system"
-	priorityConfig    = &v1.ConfigMap{
+	errTest                   = fmt.Errorf("test error")
+	priorityClassName         = "rancher-critical"
+	operatorNamespace         = "rancher-operator-system"
+	provisioningCapiNamespace = "cattle-provisioning-capi-system"
+	priorityConfig            = &v1.ConfigMap{
 		Data: map[string]string{
 			"priorityClassName": priorityClassName,
 		},

--- a/pkg/controllers/management/auth/roletemplates/common_test.go
+++ b/pkg/controllers/management/auth/roletemplates/common_test.go
@@ -1066,4 +1066,3 @@ func TestRTBContentKey(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
+++ b/pkg/controllers/management/auth/roletemplates/prtb_handler_test.go
@@ -976,7 +976,6 @@ func TestPRTBHandlerHandleMigration(t *testing.T) {
 	}
 }
 
-
 func TestDeleteDuplicatePRTBs(t *testing.T) {
 	t.Parallel()
 
@@ -1176,7 +1175,7 @@ func TestDeleteDuplicatePRTBs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "prtb-2",
 						Namespace:         "ns",
-						CreationTimestamp:  now,
+						CreationTimestamp: now,
 						DeletionTimestamp: &now,
 					},
 					UserName:         "user1",
@@ -1263,4 +1262,3 @@ func TestDeleteDuplicatePRTBs(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_validate_test.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_validate_test.go
@@ -71,9 +71,9 @@ func TestReconcileNamespaces(t *testing.T) {
 				nsMock := wranglerfake.NewMockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList](ctrl)
 				nsMock.EXPECT().
 					Enqueue(gomock.Any()).
-					DoAndReturn(func (_ string) {
+					DoAndReturn(func(_ string) {
 						*enqCounter = *enqCounter + 1
-				})
+					})
 
 				return &reconcileController{
 					namespaces: nsMock,

--- a/pkg/oidc/provider/token_test.go
+++ b/pkg/oidc/provider/token_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
 	providermocks "github.com/rancher/rancher/pkg/auth/providers/mocks"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/oidc/mocks"
@@ -620,7 +621,7 @@ func TestTokenEndpoint(t *testing.T) {
 	// register auth provider
 	mockProvider := providermocks.NewMockAuthProvider(ctrl)
 	mockProvider.EXPECT().IsDisabledProvider().Return(false, nil).AnyTimes()
-	providers.Providers[fakeAuthProvider] = mockProvider
+	providers.SetProviders(map[string]common.AuthProvider{fakeAuthProvider: mockProvider})
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/tests/controllers/oidc/oidc_provider_test.go
+++ b/tests/controllers/oidc/oidc_provider_test.go
@@ -17,6 +17,7 @@ import (
 	goidc "github.com/coreos/go-oidc/v3/oidc"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers"
+	providercommon "github.com/rancher/rancher/pkg/auth/providers/common"
 	providermocks "github.com/rancher/rancher/pkg/auth/providers/mocks"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/controllers/management/oidcprovider"
@@ -210,7 +211,7 @@ func (s *OIDCProviderSuite) TestOIDCAuthorizationCodeFlow() {
 	// mock auth provider
 	mockProvider := providermocks.NewMockAuthProvider(ctrl)
 	mockProvider.EXPECT().IsDisabledProvider().Return(false, nil).AnyTimes()
-	providers.Providers[fakeAuthProvider] = mockProvider
+	providers.SetProviders(map[string]providercommon.AuthProvider{fakeAuthProvider: mockProvider})
 
 	// create OIDC client
 	oidcClient := &apimgmtv3.OIDCClient{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The auth provider registry maintained several parallel data structures
- provider names
- which providers use user secrets
- which providers can refresh principals that duplicated knowledge each provider already has about itself. These maps were error-prone — for example, githubapp was incorrectly listed as using per-user secrets, causing silent refresh failures.

When a user secret was not found, the refresh loop marked the login as unconfirmable but still attempted to fetch the user principal. For providers like Google OAuth that require a valid stored token, this caused a JSON unmarshal error on the empty token, converting a
recoverable state into a hard refresh failure and requeue loop.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Two new methods were added to the auth provider interface so each provider declares its own capabilities. The hardcoded maps and the separate name list were removed in favor of querying providers directly. The provider registry was made concurrency-safe with a read-write mutex, the map was unexported, and the early-return bug in the refresh loop was fixed.

The refresh variable is now visible to the extra-attribute block so the principal fetch is skipped when the secret is unavailable. Existing extra attributes are preserved through the deep copy.
 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests