### PR TITLE
Don't expose local provider if it's disabled

### DIFF
--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -283,12 +283,17 @@ func IsExternalProviderEnabled() bool {
 		p := providers[hint]
 		mu.RUnlock()
 		if p != nil {
-			alreadyChecked = hint
-			if disabled, err := p.IsDisabledProvider(); err == nil && !disabled {
-				return true
+			disabled, err := p.IsDisabledProvider()
+			if err == nil {
+				if !disabled {
+					return true // Hint still valid.
+				}
+				// Got a clean "disabled" answer — safe to skip in the full scan.
+				alreadyChecked = hint
 			}
+			// On error: alreadyChecked stays "" so the full scan retries this provider.
 		}
-		lastKnownEnabled.Store("") // Stale; clear before full scan.
+		// Don't clear the hint here; the full scan overwrites it authoritatively.
 	}
 
 	// Full scan: snapshot the non-local provider list while holding the lock,
@@ -318,6 +323,7 @@ func IsExternalProviderEnabled() bool {
 			return true
 		}
 	}
+	lastKnownEnabled.Store("")
 	return false
 }
 

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
@@ -36,6 +37,12 @@ var (
 
 	// providers maps provider names to their AuthProvider implementations, populated by Configure.
 	providers = make(map[string]common.AuthProvider)
+
+	// lastKnownEnabled caches the name of the most recently confirmed active
+	// non-local provider. IsExternalProviderEnabled checks this provider first,
+	// avoiding a full scan when the same provider stays enabled across calls —
+	// the common production steady state.
+	lastKnownEnabled atomic.Value // stores string
 
 	// userExtraAttributesMap defines which token ExtraInfo keys are propagated to UserAttributes.
 	userExtraAttributesMap = map[string]bool{common.UserAttributePrincipalID: true, common.UserAttributeUserName: true}
@@ -256,16 +263,37 @@ func SetProviders(m map[string]common.AuthProvider) {
 	if m == nil {
 		m = make(map[string]common.AuthProvider)
 	}
-
 	providers = m
+	lastKnownEnabled.Store("")
 }
 
 // IsExternalProviderEnabled reports whether at least one non-local auth provider is currently enabled.
 // It consults each registered provider's IsDisabledProvider rather than querying auth config resources.
 func IsExternalProviderEnabled() bool {
-	// Snapshot the non-local provider list while holding the lock, then release
-	// before calling IsDisabledProvider — those implementations make live
-	// Kubernetes API calls that must not block the lock.
+	// Fast path: check the last known active provider first. In the common
+	// production steady state a single provider stays enabled indefinitely, so
+	// one IsDisabledProvider call is enough to confirm and return early — no
+	// snapshot allocation, no calls to any other provider.
+	//
+	// alreadyChecked records which provider the fast path called IsDisabledProvider
+	// on so the full scan below can skip it and avoid a redundant call.
+	var alreadyChecked string
+	if hint, _ := lastKnownEnabled.Load().(string); hint != "" {
+		mu.RLock()
+		p := providers[hint]
+		mu.RUnlock()
+		if p != nil {
+			alreadyChecked = hint
+			if disabled, err := p.IsDisabledProvider(); err == nil && !disabled {
+				return true
+			}
+		}
+		lastKnownEnabled.Store("") // Stale; clear before full scan.
+	}
+
+	// Full scan: snapshot the non-local provider list while holding the lock,
+	// then call IsDisabledProvider outside the lock — those implementations make
+	// live Kubernetes API calls that must not block the lock.
 	mu.RLock()
 	type entry struct {
 		name     string
@@ -273,7 +301,7 @@ func IsExternalProviderEnabled() bool {
 	}
 	snapshot := make([]entry, 0, len(providers))
 	for name, p := range providers {
-		if name != local.Name {
+		if name != local.Name && name != alreadyChecked {
 			snapshot = append(snapshot, entry{name, p})
 		}
 	}
@@ -286,6 +314,7 @@ func IsExternalProviderEnabled() bool {
 			continue
 		}
 		if !disabled {
+			lastKnownEnabled.Store(e.name)
 			return true
 		}
 	}

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -25,7 +25,9 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providers/oidc"
 	"github.com/rancher/rancher/pkg/auth/providers/saml"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -256,6 +258,45 @@ func SetProviders(m map[string]common.AuthProvider) {
 	}
 
 	providers = m
+}
+
+// IsExternalProviderEnabled reports whether at least one non-local auth provider is currently enabled.
+// It consults each registered provider's IsDisabledProvider rather than querying auth config resources.
+func IsExternalProviderEnabled() bool {
+	// Snapshot the non-local provider list while holding the lock, then release
+	// before calling IsDisabledProvider — those implementations make live
+	// Kubernetes API calls that must not block the lock.
+	mu.RLock()
+	type entry struct {
+		name     string
+		provider common.AuthProvider
+	}
+	snapshot := make([]entry, 0, len(providers))
+	for name, p := range providers {
+		if name != local.Name {
+			snapshot = append(snapshot, entry{name, p})
+		}
+	}
+	mu.RUnlock()
+
+	for _, e := range snapshot {
+		disabled, err := e.provider.IsDisabledProvider()
+		if err != nil {
+			logrus.Warnf("checking if provider %s is disabled: %v", e.name, err)
+			continue
+		}
+		if !disabled {
+			return true
+		}
+	}
+	return false
+}
+
+// IsLocalHidden reports whether the local auth provider should be hidden from public-facing endpoints.
+// It returns true when the HideLocalAuthProvider feature flag is enabled and at least one external
+// auth provider is currently active.
+func IsLocalHidden() bool {
+	return features.HideLocalAuthProvider.Enabled() && IsExternalProviderEnabled()
 }
 
 // ProviderUsesUserSecrets reports whether the named provider stores per-user secrets for token refresh.

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rancher/rancher/pkg/auth/providers/common"
@@ -8,7 +9,10 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providers/github"
 	"github.com/rancher/rancher/pkg/auth/providers/githubapp"
 	"github.com/rancher/rancher/pkg/auth/providers/local"
+	"github.com/rancher/rancher/pkg/auth/providers/mocks"
+	"github.com/rancher/rancher/pkg/features"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestIsSAMLProvider(t *testing.T) {
@@ -54,4 +58,124 @@ func TestProviderCanRefreshPrincipals(t *testing.T) {
 
 	assert.True(t, ProviderCanRefreshPrincipals(github.Name))
 	assert.False(t, ProviderCanRefreshPrincipals(genericoidc.Name))
+}
+
+func TestIsExternalProviderEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	active := mocks.NewMockAuthProvider(ctrl)
+	active.EXPECT().IsDisabledProvider().Return(false, nil).AnyTimes()
+
+	inactive := mocks.NewMockAuthProvider(ctrl)
+	inactive.EXPECT().IsDisabledProvider().Return(true, nil).AnyTimes()
+
+	broken := mocks.NewMockAuthProvider(ctrl)
+	broken.EXPECT().IsDisabledProvider().Return(false, fmt.Errorf("db timeout")).AnyTimes()
+
+	tests := []struct {
+		name     string
+		registry map[string]common.AuthProvider
+		want     bool
+	}{
+		{
+			name:     "only local registered",
+			registry: map[string]common.AuthProvider{local.Name: &local.Provider{}},
+			want:     false,
+		},
+		{
+			name: "external provider disabled",
+			registry: map[string]common.AuthProvider{
+				local.Name: &local.Provider{},
+				"github":   inactive,
+			},
+			want: false,
+		},
+		{
+			name: "external provider enabled",
+			registry: map[string]common.AuthProvider{
+				local.Name: &local.Provider{},
+				"github":   active,
+			},
+			want: true,
+		},
+		{
+			// When a provider cannot be reached, the safe default is to treat it as
+			// not enabled and keep local auth visible. Hiding local auth when external
+			// auth is unreachable would lock admins out of the cluster.
+			name: "unreachable provider keeps local visible",
+			registry: map[string]common.AuthProvider{
+				local.Name: &local.Provider{},
+				"github":   broken,
+			},
+			want: false,
+		},
+		{
+			name: "one broken one active returns true",
+			registry: map[string]common.AuthProvider{
+				local.Name: &local.Provider{},
+				"github":   broken,
+				"okta":     active,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetProviders(tt.registry)
+			defer SetProviders(nil)
+			assert.Equal(t, tt.want, IsExternalProviderEnabled())
+		})
+	}
+}
+
+func TestIsLocalHidden(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	active := mocks.NewMockAuthProvider(ctrl)
+	active.EXPECT().IsDisabledProvider().Return(false, nil).AnyTimes()
+
+	tests := []struct {
+		name     string
+		flag     bool
+		registry map[string]common.AuthProvider
+		want     bool
+	}{
+		{
+			name: "feature flag off skips provider check",
+			flag: false,
+			registry: map[string]common.AuthProvider{
+				local.Name: &local.Provider{},
+				"github":   active,
+			},
+			want: false,
+		},
+		{
+			name: "feature flag on no external provider",
+			flag: true,
+			registry: map[string]common.AuthProvider{
+				local.Name: &local.Provider{},
+			},
+			want: false,
+		},
+		{
+			name: "feature flag on external provider active",
+			flag: true,
+			registry: map[string]common.AuthProvider{
+				local.Name: &local.Provider{},
+				"github":   active,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features.HideLocalAuthProvider.Set(tt.flag)
+			defer features.HideLocalAuthProvider.Set(false)
+			SetProviders(tt.registry)
+			defer SetProviders(nil)
+			assert.Equal(t, tt.want, IsLocalHidden())
+		})
+	}
 }

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -179,3 +179,24 @@ func TestIsLocalHidden(t *testing.T) {
 		})
 	}
 }
