### PR TITLE
enable turtls rancher-credential-translation feature

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -329,6 +329,9 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 				}
 				// add image pull secrets, turtles uses string references at

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -206,6 +206,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -323,6 +326,9 @@ func Test_ChartInstallation(t *testing.T) {
 					"priorityClassName": priorityClassName,
 					"features": map[string]interface{}{
 						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+						"rancher-credential-translation": map[string]interface{}{
 							"enabled": true,
 						},
 					},
@@ -444,6 +450,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -533,6 +542,9 @@ func Test_ChartInstallation(t *testing.T) {
 					"priorityClassName": priorityClassName,
 					"features": map[string]interface{}{
 						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+						"rancher-credential-translation": map[string]interface{}{
 							"enabled": true,
 						},
 					},
@@ -626,6 +638,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -716,6 +731,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -804,6 +822,9 @@ func Test_ChartInstallation(t *testing.T) {
 					"priorityClassName": priorityClassName,
 					"features": map[string]interface{}{
 						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+						"rancher-credential-translation": map[string]interface{}{
 							"enabled": true,
 						},
 					},
@@ -947,6 +968,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -1060,6 +1084,9 @@ func Test_ChartInstallation(t *testing.T) {
 					"priorityClassName": priorityClassName,
 					"features": map[string]interface{}{
 						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+						"rancher-credential-translation": map[string]interface{}{
 							"enabled": true,
 						},
 					},
@@ -1177,6 +1204,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -1262,6 +1292,9 @@ func Test_ChartInstallation(t *testing.T) {
 				expectedTurtlesValues := map[string]interface{}{
 					"features": map[string]interface{}{
 						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+						"rancher-credential-translation": map[string]interface{}{
 							"enabled": true,
 						},
 					},
@@ -1408,6 +1441,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -1548,6 +1584,9 @@ func Test_ChartInstallation(t *testing.T) {
 				expectedTurtlesValues := map[string]interface{}{
 					"features": map[string]interface{}{
 						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+						"rancher-credential-translation": map[string]interface{}{
 							"enabled": true,
 						},
 					},
@@ -1719,6 +1758,9 @@ func Test_ChartInstallation(t *testing.T) {
 						"no-cert-manager": map[string]interface{}{
 							"enabled": true,
 						},
+						"rancher-credential-translation": map[string]interface{}{
+							"enabled": true,
+						},
 					},
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
@@ -1843,6 +1885,9 @@ func Test_ChartInstallation(t *testing.T) {
 					"priorityClassName": priorityClassName,
 					"features": map[string]interface{}{
 						"no-cert-manager": map[string]interface{}{
+							"enabled": true,
+						},
+						"rancher-credential-translation": map[string]interface{}{
 							"enabled": true,
 						},
 					},
@@ -2038,6 +2083,9 @@ func Test_TurtlesInstallation(t *testing.T) {
 			"no-cert-manager": map[string]interface{}{
 				"enabled": true,
 			},
+			"rancher-credential-translation": map[string]interface{}{
+				"enabled": true,
+			},
 		},
 		"global": map[string]interface{}{
 			"cattle": map[string]interface{}{
@@ -2106,6 +2154,9 @@ func Test_TurtlesWinsWhenBothEnabled(t *testing.T) {
 		"priorityClassName": priorityClassName,
 		"features": map[string]interface{}{
 			"no-cert-manager": map[string]interface{}{
+				"enabled": true,
+			},
+			"rancher-credential-translation": map[string]interface{}{
 				"enabled": true,
 			},
 		},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- https://github.com/rancher/rancher/issues/55023  


This PR enables Turtles' `rancher-credential-translation` feature. 
 

Dev validation:

The rancher-turtles app is deployed with the `rancher-credential-translation` feature enabled. 

```
helm -n cattle-turtles-system get values rancher-turtles
USER-SUPPLIED VALUES:
features:
  no-cert-manager:
    enabled: true
  rancher-credential-translation:
    enabled: true
global:
  cattle:
    systemDefaultRegistry: ""
image:
  repository: rancher/turtles
```

 Also, see the value in the rancher-turtles-controller-manager deployment:  
```
    spec:
      containers:
      - args:
        - --leader-elect
        - --feature-gates=agent-tls-mode=true,no-cert-manager=true,use-rancher-default-registry=true,use-caapf=false,rancher-credential-translation=true