### PR TITLE
Avoid losing provider refresh triggers to 409 conflicts

### DIFF
--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -152,6 +152,11 @@ func (r *refresher) triggerUserRefresh(userName string, force bool) {
 	// contention with the refresh-consumer writeback.
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest, err := r.userAttributes.Get(userName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// The user attribute was deleted between the cache read and this
+			// retry (user cleanup, provider disable). Nothing to refresh.
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -161,8 +166,13 @@ func (r *refresher) triggerUserRefresh(userName string, force bool) {
 		if latest.NeedsRefresh {
 			return nil
 		}
+
 		latest.NeedsRefresh = true
 		_, err = r.userAttributes.Update(latest)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
 		return err
 	})
 	if err != nil {

--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 )
 
@@ -137,22 +138,35 @@ func (r *refresher) triggerUserRefresh(userName string, force bool) {
 		return
 	}
 
-	attribs.NeedsRefresh = true
 	if needCreate {
-		_, err := r.userAttributes.Create(attribs)
-		if err != nil {
+		attribs.NeedsRefresh = true
+		if _, err := r.userAttributes.Create(attribs); err != nil {
 			logrus.Errorf("Error creating user attribute to trigger refresh: %v", err)
 		}
-	} else {
-		_, err = r.userAttributes.Update(attribs)
+		return
+	}
+
+	// Re-fetch from the API server (not the lister) inside the retry so the
+	// ResourceVersion is fresh; the initial read above came from the informer
+	// cache and can be stale, which has caused frequent 409 conflicts under
+	// contention with the refresh-consumer writeback.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := r.userAttributes.Get(userName, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsConflict(err) {
-				// User attribute has just been updated, triggering the refresh.
-				logrus.Debugf("Error updating user attribute to trigger refresh: %v", err)
-			} else {
-				logrus.Errorf("Error updating user attribute to trigger refresh: %v", err)
-			}
+			return err
 		}
+		if _, ok := latest.Annotations[common.ProviderRefreshErrorAnnotation]; ok {
+			return nil
+		}
+		if latest.NeedsRefresh {
+			return nil
+		}
+		latest.NeedsRefresh = true
+		_, err = r.userAttributes.Update(latest)
+		return err
+	})
+	if err != nil {
+		logrus.Errorf("Error updating user attribute to trigger refresh: %v", err)
 	}
 }
 

--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -726,6 +726,42 @@ func TestTriggerUserRefreshNoopsWhenAlreadyPending(t *testing.T) {
 		"Update should be skipped when the fresh copy already has NeedsRefresh=true")
 }
 
+func TestTriggerUserRefreshIgnoresUserAttributeNotFound(t *testing.T) {
+	t.Parallel()
+
+	userID := "u-abcdef"
+	cachedAttribs := &apiv3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{Name: userID},
+	}
+
+	r := &refresher{
+		ensureAndGetUserAttribute: func(userName string) (*apiv3.UserAttribute, bool, error) {
+			return cachedAttribs.DeepCopy(), false, nil
+		},
+		userLister: &fakes.UserListerMock{
+			GetFunc: func(namespace, name string) (*apiv3.User, error) {
+				return &apiv3.User{
+					ObjectMeta:   metav1.ObjectMeta{Name: userID},
+					PrincipalIDs: []string{"azuread_user://some-guid"},
+				}, nil
+			},
+		},
+		userAttributes: &fakes.UserAttributeInterfaceMock{
+			GetFunc: func(name string, _ metav1.GetOptions) (*apiv3.UserAttribute, error) {
+				return nil, apierrors.NewNotFound(
+					schema.GroupResource{Group: "management.cattle.io", Resource: "userattributes"},
+					name)
+			},
+		},
+	}
+
+	r.triggerUserRefresh(userID, true)
+
+	mock := r.userAttributes.(*fakes.UserAttributeInterfaceMock)
+	assert.Empty(t, mock.UpdateCalls(),
+		"Update must not be called when the user attribute is gone")
+}
+
 func TestTriggerUserRefreshRetriesOnConflict(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ktypes "k8s.io/apimachinery/pkg/types"
 )
 
