### PR TITLE
SCIM: Handle user re-provisioning on username change

### DIFF
--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 )
 
 // Bool represents a boolean value that can be unmarshaled from JSON strings or boolean literals.
@@ -206,6 +208,7 @@ func (s *SCIMServer) ListUsers(w http.ResponseWriter, r *http.Request) {
 
 // CreateUser creates a new user.
 // Returns:
+//   - 200 when re-provisioning a previously deactivated user (matched by externalId)
 //   - 201 on success
 //   - 400 for invalid requests
 //   - 409 if the user already exists.
@@ -248,6 +251,12 @@ func (s *SCIMServer) CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	type reprovisionMatch struct {
+		user *v3.User
+		attr *v3.UserAttribute
+	}
+	var reprovisionCandidate *reprovisionMatch
+
 	for _, user := range list {
 		attr, err := s.userAttributeCache.Get(user.Name)
 		if err != nil {
@@ -265,6 +274,22 @@ func (s *SCIMServer) CreateUser(w http.ResponseWriter, r *http.Request) {
 			writeError(w, NewError(http.StatusConflict, fmt.Sprintf("User with username %s already exists", payload.UserName)))
 			return
 		}
+
+		if payload.ExternalID != "" {
+			eid := first(attr.ExtraByProvider[provider]["externalid"])
+			if strings.EqualFold(eid, payload.ExternalID) {
+				if user.GetEnabled() {
+					writeError(w, NewError(http.StatusConflict, fmt.Sprintf("Active user with externalId %s already exists", payload.ExternalID)))
+					return
+				}
+				reprovisionCandidate = &reprovisionMatch{user: user, attr: attr}
+			}
+		}
+	}
+
+	if reprovisionCandidate != nil && cfg.UserIDAttribute == UserIDExternalID {
+		s.reprovisionUser(w, r, provider, payload, reprovisionCandidate.user, reprovisionCandidate.attr)
+		return
 	}
 
 	principalName := userPrincipalName(provider, uid)
@@ -326,6 +351,74 @@ func (s *SCIMServer) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Location", location)
 	writeResponse(w, response, http.StatusCreated)
+}
+
+// reprovisionUser re-enables a previously deactivated user whose externalId
+// matches the incoming CreateUser payload. Some IdPs deactivate and re-provision
+// a user instead of updating in-place when the userName changes.
+// The principal is not modified — this only applies when the principal is based on
+// externalId (stable), not userName.
+func (s *SCIMServer) reprovisionUser(w http.ResponseWriter, r *http.Request, provider string, payload scimUser, user *v3.User, attr *v3.UserAttribute) {
+	attr = attr.DeepCopy()
+	attr.ExtraByProvider[provider]["username"] = []string{payload.UserName}
+
+	var primaryEmail string
+	for _, email := range payload.Emails {
+		if email.Primary {
+			primaryEmail = email.Value
+			break
+		}
+	}
+	if primaryEmail != "" {
+		attr.ExtraByProvider[provider]["email"] = []string{primaryEmail}
+	}
+
+	if _, err := s.userAttributes.Update(attr); err != nil {
+		logrus.Errorf("scim::reprovisionUser: failed to update user attributes for %s: %s", user.Name, err)
+		writeError(w, NewInternalError())
+		return
+	}
+
+	user = user.DeepCopy()
+	user.Enabled = ptr.To(true)
+	displayName := payload.DisplayName
+	if displayName == "" {
+		displayName = payload.UserName
+	}
+	if user.DisplayName != displayName {
+		user.DisplayName = displayName
+	}
+
+	if _, err := s.users.Update(user); err != nil {
+		logrus.Errorf("scim::reprovisionUser: failed to update user %s: %s", user.Name, err)
+		writeError(w, NewInternalError())
+		return
+	}
+
+	location := locationURL(r, provider, userEndpoint, user.Name)
+	response := map[string]any{
+		"schemas":    []string{userSchemaID},
+		"id":         user.Name,
+		"userName":   payload.UserName,
+		"externalId": first(attr.ExtraByProvider[provider]["externalid"]),
+		"active":     true,
+		"meta": map[string]any{
+			"resourceType": userResource,
+			"created":      user.CreationTimestamp,
+			"location":     location,
+		},
+	}
+	if primaryEmail != "" {
+		response["emails"] = []map[string]any{
+			{
+				"value":   primaryEmail,
+				"primary": true,
+			},
+		}
+	}
+
+	w.Header().Set("Location", location)
+	writeResponse(w, response, http.StatusOK)
 }
 
 // GetUser retrieves a user by their ID.
@@ -447,7 +540,7 @@ func (s *SCIMServer) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	if userName := first(attr.ExtraByProvider[provider]["username"]); userName != payload.UserName {
 		if cfg.UserIDAttribute != UserIDExternalID {
-			writeError(w, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier"))
+			writeError(w, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier", "mutability"))
 			return
 		}
 		attr.ExtraByProvider[provider]["username"] = []string{payload.UserName}
@@ -614,7 +707,12 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 			updateAttr, updateUser, err := applyPatchUser(provider, attr, user, op, cfg)
 			if err != nil {
 				logrus.Errorf("scim::PatchUser: failed to apply %s operation: %s", op.Op, err)
-				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply %s operation: %s", op.Op, err)))
+				var scimErr *Error
+				if errors.As(err, &scimErr) {
+					writeError(w, scimErr)
+				} else {
+					writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply %s operation: %s", op.Op, err)))
+				}
 				return
 			}
 			if updateAttr {
@@ -734,7 +832,7 @@ func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op p
 		}
 	case "username":
 		if cfg.UserIDAttribute != UserIDExternalID {
-			return false, false, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier")
+			return false, false, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier", "mutability")
 		}
 
 		username, ok := op.Value.(string)

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -271,8 +271,14 @@ func (s *SCIMServer) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 		userName := first(attr.ExtraByProvider[provider]["username"])
 		if strings.EqualFold(userName, payload.UserName) {
-			writeError(w, NewError(http.StatusConflict, fmt.Sprintf("User with username %s already exists", payload.UserName)))
-			return
+			// Allow fall-through for a disabled user whose externalId matches the payload.
+			// This handles retries after a partial failure in reprovisionUser where
+			// userAttributes was updated (new username) but the user wasn't re-enabled.
+			if user.GetEnabled() || payload.ExternalID == "" ||
+				!strings.EqualFold(first(attr.ExtraByProvider[provider]["externalid"]), payload.ExternalID) {
+				writeError(w, NewError(http.StatusConflict, fmt.Sprintf("User with username %s already exists", payload.UserName)))
+				return
+			}
 		}
 
 		if payload.ExternalID != "" {

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -488,6 +488,43 @@ func (s *SCIMServer) GetUser(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, response)
 }
 
+func (s *SCIMServer) checkUserConflict(provider, userName, externalID, excludeUser string) *Error {
+	if userName == "" && externalID == "" {
+		return nil
+	}
+
+	users, err := s.userCache.List(labels.Everything())
+	if err != nil {
+		logrus.Errorf("scim::checkUserConflict: failed to list users: %s", err)
+		return NewInternalError()
+	}
+
+	for _, u := range users {
+		if u.Name == excludeUser {
+			continue
+		}
+
+		attr, err := s.userAttributeCache.Get(u.Name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			logrus.Errorf("scim::checkUserConflict: failed to get user attributes for %s: %s", u.Name, err)
+			return NewInternalError()
+		}
+
+		if userName != "" && strings.EqualFold(first(attr.ExtraByProvider[provider]["username"]), userName) {
+			return NewError(http.StatusConflict, fmt.Sprintf("User with username %s already exists", userName))
+		}
+
+		if externalID != "" && strings.EqualFold(first(attr.ExtraByProvider[provider]["externalid"]), externalID) {
+			return NewError(http.StatusConflict, fmt.Sprintf("User with externalId %s already exists", externalID))
+		}
+	}
+
+	return nil
+}
+
 // UpdateUser updates an existing user.
 // Returns:
 //   - 200 on success
@@ -544,17 +581,27 @@ func (s *SCIMServer) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	if attr.ExtraByProvider[provider] == nil {
 		attr.ExtraByProvider[provider] = map[string][]string{}
 	}
+
+	var changedUserName, changedExternalID string
+
 	if userName := first(attr.ExtraByProvider[provider]["username"]); userName != payload.UserName {
 		if cfg.UserIDAttribute != UserIDExternalID {
 			writeError(w, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier", "mutability"))
 			return
 		}
+		changedUserName = payload.UserName
 		attr.ExtraByProvider[provider]["username"] = []string{payload.UserName}
 		shouldUpdateAttr = true
 	}
-	if externalId := first(attr.ExtraByProvider[provider]["externalid"]); externalId != payload.ExternalID {
+	if externalID := first(attr.ExtraByProvider[provider]["externalid"]); externalID != payload.ExternalID {
+		changedExternalID = payload.ExternalID
 		attr.ExtraByProvider[provider]["externalid"] = []string{payload.ExternalID}
 		shouldUpdateAttr = true
+	}
+
+	if scimErr := s.checkUserConflict(provider, changedUserName, changedExternalID, user.Name); scimErr != nil {
+		writeError(w, scimErr)
+		return
 	}
 
 	payloadActive := payload.Active.Bool()
@@ -706,6 +753,9 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.getConfig(provider)
 
+	origUserName := first(attr.ExtraByProvider[provider]["username"])
+	origExternalID := first(attr.ExtraByProvider[provider]["externalid"])
+
 	var shouldUpdateAttr, shouldUpdateUser bool
 	for _, op := range payload.Operations {
 		switch strings.ToLower(op.Op) {
@@ -731,6 +781,18 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 			writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Unsupported patch operation: %s", op.Op)))
 			return
 		}
+	}
+
+	var changedUserName, changedExternalID string
+	if newUserName := first(attr.ExtraByProvider[provider]["username"]); newUserName != origUserName {
+		changedUserName = newUserName
+	}
+	if newExternalID := first(attr.ExtraByProvider[provider]["externalid"]); newExternalID != origExternalID {
+		changedExternalID = newExternalID
+	}
+	if scimErr := s.checkUserConflict(provider, changedUserName, changedExternalID, user.Name); scimErr != nil {
+		writeError(w, scimErr)
+		return
 	}
 
 	if shouldUpdateAttr {

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -1470,11 +1470,14 @@ func TestUpdateUser(t *testing.T) {
 		userID := "u-abc123"
 		enabled := true
 
-		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userCache.EXPECT().Get(userID).Return(&v3.User{
+		existingUser := &v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			Enabled:    &enabled,
-		}, nil)
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
 
 		existingAttr := &v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
@@ -1918,11 +1921,14 @@ func TestUpdateUser(t *testing.T) {
 		userID := "u-abc123"
 		enabled := true
 
-		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userCache.EXPECT().Get(userID).Return(&v3.User{
+		existingUser := &v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			Enabled:    &enabled,
-		}, nil)
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
 
 		existingAttr := &v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
@@ -2010,6 +2016,130 @@ func TestUpdateUser(t *testing.T) {
 
 		srv.UpdateUser(w, r)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("rejects externalId conflicting with another user", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		otherUserID := "u-other"
+		enabled := true
+
+		existingUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}
+		otherUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			Enabled:    &enabled,
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-111"},
+				},
+			},
+		}, nil)
+		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"jane.doe"},
+					"externalid": {"ext-222"},
+				},
+			},
+		}, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "john.doe",
+			"externalId": "ext-222",
+			"active": true
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateUser(w, r)
+		require.Equal(t, http.StatusConflict, w.Code)
+	})
+
+	t.Run("rejects username conflicting with another user", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		otherUserID := "u-other"
+		enabled := true
+
+		existingUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}
+		otherUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			Enabled:    &enabled,
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-111"},
+				},
+			},
+		}, nil)
+		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"jane.doe"},
+					"externalid": {"ext-222"},
+				},
+			},
+		}, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "jane.doe",
+			"externalId": "ext-111",
+			"active": true
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateUser(w, r)
+		require.Equal(t, http.StatusConflict, w.Code)
 	})
 }
 
@@ -2302,11 +2432,14 @@ func TestPatchUser(t *testing.T) {
 		userID := "u-abc123"
 		enabled := true
 
-		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userCache.EXPECT().Get(userID).Return(&v3.User{
+		existingUser := &v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			Enabled:    &enabled,
-		}, nil)
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
 
 		existingAttr := &v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
@@ -2418,11 +2551,14 @@ func TestPatchUser(t *testing.T) {
 		userID := "u-abc123"
 		enabled := true
 
-		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userCache.EXPECT().Get(userID).Return(&v3.User{
+		existingUser := &v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			Enabled:    &enabled,
-		}, nil)
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
 
 		existingAttr := &v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
@@ -2624,11 +2760,14 @@ func TestPatchUser(t *testing.T) {
 		userID := "u-abc123"
 		enabled := true
 
-		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userCache.EXPECT().Get(userID).Return(&v3.User{
+		existingUser := &v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			Enabled:    &enabled,
-		}, nil)
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
 
 		existingAttr := &v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
@@ -3020,11 +3159,14 @@ func TestPatchUser(t *testing.T) {
 		userID := "u-abc123"
 		enabled := true
 
-		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userCache.EXPECT().Get(userID).Return(&v3.User{
+		existingUser := &v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			Enabled:    &enabled,
-		}, nil)
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
 
 		existingAttr := &v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
@@ -3168,11 +3310,14 @@ func TestPatchUser(t *testing.T) {
 		userID := "u-abc123"
 		enabled := true
 
-		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userCache.EXPECT().Get(userID).Return(&v3.User{
+		existingUser := &v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			Enabled:    &enabled,
-		}, nil)
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
 
 		existingAttr := &v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
@@ -3318,5 +3463,125 @@ func TestPatchUser(t *testing.T) {
 		require.Len(t, emails, 1)
 		emailMap := emails[0].(map[string]any)
 		assert.Equal(t, "new@example.com", emailMap["value"])
+	})
+
+	t.Run("rejects externalId conflicting with another user", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		otherUserID := "u-other"
+		enabled := true
+
+		existingUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}
+		otherUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			Enabled:    &enabled,
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-111"},
+				},
+			},
+		}, nil)
+		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"jane.doe"},
+					"externalid": {"ext-222"},
+				},
+			},
+		}, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "externalId", "value": "ext-222"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusConflict, w.Code)
+	})
+
+	t.Run("rejects username conflicting with another user", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		otherUserID := "u-other"
+		enabled := true
+
+		existingUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}
+		otherUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			Enabled:    &enabled,
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-111"},
+				},
+			},
+		}, nil)
+		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"jane.doe"},
+					"externalid": {"ext-222"},
+				},
+			},
+		}, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "userName", "value": "jane.doe"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusConflict, w.Code)
 	})
 }

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -548,7 +548,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -607,7 +608,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -638,7 +640,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -669,7 +672,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -703,7 +707,8 @@ func TestGetUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.GetUser(w, r)
@@ -1086,6 +1091,297 @@ func TestCreateUser(t *testing.T) {
 		srv.CreateUser(w, r)
 		require.Equal(t, http.StatusCreated, w.Code)
 	})
+
+	t.Run("re-provisions disabled user with matching externalId", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		disabledUserID := "u-disabled"
+		disabled := false
+
+		disabledUser := &v3.User{
+			ObjectMeta:  metav1.ObjectMeta{Name: disabledUserID},
+			Enabled:     &disabled,
+			DisplayName: "Old Name",
+		}
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: disabledUserID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":    {"old.name"},
+					"externalid":  {"ext-shared"},
+					"principalid": {provider + "_user://ext-shared"},
+				},
+			},
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{disabledUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(disabledUserID).Return(existingAttr, nil)
+
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+			assert.Equal(t, "new.name", first(attr.ExtraByProvider[provider]["username"]))
+			assert.Equal(t, "new@example.com", first(attr.ExtraByProvider[provider]["email"]))
+			return attr, nil
+		})
+
+		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+			assert.Equal(t, true, *u.Enabled)
+			assert.Equal(t, "New Name", u.DisplayName)
+			return u, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			users:              userClient,
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "new.name",
+			"displayName": "New Name",
+			"externalId": "ext-shared",
+			"emails": [{"value": "new@example.com", "primary": true}]
+		}`
+		r := httptest.NewRequest(http.MethodPost, "/v1-scim/"+provider+"/Users", bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		w := httptest.NewRecorder()
+
+		srv.CreateUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, disabledUserID, resp["id"])
+		assert.Equal(t, "new.name", resp["userName"])
+		assert.Equal(t, "ext-shared", resp["externalId"])
+		assert.Equal(t, true, resp["active"])
+
+		emails, ok := resp["emails"].([]any)
+		require.True(t, ok)
+		require.Len(t, emails, 1)
+		email := emails[0].(map[string]any)
+		assert.Equal(t, "new@example.com", email["value"])
+	})
+
+	t.Run("does not re-provision in userName mode", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		disabled := false
+		disabledUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-disabled"},
+			Enabled:    &disabled,
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{disabledUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get("u-disabled").Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-disabled"},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":    {"old.name"},
+					"externalid":  {"ext-shared"},
+					"principalid": {provider + "_user://old.name"},
+				},
+			},
+		}, nil)
+
+		enabled := true
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureUser(provider+"_user://new.name", "new.name").Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-newuser"},
+			Enabled:    &enabled,
+		}, nil)
+		userMGR.EXPECT().UserAttributeCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "new.name",
+			"externalId": "ext-shared"
+		}`
+		r := httptest.NewRequest(http.MethodPost, "/v1-scim/"+provider+"/Users", bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		w := httptest.NewRecorder()
+
+		srv.CreateUser(w, r)
+		require.Equal(t, http.StatusCreated, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "u-newuser", resp["id"])
+	})
+
+	t.Run("rejects duplicate externalId on active user", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		activeUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-active"},
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{activeUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get("u-active").Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-active"},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"existing.user"},
+					"externalid": {"ext-shared"},
+				},
+			},
+		}, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "different.name",
+			"externalId": "ext-shared"
+		}`
+		r := httptest.NewRequest(http.MethodPost, "/v1-scim/"+provider+"/Users", bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		w := httptest.NewRecorder()
+
+		srv.CreateUser(w, r)
+		require.Equal(t, http.StatusConflict, w.Code)
+
+		var resp Error
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Detail, "externalId")
+	})
+
+	t.Run("externalId match is provider-scoped", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		existingUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-other"},
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get("u-other").Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-other"},
+			ExtraByProvider: map[string]map[string][]string{
+				"azuread": {
+					"username":   {"some.user"},
+					"externalid": {"ext-shared"},
+				},
+			},
+		}, nil)
+
+		enabled := true
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureUser(gomock.Any(), gomock.Any()).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-newuser"},
+			Enabled:    &enabled,
+		}, nil)
+		userMGR.EXPECT().UserAttributeCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "new.user",
+			"externalId": "ext-shared"
+		}`
+		r := httptest.NewRequest(http.MethodPost, "/v1-scim/"+provider+"/Users", bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		w := httptest.NewRecorder()
+
+		srv.CreateUser(w, r)
+		require.Equal(t, http.StatusCreated, w.Code)
+	})
+
+	t.Run("no externalId in payload skips matching", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		existingUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-existing"},
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get("u-existing").Return(&v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-existing"},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"other.user"},
+					"externalid": {"ext-12345"},
+				},
+			},
+		}, nil)
+
+		enabled := true
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureUser("okta_user://new.user", "new.user").Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-newuser"},
+			Enabled:    &enabled,
+		}, nil)
+		userMGR.EXPECT().UserAttributeCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "new.user"
+		}`
+		r := httptest.NewRequest(http.MethodPost, "/v1-scim/"+provider+"/Users", bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		w := httptest.NewRecorder()
+
+		srv.CreateUser(w, r)
+		require.Equal(t, http.StatusCreated, w.Code)
+	})
 }
 
 func TestUpdateUser(t *testing.T) {
@@ -1138,7 +1434,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1198,7 +1495,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1208,6 +1506,7 @@ func TestUpdateUser(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.Contains(t, resp.Detail, "cannot be changed")
+		assert.Equal(t, "mutability", resp.ScimType)
 	})
 
 	t.Run("deactivates user", func(t *testing.T) {
@@ -1254,7 +1553,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": false
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1311,7 +1611,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1362,7 +1663,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1387,7 +1689,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1422,7 +1725,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1467,7 +1771,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": false
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1493,7 +1798,8 @@ func TestUpdateUser(t *testing.T) {
 
 		body := `not valid json`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1514,7 +1820,8 @@ func TestUpdateUser(t *testing.T) {
 
 		body := `{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"]}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1571,7 +1878,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": true
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1619,7 +1927,8 @@ func TestUpdateUser(t *testing.T) {
 			"active": false
 		}`
 		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.UpdateUser(w, r)
@@ -1649,7 +1958,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1670,7 +1980,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1699,7 +2010,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1722,7 +2034,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1754,7 +2067,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1774,7 +2088,8 @@ func TestDeleteUser(t *testing.T) {
 		}
 
 		r := httptest.NewRequest(http.MethodDelete, "/v1-scim/"+provider+"/Users/"+userID, nil)
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.DeleteUser(w, r)
@@ -1827,7 +2142,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -1890,7 +2206,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": "True"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -1944,7 +2261,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "externalId", "value": "new-ext-id"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -1999,7 +2317,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "emails[primary eq true].value", "value": "new@example.com"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2061,7 +2380,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "value": {"externalId": "new-ext-id", "active": false}}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2110,7 +2430,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "displayName", "value": "New Name"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2158,7 +2479,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "add", "path": "displayName", "value": "John Doe"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2206,7 +2528,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "add", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2262,7 +2585,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "userName", "value": "new.name"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2308,11 +2632,17 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "userName", "value": "new.name"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
 		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		var resp Error
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "mutability", resp.ScimType)
 	})
 
 	t.Run("no update when value unchanged", func(t *testing.T) {
@@ -2351,7 +2681,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": true}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2375,7 +2706,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2402,7 +2734,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2444,11 +2777,12 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
-		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, http.StatusConflict, w.Code)
 	})
 
 	t.Run("unsupported operation", func(t *testing.T) {
@@ -2485,7 +2819,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "remove", "path": "active"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2526,7 +2861,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "unsupportedPath", "value": "test"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2551,7 +2887,8 @@ func TestPatchUser(t *testing.T) {
 
 		body := `not valid json`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2592,7 +2929,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": "not-a-boolean"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2638,7 +2976,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "externalId", "value": "new-ext-id"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2683,7 +3022,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2732,7 +3072,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:active", "value": false}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2786,7 +3127,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:externalId", "value": "new-ext-id"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2833,7 +3175,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:Group:displayName", "value": "test"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)
@@ -2883,7 +3226,8 @@ func TestPatchUser(t *testing.T) {
 			"Operations": [{"op": "replace", "path": "urn:ietf:params:scim:schemas:core:2.0:User:emails[primary eq true].value", "value": "new@example.com"}]
 		}`
 		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
-		r.SetPathValue("provider", provider); r.SetPathValue("id", userID)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
 		w := httptest.NewRecorder()
 
 		srv.PatchUser(w, r)

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -1176,6 +1176,83 @@ func TestCreateUser(t *testing.T) {
 		assert.Equal(t, "new@example.com", email["value"])
 	})
 
+	t.Run("re-provisions disabled user after partial failure (attr already updated)", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		disabledUserID := "u-disabled"
+		disabled := false
+
+		disabledUser := &v3.User{
+			ObjectMeta:  metav1.ObjectMeta{Name: disabledUserID},
+			Enabled:     &disabled,
+			DisplayName: "Old Name",
+		}
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: disabledUserID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":    {"new.name"},
+					"externalid":  {"ext-shared"},
+					"principalid": {provider + "_user://ext-shared"},
+				},
+			},
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{disabledUser}, nil)
+
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(disabledUserID).Return(existingAttr, nil)
+
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+			assert.Equal(t, "new.name", first(attr.ExtraByProvider[provider]["username"]))
+			return attr, nil
+		})
+
+		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+			assert.Equal(t, true, *u.Enabled)
+			assert.Equal(t, "New Name", u.DisplayName)
+			return u, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			users:              userClient,
+			userAttributeCache: userAttributeCache,
+			userAttributes:     userAttrClient,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "new.name",
+			"displayName": "New Name",
+			"externalId": "ext-shared",
+			"emails": [{"value": "new@example.com", "primary": true}]
+		}`
+		r := httptest.NewRequest(http.MethodPost, "/v1-scim/"+provider+"/Users", bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		w := httptest.NewRecorder()
+
+		srv.CreateUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, disabledUserID, resp["id"])
+		assert.Equal(t, "new.name", resp["userName"])
+		assert.Equal(t, "ext-shared", resp["externalId"])
+		assert.Equal(t, true, resp["active"])
+	})
+
 	t.Run("does not re-provision in userName mode", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
## Issue: #54024 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a user's `username` changes, some identity providers may deactivate the existing SCIM user and provision a new one instead of updating in-place. In `externalId` mode (`UserIDAttribute == UserIDExternalID`) this left the original user disabled with no way to recover via SCIM.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

### Changes

- `POST /Users` with an `externalId` matching a disabled user for the same provider now re-enables and updates the existing user (username, email, displayName) instead of creating a duplicate. Returns 200.
- `POST /Users` with an `externalId` matching an *active* user returns 409 Conflict, in both `userName` and `externalId` modes.
- userName immutability errors in PUT and PATCH now include `scimType: "mutability"` per RFC 7644 3.12.
- `applyPatchUser` errors now propagate with their original status code instead of being wrapped as 400. Fixes "cannot deprovision default admin" returning 400 instead of 409.

### Decisions and tradeoffs

- Re-provisioning only fires when `UserIDAttribute = externalId`. In `userName` mode the principal is `{provider}_user://{userName}`, so a different username means a different principal, a different `User.Name` hash, and would need full rename logic (PrincipalIDs, EnsureUser collision handling, binding updates). Deferred to #48699.
- POST returning 200 for re-provisioning is technically non-compliant with RFC 7644 3.3 (MUST return 201). We do it because the resource already existed. Some IdPs may treat non-201 from POST as an error — needs testing with Okta and Azure.
- If data corruption left multiple disabled users with the same `externalId`, the last match from the cache wins (non-deterministic). Fine for a recovery path; the 409 on active duplicates prevents new ones going forward.
- The `userName` uniqueness check runs before `externalId` matching, so re-provisioning can't bypass userName conflicts.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests

### Validation

- [ ] `POST /Users` with externalId matching a disabled user (externalId mode) → 200, user re-enabled, metadata updated
- [ ] `POST /Users` with externalId matching a disabled user (userName mode) → 201, new user created (no re-provision)
- [ ] `POST /Users` with externalId matching an active user → 409
- [ ] `POST /Users` with externalId matching a different provider → no conflict, 201
- [ ] `POST /Users` with no externalId → existing behavior unchanged
- [ ] `PUT /Users` with userName change (userName mode) → 400 with `scimType: "mutability"`
- [ ] `PATCH /Users` with userName change (userName mode) → 400 with `scimType: "mutability"`
- [ ] `PATCH /Users` deactivate default admin → 409 (not 400)
