### PR TITLE
OIDC: Accept string-valued groups claim from IdPs

### DIFF
--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -77,6 +77,126 @@ type ClaimInfo struct {
 	Roles []string `json:"roles"`
 }
 
+// UnmarshalJSON decodes a ClaimInfo while tolerating IdPs that emit the
+// "groups", "full_group_path", or "roles" claim as a single string instead of
+// an array of strings (some OIDC providers serialize a single-element
+// IEnumerable<string> as a scalar). Each of these fields is accepted as
+// either a string or a JSON array of strings. Fields missing from the input
+// JSON are left untouched, matching the partial-update semantics of the
+// default json.Unmarshal so that UserInfo-overrides-ID-token behavior is
+// preserved.
+func (c *ClaimInfo) UnmarshalJSON(data []byte) error {
+	type claimInfoAlias ClaimInfo
+	raw := struct {
+		*claimInfoAlias
+		Groups        json.RawMessage `json:"groups"`
+		FullGroupPath json.RawMessage `json:"full_group_path"`
+		Roles         json.RawMessage `json:"roles"`
+	}{claimInfoAlias: (*claimInfoAlias)(c)}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.Groups != nil {
+		groups, err := decodeStringOrSlice(raw.Groups)
+		if err != nil {
+			return fmt.Errorf("groups claim: %w", err)
+		}
+		c.Groups = groups
+	}
+	if raw.FullGroupPath != nil {
+		fullGroupPath, err := decodeStringOrSlice(raw.FullGroupPath)
+		if err != nil {
+			return fmt.Errorf("full_group_path claim: %w", err)
+		}
+		c.FullGroupPath = fullGroupPath
+	}
+	if raw.Roles != nil {
+		roles, err := decodeStringOrSlice(raw.Roles)
+		if err != nil {
+			return fmt.Errorf("roles claim: %w", err)
+		}
+		c.Roles = roles
+	}
+
+	return nil
+}
+
+// decodeStringOrSlice decodes a JSON value that may be either a string or an
+// array of strings into a []string. A scalar string becomes a single-element
+// slice; an array becomes a slice with one element per array entry. Null,
+// empty, or absent values yield a nil slice. Empty strings inside an array are
+// dropped (a scalar empty string also yields nil).
+func decodeStringOrSlice(data json.RawMessage) ([]string, error) {
+	if len(data) == 0 || string(data) == "null" {
+		return nil, nil
+	}
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		out := arr[:0]
+		for _, s := range arr {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		return out, nil
+	}
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		if single == "" {
+			return nil, nil
+		}
+		return []string{single}, nil
+	}
+	return nil, errors.New("value must be a string or array of strings")
+}
+
+// coerceToStringSlice converts a claim value obtained from a decoded claim map
+// into a []string. It accepts a string (returned as a single-element slice),
+// an []any (each element type-asserted to string), or a []string. Other
+// shapes return nil. Empty strings are dropped.
+func coerceToStringSlice(v any) []string {
+	switch value := v.(type) {
+	case nil:
+		return nil
+	case string:
+		if value == "" {
+			return nil
+		}
+		return []string{value}
+	case []string:
+		out := make([]string, 0, len(value))
+		for _, s := range value {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(value))
+		for _, item := range value {
+			s, ok := item.(string)
+			if !ok {
+				logrus.Warn("OpenIDCProvider: failed to convert group to string")
+				continue
+			}
+			if s == "" {
+				continue
+			}
+			out = append(out, s)
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, TokenMgr *tokens.Manager) common.AuthProvider {
 	p := &OpenIDCProvider{
 		Name:        Name,
@@ -641,31 +761,24 @@ func applyCustomClaims(idToken *oidc.IDToken, userInfo *oidc.UserInfo, config *a
 	}
 
 	if config.GroupsClaim != "" {
-		groupsClaim, err := getValueFromClaims[[]any](idToken, config.GroupsClaim)
+		// The custom groups claim may arrive as either an array of strings or
+		// a single string (some IdPs emit a scalar when a user has only one
+		// group). Read the raw claim value and coerce it to []string so both
+		// shapes work.
+		rawGroups, err := getRawClaim(idToken, config.GroupsClaim)
 		if err != nil {
 			return fmt.Errorf("failed to parse groups claims: %w", err)
 		}
-		// UserInfo overrides ID token.
-		if raw, ok := userInfoRawClaims[config.GroupsClaim]; ok {
-			if rawSlice, ok := raw.([]any); ok {
-				groupsClaim = rawSlice
-			}
+		// UserInfo overrides ID token. A nil value (for example "role": null
+		// in the UserInfo payload) is ignored so the ID-token value is
+		// preserved rather than silently cleared.
+		if v, ok := userInfoRawClaims[config.GroupsClaim]; ok && v != nil {
+			rawGroups = v
 		}
 
-		if len(groupsClaim) > 0 {
+		if groups := coerceToStringSlice(rawGroups); len(groups) > 0 {
 			logrus.Debugf("OpenIDCProvider: using custom groups claim")
-			groups := make([]string, 0, len(groupsClaim))
-			for _, g := range groupsClaim {
-				group, ok := g.(string)
-				if !ok || group == "" {
-					logrus.Warn("OpenIDCProvider: failed to convert group to string")
-					continue
-				}
-				groups = append(groups, group)
-			}
-			if len(groups) > 0 {
-				claimInfo.Groups = groups
-			}
+			claimInfo.Groups = groups
 		}
 	}
 
@@ -940,6 +1053,18 @@ func getValueFromClaims[T any](idToken *oidc.IDToken, name string) (T, error) {
 	}
 
 	return claim, nil
+}
+
+// getRawClaim returns the raw value of the named claim from the ID token
+// without enforcing a specific Go type, allowing the caller to handle claims
+// that may arrive in more than one JSON shape (for example a string or an
+// array of strings). It returns nil if the claim is absent.
+func getRawClaim(idToken *oidc.IDToken, name string) (any, error) {
+	var mapClaims jwt.MapClaims
+	if err := idToken.Claims(&mapClaims); err != nil {
+		return nil, fmt.Errorf("failed to parse claims: %w", err)
+	}
+	return mapClaims[name], nil
 }
 
 func deletePKCEVerifier(req *http.Request, w http.ResponseWriter) {

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -110,6 +110,115 @@ func TestParseACRFromAccessToken(t *testing.T) {
 	}
 }
 
+func TestClaimInfoUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in          string
+		initial     *ClaimInfo
+		want        ClaimInfo
+		expectError bool
+	}{
+		"groups as array": {
+			in:   `{"sub":"u1","groups":["a","b"]}`,
+			want: ClaimInfo{Subject: "u1", Groups: []string{"a", "b"}},
+		},
+		"groups as single string": {
+			in:   `{"sub":"u1","groups":"only"}`,
+			want: ClaimInfo{Subject: "u1", Groups: []string{"only"}},
+		},
+		"groups as empty string yields nil slice": {
+			in:   `{"sub":"u1","groups":""}`,
+			want: ClaimInfo{Subject: "u1"},
+		},
+		"groups as null yields nil slice": {
+			in:   `{"sub":"u1","groups":null}`,
+			want: ClaimInfo{Subject: "u1"},
+		},
+		"groups as empty array yields empty slice": {
+			in:   `{"sub":"u1","groups":[]}`,
+			want: ClaimInfo{Subject: "u1", Groups: []string{}},
+		},
+		"groups array with empty string entry drops the empty entry": {
+			in:   `{"sub":"u1","groups":["a",""]}`,
+			want: ClaimInfo{Subject: "u1", Groups: []string{"a"}},
+		},
+		"groups array of only empty strings yields empty slice": {
+			in:   `{"sub":"u1","groups":["",""]}`,
+			want: ClaimInfo{Subject: "u1", Groups: []string{}},
+		},
+		"groups missing leaves existing value untouched": {
+			in:      `{"sub":"u1"}`,
+			initial: &ClaimInfo{Groups: []string{"previously", "set"}},
+			want:    ClaimInfo{Subject: "u1", Groups: []string{"previously", "set"}},
+		},
+		"groups present replaces existing value": {
+			in:      `{"sub":"u1","groups":"new"}`,
+			initial: &ClaimInfo{Groups: []string{"old"}},
+			want:    ClaimInfo{Subject: "u1", Groups: []string{"new"}},
+		},
+		"full_group_path as single string": {
+			in:   `{"sub":"u1","full_group_path":"/team/lead"}`,
+			want: ClaimInfo{Subject: "u1", FullGroupPath: []string{"/team/lead"}},
+		},
+		"full_group_path as array": {
+			in:   `{"sub":"u1","full_group_path":["/a","/b"]}`,
+			want: ClaimInfo{Subject: "u1", FullGroupPath: []string{"/a", "/b"}},
+		},
+		"roles as single string": {
+			in:   `{"sub":"u1","roles":"admin"}`,
+			want: ClaimInfo{Subject: "u1", Roles: []string{"admin"}},
+		},
+		"roles as array": {
+			in:   `{"sub":"u1","roles":["admin","viewer"]}`,
+			want: ClaimInfo{Subject: "u1", Roles: []string{"admin", "viewer"}},
+		},
+		"all string-or-array fields together": {
+			in: `{
+				"sub":"u1",
+				"name":"User One",
+				"email":"u1@example.com",
+				"groups":"g",
+				"full_group_path":"/g",
+				"roles":"r"
+			}`,
+			want: ClaimInfo{
+				Subject:       "u1",
+				Name:          "User One",
+				Email:         "u1@example.com",
+				Groups:        []string{"g"},
+				FullGroupPath: []string{"/g"},
+				Roles:         []string{"r"},
+			},
+		},
+		"groups as number is rejected": {
+			in:          `{"sub":"u1","groups":42}`,
+			expectError: true,
+		},
+		"invalid json is rejected": {
+			in:          `{"sub":`,
+			expectError: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := ClaimInfo{}
+			if tt.initial != nil {
+				got = *tt.initial
+			}
+			err := json.Unmarshal([]byte(tt.in), &got)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetUserInfoFromAuthCode(t *testing.T) {
 	const (
 		providerName = "keycloak"
@@ -253,6 +362,196 @@ func TestGetUserInfoFromAuthCode(t *testing.T) {
 			expectedClaimInfo: &ClaimInfo{
 				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
 				Groups:  []string{"group1", "group2"},
+			},
+		},
+		"get single group with GroupsClaim as string in ID token": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.GroupsClaim = "role"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud":  "test",
+					"exp":  time.Now().Add(5 * time.Minute).Unix(),
+					"iss":  "http://localhost:" + port,
+					"role": "RANCHER_ADMIN",
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				require.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd"
+              }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:  []string{"RANCHER_ADMIN"},
+			},
+		},
+		"get single group with GroupsClaim as string in UserInfo": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.GroupsClaim = "role"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud": "test",
+					"exp": time.Now().Add(5 * time.Minute).Unix(),
+					"iss": "http://localhost:" + port,
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				require.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				"role": "RANCHER_ADMIN"
+              }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:  []string{"RANCHER_ADMIN"},
+			},
+		},
+		"null GroupsClaim in UserInfo preserves ID token groups": {
+			config: func(port string) *apiv3.OIDCConfig {
+				c := newOIDCConfig(port)
+				c.GroupsClaim = "role"
+
+				return c
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud":  "test",
+					"exp":  time.Now().Add(5 * time.Minute).Unix(),
+					"iss":  "http://localhost:" + port,
+					"role": []string{"FROM_ID_TOKEN"},
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				require.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				"role": null
+              }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:  []string{"FROM_ID_TOKEN"},
+			},
+		},
+		"get single group from standard groups claim as string": {
+			config: func(port string) *apiv3.OIDCConfig {
+				return newOIDCConfig(port)
+			},
+			oidcProviderResponses: func(port string) oidcResponses {
+				res := newOIDCResponses(privateKey, port)
+				tokenJWT := jwt.New(jwt.SigningMethodRS256)
+				tokenJWT.Claims = jwt.MapClaims{
+					"aud":    "test",
+					"exp":    time.Now().Add(5 * time.Minute).Unix(),
+					"iss":    "http://localhost:" + port,
+					"groups": "only-group",
+				}
+				tokenStr, err := tokenJWT.SignedString(privateKey)
+				require.NoError(t, err)
+
+				token := &Token{
+					Token: oauth2.Token{
+						AccessToken:  tokenStr,
+						Expiry:       time.Now().Add(5 * time.Minute),
+						RefreshToken: tokenStr,
+					},
+					IDToken: tokenStr,
+				}
+				res.token = token
+				res.user = `{
+				"sub": "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd"
+              }`
+				return res
+			},
+			tokenManagerMock: func(token *Token) tokenManager {
+				mock := mocks.NewMocktokenManager(ctrl)
+				mock.EXPECT().UpdateSecret(userId, providerName, EqToken(token.IDToken))
+
+				return mock
+			},
+			expectedUserInfoSubject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			expectedUserInfoClaimInfo: ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+			},
+			expectedClaimInfo: &ClaimInfo{
+				Subject: "a8d0d2c4-6543-4546-8f1a-73e1d7dffcbd",
+				Groups:  []string{"only-group"},
 			},
 		},
 		"error - invalid certificate": {


### PR DESCRIPTION
## Issue: #55857<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The OIDC provider assigned no group principals to a user whose IdP emitted the groups claim as a single JSON string instead of an array. Some providers (IdentityServer among them) serialize a one-element claim as a scalar and a multi-element claim as an array, so a user with a single group received nothing while the same user with two or more groups was mapped correctly.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Decoding for the standard groups, full_group_path, and roles claims now accepts either a JSON string or a JSON array of strings, with a scalar treated as a one-element list. The custom GroupsClaim configuration field follows the same rule for both the ID token and the UserInfo response. UserInfo continues to override the ID token when both carry the claim.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests