### PR TITLE
Improve handling PRTB edge cases

### DIFF
--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -175,33 +175,16 @@ func (p *prtbLifecycle) ensurePSAPermissions(binding *v3.ProjectRoleTemplateBind
 
 	// ensure ClusterRole exists with correct updatepsa rules
 	psaCRWanted := addUpdatepsaClusterRole(projectName)
-	psaCR, err := p.crLister.Get(psaCRWanted.Name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// create ClusterRole if it doesn't exist
-			psaCR, err = p.crClient.Create(psaCRWanted)
-			if err != nil && !apierrors.IsAlreadyExists(err) {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-
-	// verify existing ClusterRole has the correct updatepsa rules
-	if !reflect.DeepEqual(psaCR.Rules, psaCRWanted.Rules) {
-		// if the CR have been modified, restore it
-		psaCR = addUpdatepsaClusterRole(projectName)
-		_, err = p.crClient.Update(psaCR)
-		if err != nil {
-			return err
-		}
+	if err := pkgrbac.CreateOrUpdateResource(psaCRWanted, p.crClient, func(current, desired *rbacv1.ClusterRole) bool {
+		return reflect.DeepEqual(current.Rules, desired.Rules)
+	}); err != nil {
+		return err
 	}
 
 	ref := rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
 		Kind:     "ClusterRole",
-		Name:     psaCR.Name,
+		Name:     psaCRWanted.Name,
 	}
 
 	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
@@ -271,13 +254,19 @@ func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding)
 // This function always checks for the PSA permissions in case they were removed and the CR/CRB still exist.
 // Ignore NotFound errors since we check even if the permissions don't exist, and we want to ensure the resources are deleted if they are there.
 func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTemplateBinding) error {
+	// A subject-less PRTB never gets PSA resources created (syncPRTB returns early for these),
+	// so there is nothing to clean up. BuildSubjectFromRTB would return an error for such a
+	// binding, which would leave the PRTB stuck in terminating state.
+	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" {
+		return nil
+	}
+
 	_, projectName, found := strings.Cut(binding.ProjectName, ":")
 	if !found {
 		return fmt.Errorf("invalid project name format")
 	}
 
-	// delete the ClusterRoleBinding first
-	psaCRName := fmt.Sprintf("%s-namespaces-psa", projectName)
+	psaCRName := projectName + "-namespaces-psa"
 	ref := rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
 		Kind:     "ClusterRole",
@@ -287,26 +276,28 @@ func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTempla
 	if err != nil {
 		return err
 	}
+
 	psaCRBName := pkgrbac.NameForClusterRoleBindingWithOwner(ref, subject, binding.Name)
-	err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("error deleting clusterrolebinding %v: %w", psaCRBName, err)
 	}
 
 	// In previous versions, the ClusterRoleBinding name didn't include the binding name as an owner label.
 	// We need to check and delete the legacy ClusterRoleBinding if it exists to ensure proper cleanup.
 	psaCRBName = pkgrbac.NameForClusterRoleBinding(ref, subject)
-	err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("error deleting clusterrolebinding %v: %w", psaCRBName, err)
 	}
 
 	// if ClusterRole is not used by other ClusterRoleBindings:
 	// then delete the ClusterRole
 	// skip the deletion otherwise
-	if !p.isClusterRoleUsed(psaCRName) {
-		err = p.crClient.Delete(psaCRName, &metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
+	clusterRoleInUse, err := p.isClusterRoleUsed(psaCRName)
+	if err != nil {
+		return fmt.Errorf("error checking if clusterrole %v is used: %w", psaCRName, err)
+	}
+	if !clusterRoleInUse {
+		if err = p.crClient.Delete(psaCRName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("error deleting clusterrole %v: %w", psaCRName, err)
 		}
 	}
@@ -314,20 +305,20 @@ func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTempla
 	return nil
 }
 
-// isClusterRoleUsed checks if a ClusterRole is referenced by any ClusterRoleBinding
-func (p *prtbLifecycle) isClusterRoleUsed(clusterRoleName string) bool {
+// isClusterRoleUsed checks if a ClusterRole is referenced by any ClusterRoleBinding.
+func (p *prtbLifecycle) isClusterRoleUsed(clusterRoleName string) (bool, error) {
 	bindings, err := p.crbClient.List(metav1.ListOptions{})
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	for _, binding := range bindings.Items {
 		if binding.RoleRef.Kind == "ClusterRole" && binding.RoleRef.Name == clusterRoleName {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 func (p *prtbLifecycle) reconcileProjectAccessToGlobalResources(binding *v3.ProjectRoleTemplateBinding, rts map[string]*v3.RoleTemplate) error {

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -294,7 +294,7 @@ func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTempla
 	// skip the deletion otherwise
 	clusterRoleInUse, err := p.isClusterRoleUsed(psaCRName)
 	if err != nil {
-		return fmt.Errorf("error checking if clusterrole %v is used: %w", psaCRName, err)
+		logrus.Errorf("Error checking if clusterrole %v is used, continuing with deletion: %v", psaCRName, err)
 	}
 	if !clusterRoleInUse {
 		if err = p.crClient.Delete(psaCRName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
@@ -306,13 +306,14 @@ func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTempla
 }
 
 // isClusterRoleUsed checks if a ClusterRole is referenced by any ClusterRoleBinding.
+// If there is an error while listing the ClusterRoleBindings, it returns false.
 func (p *prtbLifecycle) isClusterRoleUsed(clusterRoleName string) (bool, error) {
-	bindings, err := p.crbClient.List(metav1.ListOptions{})
+	bindings, err := p.crbLister.List(labels.Everything())
 	if err != nil {
 		return false, err
 	}
 
-	for _, binding := range bindings.Items {
+	for _, binding := range bindings {
 		if binding.RoleRef.Kind == "ClusterRole" && binding.RoleRef.Name == clusterRoleName {
 			return true, nil
 		}

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -529,8 +529,11 @@ func Test_ensurePSAPermissions(t *testing.T) {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
 				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Times(2)
-				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
+
+				crbListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+				crbListerMock.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{}, nil)
+				p.crbLister = crbListerMock
 
 				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
 				crClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
@@ -738,8 +741,11 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
 				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
+
+				crbListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+				crbListerMock.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{}, nil)
+				p.crbLister = crbListerMock
 
 				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
 				crClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
@@ -788,8 +794,11 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
 				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
+
+				crbListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+				crbListerMock.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{}, nil)
+				p.crbLister = crbListerMock
 
 				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
 				crClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error"))
@@ -805,17 +814,18 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
 				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{
-					Items: []rbacv1.ClusterRoleBinding{
-						{
-							RoleRef: rbacv1.RoleRef{
-								Kind: "ClusterRole",
-								Name: psaClusterRoleName,
-							},
+				p.crbClient = crbClientMock
+
+				crbListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+				crbListerMock.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{
+					{
+						RoleRef: rbacv1.RoleRef{
+							Kind: "ClusterRole",
+							Name: psaClusterRoleName,
 						},
 					},
 				}, nil)
-				p.crbClient = crbClientMock
+				p.crbLister = crbListerMock
 				return p
 			},
 			binding: testBinding.DeepCopy(),
@@ -827,8 +837,11 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
 				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Times(2)
-				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
+
+				crbListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+				crbListerMock.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{}, nil)
+				p.crbLister = crbListerMock
 
 				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
 				crClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
@@ -844,12 +857,19 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
 				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-				crbClientMock.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
 				p.crbClient = crbClientMock
+
+				crbListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+				crbListerMock.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
+				p.crbLister = crbListerMock
+
+				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+				p.crClient = crClientMock
 				return p
 			},
 			binding: testBinding.DeepCopy(),
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -487,11 +487,8 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "create psa rbac resources without errors",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, ""))
-				p.crLister = crListerMock
-
 				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, ""))
 				crClientMock.EXPECT().Create(gomock.Any()).Return(&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{Name: psaClusterRoleName},
 					Rules:      psaRules,
@@ -554,14 +551,11 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "existing CR with correct rules does not update",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(&rbacv1.ClusterRole{
+				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{Name: psaClusterRoleName},
 					Rules:      psaRules,
 				}, nil)
-				p.crLister = crListerMock
-
-				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
 				// No Update expected since rules match
 				p.crClient = crClientMock
 
@@ -580,14 +574,11 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "CRB already exists is not an error",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(&rbacv1.ClusterRole{
+				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{Name: psaClusterRoleName},
 					Rules:      psaRules,
 				}, nil)
-				p.crLister = crListerMock
-
-				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
 				p.crClient = crClientMock
 
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
@@ -605,11 +596,8 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "unable to create CRB",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, ""))
-				p.crLister = crListerMock
-
 				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, ""))
 				crClientMock.EXPECT().Create(gomock.Any()).Return(&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{Name: psaClusterRoleName},
 					Rules:      psaRules,
@@ -631,11 +619,8 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "unable to create CR",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, ""))
-				p.crLister = crListerMock
-
 				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, ""))
 				crClientMock.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("error"))
 				p.crClient = crClientMock
 				return p
@@ -650,8 +635,8 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "unable to update CR",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(&rbacv1.ClusterRole{
+				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{Name: psaClusterRoleName},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -668,9 +653,6 @@ func Test_ensurePSAPermissions(t *testing.T) {
 						},
 					},
 				}, nil)
-				p.crLister = crListerMock
-
-				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
 				crClientMock.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("error"))
 				p.crClient = crClientMock
 				return p
@@ -685,9 +667,9 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "get CR fails with non-NotFound error",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(nil, fmt.Errorf("internal error"))
-				p.crLister = crListerMock
+				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(nil, fmt.Errorf("internal error"))
+				p.crClient = crClientMock
 				return p
 			},
 			args: args{
@@ -700,12 +682,12 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			name: "no subject on binding fails",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
-				crListerMock := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl)
-				crListerMock.EXPECT().Get(psaClusterRoleName).Return(&rbacv1.ClusterRole{
+				crClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl)
+				crClientMock.EXPECT().Get(psaClusterRoleName, gomock.Any()).Return(&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{Name: psaClusterRoleName},
 					Rules:      psaRules,
 				}, nil)
-				p.crLister = crListerMock
+				p.crClient = crClientMock
 				return p
 			},
 			args: args{
@@ -779,14 +761,14 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "no subject on binding fails",
+			name: "no subject on binding is a no-op",
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				return &prtbLifecycle{}
 			},
 			binding: &apisV3.ProjectRoleTemplateBinding{
 				ProjectName: "c-abc:p-example",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "unable to delete CRB",
@@ -855,6 +837,19 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 			},
 			binding: testBinding.DeepCopy(),
 			wantErr: false,
+		},
+		{
+			name: "unable to list CRBs",
+			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
+				p := &prtbLifecycle{}
+				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
+				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+				crbClientMock.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
+				p.crbClient = crbClientMock
+				return p
+			},
+			binding: testBinding.DeepCopy(),
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
There's a couple edge cases that were missed in https://github.com/rancher/rancher/pull/55621

Specifically:
1. L183: If there is a `AlreadyExists` error, the CRB will be nil and cause a panic in the `DeepEqual` call after
2. L260: If there are no subjects in the PRTB, it was possible to get into a state where the PRTB gets stuck in terminating
3. L318: Error not being surfaced from `isClusterRoleUsed`
 
## Solution
1. Use the common `CreateOrUpdateResource` helper function since it handles this behaviour
2. Check if the subjects exist. Added a comment explaining why
3. Return the error along with the result to be handled by the caller
 
## Testing


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_