### PR TITLE
[main] Ensure fleet-agent is deployed with pull secrets 

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,6 +4,6 @@ remoteDialerProxyVersion: 110.0.0+up0.8.0-rc.9
 turtlesVersion: 110.0.0+up0.27.0-rc.3
 cspAdapterMinVersion: 109.0.0+up9.0.0-rc.3
 defaultShellVersion: rancher/shell:v0.8.0-rc.4
-fleetVersion: 110.0.0+up0.16.0-alpha.10
+fleetVersion: 110.0.0+up0.16.0-alpha.11
 defaultSccOperatorImage: rancher/scc-operator:v0.4.2-rc.1
 chartAuditLogImage: rancher/mirrored-bci-micro:16.0-15.11

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/rancher/channelserver v0.11.0
 	github.com/rancher/dynamiclistener v0.9.0-rc.1
 	github.com/rancher/eks-operator v1.15.0-rc.2
-	github.com/rancher/fleet/pkg/apis v0.16.0-alpha.9
+	github.com/rancher/fleet/pkg/apis v0.16.0-alpha.11
 	github.com/rancher/gke-operator v1.15.0-rc.2
 	github.com/rancher/jsonpath v0.0.0-20250620213443-ad24535cf0c1
 	github.com/rancher/kubernetes-provider-detector v0.1.6-0.20240606163014-fcae75779379

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/rancher/dynamiclistener v0.9.0-rc.1 h1:tmV3fgvB5pXSOMrb7G1DSno5C9XTfo
 github.com/rancher/dynamiclistener v0.9.0-rc.1/go.mod h1:HG2E4ZcZKAc6JymJLy74ROKMTtsKyrA1fyQSR/g/+0w=
 github.com/rancher/eks-operator v1.15.0-rc.2 h1:fJOeSZbMlzYSnL78PW8RyDtanXZgZWgMYuYo8l1S7Ik=
 github.com/rancher/eks-operator v1.15.0-rc.2/go.mod h1:1IR5/LPJVm2MUNPPbUZbGLRadYdQsqB7LEiC6ToIkKs=
-github.com/rancher/fleet/pkg/apis v0.16.0-alpha.9 h1:kzPt2G5ytmVXoh9ST7L7Rt2cdwM7ItIZZyY5wosU6xY=
-github.com/rancher/fleet/pkg/apis v0.16.0-alpha.9/go.mod h1:NjLJbrJ76K5vf8Djv3evIL1RnS4WDu8RpEjnyisIPRI=
+github.com/rancher/fleet/pkg/apis v0.16.0-alpha.11 h1:QTdiBfDAwlN9cfHHwmjSdssGmtb5Pd73T+EWURirsVE=
+github.com/rancher/fleet/pkg/apis v0.16.0-alpha.11/go.mod h1:FokB3uJlq7OPMEyKTMUuudzKTg1vmMG9MEzxCFPinVY=
 github.com/rancher/gke-operator v1.15.0-rc.2 h1:Q5rZcMroS3peK+2NmpUi+77F1mFitgifqD+KI7ye7jM=
 github.com/rancher/gke-operator v1.15.0-rc.2/go.mod h1:nEHw8ZiG6Os1g1JVDPtfpKNMlAZQNV/rvNMxozeua6w=
 github.com/rancher/jsonpath v0.0.0-20250620213443-ad24535cf0c1 h1:vRtxuvIF0UarXIAwGYNwSFoRYJadVnOrD8kx2qrZyN8=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/rancher/aks-operator v1.15.0-rc.2
 	github.com/rancher/ali-operator v1.15.0-rc.2
 	github.com/rancher/eks-operator v1.15.0-rc.2
-	github.com/rancher/fleet/pkg/apis v0.16.0-alpha.9
+	github.com/rancher/fleet/pkg/apis v0.16.0-alpha.11
 	github.com/rancher/gke-operator v1.15.0-rc.2
 	github.com/rancher/norman v0.9.7
 	github.com/rancher/rancher/pkg/plan v0.0.0-20260428222332-2696373f4152

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -70,8 +70,8 @@ github.com/rancher/ali-operator v1.15.0-rc.2 h1:OrXXR8tcnmiXD2BElfZK3ch75Pbleduy
 github.com/rancher/ali-operator v1.15.0-rc.2/go.mod h1:ugZqUh9MqYB0iGNxmHoSFd/nIDBui6sTyAbTG2KuF2g=
 github.com/rancher/eks-operator v1.15.0-rc.2 h1:fJOeSZbMlzYSnL78PW8RyDtanXZgZWgMYuYo8l1S7Ik=
 github.com/rancher/eks-operator v1.15.0-rc.2/go.mod h1:1IR5/LPJVm2MUNPPbUZbGLRadYdQsqB7LEiC6ToIkKs=
-github.com/rancher/fleet/pkg/apis v0.16.0-alpha.9 h1:kzPt2G5ytmVXoh9ST7L7Rt2cdwM7ItIZZyY5wosU6xY=
-github.com/rancher/fleet/pkg/apis v0.16.0-alpha.9/go.mod h1:NjLJbrJ76K5vf8Djv3evIL1RnS4WDu8RpEjnyisIPRI=
+github.com/rancher/fleet/pkg/apis v0.16.0-alpha.11 h1:QTdiBfDAwlN9cfHHwmjSdssGmtb5Pd73T+EWURirsVE=
+github.com/rancher/fleet/pkg/apis v0.16.0-alpha.11/go.mod h1:FokB3uJlq7OPMEyKTMUuudzKTg1vmMG9MEzxCFPinVY=
 github.com/rancher/gke-operator v1.15.0-rc.2 h1:Q5rZcMroS3peK+2NmpUi+77F1mFitgifqD+KI7ye7jM=
 github.com/rancher/gke-operator v1.15.0-rc.2/go.mod h1:nEHw8ZiG6Os1g1JVDPtfpKNMlAZQNV/rvNMxozeua6w=
 github.com/rancher/lasso v0.2.9 h1:5Xk9Qid+YDOLpa6s5xalcSR0cA5BMbgWcaOZ8kdNU7k=

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,7 +7,7 @@ const (
 	CspAdapterMinVersion     = "109.0.0+up9.0.0-rc.3"
 	DefaultSccOperatorImage  = "rancher/scc-operator:v0.4.2-rc.1"
 	DefaultShellVersion      = "rancher/shell:v0.8.0-rc.4"
-	FleetVersion             = "110.0.0+up0.16.0-alpha.10"
+	FleetVersion             = "110.0.0+up0.16.0-alpha.11"
 	RemoteDialerProxyVersion = "110.0.0+up0.8.0-rc.9"
 	TurtlesVersion           = "110.0.0+up0.27.0-rc.3"
 	WebhookVersion           = "110.0.0+up0.11.0-rc.15"

--- a/pkg/capr/planner/registry.go
+++ b/pkg/capr/planner/registry.go
@@ -164,7 +164,7 @@ func (p *Planner) renderRegistries(controlPlane *rkev1.RKEControlPlane) (registr
 				break
 			}
 			if !foundCredentials {
-				logrus.Warnf("[planner] no global pull secret contained credentials for registry %q. registries.yaml will be unpopulated.", GSDR)
+				logrus.Debugf("[planner] [%s] no global pull secret contained credentials for registry %q. registries.yaml will be unpopulated.", controlPlane.Name, GSDR)
 			}
 		}
 	}

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -63,6 +63,16 @@ func (p *PrivateRegistry) PullSecretsAsObjectReferences() []kcorev1.LocalObjectR
 	return out
 }
 
+func (p *PrivateRegistry) DownstreamPullSecretsAsObjectReferences() []kcorev1.LocalObjectReference {
+	var out []kcorev1.LocalObjectReference
+	for _, secret := range p.PullSecrets {
+		out = append(out, kcorev1.LocalObjectReference{
+			Name: GeneratePullSecretName(secret.Name),
+		})
+	}
+	return out
+}
+
 // GetPrivateRegistryURL returns the URL of the private registry specified. It will return the cluster level registry if
 // one is found, or the global system default registry if no cluster level registry is found. If neither is found, it will
 // return an empty string.

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -10,7 +10,7 @@ import (
 
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
-	mgmtcluster "github.com/rancher/rancher/pkg/cluster"
+	clusterutils "github.com/rancher/rancher/pkg/cluster"
 	fleetpkg "github.com/rancher/rancher/pkg/fleet"
 	fleetcontrollers "github.com/rancher/rancher/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -19,12 +19,12 @@ import (
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/taints"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/sirupsen/logrus"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/yaml"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,14 +49,15 @@ func (g fleetHostGetter) GetClusterHost(cfg clientcmd.ClientConfig) (string, []b
 }
 
 type handler struct {
-	clientConfig      clientcmd.ClientConfig
-	clusters          v3.ClusterClient
-	clustersCache     v3.ClusterCache
-	hostGetter        ClusterHostGetter
-	secretsController corecontrollers.SecretController
-	nodesController   corecontrollers.NodeController
-	fleetClusters     fleetcontrollers.ClusterController
-	getPrivateRepoURL func(*provv1.Cluster, *apimgmtv3.Cluster) string
+	clientConfig              clientcmd.ClientConfig
+	clusters                  v3.ClusterClient
+	clustersCache             v3.ClusterCache
+	hostGetter                ClusterHostGetter
+	secretsController         corecontrollers.SecretController
+	nodesController           corecontrollers.NodeController
+	fleetClusters             fleetcontrollers.ClusterController
+	getPrivateRepoURL         func(*provv1.Cluster, *apimgmtv3.Cluster) string
+	getPrivateRepoPullSecrets func(*apimgmtv3.Cluster) *[]corev1.LocalObjectReference
 }
 
 // Register registers the fleetcluster controller, which is responsible for creating fleet cluster objects.
