### PR TITLE
drop unnecessary dependencies on images export

### DIFF
--- a/pkg/image/external/external.go
+++ b/pkg/image/external/external.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/rancher/rancher/pkg/controllers/managementuser/nodesyncer"
 	"github.com/rancher/rancher/pkg/image"
 	"github.com/sirupsen/logrus"
 )
@@ -61,7 +60,7 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 				continue
 			}
 
-			versionGTMin, err := nodesyncer.IsNewerVersion(minVersion, rancherVersion)
+			versionGTMin, err := isNewerVersion(minVersion, rancherVersion)
 			if err != nil {
 				continue
 			}
@@ -70,7 +69,7 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 				continue
 			}
 
-			versionLTMax, err := nodesyncer.IsNewerVersion(rancherVersion, maxVersion)
+			versionLTMax, err := isNewerVersion(rancherVersion, maxVersion)
 			if err != nil {
 				continue
 			}
@@ -122,6 +121,33 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 	sort.Strings(externalImages)
 	logrus.Infof("finished generating %s image list...", source)
 	return externalImages, nil
+}
+
+// isNewerVersion returns true if updated versions semver is newer and false if its
+// semver is older. If semver is equal then metadata is alphanumerically compared.
+func isNewerVersion(prevVersion, updatedVersion string) (bool, error) {
+	parseErrMsg := "failed to parse version: %v"
+	prevVer, err := semver.NewVersion(prevVersion)
+	if err != nil {
+		return false, fmt.Errorf(parseErrMsg, err)
+	}
+
+	updatedVer, err := semver.NewVersion(updatedVersion)
+	if err != nil {
+		return false, fmt.Errorf(parseErrMsg, err)
+	}
+
+	switch updatedVer.Compare(*prevVer) {
+	case -1:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		// using metadata to determine precedence is against semver standards
+		// this is ignored because because k3s uses it to precedence between
+		// two versions based on same k8s version
+		return updatedVer.Metadata > prevVer.Metadata, nil
+	}
 }
 
 // downloadExternalSupportingImages downloads the list of images used by a Source from GitHub releases.

--- a/pkg/image/external/external.go
+++ b/pkg/image/external/external.go
@@ -127,12 +127,12 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 // semver is older. If semver is equal then metadata is alphanumerically compared.
 func isNewerVersion(prevVersion, updatedVersion string) (bool, error) {
 	parseErrMsg := "failed to parse version: %v"
-	prevVer, err := semver.NewVersion(prevVersion)
+	prevVer, err := semver.NewVersion(strings.TrimPrefix(prevVersion, "v"))
 	if err != nil {
 		return false, fmt.Errorf(parseErrMsg, err)
 	}
 
-	updatedVer, err := semver.NewVersion(updatedVersion)
+	updatedVer, err := semver.NewVersion(strings.TrimPrefix(updatedVersion, "v"))
 	if err != nil {
 		return false, fmt.Errorf(parseErrMsg, err)
 	}

--- a/pkg/image/external/external_test.go
+++ b/pkg/image/external/external_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/rancher/rancher/pkg/image"
-	"github.com/rancher/rancher/pkg/kontainerdrivermetadata"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -103,7 +102,7 @@ func TestGetExternalImages(t *testing.T) {
 			if err != nil {
 				t.Errorf("failed to read response from url %v", tt.args.kdmUrl)
 			}
-			data, err := kontainerdrivermetadata.FromData(resp)
+			data, err := image.KDMFromData(resp)
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/image/kdm.go
+++ b/pkg/image/kdm.go
@@ -1,0 +1,19 @@
+package image
+
+import "encoding/json"
+
+type KDMData struct {
+	// K3S specific data, opaque and defined by the config file in kdm
+	K3S map[string]interface{} `json:"k3s,omitempty"`
+	// Rke2 specific data, defined by the config file in kdm
+	RKE2 map[string]interface{} `json:"rke2,omitempty"`
+}
+
+func KDMFromData(b []byte) (KDMData, error) {
+	d := &KDMData{}
+
+	if err := json.Unmarshal(b, d); err != nil {
+		return KDMData{}, err
+	}
+	return *d, nil
+}

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -11,7 +11,6 @@ import (
 	"github.com/coreos/go-semver/semver"
 	img "github.com/rancher/rancher/pkg/image"
 	ext "github.com/rancher/rancher/pkg/image/external"
-	"github.com/rancher/rancher/pkg/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/settings"
 )
 
@@ -76,7 +75,7 @@ func GatherTargetArtifactsAndSources(
 	if err != nil {
 		return ArtifactTargetsAndSources{}, fmt.Errorf("could not read data.json: %w", err)
 	}
-	data, err := kontainerdrivermetadata.FromData(b)
+	data, err := img.KDMFromData(b)
 	if err != nil {
 		return ArtifactTargetsAndSources{}, fmt.Errorf("could not load KDM data: %w", err)
 	}

--- a/pkg/kontainerdrivermetadata/handler.go
+++ b/pkg/kontainerdrivermetadata/handler.go
@@ -2,7 +2,6 @@ package kontainerdrivermetadata
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/blang/semver"
@@ -17,13 +16,6 @@ import (
 type MetadataController struct {
 	Settings mgmtcontrollers.SettingController
 	ctx      context.Context
-}
-
-type Data struct {
-	// K3S specific data, opaque and defined by the config file in kdm
-	K3S map[string]interface{} `json:"k3s,omitempty"`
-	// Rke2 specific data, defined by the config file in kdm
-	RKE2 map[string]interface{} `json:"rke2,omitempty"`
 }
 
 func Register(ctx context.Context, wContext *wrangler.Context) {
@@ -133,13 +125,4 @@ func getKubernetesVersionRange(ctx context.Context, runtime, serverVersion strin
 	maxVersion := versions[len(versions)-1]
 	uiSupported := fmt.Sprintf(">=v%d.%d.x <=v%d.%d.x", minVersion.Major, minVersion.Minor, maxVersion.Major, maxVersion.Minor)
 	return uiSupported, nil
-}
-
-func FromData(b []byte) (Data, error) {
-	d := &Data{}
-
-	if err := json.Unmarshal(b, d); err != nil {
-		return Data{}, err
-	}
-	return *d, nil
 }


### PR DESCRIPTION
- **drop nodesyncer dependency**
- **move data and fromdata to image package**

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The pkg/image/export package uses thousands of dependencies that are completely unnecessary for its functionality. Making running this
code a lot slower.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Remove unnecessary dependencies by duplicating or moving code.

- Copied the isNewerVersion function from nodesyncer to the image package, and removed the dependency on nodesyncer.
- Moved kdm data and fromdata to image package, and removed the dependency on kdm.

Before:

```
real    1m4.424s
user    6m18.036s
sys     0m27.278s
```

After:

```
real    0m29.403s
user    2m42.628s
sys     0m12.932s
```

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Compare the outputs of before and after:

```sh
cd rancher/rancher
git switch be6e739d6 --detach
export CATTLE_KDM_BRANCH=$(grep CATTLE_KDM_BRANCH= package/Dockerfile -m1 | cut -d '=' -f2) && \
  mkdir -p bin && \
  curl -sLf "https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json" > bin/data.json && \
  ./scripts/create-components-images-files.sh

rm -rf bin/build
mkdir -p /tmp/images-files/
cp -r ./bin /tmp/images-files/before

cd <pr-owner>/rancher

export CATTLE_KDM_BRANCH=$(grep CATTLE_KDM_BRANCH= package/Dockerfile -m1 | cut -d '=' -f2) && \
  mkdir -p bin && \
  curl -sLf "https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json" > bin/data.json && \
  ./scripts/create-components-images-files.sh

rm -rf bin/build
cp -r ./bin /tmp/images-files/after


diff /tmp/images-files/before/rancher-images.txt /tmp/images-files/after/rancher-images.txt
diff /tmp/images-files/before/rancher-windows-images.txt /tmp/images-files/after/rancher-windows-images.txt
diff <(sort /tmp/images-files/before/rancher-images-origins.txt) <( sort /tmp/images-files/after/rancher-images-origins.txt)
```

## Engineering Testing

### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
- Test types added/modified:
  - Unit
  - Integration (Go Framework)
  - Integration (v2prov Framework)
  - Validation (Go Framework)
  - Other - Explain: _EXPLAIN_
  - None
  - _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
- If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
- If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:

- _TODO_
