### PR TITLE
support IPv6 Kubernetes service host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.36.1
 	k8s.io/cri-api => k8s.io/cri-api v0.36.1
 	k8s.io/cri-client => k8s.io/cri-client v0.36.1
+	k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.1
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.36.1
 	k8s.io/endpointslice => k8s.io/endpointslice v0.36.1

--- a/pkg/agent/cluster/cluster.go
+++ b/pkg/agent/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
+	"github.com/rancher/rancher/pkg/utils"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,6 +98,10 @@ func Params() (map[string]interface{}, error) {
 	kubernetesServicePort, err := getenv(kubernetesServicePortKey)
 	if err != nil {
 		return nil, err
+	}
+
+	if utils.IsPlainIPV6(kubernetesServiceHost) {
+		kubernetesServiceHost = "[" + kubernetesServiceHost + "]"
 	}
 
 	return map[string]interface{}{

--- a/pkg/tunnelserver/mcmauthorizer/tunnel.go
+++ b/pkg/tunnelserver/mcmauthorizer/tunnel.go
@@ -16,6 +16,7 @@ import (
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	"github.com/rancher/rancher/pkg/kontainerdriver"
 	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/utils"
 
 	"github.com/rancher/norman/types/convert"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
@@ -297,7 +298,7 @@ func (t *Authorizer) authorizeCluster(cluster *v3.Cluster, inCluster *cluster, r
 		}
 	}
 
-	apiEndpoint := "https://" + inCluster.Address
+	apiEndpoint := "https://" + formatAddress(inCluster.Address)
 	token := inCluster.Token
 	caCert := inCluster.CACert
 
@@ -418,4 +419,29 @@ func (t *Authorizer) toCustomConfig(machine *client.Node) *v32.CustomConfig {
 		return nil
 	}
 	return result
+}
+
+// formatAddress ensures that an address containing a bare IPv6 host (without brackets)
+// is properly formatted with brackets for use in a URL. Addresses that are already
+// bracketed or are IPv4 are returned as-is.
+func formatAddress(address string) string {
+	// Already bracketed
+	if strings.HasPrefix(address, "[") {
+		return address
+	}
+
+	// Find the last colon - for IPv6 addresses there will be multiple colons
+	lastColon := strings.LastIndex(address, ":")
+	if lastColon < 0 {
+		return address
+	}
+
+	host := address[:lastColon]
+	port := address[lastColon+1:]
+
+	if utils.IsPlainIPV6(host) {
+		return "[" + host + "]:" + port
+	}
+
+	return address
 }

--- a/pkg/tunnelserver/mcmauthorizer/tunnel_test.go
+++ b/pkg/tunnelserver/mcmauthorizer/tunnel_test.go
@@ -1,0 +1,63 @@
+package mcmauthorizer
+
+import (
+	"testing"
+)
+
+func TestFormatAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		expected string
+	}{
+		{
+			name:     "bare IPv6 with port",
+			address:  "2001:cafe:43::1:443",
+			expected: "[2001:cafe:43::1]:443",
+		},
+		{
+			name:     "bare IPv6 loopback with port",
+			address:  "::1:6443",
+			expected: "[::1]:6443",
+		},
+		{
+			name:     "already bracketed IPv6",
+			address:  "[2001:cafe:43::1]:443",
+			expected: "[2001:cafe:43::1]:443",
+		},
+		{
+			name:     "IPv4 with port",
+			address:  "192.168.1.1:6443",
+			expected: "192.168.1.1:6443",
+		},
+		{
+			name:     "hostname with port",
+			address:  "my-cluster.example.com:6443",
+			expected: "my-cluster.example.com:6443",
+		},
+		{
+			name:     "no port",
+			address:  "192.168.1.1",
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "full IPv6 with port",
+			address:  "2001:0db8:85a3:0000:0000:8a2e:0370:7334:443",
+			expected: "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443",
+		},
+		{
+			name:     "empty string",
+			address:  "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatAddress(tt.address)
+			if result != tt.expected {
+				t.Errorf("formatAddress(%q) = %q, want %q", tt.address, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- https://github.com/rancher/rancher/issues/55347
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Rancher Cluster Agent reports the downstream cluster k8s service address to Rancher.  It reads the environment variable `KUBERNETES_SERVICE_HOST` inside the pod to get the address, when the address is IPv6 (for example, `2001:cafe:43::1`), Rancher Cluster Agent does not properly format the address when constructing the server URL. As a result, Rancher later fails to parse the generated address (`https://2001:cafe:43::1:443`) because the IPv6 address is not enclosed in square brackets as required by URL syntax.


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This PR introduces the following two fixes:

1. Rancher cluster agent now properly brackets IPv6 addresses. 
2. Rnacher double-checks and formats the address before using it. 


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

This is not tested locally due to the complexity of setting up an IPv6-only testing environment. We will rely on QA's automation to validate the fix. 

### Automated Testing
 
Unit tests are added for the new functions. 
 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 

Provisioning of IPv6-only node-driver cluster should work. 


### Regressions Considerations
 
Provisioning of node-driver cluster with various network configurations. 


Existing / newly added automated tests that provide evidence there are no regressions:
 
n/a 