### PR TITLE
Improve Dockerfile-related CI checks and aligns checksum naming

### DIFF
--- a/.github/actions/rancher-chart/build/action.yml
+++ b/.github/actions/rancher-chart/build/action.yml
@@ -15,22 +15,22 @@ runs:
       env:
          HELM_UNITTEST_VERSION: ${{ steps.env.outputs.HELM_UNITTEST_VERSION }}
          HELM_VERSION: ${{ steps.env.outputs.HELM_VERSION }}
-         HELM_HASH_amd64: ${{ steps.env.outputs.HELM_HASH_amd64 }}
-         HELM_HASH_arm64: ${{ steps.env.outputs.HELM_HASH_arm64 }}
+         HELM_CHECKSUM_amd64: ${{ steps.env.outputs.HELM_CHECKSUM_amd64 }}
+         HELM_CHECKSUM_arm64: ${{ steps.env.outputs.HELM_CHECKSUM_arm64 }}
       shell: bash
       run: |
         set -ex
         OS_ARCH=$(uname -m)
         if [ "$OS_ARCH" = "x86_64" ]; then
           ARCH="amd64"
-          HELM_HASH="${HELM_HASH_amd64}"
+          HELM_CHECKSUM="${HELM_CHECKSUM_amd64}"
         elif [ "$OS_ARCH" = "aarch64" ]; then
           ARCH="arm64"
-          HELM_HASH="${HELM_HASH_arm64}"
+          HELM_CHECKSUM="${HELM_CHECKSUM_arm64}"
         fi
         HELM_URL="https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz"
         curl "${HELM_URL}" -o /tmp/helm.tar.gz && \
-        echo "${HELM_HASH}  /tmp/helm.tar.gz" | sha256sum -c - && \
+        echo "${HELM_CHECKSUM}  /tmp/helm.tar.gz" | sha256sum -c - && \
         tar xvzf /tmp/helm.tar.gz --strip-components=1 -C /tmp/ && \
         mv /tmp/helm /usr/bin/helm && \
         chmod +x /usr/bin/helm

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -15,12 +15,12 @@ outputs:
   HELM_VERSION: 
     description: "HELM_VERSION from package/Dockerfile.installer"
     value: ${{ steps.vars.outputs.HELM_VERSION }}
-  HELM_HASH_amd64: 
-    description: "HELM_HASH_amd64 from package/Dockerfile.installer"
-    value: ${{ steps.vars.outputs.HELM_HASH_amd64 }}
-  HELM_HASH_arm64: 
-    description: "HELM_HASH_arm64 from package/Dockerfile.installer"
-    value: ${{ steps.vars.outputs.HELM_HASH_arm64 }}
+  HELM_CHECKSUM_amd64: 
+    description: "HELM_CHECKSUM_amd64 from package/Dockerfile.installer"
+    value: ${{ steps.vars.outputs.HELM_CHECKSUM_amd64 }}
+  HELM_CHECKSUM_arm64: 
+    description: "HELM_CHECKSUM_arm64 from package/Dockerfile.installer"
+    value: ${{ steps.vars.outputs.HELM_CHECKSUM_arm64 }}
   CATTLE_HELM_VERSION: 
     description: "CATTLE_HELM_VERSION from package/Dockerfile"
     value: ${{ steps.vars.outputs.CATTLE_HELM_VERSION }}
@@ -58,8 +58,8 @@ runs:
         CATTLE_KDM_BRANCH=$(grep -m1 'ARG CATTLE_KDM_BRANCH=' package/Dockerfile | cut -d '=' -f2)
         CATTLE_K3S_VERSION=$(grep -m1 'ENV CATTLE_K3S_VERSION=' package/Dockerfile | cut -d '=' -f2)
         HELM_VERSION=$(grep -m1 'ENV HELM_VERSION=' package/Dockerfile.installer | cut -d '=' -f2)
-        HELM_HASH_amd64=$(grep -m1 'ENV HELM_HASH_amd64=' package/Dockerfile.installer | cut -d '=' -f2)
-        HELM_HASH_arm64=$(grep -m1 'ENV HELM_HASH_arm64=' package/Dockerfile.installer | cut -d '=' -f2)
+        HELM_CHECKSUM_amd64=$(grep -m1 'ENV HELM_CHECKSUM_amd64=' package/Dockerfile.installer | cut -d '=' -f2)
+        HELM_CHECKSUM_arm64=$(grep -m1 'ENV HELM_CHECKSUM_arm64=' package/Dockerfile.installer | cut -d '=' -f2)
         GO_VERSION=$(grep -m1 'golang:' package/Dockerfile | cut -d ':' -f2 | cut -d ' ' -f1)
         HELM_UNITTEST_VERSION=$(grep -m1 'ENV HELM_UNITTEST_VERSION=' Dockerfile.runtime | cut -d '=' -f2)
         CATTLE_RANCHER_WEBHOOK_VERSION=$CATTLE_RANCHER_WEBHOOK_VERSION
@@ -81,12 +81,12 @@ runs:
           echo "HELM_VERSION not found"
           exit 1
         fi
-        if [[ -z "$HELM_HASH_amd64" ]]; then
-          echo "HELM_HASH_amd64 not found"
+        if [[ -z "$HELM_CHECKSUM_amd64" ]]; then
+          echo "HELM_CHECKSUM_amd64 not found"
           exit 1
         fi
-        if [[ -z "$HELM_HASH_arm64" ]]; then
-          echo "HELM_HASH_arm64 not found"
+        if [[ -z "$HELM_CHECKSUM_arm64" ]]; then
+          echo "HELM_CHECKSUM_arm64 not found"
           exit 1
         fi
         if [[ -z "$CATTLE_HELM_VERSION" ]]; then
@@ -124,8 +124,8 @@ runs:
         echo "CATTLE_KDM_BRANCH=$CATTLE_KDM_BRANCH" >> $GITHUB_OUTPUT
         echo "CATTLE_K3S_VERSION=$CATTLE_K3S_VERSION" >> $GITHUB_OUTPUT 
         echo "HELM_VERSION=$HELM_VERSION" >> $GITHUB_OUTPUT 
-        echo "HELM_HASH_amd64=$HELM_HASH_amd64" >> $GITHUB_OUTPUT 
-        echo "HELM_HASH_arm64=$HELM_HASH_arm64" >> $GITHUB_OUTPUT 
+        echo "HELM_CHECKSUM_amd64=$HELM_CHECKSUM_amd64" >> $GITHUB_OUTPUT 
+        echo "HELM_CHECKSUM_arm64=$HELM_CHECKSUM_arm64" >> $GITHUB_OUTPUT 
 
         echo "GO_VERSION=$GO_VERSION" >> $GITHUB_OUTPUT 
         echo "HELM_UNITTEST_VERSION=$HELM_UNITTEST_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,6 +71,30 @@ jobs:
           persist-credentials: false
       - name: setup and build
         uses: ./.github/actions/build-images/agent
+  build-installer:
+    runs-on: runs-on,runner=4cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Verify installer Dockerfile build
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          file: ./package/Dockerfile.installer
+          build-args: |
+            BUILDARCH=amd64
+            VERSION=0.0.0
+          platforms: linux/amd64
+          load: false
+          push: false
+          cache-from: type=gha,scope=pr-build-installer
+          cache-to: type=gha,mode=min,scope=pr-build-installer
   integration-tests:
     permissions:
       contents: read

--- a/.github/workflows/verify-generated-code-changes.yml
+++ b/.github/workflows/verify-generated-code-changes.yml
@@ -12,7 +12,6 @@ permissions:
   id-token: none
 
 env:
-  MAIN_BRANCH: origin/main
   GOARCH: amd64
   CGO_ENABLED: 0
   SETUP_GO_VERSION: '1.26.*'

--- a/package/Dockerfile.installer
+++ b/package/Dockerfile.installer
@@ -13,17 +13,17 @@ ENV CHART_VERSION=${VERSION}
 # renovate: datasource=github-release-attachments depName=helm/helm
 ENV HELM_VERSION=v4.2.0
 # renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.2.0
