### PR TITLE
[v2.14.2-hotfix-64aa] Add diagnostic logging for ClusterAuthToken sync

### DIFF
--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -3,6 +3,8 @@ package clusterauthtoken
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	lassocache "github.com/rancher/lasso/pkg/cache"
 	"github.com/rancher/lasso/pkg/client"
@@ -151,7 +153,11 @@ func Register(ctx context.Context, cluster *config.UserContext, secretsCache cor
 		clusterUserAttribute,
 	}).Sync)
 
+	scheduleStartupCensus(tokenInformer)
+	logrus.Infof("[clusterauthtoken-sync] cluster=%s v3 Token handlers registered", clusterName)
+
 	cluster.Management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
+		logrus.Infof("[clusterauthtoken-sync] cluster=%s ext API ready, registering ext Token handlers", clusterName)
 		extToken := w.Client.Token()
 		handler.extTokenIndexer.Store(extToken.Informer().GetIndexer())
 		extTokenLifecycle(ctx, extToken, extTokenController, clusterName, handler)
@@ -163,7 +169,100 @@ func Register(ctx context.Context, cluster *config.UserContext, secretsCache cor
 			extTokenStore: extstore.NewSystemFromWrangler(cluster.Management.Wrangler),
 		}
 		cluster.Cluster.ClusterAuthTokens(namespace).AddHandler(ctx, clusterAuthTokenController, catHandler.sync)
+		logrus.Infof("[clusterauthtoken-sync] cluster=%s ext Token handlers registered", clusterName)
+		scheduleExtStartupCensus(extToken.Informer())
 	})
