### PR TITLE
[main] Autoscaler HelmOp Secret Improvements

### DIFF
--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -91,37 +91,14 @@ func GetPrivateRegistry(importedOrHostedCluster *v3.Cluster) (registry *PrivateR
 	if clr := GetImportedPrivateClusterLevelRegistry(importedOrHostedCluster); clr != nil {
 		return clr, false
 	}
-	return getDefaultRegistryConfiguration("", ""), true
-}
-
-func getDefaultRegistryConfiguration(registryURL, pullSecretNames string) *PrivateRegistry {
+	registryURL := settings.SystemDefaultRegistry.Get()
 	if registryURL == "" {
-		registryURL = settings.SystemDefaultRegistry.Get()
+		return nil, false
 	}
-	if registryURL == "" {
-		return nil
-	}
-
-	if pullSecretNames == "" {
-		pullSecretNames = settings.SystemDefaultRegistryPullSecrets.Get()
-	}
-
-	var globalSecrets []kcorev1.SecretReference
-	for _, pullSecret := range strings.Split(pullSecretNames, ",") {
-		pullSecret = strings.TrimSpace(pullSecret)
-		if pullSecret == "" {
-			continue
-		}
-		globalSecrets = append(globalSecrets, kcorev1.SecretReference{
-			Namespace: namespaces.System,
-			Name:      pullSecret,
-		})
-	}
-
 	return &PrivateRegistry{
 		URL:         registryURL,
-		PullSecrets: globalSecrets,
-	}
+		PullSecrets: GlobalPullSecretRefs(),
+	}, true
 }
 
 // GetImportedPrivateClusterLevelRegistry returns the cluster-level registry for the given clusters.management.cattle.io/v3
@@ -199,6 +176,22 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 
 	// no registry configured
 	return "", nil, nil
+}
+
+// GlobalPullSecretRefs returns the secret references parsed from the SystemDefaultRegistryPullSecrets
+// setting.
+func GlobalPullSecretRefs() []kcorev1.SecretReference {
+	var refs []kcorev1.SecretReference
+	for _, psName := range strings.Split(settings.SystemDefaultRegistryPullSecrets.Get(), ",") {
+		psName = strings.TrimSpace(psName)
+		if psName != "" {
+			refs = append(refs, kcorev1.SecretReference{
+				Namespace: namespaces.System,
+				Name:      psName,
+			})
+		}
+	}
+	return refs
 }
 
 // GeneratePullSecretName accepts an image pull secret name and returns a new name that

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -343,7 +343,7 @@ func TestGetPrivateRegistry(t *testing.T) {
 			name:              "nil cluster, no GSDR",
 			cluster:           nil,
 			expectedRegistry:  nil,
-			expectedIsDefault: true,
+			expectedIsDefault: false,
 		},
 		{
 			name:              "nil cluster, GSDR set",
@@ -479,7 +479,7 @@ func TestGetPrivateRegistry(t *testing.T) {
 				Spec: v3.ClusterSpec{},
 			},
 			expectedRegistry:  nil,
-			expectedIsDefault: true,
+			expectedIsDefault: false,
 		},
 	}
 
@@ -583,6 +583,60 @@ func TestPrivateRegistryPullSecretNamesAsSlice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.expected, tt.registry.PullSecretNamesAsSlice())
+		})
+	}
+}
+
+// TestGlobalPullSecretRefs tests that GlobalPullSecretRefs correctly parses the
+// SystemDefaultRegistryPullSecrets setting without requiring SystemDefaultRegistry to be set.
+func TestGlobalPullSecretRefs(t *testing.T) {
+	tests := []struct {
+		name     string
+		setting  string
+		expected []corev1.SecretReference
+	}{
+		{
+			name:     "empty setting returns nil",
+			setting:  "",
+			expected: nil,
+		},
+		{
+			name:    "single secret name",
+			setting: "my-secret",
+			expected: []corev1.SecretReference{
+				{Namespace: namespaces.System, Name: "my-secret"},
+			},
+		},
+		{
+			name:    "multiple secret names",
+			setting: "secret-a,secret-b,secret-c",
+			expected: []corev1.SecretReference{
+				{Namespace: namespaces.System, Name: "secret-a"},
+				{Namespace: namespaces.System, Name: "secret-b"},
+				{Namespace: namespaces.System, Name: "secret-c"},
+			},
+		},
+		{
+			name:    "whitespace around names is trimmed",
+			setting: " secret-a , secret-b ",
+			expected: []corev1.SecretReference{
+				{Namespace: namespaces.System, Name: "secret-a"},
+				{Namespace: namespaces.System, Name: "secret-b"},
+			},
+		},
+		{
+			name:     "only whitespace and commas returns nil",
+			setting:  " , , ",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, settings.SystemDefaultRegistryPullSecrets.Set(tt.setting))
+			t.Cleanup(func() { settings.SystemDefaultRegistryPullSecrets.Set("") })
+
+			assert.Equal(t, tt.expected, GlobalPullSecretRefs())
 		})
 	}
 }

