### PR TITLE
Fix(auth/cleanup): preserve users with principals from multiple auth …

### DIFF
--- a/pkg/auth/cleanup/service.go
+++ b/pkg/auth/cleanup/service.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type extTokenStore interface {
@@ -139,7 +140,7 @@ func (s *Service) deleteClusterRoleTemplateBindings(provider string) error {
 	}
 
 	for _, b := range list {
-		if getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName) == provider {
+		if getProvidersFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName).Has(provider) {
 			err := s.clusterRoleTemplateBindingsClient.Delete(b.Namespace, b.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
@@ -157,7 +158,7 @@ func (s *Service) deleteGlobalRoleBindings(provider string) error {
 	}
 
 	for _, b := range list {
-		if getProviderNameFromPrincipalNames(b.GroupPrincipalName) == provider {
+		if getProvidersFromPrincipalNames(b.GroupPrincipalName).Has(provider) {
 			err := s.globalRoleBindingsClient.Delete(b.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
@@ -175,7 +176,7 @@ func (s *Service) deleteProjectRoleTemplateBindings(provider string) error {
 	}
 
 	for _, b := range prtbs {
-		if getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName) == provider {
+		if getProvidersFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName).Has(provider) {
 			err := s.projectRoleTemplateBindingsClient.Delete(b.Namespace, b.Name, &metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
@@ -200,7 +201,8 @@ func (s *Service) deleteUsers(provider string) error {
 	}
 
 	for _, u := range users.Items {
-		if getProviderNameFromPrincipalNames(u.PrincipalIDs...) != provider {
+		providers := getProvidersFromPrincipalNames(u.PrincipalIDs...)
+		if !providers.Has(provider) || providers.Len() > 1 {
 			continue
 		}
 		// A fully external user (who was never local) has no password.
@@ -287,14 +289,16 @@ func (s *Service) resetLocalUser(user *v3.User) error {
 	return nil
 }
 
-// getProviderNameFromPrincipalNames tries to extract the provider name from any one string that represents
-// a user principal or group principal.
-func getProviderNameFromPrincipalNames(names ...string) string {
+// getProvidersFromPrincipalNames returns the set of non-local provider names extracted from
+// the given principal ID strings. Each principal has the form "<provider>_<type>://<id>",
+// where <type> is "user" or "group". Local principals are excluded from the result.
+func getProvidersFromPrincipalNames(names ...string) sets.Set[string] {
+	providers := sets.New[string]()
 	for _, name := range names {
 		parts := strings.Split(name, "_")
 		if len(parts) > 0 && parts[0] != "" && !strings.HasPrefix(parts[0], "local") {
-			return parts[0]
+			providers.Insert(parts[0])
 		}
 	}
-	return ""
+	return providers
 }

--- a/pkg/auth/cleanup/service_test.go
+++ b/pkg/auth/cleanup/service_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
@@ -110,6 +112,12 @@ func TestRunCleanup(t *testing.T) {
 				Labels: map[string]string{"authz.management.cattle.io/bootstrapping": "admin-user"}},
 			PrincipalIDs: []string{"local://boss", "azuread_user://authprincipal"},
 		},
+		// migrating has principals from both azuread (being disabled) and genericoidc,
+		// so it must be preserved even though azuread appears first in the list.
+		"migrating": {
+			ObjectMeta:   metav1.ObjectMeta{Name: "migrating"},
+			PrincipalIDs: []string{"azuread_user://migrating", "local://migrating", "genericoidc_user://migrating"},
+		},
 	}
 
 	var tokenStore = map[string]*v3.Token{
@@ -203,18 +211,27 @@ func TestRunCleanup(t *testing.T) {
 	assert.Len(t, globalRoleBindingStore, 1)
 	assert.Len(t, clusterRoleTemplateBindingStore, 1)
 	assert.Len(t, projectRoleTemplateBindingStore, 1)
-	assert.Len(t, userStore, 2)
+	assert.Len(t, userStore, 3)
 	assert.Len(t, secretStore, 1)
 	assert.Len(t, tokenStore, 2)
 	assert.Empty(t, tokenStore["azure-123"])
 	assert.Len(t, extTokens, 1)
 	assert.NotNil(t, extTokens["ext-local-1"])
 
+	// Users that were reset (former local admins) must have only their local principal left.
 	for _, user := range userStore {
-		require.Lenf(t, user.PrincipalIDs, 1, "every user after cleanup must have only one principal ID, got %d", len(user.PrincipalIDs))
+		if user.Name == "migrating" {
+			continue
+		}
+		require.Lenf(t, user.PrincipalIDs, 1, "every reset user after cleanup must have only one principal ID, got %d", len(user.PrincipalIDs))
 		principalID := user.PrincipalIDs[0]
 		assert.Truef(t, strings.HasPrefix(principalID, "local"), "the only principal ID has 'local' as a prefix, got %s", principalID)
 	}
+	// The migrating user has principals from both azuread (disabled) and genericoidc (active),
+	// so it must be preserved untouched.
+	migrating, exists := userStore["migrating"]
+	require.True(t, exists, "multi-provider user must not be deleted during single-provider cleanup")
+	assert.Contains(t, migrating.PrincipalIDs, "genericoidc_user://migrating")
 }
 
 func newMockCleanupService(t *testing.T,
@@ -486,6 +503,55 @@ func TestDeleteExtTokens(t *testing.T) {
 			for _, name := range tt.wantLeft {
 				assert.Contains(t, store.tokens, name)
 			}
+		})
+	}
+}
+
+func TestGetProvidersFromPrincipalNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []string
+		expected sets.Set[string]
+	}{
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: sets.New[string](),
+		},
+		{
+			name:     "local principal only",
+			input:    []string{"local://u-abc"},
+			expected: sets.New[string](),
+		},
+		{
+			name:     "single external provider",
+			input:    []string{"azuread_user://alice", "local://u-abc"},
+			expected: sets.New("azuread"),
+		},
+		{
+			name:     "multiple principals same provider",
+			input:    []string{"openldap_user://alice", "openldap_group://engineers"},
+			expected: sets.New("openldap"),
+		},
+		{
+			name:     "multiple providers",
+			input:    []string{"openldap_user://alice", "local://u-abc", "genericoidc_user://alice"},
+			expected: sets.New("openldap", "genericoidc"),
+		},
+		{
+			name:     "group principal",
+			input:    []string{"azuread_group://mygroup"},
+			expected: sets.New("azuread"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := getProvidersFromPrincipalNames(tt.input...)
+			assert.True(t, got.Equal(tt.expected), "got %v, want %v", got, tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher/issues/55599

## Problem
When disabling an auth provider, the cleanup routine calls `getProviderNameFromPrincipalNames` to decide whether to delete a user. That function returns the first non-local provider it finds in `principalIds`, so a user with principals from multiple providers (e.g. someone mid-migration from LDAP to OIDC) gets deleted if the provider being disabled appears first in the list, regardless of whether the user still has a valid login path through another active provider.

## Solution
Renamed `getProviderNameFromPrincipalNames` to `getProvidersFromPrincipalNames` and changed its return type from `string` to `sets.Set[string]`, collecting all non-local providers from the given principal IDs instead of stopping at the first.

Updated all callers:
- Binding deletions (`deleteClusterRoleTemplateBindings`, `deleteGlobalRoleBindings`, `deleteProjectRoleTemplateBindings`) use `.Has(provider)` instead of `== provider`. Behaviour is identical since a binding's principal always belongs to a single provider.
- `deleteUsers` skips any user whose provider set contains more than just the disabled provider (`providers.Len() > 1`), preserving users that have a valid principal from another active provider.

Fixing the abstraction rather than inlining a special case in `deleteUsers` keeps the logic consistent across the entire cleanup service.

## Testing

### Manual Testing
Reproduced the bug by creating a user with `["openldap_user://...", "local://...", "genericoidc_user://..."]` and disabling the LDAP provider. Before the fix the user was deleted; after the fix it is preserved.

### Automated Testing
* Test types added/modified:
    * Unit

`TestGetProvidersFromPrincipalNames` covers: empty input, local-only principals, single provider, multiple principals for the same provider, and multiple distinct providers.

`TestRunCleanup` extended with a multi-provider user fixture (`azuread_user://...` + `genericoidc_user://...`). Asserts the user is not deleted when `azuread` is disabled and that its OIDC principal is still present.

## QA Testing Considerations
Any user with principals from more than one auth provider should be preserved when one of those providers is disabled. The main scenario to validate is a user mid-migration between two external providers (e.g. LDAP to OIDC): disabling the source provider must not delete the user.

### Regressions Considerations
The change touches all three binding-cleanup paths and user deletion. Regression probability is low: the binding callers' behaviour is semantically identical, and the user deletion change is strictly less aggressive (it skips users it previously would have wrongly deleted).

Existing / newly added automated tests that provide evidence there are no regressions:
* `TestRunCleanup` covers the full cleanup flow including user deletion, resets, token and binding removal; existing assertions are unchanged for single-provider users.
* `TestGetProvidersFromPrincipalNames` unit-tests the modified function directly.
* `TestDeleteExtTokens` covers the token cleanup path, unaffected and still passing.