### PR TITLE
Fix arg list too long when closing CI testing PR

### DIFF
--- a/.github/workflows/ci-testing-restart-ci.yml
+++ b/.github/workflows/ci-testing-restart-ci.yml
@@ -164,10 +164,13 @@ jobs:
           if [[ "$INCOMPLETE_WORKFLOWS" -eq 0 ]]; then
             echo "All workflows have reached their attempt limits. Closing PR..."
 
-            if FAILURE_REPORT=$(python3 .github/scripts/list-ci-failures-for-pr.py "$PR_NUMBER" 2>&1); then
-              gh pr close "$PR_NUMBER" --comment "$FAILURE_REPORT" --delete-branch
+            REPORT_FILE=$(mktemp)
+            if python3 .github/scripts/list-ci-failures-for-pr.py "$PR_NUMBER" > "$REPORT_FILE" 2>&1; then
+              gh pr comment "$PR_NUMBER" --body-file "$REPORT_FILE"
             else
               echo "❌ Failure report could not be generated."
-              gh pr close "$PR_NUMBER" --comment "Closing PR after completing all CI test runs ($MAX_ATTEMPTS per workflow)" --delete-branch
+              gh pr comment "$PR_NUMBER" --body "Closing PR after completing all CI test runs ($MAX_ATTEMPTS per workflow)"
             fi
+            rm -f "$REPORT_FILE"
+            gh pr close "$PR_NUMBER" --delete-branch
           fi


### PR DESCRIPTION
When closing a CI testing PR, the failure report generated by `list-ci-failures-for-pr.py` can exceed the kernel `ARG_MAX` limit when passed directly as a `--comment` argument to `gh pr close`. This causes the error `Argument list too long`.

The fix writes the report to a temp file and posts it via `gh pr comment --body-file`, then closes the PR in a separate `gh pr close` call without inline comment text.

Refers https://github.com/rancher/rancher/actions/runs/27971035575/job/82798036061