### PR TITLE
Bump github.com/rancher/webhook to v0.8.7-rc.10

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-webhookVersion: 107.0.7+up0.8.7-rc.9
+webhookVersion: 107.0.7+up0.8.7-rc.10
 remoteDialerProxyVersion: 106.0.2+up0.5.1
 provisioningCAPIVersion: 107.0.0+up0.8.0
 cspAdapterMinVersion: 107.0.0+up7.0.0

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -9,5 +9,5 @@ const (
 	FleetVersion             = "107.0.12+up0.13.12"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"
 	RemoteDialerProxyVersion = "106.0.2+up0.5.1"
-	WebhookVersion           = "107.0.7+up0.8.7-rc.9"
+	WebhookVersion           = "107.0.7+up0.8.7-rc.10"
 )


### PR DESCRIPTION
Automated bump of `github.com/rancher/webhook` to `v0.8.7-rc.10` on `release/v2.12`.

Tracker: https://github.com/rancher/frameworks-automation/issues/142

This PR was opened by the release-automation reconciler. CI will run on push; review and merge as usual.