### PR TITLE
Make the rancherNamespaces helm test work when a registry is set

### DIFF
--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -739,19 +739,11 @@ tests:
       annotations:
         foo: bar
   asserts:
-    - equal:
+    - contains:
         path: spec.template.spec.containers[0].env
-        value:
-          - name: CATTLE_NAMESPACE
-            value: NAMESPACE
-          - name: CATTLE_PEER_SERVICE
-            value: RELEASE-NAME-rancher
-          - name: IMPERATIVE_API_DIRECT
-            value: "true"
-          - name: IMPERATIVE_API_APP_SELECTOR
-            value: RELEASE-NAME-rancher
-          - name: RANCHER_NAMESPACES_OPTIONS
-            value: "{\"annotations\":{\"foo\":\"bar\"},\"enabled\":true,\"labels\":{\"foo\":\"bar\"}}"
+        content:
+          name: RANCHER_NAMESPACES_OPTIONS
+          value: "{\"annotations\":{\"foo\":\"bar\"},\"enabled\":true,\"labels\":{\"foo\":\"bar\"}}"
 - it: should not add CATTLE_BASE_REGISTRY_PULL_SECRETS to env when imagePullSecrets is empty
   asserts:
     - notContains:


### PR DESCRIPTION
## Issue: 
 
## Problem
The RCS and Hotfix workflows set `REGISTRY`, which causes a helm unittest to fail, so the chart can't be built in these workflows.
 
## Solution
Change the test to check if the relevant element is contained in the `env` value in the helm unittest, instead of an exact match for `env`.

## Engineering Testing
### Manual Testing
Manually set `REGISTRY` in a local build container, built and ran the helm tests with and without the fix and checked that the tests failed and then passed.