### PR TITLE
[v2.11] Remove integration tests from push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -50,13 +50,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: setup and build
         uses: ./.github/actions/build-images/agent
-  integration-tests:
-    needs: [build-server, build-agent]
-    uses: ./.github/workflows/integration-tests.yml
-    permissions:
-      contents: read
   push-images:
-    needs: [unit-tests, integration-tests]
+    needs: [unit-tests, build-server, build-agent]
     strategy:
       matrix:
         os: [linux]


### PR DESCRIPTION


Integration tests run on every PR before merge, so re-running them on push to main and release branches duplicates work that has already been validated. Provisioning tests are already excluded from push CI by the same reasoning.

Remove the integration-tests job and update push-images to depend directly on unit-tests, build-server, and build-agent instead.

Backports #55126