### PR TITLE
Hide local auth provider from the `/v[13]-public/authproviders` endpoints

### DIFF
--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -217,13 +217,18 @@ func (l *Provider) IsHidden() bool {
 	}
 
 	// Check for active external auth provider, query etcd
+	// Check for active external auth provider, query cache. keep visible without cache
+	if l.authConfigCache == nil {
+		logrus.Warnf("unable to properly determine if local is hidden, keeping visible: no auth config cache")
+		return false
+	}
 	acList, err := l.authConfigCache.List(labels.Everything())
 	if err != nil {
-		logrus.Errorf("unable to properly determine if local is hidden, keeping visible: %v", err)
+		logrus.Warnf("unable to properly determine if local is hidden, keeping visible: %v", err)
 		return false
 	}
 	for _, ac := range acList {
-		if ac.Enabled && ac.Name != "local" {
+		if ac.Enabled && ac.Name != Name {
 			return true
 		}
 	}

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/local/pbkdf2"
+	"github.com/rancher/rancher/pkg/features"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/user"
@@ -46,13 +48,14 @@ type PasswordVerifier interface {
 }
 
 type Provider struct {
-	userLister   v3.UserLister
-	groupLister  v3.GroupLister
-	userIndexer  cache.Indexer
-	gmIndexer    cache.Indexer
-	groupIndexer cache.Indexer
-	userMgr      user.Manager
-	pwdVerifier  PasswordVerifier
+	userLister      v3.UserLister
+	groupLister     v3.GroupLister
+	userIndexer     cache.Indexer
+	gmIndexer       cache.Indexer
+	groupIndexer    cache.Indexer
+	userMgr         user.Manager
+	pwdVerifier     PasswordVerifier
+	authConfigCache mgmtv3.AuthConfigCache
 }
 
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMgr user.Manager) common.AuthProvider {
@@ -69,13 +72,14 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMgr user.
 	_ = gInformer.AddIndexers(gIndexers)
 
 	l := &Provider{
-		userIndexer:  informer.GetIndexer(),
-		gmIndexer:    gmInformer.GetIndexer(),
-		groupLister:  mgmtCtx.Management.Groups("").Controller().Lister(),
-		groupIndexer: gInformer.GetIndexer(),
-		userLister:   mgmtCtx.Management.Users("").Controller().Lister(),
-		userMgr:      userMgr,
-		pwdVerifier:  pbkdf2.New(mgmtCtx.Wrangler.Core.Secret().Cache(), mgmtCtx.Wrangler.Core.Secret()),
+		userIndexer:     informer.GetIndexer(),
+		gmIndexer:       gmInformer.GetIndexer(),
+		groupLister:     mgmtCtx.Management.Groups("").Controller().Lister(),
+		groupIndexer:    gInformer.GetIndexer(),
+		userLister:      mgmtCtx.Management.Users("").Controller().Lister(),
+		authConfigCache: mgmtCtx.Wrangler.Mgmt.AuthConfig().Cache(),
+		userMgr:         userMgr,
+		pwdVerifier:     pbkdf2.New(mgmtCtx.Wrangler.Core.Secret().Cache(), mgmtCtx.Wrangler.Core.Secret()),
 	}
 	return l
 }
@@ -204,6 +208,28 @@ func (l *Provider) getGroupPrincipals(user *apiv3.User) ([]apiv3.Principal, erro
 
 func (l *Provider) UsesUserSecrets() bool      { return false }
 func (l *Provider) CanRefreshPrincipals() bool { return true }
+
+func (l *Provider) IsHidden() bool {
+	// Check policy first, fast
+	hide := features.HideLocalAuthProvider.Enabled()
+	if !hide {
+		return false
+	}
+
+	// Check for active external auth provider, query etcd
+	acList, err := l.authConfigCache.List(labels.Everything())
+	if err != nil {
+		logrus.Errorf("unable to properly determine if local is hidden, keeping visible: %v", err)
+		return false
+	}
+	for _, ac := range acList {
+		if ac.Enabled && ac.Name != "local" {
+			return true
+		}
+	}
+
+	return false
+}
 
 func (l *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]apiv3.Principal, error) {
 	userID := strings.SplitN(principalID, "://", 2)[1]

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -84,6 +84,10 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMgr user.
 	return l
 }
 
