### PR TITLE
Update global role status with the right observed generation

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -459,7 +459,7 @@ func (gr *globalRoleLifecycle) updateStatus(globalRole *v3.GlobalRole, localCond
 		if err != nil {
 			return err
 		}
-		if status.CompareConditions(grFromCluster.Status.Conditions, localConditions) {
+		if status.CompareConditions(grFromCluster.Status.Conditions, localConditions) && grFromCluster.Status.ObservedGeneration == globalRole.ObjectMeta.Generation {
 			return nil
 		}
 

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -452,7 +452,7 @@ func (gr *globalRoleLifecycle) deleteInheritedNamespacedRoles(globalRole *v3.Glo
 }
 
 // updateStatus updates the Status field of the GlobalRole. localConditions are created in each reconciliation loop.
-// Status is only updated if any condition has changed.
+// Status is updated if any condition has changed or if the generation observed by the status is different from the current generation of the GlobalRole.
 func (gr *globalRoleLifecycle) updateStatus(globalRole *v3.GlobalRole, localConditions []metav1.Condition) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		grFromCluster, err := gr.grCache.Get(globalRole.Name)

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -110,8 +110,6 @@ var (
 	}
 )
 
-func int64ptr(i int64) *int64 { return &i }
-
 func TestReconcileGlobalRole(t *testing.T) {
 	t.Parallel()
 
@@ -615,7 +613,7 @@ func TestUpdateStatus(t *testing.T) {
 		wantSummary            string
 		wantSkipUpdate         bool
 		inputGlobalRole        *v3.GlobalRole
-		wantObservedGeneration *int64
+		wantObservedGeneration int64
 	}{
 		{
 			name: "conditions unchanged - no update",
@@ -646,7 +644,7 @@ func TestUpdateStatus(t *testing.T) {
 			},
 			inputGlobalRole:        &v3.GlobalRole{ObjectMeta: metav1.ObjectMeta{Generation: 3}},
 			wantSummary:            status.SummaryCompleted,
-			wantObservedGeneration: int64ptr(3),
+			wantObservedGeneration: 3,
 		},
 		{
 			name: "all conditions true - completed summary",
@@ -714,10 +712,7 @@ func TestUpdateStatus(t *testing.T) {
 			if test.wantSummary != "" {
 				require.NotNil(t, updatedGR)
 				require.Equal(t, test.wantSummary, updatedGR.Status.Summary)
-			}
-			if test.wantObservedGeneration != nil {
-				require.NotNil(t, updatedGR)
-				require.Equal(t, *test.wantObservedGeneration, updatedGR.Status.ObservedGeneration)
+				require.Equal(t, test.wantObservedGeneration, updatedGR.Status.ObservedGeneration)
 			}
 		})
 	}

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -110,6 +110,8 @@ var (
 	}
 )
 
+func int64ptr(i int64) *int64 { return &i }
+
 func TestReconcileGlobalRole(t *testing.T) {
 	t.Parallel()
 
@@ -604,14 +606,16 @@ func TestUpdateStatus(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		localConditions []metav1.Condition
-		grFromCluster   *v3.GlobalRole
-		grCacheErr      error
-		updateErr       error
-		wantError       bool
-		wantSummary     string
-		wantSkipUpdate  bool
+		name                   string
+		localConditions        []metav1.Condition
+		grFromCluster          *v3.GlobalRole
+		grCacheErr             error
+		updateErr              error
+		wantError              bool
+		wantSummary            string
+		wantSkipUpdate         bool
+		inputGlobalRole        *v3.GlobalRole
+		wantObservedGeneration *int64
 	}{
 		{
 			name: "conditions unchanged - no update",
@@ -634,13 +638,15 @@ func TestUpdateStatus(t *testing.T) {
 			},
 			grFromCluster: &v3.GlobalRole{
 				Status: v3.GlobalRoleStatus{
-					ObservedGeneration: 1,
+					ObservedGeneration: 2,
 					Conditions: []metav1.Condition{
 						{Type: ClusterRoleExists, Status: metav1.ConditionTrue, Reason: ClusterRoleExists},
 					},
 				},
 			},
-			wantSummary: status.SummaryCompleted,
+			inputGlobalRole:        &v3.GlobalRole{ObjectMeta: metav1.ObjectMeta{Generation: 3}},
+			wantSummary:            status.SummaryCompleted,
+			wantObservedGeneration: int64ptr(3),
 		},
 		{
 			name: "all conditions true - completed summary",
@@ -695,7 +701,11 @@ func TestUpdateStatus(t *testing.T) {
 				grCache:  grCacheMock,
 				status:   status.NewStatus(),
 			}
-			err := grLifecycle.updateStatus(&v3.GlobalRole{}, test.localConditions)
+			inputGR := test.inputGlobalRole
+			if inputGR == nil {
+				inputGR = &v3.GlobalRole{}
+			}
+			err := grLifecycle.updateStatus(inputGR, test.localConditions)
 			if test.wantError {
 				require.Error(t, err)
 			} else {
@@ -704,6 +714,10 @@ func TestUpdateStatus(t *testing.T) {
 			if test.wantSummary != "" {
 				require.NotNil(t, updatedGR)
 				require.Equal(t, test.wantSummary, updatedGR.Status.Summary)
+			}
+			if test.wantObservedGeneration != nil {
+				require.NotNil(t, updatedGR)
+				require.Equal(t, *test.wantObservedGeneration, updatedGR.Status.ObservedGeneration)
 			}
 		})
 	}

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -628,6 +628,21 @@ func TestUpdateStatus(t *testing.T) {
 			wantSkipUpdate: true,
 		},
 		{
+			name: "conditions unchanged but generation mismatch - triggers update",
+			localConditions: []metav1.Condition{
+				{Type: ClusterRoleExists, Status: metav1.ConditionTrue, Reason: ClusterRoleExists},
+			},
+			grFromCluster: &v3.GlobalRole{
+				Status: v3.GlobalRoleStatus{
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{Type: ClusterRoleExists, Status: metav1.ConditionTrue, Reason: ClusterRoleExists},
+					},
+				},
+			},
+			wantSummary: status.SummaryCompleted,
+		},
+		{
 			name: "all conditions true - completed summary",
 			localConditions: []metav1.Condition{
 				{Type: ClusterRoleExists, Status: metav1.ConditionTrue, Reason: ClusterRoleExists},
@@ -658,11 +673,9 @@ func TestUpdateStatus(t *testing.T) {
 			wantError:     true,
 		},
 	}
+	ctrl := gomock.NewController(t)
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			ctrl := gomock.NewController(t)
 			grCacheMock := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRole](ctrl)
 			grCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(test.grFromCluster, test.grCacheErr)
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54952
 
## Problem
The `observedGeneration` field was not being updated when it didn't match the `generation` field, which was causing an issue within the UI to display that the globalrole was not ready.
 
## Solution
If they mismatch, make sure to continue with an update to make sure they match.
 
## Testing

## Engineering Testing
### Manual Testing
If you update the rules of a GlobalRole, it will set the `observedGeneration` to the correct one. In the UI, you can see this happen as there's a slight delay so you can watch it go from "not ready" to "ready"

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Added a unit test to cover this behaviour

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_