### PR TITLE
Perform user attribute refresh for ext tokens, analogous to legacy tokens

### DIFF
--- a/pkg/controllers/management/auth/exttoken.go
+++ b/pkg/controllers/management/auth/exttoken.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/types/config"
+)
+
+const (
+	extTokenController = "mgmt-auth-ext-tokens-controller"
+)
+
+type ExtTokenController struct {
+	userAttrRefresher UserAttributeRefresher
+}
+
+func newExtTokenController(mgmt *config.ManagementContext) *ExtTokenController {
+	return &ExtTokenController{
+		userAttrRefresher: newUserAttributeRefresher(mgmt),
+	}
+}
+
+// onChange is called periodically and on real updates
+func (t *ExtTokenController) onChange(key string, obj *ext.Token) (*ext.Token, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	// remove legacy finalizers
+	if obj.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	// trigger corresponding UserAttribute resource to refresh if token potentially
+	// provides new information that is missing from the UserAttribute resource
+	if err := t.userAttrRefresher.CheckAndRefresh(obj.GetUserID()); err != nil {
+		return obj, err
+	}
+
+	return obj, nil
+}

--- a/pkg/controllers/management/auth/exttoken.go
+++ b/pkg/controllers/management/auth/exttoken.go
@@ -21,11 +21,7 @@ func newExtTokenController(mgmt *config.ManagementContext) *ExtTokenController {
 
 // onChange is called periodically and on real updates
 func (t *ExtTokenController) onChange(key string, obj *ext.Token) (*ext.Token, error) {
-	if obj == nil {
-		return nil, nil
-	}
-	// remove legacy finalizers
-	if obj.DeletionTimestamp != nil {
+	if obj == nil || obj.DeletionTimestamp != nil {
 		return nil, nil
 	}
 

--- a/pkg/controllers/management/auth/exttoken_test.go
+++ b/pkg/controllers/management/auth/exttoken_test.go
@@ -17,7 +17,6 @@ import (
 type extTokenTestCase struct {
 	description                 string
 	inputToken                  *ext.Token
-	expectedOutputToken         *ext.Token
 	inputUserAttribute          *v3.UserAttribute
 	expectedOutputUserAttribute *v3.UserAttribute
 }
@@ -68,8 +67,9 @@ func TestExtOnChange(t *testing.T) {
 	testCases := populateExtTestCases(tokens, userAttributes)
 	for _, testcase := range testCases {
 		testErr := fmt.Sprintf("test case failed: %s", testcase.description)
-		_, err := testTokenController.onChange(testcase.inputToken.Name, testcase.inputToken)
+		returnToken, err := testTokenController.onChange(testcase.inputToken.Name, testcase.inputToken)
 		assert.NoErrorf(t, err, "%s: unexpected onChange error", testErr)
+		assert.Equalf(t, testcase.inputToken, returnToken, "%s: token", testErr)
 
 		returnUserAttribute, _ := testTokenController.userAttrRefresher.userAttributesLister.Get(testcase.inputUserAttribute.Name)
 		assert.Equalf(t, testcase.expectedOutputUserAttribute, returnUserAttribute, "%s: %s", testErr, testcase.inputUserAttribute.Name)
@@ -204,8 +204,7 @@ func TestExtOnChange(t *testing.T) {
 func populateExtTestCases(tokens map[string]*ext.Token, userAttributes map[string]*v3.UserAttribute) []extTokenTestCase {
 	testCases := []extTokenTestCase{
 		{
-			inputToken:          &ext.Token{Spec: ext.TokenSpec{UserID: "testuser"}},
-			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec{UserID: "testuser"}},
+			inputToken: &ext.Token{Spec: ext.TokenSpec{UserID: "testuser"}},
 			inputUserAttribute: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testuser",
@@ -221,8 +220,7 @@ func populateExtTestCases(tokens map[string]*ext.Token, userAttributes map[strin
 				" potentially be provided by the token.",
 		},
 		{
-			inputToken:          &ext.Token{Spec: ext.TokenSpec{UserID: "testuser2"}},
-			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec{UserID: "testuser2"}},
+			inputToken: &ext.Token{Spec: ext.TokenSpec{UserID: "testuser2"}},
 			inputUserAttribute: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testuser2",
@@ -242,7 +240,6 @@ func populateExtTestCases(tokens map[string]*ext.Token, userAttributes map[strin
 	for index, testCase := range testCases {
 		id := fmt.Sprintf("test%d", index)
 		testCase.inputToken.Name = id
-		testCase.expectedOutputToken.Name = id
 		tokens[id] = testCase.inputToken.DeepCopy()
 		if testCase.inputUserAttribute == nil {
 			continue

--- a/pkg/controllers/management/auth/exttoken_test.go
+++ b/pkg/controllers/management/auth/exttoken_test.go
@@ -68,7 +68,8 @@ func TestExtOnChange(t *testing.T) {
 	testCases := populateExtTestCases(tokens, userAttributes)
 	for _, testcase := range testCases {
 		testErr := fmt.Sprintf("test case failed: %s", testcase.description)
-		testTokenController.onChange(testcase.inputToken.Name, testcase.inputToken)
+		_, err := testTokenController.onChange(testcase.inputToken.Name, testcase.inputToken)
+		assert.NoErrorf(t, err, "%s: unexpected onChange error", testErr)
 
 		returnUserAttribute, _ := testTokenController.userAttrRefresher.userAttributesLister.Get(testcase.inputUserAttribute.Name)
 		assert.Equalf(t, testcase.expectedOutputUserAttribute, returnUserAttribute, "%s: %s", testErr, testcase.inputUserAttribute.Name)
@@ -116,13 +117,13 @@ func TestExtOnChange(t *testing.T) {
 			Name: "testtoken",
 		},
 		// UserID not being "" should trigger userattribute refresh check
-		Spec: ext.TokenSpec {UserID: "abcd"},
+		Spec: ext.TokenSpec{UserID: "abcd"},
 	}
 	userAttributes = map[string]*v3.UserAttribute{
 		// ExtraByProvider being nil should trigger a userattribute update
 		"abcd": {
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "testuser",
+				Name: "abcd",
 			},
 		},
 	}
@@ -159,7 +160,7 @@ func TestExtOnChange(t *testing.T) {
 			Name: "testtoken",
 		},
 		// UserID not being "" should trigger userattribute refresh check
-		Spec: ext.TokenSpec {UserID: "abcd"},
+		Spec: ext.TokenSpec{UserID: "abcd"},
 	}
 	_, err = testUserAttributeErrorGetController.onChange(genericTestToken.Name, genericTestToken)
 	assert.NotNilf(t, err, "handler should return err when userattribute lister's get function returns non-notfound error")
@@ -194,7 +195,7 @@ func TestExtOnChange(t *testing.T) {
 			Name: "testtoken",
 		},
 		// UserID not being "" should trigger userattribute refresh check
-		Spec: ext.TokenSpec {UserID: "abcd"},
+		Spec: ext.TokenSpec{UserID: "abcd"},
 	}
 	_, err = testUserAttributeErrorGetController.onChange(genericTestToken.Name, genericTestToken)
 	assert.Nil(t, err, "handler should not return err when userattribute lister's get function returns notfound error")
@@ -203,8 +204,8 @@ func TestExtOnChange(t *testing.T) {
 func populateExtTestCases(tokens map[string]*ext.Token, userAttributes map[string]*v3.UserAttribute) []extTokenTestCase {
 	testCases := []extTokenTestCase{
 		{
-			inputToken:          &ext.Token{Spec: ext.TokenSpec {UserID: "testuser"}},
-			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec {UserID: "testuser"}},
+			inputToken:          &ext.Token{Spec: ext.TokenSpec{UserID: "testuser"}},
+			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec{UserID: "testuser"}},
 			inputUserAttribute: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testuser",
@@ -220,8 +221,8 @@ func populateExtTestCases(tokens map[string]*ext.Token, userAttributes map[strin
 				" potentially be provided by the token.",
 		},
 		{
-			inputToken:          &ext.Token{Spec: ext.TokenSpec {UserID: "testuser2"}},
-			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec {UserID: "testuser2"}},
+			inputToken:          &ext.Token{Spec: ext.TokenSpec{UserID: "testuser2"}},
+			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec{UserID: "testuser2"}},
 			inputUserAttribute: &v3.UserAttribute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testuser2",
@@ -235,7 +236,7 @@ func populateExtTestCases(tokens map[string]*ext.Token, userAttributes map[strin
 				ExtraByProvider: map[string]map[string][]string{"something": {"something": []string{"something"}}},
 			},
 			description: "Verify that UserAttribute is not triggered for a refresh if it is not missing info" +
-				" than can potentially be provided by the token.",
+				" that can potentially be provided by the token.",
 		},
 	}
 	for index, testCase := range testCases {

--- a/pkg/controllers/management/auth/exttoken_test.go
+++ b/pkg/controllers/management/auth/exttoken_test.go
@@ -1,0 +1,252 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wranglerfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type extTokenTestCase struct {
+	description                 string
+	inputToken                  *ext.Token
+	expectedOutputToken         *ext.Token
+	inputUserAttribute          *v3.UserAttribute
+	expectedOutputUserAttribute *v3.UserAttribute
+}
+
+func TestExtOnChange(t *testing.T) {
+	tokens := make(map[string]*ext.Token)
+	userAttributes := make(map[string]*v3.UserAttribute)
+
+	ctrl := gomock.NewController(t)
+
+	// setup userAttribute mock instance
+	userAttributesMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttributesMock.EXPECT().Update(gomock.Any()).DoAndReturn(
+		func(userAttribute *v3.UserAttribute) (*v3.UserAttribute, error) {
+			userAttributes[userAttribute.Name] = userAttribute.DeepCopy()
+			return userAttribute, nil
+		},
+	).AnyTimes()
+	userAttributesMock.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+			userAttribute, ok := userAttributes[name]
+			if ok {
+				return userAttribute, nil
+			}
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	).AnyTimes()
+
+	// setup userAttributesLister mock instance
+	userAttributesListerMock := wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributesListerMock.EXPECT().Get(gomock.Any()).DoAndReturn(
+		func(name string) (*v3.UserAttribute, error) {
+			userAttribute, ok := userAttributes[name]
+			if ok {
+				return userAttribute, nil
+			}
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	).AnyTimes()
+
+	testTokenController := ExtTokenController{
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
+	}
+
+	testCases := populateExtTestCases(tokens, userAttributes)
+	for _, testcase := range testCases {
+		testErr := fmt.Sprintf("test case failed: %s", testcase.description)
+		testTokenController.onChange(testcase.inputToken.Name, testcase.inputToken)
+
+		returnUserAttribute, _ := testTokenController.userAttrRefresher.userAttributesLister.Get(testcase.inputUserAttribute.Name)
+		assert.Equalf(t, testcase.expectedOutputUserAttribute, returnUserAttribute, "%s: %s", testErr, testcase.inputUserAttribute.Name)
+	}
+
+	// test error from userattribute update
+	// setup userAttribute mock instance
+	userAttributesMock = wranglerfake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttributesMock.EXPECT().Update(gomock.Any()).DoAndReturn(
+		func(userAttribute *v3.UserAttribute) (*v3.UserAttribute, error) {
+			return nil, errors.NewServiceUnavailable("test reason")
+		},
+	).AnyTimes()
+	userAttributesMock.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+			userAttribute, ok := userAttributes[name]
+			if ok {
+				return userAttribute, nil
+			}
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	).AnyTimes()
+
+	// setup userAttributesLister mock instance
+	userAttributesListerMock = wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributesListerMock.EXPECT().Get(gomock.Any()).DoAndReturn(
+		func(name string) (*v3.UserAttribute, error) {
+			userAttribute, ok := userAttributes[name]
+			if ok {
+				return userAttribute, nil
+			}
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	).AnyTimes()
+
+	testUserAttributeErrorUpdateController := ExtTokenController{
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
+	}
+
+	genericTestToken := &ext.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testtoken",
+		},
+		// UserID not being "" should trigger userattribute refresh check
+		Spec: ext.TokenSpec {UserID: "abcd"},
+	}
+	userAttributes = map[string]*v3.UserAttribute{
+		// ExtraByProvider being nil should trigger a userattribute update
+		"abcd": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testuser",
+			},
+		},
+	}
+	_, err := testUserAttributeErrorUpdateController.onChange(genericTestToken.Name, genericTestToken)
+	assert.NotNilf(t, err, "handler should return err when userattribute client's update function returns error")
+
+	// test non-notfound error from userattribute lister get
+	// setup userAttribute mock instance
+	userAttributesMock = wranglerfake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttributesMock.EXPECT().Update(gomock.Any()).DoAndReturn(
+		func(userAttribute *v3.UserAttribute) (*v3.UserAttribute, error) {
+			userAttributes[userAttribute.Name] = userAttribute.DeepCopy()
+			return userAttribute, nil
+		},
+	).AnyTimes()
+
+	// setup userAttributesLister mock instance
+	userAttributesListerMock = wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributesListerMock.EXPECT().Get(gomock.Any()).DoAndReturn(
+		func(name string) (*v3.UserAttribute, error) {
+			return nil, errors.NewServiceUnavailable("test reason")
+		},
+	)
+
+	testUserAttributeErrorGetController := ExtTokenController{
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
+	}
+
+	genericTestToken = &ext.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testtoken",
+		},
+		// UserID not being "" should trigger userattribute refresh check
+		Spec: ext.TokenSpec {UserID: "abcd"},
+	}
+	_, err = testUserAttributeErrorGetController.onChange(genericTestToken.Name, genericTestToken)
+	assert.NotNilf(t, err, "handler should return err when userattribute lister's get function returns non-notfound error")
+
+	// test notfound error from userattribute lister get
+	// setup userAttribute mock instance
+	userAttributesMock = wranglerfake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttributesMock.EXPECT().Update(gomock.Any()).DoAndReturn(
+		func(userAttribute *v3.UserAttribute) (*v3.UserAttribute, error) {
+			userAttributes[userAttribute.Name] = userAttribute.DeepCopy()
+			return userAttribute, nil
+		},
+	).AnyTimes()
+
+	// setup userAttributesLister mock instance
+	userAttributesListerMock = wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributesListerMock.EXPECT().Get(gomock.Any()).DoAndReturn(
+		func(name string) (*v3.UserAttribute, error) {
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	)
+
+	testUserAttributeErrorGetController = ExtTokenController{
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
+	}
+
+	genericTestToken = &ext.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testtoken",
+		},
+		// UserID not being "" should trigger userattribute refresh check
+		Spec: ext.TokenSpec {UserID: "abcd"},
+	}
+	_, err = testUserAttributeErrorGetController.onChange(genericTestToken.Name, genericTestToken)
+	assert.Nil(t, err, "handler should not return err when userattribute lister's get function returns notfound error")
+}
+
+func populateExtTestCases(tokens map[string]*ext.Token, userAttributes map[string]*v3.UserAttribute) []extTokenTestCase {
+	testCases := []extTokenTestCase{
+		{
+			inputToken:          &ext.Token{Spec: ext.TokenSpec {UserID: "testuser"}},
+			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec {UserID: "testuser"}},
+			inputUserAttribute: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testuser",
+				},
+			},
+			expectedOutputUserAttribute: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testuser",
+				},
+				NeedsRefresh: true,
+			},
+			description: "Verify that UserAttribute is triggered for a refresh if it is missing info that can" +
+				" potentially be provided by the token.",
+		},
+		{
+			inputToken:          &ext.Token{Spec: ext.TokenSpec {UserID: "testuser2"}},
+			expectedOutputToken: &ext.Token{Spec: ext.TokenSpec {UserID: "testuser2"}},
+			inputUserAttribute: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testuser2",
+				},
+				ExtraByProvider: map[string]map[string][]string{"something": {"something": []string{"something"}}},
+			},
+			expectedOutputUserAttribute: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testuser2",
+				},
+				ExtraByProvider: map[string]map[string][]string{"something": {"something": []string{"something"}}},
+			},
+			description: "Verify that UserAttribute is not triggered for a refresh if it is not missing info" +
+				" than can potentially be provided by the token.",
+		},
+	}
+	for index, testCase := range testCases {
+		id := fmt.Sprintf("test%d", index)
+		testCase.inputToken.Name = id
+		testCase.expectedOutputToken.Name = id
+		tokens[id] = testCase.inputToken.DeepCopy()
+		if testCase.inputUserAttribute == nil {
+			continue
+		}
+		userAttributes[testCase.inputUserAttribute.Name] = testCase.inputUserAttribute.DeepCopy()
+	}
+	return testCases
+}

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -123,6 +123,11 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, cl
 	relatedresource.Watch(ctx, "aggregation-feature-prtb-enqueuer", aggregationEnqueuer.enqueuePRTBs, management.Wrangler.Mgmt.ProjectRoleTemplateBinding(), management.Wrangler.Mgmt.Feature())
 
 	management.Wrangler.Mgmt.User().OnChange(ctx, userController, u.onChange)
