### PR TITLE
Limited jinja templating in userdata with CAPI PnP

### DIFF
--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -236,7 +236,7 @@ func (h *handler) getBootstrapSecret(namespace, name string, envVars []corev1.En
 		return nil, fmt.Errorf("error marshaling userdata")
 	}
 
-	userdataBytes = append([]byte("#cloud-config\n"), userdataBytes...)
+	userdataBytes = append([]byte("## template: jinja\n#cloud-config\n"), userdataBytes...)
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54284
 
## Problem
When using [CAPI PnP](https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/capi-infrastructure-providers) with Rancher as the control-plane/bootstrap provider, e.g. CAPA or CAPV, users can't currently use any jinja templating in their custom userdata, unlike other providers like Kubeadm and CAPRKE2.

## Solution
Change the cloud-init format to [Jinja + cloud config](https://docs.cloud-init.io/en/latest/explanation/format/jinja.html#user-data-formats-jinja).

Note that the amount of templating possible is limited: the custom userdata provided by users still needs to be parsed as yaml, so this works for templating string values in yaml, but not for templating with more complex control loops that alter the yaml structure.
 
## Engineering Testing
### Manual Testing
Provisioned clusters with jinja variables.

### Regressions Considerations
The format for userdata in existing machine deployments will be changed, but this is unlikely to cause problems unless someone had jinja templating directives even though they weren't being rendered. In addition, this only applies to Rancher + other CAPI infrastructure providers, not to Rancher with rancher/machine, and this feature is currently under tech preview.

## QA suggestions

This allow using limited jinja templating for cloud init when defining custom userdata for a given machine pool, when using CAPI PnP (e.g. CAPR + CAPA). See the [documentation](https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/capi-infrastructure-providers#customizing-userdata) for where to put custom userdata in this case.

Note that the userdata must still be parseable as yaml. This is one example of userdata that should get the instance id from the VM at bootstrap:

```
        userdata:
          inlineUserdata: |
            runcmd:
              - "This is my {{ v1.instance_id }}!"
```

Then, after logging into the provisioned vm, the message with the substituted instance id should appear in the cloud init logs (`/var/log/cloud-init-output.log`).