### PR TITLE
[2.16] make Linode node driver non-builtin

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -147,9 +147,6 @@ ENV CATTLE_MACHINE_PROVISION_IMAGE=rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION=v3.6.12
 ENV CATTLE_ETCD_CHECKSUM_amd64=d2564bb50b58e52fbaf3bde4a9561a1d04e20cdc761f795580e4d615d5d41355
 ENV CATTLE_ETCD_CHECKSUM_arm64=147afc710e164fa342ad8561bcca8903f3913bd9fb9ae0c83c857b1d868189cc
-ENV DOCKER_MACHINE_LINODE_VERSION=v0.1.16
-ENV DOCKER_MACHINE_LINODE_CHECKSUM_amd64=d9c3b8c389a022b0e5c5e8912496c18a673fa74bb52ec6ab51c0a93e0f4de06d
-ENV DOCKER_MACHINE_LINODE_CHECKSUM_arm64=1a8336f66bffc2186f5fb77642f509b9370f177397ee71f1a8cb522e5979dbec
 # For displaying Helm version in the UI only.
 ENV CATTLE_HELM_VERSION=v4.2.0
 # make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
@@ -213,26 +210,13 @@ RUN case "${ARCH}" in \
         arm64) CATTLE_MACHINE_CHECKSUM="${CATTLE_MACHINE_CHECKSUM_arm64}" ;; \
         *) echo "Unsupported: ${ARCH}"; exit 1 ;; \
     esac && \
-    case "${ARCH}" in \
-        amd64) DOCKER_MACHINE_LINODE_CHECKSUM="${DOCKER_MACHINE_LINODE_CHECKSUM_amd64}" ;; \
-        arm64) DOCKER_MACHINE_LINODE_CHECKSUM="${DOCKER_MACHINE_LINODE_CHECKSUM_arm64}" ;; \
-        *) echo "Unsupported: ${ARCH}"; exit 1 ;; \
-    esac && \
     curl -fsSL "https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz"  > /tmp/rancher-machine.tar.gz && \
     printf "%s  %s\n" "${CATTLE_MACHINE_CHECKSUM}" "/tmp/rancher-machine.tar.gz" > machine.sha256 && \
     sha256sum -c machine.sha256 && \
     rm machine.sha256 && \
     tar xvzf /tmp/rancher-machine.tar.gz -C /usr/bin && \
     rm /tmp/rancher-machine.tar.gz && \
-    chown root:root /usr/bin/rancher-machine && \
-    curl -fsSL "https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-${ARCH}.zip" > /tmp/docker-machine-driver-linode.zip && \
-    printf "%s  %s\n" "${DOCKER_MACHINE_LINODE_CHECKSUM}" "/tmp/docker-machine-driver-linode.zip" > driver-linode.sha256 && \
-    sha256sum -c driver-linode.sha256 && \
-    rm driver-linode.sha256 && \
-    unzip /tmp/docker-machine-driver-linode.zip -d /opt/drivers/management-state/bin && \
-    mkdir -p /usr/share/rancher/ui-dashboard/assets/ && \
-    ln -s /opt/drivers/management-state/bin/docker-machine-driver-linode /usr/share/rancher/ui-dashboard/assets/ && \
-    rm /tmp/docker-machine-driver-linode.zip
+    chown root:root /usr/bin/rancher-machine
 
 RUN case "${ARCH}" in \
         amd64) DOCKER_MACHINE_HARVESTER_CHECKSUM="${DOCKER_MACHINE_HARVESTER_CHECKSUM_amd64}" ;; \
@@ -244,6 +228,7 @@ RUN case "${ARCH}" in \
     sha256sum -c machine-harvester.sha256 && \
     rm machine-harvester.sha256 && \
     tar xvzf /tmp/docker-machine-driver-harvester.tar.gz -C /opt/drivers/management-state/bin && \
+    mkdir -p /usr/share/rancher/ui-dashboard/assets/ && \
     ln -s /opt/drivers/management-state/bin/docker-machine-driver-harvester /usr/share/rancher/ui-dashboard/assets/ && \
     rm /tmp/docker-machine-driver-harvester.tar.gz
 

--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -3,8 +3,6 @@ package management
 import (
 	"fmt"
 	"maps"
-	"os"
-	"os/exec"
 	"reflect"
 	"runtime"
 	"strings"
@@ -184,17 +182,24 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	if err := AddHarvesterMachineDriver(management); err != nil {
 		return err
 	}
-	linodeBuiltin := true
-	if dl := os.Getenv("CATTLE_DEV_MODE"); dl != "" {
-		linodeBuiltin = isCommandAvailable("docker-machine-driver-linode")
-	}
-	linodeDriverURL := fmt.Sprintf("https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.16/docker-machine-driver-linode_linux-%s.zip", runtime.GOARCH)
+
+	linodeDriverURL := fmt.Sprintf(
+		"https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.16/docker-machine-driver-linode_linux-%s.zip",
+		runtime.GOARCH,
+	)
 	linodeDriverChecksum := "d9c3b8c389a022b0e5c5e8912496c18a673fa74bb52ec6ab51c0a93e0f4de06d"
 	if runtime.GOARCH == "arm64" {
-		// overwrite arm driver version here
 		linodeDriverChecksum = "1a8336f66bffc2186f5fb77642f509b9370f177397ee71f1a8cb522e5979dbec"
 	}
-	if err := addMachineDriver(Linodedriver, linodeDriverURL, "", linodeDriverChecksum, []string{"api.linode.com"}, linodeBuiltin, linodeBuiltin, false, nil, management); err != nil {
+	// The linode docker-machine driver binary is no longer shipped inside the
+	// rancher image; it is downloaded from upstream on first activation.
+	//
+	// createActive=false: fresh installations land with the driver inactive.
+	// updateActive=nil:   the "disable if unused" decision is made once per
+	//   Rancher installation by disableUnusedLinodeNodeDriver, which runs early
+	//   in rancher.New() before informers start. After that the admin's choice
+	//   is preserved across restarts.
+	if err := addMachineDriver(Linodedriver, linodeDriverURL, "", linodeDriverChecksum, []string{"api.linode.com"}, false, false, false, nil, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(OCIDriver, "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.3.0/docker-machine-driver-oci-linux", "", "0a1afa6a0af85ecf3d77cc554960e36e1be5fd12b22b0155717b9289669e4021", []string{"*.oraclecloud.com"}, false, false, false, nil, management); err != nil {
@@ -387,8 +392,4 @@ func deleteMachineDriver(name, urlPrefix string, ndClient normanv3.NodeDriverInt
 	if err := ndClient.Delete(name, &v1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 		logrus.Warnf("Error deleting node driver %s: %v", name, err)
 	}
-}
-
-func isCommandAvailable(name string) bool {
-	return exec.Command("command", "-v", name).Run() == nil
 }

--- a/pkg/rancher/driver_migration.go
+++ b/pkg/rancher/driver_migration.go
@@ -1,0 +1,197 @@
+package rancher
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/data/management"
+	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	linodeDriver = management.Linodedriver
+
+	// One-shot ConfigMap marker: gates the "disable linode if unused" evaluation
+	// so it runs only on the first Rancher start, not on every subsequent restart.
+	linodeDisableCheckConfigMap = "disableunusedlinodenodedriver"
+	linodeDisableCheckKey       = "unusedLinodeNodeDriverDisabled"
+
+	linodeMachineConfigKind = "LinodeConfig"
+
+	// DynamicSchema object names created by the nodedriver lifecycle for linode.
+	linodeConfigSchemaName           = "linodeconfig"
+	linodeCredentialConfigSchemaName = "linodecredentialconfig"
+
+	// Parent DynamicSchema objects that embed the linode config fields.
+	linodeParentNodeConfig   = "nodeconfig"
+	linodeParentNodeTemplate = "nodetemplateconfig"
+	linodeParentCredential   = "credentialconfig"
+
+	// Fields in the parent DynamicSchema objects that embed the linode config fields.
+	linodeConfigField     = "linodeConfig"
+	linodeCredentialField = "linodecredentialConfig"
+
+	// CRD names generated from the linodeconfig DynamicSchema.
+	linodeConfigCRD          = "linodeconfigs.rke-machine-config.cattle.io"
+	linodeMachineCRD         = "linodemachines.rke-machine.cattle.io"
+	linodeMachineTemplateCRD = "linodemachinetemplates.rke-machine.cattle.io"
+)
+
+// disableUnusedLinodeNodeDriver runs once per Rancher installation (gated by a
+// ConfigMap marker in cattle-system) to disable the linode NodeDriver and
+// remove its associated DynamicSchema objects, parent-schema fields, and
+// generated CRDs when no provisioning cluster is using it.
+//
+// This function MUST be called early in rancher.New(), before the wrangler
+// SharedCacheFactory and lasso dynamic controller start (i.e. before
+// MultiClusterManager.Start / steveserver.New). The reason is that once lasso
+// starts it caches the RESTMappings of the linode CRDs in an internal
+// memory-cache that is never invalidated on CRD deletion, so deleting the CRDs
+// after that point causes lasso to keep resurrecting watchers for the deleted
+// GVKs, which then 404 forever. Deleting the CRDs before lasso ever sees them
+// ensures the mappings are never cached and no watchers are started.
+//
+// All operations use direct API calls (not informer caches) because this
+// function runs before any informer is synced. All deletes and updates tolerate
+// NotFound, so the function is idempotent and safe on fresh installs where the
+// driver and its CRDs do not yet exist.
+func disableUnusedLinodeNodeDriver(w *wrangler.Context) error {
+	cm, err := w.Core.ConfigMap().Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("DisableUnusedLinodeNodeDriver: failed to get marker ConfigMap: %w", err)
+	}
+	if apierrors.IsNotFound(err) {
+		cm = &corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      linodeDisableCheckConfigMap,
+				Namespace: cattleNamespace,
+			},
+			Data: make(map[string]string, 1),
+		}
+	}
+
+	// Marker already set on a previous start: nothing to do.
+	if cm.Data[linodeDisableCheckKey] == "true" {
+		return nil
+	}
+
+	inUse, err := linodeNodeDriverInUse(w)
+	if err != nil {
+		return err
+	}
+
+	if inUse {
+		logrus.Info("disableUnusedLinodeNodeDriver: linode node driver is in use by one or more provisioning clusters; leaving state unchanged")
+	} else {
+		logrus.Info("disableUnusedLinodeNodeDriver: deactivating the not in-used linode node driver")
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// 1. Deactivate the NodeDriver CR.
+			nd, err := w.Mgmt.NodeDriver().Get(linodeDriver, v1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if !nd.Spec.Active {
+				return nil // Already inactive.
+			}
+			nd = nd.DeepCopy()
+			nd.Spec.Active = false
+			if _, err := w.Mgmt.NodeDriver().Update(nd); err != nil {
+				return fmt.Errorf("failed to update NodeDriver: %w", err)
+			}
+			logrus.Debug("disableUnusedLinodeNodeDriver: deactivated nodeDriver linode")
+
+			// 2. Delete the linodeconfig and linodecredentialconfig DynamicSchema
+			//    objects. These are the source objects that the CAPR dynamicschema
+			//    controller uses to generate the rke-machine CRDs; deleting them
+			//    prevents any future re-generation.
+			for _, schemaName := range []string{linodeConfigSchemaName, linodeCredentialConfigSchemaName} {
+				if err := w.Mgmt.DynamicSchema().Delete(schemaName, &v1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete DynamicSchema %s: %w", schemaName, err)
+				}
+				logrus.Debugf("disableUnusedLinodeNodeDriver: deleted DynamicSchema %s", schemaName)
+			}
+
+			// 3. Remove the linode config fields from the parent schemas so that
+			//    getStyle() can never return node=true for linode, even if the
+			//    DynamicSchema objects are re-created.
+			parentFields := []struct{ schema, field string }{
+				{linodeParentNodeConfig, linodeConfigField},
+				{linodeParentNodeTemplate, linodeConfigField},
+				{linodeParentCredential, linodeCredentialField},
+			}
+			for _, pf := range parentFields {
+				if err := removeFieldFromSchema(w, pf.schema, pf.field); err != nil {
+					return fmt.Errorf("failed to remove field %s from schema %s: %w", pf.field, pf.schema, err)
+				}
+				logrus.Debugf("disableUnusedLinodeNodeDriver: disabled %s from schema %s", pf.field, pf.schema)
+			}
+
+			// 4. Delete the three CRDs generated from the linodeconfig DynamicSchema.
+			//    This must happen before lasso's dynamic controller starts so the CRD
+			//    RESTMappings are never cached in lasso's internal memory-cache mapper.
+			for _, crdName := range []string{linodeConfigCRD, linodeMachineCRD, linodeMachineTemplateCRD} {
+				if err := w.CRD.CustomResourceDefinition().Delete(crdName, &v1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete CRD %s: %w", crdName, err)
+				}
+				logrus.Debugf("disableUnusedLinodeNodeDriver: deleted CRD %s", crdName)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("disableUnusedLinodeNodeDriver: failed to deactivate linode NodeDriver: %w", err)
+		}
+	}
+
+	// Persist the marker regardless of in-use status so the evaluation never
+	// re-runs on subsequent starts (admin's choices are preserved thereafter).
+	cm.Data[linodeDisableCheckKey] = "true"
+	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
+}
+
+// linodeNodeDriverInUse reports whether any provisioning.cattle.io/v1 Cluster
+// has a MachinePool whose machineConfigRef matches the linode node driver.
+func linodeNodeDriverInUse(w *wrangler.Context) (bool, error) {
+	clusters, err := w.Provisioning.Cluster().List("", v1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("linodeNodeDriverInUse: failed to list provisioning clusters: %w", err)
+	}
+	for _, cluster := range clusters.Items {
+		if cluster.Spec.RKEConfig == nil {
+			continue
+		}
+		for _, pool := range cluster.Spec.RKEConfig.MachinePools {
+			// APIVersion is empty when the cluster is created via UI, so we don't check it here.
+			if pool.NodeConfig != nil && pool.NodeConfig.Kind == linodeMachineConfigKind {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// removeFieldFromSchema removes the named field from the ResourceFields of the
+// specified DynamicSchema. Tolerates NotFound (schema does not exist yet) and
+// is a no-op when the field is already absent.
+func removeFieldFromSchema(w *wrangler.Context, schemaName, fieldName string) error {
+	schema, err := w.Mgmt.DynamicSchema().Get(schemaName, v1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if _, ok := schema.Spec.ResourceFields[fieldName]; !ok {
+		return nil // Field already absent.
+	}
+	schema = schema.DeepCopy()
+	delete(schema.Spec.ResourceFields, fieldName)
+	_, err = w.Mgmt.DynamicSchema().Update(schema)
+	return err
+}

--- a/pkg/rancher/driver_migration.go
+++ b/pkg/rancher/driver_migration.go
@@ -64,18 +64,8 @@ func disableUnusedLinodeNodeDriver(w *wrangler.Context) error {
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("DisableUnusedLinodeNodeDriver: failed to get marker ConfigMap: %w", err)
 	}
-	if apierrors.IsNotFound(err) {
-		cm = &corev1.ConfigMap{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      linodeDisableCheckConfigMap,
-				Namespace: cattleNamespace,
-			},
-			Data: make(map[string]string, 1),
-		}
-	}
-
 	// Marker already set on a previous start: nothing to do.
-	if cm.Data[linodeDisableCheckKey] == "true" {
+	if cm != nil && cm.Data[linodeDisableCheckKey] == "true" {
 		return nil
 	}
 
@@ -149,13 +139,42 @@ func disableUnusedLinodeNodeDriver(w *wrangler.Context) error {
 		}
 	}
 
-	// Persist the marker regardless of in-use status so the evaluation never
-	// re-runs on subsequent starts (admin's choices are preserved thereafter).
-	if cm.Data == nil {
-		cm.Data = make(map[string]string, 1)
-	}
-	cm.Data[linodeDisableCheckKey] = "true"
-	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := w.Core.ConfigMap().Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			cm = &corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: cattleNamespace,
+					Name:      linodeDisableCheckConfigMap,
+				},
+				Data: make(map[string]string, 1),
+			}
+		} else if err != nil {
+			return err
+		}
+
+		// Marker already set by another Rancher pod: nothing to do.
+		if cm != nil && cm.Data[linodeDisableCheckKey] == "true" {
+			return nil
+		}
+
+		// Persist the marker regardless of in-use status so the evaluation never
+		// re-runs on subsequent starts (admin's choices are preserved thereafter).
+		if cm.Data == nil {
+			cm.Data = make(map[string]string, 1)
+		}
+		cm.Data[linodeDisableCheckKey] = "true"
+
+		if cm.ResourceVersion == "" {
+			_, err = w.Core.ConfigMap().Create(cm)
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
+			return err
+		}
+		_, err = w.Core.ConfigMap().Update(cm)
+		return err
+	})
 }
 
 // linodeNodeDriverInUse reports whether any provisioning.cattle.io/v1 Cluster

--- a/pkg/rancher/driver_migration.go
+++ b/pkg/rancher/driver_migration.go
@@ -87,7 +87,7 @@ func disableUnusedLinodeNodeDriver(w *wrangler.Context) error {
 	if inUse {
 		logrus.Info("disableUnusedLinodeNodeDriver: linode node driver is in use by one or more provisioning clusters; leaving state unchanged")
 	} else {
-		logrus.Info("disableUnusedLinodeNodeDriver: deactivating the not in-used linode node driver")
+		logrus.Info("disableUnusedLinodeNodeDriver: deactivating the unused linode node driver")
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			// 1. Deactivate the NodeDriver CR.
 			nd, err := w.Mgmt.NodeDriver().Get(linodeDriver, v1.GetOptions{})
@@ -151,6 +151,9 @@ func disableUnusedLinodeNodeDriver(w *wrangler.Context) error {
 
 	// Persist the marker regardless of in-use status so the evaluation never
 	// re-runs on subsequent starts (admin's choices are preserved thereafter).
+	if cm.Data == nil {
+		cm.Data = make(map[string]string, 1)
+	}
 	cm.Data[linodeDisableCheckKey] = "true"
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
 }

--- a/pkg/rancher/driver_migration_test.go
+++ b/pkg/rancher/driver_migration_test.go
@@ -140,7 +140,6 @@ func parentSchemaWithField(name, field string) *mgmtv3.DynamicSchema {
 // teardown path (deactivate NodeDriver, delete schemas, remove fields, delete
 // CRDs). All operations tolerate NotFound.
 func setupTeardownExpectations(
-	ctrl *gomock.Controller,
 	mockND *ctrlfake.MockNonNamespacedControllerInterface[*mgmtv3.NodeDriver, *mgmtv3.NodeDriverList],
 	mockDS *ctrlfake.MockNonNamespacedControllerInterface[*mgmtv3.DynamicSchema, *mgmtv3.DynamicSchemaList],
 	mockCRD *ctrlfake.MockNonNamespacedControllerInterface[*apiextv1.CustomResourceDefinition, *apiextv1.CustomResourceDefinitionList],
@@ -339,15 +338,28 @@ func TestDisableUnusedLinodeNodeDriver(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			// ConfigMap mock.
+			// disableUnusedLinodeNodeDriver() now does an initial marker read and,
+			// when it needs to persist the marker, a second Get inside a
+			// retry-on-conflict closure before Create/Update.
 			mockCM := ctrlfake.NewMockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 			if tt.storedCM != nil {
 				mockCM.EXPECT().
 					Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{}).
 					Return(tt.storedCM, nil)
+				if tt.wantMarkerWrite {
+					mockCM.EXPECT().
+						Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{}).
+						Return(tt.storedCM, nil)
+				}
 			} else {
 				mockCM.EXPECT().
 					Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{}).
 					Return(nil, markerNotFound())
+				if tt.wantMarkerWrite {
+					mockCM.EXPECT().
+						Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{}).
+						Return(nil, markerNotFound())
+				}
 			}
 
 			markerWritten := false
@@ -383,7 +395,7 @@ func TestDisableUnusedLinodeNodeDriver(t *testing.T) {
 			mockCRD := ctrlfake.NewMockNonNamespacedControllerInterface[*apiextv1.CustomResourceDefinition, *apiextv1.CustomResourceDefinitionList](ctrl)
 
 			if tt.expectTeardown {
-				setupTeardownExpectations(ctrl, mockND, mockDS, mockCRD, tt.ndActive)
+				setupTeardownExpectations(mockND, mockDS, mockCRD, tt.ndActive)
 			} else if !markerPresent && tt.clusterListErr == nil {
 				// Check if driver is actually in use to determine if we expect NodeDriver.Get to be called
 				isLinodeInUse := false

--- a/pkg/rancher/driver_migration_test.go
+++ b/pkg/rancher/driver_migration_test.go
@@ -1,0 +1,426 @@
+package rancher
+
+import (
+	"errors"
+	"testing"
+
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/capr"
+	managementv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	provisioningv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/wrangler"
+	crdv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io/v1"
+	corev1wrangler "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	ctrlfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type stubProvisioningV1ForLinode struct {
+	provisioningv1.Interface
+	clusterCtrl provisioningv1.ClusterController
+}
+
+func (s *stubProvisioningV1ForLinode) Cluster() provisioningv1.ClusterController {
+	return s.clusterCtrl
+}
+
+type stubCoreV1ForLinode struct {
+	corev1wrangler.Interface
+	configMapCtrl corev1wrangler.ConfigMapController
+}
+
+func (s *stubCoreV1ForLinode) ConfigMap() corev1wrangler.ConfigMapController {
+	return s.configMapCtrl
+}
+
+type stubMgmtV3ForLinode struct {
+	managementv3.Interface
+	nodeDriverCtrl    managementv3.NodeDriverController
+	dynamicSchemaCtrl managementv3.DynamicSchemaController
+}
+
+func (s *stubMgmtV3ForLinode) NodeDriver() managementv3.NodeDriverController {
+	return s.nodeDriverCtrl
+}
+
+func (s *stubMgmtV3ForLinode) DynamicSchema() managementv3.DynamicSchemaController {
+	return s.dynamicSchemaCtrl
+}
+
+type stubCRDForLinode struct {
+	crdv1.Interface
+	crdCtrl crdv1.CustomResourceDefinitionController
+}
+
+func (s *stubCRDForLinode) CustomResourceDefinition() crdv1.CustomResourceDefinitionController {
+	return s.crdCtrl
+}
+
+func newLinodeWranglerCtx(
+	clusterCtrl provisioningv1.ClusterController,
+	cmCtrl corev1wrangler.ConfigMapController,
+	ndCtrl managementv3.NodeDriverController,
+	dsCtrl managementv3.DynamicSchemaController,
+	crdCtrl crdv1.CustomResourceDefinitionController,
+) *wrangler.Context {
+	return &wrangler.Context{
+		Provisioning: &stubProvisioningV1ForLinode{clusterCtrl: clusterCtrl},
+		Core:         &stubCoreV1ForLinode{configMapCtrl: cmCtrl},
+		Mgmt:         &stubMgmtV3ForLinode{nodeDriverCtrl: ndCtrl, dynamicSchemaCtrl: dsCtrl},
+		CRD:          &stubCRDForLinode{crdCtrl: crdCtrl},
+	}
+}
+
+func linodePool() provv1.RKEMachinePool {
+	return provv1.RKEMachinePool{
+		NodeConfig: &corev1.ObjectReference{
+			APIVersion: capr.DefaultMachineConfigAPIVersion,
+			Kind:       linodeMachineConfigKind,
+		},
+	}
+}
+
+func otherPool() provv1.RKEMachinePool {
+	return provv1.RKEMachinePool{
+		NodeConfig: &corev1.ObjectReference{
+			APIVersion: capr.DefaultMachineConfigAPIVersion,
+			Kind:       "Amazonec2Config",
+		},
+	}
+}
+
+func markerCM(marked bool) *corev1.ConfigMap {
+	data := map[string]string{}
+	if marked {
+		data[linodeDisableCheckKey] = "true"
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            linodeDisableCheckConfigMap,
+			Namespace:       cattleNamespace,
+			ResourceVersion: "1",
+		},
+		Data: data,
+	}
+}
+
+func markerNotFound() error {
+	return apierrors.NewNotFound(
+		schema.GroupResource{Group: "", Resource: "configmaps"},
+		linodeDisableCheckConfigMap,
+	)
+}
+
+func activeNodeDriver() *mgmtv3.NodeDriver {
+	return &mgmtv3.NodeDriver{
+		ObjectMeta: v1.ObjectMeta{Name: linodeDriver, ResourceVersion: "1"},
+		Spec:       mgmtv3.NodeDriverSpec{Active: true},
+	}
+}
+
+// parentSchemaWithField returns a minimal DynamicSchema that has a given field.
+func parentSchemaWithField(name, field string) *mgmtv3.DynamicSchema {
+	return &mgmtv3.DynamicSchema{
+		ObjectMeta: v1.ObjectMeta{Name: name, ResourceVersion: "1"},
+		Spec: mgmtv3.DynamicSchemaSpec{
+			ResourceFields: map[string]mgmtv3.Field{field: {}},
+		},
+	}
+}
+
+// setupTeardownExpectations sets up the mock expectations for the full linode
+// teardown path (deactivate NodeDriver, delete schemas, remove fields, delete
+// CRDs). All operations tolerate NotFound.
+func setupTeardownExpectations(
+	ctrl *gomock.Controller,
+	mockND *ctrlfake.MockNonNamespacedControllerInterface[*mgmtv3.NodeDriver, *mgmtv3.NodeDriverList],
+	mockDS *ctrlfake.MockNonNamespacedControllerInterface[*mgmtv3.DynamicSchema, *mgmtv3.DynamicSchemaList],
+	mockCRD *ctrlfake.MockNonNamespacedControllerInterface[*apiextv1.CustomResourceDefinition, *apiextv1.CustomResourceDefinitionList],
+	ndActive bool,
+) {
+	// NodeDriver: Get + Update (if active)
+	if ndActive {
+		mockND.EXPECT().Get(linodeDriver, v1.GetOptions{}).Return(activeNodeDriver(), nil)
+		mockND.EXPECT().Update(gomock.Any()).DoAndReturn(func(nd *mgmtv3.NodeDriver) (*mgmtv3.NodeDriver, error) {
+			return nd, nil
+		})
+	} else {
+		mockND.EXPECT().Get(linodeDriver, v1.GetOptions{}).Return(nil,
+			apierrors.NewNotFound(schema.GroupResource{}, linodeDriver))
+	}
+
+	// DynamicSchema deletes (linodeconfig, linodecredentialconfig)
+	mockDS.EXPECT().Delete(linodeConfigSchemaName, gomock.Any()).Return(nil)
+	mockDS.EXPECT().Delete(linodeCredentialConfigSchemaName, gomock.Any()).Return(nil)
+
+	// Parent schema field removals: Get + Update for each
+	for _, pf := range []struct{ schema, field string }{
+		{linodeParentNodeConfig, linodeConfigField},
+		{linodeParentNodeTemplate, linodeConfigField},
+		{linodeParentCredential, linodeCredentialField},
+	} {
+		mockDS.EXPECT().Get(pf.schema, v1.GetOptions{}).
+			Return(parentSchemaWithField(pf.schema, pf.field), nil)
+		mockDS.EXPECT().Update(gomock.Any()).Return(&mgmtv3.DynamicSchema{}, nil)
+	}
+
+	// CRD deletes
+	for _, crdName := range []string{linodeConfigCRD, linodeMachineCRD, linodeMachineTemplateCRD} {
+		mockCRD.EXPECT().Delete(crdName, gomock.Any()).Return(nil)
+	}
+}
+
+func TestLinodeNodeDriverInUse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		clusters []provv1.Cluster
+		listErr  error
+		want     bool
+		wantErr  bool
+	}{
+		{name: "no clusters", want: false},
+		{
+			name:     "cluster with nil RKEConfig",
+			clusters: []provv1.Cluster{{Spec: provv1.ClusterSpec{RKEConfig: nil}}},
+			want:     false,
+		},
+		{
+			name: "cluster with empty MachinePools",
+			clusters: []provv1.Cluster{
+				{Spec: provv1.ClusterSpec{RKEConfig: &provv1.RKEConfig{}}},
+			},
+			want: false,
+		},
+		{
+			name: "pool with nil NodeConfig",
+			clusters: []provv1.Cluster{
+				{Spec: provv1.ClusterSpec{RKEConfig: &provv1.RKEConfig{
+					MachinePools: []provv1.RKEMachinePool{{NodeConfig: nil}},
+				}}},
+			},
+			want: false,
+		},
+		{
+			name: "kind matches but APIVersion empty",
+			clusters: []provv1.Cluster{
+				{Spec: provv1.ClusterSpec{RKEConfig: &provv1.RKEConfig{
+					MachinePools: []provv1.RKEMachinePool{
+						{NodeConfig: &corev1.ObjectReference{Kind: linodeMachineConfigKind}},
+					},
+				}}},
+			},
+			want: true,
+		},
+		{
+			name: "non-linode kind",
+			clusters: []provv1.Cluster{
+				{Spec: provv1.ClusterSpec{RKEConfig: &provv1.RKEConfig{
+					MachinePools: []provv1.RKEMachinePool{otherPool()},
+				}}},
+			},
+			want: false,
+		},
+		{
+			name: "LinodeConfig with correct APIVersion",
+			clusters: []provv1.Cluster{
+				{Spec: provv1.ClusterSpec{RKEConfig: &provv1.RKEConfig{
+					MachinePools: []provv1.RKEMachinePool{linodePool()},
+				}}},
+			},
+			want: true,
+		},
+		{
+			name: "mixed pools",
+			clusters: []provv1.Cluster{
+				{Spec: provv1.ClusterSpec{RKEConfig: &provv1.RKEConfig{
+					MachinePools: []provv1.RKEMachinePool{otherPool(), linodePool()},
+				}}},
+			},
+			want: true,
+		},
+		{
+			name:    "list error propagates",
+			listErr: errors.New("api error"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			mockCluster := ctrlfake.NewMockControllerInterface[*provv1.Cluster, *provv1.ClusterList](ctrl)
+			mockCluster.EXPECT().List("", v1.ListOptions{}).Return(
+				&provv1.ClusterList{Items: tt.clusters}, tt.listErr)
+			w := &wrangler.Context{
+				Provisioning: &stubProvisioningV1ForLinode{clusterCtrl: mockCluster},
+			}
+			got, err := linodeNodeDriverInUse(w)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDisableUnusedLinodeNodeDriver(t *testing.T) {
+	tests := []struct {
+		name            string
+		storedCM        *corev1.ConfigMap // nil → NotFound
+		clusters        []provv1.Cluster
+		clusterListErr  error
+		expectTeardown  bool
+		ndActive        bool
+		wantMarkerWrite bool
+		wantErr         bool
+	}{
+		{
+			name:            "marker already set – complete no-op",
+			storedCM:        markerCM(true),
+			wantMarkerWrite: false,
+		},
+		{
+			name:            "not in use, active driver – full teardown, new marker CM",
+			storedCM:        nil,
+			expectTeardown:  true,
+			ndActive:        true,
+			wantMarkerWrite: true,
+		},
+		{
+			name:            "not in use, NodeDriver NotFound – no teardown, marker written",
+			storedCM:        nil,
+			expectTeardown:  false,
+			ndActive:        false, // causes NodeDriver.Get to return NotFound in setupTeardownExpectations
+			wantMarkerWrite: true,
+		},
+		{
+			name:            "not in use - teardown, existing marker CM updated",
+			storedCM:        markerCM(false),
+			expectTeardown:  true,
+			ndActive:        true,
+			wantMarkerWrite: true,
+		},
+		{
+			name:     "in use – no teardown, only marker written",
+			storedCM: nil,
+			clusters: []provv1.Cluster{
+				{Spec: provv1.ClusterSpec{RKEConfig: &provv1.RKEConfig{
+					MachinePools: []provv1.RKEMachinePool{linodePool()},
+				}}},
+			},
+			expectTeardown:  false,
+			wantMarkerWrite: true,
+		},
+		{
+			name:           "cluster list error – returns error, no marker written",
+			storedCM:       nil,
+			clusterListErr: errors.New("list failed"),
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			// ConfigMap mock.
+			mockCM := ctrlfake.NewMockControllerInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+			if tt.storedCM != nil {
+				mockCM.EXPECT().
+					Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{}).
+					Return(tt.storedCM, nil)
+			} else {
+				mockCM.EXPECT().
+					Get(cattleNamespace, linodeDisableCheckConfigMap, v1.GetOptions{}).
+					Return(nil, markerNotFound())
+			}
+
+			markerWritten := false
+			if tt.wantMarkerWrite {
+				assertMarker := func(cm *corev1.ConfigMap) {
+					assert.Equal(t, "true", cm.Data[linodeDisableCheckKey])
+					markerWritten = true
+				}
+				if tt.storedCM != nil {
+					mockCM.EXPECT().Update(gomock.Any()).DoAndReturn(func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+						assertMarker(cm)
+						return cm, nil
+					})
+				} else {
+					mockCM.EXPECT().Create(gomock.Any()).DoAndReturn(func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+						assertMarker(cm)
+						return cm, nil
+					})
+				}
+			}
+
+			// Provisioning cluster mock (skipped when marker already present).
+			markerPresent := tt.storedCM != nil && tt.storedCM.Data[linodeDisableCheckKey] == "true"
+			mockCluster := ctrlfake.NewMockControllerInterface[*provv1.Cluster, *provv1.ClusterList](ctrl)
+			if !markerPresent {
+				mockCluster.EXPECT().List("", v1.ListOptions{}).Return(
+					&provv1.ClusterList{Items: tt.clusters}, tt.clusterListErr)
+			}
+
+			// NodeDriver, DynamicSchema, and CRD mocks.
+			mockND := ctrlfake.NewMockNonNamespacedControllerInterface[*mgmtv3.NodeDriver, *mgmtv3.NodeDriverList](ctrl)
+			mockDS := ctrlfake.NewMockNonNamespacedControllerInterface[*mgmtv3.DynamicSchema, *mgmtv3.DynamicSchemaList](ctrl)
+			mockCRD := ctrlfake.NewMockNonNamespacedControllerInterface[*apiextv1.CustomResourceDefinition, *apiextv1.CustomResourceDefinitionList](ctrl)
+
+			if tt.expectTeardown {
+				setupTeardownExpectations(ctrl, mockND, mockDS, mockCRD, tt.ndActive)
+			} else if !markerPresent && tt.clusterListErr == nil {
+				// Check if driver is actually in use to determine if we expect NodeDriver.Get to be called
+				isLinodeInUse := false
+				for _, cluster := range tt.clusters {
+					if cluster.Spec.RKEConfig != nil {
+						for _, pool := range cluster.Spec.RKEConfig.MachinePools {
+							if pool.NodeConfig != nil && pool.NodeConfig.Kind == linodeMachineConfigKind {
+								isLinodeInUse = true
+								break
+							}
+						}
+						if isLinodeInUse {
+							break
+						}
+					}
+				}
+				// Only set up the expectation if the driver is not in use and NodeDriver doesn't exist
+				if !isLinodeInUse && !tt.ndActive {
+					mockND.EXPECT().Get(linodeDriver, v1.GetOptions{}).Return(nil,
+						apierrors.NewNotFound(schema.GroupResource{}, linodeDriver))
+				}
+			}
+
+			w := newLinodeWranglerCtx(mockCluster, mockCM, mockND, mockDS, mockCRD)
+
+			err := disableUnusedLinodeNodeDriver(w)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.False(t, markerWritten, "marker should not be written on error")
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantMarkerWrite {
+				assert.True(t, markerWritten)
+			} else {
+				assert.False(t, markerWritten)
+			}
+		})
+	}
+}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -224,17 +224,10 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 
 	// Disable the linode node driver (if unused) and remove its DynamicSchema
 	// objects and generated CRDs before any informers start.
-	//
-	// This must happen here — before MultiClusterManager.Start and
-	// steveserver.New — because once lasso's dynamic controller starts it
-	// caches the RESTMappings for any CRDs it finds in discovery. Those
-	// mappings are never evicted on CRD deletion, so deleting the linode CRDs
-	// after lasso starts causes it to keep resurrecting watchers for the
-	// deleted GVKs, producing a perpetual "failed to list *unstructured.Unstructured"
-	// 404 loop in the logs. Deleting the CRDs here ensures lasso never caches
-	// them and no watches are ever started for them.
-	if err := disableUnusedLinodeNodeDriver(wranglerContext); err != nil {
-		return nil, fmt.Errorf("failed to reconcile linode node driver: %w", err)
+	if features.MCM.Enabled() && features.ProvisioningV2.Enabled() {
+		if err := disableUnusedLinodeNodeDriver(wranglerContext); err != nil {
+			return nil, fmt.Errorf("failed to reconcile linode node driver: %w", err)
+		}
 	}
 
 	if features.MCM.Enabled() && !features.Fleet.Enabled() {

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -222,6 +222,21 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, fmt.Errorf("failed to create CRDs: %w", err)
 	}
 
+	// Disable the linode node driver (if unused) and remove its DynamicSchema
+	// objects and generated CRDs before any informers start.
+	//
+	// This must happen here — before MultiClusterManager.Start and
+	// steveserver.New — because once lasso's dynamic controller starts it
+	// caches the RESTMappings for any CRDs it finds in discovery. Those
+	// mappings are never evicted on CRD deletion, so deleting the linode CRDs
+	// after lasso starts causes it to keep resurrecting watchers for the
+	// deleted GVKs, producing a perpetual "failed to list *unstructured.Unstructured"
+	// 404 loop in the logs. Deleting the CRDs here ensures lasso never caches
+	// them and no watches are ever started for them.
+	if err := disableUnusedLinodeNodeDriver(wranglerContext); err != nil {
+		return nil, fmt.Errorf("failed to reconcile linode node driver: %w", err)
+	}
+
 	if features.MCM.Enabled() && !features.Fleet.Enabled() {
 		logrus.Info("fleet can't be turned off when MCM is enabled. Turning on fleet feature")
 		if err := features.SetFeature(wranglerContext.Mgmt.Feature(), features.Fleet.Name(), true); err != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
- https://github.com/rancher/rancher/issues/54574 

## Problem

We want to migrate the embedded Linode machine driver (aka node driver) from an embedded driver to a standard URL-based one, consistent with other third-party cloud providers in Rancher.

At the same time, we want to minimize the impact on existing Rancher installations and preserve compatibility for current users.

## Solution
 
This PR makes the following changes:

- Removes the logic for downloading the Linode machine driver from the Dockerfile.
- Updates the Linode node driver to be a standard third-party URL-based driver. The driver is inactive by default to avoid unnecessary downloads of the Linode binary on fresh Rancher installations.
- Adds a one-time migration that deactivates the Linode node driver and cleans up related resources if it is not used by any existing provisioning cluster. This ensures that the Linode binary is downloaded only if it is actively used by a provisioning cluster upon upgrading Rancher. 

More details can be found in the inline comments in the PR. 

## Testing
 
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

An image built from this PR is used to perform the following tests:

1. Perform a fresh installation (docker run). Verify that the Linode node driver is disabled by default.
2. Enable the Linode node driver and verify that it is downloaded successfully.
3. Restart the Rancher container. Confirm that the Linode node driver remains active, which means that the migration is performed only once. 
4.  Delete the `disableunusedlinodenodedriver` configMap, create a dummy provisioning cluster whose machine pool uses the LinodeConfig, then restart Rancher. Confirm that the Linode node driver remains active after the restart. This test simulates the scenario that the Linode node drive is left active when there are existing provisioning clusters using it after upgrading Rancher to the new version for the first time. 
5. Delete the provisioning cluster, then restart Rancher. Observe that the Linode node driver remains active, meaning that the migration is performed only once. 
6.  Delete the `disableunusedlinodenodedriver` configMap, create and then delete a dummy provisioning cluster whose machine pool uses the LinodeConfig, then restart Rancher. Confirm that the Linode node driver is disabled. This test simulates the scenario that the Linode node drive is left active and used at least once before upgrading Rancher to the new version for the first time. It is necessary to validate that the one-time teardown does not cause lasso's dynamic controller to produce a perpetual "failed to list *unstructured.Unstructured" error. 

### Automated Testing
 
Unit tests are added. 


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
1. Fresh installation of Rancher - the Linode node driver should be deactivated, Rancher logs reflect the one-shot migration
2. Upgrading Rancher from the previous version with no existing Linode node-driver clusters -  the Linode node driver should be deactivated, related CRDs should be gone, Rancher logs reflect the one-shot migration
3. Upgrading Rancher from the previous version with some existing Linode node-driver clusters - the Linode node driver should stay active, Rancher logs reflect the one-shot migration
4. Restarting Rancher - no flipping on the Linode node driver's status

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

See the above section 

Existing / newly added automated tests that provide evidence there are no regressions:
N/A 