### PR TITLE
Fix inconsistent zypper database on resulting images

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -49,7 +49,6 @@ RUN zypper refresh && \
 
 
 FROM chroot-builder AS chroot-builder-server
-COPY --from=final / /chroot/
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
     git-core unzip sed shadow netcat-openbsd mkisofs && \
@@ -58,7 +57,6 @@ RUN zypper refresh && \
 
 
 FROM chroot-builder AS chroot-builder-agent
-COPY --from=final / /chroot/
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
     jq git-core hostname iproute2 less bash-completion bind-utils acl sysstat && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -42,24 +42,19 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-    curl util-linux ca-certificates ca-certificates-mozilla xz gzip tar gawk vim-small \
-    openssh-clients openssl patterns-base-fips && \
-    zypper --installroot /chroot clean -a && \
-    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+      curl util-linux ca-certificates ca-certificates-mozilla xz gzip tar gawk vim-small openssh-clients openssl patterns-base-fips
 
 
 FROM chroot-builder AS chroot-builder-server
-RUN zypper refresh && \
-    zypper --installroot /chroot -n in --no-recommends \
-    git-core unzip sed shadow netcat-openbsd mkisofs && \
+RUN zypper --installroot /chroot -n in --no-recommends \
+      git-core unzip sed shadow netcat-openbsd mkisofs && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 
 
 FROM chroot-builder AS chroot-builder-agent
-RUN zypper refresh && \
-    zypper --installroot /chroot -n in --no-recommends \
-    jq git-core hostname iproute2 less bash-completion bind-utils acl sysstat && \
+RUN zypper --installroot /chroot -n in --no-recommends \
+      jq git-core hostname iproute2 less bash-completion bind-utils acl sysstat && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 


### PR DESCRIPTION
## Issue: #55567
 
## Problem

While working on #55733 and trying to compare the list of system packages that were finally installed, I noticed something strange, as some of the packages installed in the intermediate stage were not appearing in the definitive images.
It turns out that we are overwriting the state in the intermediate image with the original base, which "merges" both directories (keeping new files, but overriding modified ones), which leads to an inconsistent state.
 
## Solution

Just use the intermediate image as a base, without copying the base image back again into the chroot.
 
## Testing

Differences in the installed packages count (from `zypper --installroot /chroot search -si` on the chroot builder images):
```
 92 before-pkgs-server.txt
131 after-pkgs-server.txt
```
```
 89 before-pkgs-agent.txt
145 after-pkgs-agent.txt
```