@@ -681,6 +682,90 @@ func TestTriggerUserRefreshSkipsAnnotatedUser(t *testing.T) {
 
 	assert.Empty(t, r.userAttributes.(*fakes.UserAttributeInterfaceMock).UpdateCalls(),
 		"Update should not be called for annotated user attribute")
+}
+
+func TestTriggerUserRefreshNoopsWhenAlreadyPending(t *testing.T) {
+	t.Parallel()
+
+	userID := "u-abcdef"
+	cachedAttribs := &apiv3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{Name: userID},
+	}
+	// Stale lister copy: NeedsRefresh=false. Fresh API copy: already true
+	// (a concurrent trigger won the race). triggerUserRefresh should re-read
+	// from the API, see NeedsRefresh already set, and skip Update.
+	freshAttribs := &apiv3.UserAttribute{
+		ObjectMeta:   metav1.ObjectMeta{Name: userID},
+		NeedsRefresh: true,
+	}
+
+	r := &refresher{
+		ensureAndGetUserAttribute: func(userName string) (*apiv3.UserAttribute, bool, error) {
+			return cachedAttribs.DeepCopy(), false, nil
+		},
+		userLister: &fakes.UserListerMock{
+			GetFunc: func(namespace, name string) (*apiv3.User, error) {
+				return &apiv3.User{
+					ObjectMeta:   metav1.ObjectMeta{Name: userID},
+					PrincipalIDs: []string{"azuread_user://some-guid"},
+				}, nil
+			},
+		},
+		userAttributes: &fakes.UserAttributeInterfaceMock{
+			GetFunc: func(name string, _ metav1.GetOptions) (*apiv3.UserAttribute, error) {
+				return freshAttribs.DeepCopy(), nil
+			},
+		},
+	}
+
+	r.triggerUserRefresh(userID, true)
+
+	mock := r.userAttributes.(*fakes.UserAttributeInterfaceMock)
+	assert.Len(t, mock.GetCalls(), 1, "Get should be called to re-read from the API server")
+	assert.Empty(t, mock.UpdateCalls(),
+		"Update should be skipped when the fresh copy already has NeedsRefresh=true")
+}
+
+func TestTriggerUserRefreshRetriesOnConflict(t *testing.T) {
+	t.Parallel()
+
+	userID := "u-abcdef"
+	cachedAttribs := &apiv3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{Name: userID},
+	}
+	var updateAttempts int
+
+	r := &refresher{
+		ensureAndGetUserAttribute: func(userName string) (*apiv3.UserAttribute, bool, error) {
+			return cachedAttribs.DeepCopy(), false, nil
+		},
+		userLister: &fakes.UserListerMock{
+			GetFunc: func(namespace, name string) (*apiv3.User, error) {
+				return &apiv3.User{
+					ObjectMeta:   metav1.ObjectMeta{Name: userID},
+					PrincipalIDs: []string{"azuread_user://some-guid"},
+				}, nil
+			},
+		},
+		userAttributes: &fakes.UserAttributeInterfaceMock{
+			GetFunc: func(name string, _ metav1.GetOptions) (*apiv3.UserAttribute, error) {
+				return cachedAttribs.DeepCopy(), nil
+			},
+			UpdateFunc: func(ua *apiv3.UserAttribute) (*apiv3.UserAttribute, error) {
+				updateAttempts++
+				if updateAttempts == 1 {
+					return nil, apierrors.NewConflict(
+						schema.GroupResource{Group: "management.cattle.io", Resource: "userattributes"},
+						userID, errors.New("the object has been modified"))
+				}
+				return ua, nil
+			},
+		},
+	}
+
+	r.triggerUserRefresh(userID, true)
+
+	assert.Equal(t, 2, updateAttempts, "Update should retry after a 409 conflict and then succeed")
 }
 
 func TestRefreshAttributesNonTransientError(t *testing.T) {

--- a/pkg/controllers/management/auth/token.go
+++ b/pkg/controllers/management/auth/token.go
@@ -7,7 +7,9 @@ import (
 	wrangmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -115,12 +117,19 @@ func (t *TokenController) userAttributesNeedsRefresh(user string) (bool, error) 
 }
 
 func (t *TokenController) triggerUserAttributesRefresh(user string) error {
-	userAttribute, err := t.userAttributesLister.Get(user)
-	if err != nil {
+	// Re-fetch from the API server inside the retry; the lister cache used
+	// for the gating check can be stale and lead to 409 conflicts when other
+	// writers (e.g. the refresh consumer) touch the object concurrently.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		userAttribute, err := t.userAttributes.Get(user, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if userAttribute.NeedsRefresh {
+			return nil
+		}
+		userAttribute.NeedsRefresh = true
+		_, err = t.userAttributes.Update(userAttribute)
 		return err
-	}
-
-	userAttribute.NeedsRefresh = true
-	_, err = t.userAttributes.Update(userAttribute)
-	return err
+	})
 }

--- a/pkg/controllers/management/auth/token.go
+++ b/pkg/controllers/management/auth/token.go
@@ -122,6 +122,11 @@ func (t *TokenController) triggerUserAttributesRefresh(user string) error {
 	// writers (e.g. the refresh consumer) touch the object concurrently.
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		userAttribute, err := t.userAttributes.Get(user, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			// The user attribute was deleted under us.
+			// Nothing to refresh, no point in requeuing.
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -130,6 +135,9 @@ func (t *TokenController) triggerUserAttributesRefresh(user string) error {
 		}
 		userAttribute.NeedsRefresh = true
 		_, err = t.userAttributes.Update(userAttribute)
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	})
 }

--- a/pkg/controllers/management/auth/token_test.go
+++ b/pkg/controllers/management/auth/token_test.go
@@ -57,7 +57,16 @@ func TestSync(t *testing.T) {
 			userAttributes[userAttribute.Name] = userAttribute.DeepCopy()
 			return userAttribute, nil
 		},
-	)
+	).AnyTimes()
+	userAttributesMock.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+			userAttribute, ok := userAttributes[name]
+			if ok {
+				return userAttribute, nil
+			}
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	).AnyTimes()
 
 	// setup userAttributesLister mock instance
 	userAttributesListerMock := wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
@@ -184,7 +193,16 @@ func TestSync(t *testing.T) {
 		func(userAttribute *v3.UserAttribute) (*v3.UserAttribute, error) {
 			return nil, errors.NewServiceUnavailable("test reason")
 		},
-	)
+	).AnyTimes()
+	userAttributesMock.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+			userAttribute, ok := userAttributes[name]
+			if ok {
+				return userAttribute, nil
+			}
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	).AnyTimes()
 
 	// setup userAttributesLister mock instance
 	userAttributesListerMock = wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)

--- a/pkg/controllers/management/auth/token_test.go
+++ b/pkg/controllers/management/auth/token_test.go
@@ -345,6 +345,46 @@ func TestSync(t *testing.T) {
 	assert.Nil(t, err, "handler should not return err when userattribute lister's get function returns notfound error")
 }
 
