### PR TITLE
SCIM: Accept PATCH op:Add on Group attributes

### DIFF
--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -194,8 +195,12 @@ func (s *SCIMServer) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	group, created, err := s.ensureRancherGroup(provider, payload)
+	group, created, err := s.ensureRancherGroup(provider, payload, cfg)
 	if err != nil {
+		if scimErr, ok := err.(*Error); ok {
+			writeError(w, scimErr)
+			return
+		}
 		logrus.Errorf("scim::CreateGroup: failed to ensure rancher group: %s", err)
 		writeError(w, NewInternalError())
 		return
@@ -343,7 +348,7 @@ func (s *SCIMServer) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.getConfig(provider)
 
-	group, _, err := s.ensureRancherGroup(provider, payload)
+	group, _, err := s.ensureRancherGroup(provider, payload, cfg)
 	if err != nil {
 		if scimErr, ok := err.(*Error); ok {
 			writeError(w, scimErr)
@@ -455,59 +460,66 @@ func (s *SCIMServer) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 	for _, op := range payload.Operations {
 		switch strings.ToLower(op.Op) {
-		case "replace":
-			updated, err := applyReplaceGroup(group, op, cfg)
+		case "replace", "add":
+			// Multi-valued add on members is handled differently from single-valued
+			// add/replace. Single-valued add and replace share semantics per RFC 7644 §3.5.2.
+			if strings.EqualFold(op.Op, "add") && op.Path != "" {
+				addPath, _, err := stripSchemaURN(op.Path, groupResource)
+				if err != nil {
+					writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid path %q: %s", op.Path, err)))
+					return
+				}
+				if strings.EqualFold(addPath, "members") {
+					members, ok := op.Value.([]any)
+					if !ok {
+						writeError(w, NewError(http.StatusBadRequest, "Invalid members value for add operation"))
+						return
+					}
+					for _, m := range members {
+						memberMap, ok := m.(map[string]any)
+						if !ok {
+							continue
+						}
+
+						value, _ := memberMap["value"].(string)
+						display, _ := memberMap["display"].(string)
+
+						memberType, _ := memberMap["type"].(string)
+						switch strings.ToLower(memberType) { // The default caseExact value for the type attribute is false.
+						case "", "user": // The type attribute is optional. We'll default to "User" if it's not provided.
+						case "group":
+							writeError(w, NewError(http.StatusBadRequest, "Nested groups are not supported"))
+							return
+						default:
+							writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Unsupported member type: %s", memberType)))
+							return
+						}
+
+						if value != "" {
+							membersToAdd = append(membersToAdd, scimMember{
+								Value:   value,
+								Display: display,
+							})
+						}
+					}
+					continue
+				}
+			}
+
+			updated, err := applyPatchGroup(group, op, cfg)
 			if err != nil {
-				logrus.Errorf("scim::PatchGroup: failed to apply replace operation: %s", err)
-				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply replace operation: %s", err)))
+				logrus.Errorf("scim::PatchGroup: failed to apply %s operation: %s", op.Op, err)
+				var scimErr *Error
+				if errors.As(err, &scimErr) {
+					writeError(w, scimErr)
+				} else {
+					writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Failed to apply %s operation: %s", op.Op, err)))
+				}
 				return
 			}
 
 			if updated {
 				shouldUpdateGroup = true
-			}
-		case "add":
-			addPath, _, err := stripSchemaURN(op.Path, groupResource)
-			if err != nil {
-				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid path %q: %s", op.Path, err)))
-				return
-			}
-			if strings.ToLower(addPath) != "members" {
-				writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Unsupported add path: %s", op.Path)))
-				return
-			}
-
-			members, ok := op.Value.([]any)
-			if !ok {
-				writeError(w, NewError(http.StatusBadRequest, "Invalid members value for add operation"))
-				return
-			}
-			for _, m := range members {
-				memberMap, ok := m.(map[string]any)
-				if !ok {
-					continue
-				}
-
-				value, _ := memberMap["value"].(string)
-				display, _ := memberMap["display"].(string)
-
-				memberType, _ := memberMap["type"].(string)
-				switch strings.ToLower(memberType) { // The default caseExact value for the type attribute is false.
-				case "", "user": // The type attribute is optional. We'll default to "User" if it's not provided.
-				case "group":
-					writeError(w, NewError(http.StatusBadRequest, "Nested groups are not supported"))
-					return
-				default:
-					writeError(w, NewError(http.StatusBadRequest, fmt.Sprintf("Unsupported member type: %s", memberType)))
-					return
-				}
-
-				if value != "" {
-					membersToAdd = append(membersToAdd, scimMember{
-						Value:   value,
-						Display: display,
-					})
-				}
 			}
 		case "remove":
 			removePath, _, err := stripSchemaURN(op.Path, groupResource)
@@ -925,7 +937,7 @@ func (s *SCIMServer) removeAllGroupMembers(provider, principalName string) error
 
 // ensureRancherGroup ensures that a Rancher group exists for the given SCIM group.
 // Returns the group, a boolean indicating if a new group was created, and any error.
-func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup) (*v3.Group, bool, error) {
+func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup, cfg providerConfig) (*v3.Group, bool, error) {
 	var (
 		group *v3.Group
 		err   error
@@ -957,6 +969,9 @@ func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup) (*v3.Gro
 		group = group.DeepCopy()
 
 		if group.ExternalID != grp.ExternalID {
+			if cfg.GroupIDAttribute == GroupIDExternalID {
+				return nil, false, NewError(http.StatusBadRequest, "externalId cannot be changed when it is used as the group principal identifier", "mutability")
+			}
 			group.ExternalID = grp.ExternalID
 			shouldUpdate = true
 		}
@@ -988,24 +1003,25 @@ func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup) (*v3.Gro
 	return created, true, err
 }
 
-// applyReplaceGroup applies a replace operation to a group.
-func applyReplaceGroup(group *v3.Group, op patchOp, cfg providerConfig) (bool, error) {
+// applyPatchGroup applies a SCIM PATCH add/replace operation to a group.
+// For single-valued attributes, add and replace have identical semantics (RFC 7644 §3.5.2).
+func applyPatchGroup(group *v3.Group, op patchOp, cfg providerConfig) (bool, error) {
 	if op.Path == "" {
-		// Bulk replace - replace multiple attributes at once
+		// Bulk update - apply multiple attributes at once.
 		fields, ok := op.Value.(map[string]any)
 		if !ok {
-			return false, fmt.Errorf("invalid value type for replace operation: %T", op.Value)
+			return false, fmt.Errorf("invalid value type for %s operation: %T", op.Op, op.Value)
 		}
 
 		var updated bool
 		for name, value := range fields {
-			wasUpdated, err := applyReplaceGroup(group, patchOp{
-				Op:    "replace",
+			wasUpdated, err := applyPatchGroup(group, patchOp{
+				Op:    op.Op,
 				Path:  name,
 				Value: value,
 			}, cfg)
 			if err != nil {
-				return false, fmt.Errorf("failed to apply replace operation: %v", err)
+				return false, fmt.Errorf("failed to apply %s operation: %v", op.Op, err)
 			}
 			if wasUpdated {
 				updated = true
@@ -1022,15 +1038,14 @@ func applyReplaceGroup(group *v3.Group, op patchOp, cfg providerConfig) (bool, e
 	var updated bool
 	switch strings.ToLower(path) {
 	case "displayname":
-		if cfg.GroupIDAttribute != GroupIDExternalID {
-			return false, NewError(http.StatusBadRequest, "displayName cannot be changed when it is used as the group principal identifier")
-		}
-
 		displayName, ok := op.Value.(string)
 		if !ok {
 			return false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid value for displayName: %v", op.Value))
 		}
 		if group.DisplayName != displayName {
+			if cfg.GroupIDAttribute != GroupIDExternalID {
+				return false, NewError(http.StatusBadRequest, "displayName cannot be changed when it is used as the group principal identifier", "mutability")
+			}
 			group.DisplayName = displayName
 			updated = true
 		}
@@ -1040,6 +1055,9 @@ func applyReplaceGroup(group *v3.Group, op patchOp, cfg providerConfig) (bool, e
 			return false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid value for externalId: %v", op.Value))
 		}
 		if group.ExternalID != externalID {
+			if cfg.GroupIDAttribute == GroupIDExternalID {
+				return false, NewError(http.StatusBadRequest, "externalId cannot be changed when it is used as the group principal identifier", "mutability")
+			}
 			group.ExternalID = externalID
 			updated = true
 		}

--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -195,12 +195,8 @@ func (s *SCIMServer) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	group, created, err := s.ensureRancherGroup(provider, payload, cfg)
+	group, created, err := s.ensureRancherGroup(provider, payload)
 	if err != nil {
-		if scimErr, ok := err.(*Error); ok {
-			writeError(w, scimErr)
-			return
-		}
 		logrus.Errorf("scim::CreateGroup: failed to ensure rancher group: %s", err)
 		writeError(w, NewInternalError())
 		return
@@ -348,25 +344,29 @@ func (s *SCIMServer) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.getConfig(provider)
 
-	group, _, err := s.ensureRancherGroup(provider, payload, cfg)
+	group, err := s.groupsCache.Get(id)
 	if err != nil {
-		if scimErr, ok := err.(*Error); ok {
-			writeError(w, scimErr)
+		if apierrors.IsNotFound(err) {
+			writeError(w, NewError(http.StatusNotFound, fmt.Sprintf("Group %s not found", id)))
 			return
 		}
-
-		logrus.Errorf("scim::UpdateGroup: failed to ensure rancher group %s: %s", id, err)
+		logrus.Errorf("scim::UpdateGroup: failed to get group %s: %s", id, err)
 		writeError(w, NewInternalError())
 		return
 	}
 
-	// Update DisplayName if it changed (only when externalId is the group ID).
-	if group.DisplayName != payload.DisplayName {
-		if cfg.GroupIDAttribute != GroupIDExternalID {
-			writeError(w, NewError(http.StatusBadRequest, "displayName cannot be changed when it is used as the group principal identifier"))
-			return
-		}
+	if group.ExternalID != payload.ExternalID && cfg.GroupIDAttribute == GroupIDExternalID {
+		writeError(w, NewError(http.StatusBadRequest, "externalId cannot be changed when it is used as the group principal identifier", "mutability"))
+		return
+	}
+	if group.DisplayName != payload.DisplayName && cfg.GroupIDAttribute != GroupIDExternalID {
+		writeError(w, NewError(http.StatusBadRequest, "displayName cannot be changed when it is used as the group principal identifier", "mutability"))
+		return
+	}
+
+	if group.ExternalID != payload.ExternalID || group.DisplayName != payload.DisplayName {
 		group = group.DeepCopy()
+		group.ExternalID = payload.ExternalID
 		group.DisplayName = payload.DisplayName
 		group, err = s.groups.Update(group)
 		if err != nil {
@@ -937,7 +937,7 @@ func (s *SCIMServer) removeAllGroupMembers(provider, principalName string) error
 
 // ensureRancherGroup ensures that a Rancher group exists for the given SCIM group.
 // Returns the group, a boolean indicating if a new group was created, and any error.
-func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup, cfg providerConfig) (*v3.Group, bool, error) {
+func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup) (*v3.Group, bool, error) {
 	var (
 		group *v3.Group
 		err   error
@@ -964,25 +964,9 @@ func (s *SCIMServer) ensureRancherGroup(provider string, grp scimGroup, cfg prov
 	}
 
 	if group != nil {
-		// Found existing group - update if needed and return created=false.
-		var shouldUpdate bool
-		group = group.DeepCopy()
-
-		if group.ExternalID != grp.ExternalID {
-			if cfg.GroupIDAttribute == GroupIDExternalID {
-				return nil, false, NewError(http.StatusBadRequest, "externalId cannot be changed when it is used as the group principal identifier", "mutability")
-			}
-			group.ExternalID = grp.ExternalID
-			shouldUpdate = true
-		}
-
-		if shouldUpdate {
-			group, err = s.groups.Update(group)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to update group %s: %w", group.Name, err)
-			}
-		}
-
+		// Found existing group - return as-is and let the caller decide what to do.
+		// CreateGroup treats created=false as a conflict; UpdateGroup applies its own
+		// mutability-gated updates inline rather than calling this helper.
 		return group, false, nil
 	}
 
@@ -1015,13 +999,16 @@ func applyPatchGroup(group *v3.Group, op patchOp, cfg providerConfig) (bool, err
 
 		var updated bool
 		for name, value := range fields {
+			if name == "" {
+				return false, NewError(http.StatusBadRequest, "empty attribute name in bulk operation")
+			}
 			wasUpdated, err := applyPatchGroup(group, patchOp{
 				Op:    op.Op,
 				Path:  name,
 				Value: value,
 			}, cfg)
 			if err != nil {
-				return false, fmt.Errorf("failed to apply %s operation: %v", op.Op, err)
+				return false, fmt.Errorf("failed to apply %s operation: %w", op.Op, err)
 			}
 			if wasUpdated {
 				updated = true

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -559,7 +559,7 @@ func TestApplyPatchGroup(t *testing.T) {
 
 		require.Error(t, err)
 		assert.False(t, updated)
-		assert.Contains(t, err.Error(), "cannot be changed")
+		assert.ErrorContains(t, err, "cannot be changed")
 	})
 
 	t.Run("allows displayName no-op when displayName is group ID", func(t *testing.T) {
@@ -580,7 +580,7 @@ func TestApplyPatchGroup(t *testing.T) {
 
 		require.Error(t, err)
 		assert.False(t, updated)
-		assert.Contains(t, err.Error(), "cannot be changed")
+		assert.ErrorContains(t, err, "cannot be changed")
 	})
 
 	t.Run("allows externalId no-op when externalId is group ID", func(t *testing.T) {
@@ -622,7 +622,7 @@ func TestApplyPatchGroup(t *testing.T) {
 
 		require.Error(t, err)
 		assert.False(t, updated)
-		assert.Contains(t, err.Error(), "does not match")
+		assert.ErrorContains(t, err, "does not match")
 	})
 
 	t.Run("add externalId", func(t *testing.T) {
@@ -665,7 +665,7 @@ func TestApplyPatchGroup(t *testing.T) {
 
 		require.Error(t, err)
 		assert.False(t, updated)
-		assert.Contains(t, err.Error(), "cannot be changed")
+		assert.ErrorContains(t, err, "cannot be changed")
 	})
 
 	t.Run("add bulk", func(t *testing.T) {

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -705,6 +705,44 @@ func TestApplyPatchGroup(t *testing.T) {
 		require.Error(t, err)
 		assert.False(t, updated)
 	})
+
+	t.Run("rejects empty attribute name in bulk", func(t *testing.T) {
+		group := &v3.Group{}
+		op := patchOp{
+			Op:   "add",
+			Path: "",
+			Value: map[string]any{
+				"": "value",
+			},
+		}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.Error(t, err)
+		assert.False(t, updated)
+		var scimErr *Error
+		require.ErrorAs(t, err, &scimErr)
+		assert.Equal(t, http.StatusBadRequest, scimErr.Status)
+	})
+
+	t.Run("bulk wraps inner SCIM error so callers can extract scimType", func(t *testing.T) {
+		group := &v3.Group{DisplayName: "Old Name"}
+		op := patchOp{
+			Op:   "add",
+			Path: "",
+			Value: map[string]any{
+				"displayName": "New Name",
+			},
+		}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.Error(t, err)
+		assert.False(t, updated)
+		var scimErr *Error
+		require.ErrorAs(t, err, &scimErr)
+		assert.Equal(t, "mutability", scimErr.ScimType)
+	})
 }
 
 func TestExtractMemberValueFromPath(t *testing.T) {
@@ -2186,17 +2224,10 @@ func TestCreateGroup(t *testing.T) {
 		groupsCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
 		groupsCache.EXPECT().Get("grp-existing").Return(existingGroup, nil)
 
-		// When ID is provided and exists, ensureRancherGroup updates externalId if it
-		// differs, then returns created=false, which triggers a 409 Conflict.
-		groupClient := fake.NewMockNonNamespacedClientInterface[*v3.Group, *v3.GroupList](ctrl)
-		groupClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(g *v3.Group) (*v3.Group, error) {
-			assert.Equal(t, "new-ext-id", g.ExternalID)
-			return g, nil
-		})
-
+		// When ID is provided and the group exists, CreateGroup returns 409 Conflict
+		// without persisting any change. The mutability-gated update belongs to UpdateGroup.
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			groups:      groupClient,
 			getConfig:   testDefaultGetConfig,
 		}
 
@@ -2232,17 +2263,10 @@ func TestCreateGroup(t *testing.T) {
 		groupsCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
 		groupsCache.EXPECT().List(labels.Set{authProviderLabel: provider}.AsSelector()).Return([]*v3.Group{existingGroup}, nil)
 
-		// When found by displayName with different externalId, the group is updated
-		// but created=false is returned, which triggers a 409 Conflict.
-		groupClient := fake.NewMockNonNamespacedClientInterface[*v3.Group, *v3.GroupList](ctrl)
-		groupClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(g *v3.Group) (*v3.Group, error) {
-			assert.Equal(t, "new-ext-id", g.ExternalID)
-			return g, nil
-		})
-
+		// When a group with the same displayName already exists, CreateGroup returns
+		// 409 Conflict without mutating the existing group's externalId.
 		srv := &SCIMServer{
 			groupsCache: groupsCache,
-			groups:      groupClient,
 			getConfig:   testDefaultGetConfig,
 		}
 

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -488,7 +488,7 @@ func TestSyncGroupMembersUpdatesStaleDisplayName(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestApplyReplaceGroup(t *testing.T) {
+func TestApplyPatchGroup(t *testing.T) {
 	cfg := defaultProviderConfig()
 	externalIDCfg := providerConfig{GroupIDAttribute: GroupIDExternalID}
 
@@ -496,7 +496,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{ExternalID: "old-id"}
 		op := patchOp{Op: "replace", Path: "externalId", Value: "new-id"}
 
-		updated, err := applyReplaceGroup(group, op, cfg)
+		updated, err := applyPatchGroup(group, op, cfg)
 
 		require.NoError(t, err)
 		assert.True(t, updated)
@@ -507,7 +507,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{ExternalID: "same-id"}
 		op := patchOp{Op: "replace", Path: "externalId", Value: "same-id"}
 
-		updated, err := applyReplaceGroup(group, op, cfg)
+		updated, err := applyPatchGroup(group, op, cfg)
 
 		require.NoError(t, err)
 		assert.False(t, updated)
@@ -523,7 +523,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 			},
 		}
 
-		updated, err := applyReplaceGroup(group, op, cfg)
+		updated, err := applyPatchGroup(group, op, cfg)
 
 		require.NoError(t, err)
 		assert.True(t, updated)
@@ -534,7 +534,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{}
 		op := patchOp{Op: "replace", Path: "unsupported", Value: "value"}
 
-		updated, err := applyReplaceGroup(group, op, cfg)
+		updated, err := applyPatchGroup(group, op, cfg)
 
 		require.Error(t, err)
 		assert.False(t, updated)
@@ -544,7 +544,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{DisplayName: "Old Name", ExternalID: "ext-123"}
 		op := patchOp{Op: "replace", Path: "displayName", Value: "New Name"}
 
-		updated, err := applyReplaceGroup(group, op, externalIDCfg)
+		updated, err := applyPatchGroup(group, op, externalIDCfg)
 
 		require.NoError(t, err)
 		assert.True(t, updated)
@@ -555,18 +555,49 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{DisplayName: "Old Name"}
 		op := patchOp{Op: "replace", Path: "displayName", Value: "New Name"}
 
-		updated, err := applyReplaceGroup(group, op, cfg)
+		updated, err := applyPatchGroup(group, op, cfg)
 
 		require.Error(t, err)
 		assert.False(t, updated)
 		assert.Contains(t, err.Error(), "cannot be changed")
 	})
 
+	t.Run("allows displayName no-op when displayName is group ID", func(t *testing.T) {
+		group := &v3.Group{DisplayName: "Same Name"}
+		op := patchOp{Op: "replace", Path: "displayName", Value: "Same Name"}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("rejects externalId change when externalId is group ID", func(t *testing.T) {
+		group := &v3.Group{ExternalID: "old-id"}
+		op := patchOp{Op: "replace", Path: "externalId", Value: "new-id"}
+
+		updated, err := applyPatchGroup(group, op, externalIDCfg)
+
+		require.Error(t, err)
+		assert.False(t, updated)
+		assert.Contains(t, err.Error(), "cannot be changed")
+	})
+
+	t.Run("allows externalId no-op when externalId is group ID", func(t *testing.T) {
+		group := &v3.Group{ExternalID: "same-id"}
+		op := patchOp{Op: "add", Path: "externalId", Value: "same-id"}
+
+		updated, err := applyPatchGroup(group, op, externalIDCfg)
+
+		require.NoError(t, err)
+		assert.False(t, updated)
+	})
+
 	t.Run("rejects invalid displayName value type", func(t *testing.T) {
 		group := &v3.Group{}
 		op := patchOp{Op: "replace", Path: "displayName", Value: 123}
 
-		updated, err := applyReplaceGroup(group, op, externalIDCfg)
+		updated, err := applyPatchGroup(group, op, externalIDCfg)
 
 		require.Error(t, err)
 		assert.False(t, updated)
@@ -576,7 +607,7 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{ExternalID: "old-id"}
 		op := patchOp{Op: "replace", Path: "urn:ietf:params:scim:schemas:core:2.0:Group:externalId", Value: "new-id"}
 
-		updated, err := applyReplaceGroup(group, op, cfg)
+		updated, err := applyPatchGroup(group, op, cfg)
 
 		require.NoError(t, err)
 		assert.True(t, updated)
@@ -587,11 +618,92 @@ func TestApplyReplaceGroup(t *testing.T) {
 		group := &v3.Group{}
 		op := patchOp{Op: "replace", Path: "urn:ietf:params:scim:schemas:core:2.0:User:userName", Value: "test"}
 
-		updated, err := applyReplaceGroup(group, op, cfg)
+		updated, err := applyPatchGroup(group, op, cfg)
 
 		require.Error(t, err)
 		assert.False(t, updated)
 		assert.Contains(t, err.Error(), "does not match")
+	})
+
+	t.Run("add externalId", func(t *testing.T) {
+		group := &v3.Group{ExternalID: "old-id"}
+		op := patchOp{Op: "add", Path: "externalId", Value: "new-id"}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.NoError(t, err)
+		assert.True(t, updated)
+		assert.Equal(t, "new-id", group.ExternalID)
+	})
+
+	t.Run("add externalId no-op when value same", func(t *testing.T) {
+		group := &v3.Group{ExternalID: "same-id"}
+		op := patchOp{Op: "add", Path: "externalId", Value: "same-id"}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("add displayName when externalId is group ID", func(t *testing.T) {
+		group := &v3.Group{DisplayName: "Old Name", ExternalID: "ext-123"}
+		op := patchOp{Op: "add", Path: "displayName", Value: "New Name"}
+
+		updated, err := applyPatchGroup(group, op, externalIDCfg)
+
+		require.NoError(t, err)
+		assert.True(t, updated)
+		assert.Equal(t, "New Name", group.DisplayName)
+	})
+
+	t.Run("add rejects displayName change when displayName is group ID", func(t *testing.T) {
+		group := &v3.Group{DisplayName: "Old Name"}
+		op := patchOp{Op: "add", Path: "displayName", Value: "New Name"}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.Error(t, err)
+		assert.False(t, updated)
+		assert.Contains(t, err.Error(), "cannot be changed")
+	})
+
+	t.Run("add bulk", func(t *testing.T) {
+		group := &v3.Group{DisplayName: "Old", ExternalID: "old-id"}
+		op := patchOp{
+			Op:   "add",
+			Path: "",
+			Value: map[string]any{
+				"externalId": "new-id",
+			},
+		}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.NoError(t, err)
+		assert.True(t, updated)
+		assert.Equal(t, "new-id", group.ExternalID)
+	})
+
+	t.Run("URN-prefixed add externalId", func(t *testing.T) {
+		group := &v3.Group{ExternalID: "old-id"}
+		op := patchOp{Op: "add", Path: "urn:ietf:params:scim:schemas:core:2.0:Group:externalId", Value: "new-id"}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.NoError(t, err)
+		assert.True(t, updated)
+		assert.Equal(t, "new-id", group.ExternalID)
+	})
+
+	t.Run("add rejects unsupported path", func(t *testing.T) {
+		group := &v3.Group{}
+		op := patchOp{Op: "add", Path: "unsupported", Value: "value"}
+
+		updated, err := applyPatchGroup(group, op, cfg)
+
+		require.Error(t, err)
+		assert.False(t, updated)
 	})
 }
 
@@ -995,6 +1107,160 @@ func TestPatchGroup(t *testing.T) {
 		err = json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.Equal(t, "new-external-id", resp["externalId"])
+	})
+
+	t.Run("add externalId operation", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			ExternalID:  "old-external-id",
+			Provider:    provider,
+		}
+		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		groupCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		updatedGroup := existingGroup.DeepCopy()
+		updatedGroup.ExternalID = "new-external-id"
+		groupClient := fake.NewMockNonNamespacedClientInterface[*v3.Group, *v3.GroupList](ctrl)
+		groupClient.EXPECT().Update(gomock.Any()).Return(updatedGroup, nil)
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
+
+		srv := &SCIMServer{
+			groups:      groupClient,
+			groupsCache: groupCache,
+			userCache:   userCache,
+			getConfig:   testDefaultGetConfig,
+		}
+
+		payload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":    "Add",
+					"path":  "externalId",
+					"value": "new-external-id",
+				},
+			},
+		}
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
+
+		srv.PatchGroup(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err = json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "new-external-id", resp["externalId"])
+	})
+
+	t.Run("rejects externalId change in externalId mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			ExternalID:  "old-external-id",
+			Provider:    provider,
+		}
+		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		groupCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		srv := &SCIMServer{
+			groupsCache: groupCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{GroupIDAttribute: GroupIDExternalID}
+			},
+		}
+
+		payload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":    "Add",
+					"path":  "externalId",
+					"value": "new-external-id",
+				},
+			},
+		}
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
+
+		srv.PatchGroup(w, r)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		var resp Error
+		err = json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Detail, "cannot be changed")
+		assert.Equal(t, "mutability", resp.ScimType)
+	})
+
+	t.Run("allows externalId no-op in externalId mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			ExternalID:  "same-external-id",
+			Provider:    provider,
+		}
+		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		groupCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
+
+		srv := &SCIMServer{
+			groupsCache: groupCache,
+			userCache:   userCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{GroupIDAttribute: GroupIDExternalID}
+			},
+		}
+
+		payload := map[string]any{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]any{
+				{
+					"op":    "Add",
+					"path":  "externalId",
+					"value": "same-external-id",
+				},
+			},
+		}
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewReader(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
+
+		srv.PatchGroup(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err = json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "same-external-id", resp["externalId"])
 	})
 
 	t.Run("URN-prefixed replace externalId", func(t *testing.T) {
@@ -2419,6 +2685,48 @@ func TestUpdateGroup(t *testing.T) {
 		assert.Equal(t, groupID, resp["id"])
 		assert.Equal(t, "Engineering", resp["displayName"])
 		assert.Equal(t, "new-ext-id", resp["externalId"])
+	})
+
+	t.Run("rejects externalId change with externalId config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		groupID := "grp-abc123"
+		existingGroup := &v3.Group{
+			ObjectMeta:  metav1.ObjectMeta{Name: groupID},
+			DisplayName: "Engineering",
+			ExternalID:  "old-ext-id",
+		}
+
+		groupsCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
+		groupsCache.EXPECT().Get(groupID).Return(existingGroup, nil)
+
+		srv := &SCIMServer{
+			groupsCache: groupsCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{GroupIDAttribute: GroupIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+			"id": "grp-abc123",
+			"displayName": "Engineering",
+			"externalId": "new-ext-id",
+			"members": []
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Groups/"+groupID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", groupID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateGroup(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		var resp Error
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Detail, "cannot be changed")
+		assert.Equal(t, "mutability", resp.ScimType)
 	})
 
 	t.Run("updates displayName with externalId config", func(t *testing.T) {

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -853,13 +853,16 @@ func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op p
 
 		var shouldUpdateAttr, shouldUpdateUser bool
 		for name, value := range fields {
+			if name == "" {
+				return false, false, NewError(http.StatusBadRequest, "empty attribute name in bulk operation")
+			}
 			updateAttr, updateUser, err := applyPatchUser(provider, attr, user, patchOp{
 				Op:    "replace",
 				Path:  name,
 				Value: value,
 			}, cfg)
 			if err != nil {
-				return false, false, fmt.Errorf("failed to apply replace operation: %v", err)
+				return false, false, fmt.Errorf("failed to apply %s operation: %w", op.Op, err)
 			}
 			if updateAttr {
 				shouldUpdateAttr = true

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -594,6 +594,10 @@ func (s *SCIMServer) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		shouldUpdateAttr = true
 	}
 	if externalID := first(attr.ExtraByProvider[provider]["externalid"]); externalID != payload.ExternalID {
+		if cfg.UserIDAttribute == UserIDExternalID {
+			writeError(w, NewError(http.StatusBadRequest, "externalId cannot be changed when it is used as the principal identifier", "mutability"))
+			return
+		}
 		changedExternalID = payload.ExternalID
 		attr.ExtraByProvider[provider]["externalid"] = []string{payload.ExternalID}
 		shouldUpdateAttr = true
@@ -899,16 +903,15 @@ func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op p
 			updateUser = true
 		}
 	case "username":
-		if cfg.UserIDAttribute != UserIDExternalID {
-			return false, false, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier", "mutability")
-		}
-
 		username, ok := op.Value.(string)
 		if !ok {
 			return false, false, NewError(http.StatusBadRequest, fmt.Sprintf("Invalid value for userName: %v", op.Value))
 		}
 
 		if first(attr.ExtraByProvider[provider]["username"]) != username {
+			if cfg.UserIDAttribute != UserIDExternalID {
+				return false, false, NewError(http.StatusBadRequest, "userName cannot be changed when it is used as the principal identifier", "mutability")
+			}
 			attr.ExtraByProvider[provider]["username"] = []string{username}
 			updateAttr = true
 		}
@@ -919,6 +922,9 @@ func applyPatchUser(provider string, attr *v3.UserAttribute, user *v3.User, op p
 		}
 
 		if first(attr.ExtraByProvider[provider]["externalid"]) != externalID {
+			if cfg.UserIDAttribute == UserIDExternalID {
+				return false, false, NewError(http.StatusBadRequest, "externalId cannot be changed when it is used as the principal identifier", "mutability")
+			}
 			attr.ExtraByProvider[provider]["externalid"] = []string{externalID}
 			updateAttr = true
 		}

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -1589,6 +1589,59 @@ func TestUpdateUser(t *testing.T) {
 		assert.Equal(t, "mutability", resp.ScimType)
 	})
 
+	t.Run("rejects externalId change with externalId config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"old-ext-id"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "john.doe",
+			"externalId": "new-ext-id",
+			"active": true
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateUser(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		var resp Error
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Detail, "cannot be changed")
+		assert.Equal(t, "mutability", resp.ScimType)
+	})
+
 	t.Run("deactivates user", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
@@ -2859,6 +2912,149 @@ func TestPatchUser(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.Equal(t, "mutability", resp.ScimType)
+	})
+
+	t.Run("allows userName no-op in default mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username": {"john.doe"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig:          testDefaultGetConfig,
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "replace", "path": "userName", "value": "john.doe"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("rejects externalId change in externalId mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"old-ext-id"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "Add", "path": "externalId", "value": "new-ext-id"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		var resp Error
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Detail, "cannot be changed")
+		assert.Equal(t, "mutability", resp.ScimType)
+	})
+
+	t.Run("allows externalId no-op in externalId mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"same-ext-id"},
+				},
+			},
+		}
+		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
+		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+
+		srv := &SCIMServer{
+			userCache:          userCache,
+			userAttributeCache: userAttributeCache,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations": [{"op": "Add", "path": "externalId", "value": "same-ext-id"}]
+		}`
+		r := httptest.NewRequest(http.MethodPatch, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.PatchUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "same-ext-id", resp["externalId"])
 	})
 
 	t.Run("no update when value unchanged", func(t *testing.T) {

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -42,7 +42,7 @@ func TestBoolUnmarshalJSON(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.input), &b)
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid boolean value")
+				assert.ErrorContains(t, err, "invalid boolean value")
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, bool(b))


### PR DESCRIPTION
## Issue: #54869 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Specifically https://github.com/rancher/rancher/issues/54869#issuecomment-4786477164
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
- Group PATCH only accepted `op:Replace` for `displayName` and `externalId`. Azure AD provisioning emits `op:Add` for `externalId` on existing groups. The PATCH handler rejected it with 400 "Unsupported add path: externalId".
- Mutability guards on principal-identifier attributes were also inconsistent: `userName` was rejected unconditionally when configured as the principal identifier, even for no-op re-asserts.
- `externalId` was silently mutable when it was the principal identifier. A rewrite would orphan existing RBAC bindings.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Group PATCH now accepts `op:Add` for single-valued attributes with the same semantics as `op:Replace` per RFC 7644 3.5.2. The multi-valued `op:Add` for members is unchanged. -- Mutability guards on principal-identifier attributes now trigger only when the value actually changes. Steady-state IdP re-asserts keep returning 200.
- The guards apply symmetrically across `PATCH` and `PUT` for both users and groups.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests