### PR TITLE
CAPI RBAC enhancement

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -44,6 +44,7 @@ type handler struct {
 	projectRoleTemplateBindingController mgmtcontrollers.ProjectRoleTemplateBindingController
 	projectRoleTemplateBindings          mgmtcontrollers.ProjectRoleTemplateBindingCache
 	roleTemplatesCache                   mgmtcontrollers.RoleTemplateCache
+	clusterController                    provisioningcontrollers.ClusterController
 	clusters                             provisioningcontrollers.ClusterCache
 	mgmtClusters                         mgmtcontrollers.ClusterCache
 	crdCache                             apiextcontrollers.CustomResourceDefinitionCache
@@ -78,6 +79,7 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 		projectRoleTemplateBindingController: clients.Mgmt.ProjectRoleTemplateBinding(),
 		projectRoleTemplateBindings:          clients.Mgmt.ProjectRoleTemplateBinding().Cache(),
 		roleTemplatesCache:                   clients.Mgmt.RoleTemplate().Cache(),
+		clusterController:                    clients.Provisioning.Cluster(),
 		clusters:                             clients.Provisioning.Cluster().Cache(),
 		mgmtClusters:                         clients.Mgmt.Cluster().Cache(),
 		crdCache:                             clients.CRD.CustomResourceDefinition().Cache(),

--- a/pkg/controllers/management/authprovisioningv2/cluster.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster.go
@@ -3,8 +3,10 @@ package authprovisioningv2
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/controllers/capr/dynamicschema"
 	"k8s.io/apimachinery/pkg/labels"
 
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -14,15 +16,49 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const capiResourcesCleanupFinalizer = "auth.cattle.io/capi-resources-cleanup"
+
 // OnCluster creates the roles required for users to be able to see/manage the
-// provisioning cluster resource
+// provisioning cluster resource. It also manages a finalizer to ensure that
+// cluster-indexed resources (e.g. AWSMachineTemplate) can be cleaned up by users
+// before the scoped RBAC roles are garbage-collected along with the cluster.
 func (h *handler) OnCluster(key string, cluster *v1.Cluster) (*v1.Cluster, error) {
 	if cluster == nil {
 		return cluster, nil
 	}
 
+	// Ensure the finalizer is present on all provisioning clusters
+	if !slices.Contains(cluster.Finalizers, capiResourcesCleanupFinalizer) {
+		clusterCopy := cluster.DeepCopy()
+		clusterCopy.Finalizers = append(clusterCopy.Finalizers, capiResourcesCleanupFinalizer)
+		return h.clusterController.Update(clusterCopy)
+	}
+
 	if cluster.DeletionTimestamp != nil {
-		return cluster, h.cleanClusterAdminRoleBindings(cluster)
+		// Cluster is being deleted — check if any cluster-indexed resources still exist
+		hasResources, err := h.clusterIndexedResourcesExist(cluster)
+		if err != nil {
+			return cluster, err
+		}
+		if hasResources {
+			// Re-enqueue to keep checking; this keeps the crt-* Role alive
+			// via the finalizer blocking GC on the cluster object
+			h.clusterController.EnqueueAfter(cluster.Namespace, cluster.Name, reenqueueTime)
+			return cluster, nil
+		}
+
+		// No cluster-indexed resources remain — safe to proceed with deletion
+		if err := h.cleanClusterAdminRoleBindings(cluster); err != nil {
+			return cluster, err
+		}
+
+		// Remove the finalizer to unblock GC
+		if slices.Contains(cluster.Finalizers, capiResourcesCleanupFinalizer) {
+			clusterCopy := cluster.DeepCopy()
+			clusterCopy.Finalizers = slices.DeleteFunc(clusterCopy.Finalizers,
+				func(f string) bool { return f == capiResourcesCleanupFinalizer })
+			return h.clusterController.Update(clusterCopy)
+		}
 	}
 
 	return cluster, h.createClusterViewRole(cluster)
@@ -131,4 +167,29 @@ func (h *handler) enqueueRoleTemplateBindings(cluster *v1.Cluster) error {
 	}
 
 	return nil
+}
+
+// clusterIndexedResourcesExist returns true if any cluster-indexed resources
+// (across all registered GVKs) still exist for the given cluster.
+func (h *handler) clusterIndexedResourcesExist(cluster *v1.Cluster) (bool, error) {
+	for _, candidate := range h.candidateTypes() {
+		// Skip the provisioning cluster GVK itself — the cluster being deleted
+		// is still in the index (blocked by our finalizer), which would cause
+		// a self-referential deadlock preventing the finalizer from ever being removed.
+		if candidate.GVK == h.provisioningClusterGVK {
+			continue
+		}
+		// Skip the rke machine config whose owner is the provisioning cluster
+		if candidate.GVK.Group == dynamicschema.MachineConfigAPIGroup {
+			continue
+		}
+		names, err := getResourceNames(h.dynamic, candidate, cluster)
+		if err != nil {
+			return false, err
+		}
+		if len(names) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/controllers/management/authprovisioningv2/cluster_test.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster_test.go
@@ -2,12 +2,15 @@ package authprovisioningv2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/rancher/kubernetes-provider-detector/providers"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/kubernetesprovider"
 	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	provisioningcontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/rbac"
 	wranglerrbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +23,6 @@ import (
 )
 
 func TestOnCluster(t *testing.T) {
-	ctrl := gomock.NewController(t)
 	crtbs := []*v3.ClusterRoleTemplateBinding{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -69,191 +71,330 @@ func TestOnCluster(t *testing.T) {
 	err := errors.NewBadRequest("error")
 
 	tests := map[string]struct {
-		cluster       *v1.Cluster
-		roleCacheMock func(*v1.Cluster) wranglerrbacv1.RoleCache
-		roleMock      func() wranglerrbacv1.RoleController
-		crtbCacheMock func(string) mgmtcontrollers.ClusterRoleTemplateBindingCache
-		crtbMock      func() mgmtcontrollers.ClusterRoleTemplateBindingController
-		prtbCacheMock func(string) mgmtcontrollers.ProjectRoleTemplateBindingCache
-		prtbMock      func() mgmtcontrollers.ProjectRoleTemplateBindingController
-		expectedErr   error
+		cluster            *v1.Cluster
+		roleCacheMock      func(*gomock.Controller, *v1.Cluster) wranglerrbacv1.RoleCache
+		roleMock           func(*gomock.Controller) wranglerrbacv1.RoleController
+		roleBindingMock    func(*gomock.Controller, *v1.Cluster) wranglerrbacv1.RoleBindingController
+		clusterMock        func(*gomock.Controller, *v1.Cluster) provisioningcontrollers.ClusterController
+		crtbCacheMock      func(*gomock.Controller, string) mgmtcontrollers.ClusterRoleTemplateBindingCache
+		crtbMock           func(*gomock.Controller) mgmtcontrollers.ClusterRoleTemplateBindingController
+		prtbCacheMock      func(*gomock.Controller, string) mgmtcontrollers.ProjectRoleTemplateBindingCache
+		prtbMock           func(*gomock.Controller) mgmtcontrollers.ProjectRoleTemplateBindingController
+		expectedErr        error
+		expectedFinalizers []string
 	}{
 		"role exists, don't enqueue CRTBs nor PRTBs": {
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
+					Name:       "cluster",
+					Namespace:  "fleet-default",
+					Finalizers: []string{capiResourcesCleanupFinalizer},
 					Labels: map[string]string{
 						kubernetesprovider.ProviderKey: providers.K3s, // distro is irrelevant here
 					},
 				},
 			},
-			roleCacheMock: func(cluster *v1.Cluster) wranglerrbacv1.RoleCache {
+			roleCacheMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) wranglerrbacv1.RoleCache {
 				mock := fake.NewMockCacheInterface[*rbacv1.Role](ctrl)
 				mock.EXPECT().Get(cluster.Namespace, clusterViewName(cluster)).
 					Return(&rbacv1.Role{}, nil)
 				return mock
 			},
-			roleMock: func() wranglerrbacv1.RoleController {
+			roleMock: func(ctrl *gomock.Controller) wranglerrbacv1.RoleController {
 				mock := fake.NewMockControllerInterface[*rbacv1.Role, *rbacv1.RoleList](ctrl)
 				mock.EXPECT().Update(gomock.Any())
 
 				return mock
 			},
-			crtbCacheMock: func(_ string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
+			clusterMock: func(ctrl *gomock.Controller, _ *v1.Cluster) provisioningcontrollers.ClusterController {
+				return fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](ctrl)
+			},
+			crtbCacheMock: func(ctrl *gomock.Controller, _ string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
 				return fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
 			},
-			crtbMock: func() mgmtcontrollers.ClusterRoleTemplateBindingController {
+			crtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ClusterRoleTemplateBindingController {
 				return fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 			},
-			prtbCacheMock: func(_ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
+			prtbCacheMock: func(ctrl *gomock.Controller, _ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
 				return fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
 			},
-			prtbMock: func() mgmtcontrollers.ProjectRoleTemplateBindingController {
+			prtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ProjectRoleTemplateBindingController {
 				return fake.NewMockControllerInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList](ctrl)
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedFinalizers: []string{capiResourcesCleanupFinalizer},
 		},
 		"no role, enqueue CRTBs and PRTBs": {
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
+					Name:       "cluster",
+					Namespace:  "fleet-default",
+					Finalizers: []string{capiResourcesCleanupFinalizer},
 					Labels: map[string]string{
 						kubernetesprovider.ProviderKey: providers.K3s, // distro is irrelevant here
 					},
 				},
 			},
-			roleCacheMock: func(cluster *v1.Cluster) wranglerrbacv1.RoleCache {
+			roleCacheMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) wranglerrbacv1.RoleCache {
 				mock := fake.NewMockCacheInterface[*rbacv1.Role](ctrl)
 				mock.EXPECT().Get(cluster.Namespace, clusterViewName(cluster)).
 					Return(&rbacv1.Role{}, errors.NewNotFound(schema.GroupResource{}, ""))
 				return mock
 			},
-			roleMock: func() wranglerrbacv1.RoleController {
+			roleMock: func(ctrl *gomock.Controller) wranglerrbacv1.RoleController {
 				mock := fake.NewMockControllerInterface[*rbacv1.Role, *rbacv1.RoleList](ctrl)
 				mock.EXPECT().Create(gomock.Any())
 
 				return mock
 			},
-			crtbCacheMock: func(clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
+			clusterMock: func(ctrl *gomock.Controller, _ *v1.Cluster) provisioningcontrollers.ClusterController {
+				return fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](ctrl)
+			},
+			crtbCacheMock: func(ctrl *gomock.Controller, clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
 				mock := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
 				mock.EXPECT().List(clusterName, labels.Everything()).Return(crtbs, nil)
 				return mock
 			},
-			crtbMock: func() mgmtcontrollers.ClusterRoleTemplateBindingController {
+			crtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ClusterRoleTemplateBindingController {
 				mock := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 				for _, crtb := range crtbs {
 					mock.EXPECT().Enqueue(crtb.Namespace, crtb.Name)
 				}
 				return mock
 			},
-			prtbCacheMock: func(_ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
+			prtbCacheMock: func(ctrl *gomock.Controller, _ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
 				mock := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
 				mock.EXPECT().List("", labels.Everything()).Return(prtbs, nil)
 				return mock
 			},
-			prtbMock: func() mgmtcontrollers.ProjectRoleTemplateBindingController {
+			prtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ProjectRoleTemplateBindingController {
 				mock := fake.NewMockControllerInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList](ctrl)
 				mock.EXPECT().Enqueue(prtbInCluster.Namespace, prtbInCluster.Name)
 				return mock
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedFinalizers: []string{capiResourcesCleanupFinalizer},
 		},
-		"rke enqueue CRTBs error": {
+		"enqueue CRTBs error": {
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Namespace:  "fleet-default",
+					Finalizers: []string{capiResourcesCleanupFinalizer},
 					Labels: map[string]string{
-						kubernetesprovider.ProviderKey: providers.RKE,
+						kubernetesprovider.ProviderKey: providers.K3s, // distro is irrelevant here
 					},
 				},
 			},
-			roleCacheMock: func(cluster *v1.Cluster) wranglerrbacv1.RoleCache {
+			roleCacheMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) wranglerrbacv1.RoleCache {
 				mock := fake.NewMockCacheInterface[*rbacv1.Role](ctrl)
 				mock.EXPECT().Get(cluster.Namespace, clusterViewName(cluster)).
 					Return(&rbacv1.Role{}, errors.NewNotFound(schema.GroupResource{}, ""))
 				return mock
 			},
-			roleMock: func() wranglerrbacv1.RoleController {
+			roleMock: func(ctrl *gomock.Controller) wranglerrbacv1.RoleController {
 				mock := fake.NewMockControllerInterface[*rbacv1.Role, *rbacv1.RoleList](ctrl)
 				mock.EXPECT().Create(gomock.Any())
 
 				return mock
 			},
-			crtbCacheMock: func(clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
+			clusterMock: func(ctrl *gomock.Controller, _ *v1.Cluster) provisioningcontrollers.ClusterController {
+				return fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](ctrl)
+			},
+			crtbCacheMock: func(ctrl *gomock.Controller, clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
 				mock := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
 				mock.EXPECT().List(clusterName, labels.Everything()).Return(nil, err)
 				return mock
 			},
-			crtbMock: func() mgmtcontrollers.ClusterRoleTemplateBindingController {
+			crtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ClusterRoleTemplateBindingController {
 				return fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 			},
-			prtbCacheMock: func(_ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
+			prtbCacheMock: func(ctrl *gomock.Controller, _ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
 				return fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
 			},
-			prtbMock: func() mgmtcontrollers.ProjectRoleTemplateBindingController {
+			prtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ProjectRoleTemplateBindingController {
 				return fake.NewMockControllerInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList](ctrl)
 			},
-			expectedErr: err,
+			expectedErr:        err,
+			expectedFinalizers: []string{capiResourcesCleanupFinalizer},
 		},
-		"rke enqueue PRTBs error": {
+		"enqueue PRTBs error": {
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Namespace:  "fleet-default",
+					Finalizers: []string{capiResourcesCleanupFinalizer},
 					Labels: map[string]string{
-						kubernetesprovider.ProviderKey: providers.RKE,
+						kubernetesprovider.ProviderKey: providers.K3s, // distro is irrelevant here
 					},
 				},
 			},
-			roleCacheMock: func(cluster *v1.Cluster) wranglerrbacv1.RoleCache {
+			roleCacheMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) wranglerrbacv1.RoleCache {
 				mock := fake.NewMockCacheInterface[*rbacv1.Role](ctrl)
 				mock.EXPECT().Get(cluster.Namespace, clusterViewName(cluster)).
 					Return(&rbacv1.Role{}, errors.NewNotFound(schema.GroupResource{}, ""))
 				return mock
 			},
-			roleMock: func() wranglerrbacv1.RoleController {
+			roleMock: func(ctrl *gomock.Controller) wranglerrbacv1.RoleController {
 				mock := fake.NewMockControllerInterface[*rbacv1.Role, *rbacv1.RoleList](ctrl)
 				mock.EXPECT().Create(gomock.Any())
 
 				return mock
 			},
-			crtbCacheMock: func(clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
+			clusterMock: func(ctrl *gomock.Controller, _ *v1.Cluster) provisioningcontrollers.ClusterController {
+				return fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](ctrl)
+			},
+			crtbCacheMock: func(ctrl *gomock.Controller, clusterName string) mgmtcontrollers.ClusterRoleTemplateBindingCache {
 				mock := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
 				mock.EXPECT().List(clusterName, labels.Everything()).Return(crtbs, nil)
 				return mock
 			},
-			crtbMock: func() mgmtcontrollers.ClusterRoleTemplateBindingController {
+			crtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ClusterRoleTemplateBindingController {
 				mock := fake.NewMockControllerInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 				for _, crtb := range crtbs {
 					mock.EXPECT().Enqueue(crtb.Namespace, crtb.Name)
 				}
 				return mock
 			},
-			prtbCacheMock: func(_ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
+			prtbCacheMock: func(ctrl *gomock.Controller, _ string) mgmtcontrollers.ProjectRoleTemplateBindingCache {
 				mock := fake.NewMockCacheInterface[*v3.ProjectRoleTemplateBinding](ctrl)
 				mock.EXPECT().List("", labels.Everything()).Return(nil, err)
 				return mock
 			},
-			prtbMock: func() mgmtcontrollers.ProjectRoleTemplateBindingController {
+			prtbMock: func(ctrl *gomock.Controller) mgmtcontrollers.ProjectRoleTemplateBindingController {
 				return fake.NewMockControllerInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList](ctrl)
 			},
-			expectedErr: err,
+			expectedErr:        err,
+			expectedFinalizers: []string{capiResourcesCleanupFinalizer},
+		},
+		"deleting cluster cleans admin role bindings and removes finalizer": {
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Namespace:  "fleet-default",
+					Finalizers: []string{capiResourcesCleanupFinalizer},
+					Labels: map[string]string{
+						kubernetesprovider.ProviderKey: providers.K3s, // distro is irrelevant here
+					},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			},
+			roleBindingMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) wranglerrbacv1.RoleBindingController {
+				mock := fake.NewMockControllerInterface[*rbacv1.RoleBinding, *rbacv1.RoleBindingList](ctrl)
+				mock.EXPECT().List(cluster.Namespace, metav1.ListOptions{}).Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "cleanup", Namespace: cluster.Namespace},
+						RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: rbac.ProvisioningClusterAdminName(cluster)},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "keep", Namespace: cluster.Namespace},
+						RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "other-role"},
+					},
+				}}, nil)
+				mock.EXPECT().Delete(cluster.Namespace, "cleanup", &metav1.DeleteOptions{}).Return(nil)
+				return mock
+			},
+			clusterMock: func(ctrl *gomock.Controller, _ *v1.Cluster) provisioningcontrollers.ClusterController {
+				mock := fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](ctrl)
+				mock.EXPECT().Update(gomock.Any()).DoAndReturn(func(updated *v1.Cluster) (*v1.Cluster, error) {
+					assert.Empty(t, updated.Finalizers)
+					return updated, nil
+				})
+				return mock
+			},
+			expectedErr:        nil,
+			expectedFinalizers: []string{},
+		},
+		"missing finalizer updates cluster before role handling": {
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster",
+					Namespace: "fleet-default",
+					Labels: map[string]string{
+						kubernetesprovider.ProviderKey: providers.K3s, // distro is irrelevant here
+					},
+				},
+			},
+			clusterMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) provisioningcontrollers.ClusterController {
+				mock := fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](ctrl)
+				mock.EXPECT().Update(gomock.Any()).DoAndReturn(func(updated *v1.Cluster) (*v1.Cluster, error) {
+					assert.Equal(t, []string{capiResourcesCleanupFinalizer}, updated.Finalizers)
+					return updated, nil
+				})
+				return mock
+			},
+			expectedErr:        nil,
+			expectedFinalizers: []string{capiResourcesCleanupFinalizer},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
 
-			h := handler{
-				clusterRoleTemplateBindings:          test.crtbCacheMock(test.cluster.Name),
-				clusterRoleTemplateBindingController: test.crtbMock(),
-				projectRoleTemplateBindings:          test.prtbCacheMock(test.cluster.Name),
-				projectRoleTemplateBindingController: test.prtbMock(),
-				roleCache:                            test.roleCacheMock(test.cluster),
-				roleController:                       test.roleMock(),
+			clusterName := ""
+			if test.cluster != nil {
+				clusterName = test.cluster.Name
 			}
 
-			_, err := h.OnCluster("", test.cluster)
+			var roleCache wranglerrbacv1.RoleCache
+			if test.roleCacheMock != nil {
+				roleCache = test.roleCacheMock(ctrl, test.cluster)
+			}
+
+			var roleController wranglerrbacv1.RoleController
+			if test.roleMock != nil {
+				roleController = test.roleMock(ctrl)
+			}
+
+			var roleBindingController wranglerrbacv1.RoleBindingController
+			if test.roleBindingMock != nil {
+				roleBindingController = test.roleBindingMock(ctrl, test.cluster)
+			}
+
+			var clusterController provisioningcontrollers.ClusterController
+			if test.clusterMock != nil {
+				clusterController = test.clusterMock(ctrl, test.cluster)
+			}
+
+			var crtbCache mgmtcontrollers.ClusterRoleTemplateBindingCache
+			if test.crtbCacheMock != nil {
+				crtbCache = test.crtbCacheMock(ctrl, clusterName)
+			}
+
+			var crtbController mgmtcontrollers.ClusterRoleTemplateBindingController
+			if test.crtbMock != nil {
+				crtbController = test.crtbMock(ctrl)
+			}
+
+			var prtbCache mgmtcontrollers.ProjectRoleTemplateBindingCache
+			if test.prtbCacheMock != nil {
+				prtbCache = test.prtbCacheMock(ctrl, clusterName)
+			}
+
+			var prtbController mgmtcontrollers.ProjectRoleTemplateBindingController
+			if test.prtbMock != nil {
+				prtbController = test.prtbMock(ctrl)
+			}
+
+			h := handler{
+				clusterRoleTemplateBindings:          crtbCache,
+				clusterRoleTemplateBindingController: crtbController,
+				projectRoleTemplateBindings:          prtbCache,
+				projectRoleTemplateBindingController: prtbController,
+				roleCache:                            roleCache,
+				roleController:                       roleController,
+				roleBindingController:                roleBindingController,
+				clusterController:                    clusterController,
+			}
+
+			result, err := h.OnCluster("", test.cluster)
 
 			assert.Equal(t, err, test.expectedErr)
+			if test.cluster != nil {
+				assert.Equal(t, test.expectedFinalizers, result.Finalizers)
+			}
 		})
 	}
 }

