### PR TITLE
[main] Additional SDR Pull Secret Support

### DIFF
--- a/pkg/agent/clean/credentials.go
+++ b/pkg/agent/clean/credentials.go
@@ -2,11 +2,13 @@ package clean
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +34,7 @@ func UnusedPullSecrets(ctx context.Context) {
 	}
 	secret := k8s.CoreV1().Secrets("cattle-system")
 	copiedPullSecrets, err := secret.List(ctx, metav1.ListOptions{
-		LabelSelector: "management.cattle.io/cattle-cluster-agent-pull-secret=true",
+		LabelSelector: fmt.Sprintf("%s=true", cluster.AgentPullSecretLabel),
 	})
 	if err != nil {
 		logrus.Errorf("Error listing cattle-cluster-agent-pull-secrets: %v", err)

--- a/pkg/apis/catalog.cattle.io/v1/types.go
+++ b/pkg/apis/catalog.cattle.io/v1/types.go
@@ -122,6 +122,15 @@ type RepoSpec struct {
 	// Defaults to false, which keeps the SameOrigin check enabled. Setting this to true is not recommended
 	// in production environments due to the security implications.
 	DisableSameOriginCheck bool `json:"disableSameOriginCheck,omitempty"`
+
+	// DefaultImagePullSecrets specifies one or more image pull secrets which will be used by default
+	// when deploying charts from this repository. If a chart supports image pull secrets in its values.yaml
+	// in an expected path (.Values.ImagePullSecrets, .Values.global.ImagePullSecrets, or .Values.global.cattle.imagePullSecrets)
+	// the secrets listed in this field will be automatically copied into the charts release namespace. Additionally,
+	// Rancher will inject these secret references into the charts values.yaml if no user provided value is set.
+	// Currently, this field is only honored by the "rancher-charts" repository, and can only copy secrets from the
+	// cattle-system namespace which have the appropriate labels.
+	DefaultImagePullSecrets []SecretReference `json:"defaultImagePullSecrets,omitempty"`
 }
 
 type RepoCondition string

--- a/pkg/apis/catalog.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/catalog.cattle.io/v1/zz_generated_deepcopy.go
@@ -475,6 +475,11 @@ func (in *RepoSpec) DeepCopyInto(out *RepoSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DefaultImagePullSecrets != nil {
+		in, out := &in.DefaultImagePullSecrets, &out.DefaultImagePullSecrets
+		*out = make([]SecretReference, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/capr/planner/registry.go
+++ b/pkg/capr/planner/registry.go
@@ -28,8 +28,15 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 
 	GSDR := settings.SystemDefaultRegistry.Get()
 	foundExistingGSDRConfiguration := false
+	registryConfigs := map[string]rkev1.RegistryConfig{}
+	registryMirrors := map[string]rkev1.Mirror{}
 
-	for registryName, config := range controlPlane.Spec.Registries.Configs {
+	if controlPlane.Spec.Registries != nil {
+		registryConfigs = controlPlane.Spec.Registries.Configs
+		registryMirrors = controlPlane.Spec.Registries.Mirrors
+	}
+
+	for registryName, config := range registryConfigs {
 		if registryName == GSDR {
 			foundExistingGSDRConfiguration = true
 		}
@@ -85,7 +92,10 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 
 			username := string(secret.Data[rkev1.UsernameAuthConfigSecretKey])
 			password := string(secret.Data[rkev1.PasswordAuthConfigSecretKey])
-			auth := string(secret.Data[rkev1.AuthAuthConfigSecretKey])
+			// we need to re-encode the auth block for containerd to leverage it properly.
+			// The secret cache automatically decodes data values for us to make them easier to work with,
+			// but containerd will refuse to work with an unencoded auth block.
+			auth := base64.StdEncoding.EncodeToString(secret.Data[rkev1.AuthAuthConfigSecretKey])
 			identityToken := string(secret.Data[rkev1.IdentityTokenAuthConfigSecretKey])
 
 			// need to pull out the username, password, auth, from the .dockerconfigjson key
@@ -160,7 +170,7 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 	}
 
 	data.registriesFileRaw, err = json.Marshal(map[string]interface{}{
-		"mirrors": controlPlane.Spec.Registries.Mirrors,
+		"mirrors": registryMirrors,
 		"configs": configs,
 	})
 	if err != nil {

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -65,6 +65,17 @@ var (
 		"chart.yml":  true,
 		"Chart.yml":  true,
 	}
+	valuesYAML = map[string]bool{
+		"values.yaml": true,
+		"values.yml":  true,
+		"Values.yaml": true,
+		"Values.yml":  true,
+	}
+	imagePullSecretPaths = [][]string{
+		{"global", "cattle", "imagePullSecrets"},
+		{"global", "imagePullSecrets"},
+		{"imagePullSecrets"},
+	}
 )
 
 var (
@@ -78,17 +89,20 @@ func init() {
 
 // Operations describes a helm operation, containing its namespace, roles and such
 type Operations struct {
-	namespace      string                               // namespace the operation is going to be in
-	contentManager *content.Manager                     // manager struct to retrieve information about helm repos and its charts
-	Impersonator   *podimpersonation.PodImpersonation   // the impersonator used to manage pods created using the service account of the logged in user
-	clusterRepos   catalogcontrollers.ClusterRepoClient // client for cluster repo custom resource
-	ops            catalogcontrollers.OperationClient   // client for operation custom resource
-	pods           corev1controllers.PodClient          // client for pod kubernetes resource
-	nodes          corev1controllers.NodeClient
-	apps           catalogcontrollers.AppClient        // client for apps custom resource
-	roles          rbacv1controllers.RoleClient        // client for role kubernetes resource
-	roleBindings   rbacv1controllers.RoleBindingClient // client for rolebinding kubernetes resource
-	cg             proxy.ClientGetter                  // dynamic kubernetes client factory
+	namespace         string                               // namespace the operation is going to be in
+	contentManager    *content.Manager                     // manager struct to retrieve information about helm repos and its charts
+	Impersonator      *podimpersonation.PodImpersonation   // the impersonator used to manage pods created using the service account of the logged in user
+	clusterRepos      catalogcontrollers.ClusterRepoClient // client for cluster repo custom resource
+	clusterReposCache catalogcontrollers.ClusterRepoCache
+	ops               catalogcontrollers.OperationClient // client for operation custom resource
+	pods              corev1controllers.PodClient        // client for pod kubernetes resource
+	nodes             corev1controllers.NodeClient
+	apps              catalogcontrollers.AppClient // client for apps custom resource
+	roles             rbacv1controllers.RoleClient // client for role kubernetes resource
+	secretCache       corev1controllers.SecretCache
+	secrets           corev1controllers.SecretClient
+	roleBindings      rbacv1controllers.RoleBindingClient // client for rolebinding kubernetes resource
+	cg                proxy.ClientGetter                  // dynamic kubernetes client factory
 }
 
 // NewOperations creates a new Operations struct with all fields initialized
@@ -98,19 +112,23 @@ func NewOperations(
 	rbac rbacv1controllers.Interface,
 	contentManager *content.Manager,
 	pods corev1controllers.PodClient,
-	nodes corev1controllers.NodeClient) *Operations {
+	nodes corev1controllers.NodeClient,
+	secrets corev1controllers.SecretController) *Operations {
 	return &Operations{
-		cg:             cg,
-		contentManager: contentManager,
-		namespace:      namespaces.System,
-		Impersonator:   podimpersonation.New("helm-op", cg, time.Hour, settings.FullShellImage),
-		pods:           pods,
-		clusterRepos:   catalog.ClusterRepo(),
-		ops:            catalog.Operation(),
-		apps:           catalog.App(),
-		roleBindings:   rbac.RoleBinding(),
-		roles:          rbac.Role(),
-		nodes:          nodes,
+		cg:                cg,
+		contentManager:    contentManager,
+		namespace:         namespaces.System,
+		Impersonator:      podimpersonation.New("helm-op", cg, time.Hour, settings.FullShellImage),
+		pods:              pods,
+		clusterRepos:      catalog.ClusterRepo(),
+		clusterReposCache: catalog.ClusterRepo().Cache(),
+		ops:               catalog.Operation(),
+		apps:              catalog.App(),
+		roleBindings:      rbac.RoleBinding(),
+		roles:             rbac.Role(),
+		nodes:             nodes,
+		secretCache:       secrets.Cache(),
+		secrets:           secrets,
 	}
 }
 
@@ -134,7 +152,7 @@ func (s *Operations) Uninstall(ctx context.Context, user user.Info, namespace, n
 		return nil, err
 	}
 
-	return s.createOperation(ctx, user, status, cmds, imageOverride)
+	return s.createOperation(ctx, user, status, cmds, imageOverride, name)
 }
 
 // Upgrade gets the upgrade commands using the given namespace, name and options and gets the user using the isApp flag as false.
@@ -157,7 +175,7 @@ func (s *Operations) Upgrade(ctx context.Context, user user.Info, namespace, nam
 		return nil, err
 	}
 
-	return s.createOperation(ctx, user, status, cmds, imageOverride)
+	return s.createOperation(ctx, user, status, cmds, imageOverride, name)
 }
 
 // Install gets the install commands using the given namespace, name and options and gets the user using the isApp flag as false.
@@ -180,7 +198,7 @@ func (s *Operations) Install(ctx context.Context, user user.Info, namespace, nam
 		return nil, err
 	}
 
-	return s.createOperation(ctx, user, status, cmds, imageOverride)
+	return s.createOperation(ctx, user, status, cmds, imageOverride, name)
 }
 
 // decodeParams decodes the request using its url and v1 group version into the target object
@@ -415,6 +433,7 @@ type Command struct {
 	ArgObjects       []interface{} // the arguments that will be used in the command
 	ValuesFile       string        // name of the values.yaml file
 	Values           []byte        // content of the values.yaml file
+	ChartBaseValues  []byte        // the full values.yaml file of the incoming chart
 	ChartFile        string        // name of the chart tar file
 	Chart            []byte        // content of the chart file
 	ReleaseName      string        // name of the release
@@ -552,23 +571,20 @@ func sanitizeVersion(chartVersion string) string {
 	return badChars.ReplaceAllString(chartVersion, "-")
 }
 
-// injectAnnotation receives the chart data from a tar file and injects the given annotations.
-// Returns the modified chart data
-func injectAnnotation(data []byte, annotations map[string]string) ([]byte, error) {
-	if len(annotations) == 0 {
-		return data, nil
-	}
-
+// injectAnnotationAndRetrieveValues receives the chart data from a tar file and injects the given annotations.
+// Returns the modified chart data and values.yaml of the chart.
+func injectAnnotationAndRetrieveValues(data []byte, annotations map[string]string) ([]byte, []byte, error) {
 	tgz, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var (
-		dest    = &bytes.Buffer{}
-		destGz  = gzip.NewWriter(dest)
-		destTar = tar.NewWriter(destGz)
-		tar     = tar.NewReader(tgz)
+		dest            = &bytes.Buffer{}
+		destGz          = gzip.NewWriter(dest)
+		destTar         = tar.NewWriter(destGz)
+		tar             = tar.NewReader(tgz)
+		chartValuesYaml []byte
 	)
 
 	for {
@@ -579,38 +595,43 @@ func injectAnnotation(data []byte, annotations map[string]string) ([]byte, error
 
 		data, err := io.ReadAll(tar)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// checks if its chart.yaml
 		parts := strings.Split(header.Name, "/")
-		if len(parts) == 2 && chartYAML[parts[1]] {
+		if len(parts) == 2 && chartYAML[parts[1]] && len(annotations) != 0 {
 			data, err = addAnnotations(data, annotations)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			header.Size = int64(len(data))
 		}
 
+		// checks if its values.yaml
+		if len(parts) == 2 && valuesYAML[parts[1]] {
+			chartValuesYaml = data
+		}
+
 		if err := destTar.WriteHeader(header); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		_, err = destTar.Write(data)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	if err = destTar.Close(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err = destGz.Close(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return dest.Bytes(), nil
+	return dest.Bytes(), chartValuesYaml, nil
 }
 
 // addAnnotations receives that chart.yaml data and injects the given annotations in it
@@ -645,8 +666,8 @@ func (s *Operations) getChartCommand(namespace, name, chartName, chartVersion st
 	if err != nil {
 		return Command{}, err
 	}
-
-	chartData, err = injectAnnotation(chartData, annotations)
+	var baseChartValues []byte
+	chartData, baseChartValues, err = injectAnnotationAndRetrieveValues(chartData, annotations)
 	if err != nil {
 		return Command{}, err
 	}
@@ -655,9 +676,10 @@ func (s *Operations) getChartCommand(namespace, name, chartName, chartVersion st
 	chartFileName := sanitizeCommandKeyNames(fmt.Sprintf("%s-%s.tgz", chartName, sanitizeVersion(chartVersion)))
 
 	c := Command{
-		ValuesFile: valuesFileName,
-		ChartFile:  chartFileName,
-		Chart:      chartData,
+		ValuesFile:      valuesFileName,
+		ChartBaseValues: baseChartValues,
+		ChartFile:       chartFileName,
+		Chart:           chartData,
 	}
 
 	if len(values) > 0 {
@@ -742,9 +764,13 @@ func namespace(ns string) string {
 // createOperation creates an operation and its pod, along with its roles and roleBinding.
 // Uses the Operations.Impersonator and Operations.ops to do it.
 // Returns the created catalog.Operation struct
-func (s *Operations) createOperation(ctx context.Context, user user.Info, status catalog.OperationStatus, cmds Commands, imageOverride string) (*catalog.Operation, error) {
-	if status.Action != "uninstall" {
-		_, err := s.createNamespace(ctx, status.Namespace, status.ProjectID)
+func (s *Operations) createOperation(ctx context.Context, user user.Info, status catalog.OperationStatus, cmds Commands, imageOverride string, clusterRepoName string) (*catalog.Operation, error) {
+	if status.Action == "uninstall" {
+		if err := s.deleteReleasePullSecrets(status.Namespace, status.Release); err != nil {
+			return nil, err
+		}
+	} else {
+		err := s.createNamespaceAndPullSecrets(ctx, status, cmds, clusterRepoName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/catalogv2/helmop/pull_secrets.go
+++ b/pkg/catalogv2/helmop/pull_secrets.go
@@ -1,0 +1,260 @@
+package helmop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/rancher/apiserver/pkg/types"
+	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/cluster"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// createNamespaceAndPullSecrets is responsible for creating the release namespace for chart on install/upgrade operations and managing the default image pull
+// secrets to be used by that chart. It checks if the chart supports image pull secrets and if it does, and that is has a system-default-registry configure. If so,
+// it creates/updates the pull secrets in the release namespace and injects them in the charts values.yaml if the user has not already configured them. The management
+// of pull secrets may also be skipped if the provided ctx includes a valid apiRequest, and that request specifies the 'skipPullSecrets' query parameter as 'true'.
+func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status catalog.OperationStatus, cmds Commands, clusterRepoName string) error {
+	ns, err := s.createNamespace(ctx, status.Namespace, status.ProjectID)
+	if err != nil {
+		return err
+	}
+
+	apiRequest := types.GetAPIContext(ctx)
+	if clusterRepoName != "rancher-charts" || (apiRequest != nil && apiRequest.Query.Get("skipPullSecrets") == "true") {
+		return nil
+	}
+
+	supportsPullSecrets := false
+	for i := range cmds {
+		var baseValues, values map[string]any
+		if err := yaml.Unmarshal(cmds[i].ChartBaseValues, &baseValues); err != nil {
+			log.Errorf("[helmop] createNamespaceAndPullSecrets: failed to unmarshal chart base values: %v", err)
+			return err
+		}
+
+		if err := yaml.Unmarshal(cmds[i].Values, &values); err != nil {
+			log.Errorf("[helmop] createNamespaceAndPullSecrets: failed to unmarshal chart base values: %v", err)
+			return err
+		}
+
+		sdrConfigured, err := s.SystemDefaultRegistryConfigured(values)
+		if err != nil {
+			return err
+		}
+
+		if !sdrConfigured {
+			continue
+		}
+
+		supportsPullSecrets, err = s.chartSupportsImagePullSecrets(baseValues)
+		if err != nil {
+			return err
+		}
+
+		if supportsPullSecrets {
+			break
+		}
+	}
+
+	if !supportsPullSecrets {
+		return nil
+	}
+
+	pullSecrets, err := s.createOrUpdatePullSecrets(ns.Name, clusterRepoName)
+	if err != nil {
+		return err
+	}
+
+	log.Tracef("[helmop] createOrUpdatePullSecrets returned %d secrets for namespace=%q repo=%q: %v", len(pullSecrets), ns.Name, clusterRepoName, pullSecrets)
+	for i := range cmds {
+		log.Tracef("[helmop] injecting pull secrets into command %d (release=%q, namespace=%q, valuesLen=%d, chartBaseValuesLen=%d)", i, cmds[i].ReleaseName, cmds[i].ReleaseNamespace, len(cmds[i].Values), len(cmds[i].ChartBaseValues))
+		var baseValues, values map[string]any
+		if err := yaml.Unmarshal(cmds[i].ChartBaseValues, &baseValues); err != nil {
+			log.Errorf("[helmop] injectPullSecrets: failed to unmarshal chart base values: %v", err)
+			return err
+		}
+		if err := yaml.Unmarshal(cmds[i].Values, &values); err != nil {
+			log.Errorf("[helmop] injectPullSecrets: failed to unmarshal chart base values: %v", err)
+			return err
+		}
+		cmds[i].Values, err = s.injectPullSecrets(cmds[i].ReleaseName, baseValues, values, pullSecrets)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Operations) SystemDefaultRegistryConfigured(values map[string]any) (bool, error) {
+	v, defined := getValueAtPath(values, "global", "cattle", "systemDefaultRegistry")
+	return defined && v != "", nil
+}
+
+func (s *Operations) chartSupportsImagePullSecrets(baseValues map[string]any) (bool, error) {
+	for _, path := range imagePullSecretPaths {
+		pathStr := strings.Join(path, ".")
+		if _, declared := getValueAtPath(baseValues, path...); !declared {
+			continue
+		}
+		log.Tracef("[helmop] injectPullSecrets: path %q is declared in chart base values", pathStr)
+		return true, nil
+	}
+	return false, nil
+}
+
+func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string]any, confValues map[string]any, secretNames []string) ([]byte, error) {
+	pullSecrets := make([]map[string]string, len(secretNames))
+	for i, e := range secretNames {
+		pullSecrets[i] = map[string]string{"name": e}
+	}
+
+	for _, path := range imagePullSecretPaths {
+		pathStr := strings.Join(path, ".")
+		if _, declared := getValueAtPath(baseValues, path...); !declared {
+			continue
+		}
+		if value, exists := getValueAtPath(confValues, path...); exists {
+			if secrets, ok := value.([]any); ok && len(secrets) > 0 {
+				continue
+			}
+		}
+		log.Tracef("[helmop] injectPullSecrets: injecting %d pull secrets at path %q for release %s: %v", len(pullSecrets), pathStr, releaseName, pullSecrets)
+		setValueAtPath(confValues, pullSecrets, path...)
+	}
+
+	result, err := json.Marshal(confValues)
+	if err != nil {
+		log.Errorf("[helmop] injectPullSecrets: failed to marshal modified values: %v", err)
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *Operations) createOrUpdatePullSecrets(namespace string, repoName string) ([]string, error) {
+	repo, err := s.clusterReposCache.Get(repoName)
+	if err != nil {
+		log.Errorf("[helmop] createOrUpdatePullSecrets: failed to get cluster repo %q from cache: %v", repoName, err)
+		return nil, err
+	}
+
+	if len(repo.Spec.DefaultImagePullSecrets) == 0 {
+		return nil, nil
+	}
+
+	var secretNames []string
+	for _, secret := range repo.Spec.DefaultImagePullSecrets {
+		pullSec, err := s.secretCache.Get(namespaces.System, secret.Name)
+		if err != nil {
+			log.Errorf("[helmop] createOrUpdatePullSecrets: failed to get source secret %q from namespace %q: %v", secret.Name, namespaces.System, err)
+			return nil, err
+		}
+
+		if pullSec.Labels == nil {
+			continue
+		}
+
+		_, isCopiedSecret := pullSec.Labels[cluster.CopiedPullSecretLabel]
+		_, isSourceSecret := pullSec.Labels[cluster.SourcePullSecretLabel]
+		_, isAgentSecret := pullSec.Labels["management.cattle.io/cattle-cluster-agent-pull-secret"]
+		if !isCopiedSecret && !isSourceSecret && !isAgentSecret {
+			continue
+		}
+
+		existingSec, err := s.secretCache.Get(namespace, secret.Name)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Errorf("[helmop] createOrUpdatePullSecrets: unexpected error looking up existing secret %q in namespace %q: %v", secret.Name, namespace, err)
+				return nil, err
+			}
+		}
+
+		if existingSec == nil {
+			newSec := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secret.Name,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: pullSec.Data[corev1.DockerConfigJsonKey],
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+			}
+			_, err = s.secrets.Create(newSec)
+			if err != nil {
+				log.Errorf("[helmop] createOrUpdatePullSecrets: failed to create secret %q in namespace %q: %v", secret.Name, namespace, err)
+				return nil, err
+			}
+			secretNames = append(secretNames, secret.Name)
+			continue
+		}
+
+		existingSec, needsUpdate, err := secretNeedsUpdate(existingSec, pullSec)
+		if needsUpdate {
+			_, err = s.secrets.Update(existingSec)
+			if err != nil {
+				log.Errorf("[helmop] createOrUpdatePullSecrets: failed to update secret %q in namespace %q: %v", secret.Name, namespace, err)
+				return nil, err
+			}
+		}
+
+		secretNames = append(secretNames, secret.Name)
+	}
+
+	log.Debugf("[helmop] createOrUpdatePullSecrets: completed, returning %d secret names: %v", len(secretNames), secretNames)
+	return secretNames, nil
+}
+
+func secretNeedsUpdate(existing, current *corev1.Secret) (*corev1.Secret, bool, error) {
+	dataOutdated := existing.Data[corev1.DockerConfigJsonKey] == nil || !bytes.Equal(existing.Data[corev1.DockerConfigJsonKey], current.Data[corev1.DockerConfigJsonKey])
+
+	if !dataOutdated {
+		return existing, false, nil
+	}
+
+	existing = existing.DeepCopy()
+	existing.Data[corev1.DockerConfigJsonKey] = current.Data[corev1.DockerConfigJsonKey]
+
+	return existing, true, nil
+}
+
+func getValueAtPath(data map[string]any, path ...string) (any, bool) {
+	current := any(data)
+	for i, key := range path {
+		cm, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		v, ok := cm[key]
+		if !ok {
+			return nil, false
+		}
+		if i == len(path)-1 {
+			return v, true
+		}
+		current = v
+	}
+	return nil, false
+}
+
+func setValueAtPath(data map[string]any, value any, path ...string) {
+	current := data
+	for i := 0; i < len(path)-1; i++ {
+		next, ok := current[path[i]].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			current[path[i]] = next
+		}
+		current = next
+	}
+	current[path[len(path)-1]] = value
+}

--- a/pkg/catalogv2/helmop/pull_secrets.go
+++ b/pkg/catalogv2/helmop/pull_secrets.go
@@ -4,18 +4,29 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/rancher/apiserver/pkg/types"
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/cluster"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/wrangler/v3/pkg/name"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/yaml"
 )
+
+// helmOpManagedPullSecretLabel is applied to pull secrets created in a chart's release namespace
+// by managePullSecrets, to allow them to be identified and garbage collected when no longer needed.
+const helmOpManagedPullSecretLabel = "management.cattle.io/helm-op-pull-secret"
+
+// helmOpReleaseLabelKey is applied alongside helmOpManagedPullSecretLabel to scope managed
+// pull secrets to the specific Helm release that created them, preventing cross-release cleanup.
+const helmOpReleaseLabelKey = "management.cattle.io/helm-op-release"
 
 // createNamespaceAndPullSecrets is responsible for creating the release namespace for chart on install/upgrade operations and managing the default image pull
 // secrets to be used by that chart. It checks if the chart supports image pull secrets and if it does, and that is has a system-default-registry configure. If so,
@@ -32,59 +43,38 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 		return nil
 	}
 
-	supportsPullSecrets := false
 	for i := range cmds {
-		var baseValues, values map[string]any
-		if err := yaml.Unmarshal(cmds[i].ChartBaseValues, &baseValues); err != nil {
-			log.Errorf("[helmop] createNamespaceAndPullSecrets: failed to unmarshal chart base values: %v", err)
-			return err
-		}
-
-		if err := yaml.Unmarshal(cmds[i].Values, &values); err != nil {
-			log.Errorf("[helmop] createNamespaceAndPullSecrets: failed to unmarshal chart base values: %v", err)
-			return err
-		}
-
-		sdrConfigured, err := s.SystemDefaultRegistryConfigured(values)
-		if err != nil {
-			return err
-		}
-
-		if !sdrConfigured {
+		if cmds[i].ReleaseName == "" {
 			continue
 		}
 
-		supportsPullSecrets, err = s.chartSupportsImagePullSecrets(baseValues)
+		var baseValues, values map[string]any
+		if err := yaml.Unmarshal(cmds[i].ChartBaseValues, &baseValues); err != nil {
+			log.Errorf("[helmop] createNamespaceAndPullSecrets: failed to unmarshal chart base values: %v", err)
+			return err
+		}
+
+		if err := yaml.Unmarshal(cmds[i].Values, &values); err != nil {
+			log.Errorf("[helmop] createNamespaceAndPullSecrets: failed to unmarshal chart values: %v", err)
+			return err
+		}
+
+		if !s.chartSupportsImagePullSecrets(baseValues) {
+			continue
+		}
+
+		sdr, sdrDefined := s.SystemDefaultRegistryConfigured(values)
+
+		pullSecrets, err := s.managePullSecrets(sdr, ns.Name, clusterRepoName, cmds[i].ReleaseName)
 		if err != nil {
 			return err
 		}
 
-		if supportsPullSecrets {
-			break
+		if !sdrDefined {
+			continue
 		}
-	}
 
-	if !supportsPullSecrets {
-		return nil
-	}
-
-	pullSecrets, err := s.createOrUpdatePullSecrets(ns.Name, clusterRepoName)
-	if err != nil {
-		return err
-	}
-
-	log.Tracef("[helmop] createOrUpdatePullSecrets returned %d secrets for namespace=%q repo=%q: %v", len(pullSecrets), ns.Name, clusterRepoName, pullSecrets)
-	for i := range cmds {
 		log.Tracef("[helmop] injecting pull secrets into command %d (release=%q, namespace=%q, valuesLen=%d, chartBaseValuesLen=%d)", i, cmds[i].ReleaseName, cmds[i].ReleaseNamespace, len(cmds[i].Values), len(cmds[i].ChartBaseValues))
-		var baseValues, values map[string]any
-		if err := yaml.Unmarshal(cmds[i].ChartBaseValues, &baseValues); err != nil {
-			log.Errorf("[helmop] injectPullSecrets: failed to unmarshal chart base values: %v", err)
-			return err
-		}
-		if err := yaml.Unmarshal(cmds[i].Values, &values); err != nil {
-			log.Errorf("[helmop] injectPullSecrets: failed to unmarshal chart base values: %v", err)
-			return err
-		}
 		cmds[i].Values, err = s.injectPullSecrets(cmds[i].ReleaseName, baseValues, values, pullSecrets)
 		if err != nil {
 			return err
@@ -94,21 +84,22 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 	return nil
 }
 
-func (s *Operations) SystemDefaultRegistryConfigured(values map[string]any) (bool, error) {
+func (s *Operations) SystemDefaultRegistryConfigured(values map[string]any) (string, bool) {
 	v, defined := getValueAtPath(values, "global", "cattle", "systemDefaultRegistry")
-	return defined && v != "", nil
+	sdr, ok := v.(string)
+	return sdr, defined && ok
 }
 
-func (s *Operations) chartSupportsImagePullSecrets(baseValues map[string]any) (bool, error) {
+func (s *Operations) chartSupportsImagePullSecrets(baseValues map[string]any) bool {
 	for _, path := range imagePullSecretPaths {
 		pathStr := strings.Join(path, ".")
 		if _, declared := getValueAtPath(baseValues, path...); !declared {
 			continue
 		}
 		log.Tracef("[helmop] injectPullSecrets: path %q is declared in chart base values", pathStr)
-		return true, nil
+		return true
 	}
-	return false, nil
+	return false
 }
 
 func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string]any, confValues map[string]any, secretNames []string) ([]byte, error) {
@@ -118,7 +109,6 @@ func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string
 	}
 
 	for _, path := range imagePullSecretPaths {
-		pathStr := strings.Join(path, ".")
 		if _, declared := getValueAtPath(baseValues, path...); !declared {
 			continue
 		}
@@ -127,27 +117,37 @@ func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string
 				continue
 			}
 		}
-		log.Tracef("[helmop] injectPullSecrets: injecting %d pull secrets at path %q for release %s: %v", len(pullSecrets), pathStr, releaseName, pullSecrets)
+		log.Tracef("[helmop] injectPullSecrets: injecting %d pull secrets at path %q for release %q: %v", len(pullSecrets), strings.Join(path, "."), releaseName, pullSecrets)
 		setValueAtPath(confValues, pullSecrets, path...)
 	}
 
 	result, err := json.Marshal(confValues)
 	if err != nil {
-		log.Errorf("[helmop] injectPullSecrets: failed to marshal modified values: %v", err)
+		log.Errorf("[helmop] injectPullSecrets: failed to marshal modified values for release %q: %v", releaseName, err)
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func (s *Operations) createOrUpdatePullSecrets(namespace string, repoName string) ([]string, error) {
+func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace string, repoName string, releaseName string) ([]string, error) {
 	repo, err := s.clusterReposCache.Get(repoName)
 	if err != nil {
-		log.Errorf("[helmop] createOrUpdatePullSecrets: failed to get cluster repo %q from cache: %v", repoName, err)
+		log.Errorf("[helmop] managePullSecrets: failed to get cluster repo %q from cache: %v", repoName, err)
 		return nil, err
 	}
 
+	if systemDefaultRegistry == "" {
+		if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, releaseName); err != nil {
+			return nil, err
+		}
+		return []string{}, nil
+	}
+
 	if len(repo.Spec.DefaultImagePullSecrets) == 0 {
+		if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, releaseName); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
@@ -155,7 +155,7 @@ func (s *Operations) createOrUpdatePullSecrets(namespace string, repoName string
 	for _, secret := range repo.Spec.DefaultImagePullSecrets {
 		pullSec, err := s.secretCache.Get(namespaces.System, secret.Name)
 		if err != nil {
-			log.Errorf("[helmop] createOrUpdatePullSecrets: failed to get source secret %q from namespace %q: %v", secret.Name, namespaces.System, err)
+			log.Errorf("[helmop] managePullSecrets: failed to get source secret %q from namespace %q: %v", secret.Name, namespaces.System, err)
 			return nil, err
 		}
 
@@ -163,68 +163,140 @@ func (s *Operations) createOrUpdatePullSecrets(namespace string, repoName string
 			continue
 		}
 
-		_, isCopiedSecret := pullSec.Labels[cluster.CopiedPullSecretLabel]
 		_, isSourceSecret := pullSec.Labels[cluster.SourcePullSecretLabel]
-		_, isAgentSecret := pullSec.Labels["management.cattle.io/cattle-cluster-agent-pull-secret"]
-		if !isCopiedSecret && !isSourceSecret && !isAgentSecret {
+		_, isAgentSecret := pullSec.Labels[cluster.AgentPullSecretLabel]
+		if !isSourceSecret && !isAgentSecret {
 			continue
 		}
 
-		existingSec, err := s.secretCache.Get(namespace, secret.Name)
+		if pullSec.Type != corev1.SecretTypeDockerConfigJson {
+			continue
+		}
+
+		if len(pullSec.Data[corev1.DockerConfigJsonKey]) == 0 {
+			continue
+		}
+
+		// Filter the source secret to only the entry matching the configured SDR.
+		filteredData, err := cluster.FilterDockerConfigJson(systemDefaultRegistry, pullSec.Data)
 		if err != nil {
-			if !errors.IsNotFound(err) {
-				log.Errorf("[helmop] createOrUpdatePullSecrets: unexpected error looking up existing secret %q in namespace %q: %v", secret.Name, namespace, err)
-				return nil, err
+			if err.Error() == fmt.Sprintf(cluster.ErrRegistryHostnameNotFound, systemDefaultRegistry) {
+				continue
 			}
+			log.Errorf("[helmop] managePullSecrets: failed to filter docker config for registry %q from secret %q: %v", systemDefaultRegistry, secret.Name, err)
+			return nil, err
+		}
+
+		if filteredData == nil {
+			log.Tracef("[helmop] managePullSecrets: secret %q has no entry for any configured SDR, skipping", secret.Name)
+			continue
+		}
+
+		// Scope the copied secret name to this release so that multiple charts in the same
+		// namespace don't interfere with each others secrets during uninstallation.
+		secretName := name.SafeConcatName(releaseName, secret.Name)
+
+		existingSec, err := s.secretCache.Get(namespace, secretName)
+		if err != nil && !errors.IsNotFound(err) {
+			log.Errorf("[helmop] managePullSecrets: unexpected error looking up existing secret %q in namespace %q: %v", secretName, namespace, err)
+			return nil, err
 		}
 
 		if existingSec == nil {
 			newSec := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      secret.Name,
+					Name:      secretName,
 					Namespace: namespace,
+					Labels: map[string]string{
+						helmOpManagedPullSecretLabel: "true",
+						helmOpReleaseLabelKey:        releaseName,
+					},
 				},
 				Data: map[string][]byte{
-					corev1.DockerConfigJsonKey: pullSec.Data[corev1.DockerConfigJsonKey],
+					corev1.DockerConfigJsonKey: filteredData,
 				},
 				Type: corev1.SecretTypeDockerConfigJson,
 			}
 			_, err = s.secrets.Create(newSec)
 			if err != nil {
-				log.Errorf("[helmop] createOrUpdatePullSecrets: failed to create secret %q in namespace %q: %v", secret.Name, namespace, err)
+				log.Errorf("[helmop] managePullSecrets: failed to create secret %q in namespace %q: %v", secretName, namespace, err)
 				return nil, err
 			}
-			secretNames = append(secretNames, secret.Name)
+			secretNames = append(secretNames, secretName)
 			continue
 		}
 
-		existingSec, needsUpdate, err := secretNeedsUpdate(existingSec, pullSec)
-		if needsUpdate {
+		// Only manage secrets that we created, skip user-created secrets that happen to share the name.
+		if existingSec.Labels[helmOpManagedPullSecretLabel] != "true" {
+			log.Debugf("[helmop] managePullSecrets: secret %q in namespace %q is not Rancher-managed, skipping update", secretName, namespace)
+			continue
+		}
+
+		if existingSec.Data == nil {
+			existingSec.Data = make(map[string][]byte)
+		}
+
+		if !bytes.Equal(existingSec.Data[corev1.DockerConfigJsonKey], filteredData) {
+			existingSec = existingSec.DeepCopy()
+			existingSec.Data[corev1.DockerConfigJsonKey] = filteredData
 			_, err = s.secrets.Update(existingSec)
 			if err != nil {
-				log.Errorf("[helmop] createOrUpdatePullSecrets: failed to update secret %q in namespace %q: %v", secret.Name, namespace, err)
+				log.Errorf("[helmop] managePullSecrets: failed to update secret %q in namespace %q: %v", secretName, namespace, err)
 				return nil, err
 			}
 		}
-
-		secretNames = append(secretNames, secret.Name)
+		secretNames = append(secretNames, secretName)
 	}
 
-	log.Debugf("[helmop] createOrUpdatePullSecrets: completed, returning %d secret names: %v", len(secretNames), secretNames)
+	if err := s.deleteStaleHelmOpSecrets(secretNames, namespace, releaseName); err != nil {
+		return nil, err
+	}
+
+	log.Debugf("[helmop] managePullSecrets: completed, returning %d secret names: %v", len(secretNames), secretNames)
 	return secretNames, nil
 }
 
-func secretNeedsUpdate(existing, current *corev1.Secret) (*corev1.Secret, bool, error) {
-	dataOutdated := existing.Data[corev1.DockerConfigJsonKey] == nil || !bytes.Equal(existing.Data[corev1.DockerConfigJsonKey], current.Data[corev1.DockerConfigJsonKey])
-
-	if !dataOutdated {
-		return existing, false, nil
+// deleteStaleHelmOpSecrets deletes secrets in the release namespace that were previously created
+// by managePullSecrets (identified by helmOpManagedPullSecretLabel and helmOpReleaseLabelKey)
+// but are no longer needed. It lists all managed secrets for the given release via label selector
+// and deletes any not present in activeSecretNames.
+func (s *Operations) deleteStaleHelmOpSecrets(activeSecretNames []string, namespace string, releaseName string) error {
+	active := make(map[string]struct{}, len(activeSecretNames))
+	for _, name := range activeSecretNames {
+		active[name] = struct{}{}
 	}
 
-	existing = existing.DeepCopy()
-	existing.Data[corev1.DockerConfigJsonKey] = current.Data[corev1.DockerConfigJsonKey]
+	managed, err := s.secretCache.List(namespace, labels.SelectorFromSet(labels.Set{
+		helmOpManagedPullSecretLabel: "true",
+		helmOpReleaseLabelKey:        releaseName,
+	}))
+	if err != nil {
+		log.Errorf("[helmop] deleteStaleHelmOpSecrets: failed to list managed secrets in namespace %q for release %q: %v", namespace, releaseName, err)
+		return err
+	}
 
-	return existing, true, nil
+	for _, secret := range managed {
+		if _, isActive := active[secret.Name]; isActive {
+			continue
+		}
+
+		log.Debugf("[helmop] deleteStaleHelmOpSecrets: deleting stale managed secret %q from namespace %q (release %q)", secret.Name, namespace, releaseName)
+		if err := s.secrets.Delete(namespace, secret.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			log.Errorf("[helmop] deleteStaleHelmOpSecrets: failed to delete stale secret %q in namespace %q: %v", secret.Name, namespace, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteReleasePullSecrets removes all Rancher-managed pull secrets for each release in cmds
+// from the given namespace. This is called on uninstall to clean up secrets created during install/upgrade.
+func (s *Operations) deleteReleasePullSecrets(namespace string, release string) error {
+	if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, release); err != nil {
+		return err
+	}
+	return nil
 }
 
 func getValueAtPath(data map[string]any, path ...string) (any, bool) {

--- a/pkg/catalogv2/helmop/pull_secrets.go
+++ b/pkg/catalogv2/helmop/pull_secrets.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/rancher/apiserver/pkg/types"
@@ -14,7 +14,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/name"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/yaml"
@@ -175,7 +175,7 @@ func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace s
 		// Filter the source secret to only the entry matching the configured SDR.
 		filteredData, err := cluster.FilterDockerConfigJson(systemDefaultRegistry, pullSec.Data)
 		if err != nil {
-			if err.Error() == fmt.Sprintf(cluster.ErrRegistryHostnameNotFound, systemDefaultRegistry) {
+			if errors.Is(err, cluster.ErrRegistryHostnameNotFound) {
 				continue
 			}
 			log.Errorf("[helmop] managePullSecrets: failed to filter docker config for registry %q from secret %q: %v", systemDefaultRegistry, secret.Name, err)
@@ -192,7 +192,7 @@ func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace s
 		secretName := name.SafeConcatName(releaseName, secret.Name)
 
 		existingSec, err := s.secretCache.Get(namespace, secretName)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			log.Errorf("[helmop] managePullSecrets: unexpected error looking up existing secret %q in namespace %q: %v", secretName, namespace, err)
 			return nil, err
 		}
@@ -276,7 +276,7 @@ func (s *Operations) deleteStaleHelmOpSecrets(activeSecretNames []string, namesp
 		}
 
 		log.Debugf("[helmop] deleteStaleHelmOpSecrets: deleting stale managed secret %q from namespace %q (release %q)", secret.Name, namespace, releaseName)
-		if err := s.secrets.Delete(namespace, secret.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		if err := s.secrets.Delete(namespace, secret.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			log.Errorf("[helmop] deleteStaleHelmOpSecrets: failed to delete stale secret %q in namespace %q: %v", secret.Name, namespace, err)
 			return err
 		}

--- a/pkg/catalogv2/helmop/pull_secrets.go
+++ b/pkg/catalogv2/helmop/pull_secrets.go
@@ -28,8 +28,8 @@ const helmOpManagedPullSecretLabel = "management.cattle.io/helm-op-pull-secret"
 // pull secrets to the specific Helm release that created them, preventing cross-release cleanup.
 const helmOpReleaseLabelKey = "management.cattle.io/helm-op-release"
 
-// createNamespaceAndPullSecrets is responsible for creating the release namespace for chart on install/upgrade operations and managing the default image pull
-// secrets to be used by that chart. It checks if the chart supports image pull secrets and if it does, and that is has a system-default-registry configure. If so,
+// createNamespaceAndPullSecrets is responsible for creating the release namespace for the charts on install/upgrade operations and managing the default image pull
+// secrets to be used by the charts. It checks if each chart supports image pull secrets and that it has a system-default-registry configured. If so,
 // it creates/updates the pull secrets in the release namespace and injects them in the charts values.yaml if the user has not already configured them. The management
 // of pull secrets may also be skipped if the provided ctx includes a valid apiRequest, and that request specifies the 'skipPullSecrets' query parameter as 'true'.
 func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status catalog.OperationStatus, cmds Commands, clusterRepoName string) error {
@@ -137,18 +137,11 @@ func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace s
 		return nil, err
 	}
 
-	if systemDefaultRegistry == "" {
+	if systemDefaultRegistry == "" || len(repo.Spec.DefaultImagePullSecrets) == 0 {
 		if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, releaseName); err != nil {
 			return nil, err
 		}
 		return []string{}, nil
-	}
-
-	if len(repo.Spec.DefaultImagePullSecrets) == 0 {
-		if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, releaseName); err != nil {
-			return nil, err
-		}
-		return nil, nil
 	}
 
 	var secretNames []string
@@ -163,6 +156,8 @@ func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace s
 			continue
 		}
 
+		// only allow secrets which are currently configured as global pull secrets (source),
+		// or have been delivered downstream by Rancher (agent).
 		_, isSourceSecret := pullSec.Labels[cluster.SourcePullSecretLabel]
 		_, isAgentSecret := pullSec.Labels[cluster.AgentPullSecretLabel]
 		if !isSourceSecret && !isAgentSecret {
@@ -227,7 +222,7 @@ func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace s
 		}
 
 		// Only manage secrets that we created, skip user-created secrets that happen to share the name.
-		if existingSec.Labels[helmOpManagedPullSecretLabel] != "true" {
+		if existingSec.Labels != nil && existingSec.Labels[helmOpManagedPullSecretLabel] != "true" {
 			log.Debugf("[helmop] managePullSecrets: secret %q in namespace %q is not Rancher-managed, skipping update", secretName, namespace)
 			continue
 		}

--- a/pkg/catalogv2/helmop/pull_secrets.go
+++ b/pkg/catalogv2/helmop/pull_secrets.go
@@ -87,7 +87,7 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 func (s *Operations) SystemDefaultRegistryConfigured(values map[string]any) (string, bool) {
 	v, defined := getValueAtPath(values, "global", "cattle", "systemDefaultRegistry")
 	sdr, ok := v.(string)
-	return sdr, defined && ok
+	return sdr, defined && ok && v != ""
 }
 
 func (s *Operations) chartSupportsImagePullSecrets(baseValues map[string]any) bool {

--- a/pkg/catalogv2/helmop/pull_secrets.go
+++ b/pkg/catalogv2/helmop/pull_secrets.go
@@ -63,9 +63,10 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 			continue
 		}
 
-		sdr, sdrDefined := s.SystemDefaultRegistryConfigured(values)
+		sdr, sdrDefined := s.systemDefaultRegistryConfigured(values)
+		pullSecretsPreConfigured := s.chartHasConfiguredPullSecrets(values)
 
-		pullSecrets, err := s.managePullSecrets(sdr, ns.Name, clusterRepoName, cmds[i].ReleaseName)
+		pullSecrets, err := s.managePullSecrets(sdr, ns.Name, clusterRepoName, cmds[i].ReleaseName, pullSecretsPreConfigured)
 		if err != nil {
 			return err
 		}
@@ -84,7 +85,7 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 	return nil
 }
 
-func (s *Operations) SystemDefaultRegistryConfigured(values map[string]any) (string, bool) {
+func (s *Operations) systemDefaultRegistryConfigured(values map[string]any) (string, bool) {
 	v, defined := getValueAtPath(values, "global", "cattle", "systemDefaultRegistry")
 	sdr, ok := v.(string)
 	return sdr, defined && ok && v != ""
@@ -98,6 +99,22 @@ func (s *Operations) chartSupportsImagePullSecrets(baseValues map[string]any) bo
 		}
 		log.Tracef("[helmop] injectPullSecrets: path %q is declared in chart base values", pathStr)
 		return true
+	}
+	return false
+}
+
+func (*Operations) chartHasConfiguredPullSecrets(values map[string]any) bool {
+	for _, path := range imagePullSecretPaths {
+		pathStr := strings.Join(path, ".")
+		v, declared := getValueAtPath(values, path...)
+		if !declared {
+			continue
+		}
+		pullSecret, ok := v.([]any)
+		log.Tracef("[helmop] injectPullSecrets: path %q is declared in chart base values", pathStr)
+		if ok && len(pullSecret) != 0 {
+			return true
+		}
 	}
 	return false
 }
@@ -130,14 +147,14 @@ func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string
 	return result, nil
 }
 
-func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace string, repoName string, releaseName string) ([]string, error) {
+func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace string, repoName string, releaseName string, pullSecretsPreConfigured bool) ([]string, error) {
 	repo, err := s.clusterReposCache.Get(repoName)
 	if err != nil {
 		log.Errorf("[helmop] managePullSecrets: failed to get cluster repo %q from cache: %v", repoName, err)
 		return nil, err
 	}
 
-	if systemDefaultRegistry == "" || len(repo.Spec.DefaultImagePullSecrets) == 0 {
+	if systemDefaultRegistry == "" || len(repo.Spec.DefaultImagePullSecrets) == 0 || pullSecretsPreConfigured {
 		if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, releaseName); err != nil {
 			return nil, err
 		}

--- a/pkg/catalogv2/helmop/pull_secrets_test.go
+++ b/pkg/catalogv2/helmop/pull_secrets_test.go
@@ -219,8 +219,7 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 	tests := []struct {
 		name            string
 		chartBaseValues map[string]any
-		wantSupports    bool
-		wantErr         bool
+		wantSupported   bool
 	}{
 		{
 			name: "supports global.cattle.imagePullSecrets",
@@ -231,7 +230,7 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantSupports: true,
+			wantSupported: true,
 		},
 		{
 			name: "supports global.imagePullSecrets",
@@ -240,14 +239,14 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 					"imagePullSecrets": []any{},
 				},
 			},
-			wantSupports: true,
+			wantSupported: true,
 		},
 		{
 			name: "supports top-level imagePullSecrets",
 			chartBaseValues: map[string]any{
 				"imagePullSecrets": []any{},
 			},
-			wantSupports: true,
+			wantSupported: true,
 		},
 		{
 			name: "supports none of the paths",
@@ -258,17 +257,17 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantSupports: false,
+			wantSupported: false,
 		},
 		{
 			name:            "empty values",
 			chartBaseValues: map[string]any{},
-			wantSupports:    false,
+			wantSupported:   false,
 		},
 		{
 			name:            "nil values",
 			chartBaseValues: nil,
-			wantSupports:    false,
+			wantSupported:   false,
 		},
 		{
 			name: "global key exists but imagePullSecrets missing underneath",
@@ -279,7 +278,7 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantSupports: false,
+			wantSupported: false,
 		},
 		{
 			name: "imagePullSecrets declared with non-empty list value",
@@ -288,7 +287,7 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 					map[string]any{"name": "my-secret"},
 				},
 			},
-			wantSupports: true,
+			wantSupported: true,
 		},
 		{
 			name: "multiple paths declared, first match wins",
@@ -301,19 +300,14 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 				},
 				"imagePullSecrets": []any{},
 			},
-			wantSupports: true,
+			wantSupported: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := h.chartSupportsImagePullSecrets(tt.chartBaseValues)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, tt.wantSupports, got)
+			got := h.chartSupportsImagePullSecrets(tt.chartBaseValues)
+			assert.Equal(t, tt.wantSupported, got)
 		})
 	}
 }

--- a/pkg/catalogv2/helmop/pull_secrets_test.go
+++ b/pkg/catalogv2/helmop/pull_secrets_test.go
@@ -1,0 +1,448 @@
+package helmop
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getValueAtPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      map[string]any
+		path      []string
+		wantValue any
+		wantFound bool
+	}{
+		{
+			name:      "single key exists",
+			data:      map[string]any{"foo": "bar"},
+			path:      []string{"foo"},
+			wantValue: "bar",
+			wantFound: true,
+		},
+		{
+			name:      "single key missing",
+			data:      map[string]any{"foo": "bar"},
+			path:      []string{"baz"},
+			wantValue: nil,
+			wantFound: false,
+		},
+		{
+			name: "nested key exists",
+			data: map[string]any{
+				"global": map[string]any{
+					"cattle": map[string]any{
+						"imagePullSecrets": []any{},
+					},
+				},
+			},
+			path:      []string{"global", "cattle", "imagePullSecrets"},
+			wantValue: []any{},
+			wantFound: true,
+		},
+		{
+			name: "nested key missing at intermediate level",
+			data: map[string]any{
+				"global": map[string]any{},
+			},
+			path:      []string{"global", "cattle", "imagePullSecrets"},
+			wantValue: nil,
+			wantFound: false,
+		},
+		{
+			name: "intermediate value is not a map",
+			data: map[string]any{
+				"global": "not-a-map",
+			},
+			path:      []string{"global", "cattle"},
+			wantValue: nil,
+			wantFound: false,
+		},
+		{
+			name:      "nil value stored at key",
+			data:      map[string]any{"foo": nil},
+			path:      []string{"foo"},
+			wantValue: nil,
+			wantFound: true,
+		},
+		{
+			name:      "empty data map",
+			data:      map[string]any{},
+			path:      []string{"foo"},
+			wantValue: nil,
+			wantFound: false,
+		},
+		{
+			name: "two-level path exists",
+			data: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": "value",
+				},
+			},
+			path:      []string{"global", "imagePullSecrets"},
+			wantValue: "value",
+			wantFound: true,
+		},
+		{
+			name: "path deeper than data structure",
+			data: map[string]any{
+				"a": map[string]any{
+					"b": "leaf",
+				},
+			},
+			path:      []string{"a", "b", "c"},
+			wantValue: nil,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValue, gotFound := getValueAtPath(tt.data, tt.path...)
+			assert.Equal(t, tt.wantFound, gotFound)
+			assert.Equal(t, tt.wantValue, gotValue)
+		})
+	}
+}
+
+func Test_setValueAtPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  map[string]any
+		path     []string
+		value    any
+		expected map[string]any
+	}{
+		{
+			name:    "set top-level key",
+			initial: map[string]any{},
+			path:    []string{"foo"},
+			value:   "bar",
+			expected: map[string]any{
+				"foo": "bar",
+			},
+		},
+		{
+			name:    "set nested key, intermediate maps created",
+			initial: map[string]any{},
+			path:    []string{"global", "cattle", "imagePullSecrets"},
+			value:   []any{map[string]string{"name": "my-secret"}},
+			expected: map[string]any{
+				"global": map[string]any{
+					"cattle": map[string]any{
+						"imagePullSecrets": []any{map[string]string{"name": "my-secret"}},
+					},
+				},
+			},
+		},
+		{
+			name: "overwrite existing top-level key",
+			initial: map[string]any{
+				"foo": "old",
+			},
+			path:  []string{"foo"},
+			value: "new",
+			expected: map[string]any{
+				"foo": "new",
+			},
+		},
+		{
+			name: "overwrite existing nested key",
+			initial: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{},
+				},
+			},
+			path:  []string{"global", "imagePullSecrets"},
+			value: []any{map[string]string{"name": "secret-a"}},
+			expected: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{map[string]string{"name": "secret-a"}},
+				},
+			},
+		},
+		{
+			name: "intermediate is not a map, replaced with new map",
+			initial: map[string]any{
+				"global": "not-a-map",
+			},
+			path:  []string{"global", "imagePullSecrets"},
+			value: "secrets",
+			expected: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": "secrets",
+				},
+			},
+		},
+		{
+			name: "set nil value",
+			initial: map[string]any{
+				"foo": "bar",
+			},
+			path:  []string{"foo"},
+			value: nil,
+			expected: map[string]any{
+				"foo": nil,
+			},
+		},
+		{
+			name: "preserves sibling keys",
+			initial: map[string]any{
+				"global": map[string]any{
+					"existing": "preserved",
+				},
+			},
+			path:  []string{"global", "imagePullSecrets"},
+			value: "secrets",
+			expected: map[string]any{
+				"global": map[string]any{
+					"existing":         "preserved",
+					"imagePullSecrets": "secrets",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setValueAtPath(tt.initial, tt.value, tt.path...)
+			assert.Equal(t, tt.expected, tt.initial)
+		})
+	}
+}
+
+func Test_chartSupportsImagePullSecrets(t *testing.T) {
+	h := &Operations{}
+
+	tests := []struct {
+		name            string
+		chartBaseValues map[string]any
+		wantSupports    bool
+		wantErr         bool
+	}{
+		{
+			name: "supports global.cattle.imagePullSecrets",
+			chartBaseValues: map[string]any{
+				"global": map[string]any{
+					"cattle": map[string]any{
+						"imagePullSecrets": []any{},
+					},
+				},
+			},
+			wantSupports: true,
+		},
+		{
+			name: "supports global.imagePullSecrets",
+			chartBaseValues: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{},
+				},
+			},
+			wantSupports: true,
+		},
+		{
+			name: "supports top-level imagePullSecrets",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			wantSupports: true,
+		},
+		{
+			name: "supports none of the paths",
+			chartBaseValues: map[string]any{
+				"some": map[string]any{
+					"other": map[string]any{
+						"key": "value",
+					},
+				},
+			},
+			wantSupports: false,
+		},
+		{
+			name:            "empty values",
+			chartBaseValues: map[string]any{},
+			wantSupports:    false,
+		},
+		{
+			name:            "nil values",
+			chartBaseValues: nil,
+			wantSupports:    false,
+		},
+		{
+			name: "global key exists but imagePullSecrets missing underneath",
+			chartBaseValues: map[string]any{
+				"global": map[string]any{
+					"cattle": map[string]any{
+						"someOtherKey": "value",
+					},
+				},
+			},
+			wantSupports: false,
+		},
+		{
+			name: "imagePullSecrets declared with non-empty list value",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{
+					map[string]any{"name": "my-secret"},
+				},
+			},
+			wantSupports: true,
+		},
+		{
+			name: "multiple paths declared, first match wins",
+			chartBaseValues: map[string]any{
+				"global": map[string]any{
+					"cattle": map[string]any{
+						"imagePullSecrets": []any{},
+					},
+					"imagePullSecrets": []any{},
+				},
+				"imagePullSecrets": []any{},
+			},
+			wantSupports: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := h.chartSupportsImagePullSecrets(tt.chartBaseValues)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantSupports, got)
+		})
+	}
+}
+
+func Test_injectPullSecrets(t *testing.T) {
+	h := &Operations{}
+	tests := []struct {
+		name             string
+		chartBaseValues  map[string]any
+		configuredValues map[string]any
+		expected         map[string]any
+		pullSecretNames  []string
+		wantErr          bool
+	}{
+		{
+			// No imagePullSecrets paths declared in base values; secrets should not be injected.
+			name:             "no paths declared in chart base values",
+			chartBaseValues:  map[string]any{"someOtherKey": "value"},
+			configuredValues: map[string]any{},
+			pullSecretNames:  []string{"my-secret"},
+			expected:         map[string]any{},
+		},
+		{
+			// The chart declares global.cattle.imagePullSecrets; secrets should be injected there.
+			name: "inject at global.cattle.imagePullSecrets",
+			chartBaseValues: map[string]any{
+				"global": map[string]any{
+					"cattle": map[string]any{
+						"imagePullSecrets": []any{},
+					},
+				},
+			},
+			configuredValues: map[string]any{},
+			pullSecretNames:  []string{"secret-a"},
+			expected: map[string]any{
+				"global": map[string]any{
+					"cattle": map[string]any{
+						"imagePullSecrets": []any{map[string]any{"name": "secret-a"}},
+					},
+				},
+			},
+		},
+		{
+			// The chart declares global.imagePullSecrets; secrets should be injected there.
+			name: "inject at global.imagePullSecrets",
+			chartBaseValues: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{},
+				},
+			},
+			configuredValues: map[string]any{},
+			pullSecretNames:  []string{"secret-b"},
+			expected: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{map[string]any{"name": "secret-b"}},
+				},
+			},
+		},
+		{
+			// The chart declares imagePullSecrets at root; secrets should be injected there.
+			name: "inject at root imagePullSecrets",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{},
+			pullSecretNames:  []string{"secret-c"},
+			expected: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "secret-c"}},
+			},
+		},
+		{
+			// User has already configured secrets at the path; injection should be skipped to preserve them.
+			name: "skip injection when user secrets already configured",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
+			},
+			pullSecretNames: []string{"injected-secret"},
+			expected: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
+			},
+		},
+		{
+			// Chart declares multiple paths; all declared paths without existing user secrets should be injected.
+			name: "inject at multiple declared paths",
+			chartBaseValues: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{},
+				},
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{},
+			pullSecretNames:  []string{"multi-secret"},
+			expected: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{map[string]any{"name": "multi-secret"}},
+				},
+				"imagePullSecrets": []any{map[string]any{"name": "multi-secret"}},
+			},
+		},
+		{
+			// No secret names provided; an empty list should be injected at declared paths.
+			name: "empty secret names injects empty list",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{},
+			pullSecretNames:  []string{},
+			expected: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawResult, err := h.injectPullSecrets("test", tt.chartBaseValues, tt.configuredValues, tt.pullSecretNames)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Unmarshal the JSON result for a type-safe comparison against the expected map.
+			var got map[string]any
+			assert.NoError(t, json.Unmarshal(rawResult, &got))
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/fleet"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
@@ -23,6 +22,9 @@ const (
 	// CopiedPullSecretLabel is used to track copies of the source pull secrets,
 	// so that their life cycle can be managed by other controllers (e.g. imported cluster cleanup).
 	CopiedPullSecretLabel = "management.cattle.io/rancher-managed-pull-secret"
+	// AgentPullSecretLabel is used to track pull secrets that are copied to the cattle-system namespace for use by the cattle-cluster-agent.
+	// This includes both global system default registry pull secrets and cluster level registry pull secrets for imported or hosted clusters.
+	AgentPullSecretLabel = "management.cattle.io/cattle-cluster-agent-pull-secret"
 )
 
 var MgmtNameRegexp = regexp.MustCompile("^(c-[a-z0-9]{5}|local)$")
@@ -54,16 +56,6 @@ func (p *PrivateRegistry) PullSecretsAsObjectReferences() []kcorev1.LocalObjectR
 	var out []kcorev1.LocalObjectReference
 	for _, secret := range p.PullSecrets {
 		out = append(out, kcorev1.LocalObjectReference{
-			Name: secret.Name,
-		})
-	}
-	return out
-}
-
-func (p *PrivateRegistry) PullSecretsAsSecretReferences() []catalogv1.SecretReference {
-	var out []catalogv1.SecretReference
-	for _, secret := range p.PullSecrets {
-		out = append(out, catalogv1.SecretReference{
 			Name: secret.Name,
 		})
 	}
@@ -219,26 +211,9 @@ func generateProvisionedClusterDockerConfig(cluster *v3.Cluster, secretLister v1
 		return v2ProvRegistryURL, nil, err
 	}
 
-	var configJson []byte
-	if registrySecret.Type == kcorev1.SecretTypeDockerConfigJson {
-		if registrySecret.Data == nil {
-			return v2ProvRegistryURL, nil, nil
-		}
-		_, _, _, err := UnwrapDockerConfigJson(v2ProvRegistryURL, registrySecret.Data)
-		if err != nil {
-			// A .dockerconfigjson may contain credentials for a number of registry hostnames,
-			// ensure that we are only delivering credentials for the configured hostname.
-			if err.Error() == fmt.Sprintf(ErrRegistryHostnameNotFound, v2ProvRegistryURL) {
-				return v2ProvRegistryURL, nil, nil
-			}
-			return v2ProvRegistryURL, nil, err
-		}
-		configJson, _ = registrySecret.Data[kcorev1.DockerConfigJsonKey]
-	} else {
-		configJson, err = ConvertToDockerConfigJson(v2ProvRegistryURL, registrySecret)
-		if err != nil {
-			return "", nil, fmt.Errorf("clusterDeploy: failed to convert pull secret to json for cluster %s: %w", cluster.Name, err)
-		}
+	configJson, err := generateConfigJson(v2ProvRegistryURL, registrySecret)
+	if err != nil {
+		return v2ProvRegistryURL, nil, err
 	}
 
 	if configJson == nil {
@@ -269,21 +244,50 @@ func generateImportedClusterDockerConfig(cluster *v3.Cluster, secretLister v1.Se
 
 	// build out all the cluster level pull secrets
 	for _, pullSecret := range registry.PullSecrets {
-		sec, err := secretLister.Get(pullSecret.Namespace, pullSecret.Name)
+		registrySecret, err := secretLister.Get(pullSecret.Namespace, pullSecret.Name)
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to get pull secret %s in namespace %s for cluster %s: %w", pullSecret.Name, pullSecret.Namespace, cluster.Name, err)
 		}
 
-		configJson, err := ConvertToDockerConfigJson(clusterSystemDefaultURL, sec)
+		configJson, err := generateConfigJson(clusterSystemDefaultURL, registrySecret)
 		if err != nil {
 			return "", nil, fmt.Errorf("clusterDeploy: failed to convert pull secret to json: %w", err)
 		}
 
+		if configJson == nil {
+			continue
+		}
+
 		pullSecrets = append(pullSecrets, AgentPullSecret{
-			Name:             GeneratePullSecretName(sec.Name),
+			Name:             GeneratePullSecretName(registrySecret.Name),
 			DockerConfigJSON: base64.StdEncoding.EncodeToString(configJson),
 		})
 	}
 
 	return clusterSystemDefaultURL, pullSecrets, nil
+}
+
+func generateConfigJson(clusterSystemDefaultURL string, secret *kcorev1.Secret) ([]byte, error) {
+	var configJson []byte
+	var err error
+	if secret.Type == kcorev1.SecretTypeDockerConfigJson {
+		if secret.Data == nil {
+			return nil, nil
+		}
+		// A .dockerconfigjson may contain credentials for a number of registry hostnames,
+		// we need to ensure that we are only delivering credentials for the configured hostname.
+		configJson, err = FilterDockerConfigJson(clusterSystemDefaultURL, secret.Data)
+		if err != nil {
+			if err.Error() == fmt.Sprintf(ErrRegistryHostnameNotFound, clusterSystemDefaultURL) {
+				return nil, nil
+			}
+			return nil, err
+		}
+	} else {
+		configJson, err = ConvertToDockerConfigJson(clusterSystemDefaultURL, secret)
+		if err != nil {
+			return nil, fmt.Errorf("clusterDeploy: failed to convert pull secret to json for cluster: %w", err)
+		}
+	}
+	return configJson, nil
 }

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/fleet"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
@@ -53,6 +54,16 @@ func (p *PrivateRegistry) PullSecretsAsObjectReferences() []kcorev1.LocalObjectR
 	var out []kcorev1.LocalObjectReference
 	for _, secret := range p.PullSecrets {
 		out = append(out, kcorev1.LocalObjectReference{
+			Name: secret.Name,
+		})
+	}
+	return out
+}
+
+func (p *PrivateRegistry) PullSecretsAsSecretReferences() []catalogv1.SecretReference {
+	var out []catalogv1.SecretReference
+	for _, secret := range p.PullSecrets {
+		out = append(out, catalogv1.SecretReference{
 			Name: secret.Name,
 		})
 	}

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -208,9 +208,30 @@ func generateProvisionedClusterDockerConfig(cluster *v3.Cluster, secretLister v1
 		return v2ProvRegistryURL, nil, err
 	}
 
-	configJson, err := ConvertToDockerConfigJson(v2ProvRegistryURL, registrySecret)
-	if err != nil {
-		return "", nil, fmt.Errorf("clusterDeploy: failed to convert pull secret to json for cluster %s: %w", cluster.Name, err)
+	var configJson []byte
+	if registrySecret.Type == kcorev1.SecretTypeDockerConfigJson {
+		if registrySecret.Data == nil {
+			return v2ProvRegistryURL, nil, nil
+		}
+		_, _, _, err := UnwrapDockerConfigJson(v2ProvRegistryURL, registrySecret.Data)
+		if err != nil {
+			// A .dockerconfigjson may contain credentials for a number of registry hostnames,
+			// ensure that we are only delivering credentials for the configured hostname.
+			if err.Error() == fmt.Sprintf(ErrRegistryHostnameNotFound, v2ProvRegistryURL) {
+				return v2ProvRegistryURL, nil, nil
+			}
+			return v2ProvRegistryURL, nil, err
+		}
+		configJson, _ = registrySecret.Data[kcorev1.DockerConfigJsonKey]
+	} else {
+		configJson, err = ConvertToDockerConfigJson(v2ProvRegistryURL, registrySecret)
+		if err != nil {
+			return "", nil, fmt.Errorf("clusterDeploy: failed to convert pull secret to json for cluster %s: %w", cluster.Name, err)
+		}
+	}
+
+	if configJson == nil {
+		return v2ProvRegistryURL, nil, nil
 	}
 
 	// note:

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -278,7 +279,7 @@ func generateConfigJson(clusterSystemDefaultURL string, secret *kcorev1.Secret) 
 		// we need to ensure that we are only delivering credentials for the configured hostname.
 		configJson, err = FilterDockerConfigJson(clusterSystemDefaultURL, secret.Data)
 		if err != nil {
-			if err.Error() == fmt.Sprintf(ErrRegistryHostnameNotFound, clusterSystemDefaultURL) {
+			if errors.Is(err, ErrRegistryHostnameNotFound) {
 				return nil, nil
 			}
 			return nil, err

--- a/pkg/cluster/private_registry_docker_config.go
+++ b/pkg/cluster/private_registry_docker_config.go
@@ -26,34 +26,7 @@ const (
 // ConvertToDockerConfigJson converts various types of secrets into a proper .dockerconfigjson format. Specifically, rke.cattle.io/auth-config, kubernetes.io/basic-auth,
 // and kubernetes.io/dockerconfigjson secrets are supported. This is required as the Rancher UI may specify non-dockerconfigjson secrets on the management cluster.
 func ConvertToDockerConfigJson(registryHost string, secret *kcorev1.Secret) ([]byte, error) {
-	switch secret.Type {
-	case v1.AuthConfigSecretType:
-		if secret.Data == nil {
-			return nil, fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
-		}
-		auth, ok := secret.Data["auth"]
-		if !ok {
-			return nil, fmt.Errorf(ErrAuthKeyNotFound, secret.Name, registryHost)
-		}
-		username, password, found := strings.Cut(string(auth), ":")
-		if !found {
-			return nil, fmt.Errorf(ErrAuthMalformed, secret.Name, registryHost)
-		}
-		return BuildDockerConfigJson(registryHost, username, password)
-	case kcorev1.SecretTypeBasicAuth:
-		if secret.Data == nil {
-			return nil, fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
-		}
-		username, ok := secret.Data["username"]
-		if !ok {
-			return nil, fmt.Errorf(ErrUsernameNotFound, secret.Name, registryHost)
-		}
-		password, ok := secret.Data["password"]
-		if !ok {
-			return nil, fmt.Errorf(ErrPasswordNotFound, secret.Name, registryHost)
-		}
-		return BuildDockerConfigJson(registryHost, string(username), string(password))
-	case kcorev1.SecretTypeDockerConfigJson:
+	if secret.Type == kcorev1.SecretTypeDockerConfigJson {
 		if secret.Data == nil {
 			return nil, fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
 		}
@@ -62,8 +35,52 @@ func ConvertToDockerConfigJson(registryHost string, secret *kcorev1.Secret) ([]b
 			return nil, fmt.Errorf(ErrDockerConfigKeyNotFound, secret.Name, registryHost)
 		}
 		return cfg, nil
+	}
+
+	username, password, err := ExtractUsernamePasswordFromPullSecret(registryHost, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return BuildDockerConfigJson(registryHost, username, password)
+}
+
+func ExtractUsernamePasswordFromPullSecret(registryHost string, secret *kcorev1.Secret) (string, string, error) {
+	switch secret.Type {
+	case v1.AuthConfigSecretType:
+		if secret.Data == nil {
+			return "", "", fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
+		}
+		auth, ok := secret.Data["auth"]
+		if !ok {
+			return "", "", fmt.Errorf(ErrAuthKeyNotFound, secret.Name, registryHost)
+		}
+		username, password, found := strings.Cut(string(auth), ":")
+		if !found {
+			return "", "", fmt.Errorf(ErrAuthMalformed, secret.Name, registryHost)
+		}
+		return username, password, nil
+	case kcorev1.SecretTypeBasicAuth:
+		if secret.Data == nil {
+			return "", "", fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
+		}
+		username, ok := secret.Data["username"]
+		if !ok {
+			return "", "", fmt.Errorf(ErrUsernameNotFound, secret.Name, registryHost)
+		}
+		password, ok := secret.Data["password"]
+		if !ok {
+			return "", "", fmt.Errorf(ErrPasswordNotFound, secret.Name, registryHost)
+		}
+		return string(username), string(password), nil
+	case kcorev1.SecretTypeDockerConfigJson:
+		if secret.Data == nil {
+			return "", "", fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
+		}
+		username, password, _, err := UnwrapDockerConfigJson(registryHost, secret.Data)
+		return username, password, err
 	default:
-		return nil, fmt.Errorf(ErrUnsupportedSecretType, secret.Name, registryHost, secret.Type)
+		return "", "", fmt.Errorf(ErrUnsupportedSecretType, secret.Name, registryHost, secret.Type)
 	}
 }
 

--- a/pkg/cluster/private_registry_docker_config.go
+++ b/pkg/cluster/private_registry_docker_config.go
@@ -118,3 +118,31 @@ func UnwrapDockerConfigJson(registryHostname string, configJson map[string][]byt
 	auth = fmt.Sprintf("%s:%s", entry.Username, entry.Password)
 	return entry.Username, entry.Password, base64.StdEncoding.EncodeToString([]byte(auth)), nil
 }
+
+// FilterDockerConfigJson extracts the specific Auth entry for the given registry hostname from a .dockerconfigjson
+// secret and returns a new .dockerconfigjson containing only that entry.
+func FilterDockerConfigJson(registryHostname string, configJson map[string][]byte) ([]byte, error) {
+	credJson, ok := configJson[kcorev1.DockerConfigJsonKey]
+	if !ok {
+		return nil, fmt.Errorf(ErrDockerConfigJsonNotFound, registryHostname)
+	}
+
+	var cred credentialprovider.DockerConfigJSON
+	err := json.Unmarshal(credJson, &cred)
+	if err != nil {
+		return nil, err
+	}
+
+	entry, ok := cred.Auths[registryHostname]
+	if !ok {
+		return nil, fmt.Errorf(ErrRegistryHostnameNotFound, registryHostname)
+	}
+
+	filtered := credentialprovider.DockerConfigJSON{
+		Auths: credentialprovider.DockerConfig{
+			registryHostname: entry,
+		},
+	}
+
+	return json.Marshal(filtered)
+}

--- a/pkg/cluster/private_registry_docker_config.go
+++ b/pkg/cluster/private_registry_docker_config.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,28 +12,40 @@ import (
 	"k8s.io/kubernetes/pkg/credentialprovider"
 )
 
-const (
-	ErrSecretDataNil            = "pull secret %q for registry %q has nil data"
-	ErrAuthKeyNotFound          = "pull secret %q for registry %q of type 'rke.cattle.io/auth-config' is missing the 'auth' key"
-	ErrAuthMalformed            = "pull secret %q for registry %q of type 'rke.cattle.io/auth-config' has malformed 'auth' value: expected username:password format"
-	ErrUsernameNotFound         = "pull secret %q for registry %q of type 'kubernetes.io/basic-auth' is missing the 'username' field"
-	ErrPasswordNotFound         = "pull secret %q for registry %q of type 'kubernetes.io/basic-auth' is missing the 'password' field"
-	ErrDockerConfigKeyNotFound  = "pull secret %q for registry %q of type 'kubernetes.io/dockerconfigjson' is missing the '.dockerconfigjson' field"
-	ErrUnsupportedSecretType    = "pull secret %q for registry %q has unsupported type %q"
-	ErrDockerConfigJsonNotFound = "pull secret for registry %q is missing the '.dockerconfigjson' key"
-	ErrRegistryHostnameNotFound = "registry hostname %q not found in pull secret"
+var (
+	ErrSecretDataNil            = errors.New("pull secret has nil data")
+	ErrAuthKeyNotFound          = errors.New("pull secret is missing the 'auth' key")
+	ErrAuthMalformed            = errors.New("pull secret has malformed 'auth' value: expected username:password format")
+	ErrUsernameNotFound         = errors.New("pull secret is missing the 'username' field")
+	ErrPasswordNotFound         = errors.New("pull secret is missing the 'password' field")
+	ErrDockerConfigKeyNotFound  = errors.New("pull secret is missing the '.dockerconfigjson' field")
+	ErrUnsupportedSecretType    = errors.New("pull secret has unsupported type")
+	ErrDockerConfigJsonNotFound = errors.New("pull secret is missing the '.dockerconfigjson' key")
+	ErrRegistryHostnameNotFound = errors.New("registry hostname not found in pull secret")
 )
+
+type registryError struct {
+	kind error
+	msg  string
+}
+
+func (e *registryError) Error() string        { return e.msg }
+func (e *registryError) Is(target error) bool { return errors.Is(e.kind, target) }
+
+func registryErr(kind error, format string, args ...any) error {
+	return &registryError{kind: kind, msg: fmt.Sprintf(format, args...)}
+}
 
 // ConvertToDockerConfigJson converts various types of secrets into a proper .dockerconfigjson format. Specifically, rke.cattle.io/auth-config, kubernetes.io/basic-auth,
 // and kubernetes.io/dockerconfigjson secrets are supported. This is required as the Rancher UI may specify non-dockerconfigjson secrets on the management cluster.
 func ConvertToDockerConfigJson(registryHost string, secret *kcorev1.Secret) ([]byte, error) {
 	if secret.Type == kcorev1.SecretTypeDockerConfigJson {
 		if secret.Data == nil {
-			return nil, fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
+			return nil, registryErr(ErrSecretDataNil, "pull secret %q for registry %q has nil data", secret.Name, registryHost)
 		}
 		cfg, ok := secret.Data[kcorev1.DockerConfigJsonKey]
 		if !ok {
-			return nil, fmt.Errorf(ErrDockerConfigKeyNotFound, secret.Name, registryHost)
+			return nil, registryErr(ErrDockerConfigKeyNotFound, "pull secret %q for registry %q of type 'kubernetes.io/dockerconfigjson' is missing the '.dockerconfigjson' field", secret.Name, registryHost)
 		}
 		return cfg, nil
 	}
@@ -49,38 +62,38 @@ func ExtractUsernamePasswordFromPullSecret(registryHost string, secret *kcorev1.
 	switch secret.Type {
 	case v1.AuthConfigSecretType:
 		if secret.Data == nil {
-			return "", "", fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
+			return "", "", registryErr(ErrSecretDataNil, "pull secret %q for registry %q has nil data", secret.Name, registryHost)
 		}
 		auth, ok := secret.Data["auth"]
 		if !ok {
-			return "", "", fmt.Errorf(ErrAuthKeyNotFound, secret.Name, registryHost)
+			return "", "", registryErr(ErrAuthKeyNotFound, "pull secret %q for registry %q of type 'rke.cattle.io/auth-config' is missing the 'auth' key", secret.Name, registryHost)
 		}
 		username, password, found := strings.Cut(string(auth), ":")
 		if !found {
-			return "", "", fmt.Errorf(ErrAuthMalformed, secret.Name, registryHost)
+			return "", "", registryErr(ErrAuthMalformed, "pull secret %q for registry %q of type 'rke.cattle.io/auth-config' has malformed 'auth' value: expected username:password format", secret.Name, registryHost)
 		}
 		return username, password, nil
 	case kcorev1.SecretTypeBasicAuth:
 		if secret.Data == nil {
-			return "", "", fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
+			return "", "", registryErr(ErrSecretDataNil, "pull secret %q for registry %q has nil data", secret.Name, registryHost)
 		}
 		username, ok := secret.Data["username"]
 		if !ok {
-			return "", "", fmt.Errorf(ErrUsernameNotFound, secret.Name, registryHost)
+			return "", "", registryErr(ErrUsernameNotFound, "pull secret %q for registry %q of type 'kubernetes.io/basic-auth' is missing the 'username' field", secret.Name, registryHost)
 		}
 		password, ok := secret.Data["password"]
 		if !ok {
-			return "", "", fmt.Errorf(ErrPasswordNotFound, secret.Name, registryHost)
+			return "", "", registryErr(ErrPasswordNotFound, "pull secret %q for registry %q of type 'kubernetes.io/basic-auth' is missing the 'password' field", secret.Name, registryHost)
 		}
 		return string(username), string(password), nil
 	case kcorev1.SecretTypeDockerConfigJson:
 		if secret.Data == nil {
-			return "", "", fmt.Errorf(ErrSecretDataNil, secret.Name, registryHost)
+			return "", "", registryErr(ErrSecretDataNil, "pull secret %q for registry %q has nil data", secret.Name, registryHost)
 		}
 		username, password, _, err := UnwrapDockerConfigJson(registryHost, secret.Data)
 		return username, password, err
 	default:
-		return "", "", fmt.Errorf(ErrUnsupportedSecretType, secret.Name, registryHost, secret.Type)
+		return "", "", registryErr(ErrUnsupportedSecretType, "pull secret %q for registry %q has unsupported type %q", secret.Name, registryHost, secret.Type)
 	}
 }
 
@@ -101,7 +114,7 @@ func BuildDockerConfigJson(registryHostname, username, password string) ([]byte,
 func UnwrapDockerConfigJson(registryHostname string, configJson map[string][]byte) (username string, password string, auth string, err error) {
 	credJson, ok := configJson[kcorev1.DockerConfigJsonKey]
 	if !ok {
-		return "", "", "", fmt.Errorf(ErrDockerConfigJsonNotFound, registryHostname)
+		return "", "", "", registryErr(ErrDockerConfigJsonNotFound, "pull secret for registry %q is missing the '.dockerconfigjson' key", registryHostname)
 	}
 
 	var cred credentialprovider.DockerConfigJSON
@@ -112,7 +125,7 @@ func UnwrapDockerConfigJson(registryHostname string, configJson map[string][]byt
 
 	entry, ok := cred.Auths[registryHostname]
 	if !ok {
-		return "", "", "", fmt.Errorf(ErrRegistryHostnameNotFound, registryHostname)
+		return "", "", "", registryErr(ErrRegistryHostnameNotFound, "registry hostname %q not found in pull secret", registryHostname)
 	}
 
 	auth = fmt.Sprintf("%s:%s", entry.Username, entry.Password)
@@ -124,7 +137,7 @@ func UnwrapDockerConfigJson(registryHostname string, configJson map[string][]byt
 func FilterDockerConfigJson(registryHostname string, configJson map[string][]byte) ([]byte, error) {
 	credJson, ok := configJson[kcorev1.DockerConfigJsonKey]
 	if !ok {
-		return nil, fmt.Errorf(ErrDockerConfigJsonNotFound, registryHostname)
+		return nil, registryErr(ErrDockerConfigJsonNotFound, "pull secret for registry %q is missing the '.dockerconfigjson' key", registryHostname)
 	}
 
 	var cred credentialprovider.DockerConfigJSON
@@ -135,7 +148,7 @@ func FilterDockerConfigJson(registryHostname string, configJson map[string][]byt
 
 	entry, ok := cred.Auths[registryHostname]
 	if !ok {
-		return nil, fmt.Errorf(ErrRegistryHostnameNotFound, registryHostname)
+		return nil, registryErr(ErrRegistryHostnameNotFound, "registry hostname %q not found in pull secret", registryHostname)
 	}
 
 	filtered := credentialprovider.DockerConfigJSON{

--- a/pkg/cluster/private_registry_docker_config_test.go
+++ b/pkg/cluster/private_registry_docker_config_test.go
@@ -207,6 +207,98 @@ func TestBuildDockerConfigJson(t *testing.T) {
 	}
 }
 
+func TestFilterDockerConfigJson(t *testing.T) {
+	t.Parallel()
+
+	const host = "registry.example.com"
+
+	makeConfigJSON := func(entries map[string]credentialprovider.DockerConfigEntry) map[string][]byte {
+		raw, _ := json.Marshal(credentialprovider.DockerConfigJSON{
+			Auths: credentialprovider.DockerConfig(entries),
+		})
+		return map[string][]byte{corev1.DockerConfigJsonKey: raw}
+	}
+
+	tests := []struct {
+		name           string
+		host           string
+		data           map[string][]byte
+		expectedErrMsg string
+		validate       func(t *testing.T, got []byte)
+	}{
+		{
+			name: "valid config with single entry returns that entry",
+			host: host,
+			data: makeConfigJSON(map[string]credentialprovider.DockerConfigEntry{
+				host: {Username: "myuser", Password: "mypass"},
+			}),
+			validate: func(t *testing.T, got []byte) {
+				var parsed credentialprovider.DockerConfigJSON
+				require.NoError(t, json.Unmarshal(got, &parsed))
+				require.Len(t, parsed.Auths, 1)
+				entry, ok := parsed.Auths[host]
+				require.True(t, ok)
+				assert.Equal(t, "myuser", entry.Username)
+				assert.Equal(t, "mypass", entry.Password)
+			},
+		},
+		{
+			name: "multi-entry config returns only requested hostname",
+			host: host,
+			data: makeConfigJSON(map[string]credentialprovider.DockerConfigEntry{
+				host:                 {Username: "myuser", Password: "mypass"},
+				"other.registry.com": {Username: "otheruser", Password: "otherpass"},
+			}),
+			validate: func(t *testing.T, got []byte) {
+				var parsed credentialprovider.DockerConfigJSON
+				require.NoError(t, json.Unmarshal(got, &parsed))
+				require.Len(t, parsed.Auths, 1)
+				entry, ok := parsed.Auths[host]
+				require.True(t, ok, "expected entry for %q", host)
+				assert.Equal(t, "myuser", entry.Username)
+				assert.Equal(t, "mypass", entry.Password)
+				_, hasOther := parsed.Auths["other.registry.com"]
+				assert.False(t, hasOther, "filtered config should not contain other registry entries")
+			},
+		},
+		{
+			name:           "missing .dockerconfigjson key",
+			host:           host,
+			data:           map[string][]byte{},
+			expectedErrMsg: fmt.Sprintf(ErrDockerConfigJsonNotFound, host),
+		},
+		{
+			name:           "invalid JSON",
+			host:           host,
+			data:           map[string][]byte{corev1.DockerConfigJsonKey: []byte("not-json")},
+			expectedErrMsg: "invalid character",
+		},
+		{
+			name: "hostname not found in auths",
+			host: "other.registry.example.com",
+			data: makeConfigJSON(map[string]credentialprovider.DockerConfigEntry{
+				host: {Username: "myuser", Password: "mypass"},
+			}),
+			expectedErrMsg: fmt.Sprintf(ErrRegistryHostnameNotFound, "other.registry.example.com"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := FilterDockerConfigJson(tt.host, tt.data)
+			if tt.expectedErrMsg != "" {
+				assert.ErrorContains(t, err, tt.expectedErrMsg)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			tt.validate(t, got)
+		})
+	}
+}
+
 func TestUnwrapDockerConfigJson(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cluster/private_registry_docker_config_test.go
+++ b/pkg/cluster/private_registry_docker_config_test.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	v1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
@@ -27,10 +26,10 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		secret         *corev1.Secret
-		expectedErrMsg string
-		validate       func(t *testing.T, got []byte)
+		name        string
+		secret      *corev1.Secret
+		expectedErr error
+		validate    func(t *testing.T, got []byte)
 	}{
 		{
 			name: "rke auth-config: valid",
@@ -49,7 +48,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "auth-secret"},
 				Type:       v1.AuthConfigSecretType,
 			},
-			expectedErrMsg: fmt.Sprintf(ErrSecretDataNil, "auth-secret", host),
+			expectedErr: ErrSecretDataNil,
 		},
 		{
 			name: "rke auth-config: missing auth key",
@@ -58,7 +57,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				Type:       v1.AuthConfigSecretType,
 				Data:       map[string][]byte{},
 			},
-			expectedErrMsg: fmt.Sprintf(ErrAuthKeyNotFound, "auth-secret", host),
+			expectedErr: ErrAuthKeyNotFound,
 		},
 		{
 			name: "rke auth-config: malformed auth value (no colon delimiter)",
@@ -67,7 +66,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				Type:       v1.AuthConfigSecretType,
 				Data:       map[string][]byte{"auth": []byte("myusermypass")},
 			},
-			expectedErrMsg: fmt.Sprintf(ErrAuthMalformed, "auth-secret", host),
+			expectedErr: ErrAuthMalformed,
 		},
 		{
 			name: "basic-auth: valid",
@@ -89,7 +88,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "basic-secret"},
 				Type:       corev1.SecretTypeBasicAuth,
 			},
-			expectedErrMsg: fmt.Sprintf(ErrSecretDataNil, "basic-secret", host),
+			expectedErr: ErrSecretDataNil,
 		},
 		{
 			name: "basic-auth: missing username",
@@ -98,7 +97,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				Type:       corev1.SecretTypeBasicAuth,
 				Data:       map[string][]byte{"password": []byte("mypass")},
 			},
-			expectedErrMsg: fmt.Sprintf(ErrUsernameNotFound, "basic-secret", host),
+			expectedErr: ErrUsernameNotFound,
 		},
 		{
 			name: "basic-auth: missing password",
@@ -107,7 +106,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				Type:       corev1.SecretTypeBasicAuth,
 				Data:       map[string][]byte{"username": []byte("myuser")},
 			},
-			expectedErrMsg: fmt.Sprintf(ErrPasswordNotFound, "basic-secret", host),
+			expectedErr: ErrPasswordNotFound,
 		},
 		{
 			name: "dockerconfigjson: valid passthrough",
@@ -128,7 +127,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret"},
 				Type:       corev1.SecretTypeDockerConfigJson,
 			},
-			expectedErrMsg: fmt.Sprintf(ErrSecretDataNil, "docker-secret", host),
+			expectedErr: ErrSecretDataNil,
 		},
 		{
 			name: "dockerconfigjson: missing key",
@@ -137,7 +136,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				Type:       corev1.SecretTypeDockerConfigJson,
 				Data:       map[string][]byte{},
 			},
-			expectedErrMsg: fmt.Sprintf(ErrDockerConfigKeyNotFound, "docker-secret", host),
+			expectedErr: ErrDockerConfigKeyNotFound,
 		},
 		{
 			name: "unsupported secret type",
@@ -146,7 +145,7 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 				Type:       "some.other/type",
 				Data:       map[string][]byte{},
 			},
-			expectedErrMsg: fmt.Sprintf(ErrUnsupportedSecretType, "other-secret", host, "some.other/type"),
+			expectedErr: ErrUnsupportedSecretType,
 		},
 	}
 
@@ -155,8 +154,8 @@ func TestConvertToDockerConfigJson(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ConvertToDockerConfigJson(host, tt.secret)
-			if tt.expectedErrMsg != "" {
-				assert.ErrorContains(t, err, tt.expectedErrMsg)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
 				assert.Nil(t, got)
 				return
 			}
@@ -220,11 +219,12 @@ func TestFilterDockerConfigJson(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		host           string
-		data           map[string][]byte
-		expectedErrMsg string
-		validate       func(t *testing.T, got []byte)
+		name        string
+		host        string
+		data        map[string][]byte
+		expectedErr error
+		wantErr     bool
+		validate    func(t *testing.T, got []byte)
 	}{
 		{
 			name: "valid config with single entry returns that entry",
@@ -262,16 +262,16 @@ func TestFilterDockerConfigJson(t *testing.T) {
 			},
 		},
 		{
-			name:           "missing .dockerconfigjson key",
-			host:           host,
-			data:           map[string][]byte{},
-			expectedErrMsg: fmt.Sprintf(ErrDockerConfigJsonNotFound, host),
+			name:        "missing .dockerconfigjson key",
+			host:        host,
+			data:        map[string][]byte{},
+			expectedErr: ErrDockerConfigJsonNotFound,
 		},
 		{
-			name:           "invalid JSON",
-			host:           host,
-			data:           map[string][]byte{corev1.DockerConfigJsonKey: []byte("not-json")},
-			expectedErrMsg: "invalid character",
+			name:    "invalid JSON",
+			host:    host,
+			data:    map[string][]byte{corev1.DockerConfigJsonKey: []byte("not-json")},
+			wantErr: true,
 		},
 		{
 			name: "hostname not found in auths",
@@ -279,7 +279,7 @@ func TestFilterDockerConfigJson(t *testing.T) {
 			data: makeConfigJSON(map[string]credentialprovider.DockerConfigEntry{
 				host: {Username: "myuser", Password: "mypass"},
 			}),
-			expectedErrMsg: fmt.Sprintf(ErrRegistryHostnameNotFound, "other.registry.example.com"),
+			expectedErr: ErrRegistryHostnameNotFound,
 		},
 	}
 
@@ -288,9 +288,13 @@ func TestFilterDockerConfigJson(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := FilterDockerConfigJson(tt.host, tt.data)
-			if tt.expectedErrMsg != "" {
-				assert.ErrorContains(t, err, tt.expectedErrMsg)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
 				assert.Nil(t, got)
+				return
+			}
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
@@ -323,7 +327,8 @@ func TestUnwrapDockerConfigJson(t *testing.T) {
 		expectedUsername string
 		expectedPassword string
 		expectedAuth     string
-		expectedErrMsg   string
+		expectedErr      error
+		wantErr          bool
 	}{
 		{
 			name:             "valid config with matching hostname",
@@ -334,22 +339,22 @@ func TestUnwrapDockerConfigJson(t *testing.T) {
 			expectedAuth:     base64.StdEncoding.EncodeToString([]byte("myuser:mypass")),
 		},
 		{
-			name:           "missing .dockerconfigjson key",
-			host:           host,
-			data:           map[string][]byte{},
-			expectedErrMsg: fmt.Sprintf(ErrDockerConfigJsonNotFound, host),
+			name:        "missing .dockerconfigjson key",
+			host:        host,
+			data:        map[string][]byte{},
+			expectedErr: ErrDockerConfigJsonNotFound,
 		},
 		{
-			name:           "invalid JSON",
-			host:           host,
-			data:           map[string][]byte{corev1.DockerConfigJsonKey: []byte("not-json")},
-			expectedErrMsg: "invalid character",
+			name:    "invalid JSON",
+			host:    host,
+			data:    map[string][]byte{corev1.DockerConfigJsonKey: []byte("not-json")},
+			wantErr: true,
 		},
 		{
-			name:           "hostname not found in auths",
-			host:           "other.registry.example.com",
-			data:           makeConfigJSON(host, "myuser", "mypass"),
-			expectedErrMsg: fmt.Sprintf(ErrRegistryHostnameNotFound, "other.registry.example.com"),
+			name:        "hostname not found in auths",
+			host:        "other.registry.example.com",
+			data:        makeConfigJSON(host, "myuser", "mypass"),
+			expectedErr: ErrRegistryHostnameNotFound,
 		},
 	}
 
@@ -358,8 +363,12 @@ func TestUnwrapDockerConfigJson(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			username, password, auth, err := UnwrapDockerConfigJson(tt.host, tt.data)
-			if tt.expectedErrMsg != "" {
-				assert.ErrorContains(t, err, tt.expectedErrMsg)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+				return
+			}
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/controllers/capr/autoscaler/autoscaler.go
+++ b/pkg/controllers/capr/autoscaler/autoscaler.go
@@ -109,6 +109,9 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 		if err := h.secretClient.Delete("fleet-default", autoscalerHelmSecretResourceName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logrus.Errorf("[autoscaler] failed to clean up root helm-op secret in fleet-default: %v", err)
 		}
+		if err := h.secretClient.Delete("fleet-default", autoscalerChartImagePullSecretName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			logrus.Errorf("[autoscaler] failed to clean up root image pull secret in fleet-default: %v", err)
+		}
 		clients.CAPI.Cluster().OnChange(ctx, "autoscaler-cleanup", h.ensureCleanup)
 		return
 	}

--- a/pkg/controllers/capr/autoscaler/autoscaler.go
+++ b/pkg/controllers/capr/autoscaler/autoscaler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta2"
@@ -23,12 +24,16 @@ import (
 	wranglerv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const helmSecretSync = "autoscaler-helm-secret-sync"
 
 // dynamicGetter defines the interface for the Get method from dynamic.Controller
 type dynamicGetter interface {
@@ -100,6 +105,10 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	// only run the "create" handlers if autoscaling is enabled. otherwise only run the cleanup handler
 	// (in case the user disabled autoscaling after having it enabled
 	if !features.ClusterAutoscaling.Enabled() {
+		// Clean up the shared root helm-op secret in fleet-default
+		if err := h.secretClient.Delete("fleet-default", autoscalerHelmSecretResourceName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			logrus.Errorf("[autoscaler] failed to clean up root helm-op secret in fleet-default: %v", err)
+		}
 		clients.CAPI.Cluster().OnChange(ctx, "autoscaler-cleanup", h.ensureCleanup)
 		return
 	}
@@ -107,7 +116,7 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 	// warn the user if they have the autoscaling feature-flag enabled but no chart repo set,
 	// then do not run the controller.
 	if settings.ClusterAutoscalerChartRepository.Get() == "" {
-		logrus.Warnf("[autoscaler] no value is set for the cluster-autoscaler-chart-repo Setting  - cannot enable autoscaling!")
+		logrus.Warnf("[autoscaler] no value is set for the cluster-autoscaler-chart-repo Setting - cannot enable autoscaling!")
 		return
 	}
 
@@ -116,6 +125,19 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 
 	clients.CAPI.Cluster().OnChange(ctx, "autoscaler-mgr", h.OnChange)
 	clients.Fleet.HelmOp().OnChange(ctx, "autoscaler-status-sync", h.syncHelmOpStatus)
+	clients.Mgmt.Setting().OnChange(ctx, helmSecretSync, h.syncRootHelmOpSecret)
+}
+
+// syncRootHelmOpSecret manages root HelmOp and image pull secrets in the fleet-default namespace. This secret
+// is used by the fleet agent to authenticate with the OCI registry containing the autoscaler chart, and to pull the
+// actual autoscaler image, respectively. This function ensures that the root secrets are kept up to date with
+// the current image pull secret value defined in the first value of the settings.SystemDefaultRegistryPullSecrets setting.
+func (h *autoscalerHandler) syncRootHelmOpSecret(_ string, setting *v3.Setting) (*v3.Setting, error) {
+	if setting == nil || (setting.Name != settings.SystemDefaultRegistryPullSecrets.Name && setting.Name != settings.SystemDefaultRegistry.Name) {
+		return setting, nil
+	}
+	_, _, err := h.ensureRootHelmOpSecrets()
+	return setting, err
 }
 
 // OnChange handles changes to CAPI clusters and manages autoscaler deployment.

--- a/pkg/controllers/capr/autoscaler/autoscaler_test.go
+++ b/pkg/controllers/capr/autoscaler/autoscaler_test.go
@@ -725,6 +725,7 @@ func (s *autoscalerSuite) TestPauseAutoscaling_HappyPath_SuccessfulScaling() {
 
 	// Set up mock expectations
 	s.secretCache.EXPECT().Get(cluster.Namespace, kubeconfigSecretName(cluster)).Return(secret, nil)
+	s.expectManageHelmOpSecrets("test-cluster", "test-namespace")
 	s.helmOpCache.EXPECT().Get(cluster.Namespace, helmOpName(cluster)).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.helmOp.EXPECT().Create(gomock.Any()).DoAndReturn(func(helmOp *fleet.HelmOp) (*fleet.HelmOp, error) {
 		s.Equal(0, helmOp.Spec.BundleDeploymentOptions.Helm.Values.Data["replicaCount"], "HelmOp should be scaled to 0 replicas")
@@ -778,6 +779,7 @@ func (s *autoscalerSuite) TestPauseAutoscaling_Error_FailedToScaleHelmOp() {
 
 	// Set up mock expectations
 	s.secretCache.EXPECT().Get(cluster.Namespace, kubeconfigSecretName(cluster)).Return(secret, nil)
+	s.expectManageHelmOpSecrets("test-cluster", "test-namespace")
 	s.helmOpCache.EXPECT().Get(cluster.Namespace, helmOpName(cluster)).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.helmOp.EXPECT().Create(gomock.Any()).DoAndReturn(func(helmOp *fleet.HelmOp) (*fleet.HelmOp, error) {
 		s.Equal(0, helmOp.Spec.BundleDeploymentOptions.Helm.Values.Data["replicaCount"], "HelmOp should be scaled to 0 replicas")
@@ -837,6 +839,8 @@ func (s *autoscalerSuite) TestEnsureCleanup_HappyPath_SuccessfulCleanup() {
 	secretName := kubeconfigSecretName(cluster)
 	helmOpName := helmOpName(cluster)
 
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
+
 	// User doesn't exist (should not cause error)
 	s.userCache.EXPECT().Get(userName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 
@@ -877,6 +881,8 @@ func (s *autoscalerSuite) TestEnsureCleanup_Error_HandleUninstallFails() {
 	globalRoleBindingName := globalRoleBindingName(cluster)
 	secretName := kubeconfigSecretName(cluster)
 	helmOpName := helmOpName(cluster)
+
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	// User doesn't exist
 	s.userCache.EXPECT().Get(userName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
@@ -923,6 +929,7 @@ func (s *autoscalerSuite) TestEnsureCleanup_EdgeCase_ClusterWithEmptyName() {
 	secretName := kubeconfigSecretName(cluster)
 
 	// All resources don't exist (should handle empty names gracefully)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 	s.userCache.EXPECT().Get(userName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleCache.EXPECT().Get(globalRoleName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleBindingCache.EXPECT().Get(globalRoleBindingName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
@@ -953,6 +960,7 @@ func (s *autoscalerSuite) TestEnsureCleanup_EdgeCase_ClusterWithEmptyNamespace()
 	secretName := kubeconfigSecretName(cluster)
 
 	// All resources don't exist (should handle empty namespace gracefully)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 	s.userCache.EXPECT().Get(userName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleCache.EXPECT().Get(globalRoleName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleBindingCache.EXPECT().Get(globalRoleBindingName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
@@ -983,6 +991,7 @@ func (s *autoscalerSuite) TestEnsureCleanup_EdgeCase_ClusterWithSpecialCharacter
 	secretName := kubeconfigSecretName(cluster)
 
 	// All resources don't exist (should handle special characters gracefully)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 	s.userCache.EXPECT().Get(userName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleCache.EXPECT().Get(globalRoleName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleBindingCache.EXPECT().Get(globalRoleBindingName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
@@ -1031,6 +1040,8 @@ func (s *autoscalerSuite) TestEnsureCleanup_Error_MultipleCleanupFailures() {
 	globalRoleBindingName := globalRoleBindingName(cluster)
 	secretName := kubeconfigSecretName(cluster)
 	helmOpName := helmOpName(cluster)
+
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	// User exists but deletion fails
 	userDeleteError := fmt.Errorf("failed to delete user: access denied")
@@ -1082,6 +1093,7 @@ func (s *autoscalerSuite) TestEnsureCleanup_EdgeCase_EmptyKeyParameter() {
 	secretName := kubeconfigSecretName(cluster)
 
 	// All resources don't exist (should handle empty key gracefully)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 	s.userCache.EXPECT().Get(userName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleCache.EXPECT().Get(globalRoleName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.globalRoleBindingCache.EXPECT().Get(globalRoleBindingName).Return(nil, errors.NewNotFound(schema.GroupResource{}, ""))

--- a/pkg/controllers/capr/autoscaler/fleet.go
+++ b/pkg/controllers/capr/autoscaler/fleet.go
@@ -51,6 +51,11 @@ var defaultChartVersionConfigs = k8sVersionToAutoscalerChartVersions[34]
 // one key parameter here is the kubeconfigVersion which is legitimately just involved to
 // force a re-rollout of the downstream cluster-autoscaler deployment on token-rotation.
 func (h *autoscalerHandler) ensureFleetHelmOp(cluster *capi.Cluster, kubeconfigVersion string, replicaCount int) error {
+	helmOpSecretName, imagePullSecretName, err := h.manageHelmOpSecrets(cluster)
+	if err != nil {
+		return err
+	}
+
 	bundle := fleet.HelmOpSpec{
 		BundleSpec: fleet.BundleSpec{
 			Targets: []fleet.BundleTarget{
@@ -68,7 +73,7 @@ func (h *autoscalerHandler) ensureFleetHelmOp(cluster *capi.Cluster, kubeconfigV
 					Values: &fleet.GenericMap{
 						Data: map[string]any{
 							"replicaCount": replicaCount,
-							"image":        h.getChartImageSettings(cluster),
+							"image":        h.getChartImageSettings(cluster, imagePullSecretName),
 							"autoDiscovery": map[string]any{
 								"clusterName": cluster.Name,
 								"namespace":   cluster.Namespace,
@@ -95,6 +100,24 @@ func (h *autoscalerHandler) ensureFleetHelmOp(cluster *capi.Cluster, kubeconfigV
 				},
 			},
 		},
+	}
+
+	if helmOpSecretName != "" {
+		bundle.DownstreamResources = append(bundle.DownstreamResources, fleet.DownstreamResource{
+			Kind: "secret",
+			Name: helmOpSecretName,
+		})
+		bundle.HelmSecretName = helmOpSecretName
+		bundle.HelmOpOptions = &fleet.BundleHelmOptions{
+			SecretName: helmOpSecretName,
+		}
+	}
+
+	if imagePullSecretName != "" {
+		bundle.DownstreamResources = append(bundle.DownstreamResources, fleet.DownstreamResource{
+			Kind: "secret",
+			Name: imagePullSecretName,
+		})
 	}
 
 	helmOp, err := h.helmOpCache.Get(cluster.Namespace, helmOpName(cluster))
@@ -141,18 +164,23 @@ func (h *autoscalerHandler) chartVersionsForCluster(cluster *capi.Cluster) *k8sT
 }
 
 // getChartImageSettings returns a map of the image settings to pass to the chart, this is based on the kubernetes minor version
-func (h *autoscalerHandler) getChartImageSettings(cluster *capi.Cluster) map[string]any {
-	// if we don't specify an image - just use whatever is in the chart
+func (h *autoscalerHandler) getChartImageSettings(cluster *capi.Cluster, pullSecretName string) map[string]any {
+	imageSettings := map[string]any{}
+	if pullSecretName != "" {
+		imageSettings["pullSecrets"] = []string{pullSecretName}
+	}
+
 	autoscalerImage := settings.ClusterAutoscalerImage.Get()
+	// if we don't specify an image - just use whatever is in the chart
 	if autoscalerImage == "" {
-		return map[string]any{}
+		return imageSettings
 	}
 
 	// parse out the image to properly set all the values in the chart
 	imageRef, err := reference.ParseNamed(autoscalerImage)
 	if err != nil {
 		logrus.Debugf("[autoscaler] failed to parse autoscaler image '%s': %v", autoscalerImage, err)
-		return map[string]any{}
+		return imageSettings
 	}
 
 	registry := reference.Domain(imageRef)
@@ -161,13 +189,11 @@ func (h *autoscalerHandler) getChartImageSettings(cluster *capi.Cluster) map[str
 
 	// if we are not overriding all the image settings fall back to whatever is in the chart by default
 	if registry == "" && image == "" {
-		return map[string]any{}
+		return imageSettings
 	}
 
-	imageSettings := map[string]any{
-		"repository": image,
-		"registry":   registry,
-	}
+	imageSettings["repository"] = image
+	imageSettings["registry"] = registry
 
 	// this handles if the image setting was set with a tag - we just use that
 	// instead of the hardcoded version for the k8s version
@@ -247,6 +273,17 @@ func (h *autoscalerHandler) cleanupFleet(cluster *capi.Cluster) error {
 		}
 	} else if !errors.IsNotFound(err) {
 		errs = append(errs, fmt.Errorf("failed to check existence of Helm operation %s in namespace %s: %w", helmOpName, cluster.Namespace, err))
+	}
+
+	// Delete the cluster scoped autoscaler secrets if they exist
+	provCluster, err := h.clusterCache.Get(cluster.Namespace, cluster.Name)
+	if err == nil {
+		err = h.cleanupClusterScopedSecrets(provCluster, cluster)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	} else if !errors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("failed to check existence of Cluster %s in namespace %s when cleaning up Helm operation secrets: %w", cluster.Namespace, cluster.Name, err))
 	}
 
 	// Return combined errors if any occurred

--- a/pkg/controllers/capr/autoscaler/fleet.go
+++ b/pkg/controllers/capr/autoscaler/fleet.go
@@ -283,7 +283,7 @@ func (h *autoscalerHandler) cleanupFleet(cluster *capi.Cluster) error {
 			errs = append(errs, err)
 		}
 	} else if !errors.IsNotFound(err) {
-		errs = append(errs, fmt.Errorf("failed to check existence of Cluster %s in namespace %s when cleaning up Helm operation secrets: %w", cluster.Namespace, cluster.Name, err))
+		errs = append(errs, fmt.Errorf("failed to check existence of Cluster %s in namespace %s when cleaning up Helm operation secrets: %w", cluster.Name, cluster.Namespace, err))
 	}
 
 	// Return combined errors if any occurred

--- a/pkg/controllers/capr/autoscaler/fleet_test.go
+++ b/pkg/controllers/capr/autoscaler/fleet_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rke "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/settings"
 	"go.uber.org/mock/gomock"
@@ -167,11 +168,31 @@ func (s *autoscalerSuite) expectHelmOpDelete(namespace, name string, err error) 
 	s.helmOp.EXPECT().Delete(namespace, name, &metav1.DeleteOptions{}).Return(err)
 }
 
+// expectManageHelmOpSecrets sets up the mock expectations that manageHelmOpSecrets produces
+// when the cluster has no per-cluster registry auth configured (the common test scenario).
+func (s *autoscalerSuite) expectManageHelmOpSecrets(clusterName, clusterNamespace string) {
+	provCluster := &provv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterNamespace}}
+	s.clusterCache.EXPECT().Get(clusterNamespace, clusterName).Return(provCluster, nil)
+
+	notFound := errors.NewNotFound(schema.GroupResource{}, "")
+	// cleanupClusterScopedSecrets
+	s.secretClient.EXPECT().Delete(clusterNamespace, helmOpSecretName(clusterName, clusterNamespace), gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete(clusterNamespace, autoscalerClusterScopedImagePullSecretName(clusterName), gomock.Any()).Return(notFound)
+	// ensureRootHelmOpSecrets — no global registry → attempt to delete both root secrets
+	s.secretClient.EXPECT().Delete("fleet-default", autoscalerHelmSecretResourceName, gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete("fleet-default", autoscalerChartImagePullSecretName, gomock.Any()).Return(notFound)
+}
+
+func (s *autoscalerSuite) expectCleanupFleetProvisioningClusterNotFound(clusterNamespace, clusterName string) {
+	s.clusterCache.EXPECT().Get(clusterNamespace, clusterName).Return(nil, errors.NewNotFound(schema.GroupResource{}, "cluster"))
+}
+
 // Test cases for ensureFleetHelmOp method
 
 func (s *autoscalerSuite) TestEnsureFleetHelmOp_HappyPath_CreateNewHelmOp() {
 	cluster := s.createTestCluster("test-cluster", "default")
 
+	s.expectManageHelmOpSecrets("test-cluster", "default")
 	s.expectHelmOpGet("default", "autoscaler-default-test-cluster", nil, errors.NewNotFound(schema.GroupResource{}, ""))
 	s.expectHelmOpCreate()
 
@@ -194,6 +215,7 @@ func (s *autoscalerSuite) TestEnsureFleetHelmOp_HappyPath_UpdateExistingHelmOp()
 		},
 	}
 
+	s.expectManageHelmOpSecrets("test-cluster", "default")
 	s.expectHelmOpGet("default", "autoscaler-default-test-cluster", existingHelmOp, nil)
 	s.expectHelmOpUpdate("default", "cluster-autoscaler-test-cluster")
 
@@ -226,7 +248,7 @@ func (s *autoscalerSuite) TestEnsureFleetHelmOp_HappyPath_NoUpdateNeeded() {
 						Values: &fleet.GenericMap{
 							Data: map[string]any{
 								"replicaCount": 3,
-								"image":        s.h.getChartImageSettings(cluster),
+								"image":        s.h.getChartImageSettings(cluster, ""),
 								"autoDiscovery": map[string]any{
 									"clusterName": cluster.Name,
 									"namespace":   cluster.Namespace,
@@ -254,6 +276,7 @@ func (s *autoscalerSuite) TestEnsureFleetHelmOp_HappyPath_NoUpdateNeeded() {
 		},
 	}
 
+	s.expectManageHelmOpSecrets("test-cluster", "default")
 	s.expectHelmOpGet("default", "autoscaler-default-test-cluster", existingHelmOp, nil)
 	s.helmOp.EXPECT().Update(gomock.Any()).Times(0)
 
@@ -289,7 +312,7 @@ func (s *autoscalerSuite) TestResolveImageTagVersion_EdgeCase_UnknownVersion() {
 func (s *autoscalerSuite) TestGetChartImageSettings_HappyPath_NoOverride() {
 	cluster := s.createTestCluster("test-cluster", "default")
 
-	result := s.h.getChartImageSettings(cluster)
+	result := s.h.getChartImageSettings(cluster, "")
 	s.Equal(map[string]any{}, result)
 }
 
@@ -302,7 +325,7 @@ func (s *autoscalerSuite) TestGetChartImageSettings_HappyPath_WithValidImage() {
 
 	cluster := s.createTestCluster("test-cluster", "default")
 
-	result := s.h.getChartImageSettings(cluster)
+	result := s.h.getChartImageSettings(cluster, "")
 	expected := map[string]any{
 		"repository": "cluster-autoscaler",
 		"registry":   "registry.example.com",
@@ -366,6 +389,7 @@ func (s *autoscalerSuite) TestCleanupFleet_HappyPath_HelmOpExists() {
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, &fleet.HelmOp{}, nil)
 	s.expectHelmOpDelete(cluster.Namespace, helmOpName, nil)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err)
@@ -376,6 +400,7 @@ func (s *autoscalerSuite) TestCleanupFleet_HappyPath_HelmOpDoesNotExist() {
 	helmOpName := helmOpName(cluster)
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, errors.NewNotFound(schema.GroupResource{}, ""))
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err)
@@ -387,6 +412,7 @@ func (s *autoscalerSuite) TestCleanupFleet_EdgeCase_DeleteError() {
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, &fleet.HelmOp{}, nil)
 	s.expectHelmOpDelete(cluster.Namespace, helmOpName, fmt.Errorf("delete failed"))
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.Error(err)
@@ -400,6 +426,7 @@ func (s *autoscalerSuite) TestCleanupFleet_EdgeCase_GetError() {
 	helmOpName := helmOpName(cluster)
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, fmt.Errorf("get failed"))
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.Error(err)
@@ -414,6 +441,7 @@ func (s *autoscalerSuite) TestCleanupFleet_HappyPath_SuccessfulHelmOpDeletion() 
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, &fleet.HelmOp{}, nil)
 	s.expectHelmOpDelete(cluster.Namespace, helmOpName, nil)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err, "Expected no error when successfully cleaning up HelmOp")
@@ -424,9 +452,31 @@ func (s *autoscalerSuite) TestCleanupFleet_HappyPath_NoHelmOpExists() {
 	helmOpName := helmOpName(cluster)
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, errors.NewNotFound(schema.GroupResource{}, "helmop"))
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err, "Expected no error when HelmOp doesn't exist")
+}
+
+func (s *autoscalerSuite) TestCleanupFleet_HappyPath_CleansClusterScopedSecrets() {
+	cluster := s.createTestCluster("test-cluster", "default")
+	helmOpName := helmOpName(cluster)
+	provCluster := &provv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	notFound := errors.NewNotFound(schema.GroupResource{}, "")
+
+	// HelmOp does not exist, so only cluster-scoped secret cleanup should run.
+	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, notFound)
+	s.clusterCache.EXPECT().Get(cluster.Namespace, cluster.Name).Return(provCluster, nil)
+	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name, cluster.Namespace), gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete(provCluster.Namespace, autoscalerClusterScopedImagePullSecretName(provCluster.Name), gomock.Any()).Return(notFound)
+
+	err := s.h.cleanupFleet(cluster)
+	s.NoError(err, "Expected no error when cluster-scoped cleanup secrets are absent")
 }
 
 func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToDeleteHelmOp() {
@@ -436,6 +486,7 @@ func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToDeleteHelmOp() {
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, &fleet.HelmOp{}, nil)
 	s.expectHelmOpDelete(cluster.Namespace, helmOpName, deleteError)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.Error(err, "Expected error when HelmOp deletion fails")
@@ -452,6 +503,7 @@ func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToCheckHelmOpExistence() 
 	checkError := fmt.Errorf("failed to check HelmOp existence: network timeout")
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, checkError)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.Error(err, "Expected error when HelmOp existence check fails")
@@ -462,11 +514,77 @@ func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToCheckHelmOpExistence() 
 	}
 }
 
+func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToCheckProvisioningClusterExistence() {
+	cluster := s.createTestCluster("test-cluster", "default")
+	helmOpName := helmOpName(cluster)
+	checkError := fmt.Errorf("failed to check provisioning cluster existence: network timeout")
+
+	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, errors.NewNotFound(schema.GroupResource{}, "helmop"))
+	s.clusterCache.EXPECT().Get(cluster.Namespace, cluster.Name).Return(nil, checkError)
+
+	err := s.h.cleanupFleet(cluster)
+	s.Error(err, "Expected error when provisioning cluster existence check fails")
+	if err != nil {
+		s.Contains(err.Error(), "encountered 1 errors during fleet cleanup")
+		s.Contains(err.Error(), "failed to check existence of Cluster "+cluster.Namespace+" in namespace "+cluster.Name)
+		s.Contains(err.Error(), "network timeout")
+	}
+}
+
+func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToCleanupClusterScopedSecrets() {
+	cluster := s.createTestCluster("test-cluster", "default")
+	helmOpName := helmOpName(cluster)
+	provCluster := &provv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	cleanupError := fmt.Errorf("failed to delete cluster-scoped helm secret")
+
+	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, errors.NewNotFound(schema.GroupResource{}, "helmop"))
+	s.clusterCache.EXPECT().Get(cluster.Namespace, cluster.Name).Return(provCluster, nil)
+	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name, cluster.Namespace), gomock.Any()).Return(cleanupError)
+
+	err := s.h.cleanupFleet(cluster)
+	s.Error(err, "Expected error when cluster-scoped secret cleanup fails")
+	if err != nil {
+		s.Contains(err.Error(), "encountered 1 errors during fleet cleanup")
+		s.Contains(err.Error(), "failed to delete cluster-scoped helm secret")
+	}
+}
+
+func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToDeleteClusterScopedImagePullSecret() {
+	cluster := s.createTestCluster("test-cluster", "default")
+	helmOpName := helmOpName(cluster)
+	provCluster := &provv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	notFound := errors.NewNotFound(schema.GroupResource{}, "")
+	cleanupError := fmt.Errorf("failed to delete cluster-scoped image pull secret")
+
+	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, notFound)
+	s.clusterCache.EXPECT().Get(cluster.Namespace, cluster.Name).Return(provCluster, nil)
+	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name, cluster.Namespace), gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete(provCluster.Namespace, autoscalerClusterScopedImagePullSecretName(provCluster.Name), gomock.Any()).Return(cleanupError)
+
+	err := s.h.cleanupFleet(cluster)
+	s.Error(err, "Expected error when cluster-scoped image pull secret cleanup fails")
+	if err != nil {
+		s.Contains(err.Error(), "encountered 1 errors during fleet cleanup")
+		s.Contains(err.Error(), "failed to delete cluster-scoped image pull secret")
+	}
+}
+
 func (s *autoscalerSuite) TestCleanupFleet_EdgeCase_ClusterWithEmptyName() {
 	cluster := s.createTestCluster("", "default")
 	helmOpName := helmOpName(cluster)
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, errors.NewNotFound(schema.GroupResource{}, "helmop"))
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err, "Expected no error when cluster has empty name")
@@ -477,6 +595,7 @@ func (s *autoscalerSuite) TestCleanupFleet_EdgeCase_ClusterWithEmptyNamespace() 
 	helmOpName := helmOpName(cluster)
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, errors.NewNotFound(schema.GroupResource{}, "helmop"))
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err, "Expected no error when cluster has empty namespace")
@@ -488,6 +607,7 @@ func (s *autoscalerSuite) TestCleanupFleet_EdgeCase_ClusterWithSpecialCharacters
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, &fleet.HelmOp{}, nil)
 	s.expectHelmOpDelete(cluster.Namespace, helmOpName, nil)
+	s.expectCleanupFleetProvisioningClusterNotFound(cluster.Namespace, cluster.Name)
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err, "Expected no error when cluster has special characters in name and namespace")

--- a/pkg/controllers/capr/autoscaler/fleet_test.go
+++ b/pkg/controllers/capr/autoscaler/fleet_test.go
@@ -526,7 +526,7 @@ func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToCheckProvisioningCluste
 	s.Error(err, "Expected error when provisioning cluster existence check fails")
 	if err != nil {
 		s.Contains(err.Error(), "encountered 1 errors during fleet cleanup")
-		s.Contains(err.Error(), "failed to check existence of Cluster "+cluster.Namespace+" in namespace "+cluster.Name)
+		s.Contains(err.Error(), "failed to check existence of Cluster "+cluster.Name+" in namespace "+cluster.Namespace)
 		s.Contains(err.Error(), "network timeout")
 	}
 }

--- a/pkg/controllers/capr/autoscaler/secrets.go
+++ b/pkg/controllers/capr/autoscaler/secrets.go
@@ -1,0 +1,256 @@
+package autoscaler
+
+import (
+	"bytes"
+	"strings"
+
+	provv2 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/cluster"
+	"github.com/rancher/rancher/pkg/provisioningv2/image"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
+)
+
+// manageHelmOpSecrets determines if the incoming cluster should use the global-default or cluster-scoped
+// credentials when deploying the autoscaler HelmOp, and returns the names of the Helm secret and image pull
+// secret to pass to the HelmOp bundle.
+func (h *autoscalerHandler) manageHelmOpSecrets(capiCluster *capi.Cluster) (helmOpSecretName string, imagePullSecretName string, err error) {
+	provCluster, err := h.clusterCache.Get(capiCluster.Namespace, capiCluster.Name)
+	if err != nil {
+		return "", "", err
+	}
+
+	// If the cluster has no per-cluster auth secret for the chart host, fall back to the
+	// globally configured pull secrets and clean up any cluster-scoped secrets that may
+	// have been left behind from a previous cluster-level configuration.
+	if image.GetRegistryAuthSecretForHostname(provCluster, autoScalerChartRepositoryHost()) == "" {
+		if err := h.cleanupClusterScopedSecrets(provCluster, capiCluster); err != nil {
+			return "", "", err
+		}
+		return h.ensureRootHelmOpSecrets()
+	}
+
+	helmOpSecretName, err = h.ensureClusterScopedHelmOpSecretInNamespace(provCluster, capiCluster)
+	if err != nil {
+		return "", "", err
+	}
+
+	imagePullSecretName, err = h.ensureClusterScopedImagePullSecretInNamespace(provCluster, capiCluster)
+	if err != nil {
+		return "", "", err
+	}
+
+	return helmOpSecretName, imagePullSecretName, nil
+}
+
+// ensureRootHelmOpSecrets manages the shared Helm basic-auth secret and dockerconfigjson image
+// pull secret in the fleet-default namespace. Returns the names of the Helm secret and image
+// pull secret, or empty strings if no credentials are available (in which case any previously
+// created secrets are also deleted). Creating two shared root secrets helps reduce the number
+// of objects created when there are many clusters using the GSDR and the autoscaler.
+func (h *autoscalerHandler) ensureRootHelmOpSecrets() (string, string, error) {
+	username, password, err := h.findGlobalClusterAutoScalerHostnameCreds()
+	if err != nil {
+		return "", "", err
+	}
+
+	if username == "" || password == "" {
+		if err := h.deleteSecretIfExists("fleet-default", autoscalerHelmSecretResourceName); err != nil {
+			return "", "", err
+		}
+		if err := h.deleteSecretIfExists("fleet-default", autoscalerChartImagePullSecretName); err != nil {
+			return "", "", err
+		}
+		return "", "", nil
+	}
+
+	helmOpSecret, err := h.upsertSecret("fleet-default", autoscalerHelmSecretResourceName, "", basicAuthSecretData(username, password), nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	dockerConfigData, err := dockerConfigSecretData(autoScalerChartRepositoryHost(), username, password)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Only create the global image pull secret if the chart repository host does not match the global system default registry.
+	// If the chart is coming from the GSDR, then the pull secrets will have already been configured by CAPR and a global copy is not needed.
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry == nil || registry.URL == autoScalerChartRepositoryHost() {
+		return helmOpSecret.Name, "", nil
+	}
+
+	pullSecret, err := h.upsertSecret("fleet-default", autoscalerChartImagePullSecretName, v1.SecretTypeDockerConfigJson, dockerConfigData, nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	return helmOpSecret.Name, pullSecret.Name, nil
+}
+
+// cleanupClusterScopedSecrets removes the cluster-scoped Helm secret and image pull secret
+// that may have been created when the cluster previously used a per-cluster registry configuration.
+// This is called when a cluster transitions back to the global-default registry, to avoid
+// leaving orphaned secrets behind in the cluster's namespace.
+func (h *autoscalerHandler) cleanupClusterScopedSecrets(provCluster *provv2.Cluster, capiCluster *capi.Cluster) error {
+	if err := h.deleteSecretIfExists(capiCluster.Namespace, helmOpSecretName(capiCluster.Name, capiCluster.Namespace)); err != nil {
+		return err
+	}
+	return h.deleteSecretIfExists(provCluster.Namespace, autoscalerClusterScopedImagePullSecretName(provCluster.Name))
+}
+
+// ensureClusterScopedHelmOpSecretInNamespace creates or updates a basic-auth Helm secret in the
+// provisioning cluster's namespace using the cluster-level autoscaler chart credentials.
+func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provCluster *provv2.Cluster, capiCluster *capi.Cluster) (string, error) {
+	username, password, err := h.findClusterLevelAutoScalerHostnameCreds(provCluster)
+	if err != nil {
+		return "", err
+	}
+
+	s, err := h.upsertSecret(capiCluster.Namespace, helmOpSecretName(capiCluster.Name, capiCluster.Namespace), "", basicAuthSecretData(username, password), ownerReference(capiCluster))
+	if err != nil {
+		return "", err
+	}
+	return s.Name, nil
+}
+
+// ensureClusterScopedImagePullSecretInNamespace creates or updates a dockerconfigjson image pull
+// secret in the provisioning cluster's namespace for pulling the autoscaler chart image.
+// If the chart host matches the cluster's system default registry, no secret is created because
+// credentials are already configured at provisioning time.
+func (h *autoscalerHandler) ensureClusterScopedImagePullSecretInNamespace(provCluster *provv2.Cluster, capiCluster *capi.Cluster) (string, error) {
+	chartHost := autoScalerChartRepositoryHost()
+	sdrURL, _ := image.GetPrivateRepoURLFromCluster(provCluster)
+	if chartHost == sdrURL {
+		return "", nil
+	}
+
+	username, password, err := h.findClusterLevelAutoScalerHostnameCreds(provCluster)
+	if err != nil {
+		return "", err
+	}
+
+	dockerConfigData, err := dockerConfigSecretData(chartHost, username, password)
+	if err != nil {
+		return "", err
+	}
+
+	s, err := h.upsertSecret(provCluster.Namespace, autoscalerClusterScopedImagePullSecretName(provCluster.Name), v1.SecretTypeDockerConfigJson, dockerConfigData, ownerReference(capiCluster))
+	if err != nil {
+		return "", err
+	}
+	return s.Name, nil
+}
+
+// basicAuthSecretData returns a secret data map containing username and password fields,
+// suitable for use as a Helm basic-auth credential secret.
+func basicAuthSecretData(username, password string) map[string][]byte {
+	return map[string][]byte{
+		"username": []byte(username),
+		"password": []byte(password),
+	}
+}
+
+// dockerConfigSecretData builds a dockerconfigjson data map for the given registry hostname
+// and credentials.
+func dockerConfigSecretData(host, username, password string) (map[string][]byte, error) {
+	cfg, err := cluster.BuildDockerConfigJson(host, username, password)
+	if err != nil {
+		return nil, err
+	}
+	return map[string][]byte{v1.DockerConfigJsonKey: cfg}, nil
+}
+
+// deleteSecretIfExists deletes the secret at namespace/name, silently ignoring NotFound errors.
+func (h *autoscalerHandler) deleteSecretIfExists(namespace, secretName string) error {
+	err := h.secretClient.Delete(namespace, secretName, &metav1.DeleteOptions{})
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+// upsertSecret creates or updates a secret at namespace/secretName. If the secret already exists
+// and its data is identical to the provided data, no write is performed. Returns the resulting secret.
+func (h *autoscalerHandler) upsertSecret(namespace, secretName string, secretType v1.SecretType, data map[string][]byte, owner []metav1.OwnerReference) (*v1.Secret, error) {
+	existing, err := h.secretCache.Get(namespace, secretName)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if existing != nil {
+		if !secretDataEqual(existing.Data, data) {
+			updated := existing.DeepCopy()
+			updated.Data = data
+			return h.secretClient.Update(updated)
+		}
+		return existing, nil
+	}
+	return h.secretClient.Create(&v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            secretName,
+			Namespace:       namespace,
+			OwnerReferences: owner,
+		},
+		Data: data,
+		Type: secretType,
+	})
+}
+
+// secretDataEqual reports whether two secret data maps are byte-for-byte identical.
+func secretDataEqual(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if !bytes.Equal(v, b[k]) {
+			return false
+		}
+	}
+	return true
+}
+
+// findGlobalClusterAutoScalerHostnameCreds iterates over globally configured pull secrets and
+// returns the first username/password pair that covers the autoscaler chart repository host.
+// Returns empty strings (no error) when no matching credentials are found.
+func (h *autoscalerHandler) findGlobalClusterAutoScalerHostnameCreds() (string, string, error) {
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry == nil {
+		return "", "", nil
+	}
+	for _, ps := range registry.PullSecrets {
+		sec, err := h.secretCache.Get(ps.Namespace, ps.Name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return "", "", err
+		}
+		username, password, err := cluster.ExtractUsernamePasswordFromPullSecret(autoScalerChartRepositoryHost(), sec)
+		if err != nil {
+			if strings.Contains(err.Error(), cluster.ErrRegistryHostnameNotFound) {
+				continue
+			}
+			return "", "", err
+		}
+		return username, password, nil
+	}
+	return "", "", nil
+}
+
+// findClusterLevelAutoScalerHostnameCreds looks up the credentials for the autoscaler chart host
+// from the provisioning cluster's registry configuration.
+func (h *autoscalerHandler) findClusterLevelAutoScalerHostnameCreds(provCluster *provv2.Cluster) (string, string, error) {
+	chartHost := autoScalerChartRepositoryHost()
+	ps := image.GetRegistryAuthSecretForHostname(provCluster, chartHost)
+	if ps == "" {
+		return "", "", nil
+	}
+	pullSecret, err := h.secretCache.Get(provCluster.Namespace, ps)
+	if err != nil {
+		return "", "", err
+	}
+	return cluster.ExtractUsernamePasswordFromPullSecret(chartHost, pullSecret)
+}

--- a/pkg/controllers/capr/autoscaler/secrets.go
+++ b/pkg/controllers/capr/autoscaler/secrets.go
@@ -1,14 +1,14 @@
 package autoscaler
 
 import (
-	"bytes"
-	"fmt"
+	"errors"
+	"reflect"
 
-	provv2 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -98,7 +98,7 @@ func (h *autoscalerHandler) ensureRootHelmOpSecrets() (string, string, error) {
 // that may have been created when the cluster previously used a per-cluster registry configuration.
 // This is called when a cluster transitions back to the global-default registry, to avoid
 // leaving orphaned secrets behind in the cluster's namespace.
-func (h *autoscalerHandler) cleanupClusterScopedSecrets(provCluster *provv2.Cluster, capiCluster *capi.Cluster) error {
+func (h *autoscalerHandler) cleanupClusterScopedSecrets(provCluster *provv1.Cluster, capiCluster *capi.Cluster) error {
 	if err := h.deleteSecretIfExists(capiCluster.Namespace, helmOpSecretName(capiCluster.Name, capiCluster.Namespace)); err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (h *autoscalerHandler) cleanupClusterScopedSecrets(provCluster *provv2.Clus
 
 // ensureClusterScopedHelmOpSecretInNamespace creates or updates a basic-auth Helm secret in the
 // provisioning cluster's namespace using the cluster-level autoscaler chart credentials.
-func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provCluster *provv2.Cluster, capiCluster *capi.Cluster) (string, error) {
+func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provCluster *provv1.Cluster, capiCluster *capi.Cluster) (string, error) {
 	username, password, err := h.findClusterLevelAutoScalerHostnameCreds(provCluster)
 	if err != nil {
 		return "", err
@@ -124,7 +124,7 @@ func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provClust
 // secret in the provisioning cluster's namespace for pulling the autoscaler chart image.
 // If the chart host matches the cluster's system default registry, no secret is created because
 // credentials are already configured at provisioning time.
-func (h *autoscalerHandler) ensureClusterScopedImagePullSecretInNamespace(provCluster *provv2.Cluster, capiCluster *capi.Cluster) (string, error) {
+func (h *autoscalerHandler) ensureClusterScopedImagePullSecretInNamespace(provCluster *provv1.Cluster, capiCluster *capi.Cluster) (string, error) {
 	chartHost := autoScalerChartRepositoryHost()
 	sdrURL, _ := image.GetPrivateRepoURLFromCluster(provCluster)
 	if chartHost == sdrURL {
@@ -170,7 +170,7 @@ func dockerConfigSecretData(host, username, password string) (map[string][]byte,
 // deleteSecretIfExists deletes the secret at namespace/name, silently ignoring NotFound errors.
 func (h *autoscalerHandler) deleteSecretIfExists(namespace, secretName string) error {
 	err := h.secretClient.Delete(namespace, secretName, &metav1.DeleteOptions{})
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	return err
@@ -180,15 +180,12 @@ func (h *autoscalerHandler) deleteSecretIfExists(namespace, secretName string) e
 // and its data is identical to the provided data, no write is performed.
 func (h *autoscalerHandler) upsertSecret(namespace, secretName string, secretType v1.SecretType, data map[string][]byte, owner []metav1.OwnerReference) (*v1.Secret, error) {
 	existing, err := h.secretCache.Get(namespace, secretName)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 	if existing != nil {
-		if !secretDataEqual(existing.Data, data) {
+		if !reflect.DeepEqual(existing.Data, data) {
 			updated := existing.DeepCopy()
-			if secretType != "" {
-				updated.Type = secretType
-			}
 			updated.Data = data
 			return h.secretClient.Update(updated)
 		}
@@ -205,19 +202,6 @@ func (h *autoscalerHandler) upsertSecret(namespace, secretName string, secretTyp
 	})
 }
 
-// secretDataEqual reports whether two secret data maps are identical.
-func secretDataEqual(a, b map[string][]byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		if !bytes.Equal(v, b[k]) {
-			return false
-		}
-	}
-	return true
-}
-
 // findGlobalClusterAutoScalerHostnameCreds iterates over globally configured pull secrets and
 // returns the first username/password pair that covers the autoscaler chart repository host.
 // Returns empty strings (no error) when no matching credentials are found.
@@ -228,15 +212,14 @@ func (h *autoscalerHandler) findGlobalClusterAutoScalerHostnameCreds() (string, 
 	}
 	for _, ps := range registry.PullSecrets {
 		sec, err := h.secretCache.Get(ps.Namespace, ps.Name)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				continue
-			}
+		if apierrors.IsNotFound(err) {
+			continue
+		} else if err != nil {
 			return "", "", err
 		}
 		username, password, err := cluster.ExtractUsernamePasswordFromPullSecret(autoScalerChartRepositoryHost(), sec)
 		if err != nil {
-			if err.Error() == fmt.Sprintf(cluster.ErrRegistryHostnameNotFound, autoScalerChartRepositoryHost()) {
+			if errors.Is(err, cluster.ErrRegistryHostnameNotFound) {
 				continue
 			}
 			return "", "", err
@@ -247,8 +230,9 @@ func (h *autoscalerHandler) findGlobalClusterAutoScalerHostnameCreds() (string, 
 }
 
 // findClusterLevelAutoScalerHostnameCreds looks up the credentials for the autoscaler chart host
-// from the provisioning cluster's registry configuration.
-func (h *autoscalerHandler) findClusterLevelAutoScalerHostnameCreds(provCluster *provv2.Cluster) (string, string, error) {
+// from the provisioning cluster's registry configuration. The username and password is extracted from the first
+// Auth secret found on the cluster which contains credentials for the autoscaler host.
+func (h *autoscalerHandler) findClusterLevelAutoScalerHostnameCreds(provCluster *provv1.Cluster) (string, string, error) {
 	chartHost := autoScalerChartRepositoryHost()
 	ps := image.GetRegistryAuthSecretForHostname(provCluster, chartHost)
 	if ps == "" {

--- a/pkg/controllers/capr/autoscaler/secrets.go
+++ b/pkg/controllers/capr/autoscaler/secrets.go
@@ -2,7 +2,7 @@ package autoscaler
 
 import (
 	"bytes"
-	"strings"
+	"fmt"
 
 	provv2 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/cluster"
@@ -80,6 +80,9 @@ func (h *autoscalerHandler) ensureRootHelmOpSecrets() (string, string, error) {
 	// If the chart is coming from the GSDR, then the pull secrets will have already been configured by CAPR and a global copy is not needed.
 	registry, _ := cluster.GetPrivateRegistry(nil)
 	if registry == nil || registry.URL == autoScalerChartRepositoryHost() {
+		if err := h.deleteSecretIfExists("fleet-default", autoscalerChartImagePullSecretName); err != nil {
+			return "", "", err
+		}
 		return helmOpSecret.Name, "", nil
 	}
 
@@ -174,7 +177,7 @@ func (h *autoscalerHandler) deleteSecretIfExists(namespace, secretName string) e
 }
 
 // upsertSecret creates or updates a secret at namespace/secretName. If the secret already exists
-// and its data is identical to the provided data, no write is performed. Returns the resulting secret.
+// and its data is identical to the provided data, no write is performed.
 func (h *autoscalerHandler) upsertSecret(namespace, secretName string, secretType v1.SecretType, data map[string][]byte, owner []metav1.OwnerReference) (*v1.Secret, error) {
 	existing, err := h.secretCache.Get(namespace, secretName)
 	if err != nil && !errors.IsNotFound(err) {
@@ -183,6 +186,9 @@ func (h *autoscalerHandler) upsertSecret(namespace, secretName string, secretTyp
 	if existing != nil {
 		if !secretDataEqual(existing.Data, data) {
 			updated := existing.DeepCopy()
+			if secretType != "" {
+				updated.Type = secretType
+			}
 			updated.Data = data
 			return h.secretClient.Update(updated)
 		}
@@ -199,7 +205,7 @@ func (h *autoscalerHandler) upsertSecret(namespace, secretName string, secretTyp
 	})
 }
 
-// secretDataEqual reports whether two secret data maps are byte-for-byte identical.
+// secretDataEqual reports whether two secret data maps are identical.
 func secretDataEqual(a, b map[string][]byte) bool {
 	if len(a) != len(b) {
 		return false
@@ -230,7 +236,7 @@ func (h *autoscalerHandler) findGlobalClusterAutoScalerHostnameCreds() (string, 
 		}
 		username, password, err := cluster.ExtractUsernamePasswordFromPullSecret(autoScalerChartRepositoryHost(), sec)
 		if err != nil {
-			if strings.Contains(err.Error(), cluster.ErrRegistryHostnameNotFound) {
+			if err.Error() == fmt.Sprintf(cluster.ErrRegistryHostnameNotFound, autoScalerChartRepositoryHost()) {
 				continue
 			}
 			return "", "", err

--- a/pkg/controllers/capr/autoscaler/token_rotation_test.go
+++ b/pkg/controllers/capr/autoscaler/token_rotation_test.go
@@ -6,11 +6,13 @@ import (
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
@@ -161,6 +163,7 @@ func (s *autoscalerSuite) TestRenewToken_HappyPath_SuccessfulTokenRenewal() {
 		secret.Data["token"] = []byte("new-token-value")
 		return secret, nil
 	})
+	s.expectManageHelmOpSecrets("test-cluster", "default")
 	s.helmOpCache.EXPECT().Get("default", gomock.Any()).Return(nil, errors.NewNotFound(corev1.Resource("helmops"), ""))
 	s.helmOp.EXPECT().Create(gomock.Any()).Return(&fleet.HelmOp{}, nil)
 
@@ -397,6 +400,7 @@ func (s *autoscalerSuite) TestRenewToken_Error_FailedToCreateHelmOp() {
 		},
 	}, nil)
 	s.secretClient.EXPECT().Update(gomock.Any()).Return(&corev1.Secret{}, nil)
+	s.expectManageHelmOpSecrets("test-cluster", "default")
 	s.helmOpCache.EXPECT().Get("default", gomock.Any()).Return(nil, errors.NewNotFound(corev1.Resource("helmops"), ""))
 	s.helmOp.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("failed to create helm op"))
 
@@ -733,6 +737,7 @@ func (s *autoscalerSuite) TestCheckAndRenewTokens_SingleTokenExpiringSuccessfull
 		secret.Data["token"] = []byte("new-token-value")
 		return secret, nil
 	})
+	s.expectManageHelmOpSecrets("test-cluster", "default")
 	s.helmOpCache.EXPECT().Get("default", gomock.Any()).Return(nil, errors.NewNotFound(corev1.Resource("helmops"), ""))
 	s.helmOp.EXPECT().Create(gomock.Any()).Return(&fleet.HelmOp{}, nil)
 
@@ -813,6 +818,7 @@ func (s *autoscalerSuite) TestCheckAndRenewTokens_MultipleTokensOnlyOneExpiring(
 		secret.Data["token"] = []byte("new-token-value")
 		return secret, nil
 	})
+	s.expectManageHelmOpSecrets("cluster-2", "default")
 	s.helmOpCache.EXPECT().Get("default", gomock.Any()).Return(nil, errors.NewNotFound(corev1.Resource("helmops"), ""))
 	s.helmOp.EXPECT().Create(gomock.Any()).Return(&fleet.HelmOp{}, nil)
 
@@ -898,6 +904,14 @@ func (s *autoscalerSuite) TestCheckAndRenewTokens_MultipleTokensOnlyOneNotExpiri
 		secret.Data["token"] = []byte("new-token-value")
 		return secret, nil
 	}).Times(2)
+	s.clusterCache.EXPECT().Get("default", "cluster-1").Return(
+		&provv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster-1", Namespace: "default"}}, nil,
+	).Times(2)
+	notFound := errors.NewNotFound(schema.GroupResource{}, "")
+	s.secretClient.EXPECT().Delete("default", helmOpSecretName("cluster-1", "default"), gomock.Any()).Return(notFound).Times(2)
+	s.secretClient.EXPECT().Delete("default", autoscalerClusterScopedImagePullSecretName("cluster-1"), gomock.Any()).Return(notFound).Times(2)
+	s.secretClient.EXPECT().Delete("fleet-default", autoscalerHelmSecretResourceName, gomock.Any()).Return(notFound).Times(2)
+	s.secretClient.EXPECT().Delete("fleet-default", autoscalerChartImagePullSecretName, gomock.Any()).Return(notFound).Times(2)
 	s.helmOpCache.EXPECT().Get("default", gomock.Any()).Return(nil, errors.NewNotFound(corev1.Resource("helmops"), "")).Times(2)
 	s.helmOp.EXPECT().Create(gomock.Any()).Return(&fleet.HelmOp{}, nil).Times(2)
 

--- a/pkg/controllers/capr/autoscaler/util.go
+++ b/pkg/controllers/capr/autoscaler/util.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/settings"
-	"github.com/rancher/wrangler/v3/pkg/name"
+	"github.com/rancher/wrangler/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -16,6 +16,22 @@ import (
 	"k8s.io/utils/ptr"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
+
+const (
+	autoscalerHelmSecretResourceName   = "autoscaler-helm-secret"
+	autoscalerChartImagePullSecretName = "autoscaler-chart-image-pull-secret"
+)
+
+func helmOpSecretName(clusterName, clusterNamespace string) string {
+	if clusterNamespace == "fleet-default" {
+		return autoscalerHelmSecretResourceName
+	}
+	return name.SafeConcatName(autoscalerHelmSecretResourceName, clusterName)
+}
+
+func autoscalerClusterScopedImagePullSecretName(clusterName string) string {
+	return name.SafeConcatName(autoscalerChartImagePullSecretName, clusterName)
+}
 
 // autoscalerUserName generates the autoscaler-specific name for a cluster
 func autoscalerUserName(cluster *capi.Cluster) string {
@@ -39,6 +55,20 @@ func kubeconfigSecretName(cluster *capi.Cluster) string {
 
 func helmOpName(cluster *capi.Cluster) string {
 	return name.SafeConcatName("autoscaler", cluster.Namespace, cluster.Name)
+}
+
+// autoScalerChartRepositoryHost trims away the protocol and chart path
+// from the configured settings.ClusterAutoscalerChartRepository to return just the host.
+// This is then used to identify the correct dockerconfigjson auth entry defined within the
+// first configured pull secret in the settings.SystemDefaultRegistryPullSecrets list.
+func autoScalerChartRepositoryHost() string {
+	host := settings.ClusterAutoscalerChartRepository.Get()
+	_, hostWithoutProto, found := strings.Cut(host, "://")
+	if !found {
+		hostWithoutProto = host
+	}
+	hostWithoutPath, _, found := strings.Cut(hostWithoutProto, "/")
+	return hostWithoutPath
 }
 
 // ownerReference creates an owner reference from a cluster

--- a/pkg/controllers/capr/autoscaler/util.go
+++ b/pkg/controllers/capr/autoscaler/util.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/settings"
-	"github.com/rancher/wrangler/pkg/name"
+	"github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -67,7 +67,7 @@ func autoScalerChartRepositoryHost() string {
 	if !found {
 		hostWithoutProto = host
 	}
-	hostWithoutPath, _, found := strings.Cut(hostWithoutProto, "/")
+	hostWithoutPath, _, _ := strings.Cut(hostWithoutProto, "/")
 	return hostWithoutPath
 }
 

--- a/pkg/controllers/capr/autoscaler/util_test.go
+++ b/pkg/controllers/capr/autoscaler/util_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/settings"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -282,6 +283,80 @@ func TestHelmOpName(t *testing.T) {
 			result := helmOpName(tt.cluster)
 			if result != tt.expected {
 				t.Errorf("helmOpName() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAutoScalerChartRepositoryHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		setting  string
+		expected string
+	}{
+		{
+			name:     "full URL with https and path",
+			setting:  "https://charts.example.com/autoscaler/charts",
+			expected: "charts.example.com",
+		},
+		{
+			name:     "OCI URL with https and path",
+			setting:  "oci://charts.example.com/autoscaler/charts",
+			expected: "charts.example.com",
+		},
+		{
+			name:     "full URL with http and path",
+			setting:  "http://charts.example.com/some/path",
+			expected: "charts.example.com",
+		},
+		{
+			name:     "URL with no path",
+			setting:  "https://charts.example.com",
+			expected: "charts.example.com",
+		},
+		{
+			name:     "host only, no protocol",
+			setting:  "charts.example.com",
+			expected: "charts.example.com",
+		},
+		{
+			name:     "host with path, no protocol",
+			setting:  "charts.example.com/some/path",
+			expected: "charts.example.com",
+		},
+		{
+			name:     "empty setting",
+			setting:  "",
+			expected: "",
+		},
+		{
+			name:     "host with port and path",
+			setting:  "https://registry.example.com:5000/helm/charts",
+			expected: "registry.example.com:5000",
+		},
+		{
+			name:     "host with port, no path",
+			setting:  "https://registry.example.com:5000",
+			expected: "registry.example.com:5000",
+		},
+		{
+			name:     "oci protocol",
+			setting:  "oci://registry.example.com/charts",
+			expected: "registry.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := settings.ClusterAutoscalerChartRepository.Get()
+			settings.ClusterAutoscalerChartRepository.Set(tt.setting)
+			t.Cleanup(func() {
+				settings.ClusterAutoscalerChartRepository.Set(prev)
+			})
+
+			result := autoScalerChartRepositoryHost()
+			if result != tt.expected {
+				t.Errorf("autoScalerChartRepositoryHost() = %q, want %q", result, tt.expected)
 			}
 		})
 	}

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/data"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -114,10 +115,10 @@ func (h *handler) onSetting(_ string, setting *v3.Setting) (*v3.Setting, error) 
 		},
 	}
 
-	var pullSecrets []string
+	var pullSecrets []v1.LocalObjectReference
 	registry, _ := cluster.GetPrivateRegistry(nil)
 	if registry != nil {
-		pullSecrets = registry.PullSecretNamesAsSlice()
+		pullSecrets = registry.PullSecretsAsObjectReferences()
 	}
 	systemGlobalRegistry["cattle"].(map[string]interface{})["imagePullSecrets"] = pullSecrets
 

--- a/pkg/controllers/dashboard/fleetcharts/controller_test.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller_test.go
@@ -59,7 +59,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
-							"imagePullSecrets":      ([]string)(nil),
+							"imagePullSecrets":      ([]v1.LocalObjectReference)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -113,7 +113,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
-							"imagePullSecrets":      ([]string)(nil),
+							"imagePullSecrets":      ([]v1.LocalObjectReference)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -171,7 +171,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
-							"imagePullSecrets":      ([]string)(nil),
+							"imagePullSecrets":      ([]v1.LocalObjectReference)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -229,7 +229,7 @@ bootstrap:
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
-							"imagePullSecrets":      ([]string)(nil),
+							"imagePullSecrets":      ([]v1.LocalObjectReference)(nil),
 						},
 					},
 					"bootstrap": map[string]interface{}{
@@ -290,7 +290,7 @@ bootstrap:
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": "registry.example.com",
-							"imagePullSecrets":      []string{"pull-secret-a", "pull-secret-b"},
+							"imagePullSecrets":      []v1.LocalObjectReference{{Name: "pull-secret-a"}, {Name: "pull-secret-b"}},
 						},
 					},
 					"bootstrap": map[string]interface{}{

--- a/pkg/controllers/dashboard/helm/register.go
+++ b/pkg/controllers/dashboard/helm/register.go
@@ -13,6 +13,8 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 		wrangler.Catalog.ClusterRepo(),
 		wrangler.Core.ConfigMap(),
 		wrangler.Core.ConfigMap().Cache())
+	RegisterRepoSettings(ctx, wrangler.Mgmt.Setting(),
+		wrangler.Catalog.ClusterRepo())
 	RegisterOCIRepo(ctx,
 		wrangler.Apply,
 		wrangler.Catalog.ClusterRepo(),

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"time"
 
+	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -51,6 +52,7 @@ type repoHandler struct {
 	clusterRepos   catalogcontrollers.ClusterRepoController
 	configMaps     corev1controllers.ConfigMapClient
 	configMapCache corev1controllers.ConfigMapCache
+	settings       v3.SettingController
 	apply          apply.Apply
 }
 

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -11,7 +11,7 @@ import (
 	"slices"
 	"time"
 
-	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -52,7 +52,7 @@ type repoHandler struct {
 	clusterRepos   catalogcontrollers.ClusterRepoController
 	configMaps     corev1controllers.ConfigMapClient
 	configMapCache corev1controllers.ConfigMapCache
-	settings       v3.SettingController
+	settings       mgmtcontrollers.SettingController
 	apply          apply.Apply
 }
 

--- a/pkg/controllers/dashboard/helm/setting.go
+++ b/pkg/controllers/dashboard/helm/setting.go
@@ -1,0 +1,71 @@
+package helm
+
+import (
+	"context"
+	"reflect"
+
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/cluster"
+	catalogcontrollers "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
+	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/settings"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func RegisterRepoSettings(ctx context.Context,
+	settingController v3.SettingController,
+	clusterRepos catalogcontrollers.ClusterRepoController) {
+
+	h := &repoHandler{
+		settings:     settingController,
+		clusterRepos: clusterRepos,
+	}
+
+	settingController.OnChange(ctx, "synchronize-rancher-repo-pull-secrets", h.onRegistryPullSecretsSettingsChange)
+}
+
+func (r *repoHandler) onRegistryPullSecretsSettingsChange(_ string, setting *apimgmtv3.Setting) (*apimgmtv3.Setting, error) {
+	if setting == nil || (setting.Name != settings.SystemDefaultRegistryPullSecrets.Name && setting.Name != settings.SystemDefaultRegistry.Name) {
+		return setting, nil
+	}
+
+	rancherRepo, err := r.clusterRepos.Get("rancher-charts", v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	if registry == nil || len(registry.PullSecrets) == 0 {
+		if len(rancherRepo.Spec.DefaultImagePullSecrets) > 0 {
+			rancherRepo = rancherRepo.DeepCopy()
+			rancherRepo.Spec.DefaultImagePullSecrets = nil
+			_, err = r.clusterRepos.Update(rancherRepo)
+			if err != nil {
+				return setting, err
+			}
+		}
+		return setting, nil
+	}
+
+	var secretReferences []catalogv1.SecretReference
+	for _, ps := range registry.PullSecrets {
+		secretReferences = append(secretReferences, catalogv1.SecretReference{
+			Name:      ps.Name,
+			Namespace: namespaces.System,
+		})
+	}
+
+	// Only update the repo if the pull secrets have actually changed.
+	if !reflect.DeepEqual(rancherRepo.Spec.DefaultImagePullSecrets, secretReferences) {
+		rancherRepo = rancherRepo.DeepCopy()
+		rancherRepo.Spec.DefaultImagePullSecrets = secretReferences
+		_, err = r.clusterRepos.Update(rancherRepo)
+		if err != nil {
+			return setting, err
+		}
+	}
+
+	return setting, nil
+}

--- a/pkg/controllers/dashboard/helm/setting.go
+++ b/pkg/controllers/dashboard/helm/setting.go
@@ -26,6 +26,9 @@ func RegisterRepoSettings(ctx context.Context,
 	settingController.OnChange(ctx, "synchronize-rancher-repo-pull-secrets", h.onRegistryPullSecretsSettingsChange)
 }
 
+// onRegistryPullSecretsSettingsChange ensures that the DefaultImagePullSecrets field set on the rancher-charts ClusterRepo is kept up to date
+// with the pull secrets defined in the global or cluster level registry settings. This ensures that the repo has an up-to-date reference on the pull
+// secrets that can be used when deploying rancher-managed charts.
 func (r *repoHandler) onRegistryPullSecretsSettingsChange(_ string, setting *apimgmtv3.Setting) (*apimgmtv3.Setting, error) {
 	if setting == nil || (setting.Name != settings.SystemDefaultRegistryPullSecrets.Name && setting.Name != settings.SystemDefaultRegistry.Name) {
 		return setting, nil

--- a/pkg/controllers/dashboard/privateregistry/controller.go
+++ b/pkg/controllers/dashboard/privateregistry/controller.go
@@ -349,7 +349,7 @@ func (h *handler) manageClusterSpecificPSS(_ string, cluster *v3.Cluster) (*v3.C
 		logrus.Tracef("[private-registry] resolved source pull secret %q/%q for cluster %q", ds.Namespace, ds.Name, cluster.Name)
 		sourceAuthSecrets = append(sourceAuthSecrets, s)
 	}
-	logrus.Debugf("[private-registry] resolved %d source pull secrets and found %d existing PSS(s) for cluster %q", len(sourceAuthSecrets), len(createdPSS), cluster.Name)
+	logrus.Tracef("[private-registry] resolved %d source pull secrets and found %d existing PSS(s) for cluster %q", len(sourceAuthSecrets), len(createdPSS), cluster.Name)
 
 	// Delete any PSS's that were created for secrets no longer specified on the cluster object.
 	for _, pss := range createdPSS {
@@ -456,7 +456,6 @@ func (h *handler) manageClusterSpecificPSS(_ string, cluster *v3.Cluster) (*v3.C
 func (h *handler) syncClusterOnGlobalPullSecretChange(_ string, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
 	sec, ok := obj.(*kcorev1.Secret)
 	if !ok {
-		logrus.Errorf("[private-registry] failed to convert to secret")
 		return nil, nil
 	}
 	if sec.Labels == nil || sec.Labels[util.SourcePullSecretLabel] != "true" {

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -157,7 +157,7 @@ func (h *handler) onRepo(_ string, repo *catalog.ClusterRepo) (*catalog.ClusterR
 		logrus.Tracef("[system-charts] processing chart %q (namespace=%q, release=%q, uninstall=%v)", chartDef.ChartName, chartDef.ReleaseNamespace, chartDef.ReleaseName, chartDef.Uninstall)
 
 		if chartDef.Uninstall {
-			logrus.Debugf("[system-charts] uninstalling chart %q (removeNamespace=%v)", chartDef.ChartName, chartDef.RemoveNamespace)
+			logrus.Tracef("[system-charts] uninstalling chart %q (removeNamespace=%v)", chartDef.ChartName, chartDef.RemoveNamespace)
 			// it is important to remove the chart from the desired chart list
 			h.manager.Remove(chartDef.ReleaseNamespace, chartDef.ChartName)
 			if err := h.manager.Uninstall(chartDef.ReleaseNamespace, chartDef.ChartName); err != nil {
@@ -165,7 +165,7 @@ func (h *handler) onRepo(_ string, repo *catalog.ClusterRepo) (*catalog.ClusterR
 				return repo, err
 			}
 			if chartDef.RemoveNamespace {
-				logrus.Debugf("[system-charts] deleting namespace %q for chart %q", chartDef.ReleaseNamespace, chartDef.ChartName)
+				logrus.Tracef("[system-charts] deleting namespace %q for chart %q", chartDef.ReleaseNamespace, chartDef.ChartName)
 				if err := h.namespaces.Delete(chartDef.ReleaseNamespace, nil); err != nil && !errors.IsNotFound(err) {
 					logrus.Errorf("[system-charts] failed to delete namespace %q: %v", chartDef.ReleaseNamespace, err)
 					return repo, err
@@ -227,7 +227,7 @@ func (h *handler) onRepo(_ string, repo *catalog.ClusterRepo) (*catalog.ClusterR
 			return repo, err
 		}
 
-		logrus.Debugf("[system-charts] ensured chart %q in namespace %q", chartDef.ChartName, chartDef.ReleaseNamespace)
+		logrus.Tracef("[system-charts] ensured chart %q in namespace %q", chartDef.ChartName, chartDef.ReleaseNamespace)
 		if chartDef.ChartName == chart.WebhookChartName {
 			if err := h.updateAppliedWebhookCustomization(); err != nil {
 				logrus.Warnf("[systemcharts] failed to update applied webhook customization status: %v", err)

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -502,7 +503,18 @@ func secretIgnoresNamespace(annos map[string]string, namespace string) bool {
 		return false
 	}
 	for _, ignoredNs := range strings.Split(v, ",") {
+		// If special characters are identified, treat the value as a regexp
 		ignoredNs = strings.TrimSpace(ignoredNs)
+		if strings.Contains(ignoredNs, "*") {
+			exp, err := regexp.Compile(ignoredNs)
+			if err != nil {
+				logrus.Warnf("Invalid regular expression '%s' in annotation %s: %v. Skipping regex evaluation and treating as literal string.", ignoredNs, PSSIgnoreNamespacesAnnotation, err)
+			} else {
+				if exp.MatchString(namespace) {
+					return true
+				}
+			}
+		}
 		if ignoredNs == namespace {
 			return true
 		}

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets.go
@@ -503,7 +503,7 @@ func secretIgnoresNamespace(annos map[string]string, namespace string) bool {
 		return false
 	}
 	for _, ignoredNs := range strings.Split(v, ",") {
-		// If special characters are identified, treat the value as a regexp
+		// If an asterisk ("*") is present, treat the value as a regexp
 		ignoredNs = strings.TrimSpace(ignoredNs)
 		if strings.Contains(ignoredNs, "*") {
 			exp, err := regexp.Compile(ignoredNs)

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets.go
@@ -509,10 +509,8 @@ func secretIgnoresNamespace(annos map[string]string, namespace string) bool {
 			exp, err := regexp.Compile(ignoredNs)
 			if err != nil {
 				logrus.Warnf("Invalid regular expression '%s' in annotation %s: %v. Skipping regex evaluation and treating as literal string.", ignoredNs, PSSIgnoreNamespacesAnnotation, err)
-			} else {
-				if exp.MatchString(namespace) {
-					return true
-				}
+			} else if exp.MatchString(namespace) {
+				return true
 			}
 		}
 		if ignoredNs == namespace {

--- a/pkg/controllers/managementuser/secret/project_scoped_secrets_pull_secrets_test.go
+++ b/pkg/controllers/managementuser/secret/project_scoped_secrets_pull_secrets_test.go
@@ -1227,6 +1227,104 @@ func Test_namespaceHandler_OnChange(t *testing.T) {
 	}
 }
 
+func Test_secretIgnoresNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		annos     map[string]string
+		namespace string
+		want      bool
+	}{
+		{
+			name:      "annotation absent, never ignored",
+			annos:     map[string]string{},
+			namespace: "cattle-system",
+			want:      false,
+		},
+		{
+			name:      "nil annotations, never ignored",
+			annos:     nil,
+			namespace: "cattle-system",
+			want:      false,
+		},
+		{
+			name:      "literal exact match, namespace is ignored",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "cattle-system"},
+			namespace: "cattle-system",
+			want:      true,
+		},
+		{
+			name:      "literal, no match",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "cattle-system"},
+			namespace: "kube-system",
+			want:      false,
+		},
+		{
+			name:      "multiple literals, one matches",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "kube-system,cattle-system,cattle-fleet-system"},
+			namespace: "cattle-system",
+			want:      true,
+		},
+		{
+			name:      "multiple literals, none match",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "kube-system,cattle-fleet-system"},
+			namespace: "cattle-system",
+			want:      false,
+		},
+		{
+			name:      "literal with surrounding whitespace, trimmed and matches",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "kube-system, cattle-system"},
+			namespace: "cattle-system",
+			want:      true,
+		},
+		{
+			name:      "regex with wildcard matches namespace",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "cattle-.*"},
+			namespace: "cattle-system",
+			want:      true,
+		},
+		{
+			name:      "regex with wildcard does not match namespace",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "cattle-.*"},
+			namespace: "kube-system",
+			want:      false,
+		},
+		{
+			name:      "regex with wildcard matches one of multiple namespaces",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "kube-system,cattle-.*"},
+			namespace: "cattle-fleet-system",
+			want:      true,
+		},
+		{
+			name:      "regex matches prefix pattern",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "cattle-[a-z-]*"},
+			namespace: "cattle-monitoring-system",
+			want:      true,
+		},
+		{
+			name: "invalid regex containing asterisk, falls through to literal check, no match",
+			// "*cattle" starts with a quantifier, which is invalid in Go's regexp.
+			// The implementation logs a warning and skips the regex eval, then
+			// falls through to a trimmed literal comparison which also won't match.
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: "*cattle"},
+			namespace: "cattle-system",
+			want:      false,
+		},
+		{
+			name:      "empty annotation value, no match",
+			annos:     map[string]string{PSSIgnoreNamespacesAnnotation: ""},
+			namespace: "cattle-system",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := secretIgnoresNamespace(tt.annos, tt.namespace)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func withSettings(t *testing.T, sdr, pullSecrets string) {
 	curSdr := settings.SystemDefaultRegistry.Get()
 	curSdrPull := settings.SystemDefaultRegistryPullSecrets.Get()

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -521,7 +521,7 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.DesiredAgentImage = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
 	spec.DesiredAuthImage = image.ResolveWithCluster(settings.AuthImage.Get(), cluster)
 
-	spec.ClusterSecrets.PrivateRegistrySecret = image.GetPrivateRepoSecretFromCluster(cluster)
+	spec.ClusterSecrets.PrivateRegistrySecret, _ = image.GetPrivateRepoSecretFromCluster(cluster)
 	spec.ClusterSecrets.PrivateRegistryURL, _ = image.GetPrivateRepoURLFromCluster(cluster)
 
 	spec.AgentEnvVars = nil

--- a/pkg/crds/yaml/generated/catalog.cattle.io_clusterrepos.yaml
+++ b/pkg/crds/yaml/generated/catalog.cattle.io_clusterrepos.yaml
@@ -97,6 +97,27 @@ spec:
                     description: Namespace is the namespace where the secret resides.
                     type: string
                 type: object
+              defaultImagePullSecrets:
+                description: |-
+                  DefaultImagePullSecrets specifies one or more image pull secrets which will be used by default
+                  when deploying charts from this repository. If a chart supports image pull secrets in its values.yaml
+                  in an expected path (.Values.ImagePullSecrets, .Values.global.ImagePullSecrets, or .Values.global.cattle.imagePullSecrets)
+                  the secrets listed in this field will be automatically copied into the charts release namespace. Additionally,
+                  Rancher will inject these secret references into the charts values.yaml if no user provided value is set.
+                  Currently, this field is only honored by the "rancher-charts" repository, and can only copy secrets from the
+                  cattle-system namespace which have the appropriate labels.
+                items:
+                  description: SecretReference references a Secret object which contains
+                    the credentials.
+                  properties:
+                    name:
+                      description: Name is the name of the secret.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the secret resides.
+                      type: string
+                  type: object
+                type: array
               disableSameOriginCheck:
                 description: |-
                   DisableSameOriginCheck if true attaches the Basic Auth Header to all Helm client API calls

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -1,9 +1,12 @@
 package dashboard
 
 import (
+	"slices"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/features"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -33,6 +36,17 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 		)
 	}
 
+	registry, _ := cluster.GetPrivateRegistry(nil)
+	var secretReferences []v1.SecretReference
+	if registry != nil {
+		for _, ps := range registry.PullSecrets {
+			secretReferences = append(secretReferences, v1.SecretReference{
+				Name:      ps.Name,
+				Namespace: namespaces.System,
+			})
+		}
+	}
+
 	repo, err := wrangler.Catalog.ClusterRepo().Get(repoName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = wrangler.Catalog.ClusterRepo().Create(&v1.ClusterRepo{
@@ -40,13 +54,15 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 				Name: repoName,
 			},
 			Spec: v1.RepoSpec{
-				GitRepo:   repoURL,
-				GitBranch: branchName,
+				GitRepo:                 repoURL,
+				GitBranch:               branchName,
+				DefaultImagePullSecrets: secretReferences,
 			},
 		})
-	} else if err == nil && (repo.Spec.GitRepo != repoURL || repo.Spec.GitBranch != branchName) {
+	} else if err == nil && (repo.Spec.GitRepo != repoURL || repo.Spec.GitBranch != branchName || !slices.Equal(repo.Spec.DefaultImagePullSecrets, secretReferences)) {
 		repo.Spec.GitRepo = repoURL
 		repo.Spec.GitBranch = branchName
+		repo.Spec.DefaultImagePullSecrets = secretReferences
 		_, err = wrangler.Catalog.ClusterRepo().Update(repo)
 	}
 

--- a/pkg/provisioningv2/image/resolve.go
+++ b/pkg/provisioningv2/image/resolve.go
@@ -33,12 +33,12 @@ func resolve(reg, image string) string {
 }
 
 // GetPrivateRepoSecretFromCluster returns the name of the secret containing the credentials for the cluster level system-default-registry.
-func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) string {
+func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) (string, bool) {
 	url, isGlobalDefault := GetPrivateRepoURLFromCluster(cluster)
 	if cluster != nil && cluster.Spec.RKEConfig != nil && cluster.Spec.RKEConfig.Registries != nil {
 		config, ok := cluster.Spec.RKEConfig.Registries.Configs[url]
 		if ok {
-			return config.AuthConfigSecretName
+			return config.AuthConfigSecretName, false
 		}
 	}
 
@@ -49,11 +49,23 @@ func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) string {
 		for _, entry := range strings.Split(globalPullSecrets, ",") {
 			secret := strings.TrimSpace(entry)
 			if secret != "" {
-				return secret
+				return secret, true
 			}
 		}
 	}
 
+	return "", false
+}
+
+func GetRegistryAuthSecretForHostname(cluster *v1.Cluster, url string) string {
+	if cluster == nil || cluster.Spec.RKEConfig == nil || cluster.Spec.RKEConfig.Registries == nil {
+		return ""
+	}
+	for regUrl, registry := range cluster.Spec.RKEConfig.Registries.Configs {
+		if regUrl == url {
+			return registry.AuthConfigSecretName
+		}
+	}
 	return ""
 }
 

--- a/pkg/provisioningv2/image/resolve.go
+++ b/pkg/provisioningv2/image/resolve.go
@@ -33,6 +33,7 @@ func resolve(reg, image string) string {
 }
 
 // GetPrivateRepoSecretFromCluster returns the name of the secret containing the credentials for the cluster level system-default-registry.
+// It returns the configured registry hostname and a boolean which indicates if the specified cluster inherits the global configuration.
 func GetPrivateRepoSecretFromCluster(cluster *v1.Cluster) (string, bool) {
 	url, isGlobalDefault := GetPrivateRepoURLFromCluster(cluster)
 	if cluster != nil && cluster.Spec.RKEConfig != nil && cluster.Spec.RKEConfig.Registries != nil {

--- a/pkg/provisioningv2/image/resolve_test.go
+++ b/pkg/provisioningv2/image/resolve_test.go
@@ -431,7 +431,7 @@ func TestGetPrivateRepoSecretFromCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			withGlobalRegistry(t, tt.globalRegistry)
 			withGlobalPullSecrets(t, tt.globalSecrets)
-			got := GetPrivateRepoSecretFromCluster(tt.cluster)
+			got, _ := GetPrivateRepoSecretFromCluster(tt.cluster)
 			assert.Equal(t, tt.expectedSecret, got)
 		})
 	}

--- a/pkg/scc/controllers/deployer.go
+++ b/pkg/scc/controllers/deployer.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/scc/deployer/params"
@@ -24,6 +25,12 @@ type deployersHandler struct {
 	log         log.StructuredLogger
 	sccDeployer *deployer.SCCDeployer
 	deployments deploymentControllers.DeploymentController
+}
+
+var relatedSettings = []string{
+	settings.SCCOperatorImage.Name,
+	settings.SystemDefaultRegistry.Name,
+	settings.SystemDefaultRegistryPullSecrets.Name,
 }
 
 func RegisterDeployer(
@@ -67,7 +74,7 @@ func RegisterDeployer(
 // OnRelatedSettings triggers changes to deployment if related settings change
 func (h *deployersHandler) OnRelatedSettings(_, name string, obj runtime.Object) ([]relatedresource.Key, error) {
 	if _, ok := obj.(*v3.Setting); ok {
-		if name == settings.SCCOperatorImage.Name {
+		if slices.Contains(relatedSettings, name) {
 			return []relatedresource.Key{{
 				Namespace: consts.DefaultSCCNamespace,
 				Name:      consts.DeploymentName,

--- a/pkg/scc/deployer/params/params.go
+++ b/pkg/scc/deployer/params/params.go
@@ -6,13 +6,13 @@ import (
 	"encoding/json"
 	"maps"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/scc/consts"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/version"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type SCCOperatorParams struct {
@@ -22,7 +22,8 @@ type SCCOperatorParams struct {
 
 	RefreshHash string
 
-	SCCOperatorImage string
+	SCCOperatorImage       string
+	SCCOperatorPullSecrets []corev1.LocalObjectReference
 }
 
 func ExtractSccOperatorParams() (*SCCOperatorParams, error) {
@@ -39,6 +40,11 @@ func ExtractSccOperatorParams() (*SCCOperatorParams, error) {
 		rancherGitCommit:    version.GitCommit,
 		SCCOperatorImage:    settings.FullSCCOperatorImage(),
 	}
+
+	if globalRegistry, _ := cluster.GetPrivateRegistry(nil); globalRegistry != nil {
+		params.SCCOperatorPullSecrets = globalRegistry.PullSecretsAsObjectReferences()
+	}
+
 	if err := params.setConfigHash(); err != nil {
 		return nil, err
 	}
@@ -61,6 +67,10 @@ func (p *SCCOperatorParams) setConfigHash() error {
 		hashInputData = append(hashInputData, []byte(p.SCCOperatorImage)...)
 	} else {
 		hashInputData = append(hashInputData, podSpecBytes...)
+	}
+
+	for _, pullSecret := range p.SCCOperatorPullSecrets {
+		hashInputData = append(hashInputData, []byte(pullSecret.Name)...)
 	}
 
 	// Generate the hash...
@@ -131,7 +141,7 @@ func (p *SCCOperatorParams) PrepareDeployment() *appsv1.Deployment {
 
 	// TODO: We should support the "extra tolerations" feature users are asking for
 	// ref: https://github.com/rancher/rancher/issues/48541
-	return &appsv1.Deployment{
+	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: consts.DefaultSCCNamespace,
 			Name:      consts.DeploymentName,
@@ -150,6 +160,12 @@ func (p *SCCOperatorParams) PrepareDeployment() *appsv1.Deployment {
 			},
 		},
 	}
+
+	if len(p.SCCOperatorPullSecrets) > 0 {
+		dep.Spec.Template.Spec.ImagePullSecrets = p.SCCOperatorPullSecrets
+	}
+
+	return dep
 }
 
 func (p *SCCOperatorParams) preparePodSpec() corev1.PodSpec {

--- a/pkg/scc/deployer/params/params.go
+++ b/pkg/scc/deployer/params/params.go
@@ -70,7 +70,7 @@ func (p *SCCOperatorParams) setConfigHash() error {
 	}
 
 	for _, pullSecret := range p.SCCOperatorPullSecrets {
-		hashInputData = append(hashInputData, []byte(pullSecret.Name)...)
+		hashInputData = append(hashInputData, []byte(pullSecret.Name+",")...)
 	}
 
 	// Generate the hash...

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -74,6 +74,9 @@ var (
 		"cattle-oidc-codes",
 		"cattle-oidc-client-secrets",
 		"cattle-impersonation-system",
+		"cluster-fleet-*",
+		"cattle-fleet-local-system",
+		"cattle-fleet-clusters-system",
 	}
 
 	AgentRolloutTimeout = NewSetting("agent-rollout-timeout", "300s")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -74,7 +74,7 @@ var (
 		"cattle-oidc-codes",
 		"cattle-oidc-client-secrets",
 		"cattle-impersonation-system",
-		"cluster-fleet-*",
+		"cluster-fleet-.*",
 		"cattle-fleet-local-system",
 		"cattle-fleet-clusters-system",
 	}

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -500,7 +500,8 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		rbac.Rbac().V1(),
 		content,
 		core.Core().V1().Pod(),
-		core.Core().V1().Node())
+		core.Core().V1().Node(),
+		core.Core().V1().Secret())
 
 	cache := memory.NewMemCacheClient(k8s.Discovery())
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cache)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54180, https://github.com/rancher/scc-operator/issues/93

This PR implements the finishing touches for the introduction of authenticated system default registries in the local and downstream imported/hosted clusters. At a high level, this PR updates three core areas of existing functionality: 

1. The SCC operator deployer has been updated to utilize the globally configured SDR pull secrets. It has also been updated to redeploy whenever the secrets listed in the global settings change, or if the GSDR host changes. This operator does not utilize the system-charts controller, and as such was not addressed in the prior PR. 


2. The cluster autoscaler has been updated to properly utilize either the GSDR or CSDR configuration when deploying the chart onto downstream clusters.
    + New controllers have been implemented which maintain a set of "root" HelmOp and image pull secrets using the GSDR configuration. Upon deployment of the autoscaler onto a downstream cluster which uses the GSDR, these credentials are passed as HelmOp resources and used to pull the autoscaler chart and autoscaler image from the configured repository. 
    + These controllers are also capable of generating cluster scoped credentials if authentication details for the `ClusterAutoscalerChartRepository` are present on the cluster spec. 


3. Updates have been made to `ClusterRepos` and the existing `helmop` logic to automatically deploy image pull secrets into the release namespaces of _rancher-managed_ charts. These secrets are also automatically configured when generating the charts `values.yaml`. 
    + This brings the UX of installing rancher-managed charts onto imported/hosted clusters closer to provisioned rke2/k3s clusters.
    + This logic is only utilized when deploying charts from the `rancher-charts` repository, and cannot yet be leveraged in user created repositories yet.
    + To achieve this, a new `DefaultImagePullSecrets` field has been added to the `ClusterRepos` Spec. New controllers have been introduced which ensure that this field contains the same pull secrets configured for the rest of the cluster.
     + This logic can be skipped by including the `skipPullSecrets=true` query param when making the chart install request from the UI. 
     + Only secrets which contain credentials for the system default registry set for the chart will be copied into the release namespace. 


There are also a number of smaller fixes and improvements:
+ The namespace ignore logic for project scoped secrets has been improved to accept regexps 
+ A bug was discovered during testing which prevents provisioned clusters from using `rke-auth` secret types when configuring registry authentication. This was fixed.
+ Small changes have been made to how the fleet chart is deployed, ensuring that local object references are passed to the chart. 