### PR TITLE
Cleanup ext.Tokens when disabling auth providers

### DIFF
--- a/pkg/auth/cleanup/service.go
+++ b/pkg/auth/cleanup/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/api/secrets"
 	"github.com/rancher/rancher/pkg/auth/providers/local/pbkdf2"
@@ -17,7 +18,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-var errAuthConfigNil = errors.New("cannot get auth provider if its config is nil")
+type extTokenStore interface {
+	ListForProvider(provider string) (*ext.TokenList, error)
+	Delete(name string, options *metav1.DeleteOptions) error
+}
 
 // Service performs cleanup of resources associated with an auth provider.
 type Service struct {
@@ -38,10 +42,12 @@ type Service struct {
 
 	tokensCache  controllers.TokenCache
 	tokensClient controllers.TokenClient
+
+	extTokenStore extTokenStore
 }
 
 // NewCleanupService creates and returns a new auth provider cleanup service.
-func NewCleanupService(secretsInterface wcorev1.SecretController, c controllers.Interface) *Service {
+func NewCleanupService(secretsInterface wcorev1.SecretController, c controllers.Interface, extTokens extTokenStore) *Service {
 	return &Service{
 		secretsInterface: secretsInterface,
 		secretsCache:     secretsInterface.Cache(),
@@ -60,55 +66,80 @@ func NewCleanupService(secretsInterface wcorev1.SecretController, c controllers.
 
 		tokensCache:  c.Token().Cache(),
 		tokensClient: c.Token(),
+
+		extTokenStore: extTokens,
 	}
 }
 
-// Run takes an auth config and checks if its auth provider is disabled, and ensures that any resources associated with it,
-// such as secrets, CRTBs, PRTBs, GRBs, Users, are deleted.
+// Run takes an auth config and ensures that any resources associated with its auth provider,
+// such as secrets, CRTBs, PRTBs, GRBs, users, tokens, are deleted.
+// Independent steps are best-effort: each runs regardless of earlier failures, and all errors
+// are collected and returned together.
 func (s *Service) Run(config *v3.AuthConfig) error {
+	if config == nil {
+		return fmt.Errorf("cannot clean up resources: auth config is nil")
+	}
+
+	provider := config.Name
+	var errs []error
+
 	if err := secrets.CleanupClientSecrets(s.secretsInterface, config); err != nil {
-		return fmt.Errorf("error cleaning up resources associated with a disabled auth provider %s: %w", config.Name, err)
+		errs = append(errs, fmt.Errorf("client secrets: %w", err))
 	}
 
-	if err := s.deleteGlobalRoleBindings(config); err != nil {
-		return fmt.Errorf("error cleaning up global role bindings associated with a disabled auth provider %s: %w", config.Name, err)
+	if err := s.deleteGlobalRoleBindings(provider); err != nil {
+		errs = append(errs, fmt.Errorf("global role bindings: %w", err))
 	}
 
-	if err := s.deleteClusterRoleTemplateBindings(config); err != nil {
-		return fmt.Errorf("error cleaning up cluster role template bindings associated with a disabled auth provider %s: %w", config.Name, err)
+	if err := s.deleteClusterRoleTemplateBindings(provider); err != nil {
+		errs = append(errs, fmt.Errorf("cluster role template bindings: %w", err))
 	}
 
-	if err := s.deleteProjectRoleTemplateBindings(config); err != nil {
-		return fmt.Errorf("error cleaning up project role template bindings associated with a disabled auth provider %s: %w", config.Name, err)
+	if err := s.deleteProjectRoleTemplateBindings(provider); err != nil {
+		errs = append(errs, fmt.Errorf("project role template bindings: %w", err))
 	}
 
-	if err := s.deleteUsers(config); err != nil {
-		return fmt.Errorf("error cleaning up users associated with a disabled auth provider %s: %w", config.Name, err)
+	if err := s.deleteUsersAndTokens(provider); err != nil {
+		errs = append(errs, err)
 	}
 
-	if err := s.deleteTokens(config); err != nil {
-		return fmt.Errorf("error cleaning up tokens associated with a disabled auth provider %s: %w", config.Name, err)
+	if err := scim.Cleanup(s.secretsInterface, s.groupClient, provider); err != nil {
+		errs = append(errs, fmt.Errorf("SCIM secrets: %w", err))
 	}
 
-	if err := scim.Cleanup(s.secretsInterface, s.groupClient, config.GetName()); err != nil {
-		return fmt.Errorf("error cleaning up SCIM token secrets associated with a disabled auth provider %s: %w", config.Name, err)
-	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
-func (s *Service) deleteClusterRoleTemplateBindings(config *v3.AuthConfig) error {
-	if config == nil {
-		return errAuthConfigNil
+// deleteUsersAndTokens deletes users first, then tokens. This ordering is required because the
+// user lifecycle controller's Remove handler needs tokens to exist to discover which clusters
+// have ClusterUserAttributes to clean up. If user deletion fails, token deletion is skipped
+// to preserve them for the next retry.
+func (s *Service) deleteUsersAndTokens(provider string) error {
+	if err := s.deleteUsers(provider); err != nil {
+		return fmt.Errorf("users: %w", err)
 	}
+
+	var errs []error
+
+	if err := s.deleteTokens(provider); err != nil {
+		errs = append(errs, fmt.Errorf("tokens: %w", err))
+	}
+
+	if err := s.deleteExtTokens(provider); err != nil {
+		errs = append(errs, fmt.Errorf("ext tokens: %w", err))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *Service) deleteClusterRoleTemplateBindings(provider string) error {
 	list, err := s.clusterRoleTemplateBindingsCache.List("", labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list cluster role template bindings: %w", err)
 	}
 
 	for _, b := range list {
-		providerName := getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName)
-		if providerName == config.Name {
+		if getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName) == provider {
 			err := s.clusterRoleTemplateBindingsClient.Delete(b.Namespace, b.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
@@ -119,18 +150,14 @@ func (s *Service) deleteClusterRoleTemplateBindings(config *v3.AuthConfig) error
 	return nil
 }
 
-func (s *Service) deleteGlobalRoleBindings(config *v3.AuthConfig) error {
-	if config == nil {
-		return errAuthConfigNil
-	}
+func (s *Service) deleteGlobalRoleBindings(provider string) error {
 	list, err := s.globalRoleBindingsCache.List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list global role bindings: %w", err)
 	}
 
 	for _, b := range list {
-		providerName := getProviderNameFromPrincipalNames(b.GroupPrincipalName)
-		if providerName == config.Name {
+		if getProviderNameFromPrincipalNames(b.GroupPrincipalName) == provider {
 			err := s.globalRoleBindingsClient.Delete(b.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
@@ -141,18 +168,14 @@ func (s *Service) deleteGlobalRoleBindings(config *v3.AuthConfig) error {
 	return nil
 }
 
-func (s *Service) deleteProjectRoleTemplateBindings(config *v3.AuthConfig) error {
-	if config == nil {
-		return errAuthConfigNil
-	}
+func (s *Service) deleteProjectRoleTemplateBindings(provider string) error {
 	prtbs, err := s.projectRoleTemplateBindingsCache.List("", labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list project role template bindings: %w", err)
 	}
 
 	for _, b := range prtbs {
-		providerName := getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName)
-		if providerName == config.Name {
+		if getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName) == provider {
 			err := s.projectRoleTemplateBindingsClient.Delete(b.Namespace, b.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
@@ -163,39 +186,36 @@ func (s *Service) deleteProjectRoleTemplateBindings(config *v3.AuthConfig) error
 	return nil
 }
 
-// deleteUsers deletes all external users (for the given provider specified in the config),
+// deleteUsers deletes all external users for the given provider,
 // who never were local users. It does not delete external users who were local before the provider had been set up.
 // The method only removes the external principal IDs from those users.
 // External users are those who have multiple principal IDs associated with them.
 // A local admin (not necessarily the default admin) who had set up the provider will have two principal IDs,
 // but will also have a password.
 // This is how Rancher distinguishes fully external users from those who are external, too, but were once local.
-func (s *Service) deleteUsers(config *v3.AuthConfig) error {
-	if config == nil {
-		return errAuthConfigNil
-	}
+func (s *Service) deleteUsers(provider string) error {
 	users, err := s.userClient.List(metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list users: %w", err)
 	}
 
 	for _, u := range users.Items {
-		providerName := getProviderNameFromPrincipalNames(u.PrincipalIDs...)
-		if providerName == config.Name {
-			// A fully external user (who was never local) has no password.
-			_, err := s.secretsCache.Get(pbkdf2.LocalUserPasswordsNamespace, u.Name)
+		if getProviderNameFromPrincipalNames(u.PrincipalIDs...) != provider {
+			continue
+		}
+		// A fully external user (who was never local) has no password.
+		_, err := s.secretsCache.Get(pbkdf2.LocalUserPasswordsNamespace, u.Name)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get user secret: %w", err)
+		}
+		if u.Password == "" && apierrors.IsNotFound(err) {
+			err := s.userClient.Delete(u.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to get user secret: %w", err)
+				return err
 			}
-			if u.Password == "" && apierrors.IsNotFound(err) {
-				err := s.userClient.Delete(u.Name, &metav1.DeleteOptions{})
-				if err != nil && !apierrors.IsNotFound(err) {
-					return err
-				}
-			} else {
-				if err := s.resetLocalUser(&u); err != nil {
-					return fmt.Errorf("failed to reset local user: %w", err)
-				}
+		} else {
+			if err := s.resetLocalUser(&u); err != nil {
+				return fmt.Errorf("failed to reset local user: %w", err)
 			}
 		}
 	}
@@ -203,23 +223,34 @@ func (s *Service) deleteUsers(config *v3.AuthConfig) error {
 	return nil
 }
 
-// deleteTokens deletes all the tokens created with the disabled provider
-func (s *Service) deleteTokens(config *v3.AuthConfig) error {
-	if config == nil {
-		return errAuthConfigNil
-	}
-
+func (s *Service) deleteTokens(provider string) error {
 	tokens, err := s.tokensCache.List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list tokens: %w", err)
 	}
 
 	for _, t := range tokens {
-		if t.AuthProvider == config.Name {
+		if t.AuthProvider == provider {
 			err := s.tokensClient.Delete(t.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed deleting token %s while disabling authprovider %s: %w", t.Name, t.AuthProvider, err)
+				return fmt.Errorf("failed deleting token %s while disabling auth provider %s: %w", t.Name, provider, err)
 			}
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) deleteExtTokens(provider string) error {
+	tokens, err := s.extTokenStore.ListForProvider(provider)
+	if err != nil {
+		return fmt.Errorf("failed to list ext tokens: %w", err)
+	}
+
+	for i := range tokens.Items {
+		if err := s.extTokenStore.Delete(tokens.Items[i].Name, &metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("failed deleting ext token %s while disabling auth provider %s: %w",
+				tokens.Items[i].Name, provider, err)
 		}
 	}
 

--- a/pkg/auth/cleanup/service_test.go
+++ b/pkg/auth/cleanup/service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/local/pbkdf2"
@@ -26,6 +27,33 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+type fakeExtTokenStore struct {
+	tokens    map[string]*ext.Token
+	listErr   error
+	deleteErr error
+}
+
+func (f *fakeExtTokenStore) ListForProvider(provider string) (*ext.TokenList, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var items []ext.Token
+	for _, t := range f.tokens {
+		if t.Spec.UserPrincipal.Provider == provider {
+			items = append(items, *t)
+		}
+	}
+	return &ext.TokenList{Items: items}, nil
+}
+
+func (f *fakeExtTokenStore) Delete(name string, _ *metav1.DeleteOptions) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.tokens, name)
+	return nil
+}
 
 func TestRunCleanup(t *testing.T) {
 	var globalRoleBindingStore = map[string]*v3.GlobalRoleBinding{
@@ -99,6 +127,27 @@ func TestRunCleanup(t *testing.T) {
 		},
 	}
 
+	var extTokens = map[string]*ext.Token{
+		"ext-azure-1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "ext-azure-1"},
+			Spec: ext.TokenSpec{
+				UserPrincipal: ext.TokenPrincipal{Provider: "azuread"},
+			},
+		},
+		"ext-azure-2": {
+			ObjectMeta: metav1.ObjectMeta{Name: "ext-azure-2"},
+			Spec: ext.TokenSpec{
+				UserPrincipal: ext.TokenPrincipal{Provider: "azuread"},
+			},
+		},
+		"ext-local-1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "ext-local-1"},
+			Spec: ext.TokenSpec{
+				UserPrincipal: ext.TokenPrincipal{Provider: "local"},
+			},
+		},
+	}
+
 	var secretStore = map[string]*v1.Secret{
 		"cattle-system:oauthSecretName": {
 			ObjectMeta: metav1.ObjectMeta{
@@ -130,6 +179,7 @@ func TestRunCleanup(t *testing.T) {
 		},
 	}
 
+	extStore := &fakeExtTokenStore{tokens: extTokens}
 	svc := newMockCleanupService(t,
 		globalRoleBindingStore,
 		projectRoleTemplateBindingStore,
@@ -137,6 +187,7 @@ func TestRunCleanup(t *testing.T) {
 		tokenStore,
 		userStore,
 		secretStore,
+		extStore,
 	)
 	cfg := v3.AuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -156,6 +207,8 @@ func TestRunCleanup(t *testing.T) {
 	assert.Len(t, secretStore, 1)
 	assert.Len(t, tokenStore, 2)
 	assert.Empty(t, tokenStore["azure-123"])
+	assert.Len(t, extTokens, 1)
+	assert.NotNil(t, extTokens["ext-local-1"])
 
 	for _, user := range userStore {
 		require.Lenf(t, user.PrincipalIDs, 1, "every user after cleanup must have only one principal ID, got %d", len(user.PrincipalIDs))
@@ -170,7 +223,8 @@ func newMockCleanupService(t *testing.T,
 	crtbStore map[string]*v3.ClusterRoleTemplateBinding,
 	tokenStore map[string]*v3.Token,
 	userStore map[string]*v3.User,
-	secretStore map[string]*v1.Secret) Service {
+	secretStore map[string]*v1.Secret,
+	extStore extTokenStore) Service {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 
@@ -304,6 +358,7 @@ func newMockCleanupService(t *testing.T,
 		tokensCache:                       tokenCache,
 		tokensClient:                      tokenClient,
 		userClient:                        userClient,
+		extTokenStore:                     extStore,
 	}
 }
 
@@ -344,4 +399,93 @@ func getSecretControllerMock(ctrl *gomock.Controller, store map[string]*corev1.S
 	}).AnyTimes()
 
 	return secretController
+}
+
+func TestDeleteExtTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		provider  string
+		tokens    map[string]*ext.Token
+		listErr   error
+		deleteErr error
+		wantErr   bool
+		wantLeft  []string
+	}{
+		{
+			name:     "no matching tokens",
+			provider: "azuread",
+			tokens: map[string]*ext.Token{
+				"ext-local": {
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-local"},
+					Spec:       ext.TokenSpec{UserPrincipal: ext.TokenPrincipal{Provider: "local"}},
+				},
+			},
+			wantLeft: []string{"ext-local"},
+		},
+		{
+			name:     "deletes only matching provider tokens",
+			provider: "azuread",
+			tokens: map[string]*ext.Token{
+				"ext-azure": {
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-azure"},
+					Spec:       ext.TokenSpec{UserPrincipal: ext.TokenPrincipal{Provider: "azuread"}},
+				},
+				"ext-local": {
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-local"},
+					Spec:       ext.TokenSpec{UserPrincipal: ext.TokenPrincipal{Provider: "local"}},
+				},
+				"ext-ping": {
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-ping"},
+					Spec:       ext.TokenSpec{UserPrincipal: ext.TokenPrincipal{Provider: "ping"}},
+				},
+			},
+			wantLeft: []string{"ext-local", "ext-ping"},
+		},
+		{
+			name:     "list error propagates",
+			provider: "azuread",
+			tokens:   map[string]*ext.Token{},
+			listErr:  errors.New("list failed"),
+			wantErr:  true,
+		},
+		{
+			name:     "delete error propagates",
+			provider: "azuread",
+			tokens: map[string]*ext.Token{
+				"ext-azure": {
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-azure"},
+					Spec:       ext.TokenSpec{UserPrincipal: ext.TokenPrincipal{Provider: "azuread"}},
+				},
+			},
+			deleteErr: errors.New("delete failed"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &fakeExtTokenStore{
+				tokens:    tt.tokens,
+				listErr:   tt.listErr,
+				deleteErr: tt.deleteErr,
+			}
+			svc := &Service{extTokenStore: store}
+			err := svc.deleteExtTokens(tt.provider)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, store.tokens, len(tt.wantLeft))
+			for _, name := range tt.wantLeft {
+				assert.Contains(t, store.tokens, name)
+			}
+		})
+	}
 }

--- a/pkg/controllers/management/auth/auth_config.go
+++ b/pkg/controllers/management/auth/auth_config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/rancher/pkg/auth/cleanup"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
@@ -48,10 +49,11 @@ type authConfigController struct {
 }
 
 func newAuthConfigController(mgmt *config.ManagementContext, scaledContext *config.ScaledContext) *authConfigController {
+	extTokenStore := exttokenstore.NewSystemFromWrangler(mgmt.Wrangler)
 	controller := &authConfigController{
 		users:                   mgmt.Management.Users("").Controller().Lister(),
 		authRefresher:           providerrefresh.NewUserAuthRefresher(scaledContext),
-		cleanup:                 cleanup.NewCleanupService(mgmt.Wrangler.Core.Secret(), mgmt.Wrangler.Mgmt),
+		cleanup:                 cleanup.NewCleanupService(mgmt.Wrangler.Core.Secret(), mgmt.Wrangler.Mgmt, extTokenStore),
 		authConfigsUnstructured: scaledContext.Management.AuthConfigs("").ObjectClient().UnstructuredClient(),
 	}
 	return controller

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -885,6 +885,30 @@ func (t *SystemStore) ListForUser(userName string) (*ext.TokenList, error) {
 	}, nil
 }
 
+// ListForProvider returns all ext tokens associated with the named auth
+// provider. It is an internal call invoked by other parts of Rancher.
+func (t *SystemStore) ListForProvider(provider string) (*ext.TokenList, error) {
+	secrets, err := t.secretCache.List(TokenNamespace, labels.Set(map[string]string{
+		SecretKindLabel: SecretKindLabelValue,
+	}).AsSelector())
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("failed to list tokens for provider %s: %w", provider, err))
+	}
+
+	var tokens []ext.Token
+	for _, secret := range secrets {
+		token, err := fromSecret(secret)
+		if err != nil {
+			continue
+		}
+		if token.Spec.UserPrincipal.Provider == provider {
+			tokens = append(tokens, *token)
+		}
+	}
+
+	return &ext.TokenList{Items: tokens}, nil
+}
+
 func (t *SystemStore) list(fullAccess bool, userName, authTokenID string, options *metav1.ListOptions) (*ext.TokenList, error) {
 	// Non-system requests always filter the tokens down to those of the current user.
 	// Merge our own selection request (user match!) into the caller's demands

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -2473,3 +2473,123 @@ func (w *mockWatch) ResultChan() <-chan watch.Event {
 }
 
 func (w *mockWatch) Stop() {}
+
+func TestSystemStoreListForProvider(t *testing.T) {
+	t.Parallel()
+
+	otherPrincipal := ext.TokenPrincipal{
+		Name:     "other-user",
+		Provider: "otherprovider",
+	}
+	otherPrincipalBytes, _ := json.Marshal(otherPrincipal)
+
+	otherSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "token-other",
+			Labels: map[string]string{
+				UserIDLabel:     "otheruser",
+				SecretKindLabel: SecretKindLabelValue,
+			},
+			UID: "other-uid",
+		},
+		Data: map[string][]byte{
+			FieldDescription:    []byte(""),
+			FieldEnabled:        []byte("true"),
+			FieldHash:           []byte("otherhash"),
+			FieldKind:           []byte(IsLogin),
+			FieldLastUpdateTime: []byte("14:00:00"),
+			FieldPrincipal:      otherPrincipalBytes,
+			FieldTTL:            []byte("5000"),
+			FieldUID:            []byte("other-kube-uid"),
+			FieldUserID:         []byte("otheruser"),
+		},
+	}
+
+	tests := []struct {
+		name       string
+		provider   string
+		err        error
+		wantCount  int
+		storeSetup func(scache *fake.MockCacheInterface[*corev1.Secret])
+	}{
+		{
+			name:     "cache error propagates",
+			provider: "somebody",
+			err:      apierrors.NewInternalError(fmt.Errorf("failed to list tokens for provider somebody: %w", errSomeError)),
+			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
+				scache.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(nil, errSomeError)
+			},
+		},
+		{
+			name:      "empty result",
+			provider:  "somebody",
+			wantCount: 0,
+			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
+				scache.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(nil, nil)
+			},
+		},
+		{
+			name:      "returns only matching provider",
+			provider:  "somebody",
+			wantCount: 1,
+			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
+				scache.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return([]*corev1.Secret{&properSecret, &otherSecret}, nil)
+			},
+		},
+		{
+			name:      "no match returns empty",
+			provider:  "nonexistent",
+			wantCount: 0,
+			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
+				scache.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return([]*corev1.Secret{&properSecret, &otherSecret}, nil)
+			},
+		},
+		{
+			name:      "skips broken secrets",
+			provider:  "somebody",
+			wantCount: 1,
+			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
+				scache.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return([]*corev1.Secret{&properSecret, &badSecret}, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+
+			users.EXPECT().Cache().Return(nil)
+			secrets.EXPECT().Cache().Return(scache)
+
+			store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil, nil)
+			tt.storeSetup(scache)
+
+			toks, err := store.ListForProvider(tt.provider)
+			if tt.err != nil {
+				assert.Equal(t, tt.err, err)
+				assert.Nil(t, toks)
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, toks.Items, tt.wantCount)
+				for _, tok := range toks.Items {
+					assert.Equal(t, tt.provider, tok.Spec.UserPrincipal.Provider)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: #55238 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When an auth provider was disabled, only legacy v3.Token objects were cleaned up. The newer ext.Token objects were not taken into consideration and were left behind.

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added ext.Token deletion to the auth provider cleanup service. Also independent cleanup steps are now best-effort so a failure in one area doesn't block cleanup of others. User deletion still runs before token deletion because the user lifecycle controller needs tokens to discover which clusters have resources to clean up.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->