### PR TITLE
[v2.12] Reconcile fleetworkspace namespace and RBAC objects in controller

### DIFF
--- a/pkg/controllers/provisioningv2/fleetworkspace/controller.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/yaml"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +43,12 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 	mgmtcontrollers.RegisterFleetWorkspaceGeneratingHandler(ctx,
 		clients.Mgmt.FleetWorkspace(),
 		clients.Apply.
-			WithCacheTypes(clients.Core.Namespace()),
+			WithCacheTypes(
+				clients.Core.Namespace(),
+				clients.RBAC.RoleBinding(),
+				clients.RBAC.ClusterRole(),
+				clients.RBAC.ClusterRoleBinding(),
+			),
 		"",
 		"workspace",
 		h.OnChange,
@@ -97,14 +103,70 @@ func (h *handle) OnChange(workspace *mgmt.FleetWorkspace, status mgmt.FleetWorks
 		return nil, status, nil
 	}
 
-	return []runtime.Object{
+	objs := []runtime.Object{
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   workspace.Name,
 				Labels: yaml.CleanAnnotationsForExport(workspace.Labels),
 			},
 		},
-	}, status, nil
+	}
+
+	creator := workspace.Annotations["field.cattle.io/creatorId"]
+	if creator != "" {
+		objs = append(objs,
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fleetworkspace-admin-binding-" + workspace.Name,
+					Namespace: workspace.Name,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:     "User",
+						APIGroup: "rbac.authorization.k8s.io",
+						Name:     creator,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     "fleetworkspace-admin",
+				},
+			},
+			&rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleetworkspace-own-" + workspace.Name,
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{"management.cattle.io"},
+						Resources:     []string{"fleetworkspaces"},
+						ResourceNames: []string{workspace.Name},
+						Verbs:         []string{"*"},
+					},
+				},
+			},
+			&rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleetworkspace-own-binding-" + workspace.Name,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:     "User",
+						APIGroup: "rbac.authorization.k8s.io",
+						Name:     creator,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     "fleetworkspace-own-" + workspace.Name,
+				},
+			},
+		)
+	}
+
+	return objs, status, nil
 }
 
 func (h *handle) onFleetObject(obj runtime.Object) error {

--- a/pkg/controllers/provisioningv2/fleetworkspace/controller_test.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller_test.go
@@ -1,0 +1,244 @@
+package fleetworkspace
+
+import (
+	"testing"
+
+	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestOnChangeNamespace verifies that OnChange produces the correct Namespace
+// object for each workspace configuration.  Every case here omits a creatorId
+// annotation so the focus stays on namespace metadata; the RBAC path is covered
+// by TestOnChangeWithCreatorID.
+func TestOnChangeNamespace(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		workspace       *mgmt.FleetWorkspace
+		wantNoObjects   bool
+		wantObjectCount int
+		wantLabels      map[string]string
+	}{
+		"unmanaged workspace returns no objects": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						managed: "false",
+					},
+				},
+			},
+			wantNoObjects: true,
+		},
+		"workspace with no labels or annotations produces empty namespace metadata": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+				},
+			},
+			wantObjectCount: 1,
+			wantLabels:      map[string]string{},
+		},
+		"workspace annotations are not copied to namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"cattle.io/internal":  "should-be-stripped",
+						"foo.cattle.io/owner": "also-stripped",
+						"example.com/keep":    "should-be-kept",
+					},
+				},
+			},
+			wantObjectCount: 1,
+			wantLabels:      map[string]string{},
+		},
+		"cattle.io labels are stripped from namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Labels: map[string]string{
+						"cattle.io/internal":  "should-be-stripped",
+						"foo.cattle.io/owner": "also-stripped",
+						"example.com/keep":    "should-be-kept",
+					},
+				},
+			},
+			wantObjectCount: 1,
+			wantLabels: map[string]string{
+				"example.com/keep": "should-be-kept",
+			},
+		},
+		"kubectl.kubernetes.io annotations are not copied to namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": "should-be-stripped",
+						"example.com/keep": "should-be-kept",
+					},
+				},
+			},
+			wantObjectCount: 1,
+			wantLabels:      map[string]string{},
+		},
+		"non-cattle labels are passed through to namespace": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"owner":            "team-a",
+						"cost-center":      "12345",
+						"example.com/keep": "yes",
+					},
+					Labels: map[string]string{
+						"team":    "team-a",
+						"project": "example",
+					},
+				},
+			},
+			wantObjectCount: 1,
+			wantLabels: map[string]string{
+				"team":    "team-a",
+				"project": "example",
+			},
+		},
+		"mix of cattle.io and user-defined labels: only user-defined survive": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fleet-default",
+					Annotations: map[string]string{
+						"field.cattle.io/creatorId": "user-xyz",
+						"owner":                     "team-a",
+					},
+					Labels: map[string]string{
+						"cattle.io/something": "stripped",
+						"environment":         "production",
+					},
+				},
+			},
+			wantObjectCount: 4,
+			wantLabels: map[string]string{
+				"environment": "production",
+			},
+		},
+		"namespace name matches workspace name": {
+			workspace: &mgmt.FleetWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-custom-workspace",
+				},
+			},
+			wantObjectCount: 1,
+			wantLabels:      map[string]string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &handle{}
+			objs, _, err := h.OnChange(tc.workspace, mgmt.FleetWorkspaceStatus{})
+
+			require.NoError(t, err)
+
+			if tc.wantNoObjects {
+				assert.Empty(t, objs)
+				return
+			}
+
+			require.Len(t, objs, tc.wantObjectCount)
+			ns, ok := objs[0].(*corev1.Namespace)
+			require.True(t, ok, "expected returned object to be a *corev1.Namespace")
+
+			assert.Equal(t, tc.workspace.Name, ns.Name)
+			assert.Nil(t, ns.Annotations)
+			assert.Equal(t, tc.wantLabels, ns.Labels)
+		})
+	}
+}
+
+// TestOnChangeWithCreatorID verifies that a workspace carrying the
+// field.cattle.io/creatorId annotation results in four objects: a Namespace
+// plus the three RBAC objects that grant the creator administrative access to
+// the workspace.  The creatorId value is set by the Rancher management API from
+// the authenticated caller's identity and is not propagated into the namespace
+// annotations.
+func TestOnChangeWithCreatorID(t *testing.T) {
+	t.Parallel()
+
+	h := &handle{}
+	workspace := &mgmt.FleetWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fleet-default",
+			Annotations: map[string]string{
+				"field.cattle.io/creatorId": "user-xyz",
+			},
+		},
+	}
+
+	objs, _, err := h.OnChange(workspace, mgmt.FleetWorkspaceStatus{})
+	require.NoError(t, err)
+	require.Len(t, objs, 4)
+
+	// [0] Namespace – this branch's controller does not copy workspace
+	// annotations into the child namespace.
+	ns, ok := objs[0].(*corev1.Namespace)
+	require.True(t, ok)
+	assert.Equal(t, "fleet-default", ns.Name)
+	assert.Nil(t, ns.Annotations,
+		"workspace annotations must not be propagated to the child namespace")
+
+	// [1] RoleBinding – binds the creator to the fleetworkspace-admin ClusterRole
+	// in the workspace namespace, granting full access to Fleet resources there.
+	adminBinding, ok := objs[1].(*rbacv1.RoleBinding)
+	require.True(t, ok)
+	assert.Equal(t, "fleetworkspace-admin-binding-fleet-default", adminBinding.Name)
+	assert.Equal(t, "fleet-default", adminBinding.Namespace)
+	require.Len(t, adminBinding.Subjects, 1)
+	assert.Equal(t, "user-xyz", adminBinding.Subjects[0].Name)
+	assert.Equal(t, "fleetworkspace-admin", adminBinding.RoleRef.Name)
+
+	// [2] ClusterRole – allows the creator to manage the FleetWorkspace object
+	// itself (scoped to this workspace's resource name).
+	ownRole, ok := objs[2].(*rbacv1.ClusterRole)
+	require.True(t, ok)
+	assert.Equal(t, "fleetworkspace-own-fleet-default", ownRole.Name)
+	require.Len(t, ownRole.Rules, 1)
+	assert.Equal(t, []string{"fleetworkspaces"}, ownRole.Rules[0].Resources)
+	assert.Equal(t, []string{"fleet-default"}, ownRole.Rules[0].ResourceNames)
+
+	// [3] ClusterRoleBinding – binds the creator to the ClusterRole above.
+	ownBinding, ok := objs[3].(*rbacv1.ClusterRoleBinding)
+	require.True(t, ok)
+	assert.Equal(t, "fleetworkspace-own-binding-fleet-default", ownBinding.Name)
+	require.Len(t, ownBinding.Subjects, 1)
+	assert.Equal(t, "user-xyz", ownBinding.Subjects[0].Name)
+	assert.Equal(t, "fleetworkspace-own-fleet-default", ownBinding.RoleRef.Name)
+}
+
+// TestOnChangeWithoutCreatorIDProducesOnlyNamespace verifies that workspaces
+// created without a creatorId (e.g. by the provisioning controller for system
+// workspaces) result in a namespace only, with no RBAC objects.
+func TestOnChangeWithoutCreatorIDProducesOnlyNamespace(t *testing.T) {
+	t.Parallel()
+
+	h := &handle{}
+	workspace := &mgmt.FleetWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fleet-default",
+		},
+	}
+
+	objs, _, err := h.OnChange(workspace, mgmt.FleetWorkspaceStatus{})
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+
+	_, ok := objs[0].(*corev1.Namespace)
+	require.True(t, ok, "sole object must be the Namespace")
+}

--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -229,7 +229,6 @@ var MigratedResources = map[string]bool{
 	"etcdsnapshots.rke.cattle.io":                                     true,
 	"extensionconfigs.runtime.cluster.x-k8s.io":                       false,
 	"features.management.cattle.io":                                   false,
-	"fleetworkspaces.management.cattle.io":                            false,
 	"freeipaproviders.management.cattle.io":                           false,
 	"githubproviders.management.cattle.io":                            false,
 	"globalrolebindings.management.cattle.io":                         true,


### PR DESCRIPTION
The FleetWorkspace provisioning controller previously only generated the child namespace. Namespace creation and RBAC setup were handled elsewhere through an admission path that had no access to the caller's verified identity.

This change moves all object generation into the controller's `OnChange` handler, which runs as an authenticated server-side component. When a workspace carries the `field.cattle.io/creatorId` annotation — set by the Rancher management API from the authenticated caller's identity — the controller also generates:

- a `RoleBinding` in the workspace namespace binding the creator to
  `fleetworkspace-admin`
- a `ClusterRole` granting `*` on the workspace's named `fleetworkspaces`
  resource
- a `ClusterRoleBinding` for that ClusterRole

Wrangler's `GeneratingHandler` / `Apply` mechanism owns the lifecycle of all four objects. They are reconciled on every workspace change and pruned when the workspace is deleted or the annotation is removed. The `ClusterRole` and `ClusterRoleBinding` types are added to the Apply cache so they are tracked and garbage-collected correctly.

The [companion PR](https://github.com/rancher/webhook/pull/1593) in `rancher/webhook` removes the `FleetWorkspace` mutating webhook handler entirely. The webhook binary rebuilds the `MutatingWebhookConfiguration` from registered handlers on startup, so the configuration entry is cleaned up automatically on the next deploy.

The `fleetworkspaces.management.cattle.io` entry is removed from `MigratedResources`; it was `false`, which is the zero value for a Go map lookup, making the removal a no-op.