### PR TITLE
Enable provider refresh for Cognito

### DIFF
--- a/pkg/auth/providers/cognito/cognito.go
+++ b/pkg/auth/providers/cognito/cognito.go
@@ -52,6 +52,13 @@ func (p *CognitoProvider) GetName() string {
 	return Name
 }
 
+func (p *CognitoProvider) RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error) {
+	return p.OpenIDCProvider.RefetchGroupPrincipals(principalID, secret)
+}
+
+func (p *CognitoProvider) UsesUserSecrets() bool      { return true }
+func (p *CognitoProvider) CanRefreshPrincipals() bool { return true }
+
 func (p *CognitoProvider) Logout(w http.ResponseWriter, r *http.Request, token accessor.TokenAccessor) error {
 	providerName := token.GetAuthProvider()
 	logrus.Debugf("CognitoProvider [logout]: triggered by provider %s", providerName)


### PR DESCRIPTION
## Issue: #49932 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The Cognito provider inherited disabled refresh from the generic OIDC provider, so refresh process was never attempted.
Non-transient errors like invalid_grant could never propagate, and the annotation to stop requeuing was never set.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Three refresh-related methods on the Cognito provider was overridden to delegate to the base OIDC implementation, which uses the stored OAuth2 refresh token and wraps permanent failures as non-transient errors.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