+}
+
+var (
+	censusOnce    sync.Once
+	extCensusOnce sync.Once
+)
+
+// scheduleStartupCensus launches a one-shot goroutine that, once the management
+// v3.Token informer cache has synced, walks the cache exactly once and reports
+// per-cluster counts at Info level: total v3.Tokens scoped to each cluster and
+// the subset missing the cat-token-controller lifecycle annotation. The latter
+// equals the per-cluster backlog of tokens that have never been processed by
+// the downstream sync handler — i.e. the tokens that got stuck. The number
+// should drop to zero within seconds of handler registration as the
+// re-enqueue-all from AddClusterScopedLifecycle drains the backlog. A non-zero
+// residual after a few minutes points to a remaining sync path failure.
+//
+// The walk is process-wide, not per UserContext: the management Token informer
+// cache is shared across all clusters, so a single walk is sufficient. The
+// goroutine runs at most once per process (guarded by sync.Once); subsequent
+// calls from other clusters' Register are no-ops.
+func scheduleStartupCensus(mgmtTokenInformer cache.SharedIndexInformer) {
+	censusOnce.Do(func() {
+		go runStartupCensus(mgmtTokenInformer)
+	})
+}
+
+func runStartupCensus(mgmtTokenInformer cache.SharedIndexInformer) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if !cache.WaitForCacheSync(ctx.Done(), mgmtTokenInformer.HasSynced) {
+		logrus.Warnf("[clusterauthtoken-sync] startup census skipped: management v3.Token cache did not sync within timeout")
+		return
+	}
+
+	type counts struct{ total, missing int }
+	byCluster := map[string]*counts{}
+	for _, obj := range mgmtTokenInformer.GetStore().List() {
+		t, ok := obj.(*managementv3.Token)
+		if !ok || t.ClusterName == "" {
+			continue
+		}
+		c, ok := byCluster[t.ClusterName]
+		if !ok {
+			c = &counts{}
+			byCluster[t.ClusterName] = c
+		}
+		c.total++
+		annotation := "lifecycle.cattle.io/create.cat-token-controller_" + t.ClusterName
+		if t.Annotations[annotation] != "true" {
+			c.missing++
+		}
+	}
+	for clusterName, c := range byCluster {
+		logrus.Infof("[clusterauthtoken-sync] cluster=%s startup census: v3_tokens=%d missing_lifecycle_annotation=%d",
+			clusterName, c.total, c.missing)
+	}
+}
+
+// scheduleExtStartupCensus mirrors scheduleStartupCensus for ext.Tokens. Called
+// from the EXT API DeferFunc once per UserContext; sync.Once ensures the walk
+// runs exactly once per process across all clusters. ext.Tokens are managed by
+// wrangler OnChange/OnRemove rather than Norman lifecycle, so they carry no
+// stuck-state annotation. The census reports inventory only — total ext.Tokens
+// per cluster. The actual drain is observable via the per-token "ext create"
+// Info events emitted by the sync handler.
+func scheduleExtStartupCensus(extTokenInformer cache.SharedIndexInformer) {
+	extCensusOnce.Do(func() {
+		go runExtStartupCensus(extTokenInformer)
+	})
+}
+
+func runExtStartupCensus(extTokenInformer cache.SharedIndexInformer) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if !cache.WaitForCacheSync(ctx.Done(), extTokenInformer.HasSynced) {
+		logrus.Warnf("[clusterauthtoken-sync] ext startup census skipped: ext.Token cache did not sync within timeout")
+		return
+	}
+
+	byCluster := map[string]int{}
+	for _, obj := range extTokenInformer.GetStore().List() {
+		t, ok := obj.(*extv1.Token)
+		if !ok || t.Spec.ClusterName == "" {
+			continue
+		}
+		byCluster[t.Spec.ClusterName]++
+	}
+	for clusterName, total := range byCluster {
+		logrus.Infof("[clusterauthtoken-sync] cluster=%s startup census: ext_tokens=%d", clusterName, total)
+	}
 }
 
 func newDedicatedSecretsCache(clientFactory client.SharedClientFactory, namespace string) (corecontrollers.SecretCache, controller.SharedControllerFactory) {

--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -63,7 +63,7 @@ func (h *tokenHandler) extCreate(token *extv1.Token) (*extv1.Token, error) {
 	if err := validateToken(token.GetName(), token.Spec.UserID); err != nil {
 		return token, err
 	}
-	logrus.Debugf("[%s] ext CREATE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.Spec.ClusterName)
+	logrus.Infof("[clusterauthtoken-sync] cluster=%s token=%s ext create", token.Spec.ClusterName, token.Name)
 
 	_, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
 	if !errors.IsNotFound(err) {
@@ -212,7 +212,7 @@ func (h *tokenHandler) Create(token *mgmtapiv3.Token) (runtime.Object, error) {
 	if err := validateToken(token.Name, token.UserID); err != nil {
 		return token, err
 	}
-	logrus.Debugf("[%s] v3 CREATE FOR %q INTO %q", clusterAuthTokenController, token.Name, token.ClusterName)
+	logrus.Infof("[clusterauthtoken-sync] cluster=%s token=%s v3 create", token.ClusterName, token.Name)
 
 	_, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
 	if !errors.IsNotFound(err) {
@@ -252,7 +252,17 @@ func (h *tokenHandler) Create(token *mgmtapiv3.Token) (runtime.Object, error) {
 }
 
 // createClusterAuthToken handles actions commonly taken to create a clusterAuthToken from a token.
-func (h *tokenHandler) createClusterAuthToken(token accessor.TokenAccessor, hashedValue string) error {
+func (h *tokenHandler) createClusterAuthToken(token accessor.TokenAccessor, hashedValue string) (retErr error) {
+	clusterName, tokenName := token.ObjClusterName(), token.GetName()
+	defer func() {
+		if retErr != nil {
+			logrus.Errorf("[clusterauthtoken-sync] cluster=%s token=%s createClusterAuthToken failed: %v",
+				clusterName, tokenName, retErr)
+			return
+		}
+		logrus.Infof("[clusterauthtoken-sync] cluster=%s token=%s ClusterAuthToken synced", clusterName, tokenName)
+	}()
+
 	err := h.updateClusterUserAttribute(token.GetUserID())
 	if err != nil {
 		return err

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rancher/rancher/pkg/impersonation"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/sirupsen/logrus"
 )
 
 func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *apimgmtv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
@@ -86,6 +87,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 		if err != nil {
 			return fmt.Errorf("registering clusterauthtoken factory: %w", err)
 		}
+		logrus.Infof("[clusterauthtoken-sync] cluster=%s registered downstream secrets factory", cluster.ClusterName)
 		clusterauthtoken.Register(ctx, cluster, secretsCache)
 	}
 

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -483,8 +483,9 @@ func (w *UserContext) Start(pctx context.Context) error {
 
 	for name, factory := range w.extraControllerFactories {
 		ctx := metrics.WithContextID(pctx, fmt.Sprintf("usercontext_%s_%s", name, w.ClusterName))
+		logrus.Infof("Starting extra controller factory %q for cluster %s", name, w.ClusterName)
 		if err := factory.Start(ctx, 1); err != nil {
-			return err
+			return fmt.Errorf("starting extra controller factory %q for cluster %s: %w", name, w.ClusterName, err)
 		}
 	}
 


### PR DESCRIPTION

- Info logs are now emitted at each registration milestone — factory setup, v3.Token handlers wired, ext API readiness, ext.Token handlers wired.
- A one-shot startup census walks the management v3.Token cache once per process and reports, per cluster, total v3.Tokens scoped to that cluster and the subset missing the cat-token-controller lifecycle annotation, which equals the backlog of tokens never processed by the downstream sync handler.
- An equivalent one-shot census for ext.Tokens runs after the ext API becomes ready and reports per-cluster inventory. v3.Token and ext.Token create entries are promoted from Debug to Info.
- Success and failure of the downstream ClusterAuthToken upsert are logged at the handler boundary.
- All new lines carry the [clusterauthtoken-sync] prefix for filtering. The extra controller factory startup loop also logs each factory by name.
