### PR TITLE
Expose `not found` error thrown by token deletions to match kubernetes behaviour

### DIFF
--- a/pkg/auth/cleanup/service.go
+++ b/pkg/auth/cleanup/service.go
@@ -249,6 +249,9 @@ func (s *Service) deleteExtTokens(provider string) error {
 
 	for i := range tokens.Items {
 		if err := s.extTokenStore.Delete(tokens.Items[i].Name, &metav1.DeleteOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			return fmt.Errorf("failed deleting ext token %s while disabling auth provider %s: %w",
 				tokens.Items[i].Name, provider, err)
 		}

--- a/pkg/controllers/management/auth/user.go
+++ b/pkg/controllers/management/auth/user.go
@@ -228,6 +228,9 @@ func (l *userLifecycle) onUpdate(user *v3.User) (*v3.User, error) {
 					userController, token.GetName(), token.GetUserID())
 				err := l.extTokenStore.Delete(token.GetName(), &metav1.DeleteOptions{})
 				if err != nil {
+					if errors.IsNotFound(err) {
+						continue
+					}
 					return nil, fmt.Errorf("error deleting ext token: %v", err)
 				}
 			}
@@ -488,6 +491,9 @@ func (l *userLifecycle) deleteAllExtTokens(tokens []*ext.Token) error {
 			userController, token.GetName(), token.GetUserID())
 		err := l.extTokenStore.Delete(token.GetName(), &metav1.DeleteOptions{})
 		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return fmt.Errorf("error deleting ext token: %v", err)
 		}
 	}

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -339,6 +339,9 @@ func (t *Store) DeleteCollection(
 	for _, secret := range secrets.Items {
 		token, _, err := t.deleteCore(ctx, &secret, deleteValidation, options)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			return nil, apierrors.NewInternalError(fmt.Errorf("error deleting token %s: %w",
 				secret.Name, err))
 		}

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -791,6 +791,8 @@ func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
 		return nil
 	}
 	if apierrors.IsNotFound(err) {
+		// Convert not found for secret to not found for token
+		// Returned to match k8s behaviour for resource deletion
 		return apierrors.NewNotFound(GVR.GroupResource(), name)
 	}
 

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -788,7 +788,7 @@ func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
 		return nil
 	}
 	if apierrors.IsNotFound(err) {
-		return nil
+		return apierrors.NewNotFound(GVR.GroupResource(), name)
 	}
 
 	return apierrors.NewInternalError(fmt.Errorf("failed to delete token %s: %w", name, err))

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -1694,7 +1694,7 @@ func TestSystemStoreDelete(t *testing.T) {
 			name:  "secret not found is ok",
 			token: "bogus",
 			opts:  &metav1.DeleteOptions{},
-			err:   nil,
+			err:   apierrors.NewNotFound(GVR.GroupResource(), "bogus"),
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
 					Delete("cattle-tokens", "bogus", gomock.Any()).

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -266,9 +266,73 @@ func TestStoreGroupVersionKind(t *testing.T) {
 func TestStoreDeleteCollection(t *testing.T) {
 	t.Parallel()
 
-	ctrl := gomock.NewController(t)
+	t.Run("ignore not found errors due to concurrent other delete", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		var deleteValidationCalledTimes int
+		deleteValidation := func(ctx context.Context, obj runtime.Object) error {
+			deleteValidationCalledTimes++
+			return nil
+		}
+		deleteOptions := &metav1.DeleteOptions{
+			GracePeriodSeconds: ptr.To(int64(60)),
+		}
+		listOptions := &metainternalversion.ListOptions{
+			LabelSelector: labels.Set{
+				UserIDLabel: properUser,
+				"custom":    "label",
+			}.AsSelector(),
+		}
+
+		secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		secretClient.EXPECT().List(TokenNamespace, gomock.Any()).
+			DoAndReturn(func(namespace string, options metav1.ListOptions) (*corev1.SecretList, error) {
+				labelSet, err := labels.ConvertSelectorToLabelsMap(options.LabelSelector)
+				require.NoError(t, err)
+				assert.Equal(t, properUser, labelSet[UserIDLabel])
+				assert.Equal(t, "label", labelSet["custom"])
+
+				return &corev1.SecretList{
+					ListMeta: metav1.ListMeta{
+						ResourceVersion: "1",
+					},
+					Items: []corev1.Secret{*properSecret.DeepCopy()},
+				}, nil
+			}).Times(1)
+		secretClient.EXPECT().Delete(TokenNamespace, "bogus", gomock.Any()).
+			DoAndReturn(func(namespace, name string, options *metav1.DeleteOptions) error {
+				assert.Equal(t, deleteOptions, options)
+				// report concurrent deletion of listed resource
+				return apierrors.NewNotFound(GVR.GroupResource(), name)
+			}).Times(1)
+		secretClient.EXPECT().Cache().Return(nil)
+		userClient := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+		userClient.EXPECT().Cache().Return(nil)
+		auth := NewMockauthHandler(ctrl)
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&mockUser{name: properUser}, false, true, nil)
+
+		store := New(nil, nil, nil, secretClient, userClient, nil, nil, nil, nil, auth)
+
+		obj, err := store.DeleteCollection(context.Background(), deleteValidation,
+			deleteOptions, listOptions)
+
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		require.IsType(t, &ext.TokenList{}, obj)
+
+		list := obj.(*ext.TokenList)
+		// len == 0, not listing the concurrently deleted object
+		require.Len(t, list.Items, 0)
+		assert.Equal(t, "1", list.ResourceVersion)
+
+		assert.Equal(t, deleteValidationCalledTimes, 1)
+
+	})
 
 	t.Run("admin deletes a user's tokens with a label", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
 		var deleteValidationCalledTimes int
 		deleteValidation := func(ctx context.Context, obj runtime.Object) error {
 			deleteValidationCalledTimes++

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -314,7 +314,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 
 		store := New(nil, nil, nil, secretClient, userClient, nil, nil, nil, nil, auth)
 
-		obj, err := store.DeleteCollection(context.Background(), deleteValidation,
+		obj, err := store.DeleteCollection(t.Context(), deleteValidation,
 			deleteOptions, listOptions)
 
 		require.NoError(t, err)
@@ -377,7 +377,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 
 		store := New(nil, nil, nil, secretClient, userClient, nil, nil, nil, nil, auth)
 
-		obj, err := store.DeleteCollection(context.Background(), deleteValidation,
+		obj, err := store.DeleteCollection(t.Context(), deleteValidation,
 			deleteOptions, listOptions)
 
 		require.NoError(t, err)
@@ -1573,7 +1573,7 @@ func TestSystemStoreCreateClusterScoped(t *testing.T) {
 			}
 
 			userInfo := &mockUser{name: "world"}
-			_, err := store.Create(context.Background(), GVR.GroupResource(), token, &metav1.CreateOptions{}, userInfo)
+			_, err := store.Create(t.Context(), GVR.GroupResource(), token, &metav1.CreateOptions{}, userInfo)
 
 			if test.err != "" {
 				require.Error(t, err)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#55450
 
## Problem

The ext token resource does not return a not found error when attempting to delete a non-existent object.
This does not match regular kubernetes behaviour.
 
## Solution

The `secret not found` error is now exposed to callers as `token not found` error. Various places calling the store's Delete method are updated to appropriately deal with the `not found` they now can see.
 
## Testing

updated token unit tests to handle the newly exposed `not found`.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_