--- a/pkg/controllers/capr/autoscaler/autoscaler_test.go
+++ b/pkg/controllers/capr/autoscaler/autoscaler_test.go
@@ -10,6 +10,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	"github.com/stretchr/testify/suite"
@@ -114,6 +115,11 @@ func (s *autoscalerSuite) SetupTest() {
 	s.client = &mockControllerRuntimeClient{}
 	s.context = context.Background()
 
+	s.withSettings(map[settings.Setting]string{
+		settings.SystemDefaultRegistry:            "",
+		settings.SystemDefaultRegistryPullSecrets: "",
+	})
+
 	s.h = &autoscalerHandler{
 		capiClusterCache:           s.capiClusterCache,
 		capiMachineCache:           s.capiMachineCache,
@@ -136,6 +142,22 @@ func (s *autoscalerSuite) SetupTest() {
 		client:                     s.client,
 		context:                    s.context,
 	}
+}
+
+func (s *autoscalerSuite) withSettings(values map[settings.Setting]string) {
+	s.T().Helper()
+
+	oldValues := make(map[settings.Setting]string)
+	for setting, v := range values {
+		oldValues[setting] = setting.Get()
+		s.NoError(setting.Set(v))
+	}
+
+	s.T().Cleanup(func() {
+		for setting, value := range oldValues {
+			s.NoError(setting.Set(value))
+		}
+	})
 }
 
 func (s *autoscalerSuite) TearDownTest() {

--- a/pkg/controllers/capr/autoscaler/fleet_test.go
+++ b/pkg/controllers/capr/autoscaler/fleet_test.go
@@ -176,7 +176,7 @@ func (s *autoscalerSuite) expectManageHelmOpSecrets(clusterName, clusterNamespac
 
 	notFound := errors.NewNotFound(schema.GroupResource{}, "")
 	// cleanupClusterScopedSecrets
-	s.secretClient.EXPECT().Delete(clusterNamespace, helmOpSecretName(clusterName, clusterNamespace), gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete(clusterNamespace, helmOpSecretName(clusterName), gomock.Any()).Return(notFound)
 	s.secretClient.EXPECT().Delete(clusterNamespace, autoscalerClusterScopedImagePullSecretName(clusterName), gomock.Any()).Return(notFound)
 	// ensureRootHelmOpSecrets — no global registry → attempt to delete both root secrets
 	s.secretClient.EXPECT().Delete("fleet-default", autoscalerHelmSecretResourceName, gomock.Any()).Return(notFound)
@@ -472,7 +472,7 @@ func (s *autoscalerSuite) TestCleanupFleet_HappyPath_CleansClusterScopedSecrets(
 	// HelmOp does not exist, so only cluster-scoped secret cleanup should run.
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, notFound)
 	s.clusterCache.EXPECT().Get(cluster.Namespace, cluster.Name).Return(provCluster, nil)
-	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name, cluster.Namespace), gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name), gomock.Any()).Return(notFound)
 	s.secretClient.EXPECT().Delete(provCluster.Namespace, autoscalerClusterScopedImagePullSecretName(provCluster.Name), gomock.Any()).Return(notFound)
 
 	err := s.h.cleanupFleet(cluster)
@@ -544,7 +544,7 @@ func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToCleanupClusterScopedSec
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, errors.NewNotFound(schema.GroupResource{}, "helmop"))
 	s.clusterCache.EXPECT().Get(cluster.Namespace, cluster.Name).Return(provCluster, nil)
-	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name, cluster.Namespace), gomock.Any()).Return(cleanupError)
+	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name), gomock.Any()).Return(cleanupError)
 
 	err := s.h.cleanupFleet(cluster)
 	s.Error(err, "Expected error when cluster-scoped secret cleanup fails")
@@ -568,7 +568,7 @@ func (s *autoscalerSuite) TestCleanupFleet_Error_FailedToDeleteClusterScopedImag
 
 	s.expectHelmOpGet(cluster.Namespace, helmOpName, nil, notFound)
 	s.clusterCache.EXPECT().Get(cluster.Namespace, cluster.Name).Return(provCluster, nil)
-	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name, cluster.Namespace), gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete(cluster.Namespace, helmOpSecretName(cluster.Name), gomock.Any()).Return(notFound)
 	s.secretClient.EXPECT().Delete(provCluster.Namespace, autoscalerClusterScopedImagePullSecretName(provCluster.Name), gomock.Any()).Return(cleanupError)
 
 	err := s.h.cleanupFleet(cluster)

--- a/pkg/controllers/capr/autoscaler/fleet_test.go
+++ b/pkg/controllers/capr/autoscaler/fleet_test.go
@@ -10,6 +10,7 @@ import (
 	rke "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/settings"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -599,6 +600,61 @@ func (s *autoscalerSuite) TestCleanupFleet_EdgeCase_ClusterWithEmptyNamespace() 
 
 	err := s.h.cleanupFleet(cluster)
 	s.NoError(err, "Expected no error when cluster has empty namespace")
+}
+
+func (s *autoscalerSuite) TestManageHelmOpSecrets_GSDREqualsChartHost_ClusterHasOwnSDR() {
+	const (
+		chartHost      = "charts.example.com"
+		chartRepo      = "https://charts.example.com/helm/charts"
+		pullSecretName = "autoscaler-pull-secret"
+		clusterName    = "test-cluster"
+		clusterNS      = "fleet-default"
+	)
+
+	s.withSettings(map[settings.Setting]string{
+		settings.ClusterAutoscalerChartRepository: chartRepo,
+		settings.SystemDefaultRegistry:            chartHost,
+		settings.SystemDefaultRegistryPullSecrets: pullSecretName,
+	})
+
+	provCluster := &provv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterNS},
+	}
+	capiCluster := &capi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterNS},
+	}
+	s.clusterCache.EXPECT().Get(clusterNS, clusterName).Return(provCluster, nil)
+
+	notFound := errors.NewNotFound(schema.GroupResource{}, "")
+
+	s.secretClient.EXPECT().Delete(clusterNS, helmOpSecretName(clusterName), gomock.Any()).Return(notFound)
+	s.secretClient.EXPECT().Delete(clusterNS, autoscalerClusterScopedImagePullSecretName(clusterName), gomock.Any()).Return(notFound)
+
+	pullSecretData, err := dockerConfigSecretData(chartHost, "user", "pass")
+	s.Require().NoError(err)
+	globalPullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: pullSecretName, Namespace: "cattle-system"},
+		Type:       corev1.SecretTypeDockerConfigJson,
+		Data:       pullSecretData,
+	}
+	s.secretCache.EXPECT().Get("cattle-system", pullSecretName).Return(globalPullSecret, nil)
+
+	s.secretCache.EXPECT().Get("fleet-default", autoscalerHelmSecretResourceName).Return(nil, notFound)
+	s.secretClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(sec *corev1.Secret) (*corev1.Secret, error) {
+		return sec, nil
+	})
+
+	s.secretCache.EXPECT().Get("fleet-default", autoscalerChartImagePullSecretName).Return(nil, notFound)
+	s.secretClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(sec *corev1.Secret) (*corev1.Secret, error) {
+		return sec, nil
+	})
+
+	helmOpSec, imagePullSec, err := s.h.manageHelmOpSecrets(capiCluster)
+	s.NoError(err)
+	s.Equal(autoscalerHelmSecretResourceName, helmOpSec)
+	s.Equal(autoscalerChartImagePullSecretName, imagePullSec,
+		"root image pull secret must be propagated even when GSDR equals the autoscaler chart host, "+
+			"because clusters with their own SDR do not get GSDR credentials in their containerd config")
 }
 
 func (s *autoscalerSuite) TestCleanupFleet_EdgeCase_ClusterWithSpecialCharacters() {

--- a/pkg/controllers/capr/autoscaler/secrets.go
+++ b/pkg/controllers/capr/autoscaler/secrets.go
@@ -76,10 +76,11 @@ func (h *autoscalerHandler) ensureRootHelmOpSecrets() (string, string, error) {
 		return "", "", err
 	}
 
-	// Only create the global image pull secret if the chart repository host does not match the global system default registry.
-	// If the chart is coming from the GSDR, then the pull secrets will have already been configured by CAPR and a global copy is not needed.
+	// Only skip the global image pull secret when the chart repository host exactly matches the GSDR URL.
+	// In that case CAPR already provisions those credentials to all clusters, so no separate secret is needed.
+	// When the GSDR is not configured (registry == nil), we still need to create the image pull secret.
 	registry, _ := cluster.GetPrivateRegistry(nil)
-	if registry == nil || registry.URL == autoScalerChartRepositoryHost() {
+	if registry != nil && registry.URL == autoScalerChartRepositoryHost() {
 		if err := h.deleteSecretIfExists("fleet-default", autoscalerChartImagePullSecretName); err != nil {
 			return "", "", err
 		}
@@ -99,7 +100,7 @@ func (h *autoscalerHandler) ensureRootHelmOpSecrets() (string, string, error) {
 // This is called when a cluster transitions back to the global-default registry, to avoid
 // leaving orphaned secrets behind in the cluster's namespace.
 func (h *autoscalerHandler) cleanupClusterScopedSecrets(provCluster *provv1.Cluster, capiCluster *capi.Cluster) error {
-	if err := h.deleteSecretIfExists(capiCluster.Namespace, helmOpSecretName(capiCluster.Name, capiCluster.Namespace)); err != nil {
+	if err := h.deleteSecretIfExists(capiCluster.Namespace, helmOpSecretName(capiCluster.Name)); err != nil {
 		return err
 	}
 	return h.deleteSecretIfExists(provCluster.Namespace, autoscalerClusterScopedImagePullSecretName(provCluster.Name))
@@ -113,7 +114,7 @@ func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provClust
 		return "", err
 	}
 
-	s, err := h.upsertSecret(capiCluster.Namespace, helmOpSecretName(capiCluster.Name, capiCluster.Namespace), "", basicAuthSecretData(username, password), ownerReference(capiCluster))
+	s, err := h.upsertSecret(capiCluster.Namespace, helmOpSecretName(capiCluster.Name), "", basicAuthSecretData(username, password), ownerReference(capiCluster))
 	if err != nil {
 		return "", err
 	}
@@ -204,13 +205,17 @@ func (h *autoscalerHandler) upsertSecret(namespace, secretName string, secretTyp
 
 // findGlobalClusterAutoScalerHostnameCreds iterates over globally configured pull secrets and
 // returns the first username/password pair that covers the autoscaler chart repository host.
+// When the global system default registry URL is not set, it falls back to searching the
+// SystemDefaultRegistryPullSecrets directly, since those secrets may still contain credentials
+// for the autoscaler chart repository even without a GSDR URL configured.
 // Returns empty strings (no error) when no matching credentials are found.
 func (h *autoscalerHandler) findGlobalClusterAutoScalerHostnameCreds() (string, string, error) {
 	registry, _ := cluster.GetPrivateRegistry(nil)
-	if registry == nil {
-		return "", "", nil
+	pullSecrets := cluster.GlobalPullSecretRefs()
+	if registry != nil {
+		pullSecrets = registry.PullSecrets
 	}
-	for _, ps := range registry.PullSecrets {
+	for _, ps := range pullSecrets {
 		sec, err := h.secretCache.Get(ps.Namespace, ps.Name)
 		if apierrors.IsNotFound(err) {
 			continue

--- a/pkg/controllers/capr/autoscaler/secrets.go
+++ b/pkg/controllers/capr/autoscaler/secrets.go
@@ -22,27 +22,33 @@ func (h *autoscalerHandler) manageHelmOpSecrets(capiCluster *capi.Cluster) (helm
 		return "", "", err
 	}
 
-	// If the cluster has no per-cluster auth secret for the chart host, fall back to the
-	// globally configured pull secrets and clean up any cluster-scoped secrets that may
-	// have been left behind from a previous cluster-level configuration.
-	if image.GetRegistryAuthSecretForHostname(provCluster, autoScalerChartRepositoryHost()) == "" {
-		if err := h.cleanupClusterScopedSecrets(provCluster, capiCluster); err != nil {
+	// A cluster may have one or more Registries.Configs entries for containerd purposes
+	// (TLS, mirrors), but does not cover the registry used for the autoscaler chart/image.
+	// In this case, the global credentials should be used. When the cluster _does_ have valid
+	// credentials for the chart host, the cluster-scoped secrets are used.
+	if image.GetRegistryAuthSecretForHostname(provCluster, autoScalerChartRepositoryHost()) != "" {
+		username, password, err := h.findClusterLevelAutoScalerHostnameCreds(provCluster)
+		if err != nil && !errors.Is(err, cluster.ErrRegistryHostnameNotFound) {
 			return "", "", err
 		}
-		return h.ensureRootHelmOpSecrets()
+		if username != "" && password != "" {
+			helmOpSecretName, err = h.ensureClusterScopedHelmOpSecretInNamespace(provCluster, capiCluster, username, password)
+			if err != nil {
+				return "", "", err
+			}
+			imagePullSecretName, err = h.ensureClusterScopedImagePullSecretInNamespace(provCluster, capiCluster, username, password)
+			if err != nil {
+				return "", "", err
+			}
+			return helmOpSecretName, imagePullSecretName, nil
+		}
 	}
 
-	helmOpSecretName, err = h.ensureClusterScopedHelmOpSecretInNamespace(provCluster, capiCluster)
-	if err != nil {
+	if err := h.cleanupClusterScopedSecrets(provCluster, capiCluster); err != nil {
 		return "", "", err
 	}
 
-	imagePullSecretName, err = h.ensureClusterScopedImagePullSecretInNamespace(provCluster, capiCluster)
-	if err != nil {
-		return "", "", err
-	}
-
-	return helmOpSecretName, imagePullSecretName, nil
+	return h.ensureRootHelmOpSecrets()
 }
 
 // ensureRootHelmOpSecrets manages the shared Helm basic-auth secret and dockerconfigjson image
@@ -76,17 +82,6 @@ func (h *autoscalerHandler) ensureRootHelmOpSecrets() (string, string, error) {
 		return "", "", err
 	}
 
-	// Only skip the global image pull secret when the chart repository host exactly matches the GSDR URL.
-	// In that case CAPR already provisions those credentials to all clusters, so no separate secret is needed.
-	// When the GSDR is not configured (registry == nil), we still need to create the image pull secret.
-	registry, _ := cluster.GetPrivateRegistry(nil)
-	if registry != nil && registry.URL == autoScalerChartRepositoryHost() {
-		if err := h.deleteSecretIfExists("fleet-default", autoscalerChartImagePullSecretName); err != nil {
-			return "", "", err
-		}
-		return helmOpSecret.Name, "", nil
-	}
-
 	pullSecret, err := h.upsertSecret("fleet-default", autoscalerChartImagePullSecretName, v1.SecretTypeDockerConfigJson, dockerConfigData, nil)
 	if err != nil {
 		return "", "", err
@@ -107,13 +102,9 @@ func (h *autoscalerHandler) cleanupClusterScopedSecrets(provCluster *provv1.Clus
 }
 
 // ensureClusterScopedHelmOpSecretInNamespace creates or updates a basic-auth Helm secret in the
-// provisioning cluster's namespace using the cluster-level autoscaler chart credentials.
-func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provCluster *provv1.Cluster, capiCluster *capi.Cluster) (string, error) {
-	username, password, err := h.findClusterLevelAutoScalerHostnameCreds(provCluster)
-	if err != nil {
-		return "", err
-	}
-
+// CAPI cluster's namespace using pre-fetched cluster-level autoscaler chart credentials.
+// Credentials are resolved once in manageHelmOpSecrets to avoid redundant secret cache reads.
+func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provCluster *provv1.Cluster, capiCluster *capi.Cluster, username, password string) (string, error) {
 	s, err := h.upsertSecret(capiCluster.Namespace, helmOpSecretName(capiCluster.Name), "", basicAuthSecretData(username, password), ownerReference(capiCluster))
 	if err != nil {
 		return "", err
@@ -125,16 +116,11 @@ func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provClust
 // secret in the provisioning cluster's namespace for pulling the autoscaler chart image.
 // If the chart host matches the cluster's system default registry, no secret is created because
 // credentials are already configured at provisioning time.
-func (h *autoscalerHandler) ensureClusterScopedImagePullSecretInNamespace(provCluster *provv1.Cluster, capiCluster *capi.Cluster) (string, error) {
+func (h *autoscalerHandler) ensureClusterScopedImagePullSecretInNamespace(provCluster *provv1.Cluster, capiCluster *capi.Cluster, username, password string) (string, error) {
 	chartHost := autoScalerChartRepositoryHost()
 	sdrURL, _ := image.GetPrivateRepoURLFromCluster(provCluster)
 	if chartHost == sdrURL {
 		return "", nil
-	}
-
-	username, password, err := h.findClusterLevelAutoScalerHostnameCreds(provCluster)
-	if err != nil {
-		return "", err
 	}
 
 	dockerConfigData, err := dockerConfigSecretData(chartHost, username, password)
@@ -217,9 +203,10 @@ func (h *autoscalerHandler) findGlobalClusterAutoScalerHostnameCreds() (string, 
 	}
 	for _, ps := range pullSecrets {
 		sec, err := h.secretCache.Get(ps.Namespace, ps.Name)
-		if apierrors.IsNotFound(err) {
-			continue
-		} else if err != nil {
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			return "", "", err
 		}
 		username, password, err := cluster.ExtractUsernamePasswordFromPullSecret(autoScalerChartRepositoryHost(), sec)

--- a/pkg/controllers/capr/autoscaler/secrets.go
+++ b/pkg/controllers/capr/autoscaler/secrets.go
@@ -32,7 +32,7 @@ func (h *autoscalerHandler) manageHelmOpSecrets(capiCluster *capi.Cluster) (helm
 			return "", "", err
 		}
 		if username != "" && password != "" {
-			helmOpSecretName, err = h.ensureClusterScopedHelmOpSecretInNamespace(provCluster, capiCluster, username, password)
+			helmOpSecretName, err = h.ensureClusterScopedHelmOpSecretInNamespace(capiCluster, username, password)
 			if err != nil {
 				return "", "", err
 			}
@@ -104,7 +104,7 @@ func (h *autoscalerHandler) cleanupClusterScopedSecrets(provCluster *provv1.Clus
 // ensureClusterScopedHelmOpSecretInNamespace creates or updates a basic-auth Helm secret in the
 // CAPI cluster's namespace using pre-fetched cluster-level autoscaler chart credentials.
 // Credentials are resolved once in manageHelmOpSecrets to avoid redundant secret cache reads.
-func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(provCluster *provv1.Cluster, capiCluster *capi.Cluster, username, password string) (string, error) {
+func (h *autoscalerHandler) ensureClusterScopedHelmOpSecretInNamespace(capiCluster *capi.Cluster, username, password string) (string, error) {
 	s, err := h.upsertSecret(capiCluster.Namespace, helmOpSecretName(capiCluster.Name), "", basicAuthSecretData(username, password), ownerReference(capiCluster))
 	if err != nil {
 		return "", err

--- a/pkg/controllers/capr/autoscaler/token_rotation_test.go
+++ b/pkg/controllers/capr/autoscaler/token_rotation_test.go
@@ -908,7 +908,7 @@ func (s *autoscalerSuite) TestCheckAndRenewTokens_MultipleTokensOnlyOneNotExpiri
 		&provv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster-1", Namespace: "default"}}, nil,
 	).Times(2)
 	notFound := errors.NewNotFound(schema.GroupResource{}, "")
-	s.secretClient.EXPECT().Delete("default", helmOpSecretName("cluster-1", "default"), gomock.Any()).Return(notFound).Times(2)
+	s.secretClient.EXPECT().Delete("default", helmOpSecretName("cluster-1"), gomock.Any()).Return(notFound).Times(2)
 	s.secretClient.EXPECT().Delete("default", autoscalerClusterScopedImagePullSecretName("cluster-1"), gomock.Any()).Return(notFound).Times(2)
 	s.secretClient.EXPECT().Delete("fleet-default", autoscalerHelmSecretResourceName, gomock.Any()).Return(notFound).Times(2)
 	s.secretClient.EXPECT().Delete("fleet-default", autoscalerChartImagePullSecretName, gomock.Any()).Return(notFound).Times(2)

--- a/pkg/controllers/capr/autoscaler/util.go
+++ b/pkg/controllers/capr/autoscaler/util.go
@@ -22,10 +22,7 @@ const (
 	autoscalerChartImagePullSecretName = "autoscaler-chart-image-pull-secret"
 )
 
-func helmOpSecretName(clusterName, clusterNamespace string) string {
-	if clusterNamespace == "fleet-default" {
-		return autoscalerHelmSecretResourceName
-	}
+func helmOpSecretName(clusterName string) string {
 	return name.SafeConcatName(autoscalerHelmSecretResourceName, clusterName)
 }
 

--- a/pkg/controllers/capr/autoscaler/util_test.go
+++ b/pkg/controllers/capr/autoscaler/util_test.go
@@ -288,38 +288,6 @@ func TestHelmOpName(t *testing.T) {
 	}
 }
 
-func TestHelmOpSecretName(t *testing.T) {
-	tests := []struct {
-		name        string
-		clusterName string
-		expected    string
-	}{
-		{
-			name:        "regular cluster",
-			clusterName: "my-cluster",
-			expected:    "autoscaler-helm-secret-my-cluster",
-		},
-		{
-			name:        "v2prov cluster in fleet-default namespace",
-			clusterName: "fleet-default-cluster",
-			expected:    "autoscaler-helm-secret-fleet-default-cluster",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := helmOpSecretName(tt.clusterName)
-			if result != tt.expected {
-				t.Errorf("helmOpSecretName() = %q, want %q", result, tt.expected)
-			}
-			// The result must never equal the global root secret name.
-			if result == autoscalerHelmSecretResourceName {
-				t.Errorf("helmOpSecretName() returned the global root secret name %q, which would cause cluster-level credentials to overwrite the shared secret", result)
-			}
-		})
-	}
-}
-
 func TestAutoScalerChartRepositoryHost(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/controllers/capr/autoscaler/util_test.go
+++ b/pkg/controllers/capr/autoscaler/util_test.go
@@ -288,6 +288,38 @@ func TestHelmOpName(t *testing.T) {
 	}
 }
 
+func TestHelmOpSecretName(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		expected    string
+	}{
+		{
+			name:        "regular cluster",
+			clusterName: "my-cluster",
+			expected:    "autoscaler-helm-secret-my-cluster",
+		},
+		{
+			name:        "v2prov cluster in fleet-default namespace",
+			clusterName: "fleet-default-cluster",
+			expected:    "autoscaler-helm-secret-fleet-default-cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := helmOpSecretName(tt.clusterName)
+			if result != tt.expected {
+				t.Errorf("helmOpSecretName() = %q, want %q", result, tt.expected)
+			}
+			// The result must never equal the global root secret name.
+			if result == autoscalerHelmSecretResourceName {
+				t.Errorf("helmOpSecretName() returned the global root secret name %q, which would cause cluster-level credentials to overwrite the shared secret", result)
+			}
+		})
+	}
+}
+
 func TestAutoScalerChartRepositoryHost(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/controllers/dashboard/privateregistry/controller_test.go
+++ b/pkg/controllers/dashboard/privateregistry/controller_test.go
@@ -58,16 +58,24 @@ func systemProject(clusterName, projectName string, extraLabels map[string]strin
 	}
 }
 
-func withSettings(t *testing.T, registryURL, pullSecrets string) {
+func withSettings(t *testing.T, values map[settings.Setting]string) {
 	t.Helper()
-	origRegistry := settings.SystemDefaultRegistry.Get()
-	origPullSecrets := settings.SystemDefaultRegistryPullSecrets.Get()
+	oldValues := make(map[settings.Setting]string)
+	for setting, v := range values {
+		oldValues[setting] = setting.Get()
+		if err := setting.Set(v); err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+	}
 	t.Cleanup(func() {
-		settings.SystemDefaultRegistry.Set(origRegistry)
-		settings.SystemDefaultRegistryPullSecrets.Set(origPullSecrets)
+		for setting, value := range oldValues {
+			if err := setting.Set(value); err != nil {
+				t.Error(err)
+				t.FailNow()
+			}
+		}
 	})
-	settings.SystemDefaultRegistry.Set(registryURL)
-	settings.SystemDefaultRegistryPullSecrets.Set(pullSecrets)
 }
 
 func Test_handler_labelSystemProject(t *testing.T) {
@@ -264,7 +272,11 @@ func Test_handler_labelSystemProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			withSettings(t, map[settings.Setting]string{
+				settings.SystemDefaultRegistry:            tt.registryURL,
+				settings.SystemDefaultRegistryPullSecrets: tt.pullSecrets,
+			})
 
 			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
 			if tt.setupProjectCache != nil {
@@ -544,7 +556,10 @@ func Test_handler_labelSourceGlobalRegistryPullSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			withSettings(t, tt.registryURL, tt.pullSecrets)
+			withSettings(t, map[settings.Setting]string{
+				settings.SystemDefaultRegistry:            tt.registryURL,
+				settings.SystemDefaultRegistryPullSecrets: tt.pullSecrets,
+			})
 
 			secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
 			if tt.setupSecretCache != nil {
@@ -1359,7 +1374,11 @@ func Test_handler_manageClusterSpecificPSS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			withSettings(t, map[settings.Setting]string{
+				settings.SystemDefaultRegistry:            tt.registryURL,
+				settings.SystemDefaultRegistryPullSecrets: tt.pullSecrets,
+			})
 
 			projectCache := fake.NewMockCacheInterface[*v3.Project](ctrl)
 			if tt.setupProjectCache != nil {
@@ -1604,7 +1623,10 @@ func Test_handler_labelSourceGlobalRegistryPullSecretOnChange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			withSettings(t, tt.registryURL, tt.pullSecrets)
+			withSettings(t, map[settings.Setting]string{
+				settings.SystemDefaultRegistry:            tt.registryURL,
+				settings.SystemDefaultRegistryPullSecrets: tt.pullSecrets,
+			})
 
 			secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
 			if tt.setupSecretClient != nil {
@@ -1741,6 +1763,11 @@ func Test_findV3ClustersUsingGlobalPullSecrets(t *testing.T) {
 			},
 		}
 	}
+
+	withSettings(t, map[settings.Setting]string{
+		settings.SystemDefaultRegistry:            "a-global-registry",
+		settings.SystemDefaultRegistryPullSecrets: "",
+	})
 
 	tests := []struct {
 		name       string
@@ -1925,7 +1952,11 @@ func Test_handler_syncClusterOnGlobalPullSecretChange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			withSettings(t, tt.registryURL, tt.pullSecrets)
+
+			withSettings(t, map[settings.Setting]string{
+				settings.SystemDefaultRegistry:            tt.registryURL,
+				settings.SystemDefaultRegistryPullSecrets: tt.pullSecrets,
+			})
 
 			clusterCache := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](ctrl)
 			if tt.setupCache != nil {
@@ -1952,6 +1983,11 @@ func Test_handler_syncClusterOnGlobalPullSecretChange(t *testing.T) {
 func Test_handler_syncClusterOnGlobalRegistrySettingChange(t *testing.T) {
 	importedCluster := &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-abcde"}}
 	localCluster := &v3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "local"}}
+
+	withSettings(t, map[settings.Setting]string{
+		settings.SystemDefaultRegistry:            "a-private-registry",
+		settings.SystemDefaultRegistryPullSecrets: "",
+	})
 
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/54180, https://github.com/rancher/rancher/issues/55537
 
## Problem

The initial implementation of authenticated registry support for the cluster autoscaler incorrectly handles cluster level configurations for the autoscaler chart registry. The default HelmOp secret created in the `fleet-default` namespace can be incorrectly modified if a downstream cluster defines cluster level credentials for the registry host specified in the `cluster-autoscaler-chart-repository` setting. This has the potential to impact the secret delivered to other downstream clusters which should utilize the global default (as they do not redefine credentials at the cluster level).


## Solution
Ensure that the cluster level registry information does not impact the "Root" HelmOp secret which is derived from the global settings.

This PR also makes a minor change to _when_ the "Root" HelmOp and image pull secrets are generated. Previously, they would only be generated if the `system-default-registry` global setting was defined. However, this prevents potential configurations wherein only the autoscaler chart and image should come from a private registry, but other system-charts should not. Now, both secrets will be created so long as a pull secret is defined globally which contains credentials for the autoscaler chart registry, regardless of the `sysetm-default-registry` value.

## Testing

- Enable the cluster-autoscaling feature flag and set ClusterAutoscalerChartRepository                                                         
- Configure global pull secrets so the root secrets are created
- On a v2prov cluster, add per-cluster registry credentials matching the chart repo host
- Verify fleet-default/autoscaler-helm-secret is NOT overwritten (still has global creds, no owner reference)
- Verify fleet-default/autoscaler-helm-secret-{clusterName} is created with cluster-level creds
- Remove per-cluster credentials from the cluster (transition back to global)
- Verify fleet-default/autoscaler-helm-secret is NOT deleted
- Verify fleet-default/autoscaler-helm-secret-{clusterName} is deleted

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: Updated and added unit tests

## QA Testing Considerations
You'll need two users setup for whatever authenticated registry you're testing against.
 
### Regressions Considerations
n/a