### PR TITLE
Classify revoked Google and GitHub tokens as non-transient

### DIFF
--- a/pkg/auth/providers/github/github_client.go
+++ b/pkg/auth/providers/github/github_client.go
@@ -356,11 +356,12 @@ func (g *GClient) getFromGithub(githubAccessToken string, url string) ([]byte, s
 		return nil, "", err
 	}
 	defer resp.Body.Close()
-	// Check the status code
+	// Check the status code. 401 means the user's token was revoked at GitHub
+	// (account deleted, OAuth app uninstalled, PAT revoked); 404 means the
+	// resource (e.g. the user) is gone. Neither resolves on retry.
 	switch resp.StatusCode {
-	case 200:
-	case 201:
-	case 404:
+	case 200, 201:
+	case 401, 404:
 		return nil, "", &common.NonTransientError{Err: fmt.Errorf("request failed, got status code: %d", resp.StatusCode)}
 	default:
 		return nil, "", fmt.Errorf("request failed, got status code: %d", resp.StatusCode)

--- a/pkg/auth/providers/github/github_client_test.go
+++ b/pkg/auth/providers/github/github_client_test.go
@@ -83,6 +83,22 @@ func TestGetFromGithubReturnsNonTransientErrorOn404(t *testing.T) {
 	assert.ErrorAs(t, err, &nte)
 }
 
+func TestGetFromGithubReturnsNonTransientErrorOn401(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	gcClient := &GClient{httpClient: srv.Client()}
+	_, _, err := gcClient.getFromGithub("token", srv.URL)
+
+	require.Error(t, err)
+	var nte *common.NonTransientError
+	assert.ErrorAs(t, err, &nte)
+}
+
 func TestGetFromGithubReturnsGenericErrorOnOtherFailure(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/providers/googleoauth/goauth_helper.go
+++ b/pkg/auth/providers/googleoauth/goauth_helper.go
@@ -3,6 +3,7 @@ package googleoauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -37,7 +38,8 @@ func (g *googleOauthProvider) getUserInfoAndGroups(adminSvc *admin.Service, gOAu
 		// The error for this group request could be 403, because svc acc was not provided, and we're relying on individual
 		// users' creds to get groups
 		if config.ServiceAccountCredential == "" {
-			if gErr, ok := err.(*googleapi.Error); !ok || gErr.Code != http.StatusForbidden {
+			var gErr *googleapi.Error
+			if !errors.As(err, &gErr) || gErr.Code != http.StatusForbidden {
 				// if the error is not forbidden, return the error
 				return userPrincipal, groupPrincipals, err
 			}
@@ -82,7 +84,8 @@ func (g *googleOauthProvider) getGroupsUserBelongsTo(adminSvc *admin.Service, us
 		// users' creds to get groups
 		if config.ServiceAccountCredential == "" {
 			// used the client creds, if error is forbidden, don't throw error
-			if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusForbidden {
+			var gErr *googleapi.Error
+			if errors.As(err, &gErr) && gErr.Code == http.StatusForbidden {
 				return groupPrincipals, nil
 			}
 		}
@@ -106,7 +109,8 @@ func (g *googleOauthProvider) searchPrincipals(adminSvc *admin.Service, searchKe
 		if err != nil {
 			if config.ServiceAccountCredential == "" {
 				// used the client creds, must try once with viewType domain_public
-				if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusForbidden {
+				var gErr *googleapi.Error
+				if errors.As(err, &gErr) && gErr.Code == http.StatusForbidden {
 					userAccounts, err = g.searchUsers(adminSvc, searchKey, config, true)
 					if err != nil {
 						return nil, err
@@ -126,7 +130,8 @@ func (g *googleOauthProvider) searchPrincipals(adminSvc *admin.Service, searchKe
 		if err != nil {
 			if config.ServiceAccountCredential == "" {
 				// used the client creds, if error is forbidden, don't throw error
-				if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusForbidden {
+				var gErr *googleapi.Error
+				if errors.As(err, &gErr) && gErr.Code == http.StatusForbidden {
 					return accounts, nil
 				}
 			}

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -3,6 +3,7 @@ package googleoauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -192,7 +193,8 @@ func (g *googleOauthProvider) GetPrincipal(principalID string, token accessor.To
 		if err != nil {
 			if config.ServiceAccountCredential == "" {
 				// used client creds, try get again with viewType=domain_public
-				if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusForbidden {
+				var gErr *googleapi.Error
+				if errors.As(err, &gErr) && gErr.Code == http.StatusForbidden {
 					user, err = adminSvc.Users.Get(externalID).ViewType(domainPublicViewType).Do()
 					if err != nil {
 						return principal, wrapGoogleNonTransient(err)
@@ -222,7 +224,8 @@ func (g *googleOauthProvider) GetPrincipal(principalID string, token accessor.To
 			if config.ServiceAccountCredential == "" {
 				// used client creds, getting group for non-admin might fail with forbidden, if that's the case don't throw
 				// error
-				if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusForbidden {
+				var gErr *googleapi.Error
+				if errors.As(err, &gErr) && gErr.Code == http.StatusForbidden {
 					return principal, nil
 				}
 			}
@@ -445,7 +448,16 @@ func (g *googleOauthProvider) IsDisabledProvider() (bool, error) {
 }
 
 func wrapGoogleNonTransient(err error) error {
-	if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusNotFound {
+	var gErr *googleapi.Error
+	if errors.As(err, &gErr) && gErr.Code == http.StatusNotFound {
+		return &common.NonTransientError{Err: err}
+	}
+	// invalid_grant means the per-user refresh token was revoked at Google
+	// (user deleted in Workspace, OAuth consent withdrawn). The TokenSource
+	// surfaces this when an API call drives a token refresh, so it can also
+	// reach us wrapped inside a googleapi request error.
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant" {
 		return &common.NonTransientError{Err: err}
 	}
 	return err

--- a/pkg/auth/providers/googleoauth/goauth_provider_test.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider_test.go
@@ -8,11 +8,15 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 )
 
 func TestWrapGoogleNonTransient(t *testing.T) {
 	t.Parallel()
+
+	invalidGrant := &oauth2.RetrieveError{ErrorCode: "invalid_grant"}
+	wrappedInvalidGrant := fmt.Errorf("token refresh failed: %w", invalidGrant)
 
 	tests := []struct {
 		name             string
@@ -32,6 +36,21 @@ func TestWrapGoogleNonTransient(t *testing.T) {
 		{
 			name:             "Google API 500 error",
 			err:              &googleapi.Error{Code: http.StatusInternalServerError},
+			wantNonTransient: false,
+		},
+		{
+			name:             "OAuth2 invalid_grant",
+			err:              invalidGrant,
+			wantNonTransient: true,
+		},
+		{
+			name:             "OAuth2 invalid_grant wrapped",
+			err:              wrappedInvalidGrant,
+			wantNonTransient: true,
+		},
+		{
+			name:             "OAuth2 other retrieve error",
+			err:              &oauth2.RetrieveError{ErrorCode: "temporarily_unavailable"},
 			wantNonTransient: false,
 		},
 		{


### PR DESCRIPTION
## Issue: #49932 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a Google Workspace user is deleted or their OAuth consent withdrawn, the failed refresh keeps requeuing instead of stopping until the user logs in again. The same happens for GitHub when a token is revoked or the user is deleted. The skip annotation is not applied because neither provider recognizes the revoked-credential error as non-transient.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Revoked OAuth grants from Google and unauthorized GitHub API responses are now classified as non-transient. Google error-shape checks are reworked so they still match when the error is wrapped further down the stack.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests