### PR TITLE
Fix failing CRTB integration test

### DIFF
--- a/tests/v2/integration/rbac/projects_test.go
+++ b/tests/v2/integration/rbac/projects_test.go
@@ -30,10 +30,12 @@ import (
 func (p *RTBTestSuite) TestProjectCreatorGetsOwnerBindings() {
 	client := p.newSubSession()
 
+	user := p.createUser(client, "testuser", "user")
+
 	// Grant user the cluster-member role on the local cluster.
 	crtb, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
 		ClusterID:       p.downstreamClusterID,
-		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		UserPrincipalID: user.PrincipalIDs[0],
 		RoleTemplateID:  "cluster-member",
 	})
 	p.Require().NoError(err)
@@ -43,7 +45,7 @@ func (p *RTBTestSuite) TestProjectCreatorGetsOwnerBindings() {
 		p.Require().NoError(err)
 	})
 
-	testUser, err := client.AsUser(p.testUser)
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	// User creates a project, retrying until RBAC propagates.
@@ -90,7 +92,7 @@ func (p *RTBTestSuite) TestProjectCreatorGetsOwnerBindings() {
 	rbRoles := []string{}
 	for _, rb := range rbs.Items {
 		for _, subject := range rb.Subjects {
-			if subject.Name == p.testUser.ID {
+			if subject.Name == user.ID {
 				rbRoles = append(rbRoles, rb.RoleRef.Name)
 			}
 		}
@@ -125,9 +127,11 @@ func (p *RTBTestSuite) TestProjectCreatorGetsOwnerBindings() {
 func (p *RTBTestSuite) TestReadOnlyCannotEditSecret() {
 	client := p.newSubSession()
 
+	user := p.createUser(client, "testuser", "user")
+
 	// Create a PRTB giving the test user read-only access to the project.
 	_, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
-		UserID:         p.testUser.ID,
+		UserID:         user.ID,
 		RoleTemplateID: "read-only",
 		ProjectID:      p.project.ID,
 	})
@@ -136,7 +140,7 @@ func (p *RTBTestSuite) TestReadOnlyCannotEditSecret() {
 	// Create a namespace in the project for testing namespaced secrets.
 	ns := p.createNamespace(client, p.projectName(p.project))
 
-	testUser, err := client.AsUser(p.testUser)
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	// Read-only user should fail to create a secret.
@@ -164,6 +168,8 @@ func (p *RTBTestSuite) TestReadOnlyCannotEditSecret() {
 func (p *RTBTestSuite) TestReadOnlyCannotMoveNamespace() {
 	client := p.newSubSession()
 
+	user := p.createUser(client, "testuser", "user")
+
 	// Create two projects.
 	p1, err := client.Management.Project.Create(&management.Project{
 		ClusterID: p.downstreamClusterID,
@@ -189,14 +195,14 @@ func (p *RTBTestSuite) TestReadOnlyCannotMoveNamespace() {
 
 	// Give the test user read-only access to both projects.
 	_, err = client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
-		UserID:         p.testUser.ID,
+		UserID:         user.ID,
 		RoleTemplateID: "read-only",
 		ProjectID:      p1.ID,
 	})
 	p.Require().NoError(err)
 
 	_, err = client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
-		UserID:         p.testUser.ID,
+		UserID:         user.ID,
 		RoleTemplateID: "read-only",
 		ProjectID:      p2.ID,
 	})
@@ -205,7 +211,7 @@ func (p *RTBTestSuite) TestReadOnlyCannotMoveNamespace() {
 	// Create a namespace in project 1.
 	ns := p.createNamespace(client, p.projectName(p1))
 
-	testUser, err := client.AsUser(p.testUser)
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	// Wait until the read-only user can see the namespace.

--- a/tests/v2/integration/rbac/projects_test.go
+++ b/tests/v2/integration/rbac/projects_test.go
@@ -17,7 +17,6 @@ import (
 	extrbac "github.com/rancher/rancher/tests/v2/integration/actions/kubeapi/rbac"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	extauthz "github.com/rancher/shepherd/extensions/kubeapi/authorization"
-	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/shepherd/pkg/clientbase"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	authzv1 "k8s.io/api/authorization/v1"
@@ -32,14 +31,15 @@ func (p *RTBTestSuite) TestProjectCreatorGetsOwnerBindings() {
 	client := p.newSubSession()
 
 	// Grant user the cluster-member role on the local cluster.
-	localCluster, err := client.Management.Cluster.ByID(p.downstreamClusterID)
-	p.Require().NoError(err)
-
-	err = users.AddClusterRoleToUser(client, localCluster, p.testUser, "cluster-member", nil)
+	crtb, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+		ClusterID:       p.downstreamClusterID,
+		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		RoleTemplateID:  "cluster-member",
+	})
 	p.Require().NoError(err)
 
 	p.T().Cleanup(func() {
-		err := users.RemoveClusterRoleFromUser(client, p.testUser)
+		err := client.Management.ClusterRoleTemplateBinding.Delete(crtb)
 		p.Require().NoError(err)
 	})
 

--- a/tests/v2/integration/rbac/rtbs_test.go
+++ b/tests/v2/integration/rbac/rtbs_test.go
@@ -310,8 +310,10 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 	p.Require().NoError(err)
 
 	// Ensure the user can no longer access the namespace after the CRTB is removed.
-	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
-	p.Require().Error(err)
+	p.Require().Eventually(func() bool {
+		_, err := extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
+		return err != nil
+	}, 2*time.Minute, 2*time.Second, "waiting for namespace access to be revoked after CRTB removal")
 
 	// Test that user can get a specified namespace once granted the permission to do so via a chain of
 	// roletemplate inheritance bounded by a CRTB. Here a chain means the permission is not directly inherited from the

--- a/tests/v2/integration/rbac/rtbs_test.go
+++ b/tests/v2/integration/rbac/rtbs_test.go
@@ -37,7 +37,6 @@ func init() {
 
 type RTBTestSuite struct {
 	suite.Suite
-	testUser            *management.User
 	client              *rancher.Client
 	project             *management.Project
 	session             *session.Session
@@ -63,18 +62,13 @@ func (p *RTBTestSuite) SetupSuite() {
 	p.Require().NoError(err)
 
 	p.project = testProject
-
-	p.testUser = p.createUser(client, "testuser", "user")
 }
 
 func (p *RTBTestSuite) TearDownSuite() {
 	client, err := p.client.WithSession(p.session)
 	p.Require().NoError(err)
 
-	// Clean up the project and user we created
 	err = client.Management.Project.Delete(p.project)
-	p.Require().NoError(err)
-	err = client.Management.User.Delete(p.testUser)
 	p.Require().NoError(err)
 	p.session.Cleanup()
 }
@@ -133,9 +127,11 @@ func (p *RTBTestSuite) assertClusterAccessRevoked(userClient *rancher.Client) {
 func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 	client := p.newSubSession()
 
+	user := p.createUser(client, "testuser", "user")
+
 	createdNamespace := p.createNamespace(client, p.projectName(p.project))
 
-	testUser, err := client.AsUser(p.testUser)
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	// Test that user can get a specified secret once granted the permission to do so via roletemplate inheritance bounded
@@ -172,7 +168,7 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 
 	prtb, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
 		ProjectID:       p.project.ID,
-		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		UserPrincipalID: user.PrincipalIDs[0],
 		RoleTemplateID:  rtA.ID,
 	})
 	p.Require().NoError(err)
@@ -208,7 +204,7 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 	_, err = secrets.GetSecretByName(testUser, p.downstreamClusterID, createdNamespace.Name, secret.Name, metav1.GetOptions{})
 	p.Require().Error(err)
 
-	err = users.AddProjectMember(client, p.project, p.testUser, rtC.ID, []*authzv1.ResourceAttributes{
+	err = users.AddProjectMember(client, p.project, user, rtC.ID, []*authzv1.ResourceAttributes{
 		{
 			Verb:      "get",
 			Resource:  "secrets",
@@ -263,13 +259,15 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 	client := p.newSubSession()
 
+	user := p.createUser(client, "testuser", "user")
+
 	// Test that user can get a specified namespace once granted the permission to do so via roletemplate inheritance bounded
 	// by a CRTB.
 
 	pn := p.projectName(p.project)
 	ns := p.createNamespace(client, pn)
 
-	testUser, err := client.AsUser(p.testUser)
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
@@ -303,7 +301,7 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 
 	crtb, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
 		ClusterID:       p.downstreamClusterID,
-		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		UserPrincipalID: user.PrincipalIDs[0],
 		RoleTemplateID:  rtA.ID,
 	})
 	p.Require().NoError(err)
@@ -341,7 +339,7 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 		})
 	p.Require().NoError(err)
 
-	err = users.AddClusterRoleToUser(client, localCluster, p.testUser, rtC.ID, []*authzv1.ResourceAttributes{
+	err = users.AddClusterRoleToUser(client, localCluster, user, rtC.ID, []*authzv1.ResourceAttributes{
 		{
 			Verb:     "get",
 			Resource: "namespaces",
@@ -392,7 +390,9 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 func (p *RTBTestSuite) TestRemovingPRTBRevokesNamespaceAccess() {
 	client := p.newSubSession()
 
-	testUser, err := client.AsUser(p.testUser)
+	user := p.createUser(client, "testuser", "user")
+
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	// Helper function to create a project and add the user as project-member
@@ -406,7 +406,7 @@ func (p *RTBTestSuite) TestRemovingPRTBRevokesNamespaceAccess() {
 		p.Require().NoError(err)
 
 		prtb, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
-			UserID:         p.testUser.ID,
+			UserID:         user.ID,
 			RoleTemplateID: "project-member",
 			ProjectID:      project.ID,
 		})
@@ -466,7 +466,9 @@ func (p *RTBTestSuite) TestAPIGroupInRoleTemplate() {
 		p.T().Skip("no nodes in the cluster")
 	}
 
-	testUser, err := client.AsUser(p.testUser)
+	user := p.createUser(client, "testuser", "user")
+
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	// Validate the standard user cannot see any nodes initially.
@@ -500,9 +502,9 @@ func (p *RTBTestSuite) TestAPIGroupInRoleTemplate() {
 	}, 2*time.Minute, 2*time.Second, "role template never became available")
 
 	// Bind the user to the role template via a CRTB using the user's principal ID.
-	p.Require().NotEmpty(p.testUser.PrincipalIDs, "test user has no principal IDs")
+	p.Require().NotEmpty(user.PrincipalIDs, "test user has no principal IDs")
 	_, err = client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
-		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		UserPrincipalID: user.PrincipalIDs[0],
 		RoleTemplateID:  rt.ID,
 		ClusterID:       p.downstreamClusterID,
 	})
@@ -527,14 +529,16 @@ func (p *RTBTestSuite) TestAPIGroupInRoleTemplate() {
 func (p *RTBTestSuite) TestDeletingPRTBRemovesClusterAccess() {
 	client := p.newSubSession()
 
-	testUser, err := client.AsUser(p.testUser)
+	user := p.createUser(client, "testuser", "user")
+
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	mbo := "membership-binding-owner"
 
 	// Admin creates a PRTB giving user project-member on the suite project.
 	prtb, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
-		UserID:         p.testUser.ID,
+		UserID:         user.ID,
 		RoleTemplateID: "project-member",
 		ProjectID:      p.project.ID,
 	})
@@ -575,7 +579,9 @@ func (p *RTBTestSuite) TestDeletingPRTBRemovesClusterAccess() {
 func (p *RTBTestSuite) TestDeletingPRTBCleansUpLegacyMembershipLabels() {
 	client := p.newSubSession()
 
-	testUser, err := client.AsUser(p.testUser)
+	user := p.createUser(client, "testuser", "user")
+
+	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
 	mbo := "membership-binding-owner"
@@ -584,7 +590,7 @@ func (p *RTBTestSuite) TestDeletingPRTBCleansUpLegacyMembershipLabels() {
 
 	// Admin creates a PRTB giving user project-member on the suite project.
 	prtb, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
-		UserID:         p.testUser.ID,
+		UserID:         user.ID,
 		RoleTemplateID: "project-member",
 		ProjectID:      p.project.ID,
 	})
@@ -659,10 +665,12 @@ func (p *RTBTestSuite) TestDeletingPRTBCleansUpLegacyMembershipLabels() {
 func (p *RTBTestSuite) TestCRTBCannotTargetUsersAndGroup() {
 	client := p.newSubSession()
 
+	user := p.createUser(client, "testuser", "user")
+
 	_, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
 		Name:             namegen.AppendRandomString("crtb-"),
 		ClusterID:        "local",
-		UserID:           p.testUser.ID,
+		UserID:           user.ID,
 		GroupPrincipalID: "someauthprovidergroupid",
 		RoleTemplateID:   "clustercatalogs-view",
 	})
@@ -693,10 +701,12 @@ func (p *RTBTestSuite) TestCRTBMustHaveTarget() {
 func (p *RTBTestSuite) TestCRTBCannotUpdateSubjectsOrCluster() {
 	client := p.newSubSession()
 
+	user := p.createUser(client, "testuser", "user")
+
 	oldCRTB, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
 		Name:           namegen.AppendRandomString("crtb-"),
 		ClusterID:      "local",
-		UserID:         p.testUser.ID,
+		UserID:         user.ID,
 		RoleTemplateID: "clustercatalogs-view",
 	})
 	p.Require().NoError(err)

--- a/tests/v2/integration/rbac/rtbs_test.go
+++ b/tests/v2/integration/rbac/rtbs_test.go
@@ -309,6 +309,10 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 	err = users.RemoveClusterRoleFromUser(client, p.testUser)
 	p.Require().NoError(err)
 
+	// Ensure the user can no longer access the namespace after the CRTB is removed.
+	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
+	p.Require().Error(err)
+
 	// Test that user can get a specified namespace once granted the permission to do so via a chain of
 	// roletemplate inheritance bounded by a CRTB. Here a chain means the permission is not directly inherited from the
 	// parent.
@@ -320,9 +324,6 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 			RoleTemplateIDs: []string{rtA.ID},
 		})
 	p.Require().NoError(err)
-
-	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
-	p.Require().Error(err)
 
 	err = users.AddClusterRoleToUser(client, localCluster, p.testUser, rtC.ID, []*authzv1.ResourceAttributes{
 		{

--- a/tests/v2/integration/rbac/rtbs_test.go
+++ b/tests/v2/integration/rbac/rtbs_test.go
@@ -170,7 +170,14 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 		})
 	p.Require().NoError(err)
 
-	err = users.AddProjectMember(client, p.project, p.testUser, rtA.ID, []*authzv1.ResourceAttributes{
+	prtb, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
+		ProjectID:       p.project.ID,
+		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		RoleTemplateID:  rtA.ID,
+	})
+	p.Require().NoError(err)
+
+	err = extauthz.WaitForAllowed(testUser, p.downstreamClusterID, []*authzv1.ResourceAttributes{
 		{
 			Verb:      "get",
 			Resource:  "secrets",
@@ -183,7 +190,7 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 	secret, err = secrets.GetSecretByName(testUser, p.downstreamClusterID, createdNamespace.Name, secret.Name, metav1.GetOptions{})
 	p.Require().NoError(err)
 
-	err = users.RemoveProjectMember(client, p.testUser)
+	err = client.Management.ProjectRoleTemplateBinding.Delete(prtb)
 	p.Require().NoError(err)
 
 	// Test that user can get a specified secret once granted the permission to do so via a chain of
@@ -294,7 +301,14 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 	localCluster, err := p.client.Management.Cluster.ByID(p.downstreamClusterID)
 	p.Require().NoError(err)
 
-	err = users.AddClusterRoleToUser(client, localCluster, p.testUser, rtA.ID, []*authzv1.ResourceAttributes{
+	crtb, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+		ClusterID:       p.downstreamClusterID,
+		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		RoleTemplateID:  rtA.ID,
+	})
+	p.Require().NoError(err)
+
+	err = extauthz.WaitForAllowed(testUser, p.downstreamClusterID, []*authzv1.ResourceAttributes{
 		{
 			Verb:     "get",
 			Resource: "namespaces",
@@ -306,7 +320,7 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
 	p.Require().NoError(err)
 
-	err = users.RemoveClusterRoleFromUser(client, p.testUser)
+	err = client.Management.ClusterRoleTemplateBinding.Delete(crtb)
 	p.Require().NoError(err)
 
 	// Ensure the user can no longer access the namespace after the CRTB is removed.

--- a/tests/v2/integration/rbac/rtbs_test.go
+++ b/tests/v2/integration/rbac/rtbs_test.go
@@ -201,8 +201,10 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 		})
 	p.Require().NoError(err)
 
-	_, err = secrets.GetSecretByName(testUser, p.downstreamClusterID, createdNamespace.Name, secret.Name, metav1.GetOptions{})
-	p.Require().Error(err)
+	p.Require().Eventually(func() bool {
+		_, err := secrets.GetSecretByName(testUser, p.downstreamClusterID, createdNamespace.Name, secret.Name, metav1.GetOptions{})
+		return err != nil
+	}, 2*time.Minute, 2*time.Second, "waiting for secret access to be revoked after PRTB removal")
 
 	err = users.AddProjectMember(client, p.project, user, rtC.ID, []*authzv1.ResourceAttributes{
 		{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Integration test was failing. The problem was that the permissions weren't deleted fast enough, so when a check occurred to make sure that they got removed, it was happening before the controllers were able to remove the RBAC.
 
## Solution
This adds a wait around the assertion to ensure the changes eventually happen, but don't fail if it doesn't happen right away.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_