### PR TITLE
Clean up v3.Tokens when ext.Kubeconfig is deleted

### DIFF
--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -1378,11 +1378,8 @@ func (s *Store) delete(
 		return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting configmap for kubeconfig %s: %w", configMap.Name, err))
 	}
 
-	// Token IDs are tracked in status.tokens. Probe the ext store first to
-	// decide whether the token lives there or in the v3 token client. The
-	// v3 fallback is needed for pre-migration kubeconfigs that reference v3
-	// tokens. SystemStore.Delete swallows NotFound, so it can't be used to
-	// distinguish the two stores on its own.
+	// Token IDs are tracked in status.tokens. Delete each token, falling back
+	// to the v3 token client for pre-migration kubeconfigs that reference v3 tokens.
 	for _, tokenName := range kubeconfig.Status.Tokens {
 		delOptions := &metav1.DeleteOptions{
 			GracePeriodSeconds: options.GracePeriodSeconds,
@@ -1390,18 +1387,13 @@ func (s *Store) delete(
 			DryRun:             options.DryRun, // Pass through the dry run flag instead of handling it explicitly.
 		}
 
-		_, getErr := s.tokenStore.GetSecret(tokenName, &metav1.GetOptions{}, false)
-		switch {
-		case getErr == nil:
-			if err := s.tokenStore.Delete(tokenName, delOptions); err != nil {
-				return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting ext token %s for kubeconfig %s: %w", tokenName, configMap.Name, err))
-			}
-		case apierrors.IsNotFound(getErr):
-			if err := s.v3Tokens.Delete(tokenName, delOptions); err != nil && !apierrors.IsNotFound(err) {
-				return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting v3 token %s for kubeconfig %s: %w", tokenName, configMap.Name, err))
-			}
-		default:
-			return nil, false, apierrors.NewInternalError(fmt.Errorf("error probing ext token %s for kubeconfig %s: %w", tokenName, configMap.Name, getErr))
+		err := s.tokenStore.Delete(tokenName, delOptions)
+		if apierrors.IsNotFound(err) {
+			// Not an ext token — try v3 token for backward compatibility.
+			err = s.v3Tokens.Delete(tokenName, delOptions)
+		}
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting token %s for kubeconfig %s: %w", tokenName, configMap.Name, err))
 		}
 	}
 

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -868,6 +868,7 @@ func (s *Store) buildExtToken(userName string, authToken accessor.TokenAccessor,
 	return &ext.Token{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
+				tokens.TokenKindLabel:         KindLabelValue,
 				tokens.TokenKubeconfigIDLabel: kubeConfigID,
 			},
 		},
@@ -1377,8 +1378,11 @@ func (s *Store) delete(
 		return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting configmap for kubeconfig %s: %w", configMap.Name, err))
 	}
 
-	// Token IDs are tracked in status.tokens. Delete each token, falling back
-	// to the v3 token client for pre-migration kubeconfigs that reference v3 tokens.
+	// Token IDs are tracked in status.tokens. Probe the ext store first to
+	// decide whether the token lives there or in the v3 token client. The
+	// v3 fallback is needed for pre-migration kubeconfigs that reference v3
+	// tokens. SystemStore.Delete swallows NotFound, so it can't be used to
+	// distinguish the two stores on its own.
 	for _, tokenName := range kubeconfig.Status.Tokens {
 		delOptions := &metav1.DeleteOptions{
 			GracePeriodSeconds: options.GracePeriodSeconds,
@@ -1386,13 +1390,18 @@ func (s *Store) delete(
 			DryRun:             options.DryRun, // Pass through the dry run flag instead of handling it explicitly.
 		}
 
-		err := s.tokenStore.Delete(tokenName, delOptions)
-		if apierrors.IsNotFound(err) {
-			// Not an ext token — try v3 token for backward compatibility.
-			err = s.v3Tokens.Delete(tokenName, delOptions)
-		}
-		if err != nil && !apierrors.IsNotFound(err) {
-			return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting token %s for kubeconfig %s: %w", tokenName, configMap.Name, err))
+		_, getErr := s.tokenStore.GetSecret(tokenName, &metav1.GetOptions{}, false)
+		switch {
+		case getErr == nil:
+			if err := s.tokenStore.Delete(tokenName, delOptions); err != nil {
+				return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting ext token %s for kubeconfig %s: %w", tokenName, configMap.Name, err))
+			}
+		case apierrors.IsNotFound(getErr):
+			if err := s.v3Tokens.Delete(tokenName, delOptions); err != nil && !apierrors.IsNotFound(err) {
+				return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting v3 token %s for kubeconfig %s: %w", tokenName, configMap.Name, err))
+			}
+		default:
+			return nil, false, apierrors.NewInternalError(fmt.Errorf("error probing ext token %s for kubeconfig %s: %w", tokenName, configMap.Name, getErr))
 		}
 	}
 

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -95,9 +95,8 @@ func (f *fakeTokenManager) generate(token *ext.Token) (*ext.Token, error) {
 }
 
 type fakeTokenStore struct {
-	fetchFunc     func(tokenID string) (accessor.TokenAccessor, error)
-	getSecretFunc func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error)
-	deleteFunc    func(name string, options *metav1.DeleteOptions) error
+	fetchFunc  func(tokenID string) (accessor.TokenAccessor, error)
+	deleteFunc func(name string, options *metav1.DeleteOptions) error
 }
 
 func (f *fakeTokenStore) Fetch(tokenID string) (accessor.TokenAccessor, error) {
@@ -108,9 +107,6 @@ func (f *fakeTokenStore) Fetch(tokenID string) (accessor.TokenAccessor, error) {
 }
 
 func (f *fakeTokenStore) GetSecret(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
-	if f.getSecretFunc != nil {
-		return f.getSecretFunc(name, options, useCache)
-	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -2769,15 +2765,9 @@ func TestStoreDelete(t *testing.T) {
 		}).Times(1)
 		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
 
-		var probed []string
 		extTokenStore := &fakeTokenStore{
-			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
-				probed = append(probed, name)
-				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
-			},
 			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
-				require.Fail(t, "ext token store delete should not be called for v3 tokens")
-				return nil
+				return apierrors.NewNotFound(gvr.GroupResource(), name)
 			},
 		}
 
@@ -2808,7 +2798,6 @@ func TestStoreDelete(t *testing.T) {
 		obj, _, err := store.Delete(ctx, kubeconfigID, nil, deleteOptions)
 		require.NoError(t, err)
 		require.NotNil(t, obj)
-		assert.ElementsMatch(t, []string{v3TokenID1, v3TokenID2}, probed)
 		assert.ElementsMatch(t, []string{v3TokenID1, v3TokenID2}, deletedV3)
 	})
 	t.Run("admin deletes a kubeconfig with mixed ext and v3 tokens", func(t *testing.T) {
@@ -2824,19 +2813,14 @@ func TestStoreDelete(t *testing.T) {
 		}).Times(1)
 		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
 
-		var probed []string
 		var deletedExt []string
 		extTokenStore := &fakeTokenStore{
-			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
-				probed = append(probed, name)
-				if name == extTokenID {
-					return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name}}, nil
-				}
-				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
-			},
 			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
