### PR TITLE
Handle the AlreadyExists error when creating roles.

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -310,7 +310,11 @@ func (m *manager) createProjectMembershipRole(roleName, namespace string, projec
 	return nil
 }
 
-func (m *manager) createMembershipRole(resourceType, roleName string, makeOwner bool, ownerObject interface{}, client *objectclient.ObjectClient, clusterRole bool) error {
+type objectCreator interface {
+	Create(o runtime.Object) (runtime.Object, error)
+}
+
+func (m *manager) createMembershipRole(resourceType, roleName string, makeOwner bool, ownerObject interface{}, client objectCreator, clusterRole bool) error {
 	metaObj, err := meta.Accessor(ownerObject)
 	if err != nil {
 		return err
@@ -359,7 +363,11 @@ func (m *manager) createMembershipRole(resourceType, roleName string, makeOwner 
 		}
 	}
 	_, err = client.Create(toCreate)
-	return err
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return fmt.Errorf("failed to create role: %w", err)
 }
 
 // The CRTB has been deleted or modified, either delete or update the membership binding so that the subject

--- a/pkg/controllers/management/auth/manager_test.go
+++ b/pkg/controllers/management/auth/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -874,4 +875,37 @@ func Test_gatherRoleTemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeObjectCreator is a minimal objectCreator whose Create always returns the
+// configured error, simulating a specific API-server response.
+type fakeObjectCreator struct{ err error }
+
+func (f *fakeObjectCreator) Create(_ runtime.Object) (runtime.Object, error) {
+	return nil, f.err
+}
+
+func TestCreateMembershipRole_AlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	cluster := &v3.Cluster{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "management.cattle.io/v3",
+			Kind:       "Cluster",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-cluster",
+			UID:  "1234-abcd",
+		},
+	}
+
+	alreadyExistsErr := errors.NewAlreadyExists(
+		schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"},
+		"test-role",
+	)
+
+	m := &manager{}
+
+	err := m.createMembershipRole(clusterResource, "test-role", false, cluster, &fakeObjectCreator{err: alreadyExistsErr}, true)
+	require.NoError(t, err)
 }

--- a/pkg/controllers/management/auth/zz_manager_fakes.go
+++ b/pkg/controllers/management/auth/zz_manager_fakes.go
@@ -168,3 +168,42 @@ func (mr *MockmanagerInterfaceMockRecorder) removeAuthV2Permissions(arg0, arg1 a
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeAuthV2Permissions", reflect.TypeOf((*MockmanagerInterface)(nil).removeAuthV2Permissions), arg0, arg1)
 }
+
+// MockobjectCreator is a mock of objectCreator interface.
+type MockobjectCreator struct {
+	ctrl     *gomock.Controller
+	recorder *MockobjectCreatorMockRecorder
+	isgomock struct{}
+}
+
+// MockobjectCreatorMockRecorder is the mock recorder for MockobjectCreator.
+type MockobjectCreatorMockRecorder struct {
+	mock *MockobjectCreator
+}
+
+// NewMockobjectCreator creates a new mock instance.
+func NewMockobjectCreator(ctrl *gomock.Controller) *MockobjectCreator {
+	mock := &MockobjectCreator{ctrl: ctrl}
+	mock.recorder = &MockobjectCreatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockobjectCreator) EXPECT() *MockobjectCreatorMockRecorder {
+	return m.recorder
+}
+
+// Create mocks base method.
+func (m *MockobjectCreator) Create(o runtime.Object) (runtime.Object, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", o)
+	ret0, _ := ret[0].(runtime.Object)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockobjectCreatorMockRecorder) Create(o any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockobjectCreator)(nil).Create), o)
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
If the cache is stale when creating roles in the "mgmt-auth-prtb-controller" the "AlreadyExists" error is not handled and causes the synchronisation to stop.

## Solution
This simply ignores the "AlreadyExists".
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Tests are added.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_