### PR TITLE
Tune Renovate throughput and branch targets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,6 @@
   ],
   "prHourlyLimit": 6,
   "prConcurrentLimit": 10,
-  "prCreation": "status-success",
   "packageRules": [
     {
       "matchBaseBranches": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     "release/v2.13",
     "release/v2.12",
     "release/v2.11",
-    "release/v2.10"
+    "release/v2.14"
   ],
   "ignoreDeps": [
     "go.qase.io/client"
@@ -43,10 +43,10 @@
     },
     {
       "matchBaseBranches": [
-        "release/v2.10"
+        "release/v2.14"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.10#release"
+        "github>rancher/renovate-config//rancher-2.14#release"
       ]
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,8 +13,8 @@
   "ignoreDeps": [
     "go.qase.io/client"
   ],
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 4,
+  "prHourlyLimit": 6,
+  "prConcurrentLimit": 10,
   "prCreation": "status-success",
   "packageRules": [
     {


### PR DESCRIPTION
This updates Renovate behavior to improve update flow in Rancher. It increases PR throughput, removes EOL branch targeting, adds release v2.14 targeting, and removes CI-success gating for initial PR creation so flaky checks do not block visibility of updates.

- Increase PR limits to reduce branch-limit saturation and unblock new update branches.
- Replace release v2.10 with release v2.14 in base branch patterns and branch-specific preset mapping.
- Change prCreation to default so Renovate can open PRs even when CI is unstable.