### PR TITLE
Migrate user lifecycle from Norman to Wrangler

### DIFF
--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -106,7 +106,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, cl
 	relatedresource.Watch(ctx, "aggregation-feature-crtb-enqueuer", aggregationEnqueuer.enqueueCRTBs, management.Wrangler.Mgmt.ClusterRoleTemplateBinding(), management.Wrangler.Mgmt.Feature())
 	relatedresource.Watch(ctx, "aggregation-feature-prtb-enqueuer", aggregationEnqueuer.enqueuePRTBs, management.Wrangler.Mgmt.ProjectRoleTemplateBinding(), management.Wrangler.Mgmt.Feature())
 
-	management.Management.Users("").AddLifecycle(ctx, userController, u)
+	management.Wrangler.Mgmt.User().OnChange(ctx, userController, u.onChange)
 }
 
 func RegisterLate(ctx context.Context, management *config.ManagementContext) {

--- a/pkg/controllers/management/auth/user.go
+++ b/pkg/controllers/management/auth/user.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
@@ -53,6 +54,10 @@ const (
 	grbByUserRefKey   = "auth.management.cattle.io/grb-by-user-ref"
 	tokenByUserRefKey = "auth.management.cattle.io/token-by-user-ref"
 	userController    = "mgmt-auth-users-controller"
+
+	userLifecycleAnnotation = "lifecycle.cattle.io/create.mgmt-auth-users-controller"
+	userLifecycleFinalizer  = "controller.cattle.io/mgmt-auth-users-controller"
+	legacyUserFinalizer     = "controller.cattle.io/cat-user-controller"
 )
 
 func newUserLifecycle(management *config.ManagementContext, clusterManager *clustermanager.Manager) *userLifecycle {
@@ -140,16 +145,37 @@ func hasLocalPrincipalID(user *v3.User) bool {
 	return match
 }
 
-// Create creates a new user role binding and sets the Status.Conditions.Type = "InitialRolesPopulated",
-// and then returns the object. Otherwise returns an error.
-func (l *userLifecycle) Create(user *v3.User) (runtime.Object, error) {
+func (l *userLifecycle) onChange(_ string, user *v3.User) (*v3.User, error) {
+	if user == nil {
+		return nil, nil
+	}
+
+	if user.DeletionTimestamp != nil {
+		if !slices.Contains(user.GetFinalizers(), userLifecycleFinalizer) {
+			return user, nil
+		}
+		return l.onRemove(user)
+	}
+
+	if user.Annotations[userLifecycleAnnotation] != "true" {
+		return l.onCreate(user)
+	}
+
+	return l.onUpdate(user)
+}
+
+func (l *userLifecycle) onCreate(user *v3.User) (*v3.User, error) {
+	user = user.DeepCopy()
+
+	if !slices.Contains(user.Finalizers, userLifecycleFinalizer) {
+		user.Finalizers = append(user.Finalizers, userLifecycleFinalizer)
+	}
+
 	if !hasLocalPrincipalID(user) {
 		user.PrincipalIDs = append(user.PrincipalIDs, "local://"+user.Name)
 	}
 
-	// creatorIDAnn indicates it was created through the API, create the new
-	// user bindings and add the annotation UserConditionInitialRolesPopulated
-	if user.ObjectMeta.Annotations[project_cluster.CreatorIDAnnotation] != "" {
+	if user.Annotations[project_cluster.CreatorIDAnnotation] != "" {
 		u, err := v3.UserConditionInitialRolesPopulated.DoUntilTrue(user, func() (runtime.Object, error) {
 			err := l.userManager.CreateNewUserClusterRoleBinding(user.Name, user.UID)
 			if err != nil {
@@ -163,11 +189,15 @@ func (l *userLifecycle) Create(user *v3.User) (runtime.Object, error) {
 		user = u.(*v3.User)
 	}
 
-	return user, nil
+	if user.Annotations == nil {
+		user.Annotations = map[string]string{}
+	}
+	user.Annotations[userLifecycleAnnotation] = "true"
+
+	return l.users.Update(user)
 }
 
-func (l *userLifecycle) Updated(user *v3.User) (runtime.Object, error) {
-	// Migrate local users as part of the password field deprecation in the User resource. Password are now stored in secrets.
+func (l *userLifecycle) onUpdate(user *v3.User) (*v3.User, error) {
 	if user.Password != "" {
 		if err := l.passwordMigrator.Migrate(user); err != nil {
 			return nil, err
@@ -180,9 +210,6 @@ func (l *userLifecycle) Updated(user *v3.User) (runtime.Object, error) {
 	}
 
 	if user.Enabled != nil && !*user.Enabled {
-		// New functionality. Not done for norman tokens, here. See refresher.go which
-		// deletes/disables tokens when a user is disabled. Having it here makes it a more
-		// immediate response to the user's change of status.
 		extTokens, err := l.getExtTokensByUserName(user.Name)
 		if err != nil {
 			return nil, err
@@ -190,7 +217,6 @@ func (l *userLifecycle) Updated(user *v3.User) (runtime.Object, error) {
 
 		for _, token := range extTokens {
 			if token.GetIsDerived() {
-				// Non-login tokens are disabled
 				logrus.Infof("[%v] Disabling ext token %v for user %v",
 					userController, token.GetName(), token.GetUserID())
 				err := l.extTokenStore.Disable(token.GetName())
@@ -198,7 +224,6 @@ func (l *userLifecycle) Updated(user *v3.User) (runtime.Object, error) {
 					return nil, fmt.Errorf("error updating ext token: %v", err)
 				}
 			} else {
-				// Login tokens are deleted.
 				logrus.Infof("[%v] Deleting token %v for user %v",
 					userController, token.GetName(), token.GetUserID())
 				err := l.extTokenStore.Delete(token.GetName(), &metav1.DeleteOptions{})
@@ -212,7 +237,7 @@ func (l *userLifecycle) Updated(user *v3.User) (runtime.Object, error) {
 	return user, nil
 }
 
-func (l *userLifecycle) Remove(user *v3.User) (runtime.Object, error) {
+func (l *userLifecycle) onRemove(user *v3.User) (*v3.User, error) {
 	clusterRoles, err := l.getCRTBByUserName(user.Name)
 	if err != nil {
 		return nil, err
@@ -276,12 +301,7 @@ func (l *userLifecycle) Remove(user *v3.User) (runtime.Object, error) {
 		return nil, err
 	}
 
-	user, err = l.removeLegacyFinalizers(user)
-	if err != nil {
-		return nil, err
-	}
-
-	return user, nil
+	return l.removeFinalizer(user)
 }
 
 func (l *userLifecycle) getCRTBByUserName(username string) ([]*v3.ClusterRoleTemplateBinding, error) {
@@ -511,19 +531,14 @@ func (l *userLifecycle) deleteUserSecret(username string) error {
 	return l.secrets.Delete("cattle-system", username+"-secret", &metav1.DeleteOptions{})
 }
 
-func (l *userLifecycle) removeLegacyFinalizers(user *v3.User) (*v3.User, error) {
-	finalizers := user.GetFinalizers()
-	for i, finalizer := range finalizers {
-		if finalizer == "controller.cattle.io/cat-user-controller" {
-			finalizers = append(finalizers[:i], finalizers[i+1:]...)
-			user = user.DeepCopy()
-			user.SetFinalizers(finalizers)
-			updatedUser, err := l.users.Update(user)
-			if err != nil {
-				return nil, err
-			}
-			return updatedUser, err
+func (l *userLifecycle) removeFinalizer(user *v3.User) (*v3.User, error) {
+	user = user.DeepCopy()
+	finalizers := make([]string, 0, len(user.Finalizers))
+	for _, f := range user.Finalizers {
+		if f != userLifecycleFinalizer && f != legacyUserFinalizer {
+			finalizers = append(finalizers, f)
 		}
 	}
-	return user, nil
+	user.SetFinalizers(finalizers)
+	return l.users.Update(user)
 }

--- a/pkg/controllers/management/auth/user_test.go
+++ b/pkg/controllers/management/auth/user_test.go
@@ -105,25 +105,26 @@ func TestHasLocalPrincipalID(t *testing.T) {
 	}
 }
 
-func TestCreate(t *testing.T) {
+func TestOnCreate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockUserManager := userMocks.NewMockManager(ctrl)
+	usersMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 
 	ul := &userLifecycle{
 		userManager: mockUserManager,
+		users:       usersMock,
 	}
 
 	tests := []struct {
 		name          string
 		inputUser     *v3.User
 		mockSetup     func()
-		expectedUser  *v3.User
 		expectedError bool
 	}{
 		{
-			name: "User without local principal IDs",
+			name: "user without local principal IDs",
 			inputUser: &v3.User{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "testuser",
@@ -131,18 +132,18 @@ func TestCreate(t *testing.T) {
 				},
 				PrincipalIDs: []string{},
 			},
-			mockSetup: func() {},
-			expectedUser: &v3.User{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "testuser",
-					Annotations: map[string]string{},
-				},
-				PrincipalIDs: []string{"local://testuser"},
+			mockSetup: func() {
+				usersMock.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+					assert.Contains(t, u.PrincipalIDs, "local://testuser")
+					assert.Contains(t, u.Finalizers, userLifecycleFinalizer)
+					assert.Equal(t, "true", u.Annotations[userLifecycleAnnotation])
+					return u, nil
+				})
 			},
 			expectedError: false,
 		},
 		{
-			name: "User with creatorID annotation and successful role binding",
+			name: "user with creatorID annotation and successful role binding",
 			inputUser: &v3.User{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "testuser",
@@ -153,18 +154,17 @@ func TestCreate(t *testing.T) {
 			},
 			mockSetup: func() {
 				mockUserManager.EXPECT().CreateNewUserClusterRoleBinding("testuser", defaultCRTB.UID).Return(nil)
-			},
-			expectedUser: &v3.User{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "testuser",
-					Annotations: map[string]string{project_cluster.CreatorIDAnnotation: "creator"},
-				},
-				PrincipalIDs: []string{"local://testuser"},
+				usersMock.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+					assert.Contains(t, u.PrincipalIDs, "local://testuser")
+					assert.Contains(t, u.Finalizers, userLifecycleFinalizer)
+					assert.Equal(t, "true", u.Annotations[userLifecycleAnnotation])
+					return u, nil
+				})
 			},
 			expectedError: false,
 		},
 		{
-			name: "User with creatorID annotation and role binding error",
+			name: "user with creatorID annotation and role binding error",
 			inputUser: &v3.User{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "testuser",
@@ -175,7 +175,6 @@ func TestCreate(t *testing.T) {
 			mockSetup: func() {
 				mockUserManager.EXPECT().CreateNewUserClusterRoleBinding("testuser", defaultCRTB.UID).Return(fmt.Errorf("role binding error"))
 			},
-			expectedUser:  nil,
 			expectedError: true,
 		},
 	}
@@ -184,7 +183,7 @@ func TestCreate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.mockSetup()
 
-			_, err := ul.Create(tt.inputUser)
+			_, err := ul.onCreate(tt.inputUser)
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -195,7 +194,7 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestUpdated(t *testing.T) {
+func TestOnUpdate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockUserManager := userMocks.NewMockManager(ctrl)
@@ -580,7 +579,7 @@ func TestUpdated(t *testing.T) {
 				Users:   users,
 			}
 
-			_, err := ul.Updated(tt.inputUser)
+			_, err := ul.onUpdate(tt.inputUser)
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -984,9 +983,8 @@ func TestDeleteUserSecret(t *testing.T) {
 	}
 }
 
-func TestRemoveLegacyFinalizers(t *testing.T) {
+func TestRemoveFinalizer(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	//usersMock := &managementFakes.UserInterfaceMock{}
 	usersMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
 
 	ul := &userLifecycle{
@@ -1000,50 +998,54 @@ func TestRemoveLegacyFinalizers(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "no need to remove finalizers",
+			name: "removes lifecycle finalizer",
 			user: &v3.User{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testuser",
 					Finalizers: []string{
 						"controller.cattle.io/test-finalizer",
-					},
-				},
-			},
-			mockSetup:     func() {},
-			expectedError: false,
-		},
-		{
-			name: "remove desired finalizer",
-			user: &v3.User{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testuser",
-					Finalizers: []string{
-						"controller.cattle.io/test-finalizer",
-						"controller.cattle.io/cat-user-controller",
+						userLifecycleFinalizer,
 					},
 				},
 			},
 			mockSetup: func() {
-				usersMock.EXPECT().Update(gomock.Any()).Return(
-					&v3.User{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "testuser",
-							Finalizers: []string{
-								"controller.cattle.io/test-finalizer",
-							},
-						},
-					}, nil)
+				usersMock.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+					assert.NotContains(t, u.Finalizers, userLifecycleFinalizer)
+					assert.Contains(t, u.Finalizers, "controller.cattle.io/test-finalizer")
+					return u, nil
+				})
 			},
 			expectedError: false,
 		},
 		{
-			name: "got error when updating user",
+			name: "removes both lifecycle and legacy finalizers",
 			user: &v3.User{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testuser",
 					Finalizers: []string{
 						"controller.cattle.io/test-finalizer",
-						"controller.cattle.io/cat-user-controller",
+						userLifecycleFinalizer,
+						legacyUserFinalizer,
+					},
+				},
+			},
+			mockSetup: func() {
+				usersMock.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+					assert.NotContains(t, u.Finalizers, userLifecycleFinalizer)
+					assert.NotContains(t, u.Finalizers, legacyUserFinalizer)
+					assert.Contains(t, u.Finalizers, "controller.cattle.io/test-finalizer")
+					return u, nil
+				})
+			},
+			expectedError: false,
+		},
+		{
+			name: "update error",
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testuser",
+					Finalizers: []string{
+						userLifecycleFinalizer,
 					},
 				},
 			},
@@ -1058,14 +1060,90 @@ func TestRemoveLegacyFinalizers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.mockSetup()
 
-			user, err := ul.removeLegacyFinalizers(tt.user)
+			_, err := ul.removeFinalizer(tt.user)
 
 			if tt.expectedError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.NotContains(t, user.Finalizers, "controller.cattle.io/cat-user-controller")
 			}
 		})
 	}
+}
+
+func TestOnChange(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+
+	t.Run("nil user returns nil", func(t *testing.T) {
+		t.Parallel()
+		ul := &userLifecycle{}
+		got, err := ul.onChange("", nil)
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("deleted user without finalizer is skipped", func(t *testing.T) {
+		t.Parallel()
+		ul := &userLifecycle{}
+		user := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "u-abc",
+				DeletionTimestamp: &now,
+			},
+		}
+		got, err := ul.onChange("u-abc", user)
+		assert.NoError(t, err)
+		assert.Equal(t, user, got)
+	})
+
+	t.Run("uninitialized user dispatches to onCreate", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		usersMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+		usersMock.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
+			assert.Equal(t, "true", u.Annotations[userLifecycleAnnotation])
+			assert.Contains(t, u.Finalizers, userLifecycleFinalizer)
+			assert.Contains(t, u.PrincipalIDs, "local://u-new")
+			return u, nil
+		})
+
+		ul := &userLifecycle{users: usersMock}
+		user := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "u-new"},
+		}
+		_, err := ul.onChange("u-new", user)
+		assert.NoError(t, err)
+	})
+
+	t.Run("initialized user dispatches to onUpdate", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockUserManager := userMocks.NewMockManager(ctrl)
+		mockUserManager.EXPECT().CreateNewUserClusterRoleBinding("u-existing", k8stypes.UID("")).Return(nil)
+
+		secrets := wranglerfake.NewMockControllerInterface[*v1.Secret, *v1.SecretList](ctrl)
+		scache := wranglerfake.NewMockCacheInterface[*v1.Secret](ctrl)
+		secrets.EXPECT().Cache().Return(scache)
+		users := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+		users.EXPECT().Cache().Return(nil)
+		timer := exttokens.NewMocktimeHandler(ctrl)
+		secrets.EXPECT().List("cattle-tokens", gomock.Any()).Return(&v1.SecretList{}, nil).AnyTimes()
+		store := exttokens.NewSystem(nil, nil, secrets, users, nil, nil, timer, nil, nil)
+
+		ul := &userLifecycle{
+			userManager:   mockUserManager,
+			extTokenStore: store,
+		}
+		user := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "u-existing",
+				Annotations: map[string]string{userLifecycleAnnotation: "true"},
+			},
+		}
+		got, err := ul.onChange("u-existing", user)
+		assert.NoError(t, err)
+		assert.Equal(t, user, got)
+	})
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The user lifecycle controller was implemented using Norman's lifecycle framework, which manages its own internal client for persisting changes. This prevented controlling which client identity is used for updates.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The Norman lifecycle hooks (Create, Updated, Remove) were replaced with a Wrangler OnChange handler that explicitly manages the initialized annotation and finalizer. The handler dispatches to onCreate, onUpdate, or onRemove based on object state. Combined the legacy finalizer cleanup into the main finalizer removal to reduce API calls on deletion.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests