### PR TITLE
Fix concurrent map access in UI plugin fs cache sync

### DIFF
--- a/pkg/controllers/dashboard/plugin/fscache.go
+++ b/pkg/controllers/dashboard/plugin/fscache.go
@@ -98,6 +98,8 @@ func (c FSCache) SyncWithControllersCache(p *v1.UIPlugin, forceUpdate bool) erro
 // Entries that aren't in the index, but present in the filesystem cache are deleted
 func (c FSCache) SyncWithIndex(index *SafeIndex, fsCacheFiles []string) error {
 	var errs error
+	index.mu.RLock()
+	defer index.mu.RUnlock()
 	for _, file := range fsCacheFiles {
 		logrus.Debugf("syncing index with filesystem cache")
 		chartName, chartVersion, err := getChartNameAndVersion(file)

--- a/pkg/controllers/dashboard/plugin/fscache_test.go
+++ b/pkg/controllers/dashboard/plugin/fscache_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"sync"
 	"testing"
 
 	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
@@ -140,6 +141,79 @@ func TestSyncWithIndex(t *testing.T) {
 					assert.Equal(t, tc.ExpectedPluginDeleted, actualPluginDeleted)
 				}
 			}
+		})
+	}
+}
+
+func TestSyncWithIndexConcurrentAccess(t *testing.T) {
+	testCases := []struct {
+		Name       string
+		NumPlugins int
+		Iterations int
+	}{
+		{
+			Name:       "SyncWithIndex is safe during concurrent index generation",
+			NumPlugins: 20,
+			Iterations: 300,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			originalRemoveAll := osRemoveAll
+			osRemoveAll = func(path string) error {
+				return nil
+			}
+			defer func() {
+				osRemoveAll = originalRemoveAll
+			}()
+
+			plugins := make([]*v1.UIPlugin, tc.NumPlugins)
+			fsCacheFiles := make([]string, tc.NumPlugins)
+
+			for i := 0; i < tc.NumPlugins; i++ {
+				name := fmt.Sprintf("test-plugin-%d", i)
+				plugins[i] = &v1.UIPlugin{
+					Spec: v1.UIPluginSpec{
+						Plugin: v1.UIPluginEntry{
+							Name:    name,
+							Version: "0.1.0",
+						},
+					},
+				}
+
+				fsCacheFiles[i] = fmt.Sprintf("%s/%s/0.1.0/plugin.js", FSCacheRootDir, name)
+			}
+
+			index := &SafeIndex{}
+			fsCache := FSCache{}
+
+			assert.NoError(t, index.Generate(plugins))
+			ready := make(chan struct{})
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			go func() {
+				defer wg.Done()
+				<-ready
+
+				for i := 0; i < tc.Iterations; i++ {
+					_ = fsCache.SyncWithIndex(index, fsCacheFiles)
+				}
+			}()
+
+			go func() {
+				defer wg.Done()
+				<-ready
+
+				for i := 0; i < tc.Iterations; i++ {
+					_ = index.Generate(plugins)
+				}
+			}()
+
+			close(ready)
+			wg.Wait()
 		})
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/55732

<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
`SafeIndex` is to protect its `Entries` map using an `RWMutex`. While all writes to the map are sync  thru [Generate()](https://github.com/rancher/rancher/blob/main/pkg/controllers/dashboard/plugin/index.go#L27) ,`Ready()`, and Cachestate(),[FSCache.SyncWithIndex()](https://github.com/rancher/rancher/blob/main/pkg/controllers/dashboard/plugin/fscache.go#L99) accessed index.Entries directly without acquiring the read lock...

When multiple [OnpluginChange()](https://github.com/rancher/rancher/blob/main/pkg/controllers/dashboard/plugin/controller.go#L50) handlers were processed concurrently, one go routine could rebuild the index while the other was reading from it, hence runtime detected the race and terminated it. 

<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Sync all reads of `SafeIndex.Entries` by acquiring the read lock before accessing the map.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_