@@ -66,13 +67,14 @@ type handler struct {
 // corresponding clusters.management.cattle.io/v3 object, if one does not already exist, and vice-versa)
 func Register(ctx context.Context, clients *wrangler.Context) {
 	h := &handler{
-		clientConfig:      clients.ClientConfig,
-		clusters:          clients.Mgmt.Cluster(),
-		clustersCache:     clients.Mgmt.Cluster().Cache(),
-		hostGetter:        fleetHostGetter{},
-		secretsController: clients.Core.Secret(),
-		nodesController:   clients.Core.Node(),
-		fleetClusters:     clients.Fleet.Cluster(),
+		clientConfig:              clients.ClientConfig,
+		clusters:                  clients.Mgmt.Cluster(),
+		clustersCache:             clients.Mgmt.Cluster().Cache(),
+		hostGetter:                fleetHostGetter{},
+		secretsController:         clients.Core.Secret(),
+		nodesController:           clients.Core.Node(),
+		fleetClusters:             clients.Fleet.Cluster(),
+		getPrivateRepoPullSecrets: getPrivateRepoSecrets,
 	}
 
 	h.getPrivateRepoURL = func(cluster *provv1.Cluster, mgmtCluster *apimgmtv3.Cluster) string {
@@ -80,7 +82,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 			// If the RKEConfig is nil, we are likely dealing with
 			// a legacy (v3/mgmt) cluster, and need to check the v3
 			// cluster for the cluster level registry.
-			return mgmtcluster.GetPrivateRegistryURL(mgmtCluster)
+			return clusterutils.GetPrivateRegistryURL(mgmtCluster)
 		}
 		url, _ := image.GetPrivateRepoURLFromCluster(cluster)
 		return url
@@ -207,7 +209,7 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 	agentNamespace := ""
 	clientSecret := status.ClientSecretName
 
-	tolerations := mgmtcluster.GetFleetAgentTolerations(mgmtCluster)
+	tolerations := clusterutils.GetFleetAgentTolerations(mgmtCluster)
 	objs := []runtime.Object{}
 	if mgmtCluster.Spec.Internal {
 		// When not running inside a cluster (which may happen in local dev setups), do not populate API server
@@ -239,7 +241,7 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 		}
 	}
 
-	agentAffinity, err := mgmtcluster.GetFleetAgentAffinity(mgmtCluster)
+	agentAffinity, err := clusterutils.GetFleetAgentAffinity(mgmtCluster)
 	if err != nil {
 		return nil, status, err
 	}
@@ -281,8 +283,9 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 			PrivateRepoURL:               h.getPrivateRepoURL(cluster, mgmtCluster),
 			AgentTolerations:             tolerations,
 			AgentAffinity:                agentAffinity,
-			AgentResources:               mgmtcluster.GetFleetAgentResourceRequirements(mgmtCluster),
+			AgentResources:               clusterutils.GetFleetAgentResourceRequirements(mgmtCluster),
 			AgentSchedulingCustomization: schedulingCustomization,
+			AgentPullSecrets:             h.getPrivateRepoPullSecrets(mgmtCluster),
 		},
 	}), status, nil
 }
