### PR TITLE
Fix gateway-cert.yaml template indentation

### DIFF
--- a/chart/templates/ingate/gateway-cert.yaml
+++ b/chart/templates/ingate/gateway-cert.yaml
@@ -2,14 +2,14 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-    name: {{ include "rancher.gateway" . }}-tls
-    labels:
+  name: {{ include "rancher.gateway" . }}-tls
+  labels:
 {{ include "rancher.labels" . | indent 4 }}
 spec:
-    secretName: {{ .Values.gateway.gatewayClass.tls.secretName }}
-    issuerRef:
-        name: {{ template "rancher.fullname" . }}
-        kind: Issuer
-    dnsNames:
-        - {{ .Values.hostname }}
+  secretName: {{ .Values.gateway.gatewayClass.tls.secretName }}
+  issuerRef:
+    name: {{ template "rancher.fullname" . }}
+    kind: Issuer
+  dnsNames:
+    - {{ .Values.hostname }}
 {{- end }}


### PR DESCRIPTION
This fix the wrong indentation on gateway-cert template:

```diff
diff --git a/before.yaml b/after.yaml
index 0de699fde..41d05e0b5 100644
--- a/before.yaml
+++ b/after.yaml
@@ -212,19 +212,19 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-    name: rancher-gateway-tls
-    labels:
+  name: rancher-gateway-tls
+  labels:
     app: rancher
     chart: rancher-0.0.0-1781360487.commit-c0e735538.55081
     heritage: Helm
     release: rancher
 spec:
-    secretName: tls-rancher-ingress
-    issuerRef:
-        name: rancher
-        kind: Issuer
-    dnsNames:
-        -
+  secretName: tls-rancher-ingress
+  issuerRef:
+    name: rancher
+    kind: Issuer
+  dnsNames:
+    -
 ---
 # Source: rancher/templates/ingate/gateway.yaml
 apiVersion: gateway.networking.k8s.io/v1
```