+
+func TestIsLocalHiddenReflectsProviderStateChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	provider := mocks.NewMockAuthProvider(ctrl)
+	gomock.InOrder(
+		provider.EXPECT().IsDisabledProvider().Return(false, nil), // external enabled
+		provider.EXPECT().IsDisabledProvider().Return(true, nil),  // external disabled
+	)
+
+	features.HideLocalAuthProvider.Set(true)
+	defer features.HideLocalAuthProvider.Set(false)
+	SetProviders(map[string]common.AuthProvider{
+		local.Name: &local.Provider{},
+		"github":   provider,
+	})
+	defer SetProviders(nil)
+
+	assert.True(t, IsLocalHidden(), "local should be hidden while external provider is active")
+	assert.False(t, IsLocalHidden(), "local should reappear after external provider is disabled")
+}

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -180,6 +180,26 @@ func TestIsLocalHidden(t *testing.T) {
 	}
 }
 
+func TestIsExternalProviderEnabledFastPathErrorRetriedInFullScan(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	provider := mocks.NewMockAuthProvider(ctrl)
+	gomock.InOrder(
+		provider.EXPECT().IsDisabledProvider().Return(false, nil),                           // full scan warms the hint
+		provider.EXPECT().IsDisabledProvider().Return(false, fmt.Errorf("transient error")), // fast path errors: alreadyChecked must stay ""
+		provider.EXPECT().IsDisabledProvider().Return(false, nil),                           // full scan retries and confirms enabled
+	)
+
+	SetProviders(map[string]common.AuthProvider{
+		local.Name: &local.Provider{},
+		"github":   provider,
+	})
+	defer SetProviders(nil)
+
+	assert.True(t, IsExternalProviderEnabled(), "first call: full scan finds provider enabled and warms hint")
+	assert.True(t, IsExternalProviderEnabled(), "second call: fast-path error must not prevent full scan from retrying the provider")
+}
+
 func TestIsLocalHiddenReflectsProviderStateChange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -238,6 +238,11 @@ func (h *loginHandler) login(w http.ResponseWriter, r *http.Request, input login
 		return
 	}
 
+	if input.GetName() == local.Name && providers.IsLocalHidden() {
+		util.ReturnAPIError(w, httperror.NewAPIError(httperror.NotFound, ""))
+		return
+	}
+
 	if providers.IsSAMLProviderType(input.GetType()) {
 		// SAML's login flow is different. Unlike other providers it gets the logged in user's data
 		// via the POST from the identity provider on a separate endpoint.

--- a/pkg/auth/providers/publicapi/store.go
+++ b/pkg/auth/providers/publicapi/store.go
@@ -50,6 +50,9 @@ func (s *authProvidersStore) ByID(apiContext *types.APIContext, schema *types.Sc
 	}
 	u, _ := o.(runtime.Unstructured)
 	config := u.UnstructuredContent()
+	if enabled, ok := config["enabled"].(bool); !ok || !enabled {
+		return nil, httperror.NewAPIError(httperror.NotFound, "")
+	}
 	if t, ok := config["type"].(string); ok && t != "" {
 		p := providers.GetProviderByType(t)
 		if p == nil {

--- a/pkg/auth/providers/publicapi/store.go
+++ b/pkg/auth/providers/publicapi/store.go
@@ -67,9 +67,17 @@ func (s *authProvidersStore) ByID(apiContext *types.APIContext, schema *types.Sc
 }
 
 func (s *authProvidersStore) List(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) ([]map[string]any, error) {
-	rrr, _ := s.authConfigsRaw.List(metav1.ListOptions{})
+	rrr, err := s.authConfigsRaw.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
 	var result []map[string]any
 	list, _ := rrr.(*unstructured.UnstructuredList)
+	if list == nil {
+		return nil, nil
+	}
+
 	for _, i := range list.Items {
 		if t, ok := i.Object["type"].(string); ok && t != "" {
 			if enabled, ok := i.Object["enabled"].(bool); ok && enabled {

--- a/pkg/auth/providers/publicapi/store.go
+++ b/pkg/auth/providers/publicapi/store.go
@@ -12,6 +12,7 @@ import (
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/local"
 	"github.com/rancher/rancher/pkg/auth/util"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -39,6 +40,10 @@ type authProvidersStore struct {
 }
 
 func (s *authProvidersStore) ByID(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]any, error) {
+	if id == local.Name && providers.IsLocalHidden() {
+		return nil, httperror.NewAPIError(httperror.NotFound, "")
+	}
+
 	o, err := s.authConfigsRaw.Get(id, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -46,8 +51,12 @@ func (s *authProvidersStore) ByID(apiContext *types.APIContext, schema *types.Sc
 	u, _ := o.(runtime.Unstructured)
 	config := u.UnstructuredContent()
 	if t, ok := config["type"].(string); ok && t != "" {
+		p := providers.GetProviderByType(t)
+		if p == nil {
+			return nil, httperror.NewAPIError(httperror.NotFound, "")
+		}
 		config[".host"] = util.GetHost(apiContext.Request)
-		provider, err := providers.GetProviderByType(t).TransformToAuthProvider(config)
+		provider, err := p.TransformToAuthProvider(config)
 		if err != nil {
 			return nil, err
 		}
@@ -64,8 +73,15 @@ func (s *authProvidersStore) List(apiContext *types.APIContext, schema *types.Sc
 	for _, i := range list.Items {
 		if t, ok := i.Object["type"].(string); ok && t != "" {
 			if enabled, ok := i.Object["enabled"].(bool); ok && enabled {
+				p := providers.GetProviderByType(t)
+				if p == nil {
+					continue
+				}
+				if p.GetName() == local.Name && providers.IsLocalHidden() {
+					continue
+				}
 				i.Object[".host"] = util.GetHost(apiContext.Request)
-				provider, err := providers.GetProviderByType(t).TransformToAuthProvider(i.Object)
+				provider, err := p.TransformToAuthProvider(i.Object)
 				if err != nil {
 					return result, err
 				}
@@ -158,6 +174,9 @@ func (s *v1AuthProviderStore) List(w http.ResponseWriter, r *http.Request) {
 		if !authConfig.Enabled {
 			continue
 		}
+		if authConfig.Name == local.Name && providers.IsLocalHidden() {
+			continue
+		}
 
 		raw, err := s.authConfigsUnstructured.Get(r.Context(), authConfig.Name, metav1.GetOptions{})
 		if err != nil {
@@ -168,7 +187,12 @@ func (s *v1AuthProviderStore) List(w http.ResponseWriter, r *http.Request) {
 
 		raw.Object[".host"] = util.GetHost(r)
 
-		authProvider, err := s.getProviderByType(authConfig.Type).TransformToAuthProvider(raw.Object)
+		p := s.getProviderByType(authConfig.Type)
+		if p == nil {
+			logrus.Errorf("v1AuthProviderStore: No provider registered for type %s, skipping", authConfig.Type)
+			continue
+		}
+		authProvider, err := p.TransformToAuthProvider(raw.Object)
 		if err != nil {
 			logrus.Errorf("v1AuthProviderStore: Getting authprovider %s: %s", authConfig.Type, err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/pkg/auth/providers/publicapi/store_test.go
+++ b/pkg/auth/providers/publicapi/store_test.go
@@ -2,16 +2,23 @@ package publicapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/objectclient"
+	normantypes "github.com/rancher/norman/types"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/github"
 	"github.com/rancher/rancher/pkg/auth/providers/local"
+	"github.com/rancher/rancher/pkg/auth/providers/mocks"
 	"github.com/rancher/rancher/pkg/auth/providers/saml"
+	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/require"
@@ -21,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
@@ -130,6 +139,123 @@ func TestV1AuthProviderStoreList(t *testing.T) {
 	require.Equal(t, wantPayload, gotPayload)
 }
 
+func TestV1AuthProviderStoreListLocalHidden(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	// externalMock stands in for the global provider registry entry that makes
+	// IsExternalProviderEnabled() return true, which in turn makes IsLocalHidden() true.
+	externalMock := mocks.NewMockAuthProvider(ctrl)
+	externalMock.EXPECT().IsDisabledProvider().Return(false, nil).AnyTimes()
+
+	providers.SetProviders(map[string]common.AuthProvider{"okta": externalMock})
+	defer providers.SetProviders(nil)
+	features.HideLocalAuthProvider.Set(true)
+	defer features.HideLocalAuthProvider.Set(false)
+
+	authConfigCache := fake.NewMockNonNamespacedCacheInterface[*apiv3.AuthConfig](ctrl)
+	authConfigCache.EXPECT().List(labels.Everything()).Return([]*apiv3.AuthConfig{
+		{ObjectMeta: metav1.ObjectMeta{Name: local.Name}, Type: "localConfig", Enabled: true},
+		{ObjectMeta: metav1.ObjectMeta{Name: "okta"}, Type: "oktaConfig", Enabled: true},
+	}, nil).Times(1)
+
+	oktaConfig := &unstructured.Unstructured{}
+	oktaConfig.SetUnstructuredContent(map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "AuthConfig",
+		"metadata":   map[string]any{"name": "okta"},
+		"type":       "oktaConfig",
+		"enabled":    true,
+	})
+
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), oktaConfig)
+	authConfigUnstructured := fakeDynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "authconfigs",
+	})
+
+	store := v1AuthProviderStore{
+		authConfigCache:         authConfigCache,
+		authConfigsUnstructured: authConfigUnstructured,
+		getProviderByType: func(providerType string) common.AuthProvider {
+			if providerType == "oktaConfig" {
+				return &saml.Provider{}
+			}
+			require.FailNow(t, "unexpected provider type "+providerType)
+			return nil
+		},
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/v1-public/authproviders", nil)
+	w := httptest.NewRecorder()
+
+	store.List(w, r)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	gotPayload := map[string]any{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &gotPayload))
+	data, ok := gotPayload["data"].([]any)
+	require.True(t, ok)
+	require.Len(t, data, 1)
+	require.Equal(t, "okta", data[0].(map[string]any)["id"])
+}
+
+func TestV1AuthProviderStoreListUnregisteredType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	authConfigCache := fake.NewMockNonNamespacedCacheInterface[*apiv3.AuthConfig](ctrl)
+	authConfigCache.EXPECT().List(labels.Everything()).Return([]*apiv3.AuthConfig{
+		{ObjectMeta: metav1.ObjectMeta{Name: "unknown"}, Type: "unknownConfig", Enabled: true},
+		{ObjectMeta: metav1.ObjectMeta{Name: "okta"}, Type: "oktaConfig", Enabled: true},
+	}, nil).Times(1)
+
+	unknownConfig := &unstructured.Unstructured{}
+	unknownConfig.SetUnstructuredContent(map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "AuthConfig",
+		"metadata":   map[string]any{"name": "unknown"},
+		"type":       "unknownConfig",
+		"enabled":    true,
+	})
+	oktaConfig := &unstructured.Unstructured{}
+	oktaConfig.SetUnstructuredContent(map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "AuthConfig",
+		"metadata":   map[string]any{"name": "okta"},
+		"type":       "oktaConfig",
+		"enabled":    true,
+	})
+
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), unknownConfig, oktaConfig)
+	authConfigUnstructured := fakeDynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "authconfigs",
+	})
+
+	store := v1AuthProviderStore{
+		authConfigCache:         authConfigCache,
+		authConfigsUnstructured: authConfigUnstructured,
+		getProviderByType: func(providerType string) common.AuthProvider {
+			if providerType == "oktaConfig" {
+				return &saml.Provider{}
+			}
+			return nil
+		},
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/v1-public/authproviders", nil)
+	w := httptest.NewRecorder()
+
+	store.List(w, r)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	gotPayload := map[string]any{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &gotPayload))
+	data, ok := gotPayload["data"].([]any)
+	require.True(t, ok)
+	require.Len(t, data, 1)
+	require.Equal(t, "okta", data[0].(map[string]any)["id"])
+}
+
 func TestV1AuthTokenStoreGet(t *testing.T) {
 	tokenID := "token-5lwps"
 	bearerToken := tokenID + ":jslbp8qbkvpndjj4xmvl9crwh7w96pvxrg4xltsmcbcvvcrk9thphq"
@@ -182,3 +308,325 @@ func TestV1AuthTokenStoreDelete(t *testing.T) {
 	store.Delete(w, r)
 	require.Equal(t, 200, w.Result().StatusCode)
 }
+
+func TestAuthProvidersStoreByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	localMock := mocks.NewMockAuthProvider(ctrl)
+	localMock.EXPECT().TransformToAuthProvider(gomock.Any()).
+		Return(map[string]any{"id": "local", "type": "localProvider"}, nil).AnyTimes()
+
+	externalMock := mocks.NewMockAuthProvider(ctrl)
+	externalMock.EXPECT().IsDisabledProvider().Return(false, nil).AnyTimes()
+	externalMock.EXPECT().TransformToAuthProvider(gomock.Any()).
+		Return(map[string]any{"id": "github", "type": "githubProvider"}, nil).AnyTimes()
+
+	makeUnstructured := func(obj map[string]any) runtime.Object {
+		u := &unstructured.Unstructured{}
+		u.SetUnstructuredContent(obj)
+		return u
+	}
+
+	tests := []struct {
+		name     string
+		id       string
+		flag     bool
+		registry map[string]common.AuthProvider
+		getFunc  func(string, metav1.GetOptions) (runtime.Object, error)
+		wantErr  bool
+		want404  bool
+		wantData map[string]any
+	}{
+		{
+			name: "local provider returns 404 when hidden",
+			id:   local.Name,
+			flag: true,
+			registry: map[string]common.AuthProvider{
+				local.Name: localMock,
+				"github":   externalMock,
+			},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return makeUnstructured(map[string]any{"type": "localConfig"}), nil
+			},
+			wantErr: true,
+			want404: true,
+		},
+		{
+			name: "local provider returned when feature flag is off",
+			id:   local.Name,
+			flag: false,
+			registry: map[string]common.AuthProvider{
+				local.Name: localMock,
+			},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return makeUnstructured(map[string]any{"type": "localConfig"}), nil
+			},
+			wantData: map[string]any{"id": "local", "type": "localProvider"},
+		},
+		{
+			name:     "Kubernetes error propagates",
+			id:       "github",
+			flag:     false,
+			registry: map[string]common.AuthProvider{},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return nil, fmt.Errorf("api server unavailable")
+			},
+			wantErr: true,
+		},
+		{
+			name:     "unregistered provider type returns 404",
+			id:       "unknown",
+			flag:     false,
+			registry: map[string]common.AuthProvider{},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return makeUnstructured(map[string]any{"type": "unknownConfig"}), nil
+			},
+			wantErr: true,
+			want404: true,
+		},
+		{
+			name: "registered provider returns transformed data",
+			id:   "github",
+			flag: false,
+			registry: map[string]common.AuthProvider{
+				"github": externalMock,
+			},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return makeUnstructured(map[string]any{"type": "githubConfig"}), nil
+			},
+			wantData: map[string]any{"id": "github", "type": "githubProvider"},
+		},
+		{
+			name:     "config missing type field returns 404",
+			id:       "github",
+			flag:     false,
+			registry: map[string]common.AuthProvider{},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return makeUnstructured(map[string]any{"name": "github"}), nil
+			},
+			wantErr: true,
+			want404: true,
+		},
+	}
+
+	apiCtx := &normantypes.APIContext{
+		Request: httptest.NewRequest(http.MethodGet, "/v3-public/authproviders/local", nil),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features.HideLocalAuthProvider.Set(tt.flag)
+			defer features.HideLocalAuthProvider.Set(false)
+			providers.SetProviders(tt.registry)
+			defer providers.SetProviders(nil)
+
+			store := &authProvidersStore{
+				authConfigsRaw: &fakeAuthConfigsRaw{get: tt.getFunc},
+			}
+
+			got, err := store.ByID(apiCtx, nil, tt.id)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.want404 {
+					var apiErr *httperror.APIError
+					require.ErrorAs(t, err, &apiErr)
+					require.Equal(t, httperror.NotFound, apiErr.Code)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantData, got)
+		})
+	}
+}
+
+func TestAuthProvidersStoreList(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	localMock := mocks.NewMockAuthProvider(ctrl)
+	localMock.EXPECT().GetName().Return(local.Name).AnyTimes()
+	localMock.EXPECT().TransformToAuthProvider(gomock.Any()).
+		Return(map[string]any{"id": "local", "type": "localProvider"}, nil).AnyTimes()
+
+	externalMock := mocks.NewMockAuthProvider(ctrl)
+	externalMock.EXPECT().GetName().Return("github").AnyTimes()
+	externalMock.EXPECT().IsDisabledProvider().Return(false, nil).AnyTimes()
+	externalMock.EXPECT().TransformToAuthProvider(gomock.Any()).
+		Return(map[string]any{"id": "github", "type": "githubProvider"}, nil).AnyTimes()
+
+	makeList := func(objs ...map[string]any) *unstructured.UnstructuredList {
+		l := &unstructured.UnstructuredList{}
+		for _, obj := range objs {
+			item := unstructured.Unstructured{Object: obj}
+			l.Items = append(l.Items, *item.DeepCopy())
+		}
+		return l
+	}
+
+	tests := []struct {
+		name     string
+		flag     bool
+		registry map[string]common.AuthProvider
+		listFunc func(metav1.ListOptions) (runtime.Object, error)
+		want     []map[string]any
+	}{
+		{
+			name: "local excluded when hidden",
+			flag: true,
+			registry: map[string]common.AuthProvider{
+				local.Name: localMock,
+				"github":   externalMock,
+			},
+			listFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+				return makeList(
+					map[string]any{"type": "localConfig", "enabled": true},
+					map[string]any{"type": "githubConfig", "enabled": true},
+				), nil
+			},
+			want: []map[string]any{{"id": "github", "type": "githubProvider"}},
+		},
+		{
+			name: "local included when feature flag is off",
+			flag: false,
+			registry: map[string]common.AuthProvider{
+				local.Name: localMock,
+				"github":   externalMock,
+			},
+			listFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+				return makeList(
+					map[string]any{"type": "localConfig", "enabled": true},
+					map[string]any{"type": "githubConfig", "enabled": true},
+				), nil
+			},
+			want: []map[string]any{
+				{"id": "local", "type": "localProvider"},
+				{"id": "github", "type": "githubProvider"},
+			},
+		},
+		{
+			name: "item with unregistered provider type skipped",
+			flag: false,
+			registry: map[string]common.AuthProvider{
+				"github": externalMock,
+			},
+			listFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+				return makeList(
+					map[string]any{"type": "unknownConfig", "enabled": true},
+					map[string]any{"type": "githubConfig", "enabled": true},
+				), nil
+			},
+			want: []map[string]any{{"id": "github", "type": "githubProvider"}},
+		},
+		{
+			name: "disabled items skipped",
+			flag: false,
+			registry: map[string]common.AuthProvider{
+				"github": externalMock,
+			},
+			listFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+				return makeList(
+					map[string]any{"type": "githubConfig", "enabled": false},
+					map[string]any{"type": "githubConfig", "enabled": true},
+				), nil
+			},
+			want: []map[string]any{{"id": "github", "type": "githubProvider"}},
+		},
+		{
+			name: "items missing type field skipped",
+			flag: false,
+			registry: map[string]common.AuthProvider{
+				"github": externalMock,
+			},
+			listFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+				return makeList(
+					map[string]any{"name": "notype", "enabled": true},
+					map[string]any{"type": "githubConfig", "enabled": true},
+				), nil
+			},
+			want: []map[string]any{{"id": "github", "type": "githubProvider"}},
+		},
+		{
+			name:     "empty list returns nil",
+			flag:     false,
+			registry: map[string]common.AuthProvider{},
+			listFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+				return makeList(), nil
+			},
+			want: nil,
+		},
+	}
+
+	apiCtx := &normantypes.APIContext{
+		Request: httptest.NewRequest(http.MethodGet, "/v3-public/authproviders", nil),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features.HideLocalAuthProvider.Set(tt.flag)
+			defer features.HideLocalAuthProvider.Set(false)
+			providers.SetProviders(tt.registry)
+			defer providers.SetProviders(nil)
+
+			store := &authProvidersStore{
+				authConfigsRaw: &fakeAuthConfigsRaw{list: tt.listFunc},
+			}
+
+			got, err := store.List(apiCtx, nil, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// fakeAuthConfigsRaw implements objectclient.GenericClient for tests.
+// Only Get and List are wired up; all other methods panic if called.
+type fakeAuthConfigsRaw struct {
+	get  func(string, metav1.GetOptions) (runtime.Object, error)
+	list func(metav1.ListOptions) (runtime.Object, error)
+}
+
+func (f *fakeAuthConfigsRaw) Get(name string, opts metav1.GetOptions) (runtime.Object, error) {
+	if f.get == nil {
+		panic("unexpected call to Get")
+	}
+	return f.get(name, opts)
+}
+
+func (f *fakeAuthConfigsRaw) List(opts metav1.ListOptions) (runtime.Object, error) {
+	if f.list == nil {
+		panic("unexpected call to List")
+	}
+	return f.list(opts)
+}
+
+func (f *fakeAuthConfigsRaw) UnstructuredClient() objectclient.GenericClient { panic("not called") }
+func (f *fakeAuthConfigsRaw) GroupVersionKind() schema.GroupVersionKind      { panic("not called") }
+func (f *fakeAuthConfigsRaw) Create(_ runtime.Object) (runtime.Object, error) {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) GetNamespaced(_, _ string, _ metav1.GetOptions) (runtime.Object, error) {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) Update(_ string, _ runtime.Object) (runtime.Object, error) {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) UpdateStatus(_ string, _ runtime.Object) (runtime.Object, error) {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) DeleteNamespaced(_, _ string, _ *metav1.DeleteOptions) error {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) Delete(_ string, _ *metav1.DeleteOptions) error { panic("not called") }
+func (f *fakeAuthConfigsRaw) ListNamespaced(_ string, _ metav1.ListOptions) (runtime.Object, error) {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) Watch(_ metav1.ListOptions) (watch.Interface, error) {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) DeleteCollection(_ *metav1.DeleteOptions, _ metav1.ListOptions) error {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) Patch(_ string, _ runtime.Object, _ k8stypes.PatchType, _ []byte, _ ...string) (runtime.Object, error) {
+	panic("not called")
+}
+func (f *fakeAuthConfigsRaw) ObjectFactory() objectclient.ObjectFactory { panic("not called") }

--- a/pkg/auth/providers/publicapi/store_test.go
+++ b/pkg/auth/providers/publicapi/store_test.go
@@ -408,12 +408,23 @@ func TestAuthProvidersStoreByID(t *testing.T) {
 			want404: true,
 		},
 		{
+			name:     "config missing enabled field returns 404",
+			id:       "github",
+			flag:     false,
+			registry: map[string]common.AuthProvider{},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return makeUnstructured(map[string]any{"type": "githubConfig"}), nil
+			},
+			wantErr: true,
+			want404: true,
+		},
+		{
 			name:     "config missing type field returns 404",
 			id:       "github",
 			flag:     false,
 			registry: map[string]common.AuthProvider{},
 			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
-				return makeUnstructured(map[string]any{"name": "github"}), nil
+				return makeUnstructured(map[string]any{"name": "github", "enabled": true}), nil
 			},
 			wantErr: true,
 			want404: true,

--- a/pkg/auth/providers/publicapi/store_test.go
+++ b/pkg/auth/providers/publicapi/store_test.go
@@ -556,6 +556,22 @@ func TestAuthProvidersStoreList(t *testing.T) {
 		},
 	}
 
+	// Kubernetes API error must be returned, not silently discarded.
+	t.Run("Kubernetes List error propagates", func(t *testing.T) {
+		store := &authProvidersStore{
+			authConfigsRaw: &fakeAuthConfigsRaw{
+				list: func(_ metav1.ListOptions) (runtime.Object, error) {
+					return nil, fmt.Errorf("api server unavailable")
+				},
+			},
+		}
+		ctx := &normantypes.APIContext{
+			Request: httptest.NewRequest(http.MethodGet, "/v3-public/authproviders", nil),
+		}
+		_, err := store.List(ctx, nil, nil)
+		require.Error(t, err)
+	})
+
 	apiCtx := &normantypes.APIContext{
 		Request: httptest.NewRequest(http.MethodGet, "/v3-public/authproviders", nil),
 	}

--- a/pkg/auth/providers/publicapi/store_test.go
+++ b/pkg/auth/providers/publicapi/store_test.go
@@ -359,7 +359,7 @@ func TestAuthProvidersStoreByID(t *testing.T) {
 				local.Name: localMock,
 			},
 			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
-				return makeUnstructured(map[string]any{"type": "localConfig"}), nil
+				return makeUnstructured(map[string]any{"type": "localConfig", "enabled": true}), nil
 			},
 			wantData: map[string]any{"id": "local", "type": "localProvider"},
 		},