-				deletedExt = append(deletedExt, name)
-				return nil
+				if name == extTokenID {
+					deletedExt = append(deletedExt, name)
+					return nil
+				}
+				return apierrors.NewNotFound(gvr.GroupResource(), name)
 			},
 		}
 
@@ -2862,12 +2846,11 @@ func TestStoreDelete(t *testing.T) {
 
 		_, _, err := store.Delete(ctx, kubeconfigID, nil, &metav1.DeleteOptions{})
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{extTokenID, v3TokenID}, probed)
 		assert.Equal(t, []string{extTokenID}, deletedExt)
 		assert.Equal(t, []string{v3TokenID}, deletedV3)
 	})
-	t.Run("error probing the ext token store fails the delete", func(t *testing.T) {
-		tokenID := "token-probefail"
+	t.Run("error deleting ext token fails the delete", func(t *testing.T) {
+		tokenID := "token-delfail"
 
 		cm := configMap.DeepCopy()
 		cm.Data[StatusTokensField] = `["` + tokenID + `"]`
@@ -2879,12 +2862,8 @@ func TestStoreDelete(t *testing.T) {
 		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
 
 		extTokenStore := &fakeTokenStore{
-			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
-				return nil, apierrors.NewInternalError(fmt.Errorf("boom"))
-			},
 			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
-				require.Fail(t, "ext token store delete should not be called when probe fails")
-				return nil
+				return apierrors.NewInternalError(fmt.Errorf("boom"))
 			},
 		}
 
@@ -3087,12 +3066,8 @@ func TestStoreDeleteCollection(t *testing.T) {
 		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
 
 		extTokenStore := &fakeTokenStore{
-			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
-				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
-			},
 			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
-				require.Fail(t, "ext token store delete should not be called for v3 tokens")
-				return nil
+				return apierrors.NewNotFound(gvr.GroupResource(), name)
 			},
 		}
 

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -555,6 +555,7 @@ func TestStoreCreate(t *testing.T) {
 		require.Len(t, createdTokens, 2)
 		for _, tok := range createdTokens {
 			assert.Equal(t, created.Name, tok.Labels["authn.management.cattle.io/kubeconfig-id"])
+			assert.Equal(t, KindLabelValue, tok.Labels["authn.management.cattle.io/kind"])
 		}
 
 		assert.Equal(t, "downstream1", config.CurrentContext)
@@ -2751,6 +2752,163 @@ func TestStoreDelete(t *testing.T) {
 		assert.True(t, deleteValidationCalled)
 		assert.Len(t, deletedTokens, 2)
 	})
+	t.Run("admin deletes a pre-migration kubeconfig with v3 tokens", func(t *testing.T) {
+		deleteOptions := &metav1.DeleteOptions{
+			GracePeriodSeconds: ptr.To(int64(60)),
+		}
+
+		v3TokenID1 := "kubeconfig-" + adminID + "agc66"
+		v3TokenID2 := "kubeconfig-" + adminID + "d12fg"
+
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["` + v3TokenID1 + `","` + v3TokenID2 + `"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+			return cm, nil
+		}).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
+
+		var probed []string
+		extTokenStore := &fakeTokenStore{
+			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
+				probed = append(probed, name)
+				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
+			},
+			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
+				require.Fail(t, "ext token store delete should not be called for v3 tokens")
+				return nil
+			},
+		}
+
+		var deletedV3 []string
+		v3TokenClient := fake.NewMockNonNamespacedClientInterface[*v3.Token, *v3.TokenList](ctrl)
+		v3TokenClient.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(func(name string, options *metav1.DeleteOptions) error {
+			deletedV3 = append(deletedV3, name)
+			assert.Contains(t, []string{v3TokenID1, v3TokenID2}, name)
+			assert.Equal(t, deleteOptions.GracePeriodSeconds, options.GracePeriodSeconds)
+			assert.Equal(t, deleteOptions.PropagationPolicy, options.PropagationPolicy)
+			assert.Equal(t, deleteOptions.DryRun, options.DryRun)
+			return nil
+		}).Times(2)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      extTokenStore,
+			v3Tokens:        v3TokenClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: adminID,
+		})
+
+		obj, _, err := store.Delete(ctx, kubeconfigID, nil, deleteOptions)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.ElementsMatch(t, []string{v3TokenID1, v3TokenID2}, probed)
+		assert.ElementsMatch(t, []string{v3TokenID1, v3TokenID2}, deletedV3)
+	})
+	t.Run("admin deletes a kubeconfig with mixed ext and v3 tokens", func(t *testing.T) {
+		extTokenID := "token-extabc"
+		v3TokenID := "kubeconfig-" + adminID + "v3xyz"
+
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["` + extTokenID + `","` + v3TokenID + `"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+			return cm, nil
+		}).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
+
+		var probed []string
+		var deletedExt []string
+		extTokenStore := &fakeTokenStore{
+			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
+				probed = append(probed, name)
+				if name == extTokenID {
+					return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name}}, nil
+				}
+				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
+			},
+			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
+				deletedExt = append(deletedExt, name)
+				return nil
+			},
+		}
+
+		var deletedV3 []string
+		v3TokenClient := fake.NewMockNonNamespacedClientInterface[*v3.Token, *v3.TokenList](ctrl)
+		v3TokenClient.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(func(name string, options *metav1.DeleteOptions) error {
+			deletedV3 = append(deletedV3, name)
+			return nil
+		}).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      extTokenStore,
+			v3Tokens:        v3TokenClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: adminID,
+		})
+
+		_, _, err := store.Delete(ctx, kubeconfigID, nil, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{extTokenID, v3TokenID}, probed)
+		assert.Equal(t, []string{extTokenID}, deletedExt)
+		assert.Equal(t, []string{v3TokenID}, deletedV3)
+	})
+	t.Run("error probing the ext token store fails the delete", func(t *testing.T) {
+		tokenID := "token-probefail"
+
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["` + tokenID + `"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+			return cm, nil
+		}).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
+
+		extTokenStore := &fakeTokenStore{
+			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
+				return nil, apierrors.NewInternalError(fmt.Errorf("boom"))
+			},
+			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
+				require.Fail(t, "ext token store delete should not be called when probe fails")
+				return nil
+			},
+		}
+
+		// No v3 deletes expected — the unset mock will fail loudly if called.
+		v3TokenClient := fake.NewMockNonNamespacedClientInterface[*v3.Token, *v3.TokenList](ctrl)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      extTokenStore,
+			v3Tokens:        v3TokenClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: adminID,
+		})
+
+		obj, _, err := store.Delete(ctx, kubeconfigID, nil, &metav1.DeleteOptions{})
+		require.Error(t, err)
+		require.Nil(t, obj)
+		assert.True(t, apierrors.IsInternalError(err))
+	})
 	t.Run("user can't delete other user's kubeconfig", func(t *testing.T) {
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
@@ -2907,6 +3065,60 @@ func TestStoreDeleteCollection(t *testing.T) {
 
 		assert.Equal(t, deleteValidationCalledTimes, 1)
 		assert.Len(t, deletedTokens, 2)
+	})
+	t.Run("admin deletes a pre-migration kubeconfig collection with v3 tokens", func(t *testing.T) {
+		deleteOptions := &metav1.DeleteOptions{
+			GracePeriodSeconds: ptr.To(int64(60)),
+		}
+		listOptions := &metainternalversion.ListOptions{
+			LabelSelector: labels.Set{UserIDLabel: userID}.AsSelector(),
+		}
+
+		v3TokenID := "kubeconfig-" + userID + "v3only"
+
+		cmWithV3 := configMap.DeepCopy()
+		cmWithV3.Data[StatusTokensField] = `["` + v3TokenID + `"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().List(namespace, gomock.Any()).Return(&corev1.ConfigMapList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+			Items:    []corev1.ConfigMap{*cmWithV3},
+		}, nil).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(nil).Times(1)
+
+		extTokenStore := &fakeTokenStore{
+			getSecretFunc: func(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
+				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
+			},
+			deleteFunc: func(name string, options *metav1.DeleteOptions) error {
+				require.Fail(t, "ext token store delete should not be called for v3 tokens")
+				return nil
+			},
+		}
+
+		var deletedV3 []string
+		v3TokenClient := fake.NewMockNonNamespacedClientInterface[*v3.Token, *v3.TokenList](ctrl)
+		v3TokenClient.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(func(name string, options *metav1.DeleteOptions) error {
+			deletedV3 = append(deletedV3, name)
+			return nil
+		}).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      extTokenStore,
+			v3Tokens:        v3TokenClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: adminID,
+		})
+
+		_, err := store.DeleteCollection(ctx, nil, deleteOptions, listOptions)
+		require.NoError(t, err)
+		assert.Equal(t, []string{v3TokenID}, deletedV3)
 	})
 }
 


### PR DESCRIPTION
## Issue: TBD <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Deleting an ext.Kubeconfig issued before the migration to ext.Tokens removed the ConfigMap but left its v3 Tokens behind. Tokens issued after the migration were also missing the kind label.

The root cause is #55450 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The delete path now probes the ext.Token store first to what type of token it is and uses appropriate delete logic. ext.Tokens for issued for kubeconfigs now carry both the kubeconfig-id and the kind label.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests