### PR TITLE
[main] Fix system charts reinstallation when SDR is set

### DIFF
--- a/pkg/catalogv2/helmop/pull_secrets.go
+++ b/pkg/catalogv2/helmop/pull_secrets.go
@@ -43,6 +43,12 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 		return nil
 	}
 
+	repo, err := s.clusterReposCache.Get(clusterRepoName)
+	if err != nil {
+		log.Errorf("[helmop] createNamespaceAndPullSecrets: failed to get cluster repo %q from cache: %v", clusterRepoName, err)
+		return err
+	}
+
 	for i := range cmds {
 		if cmds[i].ReleaseName == "" {
 			continue
@@ -63,20 +69,31 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 			continue
 		}
 
-		sdr, sdrDefined := s.systemDefaultRegistryConfigured(values)
-		pullSecretsPreConfigured := s.chartHasConfiguredPullSecrets(values)
+		currentManagedSecrets := buildManagedSecretNames(cmds[i].ReleaseName, repo.Spec.DefaultImagePullSecrets)
+		existingManagedSecrets, err := s.listExistingManagedSecretNames(ns.Name, cmds[i].ReleaseName)
+		if err != nil {
+			return err
+		}
+		allManagedSecrets := append(currentManagedSecrets, existingManagedSecrets...)
 
-		pullSecrets, err := s.managePullSecrets(sdr, ns.Name, clusterRepoName, cmds[i].ReleaseName, pullSecretsPreConfigured)
+		if s.chartHasOnlyUserConfiguredPullSecrets(baseValues, values, allManagedSecrets) {
+			// if the user is manually specifying image pull secret names in all supported paths,
+			// clean any managed ones up.
+			if err := s.deleteStaleHelmOpSecrets([]string{}, existingManagedSecrets, ns.Name, cmds[i].ReleaseName); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Create, update, or delete managed secret names in the charts release namespace.
+		pullSecrets, err := s.managePullSecrets(repo, s.configuredSystemDefaultRegistry(values), ns.Name, cmds[i].ReleaseName, existingManagedSecrets)
 		if err != nil {
 			return err
 		}
 
-		if !sdrDefined {
-			continue
-		}
-
+		// Ensure that the chart has the image pull secret fields correctly configured.
 		log.Tracef("[helmop] injecting pull secrets into command %d (release=%q, namespace=%q, valuesLen=%d, chartBaseValuesLen=%d)", i, cmds[i].ReleaseName, cmds[i].ReleaseNamespace, len(cmds[i].Values), len(cmds[i].ChartBaseValues))
-		cmds[i].Values, err = s.injectPullSecrets(cmds[i].ReleaseName, baseValues, values, pullSecrets)
+		cmds[i].Values, err = s.injectPullSecrets(cmds[i].ReleaseName, baseValues, values, pullSecrets, allManagedSecrets)
 		if err != nil {
 			return err
 		}
@@ -85,10 +102,13 @@ func (s *Operations) createNamespaceAndPullSecrets(ctx context.Context, status c
 	return nil
 }
 
-func (s *Operations) systemDefaultRegistryConfigured(values map[string]any) (string, bool) {
+func (s *Operations) configuredSystemDefaultRegistry(values map[string]any) string {
 	v, defined := getValueAtPath(values, "global", "cattle", "systemDefaultRegistry")
-	sdr, ok := v.(string)
-	return sdr, defined && ok && v != ""
+	if !defined {
+		return ""
+	}
+	sdr, _ := v.(string)
+	return sdr
 }
 
 func (s *Operations) chartSupportsImagePullSecrets(baseValues map[string]any) bool {
@@ -103,39 +123,113 @@ func (s *Operations) chartSupportsImagePullSecrets(baseValues map[string]any) bo
 	return false
 }
 
-func (*Operations) chartHasConfiguredPullSecrets(values map[string]any) bool {
-	for _, path := range imagePullSecretPaths {
-		pathStr := strings.Join(path, ".")
-		v, declared := getValueAtPath(values, path...)
-		if !declared {
-			continue
-		}
-		pullSecret, ok := v.([]any)
-		log.Tracef("[helmop] injectPullSecrets: path %q is declared in chart base values", pathStr)
-		if ok && len(pullSecret) != 0 {
-			return true
-		}
+// buildManagedSecretNames returns the names that managePullSecrets would assign to the
+// given cluster repo secrets when scoped to releaseName.
+func buildManagedSecretNames(releaseName string, secretRefs []catalog.SecretReference) []string {
+	names := make([]string, 0, len(secretRefs))
+	for _, ref := range secretRefs {
+		names = append(names, name.SafeConcatName(releaseName, ref.Name))
 	}
-	return false
+	return names
 }
 
-func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string]any, confValues map[string]any, secretNames []string) ([]byte, error) {
-	pullSecrets := make([]map[string]string, len(secretNames))
-	for i, e := range secretNames {
-		pullSecrets[i] = map[string]string{"name": e}
+// chartHasOnlyUserConfiguredPullSecrets returns true when every imagePullSecrets path
+// supported by the chart (present in 'baseValues') is already populated in 'values' with
+// secrets that are not Rancher-managed (i.e. none of the configured secret names appear
+// in managedSecretNames). In that case the user owns all pull secret configuration and
+// Rancher should not inject or manage pull secrets for this chart.
+func (*Operations) chartHasOnlyUserConfiguredPullSecrets(baseValues, values map[string]any, managedSecretNames []string) bool {
+	managed := make(map[string]struct{}, len(managedSecretNames))
+	for _, n := range managedSecretNames {
+		managed[n] = struct{}{}
+	}
+
+	chartSupportsPullSecrets := false
+	for _, path := range imagePullSecretPaths {
+		if _, declared := getValueAtPath(baseValues, path...); !declared {
+			continue
+		}
+		chartSupportsPullSecrets = true
+
+		// find the pull secrets configured at one of
+		// the known paths
+		secrets, _ := getValueAtPath(values, path...)
+		secretList, ok := secrets.([]any)
+		if !ok || len(secretList) == 0 {
+			return false
+		}
+
+		// determine if any of the configured secrets are managed by Rancher.
+		// If not, then the user fully owns the pull secret configuration for this path,
+		// and we should not inject or manage pull secrets for this chart.
+		for _, entry := range secretList {
+			switch v := entry.(type) {
+			case string:
+				if _, isManaged := managed[v]; isManaged {
+					return false
+				}
+			case map[string]any:
+				if n, ok := v["name"].(string); ok {
+					if _, isManaged := managed[n]; isManaged {
+						return false
+					}
+				}
+			}
+		}
+		log.Tracef("[helmop] chartHasOnlyUserConfiguredPullSecrets: path %q has user-configured secrets", strings.Join(path, "."))
+	}
+
+	return chartSupportsPullSecrets
+}
+
+// listExistingManagedSecretNames returns the names of secrets in the release namespace
+// that were previously created by managePullSecrets (identified by the managed labels).
+func (s *Operations) listExistingManagedSecretNames(namespace, releaseName string) ([]string, error) {
+	secrets, err := s.secretCache.List(namespace, labels.SelectorFromSet(labels.Set{
+		helmOpManagedPullSecretLabel: "true",
+		helmOpReleaseLabelKey:        releaseName,
+	}))
+	if err != nil {
+		log.Errorf("[helmop] listExistingManagedSecretNames: failed to list managed secrets in namespace %q for release %q: %v", namespace, releaseName, err)
+		return nil, err
+	}
+	names := make([]string, 0, len(secrets))
+	for _, sec := range secrets {
+		names = append(names, sec.Name)
+	}
+	return names, nil
+}
+
+func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string]any, confValues map[string]any, secretNames []string, knownManagedNames []string) ([]byte, error) {
+	known := make(map[string]struct{}, len(knownManagedNames))
+	for _, n := range knownManagedNames {
+		known[n] = struct{}{}
+	}
+
+	pullSecrets := make([]any, len(secretNames))
+	for i, n := range secretNames {
+		pullSecrets[i] = map[string]string{"name": n}
 	}
 
 	for _, path := range imagePullSecretPaths {
 		if _, declared := getValueAtPath(baseValues, path...); !declared {
 			continue
 		}
-		if value, exists := getValueAtPath(confValues, path...); exists {
-			if secrets, ok := value.([]any); ok && len(secrets) > 0 {
-				continue
-			}
+
+		v, _ := getValueAtPath(confValues, path...)
+		configuredPullSecrets, _ := v.([]any)
+		userConfiguredSecrets, containsRancherManagedSecret := extractUserPullSecrets(configuredPullSecrets, known)
+
+		if !containsRancherManagedSecret && len(configuredPullSecrets) > 0 {
+			continue // user fully owns this path
 		}
-		log.Tracef("[helmop] injectPullSecrets: injecting %d pull secrets at path %q for release %q: %v", len(pullSecrets), strings.Join(path, "."), releaseName, pullSecrets)
-		setValueAtPath(confValues, pullSecrets, path...)
+		if !containsRancherManagedSecret && len(secretNames) == 0 {
+			continue // nothing existed, nothing to inject
+		}
+
+		newList := append(userConfiguredSecrets, pullSecrets...)
+		log.Tracef("[helmop] injectPullSecrets: writing %d pull secrets at path %q for release %q (preserving %d user entries)", len(pullSecrets), strings.Join(path, "."), releaseName, len(userConfiguredSecrets))
+		setValueAtPath(confValues, newList, path...)
 	}
 
 	result, err := json.Marshal(confValues)
@@ -147,15 +241,37 @@ func (s *Operations) injectPullSecrets(releaseName string, baseValues map[string
 	return result, nil
 }
 
-func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace string, repoName string, releaseName string, pullSecretsPreConfigured bool) ([]string, error) {
-	repo, err := s.clusterReposCache.Get(repoName)
-	if err != nil {
-		log.Errorf("[helmop] managePullSecrets: failed to get cluster repo %q from cache: %v", repoName, err)
-		return nil, err
+// extractUserPullSecrets partitions secretList into user-owned entries and reports whether any
+// entry matched a name in managedSecrets (indicating it is managed by Rancher).
+// String entries are normalized to LocalObjectReference format ({name: str}) on the way out.
+func extractUserPullSecrets(secretList []any, managedSecrets map[string]struct{}) ([]any, bool) {
+	var userEntries []any
+	hasManagedEntry := false
+	for _, entry := range secretList {
+		switch v := entry.(type) {
+		case string:
+			if _, isKnown := managedSecrets[v]; isKnown {
+				hasManagedEntry = true
+			} else {
+				userEntries = append(userEntries, map[string]string{"name": v})
+			}
+		case map[string]any:
+			n, _ := v["name"].(string)
+			if _, isKnown := managedSecrets[n]; isKnown {
+				hasManagedEntry = true
+			} else {
+				userEntries = append(userEntries, entry)
+			}
+		default:
+			userEntries = append(userEntries, entry)
+		}
 	}
+	return userEntries, hasManagedEntry
+}
 
-	if systemDefaultRegistry == "" || len(repo.Spec.DefaultImagePullSecrets) == 0 || pullSecretsPreConfigured {
-		if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, releaseName); err != nil {
+func (s *Operations) managePullSecrets(repo *catalog.ClusterRepo, systemDefaultRegistry string, namespace string, releaseName string, existingManagedNames []string) ([]string, error) {
+	if systemDefaultRegistry == "" || len(repo.Spec.DefaultImagePullSecrets) == 0 {
+		if err := s.deleteStaleHelmOpSecrets([]string{}, existingManagedNames, namespace, releaseName); err != nil {
 			return nil, err
 		}
 		return []string{}, nil
@@ -260,7 +376,7 @@ func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace s
 		secretNames = append(secretNames, secretName)
 	}
 
-	if err := s.deleteStaleHelmOpSecrets(secretNames, namespace, releaseName); err != nil {
+	if err := s.deleteStaleHelmOpSecrets(secretNames, existingManagedNames, namespace, releaseName); err != nil {
 		return nil, err
 	}
 
@@ -268,33 +384,22 @@ func (s *Operations) managePullSecrets(systemDefaultRegistry string, namespace s
 	return secretNames, nil
 }
 
-// deleteStaleHelmOpSecrets deletes secrets in the release namespace that were previously created
-// by managePullSecrets (identified by helmOpManagedPullSecretLabel and helmOpReleaseLabelKey)
-// but are no longer needed. It lists all managed secrets for the given release via label selector
-// and deletes any not present in activeSecretNames.
-func (s *Operations) deleteStaleHelmOpSecrets(activeSecretNames []string, namespace string, releaseName string) error {
+// deleteStaleHelmOpSecrets deletes managed pull secrets for the given release that are no longer
+// active. Any name not in activeSecretNames is deleted.
+func (s *Operations) deleteStaleHelmOpSecrets(activeSecretNames []string, existingManagedNames []string, namespace string, releaseName string) error {
 	active := make(map[string]struct{}, len(activeSecretNames))
 	for _, name := range activeSecretNames {
 		active[name] = struct{}{}
 	}
 
-	managed, err := s.secretCache.List(namespace, labels.SelectorFromSet(labels.Set{
-		helmOpManagedPullSecretLabel: "true",
-		helmOpReleaseLabelKey:        releaseName,
-	}))
-	if err != nil {
-		log.Errorf("[helmop] deleteStaleHelmOpSecrets: failed to list managed secrets in namespace %q for release %q: %v", namespace, releaseName, err)
-		return err
-	}
-
-	for _, secret := range managed {
-		if _, isActive := active[secret.Name]; isActive {
+	for _, secretName := range existingManagedNames {
+		if _, isActive := active[secretName]; isActive {
 			continue
 		}
 
-		log.Debugf("[helmop] deleteStaleHelmOpSecrets: deleting stale managed secret %q from namespace %q (release %q)", secret.Name, namespace, releaseName)
-		if err := s.secrets.Delete(namespace, secret.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			log.Errorf("[helmop] deleteStaleHelmOpSecrets: failed to delete stale secret %q in namespace %q: %v", secret.Name, namespace, err)
+		log.Debugf("[helmop] deleteStaleHelmOpSecrets: deleting stale managed secret %q from namespace %q (release %q)", secretName, namespace, releaseName)
+		if err := s.secrets.Delete(namespace, secretName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			log.Errorf("[helmop] deleteStaleHelmOpSecrets: failed to delete stale secret %q in namespace %q: %v", secretName, namespace, err)
 			return err
 		}
 	}
@@ -302,13 +407,14 @@ func (s *Operations) deleteStaleHelmOpSecrets(activeSecretNames []string, namesp
 	return nil
 }
 
-// deleteReleasePullSecrets removes all Rancher-managed pull secrets for each release in cmds
-// from the given namespace. This is called on uninstall to clean up secrets created during install/upgrade.
+// deleteReleasePullSecrets removes all Rancher-managed pull secrets for the given release from
+// the namespace. Called on uninstall to clean up secrets created during install/upgrade.
 func (s *Operations) deleteReleasePullSecrets(namespace string, release string) error {
-	if err := s.deleteStaleHelmOpSecrets([]string{}, namespace, release); err != nil {
+	existing, err := s.listExistingManagedSecretNames(namespace, release)
+	if err != nil {
 		return err
 	}
-	return nil
+	return s.deleteStaleHelmOpSecrets([]string{}, existing, namespace, release)
 }
 
 func getValueAtPath(data map[string]any, path ...string) (any, bool) {

--- a/pkg/catalogv2/helmop/pull_secrets_test.go
+++ b/pkg/catalogv2/helmop/pull_secrets_test.go
@@ -312,18 +312,150 @@ func Test_chartSupportsImagePullSecrets(t *testing.T) {
 	}
 }
 
+func Test_chartHasOnlyUserConfiguredPullSecrets(t *testing.T) {
+	h := &Operations{}
+
+	tests := []struct {
+		name               string
+		baseValues         map[string]any
+		values             map[string]any
+		managedSecretNames []string
+		want               bool
+	}{
+		{
+			name: "all user secrets at single supported path",
+			baseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			values: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
+			},
+			managedSecretNames: []string{"release-foo"},
+			want:               true,
+		},
+		{
+			name: "path contains a managed secret",
+			baseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			values: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "release-foo"}},
+			},
+			managedSecretNames: []string{"release-foo"},
+			want:               false,
+		},
+		{
+			name: "supported path is empty in values",
+			baseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			values:             map[string]any{},
+			managedSecretNames: []string{"release-foo"},
+			want:               false,
+		},
+		{
+			name: "chart has no supported pull-secret paths",
+			baseValues: map[string]any{
+				"someOtherKey": "value",
+			},
+			values: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
+			},
+			managedSecretNames: []string{},
+			want:               false,
+		},
+		{
+			name: "multiple supported paths, all user-only",
+			baseValues: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{},
+				},
+				"imagePullSecrets": []any{},
+			},
+			values: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
+				},
+				"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
+			},
+			managedSecretNames: []string{"release-foo"},
+			want:               true,
+		},
+		{
+			name: "multiple supported paths, one path has a managed secret",
+			baseValues: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{},
+				},
+				"imagePullSecrets": []any{},
+			},
+			values: map[string]any{
+				"global": map[string]any{
+					"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
+				},
+				"imagePullSecrets": []any{map[string]any{"name": "release-foo"}},
+			},
+			managedSecretNames: []string{"release-foo"},
+			want:               false,
+		},
+		{
+			name: "mixed path with user and managed secret",
+			baseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			values: map[string]any{
+				"imagePullSecrets": []any{
+					map[string]any{"name": "user-secret"},
+					map[string]any{"name": "release-foo"},
+				},
+			},
+			managedSecretNames: []string{"release-foo"},
+			want:               false,
+		},
+		{
+			name: "string entry matching managed name is detected as managed",
+			baseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			values: map[string]any{
+				"imagePullSecrets": []any{"release-foo"},
+			},
+			managedSecretNames: []string{"release-foo"},
+			want:               false,
+		},
+		{
+			name: "string entry not matching any managed name is treated as user-owned",
+			baseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			values: map[string]any{
+				"imagePullSecrets": []any{"user-secret"},
+			},
+			managedSecretNames: []string{"release-foo"},
+			want:               true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := h.chartHasOnlyUserConfiguredPullSecrets(tt.baseValues, tt.values, tt.managedSecretNames)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_injectPullSecrets(t *testing.T) {
 	h := &Operations{}
 	tests := []struct {
-		name             string
-		chartBaseValues  map[string]any
-		configuredValues map[string]any
-		expected         map[string]any
-		pullSecretNames  []string
-		wantErr          bool
+		name              string
+		chartBaseValues   map[string]any
+		configuredValues  map[string]any
+		expected          map[string]any
+		pullSecretNames   []string
+		knownManagedNames []string
+		wantErr           bool
 	}{
 		{
-			// No imagePullSecrets paths declared in base values; secrets should not be injected.
 			name:             "no paths declared in chart base values",
 			chartBaseValues:  map[string]any{"someOtherKey": "value"},
 			configuredValues: map[string]any{},
@@ -331,7 +463,6 @@ func Test_injectPullSecrets(t *testing.T) {
 			expected:         map[string]any{},
 		},
 		{
-			// The chart declares global.cattle.imagePullSecrets; secrets should be injected there.
 			name: "inject at global.cattle.imagePullSecrets",
 			chartBaseValues: map[string]any{
 				"global": map[string]any{
@@ -351,7 +482,6 @@ func Test_injectPullSecrets(t *testing.T) {
 			},
 		},
 		{
-			// The chart declares global.imagePullSecrets; secrets should be injected there.
 			name: "inject at global.imagePullSecrets",
 			chartBaseValues: map[string]any{
 				"global": map[string]any{
@@ -367,7 +497,6 @@ func Test_injectPullSecrets(t *testing.T) {
 			},
 		},
 		{
-			// The chart declares imagePullSecrets at root; secrets should be injected there.
 			name: "inject at root imagePullSecrets",
 			chartBaseValues: map[string]any{
 				"imagePullSecrets": []any{},
@@ -379,22 +508,21 @@ func Test_injectPullSecrets(t *testing.T) {
 			},
 		},
 		{
-			// User has already configured secrets at the path; injection should be skipped to preserve them.
-			name: "skip injection when user secrets already configured",
+			name: "skip injection when path has only user secrets",
 			chartBaseValues: map[string]any{
 				"imagePullSecrets": []any{},
 			},
 			configuredValues: map[string]any{
 				"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
 			},
-			pullSecretNames: []string{"injected-secret"},
+			pullSecretNames:   []string{"injected-secret"},
+			knownManagedNames: []string{"injected-secret"},
 			expected: map[string]any{
 				"imagePullSecrets": []any{map[string]any{"name": "user-secret"}},
 			},
 		},
 		{
-			// Chart declares multiple paths; all declared paths without existing user secrets should be injected.
-			name: "inject at multiple declared paths",
+			name: "injects at multiple declared paths",
 			chartBaseValues: map[string]any{
 				"global": map[string]any{
 					"imagePullSecrets": []any{},
@@ -411,22 +539,99 @@ func Test_injectPullSecrets(t *testing.T) {
 			},
 		},
 		{
-			// No secret names provided; an empty list should be injected at declared paths.
-			name: "empty secret names injects empty list",
+			name: "no secrets and no existing values leaves path untouched",
 			chartBaseValues: map[string]any{
 				"imagePullSecrets": []any{},
 			},
 			configuredValues: map[string]any{},
 			pullSecretNames:  []string{},
-			expected: map[string]any{
+			expected:         map[string]any{},
+		},
+		{
+			name: "upgrade: managed secret already in values is kept",
+			chartBaseValues: map[string]any{
 				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "release-secret-a"}},
+			},
+			pullSecretNames:   []string{"release-secret-a"},
+			knownManagedNames: []string{"release-secret-a"},
+			expected: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "release-secret-a"}},
+			},
+		},
+		{
+			name: "stale managed secret cleared when cluster repo removes it",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "release-secret-a"}},
+			},
+			pullSecretNames:   []string{},
+			knownManagedNames: []string{"release-secret-a"},
+			expected: map[string]any{
+				// All entries were managed and have been removed, path is set to null.
+				"imagePullSecrets": nil,
+			},
+		},
+		{
+			name: "mixed path: user secrets preserved, stale managed replaced",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{
+				"imagePullSecrets": []any{
+					map[string]any{"name": "user-secret"},
+					map[string]any{"name": "release-old"},
+				},
+			},
+			pullSecretNames:   []string{"release-new"},
+			knownManagedNames: []string{"release-old", "release-new"},
+			expected: map[string]any{
+				"imagePullSecrets": []any{
+					map[string]any{"name": "user-secret"},
+					map[string]any{"name": "release-new"},
+				},
+			},
+		},
+		{
+			name: "user string entries normalized to LocalObjectReference",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{
+				"imagePullSecrets": []any{"user-secret", map[string]any{"name": "release-managed"}},
+			},
+			pullSecretNames:   []string{"release-new"},
+			knownManagedNames: []string{"release-managed", "release-new"},
+			expected: map[string]any{
+				"imagePullSecrets": []any{
+					map[string]any{"name": "user-secret"},
+					map[string]any{"name": "release-new"},
+				},
+			},
+		},
+		{
+			name: "user-provided string matching managed name treated as managed",
+			chartBaseValues: map[string]any{
+				"imagePullSecrets": []any{},
+			},
+			configuredValues: map[string]any{
+				"imagePullSecrets": []any{"release-managed"},
+			},
+			pullSecretNames:   []string{"release-managed"},
+			knownManagedNames: []string{"release-managed"},
+			expected: map[string]any{
+				"imagePullSecrets": []any{map[string]any{"name": "release-managed"}},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rawResult, err := h.injectPullSecrets("test", tt.chartBaseValues, tt.configuredValues, tt.pullSecretNames)
+			rawResult, err := h.injectPullSecrets("test", tt.chartBaseValues, tt.configuredValues, tt.pullSecretNames, tt.knownManagedNames)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -437,6 +642,74 @@ func Test_injectPullSecrets(t *testing.T) {
 			var got map[string]any
 			assert.NoError(t, json.Unmarshal(rawResult, &got))
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func Test_extractUserPullSecrets(t *testing.T) {
+	managed := map[string]struct{}{"release-foo": {}}
+
+	tests := []struct {
+		name             string
+		secretList       []any
+		wantUserEntries  []any
+		wantManagedFound bool
+	}{
+		{
+			name:             "string entry not in known is normalized to LocalObjectReference",
+			secretList:       []any{"user-secret"},
+			wantUserEntries:  []any{map[string]string{"name": "user-secret"}},
+			wantManagedFound: false,
+		},
+		{
+			name:             "string entry matching managed name is treated as managed",
+			secretList:       []any{"release-foo"},
+			wantUserEntries:  nil,
+			wantManagedFound: true,
+		},
+		{
+			name:             "map entry in known is treated as managed",
+			secretList:       []any{map[string]any{"name": "release-foo"}},
+			wantUserEntries:  nil,
+			wantManagedFound: true,
+		},
+		{
+			name:             "map entry not in known is preserved as-is",
+			secretList:       []any{map[string]any{"name": "user-secret"}},
+			wantUserEntries:  []any{map[string]any{"name": "user-secret"}},
+			wantManagedFound: false,
+		},
+		{
+			name: "mixed string user + managed map: string normalized, managed removed",
+			secretList: []any{
+				"user-secret",
+				map[string]any{"name": "release-foo"},
+			},
+			wantUserEntries:  []any{map[string]string{"name": "user-secret"}},
+			wantManagedFound: true,
+		},
+		{
+			name: "string matching managed name alongside a user map entry",
+			secretList: []any{
+				"release-foo",
+				map[string]any{"name": "user-secret"},
+			},
+			wantUserEntries:  []any{map[string]any{"name": "user-secret"}},
+			wantManagedFound: true,
+		},
+		{
+			name:             "empty list returns nil user entries and no managed found",
+			secretList:       []any{},
+			wantUserEntries:  nil,
+			wantManagedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEntries, gotManaged := extractUserPullSecrets(tt.secretList, managed)
+			assert.Equal(t, tt.wantUserEntries, gotEntries)
+			assert.Equal(t, tt.wantManagedFound, gotManaged)
 		})
 	}
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55453
 
## Problem

The latest RC of Rancher may reinstall the default system-charts unnecessarily. This is due to a flaw in the image pull secret injection logic added for user installable charts. This impacted system-charts as they ultimately use the same install logic.

When a system default registry is configured, but no associated pull secrets are configured globally, Rancher attempted to inject an empty slice of pull secrets into the charts values. This results in misleading configuration drift (empty slice of pull secrets vs nil / missing field), and subsequent redeployment. 

During investigation of this issue, a few other problems were found with how this process was being done. Namely, Rancher did not properly handle the case where the user has provided their own pull secrets in values.yaml. As a result, Rancher would incorrectly clean up its managed pull secretes on a chart upgrade.
 
## Solution

Rework how the image pull secret propagation and command injection logic works to ensure that pulls secrets are properly managed in release namespaces, and that chart commands are not modified unnecessarily. This also improves how users can pass their own pull secrets to charts, in addition to managed pull secrets. 

## Testing
+ Spin up rancher on `head` 
+ Configure the `system-default-registry` setting to point to a custom private registry, without authentication
  + _dont_ configure the new `system-default-registry-pull-secrets` setting
+ Helm op pods should only redeploy each system chart once, so that it pulls from the correct registry.

---

+ Add one or more system default registry pull secrets, and change the system default registry to point to an authenticated registry. 
+ Deploy a chart which supports image pull secrets in one of the predefined paths (e.g. `global.cattle.imagePullSecrets`) 
   + I used a custom chart built from my rancher/charts fork, which I can share with QA if needed. 
   + Once image pull secret support is fixed in rancher-monitoring, these changes could be tested with that chart
+ Ensure that the chart is automatically configured, and that the expected pull secrets are placed into the release namespace of the chart
+ Modify the global system default registry pull secrets setting to point to a new secret
+ Update the chart
+ Ensure that the secrets are updated in the release namespace, and that the correct secret names are passed to the chart. 

---

+ Perform the second test again, but manually specify image pull secrets when installing the chart
+ Ensure that Rancher does not deploy image pull secrets into the charts release namespace. 

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: some more unit tests

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_