### PR TITLE
[v2.14] Fix updatePSA regression

### DIFF
--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -209,7 +209,7 @@ func (p *prtbLifecycle) ensurePSAPermissions(binding *v3.ProjectRoleTemplateBind
 		return err
 	}
 
-	psaCRBName := pkgrbac.NameForClusterRoleBinding(ref, subject)
+	psaCRBName := pkgrbac.NameForClusterRoleBindingWithOwner(ref, subject, binding.Name)
 
 	// create ClusterRoleBinding to bind the ClusterRole to the user/group
 	psaCRB := &rbacv1.ClusterRoleBinding{
@@ -287,7 +287,15 @@ func (p *prtbLifecycle) ensurePSAPermissionsDelete(binding *v3.ProjectRoleTempla
 	if err != nil {
 		return err
 	}
-	psaCRBName := pkgrbac.NameForClusterRoleBinding(ref, subject)
+	psaCRBName := pkgrbac.NameForClusterRoleBindingWithOwner(ref, subject, binding.Name)
+	err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting clusterrolebinding %v: %w", psaCRBName, err)
+	}
+
+	// In previous versions, the ClusterRoleBinding name didn't include the binding name as an owner label.
+	// We need to check and delete the legacy ClusterRoleBinding if it exists to ensure proper cleanup.
+	psaCRBName = pkgrbac.NameForClusterRoleBinding(ref, subject)
 	err = p.crbClient.Delete(psaCRBName, &metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("error deleting clusterrolebinding %v: %w", psaCRBName, err)

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -531,7 +531,7 @@ func Test_ensurePSAPermissions(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
-				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Times(2)
 				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
 
@@ -755,7 +755,7 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
-				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
 
@@ -805,7 +805,7 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
-				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
 
@@ -822,7 +822,7 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
-				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{
 					Items: []rbacv1.ClusterRoleBinding{
 						{
@@ -844,7 +844,7 @@ func Test_ensurePSAPermissionsDelete(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) *prtbLifecycle {
 				p := &prtbLifecycle{}
 				crbClientMock := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
-				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				crbClientMock.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Times(2)
 				crbClientMock.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				p.crbClient = crbClientMock
 

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -217,6 +217,17 @@ func NameForClusterRoleBinding(role rbacv1.RoleRef, subject rbacv1.Subject) stri
 	return nm
 }
 
+// NameForClusterRoleBindingWithOwner returns a deterministic name for a ClusterRoleBinding with the provided roleName, subject, and owner.
+// The owner name is included in the hash so that different owners can have distinct ClusterRoleBindings for the same role and subject.
+func NameForClusterRoleBindingWithOwner(role rbacv1.RoleRef, subject rbacv1.Subject, owner string) string {
+	var name strings.Builder
+	name.WriteString("crb-")
+	name.WriteString(getBindingHash(owner, role, subject))
+	nm := name.String()
+	logrus.Debugf("ClusterRoleBinding with role.kind=%s role.name=%s subject.kind=%s subject.name=%s owner=%s has name: %s", role.Kind, role.Name, subject.Kind, subject.Name, owner, nm)
+	return nm
+}
+
 // getBindingHash returns a hash created from the passed in arguments
 // uses base32 encoding for hash, since all characters in encoding scheme are valid in k8s resource names
 // probability of collision is: 1/32^10 == 1/(2^5)^10 == 1/2^50 (sufficiently low)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55669
 
This is a backport of 2 commits from https://github.com/rancher/rancher/pull/55621

## Problem
When multiple PRTBs are given to a user, if one contains updatePSA and another doesn't, then the user loses the ability to update PSA labels on namespaces in the project.
 
## Solution
We need to build the unique CRB name with an owner reference so it doesn't accidentally remove a CRB created by a different PRTB. If we just use roleRef and subject, we will conflict.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_