@@ -379,7 +379,7 @@ func TestAuthProvidersStoreByID(t *testing.T) {
 			flag:     false,
 			registry: map[string]common.AuthProvider{},
 			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
-				return makeUnstructured(map[string]any{"type": "unknownConfig"}), nil
+				return makeUnstructured(map[string]any{"type": "unknownConfig", "enabled": true}), nil
 			},
 			wantErr: true,
 			want404: true,
@@ -392,9 +392,20 @@ func TestAuthProvidersStoreByID(t *testing.T) {
 				"github": externalMock,
 			},
 			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
-				return makeUnstructured(map[string]any{"type": "githubConfig"}), nil
+				return makeUnstructured(map[string]any{"type": "githubConfig", "enabled": true}), nil
 			},
 			wantData: map[string]any{"id": "github", "type": "githubProvider"},
+		},
+		{
+			name:     "disabled provider returns 404",
+			id:       "github",
+			flag:     false,
+			registry: map[string]common.AuthProvider{"github": externalMock},
+			getFunc: func(_ string, _ metav1.GetOptions) (runtime.Object, error) {
+				return makeUnstructured(map[string]any{"type": "githubConfig", "enabled": false}), nil
+			},
+			wantErr: true,
+			want404: true,
 		},
 		{
 			name:     "config missing type field returns 404",


### PR DESCRIPTION
## Issue: #46078<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Local auth provider should not be exposed and login with it should not be possible if the `hide-local-auth-provider` feature flag is set.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Don't return local auth provider in `/{v1|v3}-public` endpoints and return 404 if an attempt is made to login with the local provider when the flag is set.
- Cache the name of the last confirmed enabled external provider, avoiding a full scan when the same provider stays enabled — which is the common case in production.

Additional fixes:

- Fix nil panic on discarded authConfigsRaw.List error.
- Don't expose disabled providers accessed by id in /v3-public
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
- Unit tests