### PR TITLE
documentation cross-reference to webhook, as its CI depends on the format

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -139,6 +139,7 @@ var (
 	ClusterTemplateEnforcement          = NewSetting("cluster-template-enforcement", "false")
 	InitialDockerRootDir                = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
+	// ATTENTION: This file and the following line are used in the rancher/webhook CI to extract the default branch they need
 	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.15")
 	SystemManagedChartsOperationTimeout = NewSetting("system-managed-charts-operation-timeout", "300s")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none


### PR DESCRIPTION
## Issue:

No issue. Internal piece of tech debt (IMHO). 
 
## Problem

The webhook CI depends on the specific format of the setting `ChartDefaultBranch`.

## Solution
 
This PR adds a comment to ensure that maintainers are aware of this dependency and of the need to update the webhook CI should the format be changed.
  
## Testing

N/A
