### PR TITLE
Delete ext session tokens on forced logout for dashboard

### DIFF
--- a/pkg/ext/common/common.go
+++ b/pkg/ext/common/common.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,9 @@ func EnsureNamespace(nsCache v1.NamespaceCache, nsClient v1.NamespaceClient, nam
 		}
 
 		if !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("error getting namespace %s: %w", name, err)
+			// was: return false, fmt.Errorf(...)  <-- exits immediately
+			logrus.Debugf("ensure namespace failure, retry: %s", err)
+			return false, nil // retry instead
 		}
 
 		_, err = nsClient.Create(&corev1.Namespace{

--- a/pkg/ext/common/common.go
+++ b/pkg/ext/common/common.go
@@ -30,9 +30,9 @@ func EnsureNamespace(nsCache v1.NamespaceCache, nsClient v1.NamespaceClient, nam
 		}
 
 		if !apierrors.IsNotFound(err) {
-			// was: return false, fmt.Errorf(...)  <-- exits immediately
+			// retry after transient error, instead of exiting
 			logrus.Debugf("ensure namespace failure, retry: %s", err)
-			return false, nil // retry instead
+			return false, nil
 		}
 
 		_, err = nsClient.Create(&corev1.Namespace{

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -914,6 +914,13 @@ func (t *SystemStore) ListForProvider(provider string) (*ext.TokenList, error) {
 	return &ext.TokenList{Items: tokens}, nil
 }
 
+// List returns all ext tokens as per the provided options. This is an internal
+// call invoked by other parts of Rancher. It runs with full access. None of the
+// returned tokens are marked as current.
+func (t *SystemStore) List(options *metav1.ListOptions) (*ext.TokenList, error) {
+	return t.list(true, "", "", options)
+}
+
 func (t *SystemStore) list(fullAccess bool, userName, authTokenID string, options *metav1.ListOptions) (*ext.TokenList, error) {
 	// Non-system requests always filter the tokens down to those of the current user.
 	// Merge our own selection request (user match!) into the caller's demands
@@ -1502,9 +1509,13 @@ func SessionID(ctx context.Context) (string, error) {
 // requests a filter for a different user than itself.
 func ListOptionMerge(fullAccess bool, userName string, options *metav1.ListOptions) (metav1.ListOptions, error) {
 	var localOptions metav1.ListOptions
+	empty := metav1.ListOptions{}
 
 	// for admins we do not impose any additional restrictions over the requested
 	if fullAccess {
+		if options == nil {
+			return empty, nil
+		}
 		return *options, nil
 	}
 
@@ -1512,7 +1523,6 @@ func ListOptionMerge(fullAccess bool, userName string, options *metav1.ListOptio
 	userIDSelector := labels.Set(map[string]string{
 		UserIDLabel: userName,
 	})
-	empty := metav1.ListOptions{}
 	if options == nil || *options == empty {
 		// No external filter to contend with, just set the internal filter.
 		localOptions = metav1.ListOptions{

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -918,6 +918,16 @@ func (t *SystemStore) ListForProvider(provider string) (*ext.TokenList, error) {
 // call invoked by other parts of Rancher. It runs with full access. None of the
 // returned tokens are marked as current.
 func (t *SystemStore) List(options *metav1.ListOptions) (*ext.TokenList, error) {
+	// As a visible method possibly called during Rancher start (migrations)
+	// ensure that the backing namespace exists when the store is fully
+	// wired; the namespace may not exist yet on clusters that have never
+	// created ext tokens.
+	if t.namespaceClient != nil && t.namespaceCache != nil {
+		if err := t.ensureNamespace(); err != nil {
+			return nil, apierrors.NewInternalError(fmt.Errorf("error ensuring namespace %s: %w",
+				TokenNamespace, err))
+		}
+	}
 	return t.list(true, "", "", options)
 }
 

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -785,6 +785,7 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 	return newToken, nil
 }
 
+// Delete is the core deletion method to remove a single named token
 func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
 	err := t.secretClient.Delete(TokenNamespace, name, options)
 	if err == nil {
@@ -797,6 +798,32 @@ func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
 	}
 
 	return apierrors.NewInternalError(fmt.Errorf("failed to delete token %s: %w", name, err))
+}
+
+// DeleteCollection is an internal bulk deletion method for use by other parts of Rancher.
+func (t *SystemStore) DeleteCollection(options *metav1.ListOptions) error {
+	localOptions, err := ListOptionMerge(true, "", options)
+	if err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("failed to process list options: %w", err))
+	}
+
+	// Deliberately using client instead of the cache as the latter may not be yet synced/populated.
+	secrets, err := t.secretClient.List(TokenNamespace, localOptions)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // namespace absent - no tokens exist.
+		}
+		return apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", err))
+	}
+
+	for _, s := range secrets.Items {
+		err = t.secretClient.Delete(TokenNamespace, s.Name, &metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return apierrors.NewInternalError(fmt.Errorf("failed to delete token %s: %w", s.Name, err))
+		}
+	}
+
+	return nil
 }
 
 // Get retrieves the named ext token, without permission checking
@@ -912,23 +939,6 @@ func (t *SystemStore) ListForProvider(provider string) (*ext.TokenList, error) {
 	}
 
 	return &ext.TokenList{Items: tokens}, nil
-}
-
-// List returns all ext tokens as per the provided options. This is an internal
-// call invoked by other parts of Rancher. It runs with full access. None of the
-// returned tokens are marked as current.
-func (t *SystemStore) List(options *metav1.ListOptions) (*ext.TokenList, error) {
-	// As a visible method possibly called during Rancher start (migrations)
-	// ensure that the backing namespace exists when the store is fully
-	// wired; the namespace may not exist yet on clusters that have never
-	// created ext tokens.
-	if t.namespaceClient != nil && t.namespaceCache != nil {
-		if err := t.ensureNamespace(); err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("error ensuring namespace %s: %w",
-				TokenNamespace, err))
-		}
-	}
-	return t.list(true, "", "", options)
 }
 
 func (t *SystemStore) list(fullAccess bool, userName, authTokenID string, options *metav1.ListOptions) (*ext.TokenList, error) {

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -808,19 +808,11 @@ func (t *SystemStore) DeleteCollection(options *metav1.ListOptions) error {
 	}
 
 	// Deliberately using client instead of the cache as the latter may not be yet synced/populated.
-	secrets, err := t.secretClient.List(TokenNamespace, localOptions)
-	if err != nil {
+	if err := t.secretClient.DeleteCollection(TokenNamespace, metav1.DeleteOptions{}, localOptions); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil // namespace absent - no tokens exist.
+			return nil
 		}
-		return apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", err))
-	}
-
-	for _, s := range secrets.Items {
-		err = t.secretClient.Delete(TokenNamespace, s.Name, &metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return apierrors.NewInternalError(fmt.Errorf("failed to delete token %s: %w", s.Name, err))
-		}
+		return apierrors.NewInternalError(fmt.Errorf("failed to delete tokens: %w", err))
 	}
 
 	return nil

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -1767,81 +1767,41 @@ func TestSystemStoreDeleteCollection(t *testing.T) {
 		{
 			name: "some arbitrary error",
 			opts: &metav1.ListOptions{},
-			err:  apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", errSomeError)),
+			err:  apierrors.NewInternalError(fmt.Errorf("failed to delete tokens: %w", errSomeError)),
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List(TokenNamespace, gomock.Any()).
-					Return(nil, errSomeError)
+					DeleteCollection(TokenNamespace, metav1.DeleteOptions{}, gomock.Any()).
+					Return(errSomeError)
 			},
 		},
 		{
-			name: "namespace not found, not an error, nothing to delete",
+			name: "namespace not found error, ignored",
 			opts: &metav1.ListOptions{},
 			err:  nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List(TokenNamespace, gomock.Any()).
-					Return(nil, apierrors.NewNotFound(GVR.GroupResource(), TokenNamespace))
+					DeleteCollection(TokenNamespace, metav1.DeleteOptions{}, metav1.ListOptions{}).
+					Return(apierrors.NewNotFound(GVR.GroupResource(), TokenNamespace))
 			},
 		},
 		{
-			name: "ok, empty",
+			name: "empty options",
 			opts: &metav1.ListOptions{},
 			err:  nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List(TokenNamespace, gomock.Any()).
-					Return(&corev1.SecretList{}, nil)
+					DeleteCollection(TokenNamespace, metav1.DeleteOptions{}, metav1.ListOptions{}).
+					Return(nil)
 			},
 		},
 		{
-			name: "ok, empty, nil options",
+			name: "nil options",
 			opts: nil,
 			err:  nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List(TokenNamespace, gomock.Any()).
-					Return(&corev1.SecretList{}, nil)
-			},
-		},
-		{
-			name: "ok, not empty",
-			opts: &metav1.ListOptions{},
-			err:  nil,
-			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
-				secrets.EXPECT().Delete(TokenNamespace, properSecret.Name, gomock.Any()).
+					DeleteCollection(TokenNamespace, metav1.DeleteOptions{}, metav1.ListOptions{}).
 					Return(nil)
-				secrets.EXPECT().
-					List(TokenNamespace, gomock.Any()).
-					Return(&corev1.SecretList{
-						ListMeta: metav1.ListMeta{
-							ResourceVersion:    "1",
-							Continue:           "true",
-							RemainingItemCount: ptr.To(int64(2)),
-						},
-						Items: []corev1.Secret{
-							properSecret,
-						},
-					}, nil)
-			},
-		},
-		{
-			name: "ok, delete broken secrets as well",
-			opts: &metav1.ListOptions{},
-			err:  nil,
-			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
-				secrets.EXPECT().Delete(TokenNamespace, properSecret.Name, gomock.Any()).
-					Return(nil)
-				secrets.EXPECT().Delete(TokenNamespace, badSecret.Name, gomock.Any()).
-					Return(nil)
-				secrets.EXPECT().
-					List(TokenNamespace, gomock.Any()).
-					Return(&corev1.SecretList{
-						Items: []corev1.Secret{
-							properSecret,
-							badSecret,
-						},
-					}, nil)
 			},
 		},
 	}

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -1622,6 +1622,18 @@ func TestSystemStoreList(t *testing.T) {
 			},
 		},
 		{
+			name: "ok, empty, nil options",
+			user: "",
+			opts: nil,
+			err:  nil,
+			toks: &ext.TokenList{Items: []ext.Token{}},
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(&corev1.SecretList{}, nil)
+			},
+		},
+		{
 			name: "ok, not empty, not current",
 			user: properUser,
 			opts: &metav1.ListOptions{},
@@ -1734,6 +1746,131 @@ func TestSystemStoreList(t *testing.T) {
 
 			// perform test and validate results
 			toks, err := store.list(test.isadmin, test.user, test.session, test.opts)
+			if test.err != nil {
+				assert.Equal(t, test.err, err)
+				assert.Nil(t, toks)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.toks, toks)
+			}
+		})
+	}
+}
+
+func TestSystemStoreListExported(t *testing.T) {
+	tests := []struct {
+		name       string              // test name
+		opts       *metav1.ListOptions // list options
+		err        error               // expected op result, error
+		toks       *ext.TokenList      // expected op result, token list
+		storeSetup func(               // configure store backend clients
+			secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
+	}{
+		{
+			name: "some arbitrary error",
+			opts: &metav1.ListOptions{},
+			err:  apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", errSomeError)),
+			toks: nil,
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(nil, errSomeError)
+			},
+		},
+		{
+			name: "ok, empty",
+			opts: &metav1.ListOptions{},
+			err:  nil,
+			toks: &ext.TokenList{Items: []ext.Token{}},
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(&corev1.SecretList{}, nil)
+			},
+		},
+		{
+			name: "ok, empty, nil options",
+			opts: nil,
+			err:  nil,
+			toks: &ext.TokenList{Items: []ext.Token{}},
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(&corev1.SecretList{}, nil)
+			},
+		},
+		{
+			name: "ok, not empty",
+			opts: &metav1.ListOptions{},
+			err:  nil,
+			toks: &ext.TokenList{
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "1",
+					Continue:           "true",
+					RemainingItemCount: ptr.To(int64(2)),
+				},
+				Items: []ext.Token{
+					properToken,
+				},
+			},
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(&corev1.SecretList{
+						ListMeta: metav1.ListMeta{
+							ResourceVersion:    "1",
+							Continue:           "true",
+							RemainingItemCount: ptr.To(int64(2)),
+						},
+						Items: []corev1.Secret{
+							properSecret,
+						},
+					}, nil)
+			},
+		},
+		{
+			name: "ok, ignore broken secrets",
+			opts: &metav1.ListOptions{},
+			err:  nil,
+			toks: &ext.TokenList{
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "",
+					Continue:           "",
+					RemainingItemCount: nil,
+				},
+				Items: []ext.Token{
+					properToken,
+				},
+			},
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					List("cattle-tokens", gomock.Any()).
+					Return(&corev1.SecretList{
+						Items: []corev1.Secret{
+							properSecret,
+							badSecret,
+						},
+					}, nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			// assemble and configure store from mock clients ...
+			secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+
+			users.EXPECT().Cache().Return(nil)
+			secrets.EXPECT().Cache().Return(nil)
+
+			store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil, nil)
+			test.storeSetup(secrets)
+
+			// perform test and validate results
+			toks, err := store.List(test.opts)
 			if test.err != nil {
 				assert.Equal(t, test.err, err)
 				assert.Nil(t, toks)

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -406,7 +406,7 @@ func TestStoreDelete(t *testing.T) {
 			Return(&mockUser{name: "laber"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
+		secrets.EXPECT().Get(TokenNamespace, "bogus", gomock.Any()).
 			Return(nil, errSomeError)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -427,7 +427,7 @@ func TestStoreDelete(t *testing.T) {
 			Return(&mockUser{name: "laber"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
+		secrets.EXPECT().Get(TokenNamespace, "bogus", gomock.Any()).
 			Return(nil, apierrors.NewNotFound(GVR.GroupResource(), "bogus"))
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -465,7 +465,7 @@ func TestStoreDelete(t *testing.T) {
 			Return(&mockUser{name: "lkajdl/ksjlkds"}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
+		secrets.EXPECT().Get(TokenNamespace, "bogus", gomock.Any()).
 			Return(&properSecret, nil)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -485,10 +485,10 @@ func TestStoreDelete(t *testing.T) {
 			Return(&mockUser{name: properUser}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
+		secrets.EXPECT().Get(TokenNamespace, "bogus", gomock.Any()).
 			Return(&properSecret, nil)
 		secrets.EXPECT().
-			Delete("cattle-tokens", "bogus", gomock.Any()).
+			Delete(TokenNamespace, "bogus", gomock.Any()).
 			Return(nil)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -508,10 +508,10 @@ func TestStoreDelete(t *testing.T) {
 			Return(&mockUser{name: properUser}, false, true, nil)
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Get("cattle-tokens", "bogus", gomock.Any()).
+		secrets.EXPECT().Get(TokenNamespace, "bogus", gomock.Any()).
 			Return(&properSecret, nil)
 		secrets.EXPECT().
-			Delete("cattle-tokens", "bogus", gomock.Any()).
+			Delete(TokenNamespace, "bogus", gomock.Any()).
 			DoAndReturn(func(namespace, name string, options *metav1.DeleteOptions) error {
 				// verify that the delete option data was properly translated
 				assert.Equal(t, options.Preconditions, metav1.NewUIDPreconditions("bombastic"))
@@ -545,7 +545,7 @@ func TestStoreGet(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
 		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+			Get(TokenNamespace, "bogus").
 			Return(&properSecret, nil)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -568,7 +568,7 @@ func TestStoreGet(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
 		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+			Get(TokenNamespace, "bogus").
 			Return(&properSecret, nil)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -591,7 +591,7 @@ func TestStoreGet(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
 		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+			Get(TokenNamespace, "bogus").
 			Return(&properSecret, nil)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -672,7 +672,7 @@ func TestStoreGet(t *testing.T) {
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(scache)
 		scache.EXPECT().
-			Get("cattle-tokens", "bogus").
+			Get(TokenNamespace, "bogus").
 			Return(fieldSecret, nil)
 
 		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
@@ -696,7 +696,7 @@ func TestStoreWatch(t *testing.T) {
 
 		users.EXPECT().Cache().Return(nil)
 		secrets.EXPECT().Cache().Return(nil)
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(nil, errSomeError)
 
 		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -721,7 +721,7 @@ func TestStoreWatch(t *testing.T) {
 		secrets.EXPECT().Cache().Return(nil)
 
 		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Bookmark})
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -754,7 +754,7 @@ func TestStoreWatch(t *testing.T) {
 		secrets.EXPECT().Cache().Return(nil)
 
 		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Bookmark})
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -790,7 +790,7 @@ func TestStoreWatch(t *testing.T) {
 			watch.Event{Object: &corev1.Namespace{}, Type: watch.Added},
 			watch.Event{Object: &properSecret, Type: watch.Bookmark},
 		)
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -825,7 +825,7 @@ func TestStoreWatch(t *testing.T) {
 			watch.Event{Object: &corev1.Secret{}, Type: watch.Added},
 			watch.Event{Object: &properSecret, Type: watch.Bookmark},
 		)
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -858,7 +858,7 @@ func TestStoreWatch(t *testing.T) {
 		// return fake bookmark for easy channel management
 		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Bookmark})
 		// Expect a watch() call with filter for user
-		secrets.EXPECT().Watch("cattle-tokens", metav1.ListOptions{
+		secrets.EXPECT().Watch(TokenNamespace, metav1.ListOptions{
 			LabelSelector: UserIDLabel + "=lkajdl/ksjlkds",
 		}).Return(watcher, nil)
 
@@ -890,7 +890,7 @@ func TestStoreWatch(t *testing.T) {
 		secrets.EXPECT().Cache().Return(nil)
 
 		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Modified})
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -920,7 +920,7 @@ func TestStoreWatch(t *testing.T) {
 		secrets.EXPECT().Cache().Return(nil)
 
 		watcher := NewWatcherFor(watch.Event{Object: &properSecret, Type: watch.Modified})
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("bogus", nil)
@@ -953,7 +953,7 @@ func TestStoreWatch(t *testing.T) {
 		watcher := NewWatcherFor(
 			watch.Event{Object: &corev1.Namespace{}, Type: watch.Error},
 		)
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -988,7 +988,7 @@ func TestStoreWatch(t *testing.T) {
 			watch.Event{Object: &corev1.Namespace{}, Type: watch.Bookmark},
 			watch.Event{Object: &properSecret, Type: watch.Bookmark},
 		)
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -1029,7 +1029,7 @@ func TestStoreWatch(t *testing.T) {
 			},
 			Type: watch.Bookmark,
 		})
-		secrets.EXPECT().Watch("cattle-tokens", gomock.Any()).
+		secrets.EXPECT().Watch(TokenNamespace, gomock.Any()).
 			Return(watcher, nil)
 
 		auth.EXPECT().SessionID(gomock.Any()).Return("", nil)
@@ -1176,7 +1176,7 @@ func TestStoreCreate(t *testing.T) {
 					Return("session-token", nil)
 				token.EXPECT().Get("session-token").
 					Return(nil, errSomeError)
-				scache.EXPECT().Get("cattle-tokens", "session-token").
+				scache.EXPECT().Get(TokenNamespace, "session-token").
 					Return(nil, errSomeError)
 
 				users.EXPECT().Get("world").
@@ -1372,7 +1372,7 @@ func TestStoreCreate(t *testing.T) {
 
 				// on failure to read back the secret is deleted again
 				secrets.EXPECT().
-					Delete("cattle-tokens", "bogus", gomock.Any()).
+					Delete(TokenNamespace, "bogus", gomock.Any()).
 					Return(nil)
 
 			},
@@ -1605,7 +1605,7 @@ func TestSystemStoreList(t *testing.T) {
 			toks: nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(nil, errSomeError)
 			},
 		},
@@ -1617,7 +1617,7 @@ func TestSystemStoreList(t *testing.T) {
 			toks: &ext.TokenList{Items: []ext.Token{}},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{}, nil)
 			},
 		},
@@ -1629,7 +1629,7 @@ func TestSystemStoreList(t *testing.T) {
 			toks: &ext.TokenList{Items: []ext.Token{}},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{}, nil)
 			},
 		},
@@ -1650,7 +1650,7 @@ func TestSystemStoreList(t *testing.T) {
 			},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{
 						ListMeta: metav1.ListMeta{
 							ResourceVersion:    "1",
@@ -1681,7 +1681,7 @@ func TestSystemStoreList(t *testing.T) {
 			},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{
 						Items: []corev1.Secret{
 							properSecret,
@@ -1706,7 +1706,7 @@ func TestSystemStoreList(t *testing.T) {
 			},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{
 						Items: []corev1.Secret{
 							properSecret,
@@ -1723,7 +1723,7 @@ func TestSystemStoreList(t *testing.T) {
 			toks: &ext.TokenList{Items: []ext.Token{}},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", metav1.ListOptions{
+					List(TokenNamespace, metav1.ListOptions{
 						LabelSelector: UserIDLabel + "=other",
 					}).Return(&corev1.SecretList{Items: []corev1.Secret{}}, nil)
 			},
@@ -1773,7 +1773,7 @@ func TestSystemStoreListExported(t *testing.T) {
 			toks: nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(nil, errSomeError)
 			},
 		},
@@ -1784,7 +1784,7 @@ func TestSystemStoreListExported(t *testing.T) {
 			toks: &ext.TokenList{Items: []ext.Token{}},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{}, nil)
 			},
 		},
@@ -1795,7 +1795,7 @@ func TestSystemStoreListExported(t *testing.T) {
 			toks: &ext.TokenList{Items: []ext.Token{}},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{}, nil)
 			},
 		},
@@ -1815,7 +1815,7 @@ func TestSystemStoreListExported(t *testing.T) {
 			},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{
 						ListMeta: metav1.ListMeta{
 							ResourceVersion:    "1",
@@ -1844,7 +1844,7 @@ func TestSystemStoreListExported(t *testing.T) {
 			},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{
 						Items: []corev1.Secret{
 							properSecret,
@@ -1898,7 +1898,7 @@ func TestSystemStoreDelete(t *testing.T) {
 			err:   apierrors.NewNotFound(GVR.GroupResource(), "bogus"),
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					Delete("cattle-tokens", "bogus", gomock.Any()).
+					Delete(TokenNamespace, "bogus", gomock.Any()).
 					Return(emptyNotFoundError)
 
 			},
@@ -1910,7 +1910,7 @@ func TestSystemStoreDelete(t *testing.T) {
 			err:   apierrors.NewInternalError(fmt.Errorf("failed to delete token bogus: %w", errSomeError)),
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					Delete("cattle-tokens", "bogus", gomock.Any()).
+					Delete(TokenNamespace, "bogus", gomock.Any()).
 					Return(errSomeError)
 			},
 		},
@@ -1921,7 +1921,7 @@ func TestSystemStoreDelete(t *testing.T) {
 			err:   nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
-					Delete("cattle-tokens", "bogus", gomock.Any()).
+					Delete(TokenNamespace, "bogus", gomock.Any()).
 					Return(nil)
 			},
 		},
@@ -1966,7 +1966,7 @@ func TestSystemStoreUpdateLastUsedAt(t *testing.T) {
 		store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil, nil)
 
 		var patchData []byte
-		secrets.EXPECT().Patch("cattle-tokens", "atoken", types.JSONPatchType, gomock.Any()).
+		secrets.EXPECT().Patch(TokenNamespace, "atoken", types.JSONPatchType, gomock.Any()).
 			DoAndReturn(func(space, name string, pt types.PatchType, data []byte, subresources ...any) (*ext.Token, error) {
 				patchData = data
 				return nil, nil
@@ -1995,7 +1995,7 @@ func TestSystemStoreUpdateLastUsedAt(t *testing.T) {
 
 		store := NewSystem(nil, nil, secrets, users, nil, nil, nil, nil, nil)
 
-		secrets.EXPECT().Patch("cattle-tokens", "atoken", types.JSONPatchType, gomock.Any()).
+		secrets.EXPECT().Patch(TokenNamespace, "atoken", types.JSONPatchType, gomock.Any()).
 			Return(nil, fmt.Errorf("some error")).
 			Times(1)
 
@@ -2420,7 +2420,7 @@ func TestSystemStoreGet(t *testing.T) {
 			name: "backing secret not found",
 			storeSetup: func(secrets *fake.MockCacheInterface[*corev1.Secret]) {
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(nil, bogusNotFoundError)
 			},
 			tokname: "bogus",
@@ -2432,7 +2432,7 @@ func TestSystemStoreGet(t *testing.T) {
 			name: "some other error",
 			storeSetup: func(secrets *fake.MockCacheInterface[*corev1.Secret]) {
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(nil, errSomeError)
 			},
 			tokname: "bogus",
@@ -2445,7 +2445,7 @@ func TestSystemStoreGet(t *testing.T) {
 			name: "empty secret (not found)",
 			storeSetup: func(secrets *fake.MockCacheInterface[*corev1.Secret]) {
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(&corev1.Secret{}, nil)
 			},
 			tokname: "bogus",
@@ -2460,7 +2460,7 @@ func TestSystemStoreGet(t *testing.T) {
 				delete(reduced.Data, FieldEnabled)
 
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(reduced, nil)
 			},
 			tokname: "bogus",
@@ -2475,7 +2475,7 @@ func TestSystemStoreGet(t *testing.T) {
 				delete(reduced.Data, FieldTTL)
 
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(reduced, nil)
 			},
 			tokname: "bogus",
@@ -2490,7 +2490,7 @@ func TestSystemStoreGet(t *testing.T) {
 				delete(reduced.Data, FieldHash)
 
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(reduced, nil)
 			},
 			tokname: "bogus",
@@ -2508,7 +2508,7 @@ func TestSystemStoreGet(t *testing.T) {
 				reduced.Data[FieldPrincipal], _ = json.Marshal(up)
 
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(reduced, nil)
 			},
 			tokname: "bogus",
@@ -2524,7 +2524,7 @@ func TestSystemStoreGet(t *testing.T) {
 				delete(reduced.Data, FieldLastUpdateTime)
 
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(reduced, nil)
 			},
 			tokname: "bogus",
@@ -2542,7 +2542,7 @@ func TestSystemStoreGet(t *testing.T) {
 				reduced.Data[FieldPrincipal], _ = json.Marshal(up)
 
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(reduced, nil)
 			},
 			tokname: "bogus",
@@ -2557,7 +2557,7 @@ func TestSystemStoreGet(t *testing.T) {
 				delete(reduced.Data, FieldUID)
 
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(reduced, nil)
 			},
 			tokname: "bogus",
@@ -2569,7 +2569,7 @@ func TestSystemStoreGet(t *testing.T) {
 			name: "filled secret",
 			storeSetup: func(secrets *fake.MockCacheInterface[*corev1.Secret]) {
 				secrets.EXPECT().
-					Get("cattle-tokens", "bogus").
+					Get(TokenNamespace, "bogus").
 					Return(&properSecret, nil)
 			},
 			tokname: "bogus",
@@ -2719,7 +2719,7 @@ func TestSystemStoreListForProvider(t *testing.T) {
 			err:      apierrors.NewInternalError(fmt.Errorf("failed to list tokens for provider somebody: %w", errSomeError)),
 			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
 				scache.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(nil, errSomeError)
 			},
 		},
@@ -2729,7 +2729,7 @@ func TestSystemStoreListForProvider(t *testing.T) {
 			wantCount: 0,
 			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
 				scache.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return(nil, nil)
 			},
 		},
@@ -2739,7 +2739,7 @@ func TestSystemStoreListForProvider(t *testing.T) {
 			wantCount: 1,
 			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
 				scache.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return([]*corev1.Secret{&properSecret, &otherSecret}, nil)
 			},
 		},
@@ -2749,7 +2749,7 @@ func TestSystemStoreListForProvider(t *testing.T) {
 			wantCount: 0,
 			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
 				scache.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return([]*corev1.Secret{&properSecret, &otherSecret}, nil)
 			},
 		},
@@ -2759,7 +2759,7 @@ func TestSystemStoreListForProvider(t *testing.T) {
 			wantCount: 1,
 			storeSetup: func(scache *fake.MockCacheInterface[*corev1.Secret]) {
 				scache.EXPECT().
-					List("cattle-tokens", gomock.Any()).
+					List(TokenNamespace, gomock.Any()).
 					Return([]*corev1.Secret{&properSecret, &badSecret}, nil)
 			},
 		},

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -1602,7 +1602,6 @@ func TestSystemStoreList(t *testing.T) {
 			user: "",
 			opts: &metav1.ListOptions{},
 			err:  apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", errSomeError)),
-			toks: nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
 					List(TokenNamespace, gomock.Any()).
@@ -1757,12 +1756,11 @@ func TestSystemStoreList(t *testing.T) {
 	}
 }
 
-func TestSystemStoreListExported(t *testing.T) {
+func TestSystemStoreDeleteCollection(t *testing.T) {
 	tests := []struct {
 		name       string              // test name
 		opts       *metav1.ListOptions // list options
 		err        error               // expected op result, error
-		toks       *ext.TokenList      // expected op result, token list
 		storeSetup func(               // configure store backend clients
 			secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
 	}{
@@ -1770,7 +1768,6 @@ func TestSystemStoreListExported(t *testing.T) {
 			name: "some arbitrary error",
 			opts: &metav1.ListOptions{},
 			err:  apierrors.NewInternalError(fmt.Errorf("failed to list tokens: %w", errSomeError)),
-			toks: nil,
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
 					List(TokenNamespace, gomock.Any()).
@@ -1778,10 +1775,19 @@ func TestSystemStoreListExported(t *testing.T) {
 			},
 		},
 		{
+			name: "namespace not found, not an error, nothing to delete",
+			opts: &metav1.ListOptions{},
+			err:  nil,
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					List(TokenNamespace, gomock.Any()).
+					Return(nil, apierrors.NewNotFound(GVR.GroupResource(), TokenNamespace))
+			},
+		},
+		{
 			name: "ok, empty",
 			opts: &metav1.ListOptions{},
 			err:  nil,
-			toks: &ext.TokenList{Items: []ext.Token{}},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
 					List(TokenNamespace, gomock.Any()).
@@ -1792,7 +1798,6 @@ func TestSystemStoreListExported(t *testing.T) {
 			name: "ok, empty, nil options",
 			opts: nil,
 			err:  nil,
-			toks: &ext.TokenList{Items: []ext.Token{}},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
 					List(TokenNamespace, gomock.Any()).
@@ -1803,17 +1808,9 @@ func TestSystemStoreListExported(t *testing.T) {
 			name: "ok, not empty",
 			opts: &metav1.ListOptions{},
 			err:  nil,
-			toks: &ext.TokenList{
-				ListMeta: metav1.ListMeta{
-					ResourceVersion:    "1",
-					Continue:           "true",
-					RemainingItemCount: ptr.To(int64(2)),
-				},
-				Items: []ext.Token{
-					properToken,
-				},
-			},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().Delete(TokenNamespace, properSecret.Name, gomock.Any()).
+					Return(nil)
 				secrets.EXPECT().
 					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{
@@ -1829,20 +1826,14 @@ func TestSystemStoreListExported(t *testing.T) {
 			},
 		},
 		{
-			name: "ok, ignore broken secrets",
+			name: "ok, delete broken secrets as well",
 			opts: &metav1.ListOptions{},
 			err:  nil,
-			toks: &ext.TokenList{
-				ListMeta: metav1.ListMeta{
-					ResourceVersion:    "",
-					Continue:           "",
-					RemainingItemCount: nil,
-				},
-				Items: []ext.Token{
-					properToken,
-				},
-			},
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().Delete(TokenNamespace, properSecret.Name, gomock.Any()).
+					Return(nil)
+				secrets.EXPECT().Delete(TokenNamespace, badSecret.Name, gomock.Any()).
+					Return(nil)
 				secrets.EXPECT().
 					List(TokenNamespace, gomock.Any()).
 					Return(&corev1.SecretList{
@@ -1870,13 +1861,11 @@ func TestSystemStoreListExported(t *testing.T) {
 			test.storeSetup(secrets)
 
 			// perform test and validate results
-			toks, err := store.List(test.opts)
+			err := store.DeleteCollection(test.opts)
 			if test.err != nil {
 				assert.Equal(t, test.err, err)
-				assert.Nil(t, toks)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, test.toks, toks)
 			}
 		})
 	}

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/clusterregistrationtoken"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
@@ -78,7 +79,10 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		return err
 	}
 
-	if err := forceUpgradeLogout(wranglerContext.Core.ConfigMap(), wranglerContext.Mgmt.Token(), "v2.6.0"); err != nil {
+	if err := forceUpgradeLogout(wranglerContext.Core.ConfigMap(),
+		wranglerContext.Mgmt.Token(),
+		exttokenstore.NewSystemFromWrangler(wranglerContext),
+		"v2.6.0"); err != nil {
 		return err
 	}
 
@@ -176,7 +180,10 @@ func createOrUpdateConfigMap(configMapClient controllerv1.ConfigMapClient, cm *v
 // forceUpgradeLogout will delete all dashboard tokens forcing a logout.  This is useful when there is a major frontend
 // upgrade and we want all users to be sent to a central point.  This function will check for the `forceUpgradeLogoutConfig`
 // configuration map and only run if the last migrated version is lower than the given `migrationVersion`.
-func forceUpgradeLogout(configMapController controllerv1.ConfigMapController, tokenController v3.TokenController, migrationVersion string) error {
+func forceUpgradeLogout(configMapController controllerv1.ConfigMapController,
+	tokenController v3.TokenController,
+	extTokenStore *exttokenstore.SystemStore,
+	migrationVersion string) error {
 	cm, err := getConfigMap(configMapController, forceUpgradeLogoutConfig)
 	if err != nil || cm == nil {
 		return err
@@ -201,7 +208,7 @@ func forceUpgradeLogout(configMapController controllerv1.ConfigMapController, to
 	// list all tokens that were created for the dashboard
 	allTokens, err := tokenController.Cache().List(labels.SelectorFromSet(labels.Set{tokens.TokenKindLabel: "session"}))
 	if err != nil {
-		logrus.Error("Failed to list tokens for upgrade forced logout")
+		logrus.WithError(err).Error("Failed to list tokens for upgrade forced logout")
 		return err
 	}
 
@@ -209,7 +216,24 @@ func forceUpgradeLogout(configMapController controllerv1.ConfigMapController, to
 	for _, token := range allTokens {
 		err = tokenController.Delete(token.ObjectMeta.Name, &metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
-			logrus.Errorf("Failed to delete token [%s] for upgrade forced logout", token.Name)
+			logrus.WithError(err).Errorf("Failed to delete token [%s] for upgrade forced logout", token.Name)
+		}
+	}
+
+	// list all ext tokens that were created for the dashboard.
+	allExtTokens, err := extTokenStore.List(&metav1.ListOptions{
+		LabelSelector: labels.Set{exttokenstore.KindLabel: exttokenstore.IsLogin}.AsSelector().String(),
+	})
+	if err != nil {
+		logrus.WithError(err).Error("Failed to list ext tokens for upgrade forced logout")
+		return err
+	}
+
+	// log out all the dashboard users forcing them to be redirected to the login page
+	for _, extToken := range allExtTokens.Items {
+		err = extTokenStore.Delete(extToken.ObjectMeta.Name, &metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			logrus.WithError(err).Errorf("Failed to delete ext token [%s] for upgrade forced logout", extToken.Name)
 		}
 	}
 

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -231,7 +231,7 @@ func forceUpgradeLogout(configMapController controllerv1.ConfigMapController,
 	err = extTokenDeleter.DeleteCollection(&metav1.ListOptions{
 		LabelSelector: labels.Set{exttokenstore.KindLabel: exttokenstore.IsLogin}.AsSelector().String(),
 	})
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil {
 		logrus.WithError(err).Error("Failed to delete ext session tokens for upgrade forced logout")
 	}
 

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -220,21 +220,14 @@ func forceUpgradeLogout(configMapController controllerv1.ConfigMapController,
 		}
 	}
 
-	// list all ext tokens that were created for the dashboard.
-	allExtTokens, err := extTokenStore.List(&metav1.ListOptions{
+	// bulk delete all ext tokens that were created for the dashboard,
+	// forcing their users to be redirected to the login page
+	err = extTokenStore.DeleteCollection(&metav1.ListOptions{
 		LabelSelector: labels.Set{exttokenstore.KindLabel: exttokenstore.IsLogin}.AsSelector().String(),
 	})
 	if err != nil {
-		logrus.WithError(err).Error("Failed to list ext tokens for upgrade forced logout")
+		logrus.WithError(err).Error("Failed to delete ext session tokens for upgrade forced logout")
 		return err
-	}
-
-	// log out all the dashboard users forcing them to be redirected to the login page
-	for _, extToken := range allExtTokens.Items {
-		err = extTokenStore.Delete(extToken.ObjectMeta.Name, &metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			logrus.WithError(err).Errorf("Failed to delete ext token [%s] for upgrade forced logout", extToken.Name)
-		}
 	}
 
 	cm.Data[rancherVersionKey] = rancherversion.Version

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -74,6 +74,12 @@ var (
 	mgmtNameRegexp = regexp.MustCompile("^(c-[a-z0-9]{5}|local)$")
 )
 
+// tokenCollectionDeleter abstracts the interface to bulk deletion for tokens,
+// enabling simpler setup for testing
+type tokenCollectionDeleter interface {
+	DeleteCollection(options *metav1.ListOptions) error
+}
+
 func runMigrations(wranglerContext *wrangler.Context) error {
 	if err := migrateLocalUserPasswords(wranglerContext); err != nil {
 		return err
@@ -182,7 +188,7 @@ func createOrUpdateConfigMap(configMapClient controllerv1.ConfigMapClient, cm *v
 // configuration map and only run if the last migrated version is lower than the given `migrationVersion`.
 func forceUpgradeLogout(configMapController controllerv1.ConfigMapController,
 	tokenController v3.TokenController,
-	extTokenStore *exttokenstore.SystemStore,
+	extTokenDeleter tokenCollectionDeleter,
 	migrationVersion string) error {
 	cm, err := getConfigMap(configMapController, forceUpgradeLogoutConfig)
 	if err != nil || cm == nil {
@@ -222,7 +228,7 @@ func forceUpgradeLogout(configMapController controllerv1.ConfigMapController,
 
 	// bulk delete all ext tokens that were created for the dashboard,
 	// forcing their users to be redirected to the login page
-	err = extTokenStore.DeleteCollection(&metav1.ListOptions{
+	err = extTokenDeleter.DeleteCollection(&metav1.ListOptions{
 		LabelSelector: labels.Set{exttokenstore.KindLabel: exttokenstore.IsLogin}.AsSelector().String(),
 	})
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -216,7 +216,7 @@ func forceUpgradeLogout(configMapController controllerv1.ConfigMapController,
 	for _, token := range allTokens {
 		err = tokenController.Delete(token.ObjectMeta.Name, &metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
-			logrus.WithError(err).Errorf("Failed to delete token [%s] for upgrade forced logout", token.Name)
+			logrus.WithError(err).Errorf("Failed to delete legacy session token [%s] for upgrade forced logout", token.Name)
 		}
 	}
 
@@ -225,9 +225,8 @@ func forceUpgradeLogout(configMapController controllerv1.ConfigMapController,
 	err = extTokenStore.DeleteCollection(&metav1.ListOptions{
 		LabelSelector: labels.Set{exttokenstore.KindLabel: exttokenstore.IsLogin}.AsSelector().String(),
 	})
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		logrus.WithError(err).Error("Failed to delete ext session tokens for upgrade forced logout")
-		return err
 	}
 
 	cm.Data[rancherVersionKey] = rancherversion.Version

--- a/pkg/rancher/migrations_test.go
+++ b/pkg/rancher/migrations_test.go
@@ -46,16 +46,13 @@ func TestForceUpgradeLogout(t *testing.T) {
 
 		// migrate ext tokens
 		secrets.EXPECT().
-			List(exttokenstore.TokenNamespace, metav1.ListOptions{
-				LabelSelector: labels.Set{
-					exttokenstore.KindLabel: exttokenstore.IsLogin,
-				}.AsSelector().String(),
-			}).Return(&corev1.SecretList{
-			Items: []corev1.Secret{
-				{ObjectMeta: metav1.ObjectMeta{Name: "extsession"}},
-			}}, nil)
-		secrets.EXPECT().Delete(exttokenstore.TokenNamespace, "extsession", gomock.Any()).
-			Return(nil)
+			DeleteCollection(exttokenstore.TokenNamespace,
+				metav1.DeleteOptions{},
+				metav1.ListOptions{
+					LabelSelector: labels.Set{
+						exttokenstore.KindLabel: exttokenstore.IsLogin,
+					}.AsSelector().String(),
+				}).Return(nil)
 	}
 
 	tests := map[string]struct {
@@ -170,8 +167,8 @@ func TestForceUpgradeLogout(t *testing.T) {
 			) {
 				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
 					Return(&corev1.ConfigMap{Data: map[string]string{}}, nil)
-				
-				commonMigrationSetup (ctrl, cmCache, tokens, secrets)
+
+				commonMigrationSetup(ctrl, cmCache, tokens, secrets)
 
 				configmaps.EXPECT().Create(&corev1.ConfigMap{
 					Data: map[string]string{

--- a/pkg/rancher/migrations_test.go
+++ b/pkg/rancher/migrations_test.go
@@ -170,6 +170,28 @@ func TestForceUpgradeLogout(t *testing.T) {
 				})
 			},
 		},
+		"migration ignores ext bulk deletion errors": {
+			extCount: 1,
+			setup: func(
+				ctrl *gomock.Controller,
+				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+				extDeleter *extDeletionStub,
+			) {
+				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
+					Return(&corev1.ConfigMap{Data: map[string]string{}}, nil)
+
+				commonMigrationSetup(ctrl, cmCache, tokens, extDeleter)
+				extDeleter.err = fmt.Errorf("some error")
+
+				configmaps.EXPECT().Create(&corev1.ConfigMap{
+					Data: map[string]string{
+						rancherVersionKey: migrationTarget,
+					},
+				})
+			},
+		},
 	}
 
 	for name, spec := range tests {
@@ -205,6 +227,7 @@ func TestForceUpgradeLogout(t *testing.T) {
 type extDeletionStub struct {
 	count int
 	t     *testing.T
+	err error
 }
 
 func (e *extDeletionStub) DeleteCollection(options *metav1.ListOptions) error {
@@ -214,5 +237,5 @@ func (e *extDeletionStub) DeleteCollection(options *metav1.ListOptions) error {
 		}.AsSelector().String(),
 	})
 	e.count = e.count + 1
-	return nil
+	return e.err
 }

--- a/pkg/rancher/migrations_test.go
+++ b/pkg/rancher/migrations_test.go
@@ -1,0 +1,229 @@
+package rancher
+
+import (
+	"fmt"
+	"testing"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
+	// v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	rancherversion "github.com/rancher/rancher/pkg/version"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestForceUpgradeLogout(t *testing.T) {
+
+	const (
+		lastMigrationBeforeTarget string = "v2.0.0"
+		migrationTarget           string = "v3.0.0"
+		lastMigrationBeyondTarget string = "v4.0.0"
+	)
+	rancherversion.Version = migrationTarget
+
+	commonMigrationSetup := func(
+		ctrl *gomock.Controller,
+		configmaps *fake.MockCacheInterface[*corev1.ConfigMap],
+		v3tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+		secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+	) {
+		// migrate legacy tokens
+		tCache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Token](ctrl)
+		v3tokens.EXPECT().Cache().
+			Return(tCache)
+		tCache.EXPECT().List(labels.SelectorFromSet(labels.Set{tokens.TokenKindLabel: "session"})).
+			Return([]*apiv3.Token{
+				&apiv3.Token{ObjectMeta: metav1.ObjectMeta{Name: "v3session"}},
+			}, nil)
+		v3tokens.EXPECT().Delete("v3session", gomock.Any()).
+			Return(nil)
+
+		// migrate ext tokens
+		secrets.EXPECT().
+			List(exttokenstore.TokenNamespace, metav1.ListOptions{
+				LabelSelector: labels.Set{
+					exttokenstore.KindLabel: exttokenstore.IsLogin,
+				}.AsSelector().String(),
+			}).Return(&corev1.SecretList{
+			Items: []corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "extsession"}},
+			}}, nil)
+		secrets.EXPECT().Delete(exttokenstore.TokenNamespace, "extsession", gomock.Any()).
+			Return(nil)
+	}
+
+	tests := map[string]struct {
+		err   error
+		setup func(
+			ctrl *gomock.Controller,
+			configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+			cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+			tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+			secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+		)
+	}{
+		"config map retrieval error": {
+			err: fmt.Errorf("some transient issue"),
+			setup: func(
+				ctrl *gomock.Controller,
+				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+			) {
+				cmCache.EXPECT().Get("cattle-system", "forceupgradelogout").
+					Return(nil, fmt.Errorf("some transient issue"))
+			},
+		},
+		"no migration for last migration >= target version": {
+			setup: func(
+				ctrl *gomock.Controller,
+				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+			) {
+				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
+					Return(&corev1.ConfigMap{
+						Data: map[string]string{
+							rancherVersionKey: lastMigrationBeyondTarget,
+						},
+					}, nil)
+			},
+		},
+		"no migration for last migration == target version": {
+			setup: func(
+				ctrl *gomock.Controller,
+				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+			) {
+				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
+					Return(&corev1.ConfigMap{
+						Data: map[string]string{
+							rancherVersionKey: migrationTarget,
+						},
+					}, nil)
+			},
+		},
+		"migration triggered for last migration <= target version": {
+			setup: func(
+				ctrl *gomock.Controller,
+				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+			) {
+				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
+					Return(&corev1.ConfigMap{
+						Data: map[string]string{
+							rancherVersionKey: lastMigrationBeforeTarget,
+						},
+					}, nil)
+
+				commonMigrationSetup(ctrl, cmCache, tokens, secrets)
+
+				configmaps.EXPECT().Create(&corev1.ConfigMap{
+					Data: map[string]string{
+						rancherVersionKey: migrationTarget,
+					},
+				})
+			},
+		},
+		"migration triggered when config map not present": {
+			setup: func(
+				ctrl *gomock.Controller,
+				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+			) {
+				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).Return(nil, nil)
+
+				commonMigrationSetup(ctrl, cmCache, tokens, secrets)
+
+				configmaps.EXPECT().Create(&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      forceUpgradeLogoutConfig,
+						Namespace: cattleNamespace,
+					},
+					Data: map[string]string{
+						rancherVersionKey: migrationTarget,
+					},
+				})
+			},
+		},
+		"migration triggered when no last migration available": {
+			setup: func(
+				ctrl *gomock.Controller,
+				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
+				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
+				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+			) {
+				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
+					Return(&corev1.ConfigMap{Data: map[string]string{}}, nil)
+				
+				commonMigrationSetup (ctrl, cmCache, tokens, secrets)
+
+				configmaps.EXPECT().Create(&corev1.ConfigMap{
+					Data: map[string]string{
+						rancherVersionKey: migrationTarget,
+					},
+				})
+			},
+		},
+	}
+
+	for name, spec := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			configmaps := fake.NewMockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+			cmCache := fake.NewMockCacheInterface[*corev1.ConfigMap](ctrl)
+			configmaps.EXPECT().Cache().Return(cmCache)
+
+			tokens := fake.NewMockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
+
+			nsCache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+			nsCache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
+
+			secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			secrets.EXPECT().Cache().Return(scache)
+
+			users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
+			ucache := fake.NewMockNonNamespacedCacheInterface[*apiv3.User](ctrl)
+			users.EXPECT().Cache().Return(ucache)
+
+			tcache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Token](ctrl)
+			ccache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Cluster](ctrl)
+
+			timer := exttokenstore.NewMocktimeHandler(ctrl)
+			hasher := exttokenstore.NewMockhashHandler(ctrl)
+			auth := exttokenstore.NewMockauthHandler(ctrl)
+
+			estore := exttokenstore.NewSystem(nil, nsCache, secrets, users, tcache, ccache, timer, hasher, auth, nil)
+
+			if spec.setup != nil {
+				spec.setup(ctrl, configmaps, cmCache, tokens, secrets)
+			}
+
+			err := forceUpgradeLogout(configmaps, tokens, estore, migrationTarget)
+
+			if spec.err != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), spec.err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/rancher/migrations_test.go
+++ b/pkg/rancher/migrations_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
-	// v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	rancherversion "github.com/rancher/rancher/pkg/version"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
@@ -31,9 +30,9 @@ func TestForceUpgradeLogout(t *testing.T) {
 		ctrl *gomock.Controller,
 		configmaps *fake.MockCacheInterface[*corev1.ConfigMap],
 		v3tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-		secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+		extDeleter *extDeletionStub,
 	) {
-		// migrate legacy tokens
+		// legacy tokens
 		tCache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Token](ctrl)
 		v3tokens.EXPECT().Cache().
 			Return(tCache)
@@ -43,16 +42,6 @@ func TestForceUpgradeLogout(t *testing.T) {
 			}, nil)
 		v3tokens.EXPECT().Delete("v3session", gomock.Any()).
 			Return(nil)
-
-		// migrate ext tokens
-		secrets.EXPECT().
-			DeleteCollection(exttokenstore.TokenNamespace,
-				metav1.DeleteOptions{},
-				metav1.ListOptions{
-					LabelSelector: labels.Set{
-						exttokenstore.KindLabel: exttokenstore.IsLogin,
-					}.AsSelector().String(),
-				}).Return(nil)
 	}
 
 	tests := map[string]struct {
@@ -62,8 +51,9 @@ func TestForceUpgradeLogout(t *testing.T) {
 			configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
 			cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
 			tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-			secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+			extDeleter *extDeletionStub,
 		)
+		extCount int
 	}{
 		"config map retrieval error": {
 			err: fmt.Errorf("some transient issue"),
@@ -72,7 +62,7 @@ func TestForceUpgradeLogout(t *testing.T) {
 				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
 				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
 				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				extDeleter *extDeletionStub,
 			) {
 				cmCache.EXPECT().Get("cattle-system", "forceupgradelogout").
 					Return(nil, fmt.Errorf("some transient issue"))
@@ -84,7 +74,7 @@ func TestForceUpgradeLogout(t *testing.T) {
 				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
 				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
 				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				extDeleter *extDeletionStub,
 			) {
 				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
 					Return(&corev1.ConfigMap{
@@ -100,7 +90,7 @@ func TestForceUpgradeLogout(t *testing.T) {
 				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
 				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
 				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				extDeleter *extDeletionStub,
 			) {
 				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
 					Return(&corev1.ConfigMap{
@@ -111,12 +101,13 @@ func TestForceUpgradeLogout(t *testing.T) {
 			},
 		},
 		"migration triggered for last migration <= target version": {
+			extCount: 1,
 			setup: func(
 				ctrl *gomock.Controller,
 				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
 				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
 				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				extDeleter *extDeletionStub,
 			) {
 				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
 					Return(&corev1.ConfigMap{
@@ -125,7 +116,7 @@ func TestForceUpgradeLogout(t *testing.T) {
 						},
 					}, nil)
 
-				commonMigrationSetup(ctrl, cmCache, tokens, secrets)
+				commonMigrationSetup(ctrl, cmCache, tokens, extDeleter)
 
 				configmaps.EXPECT().Create(&corev1.ConfigMap{
 					Data: map[string]string{
@@ -135,16 +126,17 @@ func TestForceUpgradeLogout(t *testing.T) {
 			},
 		},
 		"migration triggered when config map not present": {
+			extCount: 1,
 			setup: func(
 				ctrl *gomock.Controller,
 				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
 				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
 				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				extDeleter *extDeletionStub,
 			) {
 				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).Return(nil, nil)
 
-				commonMigrationSetup(ctrl, cmCache, tokens, secrets)
+				commonMigrationSetup(ctrl, cmCache, tokens, extDeleter)
 
 				configmaps.EXPECT().Create(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -158,17 +150,18 @@ func TestForceUpgradeLogout(t *testing.T) {
 			},
 		},
 		"migration triggered when no last migration available": {
+			extCount: 1,
 			setup: func(
 				ctrl *gomock.Controller,
 				configmaps *fake.MockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList],
 				cmCache *fake.MockCacheInterface[*corev1.ConfigMap],
 				tokens *fake.MockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList],
-				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				extDeleter *extDeletionStub,
 			) {
 				cmCache.EXPECT().Get(cattleNamespace, forceUpgradeLogoutConfig).
 					Return(&corev1.ConfigMap{Data: map[string]string{}}, nil)
 
-				commonMigrationSetup(ctrl, cmCache, tokens, secrets)
+				commonMigrationSetup(ctrl, cmCache, tokens, extDeleter)
 
 				configmaps.EXPECT().Create(&corev1.ConfigMap{
 					Data: map[string]string{
@@ -189,32 +182,15 @@ func TestForceUpgradeLogout(t *testing.T) {
 
 			tokens := fake.NewMockNonNamespacedControllerInterface[*apiv3.Token, *apiv3.TokenList](ctrl)
 
-			nsCache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
-			nsCache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
-
-			secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
-			scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
-			secrets.EXPECT().Cache().Return(scache)
-
-			users := fake.NewMockNonNamespacedControllerInterface[*apiv3.User, *apiv3.UserList](ctrl)
-			ucache := fake.NewMockNonNamespacedCacheInterface[*apiv3.User](ctrl)
-			users.EXPECT().Cache().Return(ucache)
-
-			tcache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Token](ctrl)
-			ccache := fake.NewMockNonNamespacedCacheInterface[*apiv3.Cluster](ctrl)
-
-			timer := exttokenstore.NewMocktimeHandler(ctrl)
-			hasher := exttokenstore.NewMockhashHandler(ctrl)
-			auth := exttokenstore.NewMockauthHandler(ctrl)
-
-			estore := exttokenstore.NewSystem(nil, nsCache, secrets, users, tcache, ccache, timer, hasher, auth, nil)
+			eDeleter := &extDeletionStub{t: t}
 
 			if spec.setup != nil {
-				spec.setup(ctrl, configmaps, cmCache, tokens, secrets)
+				spec.setup(ctrl, configmaps, cmCache, tokens, eDeleter)
 			}
 
-			err := forceUpgradeLogout(configmaps, tokens, estore, migrationTarget)
+			err := forceUpgradeLogout(configmaps, tokens, eDeleter, migrationTarget)
 
+			require.Equal(t, eDeleter.count, spec.extCount)
 			if spec.err != nil {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), spec.err.Error())
@@ -223,4 +199,20 @@ func TestForceUpgradeLogout(t *testing.T) {
 			}
 		})
 	}
+}
+
+// extDeletionStub implements [tokenCollectionDeleter]
+type extDeletionStub struct {
+	count int
+	t     *testing.T
+}
+
+func (e *extDeletionStub) DeleteCollection(options *metav1.ListOptions) error {
+	require.Equal(e.t, options, &metav1.ListOptions{
+		LabelSelector: labels.Set{
+			exttokenstore.KindLabel: exttokenstore.IsLogin,
+		}.AsSelector().String(),
+	})
+	e.count = e.count + 1
+	return nil
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#55255
 
## Problem

The forced logout looked only for legacy session tokens when triggered.
 
## Solution

The forced logout now queries the ext token store as well.
To support this the ext token system store gained a public `List` method.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_