### PR TITLE
fix auth-prov-v2-roletemplate hander

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/role.go
+++ b/pkg/controllers/management/authprovisioningv2/role.go
@@ -12,6 +12,7 @@ import (
 	apiextcontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/name"
+	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -51,8 +52,11 @@ func (h *handler) initializeCRDs(crdClient apiextcontrollers.CustomResourceDefin
 	return nil
 }
 
+// crdToResourceMatch returns the first served and not deprecated version of the CRD as a resourceMatch,
+// or nil if there are no served versions or the CRD is not valid
 func crdToResourceMatch(crd *apiextv1.CustomResourceDefinition) *resourceMatch {
 	if crd.Status.AcceptedNames.Kind == "" || len(crd.Spec.Versions) == 0 {
+		logrus.Debugf("[authprovisioningv2] CRD %s does not have any versions or accepted names, skipping", crd.Name)
 		return nil
 	}
 
@@ -63,6 +67,11 @@ func crdToResourceMatch(crd *apiextv1.CustomResourceDefinition) *resourceMatch {
 			version = ver
 			break
 		}
+	}
+
+	if !version.Served {
+		logrus.Debugf("[authprovisioningv2] CRD %s does not have served version, skipping", crd.Name)
+		return nil
 	}
 
 	gvk := schema.GroupVersionKind{

--- a/pkg/controllers/management/authprovisioningv2/role.go
+++ b/pkg/controllers/management/authprovisioningv2/role.go
@@ -52,31 +52,40 @@ func (h *handler) initializeCRDs(crdClient apiextcontrollers.CustomResourceDefin
 	return nil
 }
 
-// crdToResourceMatch returns the first served and not deprecated version of the CRD as a resourceMatch,
-// or nil if there are no served versions or the CRD is not valid
+// crdToResourceMatch returns the first served non-deprecated version of the CRD as a resourceMatch.
+// If none exists, it falls back to the first served deprecated version.
+// It returns nil if there are no served versions or the CRD is not valid.
 func crdToResourceMatch(crd *apiextv1.CustomResourceDefinition) *resourceMatch {
 	if crd.Status.AcceptedNames.Kind == "" || len(crd.Spec.Versions) == 0 {
 		logrus.Debugf("[authprovisioningv2] CRD %s does not have any versions or accepted names, skipping", crd.Name)
 		return nil
 	}
 
-	version := crd.Spec.Versions[0]
-
+	versionName := ""
 	for _, ver := range crd.Spec.Versions {
 		if !ver.Deprecated && ver.Served {
-			version = ver
+			versionName = ver.Name
 			break
 		}
 	}
 
-	if !version.Served {
+	if versionName == "" {
+		for _, ver := range crd.Spec.Versions {
+			if ver.Served {
+				versionName = ver.Name
+				break
+			}
+		}
+	}
+
+	if versionName == "" {
 		logrus.Debugf("[authprovisioningv2] CRD %s does not have served version, skipping", crd.Name)
 		return nil
 	}
 
 	gvk := schema.GroupVersionKind{
 		Group:   crd.Spec.Group,
-		Version: version.Name,
+		Version: versionName,
 		Kind:    crd.Status.AcceptedNames.Kind,
 	}
 

--- a/pkg/controllers/management/authprovisioningv2/role.go
+++ b/pkg/controllers/management/authprovisioningv2/role.go
@@ -59,7 +59,7 @@ func crdToResourceMatch(crd *apiextv1.CustomResourceDefinition) *resourceMatch {
 	version := crd.Spec.Versions[0]
 
 	for _, ver := range crd.Spec.Versions {
-		if !ver.Deprecated {
+		if !ver.Deprecated && ver.Served {
 			version = ver
 			break
 		}

--- a/pkg/controllers/management/authprovisioningv2/role_test.go
+++ b/pkg/controllers/management/authprovisioningv2/role_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierror "k8s.io/apimachinery/pkg/api/errors"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -421,12 +421,31 @@ func Test_crdToResourceMatch(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "selects first version when all deprecated or not served",
+			name: "nil when no served non-deprecated and fallback version is not served",
 			crd: &apiextv1.CustomResourceDefinition{
 				Spec: apiextv1.CustomResourceDefinitionSpec{
 					Group: "example.io",
 					Versions: []apiextv1.CustomResourceDefinitionVersion{
 						{Name: "v1alpha1", Served: false, Deprecated: true},
+						{Name: "v1beta1", Served: true, Deprecated: true},
+					},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "Example",
+						Plural: "examples",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "falls back to first version when no served non-deprecated exists and first is served",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group: "example.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Served: true, Deprecated: true},
 						{Name: "v1beta1", Served: true, Deprecated: true},
 					},
 				},
@@ -526,7 +545,7 @@ func Test_crdToResourceMatch(t *testing.T) {
 			},
 		},
 		{
-			name: "handles CRD with only not served versions",
+			name: "nil for CRD with only not served versions",
 			crd: &apiextv1.CustomResourceDefinition{
 				Spec: apiextv1.CustomResourceDefinitionSpec{
 					Group: "example.io",
@@ -541,14 +560,7 @@ func Test_crdToResourceMatch(t *testing.T) {
 					},
 				},
 			},
-			want: &resourceMatch{
-				GVK: schema.GroupVersionKind{
-					Group:   "example.io",
-					Version: "v1alpha1",
-					Kind:    "Example",
-				},
-				Resource: "examples",
-			},
+			want: nil,
 		},
 	}
 

--- a/pkg/controllers/management/authprovisioningv2/role_test.go
+++ b/pkg/controllers/management/authprovisioningv2/role_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -377,6 +378,186 @@ func newDeletingMgmtCuster() *v3.Cluster {
 	c := &v3.Cluster{}
 	c.DeletionTimestamp = &metav1.Time{}
 	return c
+}
+
+func Test_crdToResourceMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		crd  *apiextv1.CustomResourceDefinition
+		want *resourceMatch
+	}{
+		{
+			name: "nil when AcceptedNames.Kind is empty",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group: "example.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{Name: "v1", Served: true, Storage: true},
+					},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "",
+						Plural: "examples",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "nil when Versions is empty",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group:    "example.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "Example",
+						Plural: "examples",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "selects first version when all deprecated or not served",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group: "example.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Served: false, Deprecated: true},
+						{Name: "v1beta1", Served: true, Deprecated: true},
+					},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "Example",
+						Plural: "examples",
+					},
+				},
+			},
+			want: &resourceMatch{
+				GVK: schema.GroupVersionKind{
+					Group:   "example.io",
+					Version: "v1alpha1",
+					Kind:    "Example",
+				},
+				Resource: "examples",
+			},
+		},
+		{
+			name: "selects first non-deprecated and served version",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group: "example.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Served: false, Deprecated: true},
+						{Name: "v1beta1", Served: true, Deprecated: true},
+						{Name: "v1", Served: true, Deprecated: false},
+						{Name: "v2", Served: true, Deprecated: false},
+					},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "Example",
+						Plural: "examples",
+					},
+				},
+			},
+			want: &resourceMatch{
+				GVK: schema.GroupVersionKind{
+					Group:   "example.io",
+					Version: "v1",
+					Kind:    "Example",
+				},
+				Resource: "examples",
+			},
+		},
+		{
+			name: "valid CRD with single version",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group: "test.cattle.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{Name: "v1", Served: true, Storage: true},
+					},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "TestResource",
+						Plural: "testresources",
+					},
+				},
+			},
+			want: &resourceMatch{
+				GVK: schema.GroupVersionKind{
+					Group:   "test.cattle.io",
+					Version: "v1",
+					Kind:    "TestResource",
+				},
+				Resource: "testresources",
+			},
+		},
+		{
+			name: "prefers served over not served",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group: "example.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Served: false, Deprecated: false},
+						{Name: "v1", Served: true, Deprecated: false},
+					},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "Example",
+						Plural: "examples",
+					},
+				},
+			},
+			want: &resourceMatch{
+				GVK: schema.GroupVersionKind{
+					Group:   "example.io",
+					Version: "v1",
+					Kind:    "Example",
+				},
+				Resource: "examples",
+			},
+		},
+		{
+			name: "handles CRD with only not served versions",
+			crd: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Group: "example.io",
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Served: false, Deprecated: false},
+					},
+				},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					AcceptedNames: apiextv1.CustomResourceDefinitionNames{
+						Kind:   "Example",
+						Plural: "examples",
+					},
+				},
+			},
+			want: &resourceMatch{
+				GVK: schema.GroupVersionKind{
+					Group:   "example.io",
+					Version: "v1alpha1",
+					Kind:    "Example",
+				},
+				Resource: "examples",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := crdToResourceMatch(tt.crd)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func Test_isProtectedRBACResource(t *testing.T) {

--- a/pkg/controllers/management/authprovisioningv2/role_test.go
+++ b/pkg/controllers/management/authprovisioningv2/role_test.go
@@ -421,7 +421,7 @@ func Test_crdToResourceMatch(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "nil when no served non-deprecated and fallback version is not served",
+			name: "falls back to served deprecated when no served non-deprecated exists",
 			crd: &apiextv1.CustomResourceDefinition{
 				Spec: apiextv1.CustomResourceDefinitionSpec{
 					Group: "example.io",
@@ -437,7 +437,14 @@ func Test_crdToResourceMatch(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			want: &resourceMatch{
+				GVK: schema.GroupVersionKind{
+					Group:   "example.io",
+					Version: "v1beta1",
+					Kind:    "Example",
+				},
+				Resource: "examples",
+			},
 		},
 		{
 			name: "falls back to first version when no served non-deprecated exists and first is served",


### PR DESCRIPTION
 
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- https://github.com/rancher/rancher/issues/55192  
- https://github.com/rancher/rancher/issues/54730


## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
After installing CAPA via Turtles into the local clusters, a standard user can not edit the cluster he creates. 

Rancher logs show the error: 
```
error syncing 'cluster-admin': handler auth-prov-v2-roletemplate: no matches for kind "EKSConfig" in version "bootstrap.cluster.x-k8s.io/v1beta1", requeuing
```

The bug is identified in the [crdToResourceMatch](https://github.com/rancher/rancher/blob/0932e0f2e1115f1b95eb6c2c33307f823eaf1e43/pkg/controllers/management/authprovisioningv2/role.go#L54) function. 

For a complete root cause analysis, please check [this comment](https://github.com/rancher/rancher/issues/55192#issuecomment-4511886034)


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Fix the crdToResourceMatch function to serve the first served non-deprecated version of the CRD as a resourceMatch. If none exists, it falls back to the first served deprecated version. It returns nil if there are no served versions or the CRD is not valid. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The fix was tested locally in the development environment to confirm that the standard user can edit the cluster he creates.  

See the edit options in the screenshot, and the machine in the pool:

<img width="1540" height="764" alt="Screenshot 2026-06-08 at 11 09 43 AM" src="https://github.com/user-attachments/assets/25d3c6b1-d169-41e4-97a1-0553157020c0" />



### Automated Testing
 
Unit tests are added for the crdToResourceMatch function. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
The same scenario as described in the issue. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change,  

The same scenario as described in the issue. 

Existing / newly added automated tests that provide evidence there are no regressions:

n/a 