### PR TITLE
fix: Added server-side flag

### DIFF
--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -543,6 +543,7 @@ func (c Command) renderArgs() ([]string, error) {
 
 	if v, ok := dataMap["takeOwnership"]; ok && convert.ToString(v) == "true" {
 		dataMap["force-conflicts"] = "true"
+		dataMap["server-side"] = "true"
 	}
 
 	for k, v := range dataMap {

--- a/pkg/catalogv2/helmop/operation_test.go
+++ b/pkg/catalogv2/helmop/operation_test.go
@@ -120,6 +120,46 @@ func Test_Render(t *testing.T) {
 			},
 			failMsg: "skip schema validation test case failed",
 		},
+		{
+			commands: Commands{
+				Command{
+					Operation:   "upgrade",
+					ChartFile:   "test-chart-v1.1.0.tgz",
+					Chart:       []byte("test-chart"),
+					ReleaseName: "test7",
+					ArgObjects: []interface{}{
+						map[string]interface{}{
+							"takeOwnership": true,
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"operation000":          []byte(strings.Join([]string{"upgrade", "--force-conflicts=true", "--server-side=true", "--take-ownership=true", "test7", "/home/shell/helm/test-chart-v1.1.0.tgz"}, "\x00")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "take ownership test case failed",
+		},
+		{
+			commands: Commands{
+				Command{
+					Operation:   "upgrade",
+					ChartFile:   "test-chart-v1.1.0.tgz",
+					Chart:       []byte("test-chart"),
+					ReleaseName: "test8",
+					ArgObjects: []interface{}{
+						map[string]interface{}{
+							"takeOwnership": false,
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"operation000":          []byte(strings.Join([]string{"upgrade", "--take-ownership=false", "test8", "/home/shell/helm/test-chart-v1.1.0.tgz"}, "\x00")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "take ownership false should not add force-conflicts or server-side",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Related: https://github.com/rancher/rancher/pull/54480 (PR that introduced the regression)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a chart's argObjects set takeOwnership: true, the command renderer adds --force-conflicts=true and --take-ownership=true to the helm upgrade invocation, but does not add --server-side=true. Since --force-conflicts only has meaning under Server-Side Apply, Helm rejects the combination with:
`Error: UPGRADE FAILED: invalid client update option(s): forceConflicts enabled when serverSideApply disabled`
This was first observed on the pasture environment (v2.15-2aa77eb283e7451d605fb85e1bd9b1791cd73875-head) while upgrading rancher-webhook, where every upgrade attempt failed and caused the pod count to spike past 300 as the controller kept retrying.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the command rendering logic so that when `takeOwnership: true`, the generated command now also includes `--server-side=true`
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_