### PR TITLE
[v2.15] Update csp-adapter version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ webhookVersion: 110.0.0+up0.11.0-rc.20
 remoteDialerProxyVersion: 110.0.0+up0.8.0-rc.9
 # NOTE: CAPI controller version has to be updated in scripts/package-env
 turtlesVersion: 110.0.0+up0.27.0-rc.4
-cspAdapterMinVersion: 109.0.0+up9.0.0-rc.3
+cspAdapterMinVersion: 110.0.0+up10.0.0-rc.2
 defaultShellVersion: rancher/shell:v0.8.0-rc.4
 fleetVersion: 110.0.0+up0.16.0-rc.1
 defaultSccOperatorImage: rancher/scc-operator:v0.4.2-rc.1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -4,7 +4,7 @@ package buildconfig
 
 const (
 	ChartAuditLogImage       = "rancher/mirrored-bci-micro:16.0-15.11"
-	CspAdapterMinVersion     = "109.0.0+up9.0.0-rc.3"
+	CspAdapterMinVersion     = "110.0.0+up10.0.0-rc.2"
 	DefaultSccOperatorImage  = "rancher/scc-operator:v0.4.2-rc.1"
 	DefaultShellVersion      = "rancher/shell:v0.8.0-rc.4"
 	FleetVersion             = "110.0.0+up0.16.0-rc.1"


### PR DESCRIPTION
##Issue: 
rancher/rancher#54303

##Problem:
Create new rancher-csp-adapter chart for 2.15 rancher

##Testing:

scenario 1 (fresh install):

    On an EKS cluster (k8s version 1.36), install locally built rancher with cspAdapterMinVersion: 110.0.0+up10.0.0-rc.2
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.

scenario 2 (upgrade scenario):

    Start with an EKS cluster (k8s version 1.35), install rancher 2.14.2 with csp-adapter 9.0.0
    Upgrade rancher to locally built rancher with cspAdapterMinVersion: 110.0.0+up10.0.0-rc.2
    Update charts url repo/branch and upgrade csp-adapter version to 110.0.0+up10.0.0-rc.2
    Validated the support config and licence entitlement functionality. Created a downstream EKS cluster with 21 nodes (with 1 entitlement) to trigger out-of-compliance message. Scaled down the cluster to 17 nodes, validated that the out-of-compliance message is no longer displayed. Scaled back up to 21 nodes, validated the out-of-compliance message popped up.