+// TestTriggerUserAttributesRefreshIgnoresNotFound covers the case where the
+// user attribute is deleted between the lister-based gating check and the
+// fresh API Get inside the retry loop. The trigger must no-op silently
+// instead of bubbling an error that would cause the token sync to requeue.
+func TestTriggerUserAttributesRefreshIgnoresNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	userAttribute := &v3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{Name: "abcd"},
+		// ExtraByProvider == nil so the gating check returns true and we
+		// enter triggerUserAttributesRefresh.
+	}
+
+	userAttributesMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttributesMock.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+		func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	)
+	// No Update expectation: NotFound on the Get must short-circuit.
+
+	userAttributesListerMock := wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributesListerMock.EXPECT().Get(gomock.Any()).Return(userAttribute, nil).AnyTimes()
+
+	tokensMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.Token, *v3.TokenList](ctrl)
+
+	controller := TokenController{
+		tokens:               tokensMock,
+		userAttributes:       userAttributesMock,
+		userAttributesLister: userAttributesListerMock,
+	}
+
+	token := &v3.Token{
+		ObjectMeta: metav1.ObjectMeta{Name: "testtoken"},
+		UserID:     "abcd",
+	}
+	_, err := controller.sync(token.Name, token)
+	assert.NoError(t, err, "Must not error when the user attribute is gone")
+}
+
 func populateTestCases(tokens map[string]*v3.Token, userAttributes map[string]*v3.UserAttribute) []tokenTestCase {
 	timeNow := metav1.NewTime(time.Now())
 	hashedToken, _ := hashers.GetHasher().CreateHash("1234")

--- a/pkg/controllers/management/auth/user_attribute_handler.go
+++ b/pkg/controllers/management/auth/user_attribute_handler.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -137,20 +138,25 @@ func (c *UserAttributeController) sync(key string, attribs *v3.UserAttribute) (r
 func (c *UserAttributeController) skipRefresh(name string, reason error) (runtime.Object, error) {
 	logrus.Warnf("Skipping provider refresh for %s due to non-transient error: %v", name, reason)
 
-	// Re-fetch to get a clean version (important for the 413 case where the
-	// in-memory attribs may contain bloated GroupPrincipals).
-	attribs, err := c.userAttributes.Get(name, metav1.GetOptions{})
+	// Re-fetch from the API server inside the retry: gets a clean version
+	// (important for the 413 case where the in-memory attribs may contain
+	// bloated GroupPrincipals) and keeps the ResourceVersion fresh so the
+	// annotation write doesn't lose to a concurrent trigger or consumer
+	// writeback under contention.
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		attribs, err := c.userAttributes.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if attribs.Annotations == nil {
+			attribs.Annotations = make(map[string]string)
+		}
+		attribs.Annotations[common.ProviderRefreshErrorAnnotation] = reason.Error()
+		attribs.NeedsRefresh = false
+		_, err = c.userAttributes.Update(attribs)
+		return err
+	})
 	if err != nil {
-		return nil, fmt.Errorf("error getting user attribute %s to skip refresh: %w", name, err)
-	}
-
-	if attribs.Annotations == nil {
-		attribs.Annotations = make(map[string]string)
-	}
-	attribs.Annotations[common.ProviderRefreshErrorAnnotation] = reason.Error()
-	attribs.NeedsRefresh = false
-
-	if _, err := c.userAttributes.Update(attribs); err != nil {
 		return nil, fmt.Errorf("error annotating user attribute %s to skip refresh: %w", name, err)
 	}
 

--- a/pkg/controllers/management/auth/user_attribute_handler.go
+++ b/pkg/controllers/management/auth/user_attribute_handler.go
@@ -145,6 +145,11 @@ func (c *UserAttributeController) skipRefresh(name string, reason error) (runtim
 	// writeback under contention.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		attribs, err := c.userAttributes.Get(name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// The user attribute was deleted under us.
+			// The annotation would have no reader. No point in requeuing.
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -154,6 +159,9 @@ func (c *UserAttributeController) skipRefresh(name string, reason error) (runtim
 		attribs.Annotations[common.ProviderRefreshErrorAnnotation] = reason.Error()
 		attribs.NeedsRefresh = false
 		_, err = c.userAttributes.Update(attribs)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	})
 	if err != nil {

--- a/pkg/controllers/management/auth/user_attribute_handler_test.go
+++ b/pkg/controllers/management/auth/user_attribute_handler_test.go
@@ -371,6 +371,55 @@ func TestSyncNonTransientProviderError(t *testing.T) {
 	assert.Contains(t, lastUpdated.Annotations[common.ProviderRefreshErrorAnnotation], "user not found")
 }
 
+func TestSyncNonTransientProviderErrorRetriesOnConflict(t *testing.T) {
+	userID := "u-abcdef"
+	attribs := &v3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userID,
+		},
+		NeedsRefresh: true,
+	}
+
+	var (
+		updateAttempts int
+		lastUpdated    *v3.UserAttribute
+	)
+
+	ctrl := gomock.NewController(t)
+
+	userAttributeClient := fake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttributeClient.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+		return attribs.DeepCopy(), nil
+	})
+	userAttributeClient.EXPECT().Update(gomock.Any()).AnyTimes().DoAndReturn(func(ua *v3.UserAttribute) (*v3.UserAttribute, error) {
+		updateAttempts++
+		if updateAttempts == 1 {
+			return nil, apierrors.NewConflict(
+				schema.GroupResource{Group: management.GroupName, Resource: "userattributes"},
+				userID, fmt.Errorf("the object has been modified"))
+		}
+		lastUpdated = ua.DeepCopy()
+		return lastUpdated, nil
+	})
+
+	controller := UserAttributeController{
+		userAttributes:            userAttributeClient,
+		ensureUserRetentionLabels: func(attribs *v3.UserAttribute) error { return nil },
+		providerRefresh: func(attribs *v3.UserAttribute) (*v3.UserAttribute, error) {
+			return nil, &common.NonTransientError{Err: fmt.Errorf("user not found")}
+		},
+	}
+
+	obj, err := controller.sync("", attribs)
+	require.NoError(t, err)
+	assert.Nil(t, obj)
+
+	assert.Equal(t, 2, updateAttempts, "skipRefresh should retry after a 409 conflict")
+	require.NotNil(t, lastUpdated)
+	assert.False(t, lastUpdated.NeedsRefresh)
+	assert.Contains(t, lastUpdated.Annotations, common.ProviderRefreshErrorAnnotation)
+}
+
 func TestSyncRequestEntityTooLarge(t *testing.T) {
 	userID := "u-abcdef"
 	attribs := &v3.UserAttribute{

--- a/pkg/controllers/management/auth/user_attribute_handler_test.go
+++ b/pkg/controllers/management/auth/user_attribute_handler_test.go
@@ -420,6 +420,46 @@ func TestSyncNonTransientProviderErrorRetriesOnConflict(t *testing.T) {
 	assert.Contains(t, lastUpdated.Annotations, common.ProviderRefreshErrorAnnotation)
 }
 
+func TestSyncNonTransientProviderErrorIgnoresUserAttributeNotFound(t *testing.T) {
+	userID := "u-abcdef"
+	attribs := &v3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userID,
+		},
+		NeedsRefresh: true,
+	}
+
+	ctrl := gomock.NewController(t)
+
+	userAttributeClient := fake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	gets := 0
+	userAttributeClient.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+		gets++
+		if gets == 1 {
+			// First read is the sync handler's own re-fetch at the top of sync.
+			return attribs.DeepCopy(), nil
+		}
+		// Subsequent read inside skipRefresh's retry: the user attribute is
+		// gone (e.g. the user was deleted while the refresh was in flight).
+		return nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: management.GroupName, Resource: "userattributes"},
+			name)
+	})
+	// No Update expectation: the retry must short-circuit on NotFound.
+
+	controller := UserAttributeController{
+		userAttributes:            userAttributeClient,
+		ensureUserRetentionLabels: func(attribs *v3.UserAttribute) error { return nil },
+		providerRefresh: func(attribs *v3.UserAttribute) (*v3.UserAttribute, error) {
+			return nil, &common.NonTransientError{Err: fmt.Errorf("user not found")}
+		},
+	}
+
+	obj, err := controller.sync("", attribs)
+	require.NoError(t, err, "Must not error when the user attribute is gone")
+	assert.Nil(t, obj)
+}
+
 func TestSyncRequestEntityTooLarge(t *testing.T) {
 	userID := "u-abcdef"
 	attribs := &v3.UserAttribute{


### PR DESCRIPTION
## Issue: #55383 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The trigger paths that mark a user attribute for refresh read it from the informer cache, mutate it in memory, and write it back without retry. Under contention with the refresh consumer's writeback, a concurrent trigger, or any other controller that touches the same object, the write lands on a stale resource version and produces a 409 conflict. The legitimate trigger is silently dropped, so a freshly logged-in user does not get the follow-up refresh until the next cron tick. The annotation write that skips a non-transient refresh has the same shape and the same race.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
The two trigger writes and the skip-annotation write are now wrapped in a retry that re-fetches from the API server inside each attempt, so the resource version stays current across concurrent writers. The trigger short-circuits when the fresh copy is already marked for refresh or already carries the skip annotation, avoiding a redundant write whose only effect would be a no-op watch event.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests