### PR TITLE
Fix UserInfo OIDC Custom Claims (#55390)

### DIFF
--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -499,45 +499,6 @@ func (o *OpenIDCProvider) getUserInfoFromAuthCode(rw http.ResponseWriter, req *h
 		return userInfo, oauth2Token, "", fmt.Errorf("failed to parse claims: %w", err)
 	}
 
-	// read groups from GroupsClaim if provided
-	if config.GroupsClaim != "" {
-		groupsClaim, err := getValueFromClaims[[]any](idToken, config.GroupsClaim)
-		if err != nil {
-			return userInfo, oauth2Token, "", fmt.Errorf("failed to parse groups claims: %w", err)
-		}
-
-		if len(groupsClaim) > 0 {
-			logrus.Debugf("OpenIDCProvider: using custom groups claim")
-			var groups []string
-			for _, g := range groupsClaim {
-				group, ok := g.(string)
-				if !ok {
-					logrus.Warn("OpenIDCProvider: failed to convert group to string")
-				}
-				groups = append(groups, group)
-			}
-			claimInfo.Groups = groups
-		}
-	}
-
-	// read name from nameClaim if provided
-	if config.NameClaim != "" {
-		nameClaim, err := getValueFromClaims[string](idToken, config.NameClaim)
-		if err != nil {
-			return userInfo, oauth2Token, "", fmt.Errorf("failed to parse claims: %w", err)
-		}
-		claimInfo.Name = nameClaim
-	}
-
-	// read email from emailClaim if provided
-	if config.EmailClaim != "" {
-		emailClaim, err := getValueFromClaims[string](idToken, config.EmailClaim)
-		if err != nil {
-			return userInfo, oauth2Token, "", fmt.Errorf("failed to parse claims: %w", err)
-		}
-		claimInfo.Email = emailClaim
-	}
-
 	// Valid will return false if access token is expired
 	if !oauth2Token.Valid() {
 		return userInfo, oauth2Token, "", fmt.Errorf("not valid token: %w", err)
@@ -560,6 +521,14 @@ func (o *OpenIDCProvider) getUserInfoFromAuthCode(rw http.ResponseWriter, req *h
 	logrus.Debugf("OpenIDCProvider: getUserInfo: getting user info for user %s", userName)
 	userInfo, err = provider.UserInfo(updatedContext, oauthConfig.TokenSource(updatedContext, oauth2Token))
 	if err != nil {
+		return userInfo, oauth2Token, "", err
+	}
+
+	// UserInfo overrides the ID token for standard fields.
+	if err := userInfo.Claims(&claimInfo); err != nil {
+		return userInfo, oauth2Token, "", fmt.Errorf("failed to get user info claims: %w", err)
+	}
+	if err := applyCustomClaims(idToken, userInfo, config, claimInfo); err != nil {
 		return userInfo, oauth2Token, "", err
 	}
 
@@ -624,7 +593,11 @@ func (o *OpenIDCProvider) getClaimInfoFromToken(ctx context.Context, config *api
 	if err != nil {
 		return nil, err
 	}
+	// UserInfo overrides the ID token for standard fields.
 	if err := userInfo.Claims(&claimInfo); err != nil {
+		return nil, err
+	}
+	if err := applyCustomClaims(idToken, userInfo, config, claimInfo); err != nil {
 		return nil, err
 	}
 
@@ -651,6 +624,83 @@ func ConfigToOauthConfig(endpoint oauth2.Endpoint, config *apiv3.OIDCConfig) oau
 		RedirectURL:  config.RancherURL,
 		Scopes:       finalScopes,
 	}
+}
+
+// applyCustomClaims resolves custom claim fields (GroupsClaim, NameClaim, EmailClaim)
+// from the config. For each configured claim the ID token supplies the initial value
+// and the UserInfo endpoint overrides it, so UserInfo takes precedence.
+func applyCustomClaims(idToken *oidc.IDToken, userInfo *oidc.UserInfo, config *apiv3.OIDCConfig, claimInfo *ClaimInfo) error {
+	if config.GroupsClaim == "" && config.NameClaim == "" && config.EmailClaim == "" {
+		return nil
+	}
+
+	var userInfoRawClaims map[string]any
+	if err := userInfo.Claims(&userInfoRawClaims); err != nil {
+		return fmt.Errorf("failed to parse user info claims: %w", err)
+	}
+
+	if config.GroupsClaim != "" {
+		groupsClaim, err := getValueFromClaims[[]any](idToken, config.GroupsClaim)
+		if err != nil {
+			return fmt.Errorf("failed to parse groups claims: %w", err)
+		}
+		// UserInfo overrides ID token.
+		if raw, ok := userInfoRawClaims[config.GroupsClaim]; ok {
+			if rawSlice, ok := raw.([]any); ok {
+				groupsClaim = rawSlice
+			}
+		}
+
+		if len(groupsClaim) > 0 {
+			logrus.Debugf("OpenIDCProvider: using custom groups claim")
+			groups := make([]string, 0, len(groupsClaim))
+			for _, g := range groupsClaim {
+				group, ok := g.(string)
+				if !ok || group == "" {
+					logrus.Warn("OpenIDCProvider: failed to convert group to string")
+					continue
+				}
+				groups = append(groups, group)
+			}
+			if len(groups) > 0 {
+				claimInfo.Groups = groups
+			}
+		}
+	}
+
+	if config.NameClaim != "" {
+		nameClaim, err := getValueFromClaims[string](idToken, config.NameClaim)
+		if err != nil {
+			return fmt.Errorf("failed to parse name claim: %w", err)
+		}
+		// UserInfo overrides ID token.
+		if userInfoName, ok := userInfoRawClaims[config.NameClaim].(string); ok && userInfoName != "" {
+			nameClaim = userInfoName
+		}
+		// Only override if a non-empty value was resolved; otherwise preserve any
+		// name already populated from the standard "name" claim.
+		if nameClaim != "" {
+			claimInfo.Name = nameClaim
+		}
+	}
+
+	if config.EmailClaim != "" {
+		emailClaim, err := getValueFromClaims[string](idToken, config.EmailClaim)
+		if err != nil {
+			return fmt.Errorf("failed to parse email claim: %w", err)
+		}
+		// UserInfo overrides ID token.
+		if userInfoEmail, ok := userInfoRawClaims[config.EmailClaim].(string); ok && userInfoEmail != "" {
+			emailClaim = userInfoEmail
+		}
+		// Only override if a non-empty value was resolved; otherwise preserve any
+		// email already populated from the standard "email" claim.
+		if emailClaim != "" {
+			claimInfo.Email = emailClaim
+		}
+	}
+
+	return nil
 }
 
 func (o *OpenIDCProvider) getGroupsFromClaimInfo(claimInfo ClaimInfo) []apiv3.Principal {

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -149,7 +149,12 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				FullGroupPath: []string{"/admingroup"},
 				Roles:         []string{"adminrole"},
 			},
-			expectedClaimInfo: &ClaimInfo{},
+			expectedClaimInfo: &ClaimInfo{
+				Subject:       "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:        []string{"admingroup"},
+				FullGroupPath: []string{"/admingroup"},
+				Roles:         []string{"adminrole"},
+			},
 		},
 		"get groups with GroupsClaims": {
 			config: func(port string) *apiv3.OIDCConfig {
@@ -195,7 +200,58 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
 			},
 			expectedClaimInfo: &ClaimInfo{
-				Groups: []string{"group1", "group2"},
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:  []string{"group1", "group2"},
+			},
+		},
+		"get groups with GroupsClaim present only in UserInfo": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.GroupsClaim = "custom:groups"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				// ID token intentionally omits "custom:groups".
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud": "test",
+					"exp": time.Now().Add(5 * time.Minute).Unix(),
+					"iss": "http://localhost:" + port,
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				assert.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				// UserInfo carries the groups claim.
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				"custom:groups": ["group1", "group2"]
+              }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:  []string{"group1", "group2"},
 			},
 		},
 		"error - invalid certificate": {
@@ -295,7 +351,62 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
 			},
 			expectedClaimInfo: &ClaimInfo{
-				Name:  "Test User",
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Name:    "Test User",
+				Email:   "test@example.com",
+			},
+		},
+		"nameClaim configured but claim absent preserves standard name": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.NameClaim = "display_name"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"name":  "Standard Name",
+					"aud":   "test",
+					"exp":   time.Now().Add(5 * time.Minute).Unix(),
+					"email": "test@example.com",
+					"iss":   "http://localhost:" + port,
+					// no "display_name" claim
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				assert.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd"
+                }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				// Name must be preserved from the standard "name" claim in the
+				// ID token; it must NOT be wiped to "" just because the
+				// configured NameClaim ("display_name") is absent.
+				Name:  "Standard Name",
 				Email: "test@example.com",
 			},
 		},
