### PR TITLE
Remove openssl and patterns-base-fips from server image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-      curl util-linux ca-certificates-mozilla-prebuilt xz gzip tar gawk vim-small openssh-clients
+      curl util-linux findutils ca-certificates-mozilla-prebuilt xz gzip tar gawk vim-small openssh-clients
 
 
 FROM chroot-builder AS chroot-builder-server

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -32,8 +32,7 @@ FROM --platform=$BUILDPLATFORM ${GODEP_SHEPHERD} AS godep-shepherd
 FROM --platform=$BUILDPLATFORM ${GODEP_STEVE} AS godep-steve
 FROM --platform=$BUILDPLATFORM ${GODEP_WRANGLER} AS godep-wrangler
 
-FROM registry.suse.com/bci/bci-micro:15.7 AS final
-RUN : # No-op command to create an explicit layer - this fixes a weird buildkit/buildx bug on macos arm
+FROM registry.suse.com/bci/bci-nano:15.7 AS final
 
 # Temporary build stage image
 FROM registry.suse.com/bci/bci-base:15.7 AS chroot-builder
@@ -42,7 +41,7 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-      curl util-linux ca-certificates ca-certificates-mozilla xz gzip tar gawk vim-small openssh-clients openssl patterns-base-fips
+      curl util-linux ca-certificates-mozilla-prebuilt xz gzip tar gawk vim-small openssh-clients
 
 
 FROM chroot-builder AS chroot-builder-server
@@ -123,7 +122,7 @@ RUN case "${ARCH}" in \
     chmod +x /usr/bin/tini
 
 
-# Main stage using bci-micro as the base image
+# Main stage using bci-nano as the base image
 FROM final AS base
 # Copy binaries and configuration files from builder to micro
 COPY --from=chroot-builder-server /chroot/ /
@@ -551,7 +550,7 @@ LABEL "io.artifacthub.package.logo-url"="https://raw.githubusercontent.com/ranch
 ENTRYPOINT ["entrypoint.sh"]
 
 
-# Main stage using bci-micro as the base image.
+# Main stage using bci-nano as the base image.
 FROM final AS agent
 
 # Copy binaries and configuration files from zypper to micro.

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -53,7 +53,7 @@ RUN zypper --installroot /chroot -n in --no-recommends \
 
 FROM chroot-builder AS chroot-builder-agent
 RUN zypper --installroot /chroot -n in --no-recommends \
-      jq git-core hostname iproute2 less bash-completion bind-utils acl sysstat && \
+      jq git-core hostname iproute2 less bash-completion bind-utils acl sysstat openssl && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -57,7 +57,7 @@ RUN zypper --installroot /chroot -n in --no-recommends \
 
 FROM chroot-builder AS chroot-builder-agent
 RUN zypper --installroot /chroot -n in --no-recommends \
-      sed grep jq git-core hostname iproute2 less bash-completion bind-utils acl sysstat && \
+      sed grep jq git-core hostname iproute2 less bash-completion bind-utils acl sysstat openssl && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -32,8 +32,7 @@ FROM --platform=$BUILDPLATFORM ${GODEP_SHEPHERD} AS godep-shepherd
 FROM --platform=$BUILDPLATFORM ${GODEP_STEVE} AS godep-steve
 FROM --platform=$BUILDPLATFORM ${GODEP_WRANGLER} AS godep-wrangler
 
-FROM registry.suse.com/bci/bci-micro:16.0 AS final
-RUN : # No-op command to create an explicit layer - this fixes a weird buildkit/buildx bug on macos arm
+FROM registry.suse.com/bci/bci-nano:16.0 AS final
 
 # Temporary build stage image
 FROM registry.suse.com/bci/bci-base:16.0 AS chroot-builder
@@ -46,7 +45,7 @@ RUN [ "$(grep '^VERSION=' /etc/os-release)" = "$(grep '^VERSION=' /chroot/etc/os
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-      catatonit curl util-linux ca-certificates ca-certificates-mozilla findutils xz gzip tar gawk vim-small openssh-clients openssl patterns-base-fips
+      catatonit curl util-linux ca-certificates-mozilla-prebuilt findutils xz gzip tar gawk vim-small openssh-clients
 
 
 FROM chroot-builder AS chroot-builder-server
@@ -78,7 +77,7 @@ RUN mkdir -p /var/lib/rancher-data/driver-metadata && \
     curl -sLf "https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json" > /var/lib/rancher-data/driver-metadata/data.json
 
 
-# Main stage using bci-micro as the base image
+# Main stage using bci-nano as the base image
 FROM final AS base
 # Copy binaries and configuration files from builder to micro
 COPY --from=chroot-builder-server /chroot/ /
@@ -479,7 +478,7 @@ LABEL "io.artifacthub.package.logo-url"="https://raw.githubusercontent.com/ranch
 ENTRYPOINT ["entrypoint.sh"]
 
 
-# Main stage using bci-micro as the base image.
+# Main stage using bci-nano as the base image.
 FROM final AS agent
 
 # Copy binaries and configuration files from zypper to micro.


### PR DESCRIPTION
## Issue: #55567
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Depends on:
 - #55787
 
## Problem
The `openssl` toolkit is not really needed by our Go applications, only on certain cases ([FIPS-enforced systems](https://github.com/rancher/rancher/pull/46571)). Given the nature of this dependency, it's a common subject of CVE reports, which may flag our images as vulnerable during security scannings.
 
## Solution
Since version 1.24, the Go standard library offers a set of native cryptography packages that are compliant with [FIPS 140-3](https://go.dev/doc/security/fips140), removing the need of using CGO and bindings to the openssl libraries installed in the system. This allows us to safely remove it from our deliverable images.

Also:
* Change base image to BCI Nano (basically a no-op, as other dependencies are pulling in glibc and bash, the main differences between Nano and Micro).
* Remove `ca-certificates*` with pre-built version (already included in BCI Nano and Micro now, but better being explicit).

Difference in system packages installed:
 - Server image
```diff
 bash
 bash-sh
-ca-certificates
-ca-certificates-mozilla
 ca-certificates-mozilla-prebuilt
 coreutils
 cracklib
@@ -22,7 +20,6 @@
 filesystem
 fillup
 findutils
-fips
 gawk
 git-core
 glibc
@@ -50,7 +47,6 @@
 libedit0
 libexpat1
 libfdisk1
-libffi7
 libfido2-1
 libgcc_s1
 libgmp10
@@ -66,9 +62,7 @@
 libncurses6
 libnghttp2-14
 libnsl2
-libopenssl-3-fips-provider
 libopenssl3
-libp11-kit0
 libpcre2-8-0
 libpsl5
 libreadline7
@@ -85,8 +79,6 @@
 libssh4
 libstdc++6
 libsubid5
-libtasn1
-libtasn1-6
 libtirpc-netconfig
 libtirpc3
 libudev1
@@ -102,13 +94,7 @@
 netcat-openbsd
 openssh-clients
 openssh-common
-openssh-fips
-openssl
-openssl-3
-p11-kit
-p11-kit-tools
 pam
-patterns-base-fips
 perl-base
 permissions
 sed
@@ -121,6 +107,7 @@
 sysuser-shadow
 tar
 terminfo-base
+timezone
 unzip
 update-alternatives
 util-linux
```
 - Agent image
```diff
 bash-completion
 bash-sh
 bind-utils
-ca-certificates
-ca-certificates-mozilla
 ca-certificates-mozilla-prebuilt
 coreutils
 cracklib
@@ -25,7 +23,6 @@
 filesystem
 fillup
 findutils
-fips
 gawk
 git-core
 glibc
@@ -57,7 +54,6 @@
 libelf1
 libexpat1
 libfdisk1
-libffi7
 libfido2-1
 libfstrm0
 libgcc_s1
@@ -79,9 +75,7 @@
 libnghttp2-14
 libnsl2
 libonig4
-libopenssl-3-fips-provider
 libopenssl3
-libp11-kit0
 libpcre2-8-0
 libprotobuf-c1
 libpsl5
@@ -98,8 +92,6 @@
 libssh4
 libstdc++6
 libsubid5
-libtasn1
-libtasn1-6
 libtirpc-netconfig
 libtirpc3
 libudev1
@@ -117,13 +109,9 @@
 login_defs
 openssh-clients
 openssh-common
-openssh-fips
 openssl
 openssl-3
-p11-kit
-p11-kit-tools
 pam
-patterns-base-fips
 permissions
 procmail
 sed
@@ -137,6 +125,7 @@
 sysuser-shadow
 tar
 terminfo-base
+timezone
 update-alternatives
 util-linux
 vim-data-common
```
 