-ENV HELM_HASH_amd64=97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096
+ENV HELM_CHECKSUM_amd64=97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096
 # renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.2.0
-ENV HELM_HASH_arm64=1f8de130dfbd04de64978e7b852a7a547be1404956a366608276d2520b678670
+ENV HELM_CHECKSUM_arm64=1f8de130dfbd04de64978e7b852a7a547be1404956a366608276d2520b678670
 
 RUN if [ "${BUILDARCH}" = "amd64" ]; then \
-        HELM_HASH="${HELM_HASH_amd64}"; \
+        HELM_CHECKSUM="${HELM_CHECKSUM_amd64}"; \
     elif [ "${BUILDARCH}" = "arm64" ]; then \
-        HELM_HASH="${HELM_HASH_arm64}"; \
+        HELM_CHECKSUM="${HELM_CHECKSUM_arm64}"; \
     fi; \
     wget "https://get.helm.sh/helm-${HELM_VERSION}-linux-${BUILDARCH}.tar.gz" -O /tmp/helm.tar.gz && \
-    echo "${HELM_HASH}  /tmp/helm.tar.gz" | sha256sum -c - && \
+    echo "${HELM_CHECKSUM}  /tmp/helm.tar.gz" | sha256sum -c - && \
     tar -xzf /tmp/helm.tar.gz --strip-components=1 -C /usr/bin && \
     chown root:root /usr/bin/helm && \
     chmod +x /usr/bin/helm && \
@@ -32,17 +32,17 @@ RUN if [ "${BUILDARCH}" = "amd64" ]; then \
 # renovate: datasource=github-release-attachments depName=mikefarah/yq
 ENV YQ_VERSION=v4.44.2
 # renovate: datasource=github-release-attachments depName=mikefarah/yq digestVersion=v4.44.2
-ENV YQ_HASH_amd64=e4c2570249e3993e33ffa44e592b5eee8545bd807bfbeb596c2986d86cb6c85c
+ENV YQ_CHECKSUM_amd64=e4c2570249e3993e33ffa44e592b5eee8545bd807bfbeb596c2986d86cb6c85c
 # renovate: datasource=github-release-attachments depName=mikefarah/yq digestVersion=v4.44.2
-ENV YQ_HASH_arm64=79c22d98b2ff517cb8b1c20499350cbc1e8c753483c8f72a37a299e6e9872a98
+ENV YQ_CHECKSUM_arm64=79c22d98b2ff517cb8b1c20499350cbc1e8c753483c8f72a37a299e6e9872a98
 
 RUN if [ "${BUILDARCH}" = "amd64" ]; then \
-        YQ_HASH="${YQ_HASH_amd64}"; \
+        YQ_CHECKSUM="${YQ_CHECKSUM_amd64}"; \
     elif [ "${BUILDARCH}" = "arm64" ]; then \
-        YQ_HASH="${YQ_HASH_arm64}"; \
+        YQ_CHECKSUM="${YQ_CHECKSUM_arm64}"; \
     fi; \
     wget -q https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${BUILDARCH}.tar.gz -O /tmp/yq.tar.gz && \
-    echo "${YQ_HASH}  /tmp/yq.tar.gz" | sha256sum -c - && \
+    echo "${YQ_CHECKSUM}  /tmp/yq.tar.gz" | sha256sum -c - && \
     tar xzf /tmp/yq.tar.gz && mv yq_linux_${BUILDARCH} /usr/bin/yq && \
     rm -f /tmp/yq.tar.gz
 


### PR DESCRIPTION
Improve Dockerfile-related CI checks and aligns checksum naming.

- Normalize installer checksum variables in `package/Dockerfile.installer` from `*_HASH_*` to `*_CHECKSUM_*`.
- Update CI helper actions to consume the renamed Helm checksum variables consistently.
- Build and validate the previously uncovered Dockerfile `package/Dockerfile.installer` in PR CI
- Use Buildx with GitHub cache scopes to keep the added verification relatively bandwith-friendly.