### PR TITLE
Move downstream secrets factory lifecycle into synchronous user context startup

### DIFF
--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -77,26 +77,23 @@ func RegisterFactory(cluster *config.UserContext) (corecontrollers.SecretCache, 
 	return secretsCache, nil
 }
 
-// Register wires up clusterauthtoken event handlers once the EXT API is ready.
-// secretsCache must be the value returned by RegisterFactory on the same
-// UserContext. Handler wiring is pure in-process Go with no network calls, so
-// no retry machinery is needed.
+// Register wires up clusterauthtoken event handlers. secretsCache must be the
+// value returned by RegisterFactory on the same UserContext.
+//
+// v3 Token handlers are registered immediately — they have no EXT API
+// dependency and are active as soon as the management informers deliver events,
+// eliminating the EXT API readiness window for v3 Token → ClusterAuthToken sync.
+//
+// ext Token handlers are registered once the EXT API is ready, since they
+// require the EXT API client context.
 func Register(ctx context.Context, cluster *config.UserContext, secretsCache corecontrollers.SecretCache) {
-	cluster.Management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
-		registerHandlers(ctx, cluster, secretsCache, w)
-	})
-}
+	namespace := common.DefaultNamespace
+	clusterName := cluster.ClusterName
 
-// registerHandlers wires all event handlers. It has no factory lifecycle
-// operations and makes no network calls, so it is called synchronously from
-// the DeferFunc goroutine without additional wrapping or a retry gate.
-func registerHandlers(ctx context.Context, cluster *config.UserContext, secretsCache corecontrollers.SecretCache, extAPIContext *wrangler.EXTAPIContext) {
 	tokenInformer := cluster.Management.Management.Tokens("").Controller().Informer()
 	tokenCache := cluster.Management.Wrangler.Mgmt.Token().Cache()
 	tokenClient := cluster.Management.Wrangler.Mgmt.Token()
 
-	namespace := common.DefaultNamespace
-	clusterName := cluster.ClusterName
 	clusterAuthToken := cluster.Cluster.ClusterAuthTokens(namespace)
 	clusterAuthTokenLister := cluster.Cluster.ClusterAuthTokens(namespace).Controller().Lister()
 	clusterUserAttribute := cluster.Cluster.ClusterUserAttributes(namespace)
@@ -104,11 +101,25 @@ func registerHandlers(ctx context.Context, cluster *config.UserContext, secretsC
 	clusterConfigMap := cluster.Corew.ConfigMap()
 	clusterConfigMapLister := cluster.Corew.ConfigMap().Cache()
 	clusterSecret := cluster.Corew.Secret()
-	tokenIndexer := tokenInformer.GetIndexer()
 	userLister := cluster.Management.Management.Users("").Controller().Lister()
 	userAttribute := cluster.Management.Management.UserAttributes("")
 	userAttributeLister := cluster.Management.Management.UserAttributes("").Controller().Lister()
 	settingInterface := cluster.Management.Management.Settings("")
+
+	// extTokenIndexer starts nil and is set when the EXT API becomes ready.
+	// The v3 Remove path already guards against a nil extTokenIndexer.
+	handler := &tokenHandler{
+		namespace:                  namespace,
+		clusterAuthToken:           clusterAuthToken,
+		clusterAuthTokenLister:     clusterAuthTokenLister,
+		clusterUserAttribute:       clusterUserAttribute,
+		clusterUserAttributeLister: clusterUserAttributeLister,
+		tokenIndexer:               tokenInformer.GetIndexer(),
+		userLister:                 userLister,
+		userAttributeLister:        userAttributeLister,
+		clusterSecret:              clusterSecret,
+		clusterSecretLister:        secretsCache,
+	}
 
 	cluster.Management.Management.Settings("").AddHandler(ctx, settingController, (&settingHandler{
 		namespace,
@@ -117,27 +128,10 @@ func registerHandlers(ctx context.Context, cluster *config.UserContext, secretsC
 		settingInterface,
 	}).Sync)
 
-	handler := &tokenHandler{
-		namespace:                  namespace,
-		clusterAuthToken:           clusterAuthToken,
-		clusterAuthTokenLister:     clusterAuthTokenLister,
-		clusterUserAttribute:       clusterUserAttribute,
-		clusterUserAttributeLister: clusterUserAttributeLister,
-		tokenIndexer:               tokenIndexer,
-		userLister:                 userLister,
-		userAttributeLister:        userAttributeLister,
-		clusterSecret:              clusterSecret,
-		clusterSecretLister:        secretsCache,
-	}
-
 	cluster.Management.Management.Tokens("").AddClusterScopedLifecycle(ctx,
 		tokenController,
 		clusterName,
 		handler)
-
-	extToken := extAPIContext.Client.Token()
-	handler.extTokenIndexer = extToken.Informer().GetIndexer()
-	extTokenLifecycle(ctx, extToken, extTokenController, clusterName, handler)
 
 	cluster.Management.Management.Users("").AddHandler(ctx, userController, (&userHandler{
 		namespace,
@@ -157,14 +151,19 @@ func registerHandlers(ctx context.Context, cluster *config.UserContext, secretsC
 		clusterUserAttribute,
 	}).Sync)
 
-	catHandler := &clusterAuthTokenHandler{
-		tokenCache:  tokenCache,
-		tokenClient: tokenClient,
-	}
-	catHandler.extTokenCache = extAPIContext.Client.Token().Cache()
-	catHandler.extTokenStore = extstore.NewSystemFromWrangler(cluster.Management.Wrangler)
+	cluster.Management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
+		extToken := w.Client.Token()
+		handler.extTokenIndexer = extToken.Informer().GetIndexer()
+		extTokenLifecycle(ctx, extToken, extTokenController, clusterName, handler)
 
-	cluster.Cluster.ClusterAuthTokens(namespace).AddHandler(ctx, clusterAuthTokenController, catHandler.sync)
+		catHandler := &clusterAuthTokenHandler{
+			tokenCache:    tokenCache,
+			tokenClient:   tokenClient,
+			extTokenCache: extToken.Cache(),
+			extTokenStore: extstore.NewSystemFromWrangler(cluster.Management.Wrangler),
+		}
+		cluster.Cluster.ClusterAuthTokens(namespace).AddHandler(ctx, clusterAuthTokenController, catHandler.sync)
+	})
 }
 
 func newDedicatedSecretsCache(clientFactory client.SharedClientFactory, namespace string) (corecontrollers.SecretCache, controller.SharedControllerFactory) {

--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -153,7 +153,7 @@ func Register(ctx context.Context, cluster *config.UserContext, secretsCache cor
 
 	cluster.Management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
 		extToken := w.Client.Token()
-		handler.extTokenIndexer = extToken.Informer().GetIndexer()
+		handler.extTokenIndexer.Store(extToken.Informer().GetIndexer())
 		extTokenLifecycle(ctx, extToken, extTokenController, clusterName, handler)
 
 		catHandler := &clusterAuthTokenHandler{

--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -56,14 +56,14 @@ func RegisterIndexers(scaledContext *config.ScaledContext) error {
 
 // RegisterFactory creates the dedicated namespace-scoped secrets cache for
 // clusterauthtoken handlers and registers it with the UserContext so it is
-// started by UserContext.Start() as part of doStart()'s normal factory-start
-// sequence.
+// started by UserContext.Start() as part of the cluster controller's normal
+// factory-start sequence.
 //
 // Must be called before UserContext.Start() — i.e. during managementuser.Register,
 // while the transaction is open and startContext is still nil. When Start() is
 // later called, the factory starts alongside ControllerFactory and all others;
-// if it fails, the error surfaces through doStart() to the cluster manager,
-// which logs the failure, marks the cluster unavailable, and retries.
+// if it fails, the error surfaces to the cluster manager, which logs the
+// failure, marks the cluster unavailable, and retries.
 //
 // Returns the SecretCache to pass to Register() for handler wiring.
 func RegisterFactory(cluster *config.UserContext) (corecontrollers.SecretCache, error) {

--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rancher/lasso/pkg/client"
 	"github.com/rancher/lasso/pkg/controller"
 	extv1 "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
-	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/clusterauthtoken/common"
 	extstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
@@ -19,7 +18,6 @@ import (
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
@@ -27,7 +25,6 @@ import (
 const (
 	tokenByUserAndClusterIndex = "auth.management.cattle.io/token-by-user-and-cluster"
 
-	clusterController              = "cat-cluster-controller-deferred"
 	tokenController                = "cat-token-controller"
 	extTokenController             = "cat-ext-token-controller"
 	settingController              = "cat-setting-controller"
@@ -57,32 +54,43 @@ func RegisterIndexers(scaledContext *config.ScaledContext) error {
 		})
 }
 
-// Register sets up cluster initializations to run when the cluster has started.
-func Register(ctx context.Context, cluster *config.UserContext) {
-	// Defer until the EXT API is ready
-	clusters := cluster.Management.Management.Clusters("")
+// RegisterFactory creates the dedicated namespace-scoped secrets cache for
+// clusterauthtoken handlers and registers it with the UserContext so it is
+// started by UserContext.Start() as part of doStart()'s normal factory-start
+// sequence.
+//
+// Must be called before UserContext.Start() — i.e. during managementuser.Register,
+// while the transaction is open and startContext is still nil. When Start() is
+// later called, the factory starts alongside ControllerFactory and all others;
+// if it fails, the error surfaces through doStart() to the cluster manager,
+// which logs the failure, marks the cluster unavailable, and retries.
+//
+// Returns the SecretCache to pass to Register() for handler wiring.
+func RegisterFactory(cluster *config.UserContext) (corecontrollers.SecretCache, error) {
+	clientFactory := cluster.ControllerFactory.SharedCacheFactory().SharedClientFactory()
+	secretsCache, controllerFactory := newDedicatedSecretsCache(clientFactory, common.DefaultNamespace)
+	// startContext is nil here: factory is added to extraControllerFactories
+	// without being started. UserContext.Start() starts it in its factory loop.
+	if err := cluster.RegisterExtraControllerFactory("clusterauthtoken", controllerFactory); err != nil {
+		return nil, err
+	}
+	return secretsCache, nil
+}
+
+// Register wires up clusterauthtoken event handlers once the EXT API is ready.
+// secretsCache must be the value returned by RegisterFactory on the same
+// UserContext. Handler wiring is pure in-process Go with no network calls, so
+// no retry machinery is needed.
+func Register(ctx context.Context, cluster *config.UserContext, secretsCache corecontrollers.SecretCache) {
 	cluster.Management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
-		starter := cluster.DeferredStart(ctx, func(ctx context.Context) error {
-			if err := registerDeferred(ctx, cluster, w); err != nil {
-				logrus.Errorf("[%s] Failed to register controller: %v", clusterAuthTokenController, err)
-				return err
-			}
-			return nil
-		})
-		clusters.AddHandler(ctx, clusterController, func(key string, obj *v3.Cluster) (runtime.Object, error) {
-			if obj != nil &&
-				obj.Name == cluster.ClusterName &&
-				obj.Spec.LocalClusterAuthEndpoint.Enabled {
-				return obj, starter()
-			}
-			return obj, nil
-		})
+		registerHandlers(ctx, cluster, secretsCache, w)
 	})
 }
 
-// registerDeferred sets up the handlers for the new remote cluster which sync
-// tokens (v3 and ext) to the cluster auth tokens in that remote.
-func registerDeferred(ctx context.Context, cluster *config.UserContext, extAPIContext *wrangler.EXTAPIContext) error {
+// registerHandlers wires all event handlers. It has no factory lifecycle
+// operations and makes no network calls, so it is called synchronously from
+// the DeferFunc goroutine without additional wrapping or a retry gate.
+func registerHandlers(ctx context.Context, cluster *config.UserContext, secretsCache corecontrollers.SecretCache, extAPIContext *wrangler.EXTAPIContext) {
 	tokenInformer := cluster.Management.Management.Tokens("").Controller().Informer()
 	tokenCache := cluster.Management.Wrangler.Mgmt.Token().Cache()
 	tokenClient := cluster.Management.Wrangler.Mgmt.Token()
@@ -102,14 +110,6 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext, extAPICo
 	userAttributeLister := cluster.Management.Management.UserAttributes("").Controller().Lister()
 	settingInterface := cluster.Management.Management.Settings("")
 
-	// We use a separate controller factory that only watches a single namespace. This ensures that the cache does not contain all the secrets, just those of that namespace.
-	// The default controller factory does not allow caching secrets for all namespaces, see https://github.com/rancher/rancher/issues/46827
-	clientFactory := cluster.ControllerFactory.SharedCacheFactory().SharedClientFactory()
-	clusterSecretLister, controllerFactory := newDedicatedSecretsCache(clientFactory, namespace)
-	if err := cluster.RegisterExtraControllerFactory("clusterauthtoken", controllerFactory); err != nil {
-		return err
-	}
-
 	cluster.Management.Management.Settings("").AddHandler(ctx, settingController, (&settingHandler{
 		namespace,
 		clusterConfigMap,
@@ -127,7 +127,7 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext, extAPICo
 		userLister:                 userLister,
 		userAttributeLister:        userAttributeLister,
 		clusterSecret:              clusterSecret,
-		clusterSecretLister:        clusterSecretLister,
+		clusterSecretLister:        secretsCache,
 	}
 
 	cluster.Management.Management.Tokens("").AddClusterScopedLifecycle(ctx,
@@ -161,13 +161,10 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext, extAPICo
 		tokenCache:  tokenCache,
 		tokenClient: tokenClient,
 	}
-
 	catHandler.extTokenCache = extAPIContext.Client.Token().Cache()
 	catHandler.extTokenStore = extstore.NewSystemFromWrangler(cluster.Management.Wrangler)
 
 	cluster.Cluster.ClusterAuthTokens(namespace).AddHandler(ctx, clusterAuthTokenController, catHandler.sync)
-
-	return nil
 }
 
 func newDedicatedSecretsCache(clientFactory client.SharedClientFactory, namespace string) (corecontrollers.SecretCache, controller.SharedControllerFactory) {
@@ -176,18 +173,14 @@ func newDedicatedSecretsCache(clientFactory client.SharedClientFactory, namespac
 			corev1.SchemeGroupVersion.WithKind("Secret"): namespace,
 		},
 	})
-
 	controllerFactory := controller.NewSharedControllerFactory(cacheFactory, controllers.GetOptsFromEnv(controllers.User))
 	return corecontrollers.New(controllerFactory).Secret().Cache(), controllerFactory
 }
 
-// tokenUserClusterKey computes the v3 token's key for indexing by user and
-// cluster
 func tokenUserClusterKey(token *managementv3.Token) string {
 	return fmt.Sprintf("%s/%s", token.UserID, token.ClusterName)
 }
 
-// tokenByUserAndCluster indexes v3 tokens by the user and cluster they belong to
 func tokenByUserAndCluster(obj any) ([]string, error) {
 	t, ok := obj.(*managementv3.Token)
 	if !ok {
@@ -196,7 +189,6 @@ func tokenByUserAndCluster(obj any) ([]string, error) {
 	return []string{tokenUserClusterKey(t)}, nil
 }
 
-// extTokenByUserAndCluster indexes ext tokens by the user and cluster they belong to
 func extTokenByUserAndCluster(obj any) ([]string, error) {
 	t, ok := obj.(*extv1.Token)
 	if !ok {
@@ -205,26 +197,19 @@ func extTokenByUserAndCluster(obj any) ([]string, error) {
 	return []string{extTokenUserClusterKey(t)}, nil
 }
 
-// extTokenUserClusterKey computes the ext token's key for indexing by user and
-// cluster
 func extTokenUserClusterKey(token *extv1.Token) string {
 	return fmt.Sprintf("%s/%s", token.Spec.UserID, token.Spec.ClusterName)
 }
 
-// extTokenLifecycle registers handlers watching for tokens scoped to the given
-// cluster. The handlers sync changes in these tokens to the remote cluster, as
-// cluster auth tokens.
 func extTokenLifecycle(ctx context.Context, tok ext.TokenController, controller, clusterName string, h *tokenHandler) {
 	logrus.Debugf("[%s] WATCH CLUSTER %q", clusterAuthTokenController, clusterName)
 
 	tok.OnChange(ctx,
 		controller+"-change-"+clusterName,
 		func(key string, obj *extv1.Token) (*extv1.Token, error) {
-			// ignore removals
 			if obj == nil {
 				return obj, nil
 			}
-			// handle only tokens referencing the watched cluster
 			if clusterName != obj.Spec.ClusterName {
 				return obj, nil
 			}
@@ -235,7 +220,6 @@ func extTokenLifecycle(ctx context.Context, tok ext.TokenController, controller,
 	tok.OnRemove(ctx,
 		controller+"-remove-"+clusterName,
 		func(key string, obj *extv1.Token) (*extv1.Token, error) {
-			// handle only tokens referencing the watched cluster
 			if clusterName != obj.Spec.ClusterName {
 				return obj, nil
 			}

--- a/pkg/controllers/managementuser/clusterauthtoken/register_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register_test.go
@@ -1,0 +1,48 @@
+package clusterauthtoken
+
+import (
+	"testing"
+
+	lassocache "github.com/rancher/lasso/pkg/cache"
+	"github.com/rancher/lasso/pkg/client"
+	"github.com/rancher/lasso/pkg/controller"
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+// TestRegisterFactoryDuplicate verifies that calling RegisterFactory twice on
+// the same UserContext returns a duplicate-factory error on the second call.
+// This confirms the factory is registered in UserContext.extraControllerFactories
+// on the first call, enabling UserContext.Start() to start it alongside other
+// factories in doStart().
+func TestRegisterFactoryDuplicate(t *testing.T) {
+	t.Parallel()
+	cluster := buildMinimalUserContext(t)
+
+	cache, err := RegisterFactory(cluster)
+	require.NoError(t, err)
+	assert.NotNil(t, cache)
+
+	_, err = RegisterFactory(cluster)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+// buildMinimalUserContext constructs the minimum UserContext needed to test
+// RegisterFactory. It uses a real lasso controller factory backed by a
+// no-network-contact client factory (startContext left nil so
+// RegisterExtraControllerFactory does not call factory.Start()).
+func buildMinimalUserContext(t *testing.T) *config.UserContext {
+	t.Helper()
+	cfg := &rest.Config{Host: "http://127.0.0.1:0"}
+	clientFactory, err := client.NewSharedClientFactory(cfg, nil)
+	require.NoError(t, err)
+	cacheFactory := lassocache.NewSharedCachedFactory(clientFactory, nil)
+	controllerFactory := controller.NewSharedControllerFactory(cacheFactory, nil)
+	return &config.UserContext{
+		ClusterName:       "test-cluster",
+		ControllerFactory: controllerFactory,
+	}
+}

--- a/pkg/controllers/managementuser/clusterauthtoken/register_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register_test.go
@@ -19,15 +19,15 @@ import (
 // factories in doStart().
 func TestRegisterFactoryDuplicate(t *testing.T) {
 	t.Parallel()
-	cluster := buildMinimalUserContext(t)
 
+	cluster := buildMinimalUserContext(t)
 	cache, err := RegisterFactory(cluster)
 	require.NoError(t, err)
 	assert.NotNil(t, cache)
 
 	_, err = RegisterFactory(cluster)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate")
+	assert.ErrorContains(t, err, "duplicate")
 }
 
 // buildMinimalUserContext constructs the minimum UserContext needed to test
@@ -36,11 +36,13 @@ func TestRegisterFactoryDuplicate(t *testing.T) {
 // RegisterExtraControllerFactory does not call factory.Start()).
 func buildMinimalUserContext(t *testing.T) *config.UserContext {
 	t.Helper()
+
 	cfg := &rest.Config{Host: "http://127.0.0.1:0"}
 	clientFactory, err := client.NewSharedClientFactory(cfg, nil)
 	require.NoError(t, err)
 	cacheFactory := lassocache.NewSharedCachedFactory(clientFactory, nil)
 	controllerFactory := controller.NewSharedControllerFactory(cacheFactory, nil)
+
 	return &config.UserContext{
 		ClusterName:       "test-cluster",
 		ControllerFactory: controllerFactory,

--- a/pkg/controllers/managementuser/clusterauthtoken/register_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register_test.go
@@ -16,7 +16,7 @@ import (
 // the same UserContext returns a duplicate-factory error on the second call.
 // This confirms the factory is registered in UserContext.extraControllerFactories
 // on the first call, enabling UserContext.Start() to start it alongside other
-// factories in doStart().
+// factories.
 func TestRegisterFactoryDuplicate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"sync/atomic"
 
 	clusterapiv3 "github.com/rancher/rancher/pkg/apis/cluster.cattle.io/v3"
 	extv1 "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
@@ -38,7 +39,7 @@ type tokenHandler struct {
 	clusterUserAttribute       clusterv3.ClusterUserAttributeInterface
 	clusterUserAttributeLister clusterv3.ClusterUserAttributeLister
 	tokenIndexer               cache.Indexer
-	extTokenIndexer            cache.Indexer
+	extTokenIndexer            atomic.Value // holds cache.Indexer; written once by the EXT API DeferFunc, read by v3 remove handlers
 	userLister                 managementv3.UserLister
 	userAttributeLister        managementv3.UserAttributeLister
 	clusterSecret              wcore.SecretClient
@@ -444,10 +445,9 @@ func (h *tokenHandler) remove(name, userID, key string) error {
 		return err
 	}
 
-	// skip ext tokens if feature is disabled
 	var extTokens []any
-	if h.extTokenIndexer != nil {
-		extTokens, err = h.extTokenIndexer.ByIndex(tokenByUserAndClusterIndex, key)
+	if idx, ok := h.extTokenIndexer.Load().(cache.Indexer); ok {
+		extTokens, err = idx.ByIndex(tokenByUserAndClusterIndex, key)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -86,7 +86,11 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 		if err != nil {
 			return err
 		}
-		clusterauthtoken.Register(ctx, cluster)
+		secretsCache, err := clusterauthtoken.RegisterFactory(cluster)
+		if err != nil {
+			return fmt.Errorf("registering clusterauthtoken factory: %w", err)
+		}
+		clusterauthtoken.Register(ctx, cluster, secretsCache)
 	}
 
 	return managementuserlegacy.Register(ctx, mgmt, cluster, clusterRec, kubeConfigGetter)

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -262,7 +262,11 @@ func (c *ManagementContext) WithAgent(userAgent string) *ManagementContext {
 func (w *UserContext) DeferredStart(ctx context.Context, register func(ctx context.Context) error) func() error {
 	f := w.deferredStartAsync(ctx, register)
 	return func() error {
-		go f()
+		go func() {
+			if err := f(); err != nil {
+				logrus.Errorf("deferred controller start failed for cluster %s: %v", w.ClusterName, err)
+			}
+		}()
 		return nil
 	}
 }


### PR DESCRIPTION
## Issue: #53695<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

SURE-11553

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When registering the clusterauthtoken controller for an ACE-enabled cluster, a dedicated secrets cache factory was started inside a fire-and-forget goroutine (#52262). Any failure, including a temporarily unreachable downstream cluster API, was silently discarded. The cluster manager never retried, and tokens created for the affected cluster during that window were never synced to downstream ClusterAuthTokens until a full Rancher restart.

v3.Token sync handlers were also gated behind EXT API readiness even though they have no dependency on the ext API, creating an additional window where newly created tokens were missed.

`DeferredStart` discarded errors from its background goroutine with no log output, making failures from any caller invisible.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The dedicated secrets cache factory is now registered before the user context starts, so it comes up alongside all other factories as part of normal controller startup. Failures surface to the cluster manager, which marks the cluster unavailable and retries.

v3.Token sync other handlers are now registered immediately when the user context starts. Only ext.Token handlers, which require the ext API client, remain behind the ext API readiness gate. The ext.Token indexer is shared between the immediately-registered v3.Token remove handlers and the deferred ext API setup goroutine, so it is accessed atomically.

`DeferredStart` now logs errors from its background goroutine so failures from any remaining callers (nodesyncer, CAPI registration) are visible in logs.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