+
+	management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
+		n := newExtTokenController(management.WithAgent(extTokenController))
+		w.Client.Token().OnChange(ctx, extTokenController, n.onChange)
+	})
 }
 
 func RegisterLate(ctx context.Context, management *config.ManagementContext) {

--- a/pkg/controllers/management/auth/token.go
+++ b/pkg/controllers/management/auth/token.go
@@ -6,10 +6,7 @@ import (
 	"github.com/rancher/rancher/pkg/features"
 	wrangmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -17,16 +14,14 @@ const (
 )
 
 type TokenController struct {
-	tokens               wrangmgmtv3.TokenController
-	userAttributes       wrangmgmtv3.UserAttributeController
-	userAttributesLister wrangmgmtv3.UserAttributeCache
+	tokens            wrangmgmtv3.TokenController
+	userAttrRefresher UserAttributeRefresher
 }
 
 func newTokenController(mgmt *config.ManagementContext) *TokenController {
 	n := &TokenController{
-		tokens:               mgmt.Wrangler.Mgmt.Token(),
-		userAttributes:       mgmt.Wrangler.Mgmt.UserAttribute(),
-		userAttributesLister: mgmt.Wrangler.Mgmt.UserAttribute().Cache(),
+		tokens:            mgmt.Wrangler.Mgmt.Token(),
+		userAttrRefresher: newUserAttributeRefresher(mgmt),
 	}
 	return n
 }
@@ -68,15 +63,8 @@ func (t *TokenController) sync(key string, obj *v3.Token) (runtime.Object, error
 
 	// trigger corresponding UserAttribute resource to refresh if token potentially
 	// provides new information that is missing from the UserAttribute resource
-	refreshUserAttributes, err := t.userAttributesNeedsRefresh(obj.UserID)
-	if err != nil {
+	if err := t.userAttrRefresher.CheckAndRefresh(obj.UserID); err != nil {
 		return obj, err
-	}
-
-	if refreshUserAttributes {
-		if err = t.triggerUserAttributesRefresh(obj.UserID); err != nil {
-			return obj, err
-		}
 	}
 
 	// DO NOT remove until tokenHashing is always
@@ -99,45 +87,4 @@ func (t *TokenController) sync(key string, obj *v3.Token) (runtime.Object, error
 	}
 
 	return obj, nil
-}
-
-func (t *TokenController) userAttributesNeedsRefresh(user string) (bool, error) {
-	if user == "" {
-		return false, nil
-	}
-
-	userAttribute, err := t.userAttributesLister.Get(user)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return userAttribute.ExtraByProvider == nil, nil
-}
-
-func (t *TokenController) triggerUserAttributesRefresh(user string) error {
-	// Re-fetch from the API server inside the retry; the lister cache used
-	// for the gating check can be stale and lead to 409 conflicts when other
-	// writers (e.g. the refresh consumer) touch the object concurrently.
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		userAttribute, err := t.userAttributes.Get(user, metav1.GetOptions{})
-		if errors.IsNotFound(err) {
-			// The user attribute was deleted under us.
-			// Nothing to refresh, no point in requeuing.
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if userAttribute.NeedsRefresh {
-			return nil
-		}
-		userAttribute.NeedsRefresh = true
-		_, err = t.userAttributes.Update(userAttribute)
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	})
 }

--- a/pkg/controllers/management/auth/token_test.go
+++ b/pkg/controllers/management/auth/token_test.go
@@ -81,9 +81,11 @@ func TestSync(t *testing.T) {
 	).AnyTimes()
 
 	testTokenController := TokenController{
-		tokens:               tokensMock,
-		userAttributes:       userAttributesMock,
-		userAttributesLister: userAttributesListerMock,
+		tokens: tokensMock,
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
 	}
 
 	testCases := populateTestCases(tokens, userAttributes)
@@ -109,7 +111,7 @@ func TestSync(t *testing.T) {
 		if testcase.inputUserAttribute == nil {
 			continue
 		}
-		returnUserAttribute, _ := testTokenController.userAttributesLister.Get(testcase.inputUserAttribute.Name)
+		returnUserAttribute, _ := testTokenController.userAttrRefresher.userAttributesLister.Get(testcase.inputUserAttribute.Name)
 		assert.Equalf(t, testcase.expectedOutputUserAttribute, returnUserAttribute, "%s: %s", testErr, testcase.inputUserAttribute.Name)
 	}
 
@@ -153,9 +155,11 @@ func TestSync(t *testing.T) {
 	).AnyTimes()
 
 	testTokenErrorUpdateController := TokenController{
-		tokens:               tokensMock,
-		userAttributes:       userAttributesMock,
-		userAttributesLister: userAttributesListerMock,
+		tokens: tokensMock,
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
 	}
 	genericTestToken := &v3.Token{
 		ObjectMeta: metav1.ObjectMeta{
@@ -217,9 +221,11 @@ func TestSync(t *testing.T) {
 	).AnyTimes()
 
 	testUserAttributeErrorUpdateController := TokenController{
-		tokens:               tokensMock,
-		userAttributes:       userAttributesMock,
-		userAttributesLister: userAttributesListerMock,
+		tokens: tokensMock,
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
 	}
 
 	genericTestToken = &v3.Token{
@@ -277,9 +283,11 @@ func TestSync(t *testing.T) {
 	)
 
 	testUserAttributeErrorGetController := TokenController{
-		tokens:               tokensMock,
-		userAttributes:       userAttributesMock,
-		userAttributesLister: userAttributesListerMock,
+		tokens: tokensMock,
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
 	}
 
 	genericTestToken = &v3.Token{
@@ -329,9 +337,11 @@ func TestSync(t *testing.T) {
 	)
 
 	testUserAttributeErrorGetController = TokenController{
-		tokens:               tokensMock,
-		userAttributes:       userAttributesMock,
-		userAttributesLister: userAttributesListerMock,
+		tokens: tokensMock,
+		userAttrRefresher: UserAttributeRefresher{
+			userAttributes:       userAttributesMock,
+			userAttributesLister: userAttributesListerMock,
+		},
 	}
 
 	genericTestToken = &v3.Token{
@@ -343,46 +353,6 @@ func TestSync(t *testing.T) {
 	}
 	_, err = testUserAttributeErrorGetController.sync(genericTestToken.Name, genericTestToken)
 	assert.Nil(t, err, "handler should not return err when userattribute lister's get function returns notfound error")
-}
-
-// TestTriggerUserAttributesRefreshIgnoresNotFound covers the case where the
-// user attribute is deleted between the lister-based gating check and the
-// fresh API Get inside the retry loop. The trigger must no-op silently
-// instead of bubbling an error that would cause the token sync to requeue.
-func TestTriggerUserAttributesRefreshIgnoresNotFound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	userAttribute := &v3.UserAttribute{
-		ObjectMeta: metav1.ObjectMeta{Name: "abcd"},
-		// ExtraByProvider == nil so the gating check returns true and we
-		// enter triggerUserAttributesRefresh.
-	}
-
-	userAttributesMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
-	userAttributesMock.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
-		func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
-			return nil, errors.NewNotFound(schema.GroupResource{}, name)
-		},
-	)
-	// No Update expectation: NotFound on the Get must short-circuit.
-
-	userAttributesListerMock := wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-	userAttributesListerMock.EXPECT().Get(gomock.Any()).Return(userAttribute, nil).AnyTimes()
-
-	tokensMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.Token, *v3.TokenList](ctrl)
-
-	controller := TokenController{
-		tokens:               tokensMock,
-		userAttributes:       userAttributesMock,
-		userAttributesLister: userAttributesListerMock,
-	}
-
-	token := &v3.Token{
-		ObjectMeta: metav1.ObjectMeta{Name: "testtoken"},
-		UserID:     "abcd",
-	}
-	_, err := controller.sync(token.Name, token)
-	assert.NoError(t, err, "Must not error when the user attribute is gone")
 }
 
 func populateTestCases(tokens map[string]*v3.Token, userAttributes map[string]*v3.UserAttribute) []tokenTestCase {

--- a/pkg/controllers/management/auth/token_test.go
+++ b/pkg/controllers/management/auth/token_test.go
@@ -385,7 +385,7 @@ func populateTestCases(tokens map[string]*v3.Token, userAttributes map[string]*v
 				},
 			},
 			description: "Tests that the \"controller.cattle.io/cat-token-controller\" finalizer is not removed if the token does" +
-				"not have a deltion timestamp.",
+				"not have a deletion timestamp.",
 		},
 		{
 			inputToken: &v3.Token{
@@ -417,6 +417,7 @@ func populateTestCases(tokens map[string]*v3.Token, userAttributes map[string]*v
 				TTLMillis: 300,
 				ExpiresAt: timeNow.Add(300 * time.Millisecond).UTC().Format(time.RFC3339),
 			},
+			description: "demonstrate update of the ExpiresAt field",
 		},
 		{
 			inputToken:          &v3.Token{UserID: "testuser"},
@@ -464,7 +465,7 @@ func populateTestCases(tokens map[string]*v3.Token, userAttributes map[string]*v
 				Token: hashedToken,
 			},
 			enableHashing: true,
-			description:   "",
+			description:   "Test that token key hashing is done if necessary",
 		},
 	}
 	for index, testCase := range testCases {

--- a/pkg/controllers/management/auth/user_attribute_refresher.go
+++ b/pkg/controllers/management/auth/user_attribute_refresher.go
@@ -20,7 +20,8 @@ func newUserAttributeRefresher(mgmt *config.ManagementContext) UserAttributeRefr
 	}
 }
 
-// CheckAndRefresh is invoked periodically and on real updates, by ext token controllers
+// CheckAndRefresh is invoked periodically and on real updates, by the token
+// controllers, legacy and ext
 func (t *UserAttributeRefresher) CheckAndRefresh(userID string) error {
 
 	refreshUserAttributes, err := t.needsRefresh(userID)

--- a/pkg/controllers/management/auth/user_attribute_refresher.go
+++ b/pkg/controllers/management/auth/user_attribute_refresher.go
@@ -20,7 +20,7 @@ func newUserAttributeRefresher(mgmt *config.ManagementContext) UserAttributeRefr
 	}
 }
 
-// onChange is called periodically and on real updates
+// CheckAndRefresh is invoked periodically and on real updates, by ext token controllers
 func (t *UserAttributeRefresher) CheckAndRefresh(userID string) error {
 
 	refreshUserAttributes, err := t.needsRefresh(userID)

--- a/pkg/controllers/management/auth/user_attribute_refresher.go
+++ b/pkg/controllers/management/auth/user_attribute_refresher.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	wrangmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/types/config"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+type UserAttributeRefresher struct {
+	userAttributes       wrangmgmtv3.UserAttributeController
+	userAttributesLister wrangmgmtv3.UserAttributeCache
+}
+
+func newUserAttributeRefresher(mgmt *config.ManagementContext) UserAttributeRefresher {
+	return UserAttributeRefresher{
+		userAttributes:       mgmt.Wrangler.Mgmt.UserAttribute(),
+		userAttributesLister: mgmt.Wrangler.Mgmt.UserAttribute().Cache(),
+	}
+}
+
+// onChange is called periodically and on real updates
+func (t *UserAttributeRefresher) CheckAndRefresh(userID string) error {
+
+	refreshUserAttributes, err := t.needsRefresh(userID)
+	if err != nil {
+		return err
+	}
+
+	if !refreshUserAttributes {
+		return nil
+	}
+
+	return t.triggerRefresh(userID)
+}
+
+func (t *UserAttributeRefresher) needsRefresh(user string) (bool, error) {
+	if user == "" {
+		return false, nil
+	}
+
+	userAttribute, err := t.userAttributesLister.Get(user)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return userAttribute.ExtraByProvider == nil, nil
+}
+
+func (t *UserAttributeRefresher) triggerRefresh(user string) error {
+	// Re-fetch from the API server inside the retry; the lister cache used
+	// for the gating check can be stale and lead to 409 conflicts when other
+	// writers (e.g. the refresh consumer) touch the object concurrently.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		userAttribute, err := t.userAttributes.Get(user, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			// The user attribute was deleted under us.
+			// Nothing to refresh, no point in requeuing.
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if userAttribute.NeedsRefresh {
+			return nil
+		}
+		userAttribute.NeedsRefresh = true
+		_, err = t.userAttributes.Update(userAttribute)
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	})
+}