+func (l *Provider) MockAuthConfigCache(authConfigCache mgmtv3.AuthConfigCache) {
+	l.authConfigCache = authConfigCache
+}
+
 func (l *Provider) LogoutAll(w http.ResponseWriter, r *http.Request, token accessor.TokenAccessor) error {
 	return nil
 }

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -256,6 +256,16 @@ func (h *loginHandler) login(w http.ResponseWriter, r *http.Request, input login
 		return
 	}
 
+	provider := providers.GetProviderByType(input.GetName())
+	if provider == nil {
+		util.ReturnAPIError(w, httperror.NewAPIError(httperror.NotFound, ""))
+		return
+	}
+	if lp, ok := provider.(*local.Provider); ok && lp.IsHidden() {
+		util.ReturnAPIError(w, httperror.NewAPIError(httperror.NotFound, ""))
+		return
+	}
+
 	userPrincipal, groupPrincipals, providerToken, err := providers.AuthenticateUser(w, r, input, input.GetName())
 	if err != nil {
 		if !util.IsAPIError(err) {

--- a/pkg/auth/providers/publicapi/store.go
+++ b/pkg/auth/providers/publicapi/store.go
@@ -12,6 +12,7 @@ import (
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/local"
 	"github.com/rancher/rancher/pkg/auth/util"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -39,6 +40,14 @@ type authProvidersStore struct {
 }
 
 func (s *authProvidersStore) ByID(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]any, error) {
+	provider := providers.GetProviderByType(id)
+	if provider == nil {
+		return nil, httperror.NewAPIError(httperror.NotFound, "")
+	}
+	if lp, ok := provider.(*local.Provider); ok && lp.IsHidden() {
+		return nil, httperror.NewAPIError(httperror.NotFound, "")
+	}
+
 	o, err := s.authConfigsRaw.Get(id, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -64,12 +73,20 @@ func (s *authProvidersStore) List(apiContext *types.APIContext, schema *types.Sc
 	for _, i := range list.Items {
 		if t, ok := i.Object["type"].(string); ok && t != "" {
 			if enabled, ok := i.Object["enabled"].(bool); ok && enabled {
+				provider := providers.GetProviderByType(t)
+				if provider == nil {
+					logrus.Errorf("Internal error, no provider for type %q", t)
+					continue
+				}
+				if lp, ok := provider.(*local.Provider); ok && lp.IsHidden() {
+					continue
+				}
 				i.Object[".host"] = util.GetHost(apiContext.Request)
-				provider, err := providers.GetProviderByType(t).TransformToAuthProvider(i.Object)
+				providerObj, err := provider.TransformToAuthProvider(i.Object)
 				if err != nil {
 					return result, err
 				}
-				result = append(result, provider)
+				result = append(result, providerObj)
 			}
 		}
 	}
@@ -88,6 +105,14 @@ type v3AuthTokensStore struct {
 }
 
 func (t *v3AuthTokensStore) ByID(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]any, error) {
+	provider := providers.GetProviderByType(id)
+	if provider == nil {
+		return nil, httperror.NewAPIError(httperror.NotFound, "")
+	}
+	if lp, ok := provider.(*local.Provider); ok && lp.IsHidden() {
+		return nil, httperror.NewAPIError(httperror.NotFound, "")
+	}
+
 	token, err := t.tokens.Get(namespace.GlobalNamespace, id, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -158,6 +183,14 @@ func (s *v1AuthProviderStore) List(w http.ResponseWriter, r *http.Request) {
 		if !authConfig.Enabled {
 			continue
 		}
+		authProvider := s.getProviderByType(authConfig.Type)
+		if authProvider == nil {
+			logrus.Errorf("Internal error, no provider for type %q", authConfig.Type)
+			continue
+		}
+		if lp, ok := authProvider.(*local.Provider); ok && lp.IsHidden() {
+			continue
+		}
 
 		raw, err := s.authConfigsUnstructured.Get(r.Context(), authConfig.Name, metav1.GetOptions{})
 		if err != nil {
@@ -168,14 +201,14 @@ func (s *v1AuthProviderStore) List(w http.ResponseWriter, r *http.Request) {
 
 		raw.Object[".host"] = util.GetHost(r)
 
-		authProvider, err := s.getProviderByType(authConfig.Type).TransformToAuthProvider(raw.Object)
+		authProviderObj, err := authProvider.TransformToAuthProvider(raw.Object)
 		if err != nil {
 			logrus.Errorf("v1AuthProviderStore: Getting authprovider %s: %s", authConfig.Type, err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
-		response.Data = append(response.Data, authProvider)
+		response.Data = append(response.Data, authProviderObj)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/auth/providers/publicapi/store_test.go
+++ b/pkg/auth/providers/publicapi/store_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/github"
 	"github.com/rancher/rancher/pkg/auth/providers/local"
+	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/auth/providers/saml"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
@@ -118,6 +119,114 @@ func TestV1AuthProviderStoreList(t *testing.T) {
 				"logoutAllForced":    false,
 				"logoutAllSupported": false,
 			},
+			map[string]any{
+				"id":                 "okta",
+				"type":               "oktaProvider",
+				"logoutAllEnabled":   false,
+				"logoutAllForced":    false,
+				"logoutAllSupported": false,
+			},
+		},
+	}
+	require.Equal(t, wantPayload, gotPayload)
+}
+
+func TestV1AuthProviderStoreListHideLocal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	previousHide := features.HideLocalAuthProvider.Enabled()
+	features.HideLocalAuthProvider.Set(true)
+	t.Cleanup(func () {
+		features.HideLocalAuthProvider.Set(previousHide)
+	})
+
+	authConfigCache := fake.NewMockNonNamespacedCacheInterface[*apiv3.AuthConfig](ctrl)
+	authConfigCache.EXPECT().List(labels.Everything()).Return([]*apiv3.AuthConfig{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "local"},
+			Type:       "localConfig",
+			Enabled:    true,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "okta"},
+			Type:       "oktaConfig",
+			Enabled:    true,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "github"},
+			Type:       "githubConfig",
+		},
+	}, nil).Times(2)
+
+	localConfig := &unstructured.Unstructured{}
+	localConfig.SetUnstructuredContent(map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "AuthConfig",
+		"metadata": map[string]any{
+			"name": "local",
+		},
+		"type":    "localConfig",
+		"enabled": true,
+	})
+	oktaConfig := &unstructured.Unstructured{}
+	oktaConfig.SetUnstructuredContent(map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "AuthConfig",
+		"metadata": map[string]any{
+			"name": "okta",
+		},
+		"type":    "oktaConfig",
+		"enabled": true,
+	})
+	githubConfig := &unstructured.Unstructured{}
+	githubConfig.SetUnstructuredContent(map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "AuthConfig",
+		"metadata": map[string]any{
+			"name": "github",
+		},
+		"type": "githubConfig",
+	})
+
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), localConfig, oktaConfig, githubConfig)
+	authConfigUnstructured := fakeDynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "authconfigs",
+	})
+
+	getProviderByType := func(providerType string) common.AuthProvider {
+		switch providerType {
+		case "localConfig":
+			p := &local.Provider{}
+			p.MockAuthConfigCache(authConfigCache)
+			return p
+		case "oktaConfig":
+			return &saml.Provider{}
+		case "githubConfig":
+			return &github.Provider{}
+		default:
+			require.FailNow(t, "unexpected provider type "+providerType)
+			return nil
+		}
+	}
+
+	store := v1AuthProviderStore{
+		authConfigCache:         authConfigCache,
+		authConfigsUnstructured: authConfigUnstructured,
+		getProviderByType:       getProviderByType,
+	}
+
+	r := httptest.NewRequest("GET", "/v1-public/authproviders", nil)
+	w := httptest.NewRecorder()
+
+	store.List(w, r)
+	require.Equal(t, 200, w.Result().StatusCode)
+	require.Equal(t, "application/json", w.Result().Header.Get("Content-Type"))
+	gotPayload := map[string]any{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &gotPayload))
+	wantPayload := map[string]any{
+		"data": []any{
 			map[string]any{
 				"id":                 "okta",
 				"type":               "oktaProvider",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#46078 
 
## Problem

This is part of hiding the local auth provider from users. 
The backend endpoints  `/v[13]-public/authproviders` were still showing the `local` provider even when it should be hidden as per feature flag and state of external auth providers (at least one such active).

## Solution

Modified the code delivering the backend results to hide `local` from them when necessary. To this end the provider interface gained a new method `IsHidden` by which providers can declare if they are hidden (*) or not. The loops collecting the providers for the endpoints now additionally check for hidden.

(*) Note that hidden is not the same as enabled. While we hide the `local` provider, we do not disable it.
 
## Testing

Manual testing so far, with a local Rancher setup, using Okta SAML as the active external provider.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_