### PR TITLE
Cap number of fcio/publicEndpoints annotations written for ingress objects.

### DIFF
--- a/pkg/controllers/managementagent/endpoints/workload_endpoints.go
+++ b/pkg/controllers/managementagent/endpoints/workload_endpoints.go
@@ -3,6 +3,8 @@ package endpoints
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	v32 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
@@ -190,6 +192,13 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 	}
 	if numOverfilledAnnotations == 0 {
 		return nil
+	}
+	ignoreOverfillErrorStr := os.Getenv("CATTLE_IGNORE_ENDPOINT_ANNOTATION_OVERFLOW")
+	if ignoreOverfillErrorStr != "" {
+		ignoreOverfillError, err := strconv.ParseBool(ignoreOverfillErrorStr)
+		if err == nil && ignoreOverfillError {
+			return nil
+		}
 	}
 	pluralSuffix := ""
 	if numOverfilledAnnotations > 1 {

--- a/pkg/controllers/managementagent/endpoints/workload_endpoints.go
+++ b/pkg/controllers/managementagent/endpoints/workload_endpoints.go
@@ -180,7 +180,7 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 		}
 
 		if err = checkAnnotationSize(annotations); err != nil {
-			numOverfilledAnnotations += 1
+			numOverfilledAnnotations++
 			if firstOverfillError == nil {
 				firstOverfillError = err
 			}

--- a/pkg/controllers/managementagent/endpoints/workload_endpoints.go
+++ b/pkg/controllers/managementagent/endpoints/workload_endpoints.go
@@ -14,10 +14,18 @@ import (
 	"github.com/rancher/rancher/pkg/ingresswrapper"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-const k8sAnnotationLimit = 262144 // 256 KB
+var ignoreOverfillError bool
+
+func init() {
+	ignoreOverfillErrorStr := os.Getenv("CATTLE_IGNORE_ENDPOINT_ANNOTATION_OVERFLOW")
+	if ignoreOverfillErrorStr != "" {
+		ignoreOverfillError, _ = strconv.ParseBool(ignoreOverfillErrorStr)
+	}
+}
 
 // This controller is responsible for monitoring workloads
 // and setting public endpoints on them based on HostPort pods
@@ -181,7 +189,7 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 			endpointsAnnotation: epsToUpdate,
 		}
 
-		if err = checkAnnotationSize(annotations); err != nil {
+		if err = validation.ValidateAnnotationsSize(annotations); err != nil {
 			numOverfilledAnnotations++
 			if firstOverfillError == nil {
 				firstOverfillError = err
@@ -190,30 +198,12 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 			return err
 		}
 	}
-	if numOverfilledAnnotations == 0 {
+	if numOverfilledAnnotations == 0 || ignoreOverfillError {
 		return nil
-	}
-	ignoreOverfillErrorStr := os.Getenv("CATTLE_IGNORE_ENDPOINT_ANNOTATION_OVERFLOW")
-	if ignoreOverfillErrorStr != "" {
-		ignoreOverfillError, err := strconv.ParseBool(ignoreOverfillErrorStr)
-		if err == nil && ignoreOverfillError {
-			return nil
-		}
 	}
 	pluralSuffix := ""
 	if numOverfilledAnnotations > 1 {
 		pluralSuffix = "s"
 	}
 	return fmt.Errorf("failed to update %d endpoint annotation%s: first error: %w", numOverfilledAnnotations, pluralSuffix, firstOverfillError)
-}
-
-func checkAnnotationSize(annotations map[string]string) error {
-	data, err := json.Marshal(annotations)
-	if err == nil {
-		if len(data) >= k8sAnnotationLimit {
-			return fmt.Errorf("annotation size exceeded: %d > %d", len(data), k8sAnnotationLimit)
-		}
-		return nil
-	}
-	return fmt.Errorf("couldn't convert annotation hash to a string: %w", err)
 }

--- a/pkg/controllers/managementagent/endpoints/workload_endpoints.go
+++ b/pkg/controllers/managementagent/endpoints/workload_endpoints.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+const k8sAnnotationLimit = 262144 // 256 KB
+
 // This controller is responsible for monitoring workloads
 // and setting public endpoints on them based on HostPort pods
 // and NodePort services backing up the workload
@@ -93,6 +95,8 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 		}
 	}
 
+	numOverfilledAnnotations := 0
+	var firstOverfillError error
 	for _, w := range workloads {
 		// 1. Get endpoints from services
 		var newPublicEps []v32.PublicEndpoint
@@ -174,9 +178,33 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 		annotations := map[string]string{
 			endpointsAnnotation: epsToUpdate,
 		}
-		if err = c.WorkloadController.UpdateWorkload(w, annotations); err != nil {
+
+		if err = checkAnnotationSize(annotations); err != nil {
+			numOverfilledAnnotations += 1
+			if firstOverfillError == nil {
+				firstOverfillError = err
+			}
+		} else if err = c.WorkloadController.UpdateWorkload(w, annotations); err != nil {
 			return err
 		}
 	}
-	return nil
+	if numOverfilledAnnotations == 0 {
+		return nil
+	}
+	pluralSuffix := ""
+	if numOverfilledAnnotations > 1 {
+		pluralSuffix = "s"
+	}
+	return fmt.Errorf("failed to update %d endpoint annotation%s: first error: %w", numOverfilledAnnotations, pluralSuffix, firstOverfillError)
+}
+
+func checkAnnotationSize(annotations map[string]string) error {
+	data, err := json.Marshal(annotations)
+	if err == nil {
+		if len(data) >= k8sAnnotationLimit {
+			return fmt.Errorf("annotation size exceeded: %d > %d", len(data), k8sAnnotationLimit)
+		}
+		return nil
+	}
+	return fmt.Errorf("couldn't convert annotation hash to a string: %w", err)
 }


### PR DESCRIPTION
Ref issue #42058 

This is the simplest of 4 different possibilities Claude Opus came up with (driven by Sergey).

I made the error-handling a little more complex, and don't know where a truncation condition would be reported.

Also if the environment variable `CATTLE_IGNORE_ENDPOINT_ANNOTATION_OVERFLOW` is specified and true-ish ("true", "TRUE", or "1"), overflows still don't happen, but are not reported as an error status.

Limited discussion on the previous PR at (#55200)
https://github.com/rancher/rancher/pull/55200#pullrequestreview-4373947894