--- a/pkg/controllers/management/auth/user_attribute_refresher_test.go
+++ b/pkg/controllers/management/auth/user_attribute_refresher_test.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wranglerfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestCheckAndRefreshIgnoresNotFound covers the case where the user attribute
+// is deleted between the lister-based gating check and the fresh API Get inside
+// the retry loop. The trigger must no-op silently instead of bubbling an error
+// that would cause the token sync to requeue.
+func TestCheckAndRefreshIgnoresNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	userAttribute := &v3.UserAttribute{
+		ObjectMeta: metav1.ObjectMeta{Name: "abcd"},
+		// ExtraByProvider == nil so the gating check (`needsRefresh`)
+		// returns true and we enter `triggerRefresh`.
+	}
+
+	userAttributesMock := wranglerfake.NewMockNonNamespacedControllerInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+	userAttributesMock.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+		func(name string, opts metav1.GetOptions) (*v3.UserAttribute, error) {
+			return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		},
+	)
+	// No Update expectation: NotFound on the Get must short-circuit.
+
+	userAttributesListerMock := wranglerfake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+	userAttributesListerMock.EXPECT().Get(gomock.Any()).Return(userAttribute, nil).AnyTimes()
+
+	refresher := UserAttributeRefresher{
+		userAttributes:       userAttributesMock,
+		userAttributesLister: userAttributesListerMock,
+	}
+
+	err := refresher.CheckAndRefresh("abcd")
+	assert.NoError(t, err, "Must not error when the user attribute is gone")
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#55246 
 
## Problem

The user attribute refresh performed for legacy tokens is not performed for ext tokens.

Note that three other actions done for legacy tokens (legacy finalizer removal, hashing, updating expires at) do not apply to ext tokens.
 
## Solution

  - A new controller was added, watching ext tokens and triggering user attribute refresh same as for legacy tokens.
  - Because the check and trigger are the same for both legacy and ext token the relevant code was pulled into a separate structure to be shared by existing and new controllers.
 
## Testing

  - updated unit tests for legacy controller for the changes
  - moved unit tests for refresher into separate file, and updated
  - created unit tests for the new controller

## Engineering Testing
### Manual Testing

unit tests

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_