### PR TITLE
dev-scripts/quick: improve chart/KDM cache invalidation

### DIFF
--- a/dev-scripts/quick
+++ b/dev-scripts/quick
@@ -12,6 +12,7 @@ OS="${OS:-linux}"
 ARCH="${ARCH:-amd64}"
 REPO="${REPO:-rancher}"
 BINARY_DEBUG=${BINARY_DEBUG:-false}
+REFRESH_DATA=${REFRESH_DATA:-false}
 CATTLE_K3S_VERSION=$(grep -m1 'ENV CATTLE_K3S_VERSION=' package/Dockerfile | cut -d '=' -f2)
 CATTLE_KDM_BRANCH=$(grep -m1 'ARG CATTLE_KDM_BRANCH=' package/Dockerfile | cut -d '=' -f2)
 CATTLE_RANCHER_WEBHOOK_VERSION=$(grep -m1 'webhookVersion' build.yaml | cut -d ' ' -f2)
@@ -108,6 +109,13 @@ add_context "github.com/rancher/wrangler/v3" "wrangler-context" "GODEP_WRANGLER"
 
 if [ "$needs_workdir" = "true" ]; then
   BUILD_ARGS+=("--build-arg=BUILD_WORKDIR=$PWD")
+fi
+
+if [ "$REFRESH_DATA" = "true" ]; then
+  BUILD_ARGS+=("--no-cache-filter=rancher-charts")
+  BUILD_ARGS+=("--no-cache-filter=partner-charts")
+  BUILD_ARGS+=("--no-cache-filter=rke2-charts")
+  BUILD_ARGS+=("--no-cache-filter=kdm")
 fi
 
 if [ "$TARGET" = "k3s-images" ]; then

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -77,6 +77,13 @@ ENV GOCACHE=/root/.cache/go/cache
 
 FROM builder AS rancher-charts
 ARG CHART_DEFAULT_BRANCH
+# Declaring these causes cache invalidation when any of these versions change,
+# ensuring the cloned charts are always in sync with build.yaml.
+ARG CATTLE_FLEET_VERSION
+ARG CATTLE_RANCHER_WEBHOOK_VERSION
+ARG CATTLE_REMOTEDIALER_PROXY_VERSION
+ARG CATTLE_RANCHER_TURTLES_VERSION
+ARG CATTLE_CSP_ADAPTER_MIN_VERSION
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
     # Temporarily clone from our GitHub's main repo, to avoid unnecessary load in git.rancher.io
     git config --global url."https://github.com/rancher/".insteadOf https://git.rancher.io/ && \


### PR DESCRIPTION
## Summary

- Adds a `REFRESH_DATA` env var to `dev-scripts/quick` that forces a rebuild of the remotely-fetched build stages (`rancher-charts`, `partner-charts`, `rke2-charts`, `kdm`) without invalidating the rest of the build cache. Uses `--no-cache-filter` so Go build and base image layers stay warm.
- Declares the build.yaml-sourced versions (`fleetVersion`, `webhookVersion`, `turtlesVersion`, `remoteDialerProxyVersion`, `cspAdapterMinVersion`) as ARGs in the `rancher-charts` Dockerfile stage. Docker invalidates a stage's cache when an ARG value changes, so bumping any of these versions now automatically re-clones the charts without any manual intervention.

## Usage

Manual override (e.g. branch got new commits without a version bump):
```bash
REFRESH_DATA=true make quick-server
```

Automatic: any version bump in `build.yaml` triggers a fresh clone of `rancher-charts`.

## Test plan

- [ ] Run `make quick-server` twice — confirm chart/KDM stages are `CACHED` on the second run
- [ ] Run `REFRESH_DATA=true make quick-server` — confirm chart/KDM stages re-run (no `CACHED` marker on those stages)
- [ ] Bump a version in `build.yaml` (e.g. `fleetVersion`) and run `make quick-server` — confirm only `rancher-charts` re-runs while all other stages remain `CACHED`