### PR TITLE
Minor : Add validation for empty project id and zone similar to other methods in pkg/api/norman/customization/gke/listers.go#listDiskTypes

### DIFF
--- a/pkg/api/norman/customization/gke/listers.go
+++ b/pkg/api/norman/customization/gke/listers.go
@@ -250,6 +250,10 @@ func listSharedSubnets(ctx context.Context, cap *Capabilities) ([]byte, int, err
 
 // listDiskTypes lists the available disk types for a given GCP project and region.
 func listDiskTypes(ctx context.Context, cap *Capabilities) ([]byte, int, error) {
+	if cap.ProjectID == "" || cap.Zone == "" {
+		return nil, http.StatusBadRequest, fmt.Errorf("projectId and zone are required")
+	}
+
 	client, err := getComputeServiceClient(ctx, cap.Credentials)
 	if err != nil {
 		return nil, http.StatusInternalServerError, err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55551
 
## Problem
`listDiskTypes` in `pkg/api/norman/customization/gke/listers.go` is the only lister function in the GKE handler that does not validate its required input fields (`projectId`, `zone`) before calling the Google Compute API client.

When either field is empty, the generated Go client interpolates them into the URL template `projects/{project}/zones/{zone}/diskTypes`, producing a malformed request (`projects//zones//diskTypes`). The GCE API rejects this, and Rancher wraps the Google error as a `500 Internal Server Error` with `"failed to list disk types"` — instead of the `400 Bad Request` that every sibling lister returns for missing fields.

Both `project` and `zone` are documented as required path parameters in the [GCE REST API reference](https://cloud.google.com/compute/docs/reference/rest/v1/diskTypes/list) 
 
## Solution
Add the same `projectId` and `zone` validation guard that `listMachineTypes` (which has the identical API signature `client.MachineTypes.List(project, zone)`) already uses
 
## Testing
Repro: call the `gkeDiskTypes` endpoint without the `zone` query parameter:

```
GET /meta/gke/gkeDiskTypes?cloudCredentialId=<id>&projectId=<project>
```

## Engineering Testing
### Manual Testing
Verified the code change matches the established pattern by comparing against all sibling listers in the same file. The handler's two input paths (`getCloudCredential` for GET, `getCredentialsFromBody` for POST) were traced to confirm that `zone` has no upstream validation and can reach `listDiskTypes` empty.

### Automated Testing

* Test types added/modified:
    * None
* If "None" - Reason: No existing test file or test framework exists for this package (`pkg/api/norman/customization/gke/`). None of the sibling lister functions (`listMachineTypes`, `listNetworks`, `listSubnetworks`, etc.) have unit tests. The change is a 3-line guard matching an established pattern with no new logic.
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
Test the `gkeDiskTypes` endpoint with:
1. Valid `projectId` + valid `zone` → should return disk types as before (no regression)
2. Missing `zone` query param → should now return `400` with clear error message
3. Missing `projectId` query param → should now return `400` with clear error message
4. Missing both → should return `400`

For upgrade scenarios: no impact. This only adds an early-return guard; existing valid requests are unaffected.
 
### Regressions Considerations
Probability of regression: **very low**. The change adds a guard before the API call — valid requests (non-empty `projectId` and `zone`) take the same code path as before. The only behavioral change is for previously-invalid requests that would have produced a 500, which now correctly produce a 400.

Existing / newly added automated tests that provide evidence there are no regressions:
*  No automated tests exist for this package. The sibling function `listMachineTypes` has had the identical guard since its introduction with no reported issues.