### PR TITLE
Fix MCM k8s proxy Host header to use downstream API server FQDN

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -250,7 +250,8 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		req.URL.Scheme = "https"
 	}
 
-	req.URL.Host = req.Host
+	req.URL.Host = u.Host
+	req.Host = u.Host
 	transport, err := r.getTransport()
 	if err != nil {
 		er.Error(rw, req, err)

--- a/pkg/clusterrouter/proxy/proxy_server_test.go
+++ b/pkg/clusterrouter/proxy/proxy_server_test.go
@@ -17,6 +17,47 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
+func TestServeHTTP_HostHeader(t *testing.T) {
+	t.Parallel()
+
+	const targetHost = "api.downstream-cluster.example.com:6443"
+
+	r := RemoteService{
+		transport: func() (http.RoundTripper, error) {
+			return http.DefaultTransport, nil
+		},
+		url: func() (url.URL, error) {
+			return url.URL{
+				Scheme: "https",
+				Host:   targetHost,
+			}, nil
+		},
+		cluster: &v3.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v3.ClusterSpec{
+				Internal: true,
+			},
+		},
+	}
+
+	req := &http.Request{
+		Host: "rancher.example.com",
+		URL: &url.URL{
+			Path: "/k8s/clusters/test/api/v1/pods",
+		},
+		Header: http.Header{},
+	}
+	req = req.WithContext(context.TODO())
+	rw := httptest.NewRecorder()
+
+	r.ServeHTTP(rw, req)
+
+	assert.Equal(t, targetHost, req.Host, "req.Host should be set to downstream API server host")
+	assert.Equal(t, targetHost, req.URL.Host, "req.URL.Host should be set to downstream API server host")
+}
+
 func TestServeHTTP(t *testing.T) {
 	tests := map[string]struct {
 		tokenCreator                   tokenCreator


### PR DESCRIPTION
## Issue
https://github.com/rancher/rancher/issues/54910

## Problem
Rancher's Multi-Cluster Manager (MCM) k8s proxy in `pkg/clusterrouter/proxy/proxy_server.go` forwards the **incoming** request's `Host` header to the downstream cluster API server instead of setting it to the target API server's FQDN.

This causes HTTP 404 errors when the downstream API server is fronted by an L7 reverse proxy that performs host-based routing (e.g., Gardener's Istio Ingress Gateway with `IstioTLSTermination` enabled).

The bug is at line 253:
```go
req.URL.Host = req.Host   // BUG: preserves incoming Host (e.g., "localhost" or Rancher's own hostname)
```

The variable `u` is derived from `cluster.Status.APIEndpoint` (the downstream cluster's actual API server URL), but `req.URL.Host` is set to `req.Host` — the Host header from the **incoming** request to Rancher, not the target.

## Solution
Set both `req.URL.Host` and `req.Host` to the target URL's host (`u.Host`) instead of the incoming request's host:

```go
req.URL.Host = u.Host
req.Host = u.Host
```

This ensures the outbound HTTP `Host` header matches the downstream API server's FQDN, which is standard reverse proxy behavior (nginx, envoy, HAProxy all do this by default).

**Why this is safe:**
1. kube-apiserver does not validate Host headers — setting the correct Host won't cause rejection
2. TLS SNI is unaffected — the MCM proxy uses `remotedialer` tunnels; SNI is determined by the transport layer independently of the HTTP Host header
3. No impact on local cluster — the local cluster uses `NewLocal()` which has a separate code path
4. `UpgradeAwareHandler` uses the `Location` URL (`u`) for connection establishment; fixing the Host header only affects HTTP-level routing at the destination

## Testing

### Manual Testing
- Verified with a Gardener shoot cluster on an OpenStack seed with `IstioTLSTermination` enabled
- Before fix: requests via `/k8s/clusters/{id}/...` return HTTP 404 from Istio Envoy (host mismatch)
- After fix: requests correctly reach kube-apiserver (returns 401 for unauthenticated, or proper API responses when authenticated)

Reproduction steps from the issue are valid — see [issue #54910](https://github.com/rancher/rancher/issues/54910) for details.

### Automated Testing
* Test types added/modified:
    * Unit

Added `TestServeHTTP_HostHeader` in `pkg/clusterrouter/proxy/proxy_server_test.go` that verifies:
- `req.Host` is set to the downstream API server's host (not the incoming request's host)
- `req.URL.Host` is set to the downstream API server's host

## QA Testing Considerations
- Test the MCM k8s proxy path (`/k8s/clusters/{clusterID}/...`) with downstream clusters
- Particularly test with clusters whose API server is behind an L7 proxy that validates Host headers
- Verify no regression for standard downstream clusters (RKE1/RKE2/K3s without L7 proxy)
- Verify no regression for the local cluster
- Test both fresh import and upgrade scenarios

### Regressions Considerations
**Probability of regression: Low**

The fix only changes what HTTP `Host` header is sent to the downstream API server. Since:
- kube-apiserver does not validate or use the `Host` header for routing
- The change aligns with standard reverse proxy behavior
- Only clusters with L7 proxies performing host-based routing would notice any difference (and for them, this is a fix)

Existing / newly added automated tests that provide evidence there are no regressions:
* `TestServeHTTP_HostHeader` - verifies correct Host header is set
* Existing `TestServeHTTP` cases - continue to pass (authorization/impersonation logic unaffected)