### PR TITLE
Move inheritedNamespacedRule indexer registration to be earlier

### DIFF
--- a/pkg/controllers/management/auth/globalroles/enqueue.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue.go
@@ -6,7 +6,6 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/status"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/rbac"
 	wrangler "github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
@@ -21,7 +20,6 @@ import (
 const (
 	grbGrIndex                 = "mgmt-auth-grb-gr-idex"
 	grNsIndex                  = "mgmt-auth-gr-ns-index"
-	grDownstreamNSIndex        = rbac.GRDownstreamNSIndex
 	grSafeConcatIndex          = "mgmt-auth-gr-concat-index"
 	grbSafeConcatIndex         = "mgmt-auth-grb-concat-index"
 	grbEnqueuer                = "mgmt-auth-gr-enqueue"
@@ -45,15 +43,6 @@ type globalRBACEnqueuer struct {
 func grNsIndexer(gr *v3.GlobalRole) ([]string, error) {
 	result := []string{}
 	for ns := range gr.NamespacedRules {
-		result = append(result, ns)
-	}
-	return result, nil
-}
-
-// grDownstreamNSIndexer indexes GlobalRoles by the namespaces in InheritedNamespacedRules
-func grDownstreamNSIndexer(gr *v3.GlobalRole) ([]string, error) {
-	result := []string{}
-	for ns := range gr.InheritedNamespacedRules {
 		result = append(result, ns)
 	}
 	return result, nil

--- a/pkg/controllers/management/auth/globalroles/register.go
+++ b/pkg/controllers/management/auth/globalroles/register.go
@@ -18,7 +18,6 @@ func Register(ctx context.Context, management *config.ManagementContext, cluster
 	management.Wrangler.Mgmt.GlobalRoleBinding().Cache().AddIndexer(grbSafeConcatIndex, grbSafeConcatIndexer)
 	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grNsIndex, grNsIndexer)
 	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grSafeConcatIndex, grSafeConcatIndexer)
-	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grDownstreamNSIndex, grDownstreamNSIndexer)
 	enqueuer := globalRBACEnqueuer{
 		grbCache:      management.Wrangler.Mgmt.GlobalRoleBinding().Cache(),
 		grCache:       management.Wrangler.Mgmt.GlobalRole().Cache(),

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -22,8 +22,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// RegisterWranglerIndexers registers indexers for the management context wrangler.
-// These are registered early in the startup process so that they are available for use by controllers as soon as they start.
 func RegisterWranglerIndexers(config *wrangler.Context) {
 	config.RBAC.ClusterRoleBinding().Cache().AddIndexer(rbByRoleAndSubjectIndex, rbByClusterRoleAndSubject)
 	config.RBAC.ClusterRoleBinding().Cache().AddIndexer(membershipBindingOwnerIndex, func(obj *rbacv1.ClusterRoleBinding) ([]string, error) {
@@ -34,14 +32,6 @@ func RegisterWranglerIndexers(config *wrangler.Context) {
 	config.RBAC.RoleBinding().Cache().AddIndexer(rbByRoleAndSubjectIndex, rbByRoleAndSubject)
 	config.RBAC.RoleBinding().Cache().AddIndexer(membershipBindingOwnerIndex, func(obj *rbacv1.RoleBinding) ([]string, error) {
 		return indexByMembershipBindingOwner(obj)
-	})
-
-	config.Mgmt.GlobalRole().Cache().AddIndexer(pkgrbac.GRDownstreamNSIndex, func(gr *v3.GlobalRole) ([]string, error) {
-		result := []string{}
-		for ns := range gr.InheritedNamespacedRules {
-			result = append(result, ns)
-		}
-		return result, nil
 	})
 }
 
@@ -72,6 +62,21 @@ func RegisterIndexers(scaledContext *config.ScaledContext) error {
 	}
 
 	roletemplates.RegisterIndexers(scaledContext.Wrangler)
+
+	grInformer := scaledContext.Management.GlobalRoles("").Controller().Informer()
+	grInformer.AddIndexers(map[string]cache.IndexFunc{
+		pkgrbac.GRDownstreamNSIndex: func(obj any) ([]string, error) {
+			gr, ok := obj.(*v3.GlobalRole)
+			if !ok {
+				return nil, nil
+			}
+			result := []string{}
+			for ns := range gr.InheritedNamespacedRules {
+				result = append(result, ns)
+			}
+			return result, nil
+		},
+	})
 
 	grbInformer := scaledContext.Management.GlobalRoleBindings("").Controller().Informer()
 	return grbInformer.AddIndexers(map[string]cache.IndexFunc{

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/auth/project_cluster"
 	"github.com/rancher/rancher/pkg/controllers/management/auth/roletemplates"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/generic"
@@ -21,6 +22,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// RegisterWranglerIndexers registers indexers for the management context wrangler.
+// These are registered early in the startup process so that they are available for use by controllers as soon as they start.
 func RegisterWranglerIndexers(config *wrangler.Context) {
 	config.RBAC.ClusterRoleBinding().Cache().AddIndexer(rbByRoleAndSubjectIndex, rbByClusterRoleAndSubject)
 	config.RBAC.ClusterRoleBinding().Cache().AddIndexer(membershipBindingOwnerIndex, func(obj *rbacv1.ClusterRoleBinding) ([]string, error) {
@@ -31,6 +34,14 @@ func RegisterWranglerIndexers(config *wrangler.Context) {
 	config.RBAC.RoleBinding().Cache().AddIndexer(rbByRoleAndSubjectIndex, rbByRoleAndSubject)
 	config.RBAC.RoleBinding().Cache().AddIndexer(membershipBindingOwnerIndex, func(obj *rbacv1.RoleBinding) ([]string, error) {
 		return indexByMembershipBindingOwner(obj)
+	})
+
+	config.Mgmt.GlobalRole().Cache().AddIndexer(pkgrbac.GRDownstreamNSIndex, func(gr *v3.GlobalRole) ([]string, error) {
+		result := []string{}
+		for ns := range gr.InheritedNamespacedRules {
+			result = append(result, ns)
+		}
+		return result, nil
 	})
 }
 


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/54936
https://github.com/rancher/rancher/issues/55299
 
## Problem
In certain setups, the indexer `mgmt-auth-gr-downstream-ns-index` was not getting registered. Then when the enqueuers responsible for updating global roles and global role bindings when a namespace changed would produce errors because they would attempt to fetch global roles with the unregistered indexer.
 
## Solution
The indexer was being registered inside `globalrole.Register()`, which happens within the `OnLeaderOrDie` goroutine (responsible for leader election). The controllers themselves are registered _before_ the leader election takes place before any leader election. So the controllers (including the enqueuers) were registered before the indexers were. That would lead to the errors in the logs.

To fix it, I've moved the indexers to be registered in the `RegisterIndexers` function, which always gets called before the leader election begins to happen.

The reason it can be tricky to reproduce is that this is exclusively an HA problem. In non HA setups, there is no leadership election happening as the one pod/process is always the owner. So it doesn't have the delay that an HA setup might have to cause this problem in the first place.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_