### PR TITLE
Fix OIDC race condition in Rancher running on Docker

### DIFF
--- a/pkg/oidc/provider/provider.go
+++ b/pkg/oidc/provider/provider.go
@@ -12,10 +12,12 @@ import (
 	"github.com/rancher/rancher/pkg/oidc/provider/session"
 	"github.com/rancher/rancher/pkg/oidc/randomstring"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -62,18 +64,11 @@ func NewProvider(ctx context.Context, tokenCache wrangmgmtv3.TokenCache, tokenCl
 	}
 
 	// create necessary namespaces
-	if _, err := namespaceClient.Create(&v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: secretsNamespace,
-		},
-	}); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := ensureNamespaceWithRetry(ctx, namespaceClient, secretsNamespace); err != nil {
 		return Provider{}, err
 	}
-	if _, err := namespaceClient.Create(&v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: codesNamespace,
-		},
-	}); err != nil && !apierrors.IsAlreadyExists(err) {
+
+	if err := ensureNamespaceWithRetry(ctx, namespaceClient, codesNamespace); err != nil {
 		return Provider{}, err
 	}
 
@@ -83,6 +78,20 @@ func NewProvider(ctx context.Context, tokenCache wrangmgmtv3.TokenCache, tokenCl
 		tokenHandler:    newTokenHandler(tokenCache, userLister, userAttributeLister, sessionStorage, jwks, oidcClientCache, oidcClientController, secretCache, tokenClient),
 		userInfoHandler: newUserInfoHandler(userLister, userAttributeLister, jwks),
 	}, nil
+}
+
+func ensureNamespaceWithRetry(ctx context.Context, namespaceClient corecontrollers.NamespaceClient, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, 3*time.Minute, true, func(context.Context) (bool, error) {
+		_, err := namespaceClient.Create(&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			logrus.WithError(err).Warnf("creating namespace %s failed; retrying", name)
+			return false, nil
+		}
+
+		return true, nil
+	})
 }
 
 // middleware adds security headers, and returns not found if there aren't any OIDCClients


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/42699
https://github.com/rancher/rancher/issues/53053
https://github.com/rancher/rancher/issues/54739
https://github.com/rancher/rancher/issues/54906
 
## Problem
**Error message**
```
W0525 15:38:29.918961     170 dispatcher.go:217] Failed calling webhook, failing closed rancher.cattle.io.namespaces.create-non-kubesystem: failed calling webhook "rancher.cattle.io.namespaces.create-non-kubesystem": failed to call webhook: Post "https://rancher-webhook.cattle-system.svc:443/v1/webhook/validation/namespaces?timeout=10s": no endpoints available for service "rancher-webhook"
```

**What I have noticed?**
In this state k3s does not even update Deployments, ReplicaSets, Pods, EndpointSlices, ... so basically internal controllers are not working at all. 

**How to put it together?**
The most interesting part is not updating EndpointSlices because it is directly related to the error message `no endpoints available for service`.

**Root cause**
Rancher crashes too early and internal k3s components are not able to update all resources properly. In other words: Rancher crash -> container crash -> control plane does not have time to do its job. So this is clearly the reason why Docker deployment is strongly discouraged, especially in PROD.
 
## Solution
~~**Fix**~~
- DO NOT DO it. It might silently try to install Traefik for some versions and make you Rancher in-accessible until you remove it manually.
- ~~For Rancher 2.13.3 only, for different version please find out specific k3s version~~
- ~~Expects rancher data folder in `/opt/rancher`~~
- ~~Do not copy&paste only and adapt command according to your environment to prevent data corruption.~~
```
docker run --name k3s-server --restart unless-stopped --privileged --network bridge --tmpfs /run --tmpfs /var/run --ulimit nproc=65535 --ulimit nofile=65535:65535 -v /opt/rancher/k3s:/var/lib/rancher/k3s rancher/k3s:v1.34.1-k3s1 server --node-name local-node
```
~~Let it run for multiple minutes. Control plane will finally get the chance to fix not updated resources. Then you can stop it and run your Rancher container.~~

**Proposed Solution**
Re-try for namespace creation calls.
 
## Testing
Tested on multiple envs in our LAB on Rancher 2.14.1

## Engineering Testing
### Manual Testing
Redeploy rancher with custom built image that includes this PR.

### Automated Testing
None


## QA Testing Considerations
It fixes OIDC provider. The issue is present also in non OIDC enabled rancher installations. So probably OIDC is initialised before. It waits long enough to let Control Plane starts properly.  maybe more general fix is required. I am not as deep in Rancher source code.
 
### Regressions Considerations
Potential regression to verify: non Docker installations

Existing / newly added automated tests that provide evidence there are no regressions:
None