### PR TITLE
extended logging in CRTB reconciler

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -23,12 +23,12 @@ import (
 )
 
 const (
-	/* Prior to 2.5, the label "memberhsip-binding-owner" was set on the CRB/RBs for a roleTemplateBinding with the key being the roleTemplateBinding's UID.
-	2.5 onwards, instead of the roleTemplateBinding's UID, a combination of its namespace and name will be used in this label.
-	CRB/RBs on clusters upgraded from 2.4.x to 2.5 will continue to carry the original label with UID. To ensure permissions are managed properly on upgrade,
-	we need to change the label value as well.
-	So the older label value, MembershipBindingOwnerLegacy (<=2.4.x) will continue to be "memberhsip-binding-owner" (notice the spelling mistake),
-	and the new label, MembershipBindingOwner will be "membership-binding-owner" (a different label value with the right spelling)*/
+	// Prior to 2.5, the label "memberhsip-binding-owner" was set on the CRB/RBs for a roleTemplateBinding with the key being the roleTemplateBinding's UID.
+	// 2.5 onwards, instead of the roleTemplateBinding's UID, a combination of its namespace and name will be used in this label.
+	// CRB/RBs on clusters upgraded from 2.4.x to 2.5 will continue to carry the original label with UID.
+	// To ensure permissions are managed properly on upgrade, we need to change the label value as well.
+	// So the older label value, MembershipBindingOwnerLegacy (<=2.4.x) will continue to be "memberhsip-binding-owner" (notice the spelling mistake),
+	// and the new label, MembershipBindingOwner will be "membership-binding-owner" (a different label value with the right spelling)
 	MembershipBindingOwnerLegacy = "memberhsip-binding-owner"
 	MembershipBindingOwner       = "membership-binding-owner"
 	clusterResource              = "clusters"
@@ -93,10 +93,19 @@ type crtbLifecycle struct {
 }
 
 func (c *crtbLifecycle) Create(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	logrus.Debugf("ZZZZZZ auth/CRTB create %q", obj.Name)
+
 	if features.AggregatedRoleTemplates.Enabled() {
+		logrus.Debugf("ZZZZZZ auth/CRTB create %q - skip, using aggregated role templates", obj.Name)
 		return nil, nil
 	}
 	var localConditions []metav1.Condition
+
+	logrus.Debugf("ZZZZZZ auth/CRTB create %q - reconcile", obj.Name)
+	defer func() {
+		logrus.Debugf("ZZZZZZ auth/CRTB create %q - reconcile done", obj.Name)
+	}()
+
 	obj, err := c.reconcileSubject(obj, &localConditions)
 	return obj, errors.Join(err,
 		c.reconcileBindings(obj, &localConditions),
@@ -104,10 +113,19 @@ func (c *crtbLifecycle) Create(obj *v3.ClusterRoleTemplateBinding) (runtime.Obje
 }
 
 func (c *crtbLifecycle) Updated(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	logrus.Debugf("ZZZZZZ auth/CRTB updated %q", obj.Name)
+
 	if features.AggregatedRoleTemplates.Enabled() {
+		logrus.Debugf("ZZZZZZ auth/CRTB updated %q - skip, using aggregated role templates", obj.Name)
 		return nil, nil
 	}
 	var localConditions []metav1.Condition
+
+	logrus.Debugf("ZZZZZZ auth/CRTB updated %q - reconcile", obj.Name)
+	defer func() {
+		logrus.Debugf("ZZZZZZ auth/CRTB updated %q - reconcile done", obj.Name)
+	}()
+
 	obj, err := c.reconcileSubject(obj, &localConditions)
 	return obj, errors.Join(err,
 		c.reconcileLabels(obj, &localConditions),
@@ -116,10 +134,18 @@ func (c *crtbLifecycle) Updated(obj *v3.ClusterRoleTemplateBinding) (runtime.Obj
 }
 
 func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	logrus.Debugf("ZZZZZZ auth/CRTB remove %q", obj.Name)
+
 	if features.AggregatedRoleTemplates.Enabled() {
+		logrus.Debugf("ZZZZZZ auth/CRTB remove %q - skip, using aggregated role templates", obj.Name)
 		return nil, nil
 	}
 	condition := metav1.Condition{Type: clusterRoleTemplateBindingDelete}
+
+	logrus.Debugf("ZZZZZZ auth/CRTB remove %q - reconcile", obj.Name)
+	defer func() {
+		logrus.Debugf("ZZZZZZ auth/CRTB remove %q - reconcile done", obj.Name)
+	}()
 
 	if err := c.mgr.reconcileClusterMembershipBindingForDelete("", pkgrbac.GetRTBLabel(obj.ObjectMeta)); err != nil {
 		c.s.AddCondition(&obj.Status.LocalConditions, condition, failedToDeleteClusterMembershipBinding, err)
@@ -135,6 +161,7 @@ func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Obje
 		return nil, errors.Join(err, c.updateStatus(obj, obj.Status.LocalConditions))
 	}
 
+	logrus.Debugf("ZZZZZZ auth/CRTB remove %q - no errors", obj.Name)
 	return nil, nil
 }
 
@@ -382,21 +409,27 @@ var timeNow = func() time.Time {
 }
 
 func (c *crtbLifecycle) updateStatus(crtb *v3.ClusterRoleTemplateBinding, localConditions []metav1.Condition) error {
+	logrus.Debugf("ZZZZZZ auth/CRTB update status %q, cond=((%v))", crtb.Name, localConditions)
+
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		crtbFromCluster, err := c.crtbCache.Get(crtb.Namespace, crtb.Name)
 		if err != nil {
+			logrus.Debugf("ZZZZZZ auth/CRTB update status %q, get FAIL: %v", crtb.Name, err)
 			return err
 		}
 		if status.CompareConditions(crtbFromCluster.Status.LocalConditions, localConditions) {
+			logrus.Debugf("ZZZZZZ auth/CRTB update status %q, skip, conditions unchanged", crtb.Name)
 			return nil
 		}
 
 		crtbFromCluster.Status.SummaryLocal = status.SummaryCompleted
 		if crtbFromCluster.Status.SummaryRemote == status.SummaryCompleted {
+			logrus.Debugf("ZZZZZZ auth/CRTB update status %q, summary complete (local & remote complete)", crtb.Name)
 			crtbFromCluster.Status.Summary = status.SummaryCompleted
 		}
 		for _, c := range localConditions {
 			if c.Status != metav1.ConditionTrue {
+				logrus.Debugf("ZZZZZZ auth/CRTB update status %q, summary error, local error", crtb.Name)
 				crtbFromCluster.Status.Summary = status.SummaryError
 				crtbFromCluster.Status.SummaryLocal = status.SummaryError
 				break
@@ -408,6 +441,7 @@ func (c *crtbLifecycle) updateStatus(crtb *v3.ClusterRoleTemplateBinding, localC
 		crtbFromCluster.Status.LocalConditions = localConditions
 		_, err = c.crtbClient.UpdateStatus(crtbFromCluster)
 
+		logrus.Debugf("ZZZZZZ auth/CRTB update status %q, result: %v", crtb.Name, err)
 		return err
 	})
 }

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -65,28 +65,55 @@ type crtbLifecycle struct {
 }
 
 func (c *crtbLifecycle) Create(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	logrus.Debugf("ZZZZZZ rbac/CRTB create %q", obj.Name)
+
 	if features.AggregatedRoleTemplates.Enabled() {
+		logrus.Debugf("ZZZZZZ rbac/CRTB create %q - skip, using aggregated role templates", obj.Name)
 		return nil, nil
 	}
 	remoteConditions := []metav1.Condition{}
+
+	logrus.Debugf("ZZZZZZ rbac/CRTB create %q - reconcile", obj.Name)
+	defer func() {
+		logrus.Debugf("ZZZZZZ rbac/CRTB create %q - reconcile done", obj.Name)
+	}()
+
 	return obj, errors.Join(c.syncCRTB(obj, &remoteConditions),
 		c.updateStatus(obj, remoteConditions))
 }
 
 func (c *crtbLifecycle) Updated(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	logrus.Debugf("ZZZZZZ rbac/CRTB updated %q", obj.Name)
+
 	if features.AggregatedRoleTemplates.Enabled() {
+		logrus.Debugf("ZZZZZZ rbac/CRTB updated %q - skip, using aggregated role templates", obj.Name)
 		return nil, nil
 	}
 	remoteConditions := []metav1.Condition{}
+
+	logrus.Debugf("ZZZZZZ rbac/CRTB updated %q - reconcile", obj.Name)
+	defer func() {
+		logrus.Debugf("ZZZZZZ rbac/CRTB updated %q - reconcile done", obj.Name)
+	}()
+
 	return obj, errors.Join(c.reconcileCRTBUserClusterLabels(obj, &remoteConditions),
 		c.syncCRTB(obj, &remoteConditions),
 		c.updateStatus(obj, remoteConditions))
 }
 
 func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	logrus.Debugf("ZZZZZZ rbac/CRTB remove %q", obj.Name)
+
 	if features.AggregatedRoleTemplates.Enabled() {
+		logrus.Debugf("ZZZZZZ rbac/CRTB remove %q - skip, using aggregated role templates", obj.Name)
 		return nil, nil
 	}
+
+	logrus.Debugf("ZZZZZZ rbac/CRTB remove %q - reconcile", obj.Name)
+	defer func() {
+		logrus.Debugf("ZZZZZZ rbac/CRTB remove %q - reconcile done", obj.Name)
+	}()
+
 	err := c.ensureCRTBDelete(obj, &obj.Status.RemoteConditions)
 	if err != nil {
 		return obj, errors.Join(err,
@@ -98,22 +125,31 @@ func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Obje
 func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding, remoteConditions *[]metav1.Condition) error {
 	condition := metav1.Condition{Type: clusterRolesExists}
 
+	logrus.Debugf("ZZZZZZ syncCRTB %q - role-template-name   %q", binding.Name, binding.RoleTemplateName)
+	logrus.Debugf("ZZZZZZ syncCRTB %q - user-name            %q", binding.Name, binding.UserName)
+	logrus.Debugf("ZZZZZZ syncCRTB %q - group-principal-name %q", binding.Name, binding.GroupPrincipalName)
+	logrus.Debugf("ZZZZZZ syncCRTB %q - group-name           %q", binding.Name, binding.GroupName)
+
 	if binding.RoleTemplateName == "" {
+		logrus.Debugf("ZZZZZZ syncCRTB %q - skip, no role template", binding.Name)
 		logrus.Warnf("ClusterRoleTemplateBinding %v has no role template set. Skipping.", binding.Name)
 		c.s.AddCondition(remoteConditions, condition, roleTemplateDoesNotExist, nil)
 		return nil
 	}
 
 	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" {
+		logrus.Debugf("ZZZZZZ syncCRTB %q - skip, no user, or no group", binding.Name)
 		c.s.AddCondition(remoteConditions, condition, userOrGroupDoesNotExist, nil)
 		return nil
 	}
 
 	rt, err := c.rtLister.Get("", binding.RoleTemplateName)
 	if err != nil {
+		logrus.Debugf("ZZZZZZ syncCRTB %q - skip, get FAIL: %v", binding.Name, err)
 		err = fmt.Errorf("couldn't get role template %v: %w", binding.RoleTemplateName, err)
 		c.s.AddCondition(remoteConditions, condition, failedToGetRoleTemplate, err)
 		if apierrors.IsNotFound(err) {
+			logrus.Debugf("ZZZZZZ syncCRTB %q - skip, not found", binding.Name)
 			logrus.Warnf(
 				"RoleTemplate %s not found for ClusterRoleTemplateBinding %s. Skipping.",
 				binding.RoleTemplateName,
@@ -126,11 +162,13 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding, remoteC
 
 	roles := map[string]*v3.RoleTemplate{}
 	if err := c.m.gatherRoles(rt, roles, 0); err != nil {
+		logrus.Debugf("ZZZZZZ syncCRTB %q - skip, gather roles FAIL: %v", binding.Name, err)
 		c.s.AddCondition(remoteConditions, condition, failedToGatherRoles, err)
 		return err
 	}
 
 	if err := c.m.ensureRoles(roles); err != nil {
+		logrus.Debugf("ZZZZZZ syncCRTB %q - skip, ensure roles FAIL: %v", binding.Name, err)
 		err = fmt.Errorf("couldn't ensure roles: %w", err)
 		c.s.AddCondition(remoteConditions, condition, failedToCreateRoles, err)
 		return err
@@ -139,6 +177,7 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding, remoteC
 
 	condition = metav1.Condition{Type: clusterRoleBindingsExists}
 	if err := c.m.ensureClusterBindings(roles, binding); err != nil {
+		logrus.Debugf("ZZZZZZ syncCRTB %q - skip, ensure cluster bindings FAIL: %v", binding.Name, err)
 		err = fmt.Errorf("couldn't ensure cluster bindings %v: %w", binding.Name, err)
 		c.s.AddCondition(remoteConditions, condition, failedToCreateBindings, err)
 		return err
@@ -148,6 +187,7 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding, remoteC
 	condition = metav1.Condition{Type: serviceAccountImpersonatorExists}
 	if binding.UserName != "" {
 		if err := c.m.ensureServiceAccountImpersonator(binding.UserName); err != nil {
+			logrus.Debugf("ZZZZZZ syncCRTB %q - skip, ensure impersonator FAIL: %v", binding.Name, err)
 			err = fmt.Errorf("couldn't ensure service account impersonator: %w", err)
 			c.s.AddCondition(remoteConditions, condition, failedToCreateServiceAccountImpersonator, err)
 			return err
@@ -155,6 +195,7 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding, remoteC
 	}
 	c.s.AddCondition(remoteConditions, condition, serviceAccountImpersonatorExists, nil)
 
+	logrus.Debugf("ZZZZZZ syncCRTB %q - OK", binding.Name)
 	return nil
 }
 
@@ -186,10 +227,9 @@ func (c *crtbLifecycle) ensureCRTBDelete(binding *v3.ClusterRoleTemplateBinding,
 }
 
 func (c *crtbLifecycle) reconcileCRTBUserClusterLabels(binding *v3.ClusterRoleTemplateBinding, remoteConditions *[]metav1.Condition) error {
-	/* Prior to 2.5, for every CRTB, following CRBs are created in the user clusters
-		1. CRTB.UID is the label value for a CRB, authz.cluster.cattle.io/rtb-owner=CRTB.UID
-	Using this labels, list the CRBs and update them to add a label with ns+name of CRTB
-	*/
+	// Prior to 2.5, for every CRTB, the following CRBs are created in the user clusters
+	//	1. CRTB.UID is the label value for a CRB, authz.cluster.cattle.io/rtb-owner=CRTB.UID
+	// Using this label, list the CRBs and update them to add a label with ns+name of CRTB
 	condition := metav1.Condition{Type: crtbLabelsUpdated}
 
 	if binding.Labels[rtbCrbRbLabelsUpdated] == "true" {
@@ -265,21 +305,27 @@ var timeNow = func() time.Time {
 }
 
 func (c *crtbLifecycle) updateStatus(crtb *v3.ClusterRoleTemplateBinding, remoteConditions []metav1.Condition) error {
+	logrus.Debugf("ZZZZZZ rbac/CRTB update status %q, cond=((%v))", crtb.Name, remoteConditions)
+
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		crtbFromCluster, err := c.crtbCache.Get(crtb.Namespace, crtb.Name)
 		if err != nil {
+			logrus.Debugf("ZZZZZZ rbac/CRTB update status %q, get FAIL: %v", crtb.Name, err)
 			return err
 		}
 		if status.CompareConditions(crtbFromCluster.Status.RemoteConditions, remoteConditions) {
+			logrus.Debugf("ZZZZZZ rbac/CRTB update status %q, skip, conditions unchanged", crtb.Name)
 			return nil
 		}
 
 		crtbFromCluster.Status.SummaryRemote = status.SummaryCompleted
 		if crtbFromCluster.Status.SummaryLocal == status.SummaryCompleted {
+			logrus.Debugf("ZZZZZZ rbac/CRTB update status %q, summary complete (remote & local complete)", crtb.Name)
 			crtbFromCluster.Status.Summary = status.SummaryCompleted
 		}
 		for _, c := range remoteConditions {
 			if c.Status != metav1.ConditionTrue {
+				logrus.Debugf("ZZZZZZ rbac/CRTB update status %q, summary error, remote error", crtb.Name)
 				crtbFromCluster.Status.Summary = status.SummaryError
 				crtbFromCluster.Status.SummaryRemote = status.SummaryError
 				break
@@ -290,6 +336,8 @@ func (c *crtbLifecycle) updateStatus(crtb *v3.ClusterRoleTemplateBinding, remote
 		crtbFromCluster.Status.ObservedGenerationRemote = crtb.ObjectMeta.Generation
 		crtbFromCluster.Status.RemoteConditions = remoteConditions
 		_, err = c.crtbClient.UpdateStatus(crtbFromCluster)
+
+		logrus.Debugf("ZZZZZZ rbac/CRTB update status %q, result: %v", crtb.Name, err)
 		return err
 	})
 }

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -223,34 +223,49 @@ type manager struct {
 }
 
 func (m *manager) ensureRoles(rts map[string]*v3.RoleTemplate) error {
+	logrus.Debugf("ZZZZZZ ensure clusterRoles")
 	for _, rt := range rts {
 		if rt.External {
+			logrus.Debugf("ZZZZZZ ensure clusterRole %q: skip, external", rt.Name)
 			continue
 		}
 		if err := m.ensureClusterRoles(rt); err != nil {
+			logrus.Debugf("ZZZZZZ ensure clusterRoles FAIL: %v", err)
 			return err
 		}
 	}
+	logrus.Debugf("ZZZZZZ ensure clusterRoles, OK")
 	return nil
 }
 
 func (m *manager) ensureClusterRoles(rt *v3.RoleTemplate) error {
+	logrus.Debugf("ZZZZZZ ensure clusterRole %q for roletemplate", rt.Name)
 	if clusterRole, err := m.crLister.Get(rt.Name); err == nil && clusterRole != nil {
 		err := m.compareAndUpdateClusterRole(clusterRole, rt)
 		if err == nil {
+			logrus.Debugf("ZZZZZZ ensure clusterRole %q, skip, present and matching", rt.Name)
 			return nil
 		}
 		if apierrors.IsConflict(err) {
+			logrus.Debugf("ZZZZZZ ensure clusterRole %q, conflict, retry", rt.Name)
 			// get object from etcd and retry
 			clusterRole, err := m.clusterRoles.Get(rt.Name, metav1.GetOptions{})
 			if err != nil {
+				logrus.Debugf("ZZZZZZ ensure clusterRole %q, FAIL to get: %v", rt.Name, err)
 				return errors.Wrapf(err, "error getting clusterRole %v", rt.Name)
 			}
-			return m.compareAndUpdateClusterRole(clusterRole, rt)
+			err = m.compareAndUpdateClusterRole(clusterRole, rt)
+			if err != nil {
+				logrus.Debugf("ZZZZZZ ensure clusterRole %q, FAIL to update: %v", rt.Name, err)
+			}
+			logrus.Debugf("ZZZZZZ ensure clusterRole %q, skip, present and matching", rt.Name)
+			return nil
 		}
+		logrus.Debugf("ZZZZZZ ensure clusterRole %q, FAIL to update: %v", rt.Name, err)
 		return errors.Wrapf(err, "couldn't update clusterRole %v", rt.Name)
 	}
 
+	logrus.Debugf("ZZZZZZ ensure clusterRole %q, missing, create", rt.Name)
 	return m.createClusterRole(rt)
 }
 
@@ -269,6 +284,7 @@ func (m *manager) compareAndUpdateClusterRole(clusterRole *rbacv1.ClusterRole, r
 }
 
 func (m *manager) createClusterRole(rt *v3.RoleTemplate) error {
+	logrus.Debugf("ZZZZZZ new clusterRole %q for roleTemplate %v (%v).", rt.Name, rt.DisplayName, rt.Name)
 	logrus.Infof("Creating clusterRole for roleTemplate %v (%v).", rt.DisplayName, rt.Name)
 	_, err := m.clusterRoles.Create(&rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -278,8 +294,10 @@ func (m *manager) createClusterRole(rt *v3.RoleTemplate) error {
 		Rules: rt.Rules,
 	})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
+		logrus.Debugf("ZZZZZZ new clusterRole %q FAIL: %v", rt.Name, err)
 		return errors.Wrapf(err, "couldn't create clusterRole %v", rt.Name)
 	}
+	logrus.Debugf("ZZZZZZ new clusterRole %q OK", rt.Name)
 	return nil
 }
 

--- a/pkg/controllers/managementuser/rbac/roletemplates/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/crtb_handler.go
@@ -69,7 +69,7 @@ func (c *crtbHandler) OnChange(key string, crtb *v3.ClusterRoleTemplateBinding) 
 	// Only run this controller if the CRTB is for this cluster
 	if crtb.ClusterName != c.clusterName {
 		logrus.Debugf("ZZZZZZ rbac/rt/CRTB onchange %q, skip, cluster mismatch (have %q need %q)",
-			key, crtb.ClusterName != c.clusterName)
+			key, crtb.ClusterName, c.clusterName)
 		return nil, nil
 	}
 

--- a/pkg/controllers/managementuser/rbac/roletemplates/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/crtb_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
 	wrbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
+	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -57,17 +58,28 @@ func newCRTBHandler(uc *config.UserContext) (*crtbHandler, error) {
 
 // OnChange ensures that the correct ClusterRoleBinding exists for the ClusterRoleTemplateBinding
 func (c *crtbHandler) OnChange(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+
+	logrus.Debugf("ZZZZZZ rbac/rt/CRTB onchange %q", key)
+
 	if crtb == nil || crtb.DeletionTimestamp != nil || !features.AggregatedRoleTemplates.Enabled() {
+		logrus.Debugf("ZZZZZZ rbac/rt/CRTB onchange %q, skip (missing || in deletion || no aggregation", key)
 		return nil, nil
 	}
 
 	// Only run this controller if the CRTB is for this cluster
 	if crtb.ClusterName != c.clusterName {
+		logrus.Debugf("ZZZZZZ rbac/rt/CRTB onchange %q, skip, cluster mismatch (have %q need %q)",
+			key, crtb.ClusterName != c.clusterName)
 		return nil, nil
 	}
 
+	defer func() {
+		logrus.Debugf("ZZZZZZ rbac/rt/CRTB updated %q - reconcile done", key)
+	}()
+
 	remoteConditions := []metav1.Condition{}
 	if err := c.reconcileBindings(crtb, &remoteConditions); err != nil {
+		logrus.Debugf("ZZZZZZ rbac/rt/CRTB onchange %q, FAIL reconcile bindings: %v, save", key, err)
 		return nil, errors.Join(err, c.updateStatus(crtb, remoteConditions))
 	}
 
@@ -75,9 +87,10 @@ func (c *crtbHandler) OnChange(key string, crtb *v3.ClusterRoleTemplateBinding) 
 	var err error
 	if crtb.UserName != "" {
 		err = c.impersonationHandler.ensureServiceAccountImpersonator(crtb.UserName)
+		logrus.Debugf("ZZZZZZ rbac/rt/CRTB onchange %q, impersonate: %v", key, err)
 		c.s.AddCondition(&remoteConditions, metav1.Condition{Type: ensureServiceAccountImpersonator}, serviceAccountImpersonatorExists, err)
 	}
-
+	logrus.Debugf("ZZZZZZ rbac/rt/CRTB onchange %q - save", key)
 	return crtb, errors.Join(err, c.updateStatus(crtb, remoteConditions))
 }
 
@@ -156,21 +169,27 @@ var timeNow = func() time.Time {
 }
 
 func (c *crtbHandler) updateStatus(crtb *v3.ClusterRoleTemplateBinding, remoteConditions []metav1.Condition) error {
+	logrus.Debugf("ZZZZZZ rbac/rt/CRTB update status %q, cond=((%v))", crtb.Name, remoteConditions)
+
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		crtbFromCluster, err := c.crtbCache.Get(crtb.Namespace, crtb.Name)
 		if err != nil {
+			logrus.Debugf("ZZZZZZ rbac/rt/CRTB update status %q, get FAIL: %v", crtb.Name, err)
 			return err
 		}
 		if status.CompareConditions(crtbFromCluster.Status.RemoteConditions, remoteConditions) {
+			logrus.Debugf("ZZZZZZ rbac/rt/CRTB update status %q, skip, conditions unchanged", crtb.Name)
 			return nil
 		}
 
 		crtbFromCluster.Status.SummaryRemote = status.SummaryCompleted
 		if crtbFromCluster.Status.SummaryLocal == status.SummaryCompleted {
+			logrus.Debugf("ZZZZZZ rbac/rt/CRTB update status %q, summary complete (remote & local complete)", crtb.Name)
 			crtbFromCluster.Status.Summary = status.SummaryCompleted
 		}
 		for _, c := range remoteConditions {
 			if c.Status != metav1.ConditionTrue {
+				logrus.Debugf("ZZZZZZ rbac/rt/CRTB update status %q, summary error, remote error", crtb.Name)
 				crtbFromCluster.Status.Summary = status.SummaryError
 				crtbFromCluster.Status.SummaryRemote = status.SummaryError
 				break
@@ -181,9 +200,8 @@ func (c *crtbHandler) updateStatus(crtb *v3.ClusterRoleTemplateBinding, remoteCo
 		crtbFromCluster.Status.ObservedGenerationRemote = crtb.ObjectMeta.Generation
 		crtbFromCluster.Status.RemoteConditions = remoteConditions
 		_, err = c.crtbClient.UpdateStatus(crtbFromCluster)
-		if err != nil {
-			return err
-		}
-		return nil
+
+		logrus.Debugf("ZZZZZZ rbac/rt/CRTB update status %q, result: %v", crtb.Name, err)
+		return err
 	})
 }

--- a/pkg/controllers/status/status.go
+++ b/pkg/controllers/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"time"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,11 +27,16 @@ func NewStatus() *Status {
 // AddCondition add condition to the conditions slice. Condition will be set to false if there is an error.
 func (s *Status) AddCondition(conditions *[]metav1.Condition, condition metav1.Condition, reason string, err error) {
 	if err != nil {
+		logrus.Debugf("ZZZZZZ status/add-condition error: %s", err)
+
 		condition.Status = metav1.ConditionFalse
 		condition.Message = err.Error()
 	} else {
 		condition.Status = metav1.ConditionTrue
 	}
+
+	logrus.Debugf("ZZZZZZ status/add-condition reason: %s", reason)
+
 	condition.Reason = reason
 	condition.LastTransitionTime = metav1.Time{Time: s.TimeNow()}
 
@@ -43,9 +49,12 @@ func (s *Status) AddCondition(conditions *[]metav1.Condition, condition metav1.C
 			c.Message = condition.Message
 			c.LastTransitionTime = metav1.Time{Time: s.TimeNow()}
 			found = true
+			logrus.Debug("ZZZZZZ status/add-condition replace")
+			// ZZZZZZ QUERY - break loop ?
 		}
 	}
 	if !found {
+		logrus.Debugf("ZZZZZZ status/add-condition append")
 		*conditions = append(*conditions, condition)
 	}
 }

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -215,6 +215,7 @@ func NameForClusterRoleBinding(role rbacv1.RoleRef, subject rbacv1.Subject) stri
 	name.WriteString("crb-")
 	name.WriteString(getBindingHash("", role, subject))
 	nm := name.String()
+	logrus.Debugf("ZZZZZZ CRB %q for (kind=%s role=%s subjkind=%s subject=%s", nm, role.Kind, role.Name, subject.Kind, subject.Name)
 	logrus.Debugf("ClusterRoleBinding with role.kind=%s role.name=%s subject.kind=%s subject.name=%s has name: %s", role.Kind, role.Name, subject.Kind, subject.Name, nm)
 	return nm
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

See #51011 . This is a test PR with extended logging in the CRTB controllers.

## Problem
## Solution
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_