--- a/pkg/controllers/management/authprovisioningv2/indexer.go
+++ b/pkg/controllers/management/authprovisioningv2/indexer.go
@@ -2,6 +2,7 @@ package authprovisioningv2
 
 import (
 	"fmt"
+	"strings"
 
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/capr/dynamicschema"
@@ -31,15 +32,35 @@ func getObjectClusterNames(obj runtime.Object) ([]string, error) {
 	}
 
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	if gvk.Group == dynamicschema.MachineConfigAPIGroup {
-		objMeta, err := meta.Accessor(obj)
-		// If there is an error, skip this block
-		if err == nil {
+
+	objMeta, err := meta.Accessor(obj)
+	// If there is an error, skip this block
+	if err == nil {
+		if gvk.Group == dynamicschema.MachineConfigAPIGroup {
 			for _, owner := range objMeta.GetOwnerReferences() {
 				if owner.APIVersion == "provisioning.cattle.io/v1" && owner.Kind == "Cluster" {
 					return []string{owner.Name}, nil
 				}
 			}
+		}
+
+		// Infrastructure/bootstrap/controlplane provider objects (e.g. AWSMachineTemplate)
+		// may have an ownerRef to a cluster.x-k8s.io/Cluster but no spec.clusterName field.
+		// Since the CAPI Cluster name equals the provisioning Cluster name, the ownerRef
+		// name is directly usable as the cluster name. Match on the group prefix to be
+		// version-agnostic (v1beta1, v1beta2, future v1, etc.).
+		for _, owner := range objMeta.GetOwnerReferences() {
+			if strings.HasPrefix(owner.APIVersion, "cluster.x-k8s.io/") && owner.Kind == "Cluster" {
+				return []string{owner.Name}, nil
+			}
+		}
+
+		// Infrastructure provider objects (e.g. AWSCluster, AWSMachine) carry the
+		// CAPI-standard label cluster.x-k8s.io/cluster-name set by CAPI controllers.
+		// AWSMachine for example has no spec.clusterName and its ownerRef points to a
+		// Machine (not a Cluster directly), so the label is the most reliable fallback.
+		if clusterName := objMeta.GetLabels()["cluster.x-k8s.io/cluster-name"]; clusterName != "" {
+			return []string{clusterName}, nil
 		}
 	}
 

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -46,10 +46,12 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
-		addRule().apiGroups("rke.cattle.io").resources("etcdsnapshots").verbs("get", "list", "watch")
-
-	clusterCreateRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create").
-		addNamespacedRule("fleet-default").addRule().apiGroups("").resources("secrets").verbs("create")
+		addRule().apiGroups("rke.cattle.io").resources("etcdsnapshots").verbs("get", "list", "watch").
+		addRule().apiGroups("infrastructure.cluster.x-k8s.io").resources("awsclusterstaticidentities").verbs("create")
+	clusterCreateRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create")
+	clusterCreateFleetDefault := clusterCreateRole.addNamespacedRule("fleet-default")
+	clusterCreateFleetDefault.addRule().apiGroups("").resources("secrets").verbs("create")
+	clusterCreateFleetDefault.addRule().apiGroups("infrastructure.cluster.x-k8s.io").resources("*").verbs("create")
 
 	rb.addRole("Manage Node Drivers", "nodedrivers-manage").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("*")
@@ -83,8 +85,11 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")
 
 	userRole := addUserRules(rb.addRole("User", "user"))
-	userRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create").
-		addNamespacedRule("fleet-default").addRule().apiGroups("").resources("secrets").verbs("create")
+	userRole.addRule().apiGroups("infrastructure.cluster.x-k8s.io").resources("awsclusterstaticidentities").verbs("create")
+	userRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create")
+	userFleetDefault := userRole.addNamespacedRule("fleet-default")
+	userFleetDefault.addRule().apiGroups("").resources("secrets").verbs("create")
+	userFleetDefault.addRule().apiGroups("infrastructure.cluster.x-k8s.io").resources("*").verbs("create")
 
 	rb.addRole("User Base", "user-base").
 		addRule().apiGroups("ext.cattle.io").resources("useractivities").verbs("get", "update", "patch").
@@ -372,7 +377,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 
 	// Not specific to project or cluster
 	// TODO When clusterevents has value, consider adding this back in
-	//rb.addRoleTemplate("View Events", "events-view", "", true, false, false).
+	// rb.addRoleTemplate("View Events", "events-view", "", true, false, false).
 	//	addRule().apiGroups("").resources("events").verbs("get", "list", "watch").
 	//	addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch")
 

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -46,8 +46,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
-		addRule().apiGroups("rke.cattle.io").resources("etcdsnapshots").verbs("get", "list", "watch").
-		addRule().apiGroups("infrastructure.cluster.x-k8s.io").resources("awsclusterstaticidentities").verbs("create")
+		addRule().apiGroups("rke.cattle.io").resources("etcdsnapshots").verbs("get", "list", "watch")
 	clusterCreateRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create")
 	clusterCreateFleetDefault := clusterCreateRole.addNamespacedRule("fleet-default")
 	clusterCreateFleetDefault.addRule().apiGroups("").resources("secrets").verbs("create")
@@ -85,7 +84,6 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")
 
 	userRole := addUserRules(rb.addRole("User", "user"))
-	userRole.addRule().apiGroups("infrastructure.cluster.x-k8s.io").resources("awsclusterstaticidentities").verbs("create")
 	userRole.addNamespacedRule("cattle-global-data").addRule().apiGroups("").resources("secrets").verbs("create")
 	userFleetDefault := userRole.addNamespacedRule("fleet-default")
 	userFleetDefault.addRule().apiGroups("").resources("secrets").verbs("create")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- https://github.com/rancher/rancher/issues/54989
- https://github.com/rancher/rancher/issues/54961
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
We need to update the default roles to permit users to use CAPI Infrastructure providers. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This PR introduces the following changes:

* Adds the following permissions to the user and cluster-create roles:
	* Permission to create all namespaced resources in the `infrastructure.cluster.x-k8s.io` API group within the `fleet-default` namespace.

* Updates the indexer to include resources from the `infrastructure.cluster.x-k8s.io` API group, indexed by cluster name. This allows users to access infrastructure resources associated with clusters they own.

* Fixes an issue where users could lose access to resources in the `infrastructure.cluster.x-k8s.io` API group during cluster deletion. Previously, when the provisioning cluster was removed, the associated scoped RBAC role bindings were garbage-collected as well, preventing users from cleaning up cluster-indexed resources if the provisioning cluster is deleted first. To address this, the provisioning cluster now manages a finalizer that ensures the provisioning cluster is always deleted last. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The changes were tested locally in the development environment using a local user assigned either the `user` or `cluster-create` role.

Due to the current lack of UI support and missing functionality in Turtles, cluster creation and deletion with CAPA as the infrastructure provider were performed directly using `kubectl` and YAML manifests.  

### Automated Testing
 n/a 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Standard user and cluster-create should be able to use CAPA as the infrastructure provider, and manage the lifecycle of the cluster and related resources from the `infrastructure.cluster.x-k8s.io` API group. 

Noting that this needs to be done by using kuebctl and YAML files.  

 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 
n/a 

Existing / newly added automated tests that provide evidence there are no regressions:
 
n/a