@@ -344,7 +455,117 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
 			},
 			expectedClaimInfo: &ClaimInfo{
-				Email: "test.dev@example.com",
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Email:   "test.dev@example.com",
+			},
+		},
+		"emailClaim configured but claim absent preserves standard email": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.EmailClaim = "work_email"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud":   "test",
+					"exp":   time.Now().Add(5 * time.Minute).Unix(),
+					"email": "standard@example.com",
+					"iss":   "http://localhost:" + port,
+					// no "work_email" claim
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				assert.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd"
+                }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				// Email must be preserved from the standard "email" claim in the
+				// ID token; it must NOT be wiped to "" just because the
+				// configured EmailClaim ("work_email") is absent.
+				Email: "standard@example.com",
+			},
+		},
+		"groupsClaim configured but claim absent preserves standard groups": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.GroupsClaim = "custom_groups"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud": "test",
+					"exp": time.Now().Add(5 * time.Minute).Unix(),
+					"iss": "http://localhost:" + port,
+					// no "custom_groups" claim
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				assert.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				// UserInfo has standard "groups" and "full_group_path" but no "custom_groups".
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				"groups": ["standardgroup"],
+				"full_group_path": ["/standardgroup"]
+                }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject:       "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:        []string{"standardgroup"},
+				FullGroupPath: []string{"/standardgroup"},
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				// Groups and FullGroupPath must be preserved from the standard
+				// UserInfo claims; they must NOT be wiped just because the
+				// configured GroupsClaim ("custom_groups") is absent.
+				Groups:        []string{"standardgroup"},
+				FullGroupPath: []string{"/standardgroup"},
 			},
 		},
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55486

Backport of #55390

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
We broke custom claims from the info provider when fixing custom claims from the id token.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Set up custom claims for an OIDC client but _only_ in the userinfo endpoint and these will now work.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_