@@ -308,6 +311,20 @@ func (h *handler) addAPIServer(clientSecret string) {
 	if _, err := h.secretsController.Update(secret); err != nil {
 		logrus.Warnf("local cluster provisioning: failed to update client secret: %v", err)
 	}
+}
+
+func getPrivateRepoSecrets(mgmtCluster *apimgmtv3.Cluster) *[]corev1.LocalObjectReference {
+	if !clusterutils.MgmtNameRegexp.MatchString(mgmtCluster.Name) {
+		return &[]corev1.LocalObjectReference{}
+	}
+	registry, _ := clusterutils.GetPrivateRegistry(mgmtCluster)
+	if registry == nil {
+		return &[]corev1.LocalObjectReference{}
+	}
+	if mgmtCluster.Name == "local" {
+		return new(registry.PullSecretsAsObjectReferences())
+	}
+	return new(registry.DownstreamPullSecretsAsObjectReferences())
 }
 
 func sortTolerations(tols []corev1.Toleration) {

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
@@ -2,6 +2,7 @@ package fleetcluster
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -79,7 +80,8 @@ func TestClusterCustomization(t *testing.T) {
 	require := require.New(t)
 
 	h := &handler{
-		getPrivateRepoURL: func(*provv1.Cluster, *apimgmtv3.Cluster) string { return "" },
+		getPrivateRepoURL:         func(*provv1.Cluster, *apimgmtv3.Cluster) string { return "" },
+		getPrivateRepoPullSecrets: getPrivateRepoSecrets,
 	}
 
 	cluster := &provv1.Cluster{
@@ -457,9 +459,250 @@ func TestAssignWorkspace(t *testing.T) {
 	}
 }
 
+func TestCreateCluster_WithPullSecrets(t *testing.T) {
+	tests := []struct {
+		name                       string
+		cluster                    *provv1.Cluster
+		status                     provv1.ClusterStatus
+		cachedClusters             map[string]*apimgmtv3.Cluster
+		expectedPullSecrets        []corev1.LocalObjectReference
+		privateRegistryURL         string
+		privateRegistryPullSecrets []string
+	}{
+		{
+			name: "no pull secrets",
+			cluster: &provv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "fleet-default",
+				},
+				Spec: provv1.ClusterSpec{},
+			},
+			status: provv1.ClusterStatus{
+				ClusterName:      "test-cluster",
+				ClientSecretName: "client-secret-name",
+			},
+			cachedClusters: map[string]*apimgmtv3.Cluster{
+				"test-cluster": newMgmtCluster(
+					"c-abc12",
+					map[string]string{
+						"cluster-group": "cluster-group-name",
+					},
+					nil,
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+						Internal:           false,
+					},
+				),
+			},
+		},
+		{
+			name: "one pull secret",
+			cluster: &provv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "fleet-default",
+				},
+				Spec: provv1.ClusterSpec{},
+			},
+			status: provv1.ClusterStatus{
+				ClusterName:      "test-cluster",
+				ClientSecretName: "client-secret-name",
+			},
+			expectedPullSecrets: []corev1.LocalObjectReference{{
+				Name: "ps1-rancher-managed-pull-secret",
+			}},
+			cachedClusters: map[string]*apimgmtv3.Cluster{
+				"test-cluster": newMgmtCluster(
+					"c-abc12",
+					map[string]string{
+						"cluster-group": "cluster-group-name",
+					},
+					nil,
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+						ImportedConfig: &apimgmtv3.ImportedConfig{
+							PrivateRegistryURL: "test.com",
+							PrivateRegistryPullSecrets: []string{
+								"ps1",
+							},
+						},
+					},
+				),
+			},
+		},
+		{
+			name: "one pull secret, local cluster",
+			cluster: &provv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "local",
+					Namespace: "fleet-default",
+				},
+				Spec: provv1.ClusterSpec{},
+			},
+			status: provv1.ClusterStatus{
+				ClusterName:      "local",
+				ClientSecretName: "client-secret-name",
+			},
+			expectedPullSecrets: []corev1.LocalObjectReference{{
+				Name: "ps1",
+			}},
+			cachedClusters: map[string]*apimgmtv3.Cluster{
+				"local": newMgmtCluster(
+					"local",
+					map[string]string{
+						"cluster-group": "cluster-group-name",
+					},
+					nil,
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+						ImportedConfig: &apimgmtv3.ImportedConfig{
+							PrivateRegistryURL: "test.com",
+							PrivateRegistryPullSecrets: []string{
+								"ps1",
+							},
+						},
+					},
+				),
+			},
+		},
+		{
+			name: "multiple pull secrets",
+			cluster: &provv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "fleet-default",
+				},
+				Spec: provv1.ClusterSpec{},
+			},
+			status: provv1.ClusterStatus{
+				ClusterName:      "test-cluster",
+				ClientSecretName: "client-secret-name",
+			},
+			expectedPullSecrets: []corev1.LocalObjectReference{
+				{Name: "ps1-rancher-managed-pull-secret"},
+				{Name: "ps2-rancher-managed-pull-secret"},
+			},
+			cachedClusters: map[string]*apimgmtv3.Cluster{
+				"test-cluster": newMgmtCluster(
+					"c-abc12",
+					map[string]string{
+						"cluster-group": "cluster-group-name",
+					},
+					nil,
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+						ImportedConfig: &apimgmtv3.ImportedConfig{
+							PrivateRegistryURL: "test.com",
+							PrivateRegistryPullSecrets: []string{
+								"ps1",
+								"ps2",
+							},
+						},
+					},
+				),
+			},
+		},
+		{
+			name: "provisioned cluster does not deliver misconfigured pull secrets",
+			cluster: &provv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "fleet-default",
+				},
+				Spec: provv1.ClusterSpec{},
+			},
+			status: provv1.ClusterStatus{
+				ClusterName:      "c-m-abc12",
+				ClientSecretName: "client-secret-name",
+			},
+			expectedPullSecrets: []corev1.LocalObjectReference{},
+			cachedClusters: map[string]*apimgmtv3.Cluster{
+				"c-m-abc12": newMgmtCluster(
+					"c-m-abc12",
+					map[string]string{
+						"cluster-group": "cluster-group-name",
+					},
+					nil,
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+						ImportedConfig: &apimgmtv3.ImportedConfig{
+							PrivateRegistryURL: "test.com",
+							PrivateRegistryPullSecrets: []string{
+								"ps1",
+								"ps2",
+							},
+						},
+					},
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			h := &handler{
+				getPrivateRepoURL:         func(*provv1.Cluster, *apimgmtv3.Cluster) string { return tt.privateRegistryURL },
+				getPrivateRepoPullSecrets: getPrivateRepoSecrets,
+			}
+
+			h.clustersCache = newClusterCache(t, ctrl, tt.cachedClusters)
+			objs, _, err := h.createCluster(tt.cluster, tt.status)
+			if objs == nil {
+				t.Errorf("Expected non-nil objs: %v", err)
+			}
+
+			if err != nil {
+				t.Errorf("Expected nil err")
+			}
+
+			foundCluster := false
+			for _, obj := range objs {
+				cluster, ok := obj.(*fleet.Cluster)
+
+				if !ok {
+					continue
+				}
+
+				if cluster.Name != tt.cluster.Name || cluster.Namespace != tt.cluster.Namespace {
+					continue
+				}
+
+				foundCluster = true
+
+				// ensure pull secrets are equal
+				if len(tt.expectedPullSecrets) != 0 && cluster.Spec.AgentPullSecrets == nil {
+					t.Errorf("expected pull secrets %v, got nil AgentPullSecrets", tt.expectedPullSecrets)
+					t.FailNow()
+				}
+
+				if len(tt.expectedPullSecrets) == 0 && cluster.Spec.AgentPullSecrets == nil {
+					continue
+				}
+
+				if len(tt.expectedPullSecrets) != len(*cluster.Spec.AgentPullSecrets) {
+					t.Errorf("expected %d pull secrets, got %d", len(tt.expectedPullSecrets), len(*cluster.Spec.AgentPullSecrets))
+				}
+
+				for _, lor := range *cluster.Spec.AgentPullSecrets {
+					if !slices.Contains(tt.expectedPullSecrets, lor) {
+						t.Errorf("pull secret %s was not expected", lor)
+					}
+				}
+			}
+
+			if !foundCluster {
+				t.Errorf("Did not find expected cluster %v among created objects %v", tt.cluster, objs)
+			}
+		})
+	}
+}
+
 func TestCreateCluster(t *testing.T) {
 	h := &handler{
-		getPrivateRepoURL: func(*provv1.Cluster, *apimgmtv3.Cluster) string { return "" },
+		getPrivateRepoURL:         func(*provv1.Cluster, *apimgmtv3.Cluster) string { return "" },
+		getPrivateRepoPullSecrets: getPrivateRepoSecrets,
 	}
 
 	tests := []struct {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -75,7 +75,6 @@ var (
 		"cattle-oidc-client-secrets",
 		"cattle-impersonation-system",
 		"cluster-fleet-.*",
-		"cattle-fleet-local-system",
 		"cattle-fleet-clusters-system",
 	}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54806

## Problem
Historically fleet has not supported pull secrets, either at the chart level or the fleet cluster level (i.e. fleet-agent). 
 
## Solution
Alpha 11 introduced support for both pull secrets when deploying the fleet charts, as well as passing pull secret references when deploying the fleet agent (via fleet.Cluster) 
 
## Testing
Setup Rancher to use a global SDR and a pull secret
Ensure that the fleet components properly deploy in the local cluster
Provision an imported or hosted cluster
Ensure that the fleet agent deploys properly, and has a pull secret set on the pod spec

## Engineering Testing
### Manual Testing
I've done the above using

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: unit tests

## QA Testing Considerations
We should also deploy a sample fleet workload
 
### Regressions Considerations
N/A 

Existing / newly added automated tests that provide evidence there are no regressions:
