### PR TITLE
Replace tini with catatonit

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=final / /chroot/
 # Install some packages with zypper in the chroot of the final micro image
 RUN zypper refresh && \
     zypper --installroot /chroot -n in --no-recommends \
-      curl util-linux ca-certificates ca-certificates-mozilla xz gzip tar gawk vim-small openssh-clients openssl patterns-base-fips
+      catatonit curl util-linux ca-certificates ca-certificates-mozilla xz gzip tar gawk vim-small openssh-clients openssl patterns-base-fips
 
 
 FROM chroot-builder AS chroot-builder-server
@@ -98,29 +98,6 @@ FROM builder AS kdm
 ARG CATTLE_KDM_BRANCH
 RUN mkdir -p /var/lib/rancher-data/driver-metadata && \
     curl -sLf "https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json" > /var/lib/rancher-data/driver-metadata/data.json
-
-
-FROM builder AS tini
-ARG ARCH
-ENV TINI_VERSION=v0.18.0
-ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
-    TINI_CHECKSUM_amd64=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855 \
-    TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
-    TINI_CHECKSUM_arm64=7c5463f55393985ee22357d976758aaaecd08defb3c5294d353732018169b019 \
-    TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
-    TINI_CHECKSUM_s390x=c8aaa618ea7897f26979ea10920373e06f3e6dfeb41ef95342eda2eb5672f24d
-
-RUN case "${ARCH}" in \
-        amd64) TINI_URL="${TINI_URL_amd64}"; TINI_CHECKSUM="${TINI_CHECKSUM_amd64}" ;; \
-        arm64) TINI_URL="${TINI_URL_arm64}"; TINI_CHECKSUM="${TINI_CHECKSUM_arm64}" ;; \
-        s390x) TINI_URL="${TINI_URL_s390x}"; TINI_CHECKSUM="${TINI_CHECKSUM_s390x}" ;; \
-        *) echo "Unsupported: ${ARCH}"; exit 1 ;; \
-    esac && \
-    curl -sLf "${TINI_URL}" > /usr/bin/tini && \
-    printf "%s  %s\n" "${TINI_CHECKSUM}" "/usr/bin/tini" > tini.sha256 && \
-    sha256sum -c tini.sha256 && \
-    rm tini.sha256 && \
-    chmod +x /usr/bin/tini
 
 
 # Main stage using bci-micro as the base image
@@ -332,8 +309,6 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
     ln -s /usr/bin/iptables-detect.sh /usr/bin/iptables-save && \
     ln -s /usr/bin/xtables-nft-multi /usr/bin/iptables-translate && \
     ln -s /usr/bin/xtables-nft-multi /usr/bin/xtables-monitor
-
-COPY --from=tini /usr/bin/tini /usr/bin/tini
 
 RUN mkdir -p /var/lib/rancher/k3s/agent/images/ && \
     case "${ARCH}" in \
@@ -595,7 +570,6 @@ COPY --from=rancher-charts /var/lib/rancher-data/local-catalogs/v2/rancher-chart
 COPY --from=partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974 /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974
 COPY --from=rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9
 COPY --from=kdm /var/lib/rancher-data/driver-metadata/data.json /var/lib/rancher-data/driver-metadata/data.json
-COPY --from=tini /usr/bin/tini /usr/bin/
 COPY --from=agent-build /app/agent /usr/bin/
 COPY package/loglevel package/run.sh /usr/bin/
 WORKDIR /var/lib/rancher

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -54,4 +54,4 @@ fi
 if [ -x "$(command -v c_rehash)" ]; then
   c_rehash
 fi
-exec tini -- rancher --http-listen-port=80 --https-listen-port=443 --audit-log-path=${AUDIT_LOG_PATH} --audit-level=${AUDIT_LEVEL} --audit-log-maxage=${AUDIT_LOG_MAXAGE} --audit-log-maxbackup=${AUDIT_LOG_MAXBACKUP} --audit-log-maxsize=${AUDIT_LOG_MAXSIZE} "${@}"
+exec catatonit -- rancher --http-listen-port=80 --https-listen-port=443 --audit-log-path=${AUDIT_LOG_PATH} --audit-level=${AUDIT_LEVEL} --audit-log-maxage=${AUDIT_LOG_MAXAGE} --audit-log-maxbackup=${AUDIT_LOG_MAXBACKUP} --audit-log-maxsize=${AUDIT_LOG_MAXSIZE} "${@}"

--- a/package/run.sh
+++ b/package/run.sh
@@ -256,5 +256,5 @@ if [ -n "$CATTLE_CA_CHECKSUM" ]; then
     fi
 fi
 
-exec tini -- agent
+exec catatonit -- agent
 


### PR DESCRIPTION
## Issue: #55567

Depends on #55787
 
## Problem

`tini` is installed from a externally compiled binary.
 
## Solution

Use a [SUSE originated](https://github.com/openSUSE/catatonit) alternative as `catatonit`, which is available via zypper directly.
Note: The dynamically-linked `tini` version we were using was only 24KB, while `catatonit` is statically compiled and could be ~500KB. However, this size difference is negligible considering the current Rancher images' size.
