### PR TITLE
[Backport v2.13] Cache SAML Assertion IDs

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -394,6 +395,24 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 		s.clientState.DeleteState(w, r, relayState)
 	}
 
+	// Validate the assertion's time conditions.
+	now := time.Now()
+	if err := checkAssertionTimeConditions(now, assertion.Conditions); err != nil {
+		log.Errorf("SAML: Rejected assertion ID %q: %v", assertion.ID, err)
+		http.Redirect(w, r, redirectURL+"errorCode=403", http.StatusFound)
+		return
+	}
+
+	assertionExpiry := now.Add(time.Hour)
+	if assertion.Conditions != nil && !assertion.Conditions.NotOnOrAfter.IsZero() {
+		assertionExpiry = assertion.Conditions.NotOnOrAfter
+	}
+	if s.assertionCache.seen(assertion.ID, assertionExpiry) {
+		log.Errorf("SAML: Rejected previous assertion ID %q", assertion.ID)
+		http.Redirect(w, r, redirectURL+"errorCode=403", http.StatusFound)
+		return
+	}
+
 	samlData := make(map[string][]string)
 
 	for _, attributeStatement := range assertion.AttributeStatements {
@@ -629,4 +648,79 @@ func (s *Provider) getUserIdFromRelayStateCookie(r *http.Request) (string, error
 
 func newJWTParser() *jwt.Parser {
 	return jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
+}
+
+func validateFinalRedirectURL(redirectURL string, rancherServerURL string) (string, error) {
+	if redirectURL == "" {
+		return "", errors.New("redirect URL was not provided")
+	}
+	parsed, err := url.Parse(redirectURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid redirect URL: %w", err)
+	}
+	rancherParsed, err := url.Parse(rancherServerURL)
+	if err != nil {
+		return "", fmt.Errorf("could not parse Rancher server URL: %w", err)
+	}
+	if parsed.Host != rancherParsed.Host {
+		return "", fmt.Errorf("redirect URL host %q does not match Rancher host %q", parsed.Host, rancherParsed.Host)
+	}
+
+	return redirectURL, nil
+}
+
+// checkAssertionTimeConditions returns an error if now falls outside the
+// assertion's [NotBefore, NotOnOrAfter) validity window. A nil or zero-valued
+// bound is treated as unbounded on that side.
+func checkAssertionTimeConditions(now time.Time, conditions *saml.Conditions) error {
+	if conditions == nil {
+		return nil
+	}
+	if !conditions.NotBefore.IsZero() && now.Before(conditions.NotBefore) {
+		return fmt.Errorf("current time %s is before NotBefore %s", now, conditions.NotBefore)
+	}
+	if !conditions.NotOnOrAfter.IsZero() && !now.Before(conditions.NotOnOrAfter) {
+		return fmt.Errorf("current time %s is on or after NotOnOrAfter %s", now, conditions.NotOnOrAfter)
+	}
+
+	return nil
+}
+
+// assertionCache tracks recently seen SAML assertion IDs to prevent replay attacks.
+type assertionCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time // assertion ID -> expiry time
+}
+
+func newAssertionCache() *assertionCache {
+	return &assertionCache{
+		entries: make(map[string]time.Time),
+	}
+}
+
+// seen returns true if the assertion ID was seen before.
+//
+// If not seen, it records the ID with its expiry time and returns false.
+// Expired entries are evicted lazily on each call.
+func (c *assertionCache) seen(id string, expiry time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.evict()
+	if _, ok := c.entries[id]; ok {
+		return true
+	}
+	c.entries[id] = expiry
+	return false
+}
+
+// evict removes expired entries.
+//
+// Must be called with c.mu held.
+func (c *assertionCache) evict() {
+	now := time.Now()
+	for id, exp := range c.entries {
+		if now.After(exp) {
+			delete(c.entries, id)
+		}
+	}
 }

--- a/pkg/auth/providers/saml/saml_client_test.go
+++ b/pkg/auth/providers/saml/saml_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/crewjam/saml"
 	"github.com/golang-jwt/jwt/v5"
@@ -138,6 +139,176 @@ func TestGetUserIdFromRelayState(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, test.wantUserID, userID)
+		})
+	}
+}
+
+func TestValidateFinalRedirectURL(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		redirectURL string
+		rancherURL  string
+		want        string
+		wantErr     string
+	}{
+		"empty redirect": {
+			redirectURL: "",
+			rancherURL:  "https://rancher.example.com",
+			wantErr:     "redirect URL was not provided",
+		},
+		"invalid redirect": {
+			redirectURL: "http://[::1",
+			rancherURL:  "https://rancher.example.com",
+			wantErr:     "invalid redirect URL",
+		},
+		"invalid rancher url": {
+			redirectURL: "https://rancher.example.com/verify",
+			rancherURL:  "::://not-a-url",
+			wantErr:     "could not parse Rancher server URL",
+		},
+		"mismatched hosts": {
+			redirectURL: "https://attacker.example.com/login",
+			rancherURL:  "https://rancher.example.com",
+			wantErr:     "does not match Rancher host",
+		},
+		"matching host": {
+			redirectURL: "https://rancher.example.com/dashboard/auth?token=abc",
+			rancherURL:  "https://rancher.example.com",
+			want:        "https://rancher.example.com/dashboard/auth?token=abc",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := validateFinalRedirectURL(tt.redirectURL, tt.rancherURL)
+
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAssertionCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new ID is not seen", func(t *testing.T) {
+		t.Parallel()
+		c := newAssertionCache()
+		expiry := time.Now().Add(time.Minute)
+		assert.False(t, c.seen("id-1", expiry))
+	})
+
+	t.Run("same ID seen twice", func(t *testing.T) {
+		t.Parallel()
+		c := newAssertionCache()
+		expiry := time.Now().Add(time.Minute)
+		assert.False(t, c.seen("id-replay", expiry))
+		assert.True(t, c.seen("id-replay", expiry))
+	})
+
+	t.Run("different IDs are tracked independently", func(t *testing.T) {
+		t.Parallel()
+		c := newAssertionCache()
+		expiry := time.Now().Add(time.Minute)
+		assert.False(t, c.seen("id-a", expiry))
+		assert.False(t, c.seen("id-b", expiry))
+		assert.True(t, c.seen("id-a", expiry))
+		assert.True(t, c.seen("id-b", expiry))
+	})
+
+	t.Run("expired ID is evicted and accepted again", func(t *testing.T) {
+		t.Parallel()
+		c := newAssertionCache()
+		// Insert with an already-expired time.
+		pastExpiry := time.Now().Add(-time.Second)
+		assert.False(t, c.seen("id-expired", pastExpiry))
+
+		// The entry is expired; the next call should evict it and accept a fresh one.
+		futureExpiry := time.Now().Add(time.Minute)
+		assert.False(t, c.seen("id-expired", futureExpiry))
+	})
+
+	t.Run("eviction does not remove live entries", func(t *testing.T) {
+		t.Parallel()
+		c := newAssertionCache()
+		liveExpiry := time.Now().Add(time.Minute)
+		pastExpiry := time.Now().Add(-time.Second)
+
+		assert.False(t, c.seen("id-live", liveExpiry))
+		assert.False(t, c.seen("id-stale", pastExpiry))
+
+		// Trigger eviction via any seen() call.
+		assert.False(t, c.seen("id-new", liveExpiry))
+
+		// The live entry must still be detected as a replay.
+		assert.True(t, c.seen("id-live", liveExpiry))
+	})
+}
+
+func TestCheckAssertionTimeConditions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+
+	tests := map[string]struct {
+		conditions *saml.Conditions
+		wantErr    bool
+	}{
+		"nil conditions": {
+			conditions: nil,
+			wantErr:    false,
+		},
+		"valid window: NotBefore in past, NotOnOrAfter in future": {
+			conditions: &saml.Conditions{NotBefore: past, NotOnOrAfter: future},
+			wantErr:    false,
+		},
+		"NotBefore in the future": {
+			conditions: &saml.Conditions{NotBefore: future},
+			wantErr:    true,
+		},
+		"NotOnOrAfter in the past": {
+			conditions: &saml.Conditions{NotOnOrAfter: past},
+			wantErr:    true,
+		},
+		"NotOnOrAfter exactly equal to now (on or after boundary)": {
+			conditions: &saml.Conditions{NotOnOrAfter: now},
+			wantErr:    true,
+		},
+		"NotBefore exactly equal to now (valid: now is not before itself)": {
+			conditions: &saml.Conditions{NotBefore: now},
+			wantErr:    false,
+		},
+		"only NotBefore set, in the past": {
+			conditions: &saml.Conditions{NotBefore: past},
+			wantErr:    false,
+		},
+		"only NotOnOrAfter set, in the future": {
+			conditions: &saml.Conditions{NotOnOrAfter: future},
+			wantErr:    false,
+		},
+		"zero-value Conditions (both bounds unset)": {
+			conditions: &saml.Conditions{},
+			wantErr:    false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := checkAssertionTimeConditions(now, tc.conditions)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -51,20 +51,23 @@ type Provider struct {
 	ldapProvider    common.AuthProvider
 	sloEnabled      bool
 	sloForced       bool
+
+	assertionCache *assertionCache
 }
 
 var SamlProviders = make(map[string]*Provider)
 
 func Configure(mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager, name string) common.AuthProvider {
 	provider := &Provider{
-		authConfigs: mgmtCtx.Management.AuthConfigs(""),
-		secrets:     mgmtCtx.Wrangler.Core.Secret(),
-		samlTokens:  mgmtCtx.Management.SamlTokens(""),
-		userMGR:     userMGR,
-		tokenMGR:    tokenMGR,
-		name:        name,
-		userType:    name + "_user",
-		groupType:   name + "_group",
+		authConfigs:    mgmtCtx.Management.AuthConfigs(""),
+		secrets:        mgmtCtx.Wrangler.Core.Secret(),
+		samlTokens:     mgmtCtx.Management.SamlTokens(""),
+		userMGR:        userMGR,
+		tokenMGR:       tokenMGR,
+		name:           name,
+		userType:       name + "_user",
+		groupType:      name + "_group",
+		assertionCache: newAssertionCache(),
 	}
 
 	if provider.hasLdapGroupSearch() {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently SAML Assertions are not validated very well.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This adds a cache for SAML assertion IDs to reduce the risk of reprocessing the same ID more than once and time-based validation to ensure that assertions are not out-of-date.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_