### PR TITLE
Migrate cattle-cluster-agent entrypoint logic to Go code

### DIFF
--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -30,8 +30,10 @@ var (
 
 const (
 	kubernetesSSLCertsDir = "/etc/kubernetes/ssl/certs"
-	caFileLocation        = kubernetesSSLCertsDir + "/serverca"
+	caFilename            = "serverca"
+	caFileLocation        = kubernetesSSLCertsDir + "/" + caFilename
 	dockerCertsDir        = "/etc/docker/certs.d"
+	dockerCertFilename    = "ca.crt"
 )
 
 // preStart is meant as a replacement for entrypoint logic.
@@ -47,12 +49,17 @@ func preStart(ctx context.Context) error {
 		return fmt.Errorf("error pinging %s: %w", cattleServer, err)
 	}
 
-	if err := printResolvedCattleServerHostname(cattleServer); err != nil {
+	if err := printResolvedCattleServerHostname(ctx, cattleServer, net.DefaultResolver); err != nil {
 		return err
 	}
 
 	if cattleCAChecksum := os.Getenv("CATTLE_CA_CHECKSUM"); cattleCAChecksum != "" {
-		if err := populateRancherCACerts(ctx, cattleServer, cattleCAChecksum); err != nil {
+		// eases testing
+		certsDestination := certsDirs{
+			kubernetesSSLCertsDir: kubernetesSSLCertsDir,
+			dockerCertsDir:        dockerCertsDir,
+		}
+		if err := populateRancherCACerts(ctx, cattleServer, cattleCAChecksum, certsDestination); err != nil {
 			return err
 		}
 	}
@@ -93,16 +100,20 @@ func pingCattleServer(ctx context.Context, cattleServerEnv string) (pingError er
 	return nil
 }
 
+type netResolver interface {
+	LookupHost(ctx context.Context, host string) (addrs []string, err error)
+}
+
 // printResolvedCattleServerHostname prints the IP(s) to which the provided CATTLE_SERVER hostname resolves
 // If an IP was already used, then it is a no-op
-func printResolvedCattleServerHostname(cattleServerEnv string) error {
+func printResolvedCattleServerHostname(ctx context.Context, cattleServerEnv string, resolver netResolver) error {
 	parsed, err := url.Parse(cattleServerEnv)
 	if err != nil {
 		return err
 	}
 	cattleServerHostname := parsed.Hostname()
 
-	resolved, err := net.LookupHost(cattleServerHostname)
+	resolved, err := resolver.LookupHost(ctx, cattleServerHostname)
 	if err != nil {
 		return err
 	} else if len(resolved) == 1 && resolved[0] == cattleServerHostname {
@@ -115,7 +126,7 @@ func printResolvedCattleServerHostname(cattleServerEnv string) error {
 }
 
 // populateRancherCACerts will retrieve root CA certificates from Rancher, verify them against the provided checksum, then finally write it to the filesystem.
-func populateRancherCACerts(ctx context.Context, cattleServerEnv string, cattleCAChecksumEnv string) error {
+func populateRancherCACerts(ctx context.Context, cattleServerEnv string, cattleCAChecksumEnv string, certs certsDirs) error {
 	certsURL := cattleServerEnv + "/v3/settings/cacerts"
 	rootCA, err := retrieveRancherCACerts(ctx, certsURL)
 	if err != nil {
@@ -137,7 +148,7 @@ func populateRancherCACerts(ctx context.Context, cattleServerEnv string, cattleC
 	}
 	logrus.Infof("Value from %s is an x509 certificate", certsURL)
 
-	return writeRootCACerts(rootCA, cattleServerEnv)
+	return certs.writeRootCACerts(rootCA, cattleServerEnv)
 }
 
 // retrieveRancherCACerts retrieves the "cacerts" setting from Rancher via the provided URL, decodes the response and returns the armored certificate payload.
@@ -168,17 +179,22 @@ func retrieveRancherCACerts(ctx context.Context, certsSettingsURL string) ([]byt
 	return []byte(value), nil
 }
 
+type certsDirs struct {
+	kubernetesSSLCertsDir string
+	dockerCertsDir        string
+}
+
 // writeRootCACerts writes the root CA certificates retrieved from Rancher to 2 different places:
 // - /etc/kubernetes/ssl/certs/serverca
 // - /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT/ca.crt
-func writeRootCACerts(rootCA []byte, cattleServerEnv string) error {
-	if err := os.MkdirAll(kubernetesSSLCertsDir, 0755); err != nil {
+func (w certsDirs) writeRootCACerts(rootCA []byte, cattleServerEnv string) error {
+	if err := os.MkdirAll(w.kubernetesSSLCertsDir, 0755); err != nil {
 		return err
 	}
-	if err := os.WriteFile(caFileLocation, rootCA, 0600); err != nil {
+	if err := os.Chmod(w.kubernetesSSLCertsDir, 0700); err != nil {
 		return err
 	}
-	if err := os.Chmod(kubernetesSSLCertsDir, 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(w.kubernetesSSLCertsDir, caFilename), rootCA, 0600); err != nil {
 		return err
 	}
 
@@ -188,7 +204,7 @@ func writeRootCACerts(rootCA []byte, cattleServerEnv string) error {
 	}
 	cattleServerHostnameWithPort := parsed.Host
 
-	dest := filepath.Join(dockerCertsDir, cattleServerHostnameWithPort, "ca.crt")
+	dest := filepath.Join(w.dockerCertsDir, cattleServerHostnameWithPort, dockerCertFilename)
 	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 		return err
 	}

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -41,10 +41,6 @@ const (
 // These actions were previously executed as part of the agent image's entrypoint script, before actually executing the agent binary
 // The logic has been migrated from that shell script to native Go
 func preStart(ctx context.Context) error {
-	if os.Getenv("CATTLE_ENTRYPOINT_BYPASS") == "true" {
-		return nil
-	}
-
 	cattleServer := os.Getenv("CATTLE_SERVER")
 	if err := pingCattleServer(ctx, cattleServer); err != nil {
 		return fmt.Errorf("error pinging %s: %w", cattleServer, err)

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -2,7 +2,34 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	insecureHTTPTransport http.RoundTripper = func() *http.Transport {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		return tr
+	}()
+)
+
+const (
+	kubernetesSSLCertsDir = "/etc/kubernetes/ssl/certs"
+	caFileLocation        = kubernetesSSLCertsDir + "/serverca"
+	dockerCertsDir        = " /etc/docker/certs.d"
 )
 
 // preStart is meant as a replacement for entrypoint logic.
@@ -12,5 +39,93 @@ func preStart(ctx context.Context) error {
 	if os.Getenv("CATTLE_ENTRYPOINT_BYPASS") == "true" {
 		return nil
 	}
+
+	cattleServer := os.Getenv("CATTLE_SERVER")
+	if cattleCAChecksum := os.Getenv("CATTLE_CA_CHECKSUM"); cattleCAChecksum != "" {
+		if err := populateRancherCACerts(ctx, cattleServer, cattleCAChecksum); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// populateRancherCACerts will retrieve root CA certificates from Rancher, verify them against the provided checksum, then finally write it to the filesystem.
+func populateRancherCACerts(ctx context.Context, cattleServerEnv string, cattleCAChecksumEnv string) error {
+	certsURL := cattleServerEnv + "/v3/settings/cacerts"
+	rootCA, err := retrieveRancherCACerts(ctx, certsURL)
+	if err != nil {
+		return err
+	} else if len(rootCA) == 0 {
+		return fmt.Errorf("The environment variable CATTLE_CA_CHECKSUM is set but there is no CA certificate configured at %s", certsURL)
+	}
+
+	// Verify integrity
+	sha256Hash := sha256.Sum256(rootCA)
+	if calculated := hex.EncodeToString(sha256Hash[:]); calculated != cattleCAChecksumEnv {
+		return fmt.Errorf("Configured cacerts checksum (%s) does not match given --ca-checksum (%s)\nPlease check if the correct certificate is configured at %s", calculated, cattleCAChecksumEnv, certsURL)
+	}
+
+	// Verify certificates validity
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(rootCA); !ok {
+		return fmt.Errorf("Value from %s does not look like an x509 certificate\nRetrieved cacerts:\n%s", certsURL, rootCA)
+	}
+	logrus.Infof("Value from %s is an x509 certificate", certsURL)
+
+	return writeRootCACerts(rootCA, cattleServerEnv)
+}
+
+// retrieveRancherCACerts retrieves the "cacerts" setting from Rancher via the provided URL, decodes the response and returns the armored certificate payload.
+// It's up to the caller to verify the integrity and contents of this data.
+func retrieveRancherCACerts(ctx context.Context, certsSettingsURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", certsSettingsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := http.Client{Transport: insecureHTTPTransport}
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to get CA certificates: %s", res.Status)
+	}
+
+	// Decode JSON response
+	var cacertsSetting *v3.Setting
+	if err := json.NewDecoder(res.Body).Decode(&cacertsSetting); err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificates setting: %w", err)
+	}
+	// Ensure it ends with newline (expected by the checksum)
+	value := strings.TrimSuffix(cacertsSetting.Value, "\n") + "\n"
+	return []byte(value), nil
+}
+
+// writeRootCACerts writes the root CA certificates retrieved from Rancher to 2 different places:
+// - /etc/kubernetes/ssl/certs/serverca
+// - /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT/ca.crt
+func writeRootCACerts(rootCA []byte, cattleServerEnv string) error {
+	if err := os.MkdirAll(kubernetesSSLCertsDir, 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(caFileLocation, rootCA, 0600); err != nil {
+		return err
+	}
+	if err := os.Chmod(kubernetesSSLCertsDir, 0700); err != nil {
+		return err
+	}
+
+	parsed, err := url.Parse(cattleServerEnv)
+	if err != nil {
+		return err
+	}
+	cattleServerHostnameWithPort := parsed.Host
+
+	dest := filepath.Join(dockerCertsDir, cattleServerHostnameWithPort, "ca.crt")
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(dest, rootCA, 0600)
 }

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"os"
+)
+
+// preStart is meant as a replacement for entrypoint logic.
+// These actions were previously executed as part of the agent image's entrypoint script, before actually executing the agent binary
+// The logic has been migrated from that shell script to native Go
+func preStart(ctx context.Context) error {
+	if os.Getenv("CATTLE_ENTRYPOINT_BYPASS") == "true" {
+		return nil
+	}
+	return nil
+}

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -177,8 +177,13 @@ func retrieveRancherCACerts(ctx context.Context, certsSettingsURL string) ([]byt
 	if err := json.NewDecoder(res.Body).Decode(&cacertsSetting); err != nil {
 		return nil, fmt.Errorf("failed to parse CA certificates setting: %w", err)
 	}
+	value := cacertsSetting.Value
+
 	// Ensure it ends with newline (expected by the checksum)
-	value := strings.TrimSuffix(cacertsSetting.Value, "\n") + "\n"
+	if len(value) > 0 && value[len(value)-1] != '\n' {
+		value = value + "\n"
+	}
+
 	return []byte(value), nil
 }
 

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -31,7 +31,7 @@ var (
 const (
 	kubernetesSSLCertsDir = "/etc/kubernetes/ssl/certs"
 	caFileLocation        = kubernetesSSLCertsDir + "/serverca"
-	dockerCertsDir        = " /etc/docker/certs.d"
+	dockerCertsDir        = "/etc/docker/certs.d"
 )
 
 // preStart is meant as a replacement for entrypoint logic.

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -173,7 +173,7 @@ func retrieveRancherCACerts(ctx context.Context, certsSettingsURL string) ([]byt
 	}
 
 	// Decode JSON response
-	var cacertsSetting *v3.Setting
+	var cacertsSetting v3.Setting
 	if err := json.NewDecoder(res.Body).Decode(&cacertsSetting); err != nil {
 		return nil, fmt.Errorf("failed to parse CA certificates setting: %w", err)
 	}

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -41,11 +42,36 @@ func preStart(ctx context.Context) error {
 	}
 
 	cattleServer := os.Getenv("CATTLE_SERVER")
+	if err := printResolvedCattleServerHostname(cattleServer); err != nil {
+		return err
+	}
+
 	if cattleCAChecksum := os.Getenv("CATTLE_CA_CHECKSUM"); cattleCAChecksum != "" {
 		if err := populateRancherCACerts(ctx, cattleServer, cattleCAChecksum); err != nil {
 			return err
 		}
 	}
+	return nil
+}
+
+// printResolvedCattleServerHostname prints the IP(s) to which the provided CATTLE_SERVER hostname resolves
+// If an IP was already used, then it is a no-op
+func printResolvedCattleServerHostname(cattleServerEnv string) error {
+	parsed, err := url.Parse(cattleServerEnv)
+	if err != nil {
+		return err
+	}
+	cattleServerHostname := parsed.Hostname()
+
+	resolved, err := net.LookupHost(cattleServerHostname)
+	if err != nil {
+		return err
+	} else if len(resolved) == 1 && resolved[0] == cattleServerHostname {
+		// It's an IP address, nothing to resolve
+		return nil
+	}
+
+	logrus.Infof("%s resolves to %s", cattleServerHostname, strings.Join(resolved, ", "))
 	return nil
 }
 

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -42,6 +43,10 @@ func preStart(ctx context.Context) error {
 	}
 
 	cattleServer := os.Getenv("CATTLE_SERVER")
+	if err := pingCattleServer(ctx, cattleServer); err != nil {
+		return fmt.Errorf("error pinging %s: %w", cattleServer, err)
+	}
+
 	if err := printResolvedCattleServerHostname(cattleServer); err != nil {
 		return err
 	}
@@ -51,6 +56,40 @@ func preStart(ctx context.Context) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// pingCattleServer checks Rancher server's connectivity
+func pingCattleServer(ctx context.Context, cattleServerEnv string) (pingError error) {
+	pingURL := cattleServerEnv + "/ping"
+	req, err := http.NewRequestWithContext(ctx, "GET", pingURL, nil)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if pingError != nil {
+			logrus.Errorf("%s is not accessible: %v", pingURL, pingError)
+		} else {
+			logrus.Infof("%s is accessible", pingURL)
+		}
+	}()
+
+	httpClient := http.Client{Transport: insecureHTTPTransport}
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	if _, err := io.Copy(io.Discard, res.Body); err != nil {
+		return err
+	}
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("received %q status response", res.Status)
+	}
+
 	return nil
 }
 

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
@@ -82,7 +83,10 @@ func pingCattleServer(ctx context.Context, cattleServerEnv string) (pingError er
 		}
 	}()
 
-	httpClient := http.Client{Transport: insecureHTTPTransport}
+	httpClient := http.Client{
+		Timeout:   5 * time.Minute,
+		Transport: insecureHTTPTransport,
+	}
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return err
@@ -159,7 +163,10 @@ func retrieveRancherCACerts(ctx context.Context, certsSettingsURL string) ([]byt
 		return nil, err
 	}
 
-	httpClient := http.Client{Transport: insecureHTTPTransport}
+	httpClient := http.Client{
+		Timeout:   5 * time.Minute,
+		Transport: insecureHTTPTransport,
+	}
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/cmd/agent/entrypoint.go
+++ b/cmd/agent/entrypoint.go
@@ -42,6 +42,12 @@ const (
 // The logic has been migrated from that shell script to native Go
 func preStart(ctx context.Context) error {
 	cattleServer := os.Getenv("CATTLE_SERVER")
+	if !strings.Contains(cattleServer, "://") {
+		// the original entrypoint used curl, which can work without a "protocol://" scheme.
+		// according to it's manpage, it defaults to HTTP, except some smart detection of the protocol based on the hostname (e.g. "ftp.")
+		cattleServer = "http://" + cattleServer
+	}
+
 	if err := pingCattleServer(ctx, cattleServer); err != nil {
 		return fmt.Errorf("error pinging %s: %w", cattleServer, err)
 	}

--- a/cmd/agent/entrypoint_test.go
+++ b/cmd/agent/entrypoint_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockResolver satisfies the netResolver interface for testing
+type mockResolver struct {
+	lookupFunc func(ctx context.Context, host string) ([]string, error)
+}
+
+func (m *mockResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
+	return m.lookupFunc(ctx, host)
+}
+
+func TestPreStart_Bypass(t *testing.T) {
+	t.Setenv("CATTLE_ENTRYPOINT_BYPASS", "true")
+	err := preStart(t.Context())
+	if err != nil {
+		t.Fatalf("expected no error when bypass env is true, got: %v", err)
+	}
+}
+
+func TestPingCattleServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ping" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx := t.Context()
+
+	// Test successful ping
+	if err := pingCattleServer(ctx, server.URL); err != nil {
+		t.Errorf("expected ping to succeed, got: %v", err)
+	}
+
+	// Test failing ping status code
+	if err := pingCattleServer(ctx, server.URL+"/bad-route"); err == nil {
+		t.Error("expected ping to fail for non-200 status code, got nil")
+	}
+}
+
+func TestPrintResolvedCattleServerHostname(t *testing.T) {
+	tc := []struct {
+		name          string
+		cattleServer  string
+		resolver      netResolver
+		expectedError bool
+	}{
+		{
+			name:         "domain resolution",
+			cattleServer: "https://rancher.my-domain.com:8443",
+			resolver: &mockResolver{
+				lookupFunc: func(ctx context.Context, host string) ([]string, error) {
+					return []string{"192.168.1.50", "192.168.1.51"}, nil
+				},
+			},
+		},
+		{
+			name:         "IP resolution",
+			cattleServer: "https://127.0.0.1:8443",
+			resolver: &mockResolver{
+				lookupFunc: func(ctx context.Context, host string) ([]string, error) {
+					return []string{"127.0.0.1"}, nil
+				},
+			},
+		},
+		{
+			name:         "Failed resolution",
+			cattleServer: "https://does-not-exist.local",
+			resolver: &mockResolver{
+				lookupFunc: func(ctx context.Context, host string) ([]string, error) {
+					return nil, &net.DNSError{Err: "no such host", Name: host}
+				},
+			},
+			expectedError: true,
+		},
+	}
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := printResolvedCattleServerHostname(t.Context(), tt.cattleServer, tt.resolver); (err != nil) != tt.expectedError {
+				t.Errorf("expected error: %v, got: %v", tt.expectedError, err)
+			}
+		})
+	}
+}
+
+func sha256Sum(data []byte) string {
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:])
+}
+
+func TestPopulateRancherCACerts_And_Write(t *testing.T) {
+	validCertPEM := generateValidPEM(t)
+	if validCertPEM[len(validCertPEM)-1] != '\n' {
+		validCertPEM = append(validCertPEM, '\n')
+	}
+	invalidCertPEM := []byte("---BEGIN CERTIFICATE---\nNOT-A-REAL-CERT\n---END CERTIFICATE---\n")
+
+	tc := []struct {
+		name          string
+		certPayload   []byte
+		certChecksum  string
+		expectedError string
+	}{
+		{
+			name:         "valid certificate",
+			certPayload:  validCertPEM,
+			certChecksum: sha256Sum(validCertPEM),
+		},
+		{
+			name:          "invalid certificate",
+			certPayload:   invalidCertPEM,
+			certChecksum:  sha256Sum(invalidCertPEM),
+			expectedError: "does not look like an x509 certificate",
+		},
+		{
+			name:          "integrity failure",
+			certPayload:   validCertPEM,
+			certChecksum:  "completely-wrong-checksum",
+			expectedError: "does not match",
+		},
+	}
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				setting := &v3.Setting{
+					Value: string(tt.certPayload),
+				}
+				w.WriteHeader(http.StatusOK)
+				if err := json.NewEncoder(w).Encode(setting); err != nil {
+					t.Fatal(err)
+					return
+				}
+			}))
+			defer server.Close()
+			serverHostname := strings.TrimPrefix(server.URL, "http://")
+
+			tmpDir := t.TempDir()
+			mockPaths := certsDirs{
+				kubernetesSSLCertsDir: filepath.Join(tmpDir, "k8s-ssl"),
+				dockerCertsDir:        filepath.Join(tmpDir, "docker-ssl"),
+			}
+
+			if err := populateRancherCACerts(t.Context(), server.URL, tt.certChecksum, mockPaths); err != nil {
+				if tt.expectedError == "" {
+					t.Errorf("unexpected error: %v", err)
+				} else {
+					assert.Contains(t, err.Error(), tt.expectedError)
+				}
+				return
+			} else if tt.expectedError != "" {
+				t.Errorf("expected error matching: %q, got: %v", tt.expectedError, err)
+			}
+
+			// Verify file contents were written
+			for _, p := range []string{
+				filepath.Join(tmpDir, "k8s-ssl/serverca"),
+				filepath.Join(tmpDir, fmt.Sprintf("docker-ssl/%s/ca.crt", serverHostname)),
+			} {
+				if data, err := os.ReadFile(p); err != nil {
+					t.Error(err)
+				} else if !bytes.Equal(data, tt.certPayload) {
+					t.Errorf("kube cert data mismatch")
+				}
+			}
+		})
+	}
+}

--- a/cmd/agent/entrypoint_test.go
+++ b/cmd/agent/entrypoint_test.go
@@ -30,9 +30,8 @@ func (m *mockResolver) LookupHost(ctx context.Context, host string) ([]string, e
 
 func TestPreStart_Bypass(t *testing.T) {
 	t.Setenv("CATTLE_ENTRYPOINT_BYPASS", "true")
-	err := preStart(t.Context())
-	if err != nil {
-		t.Fatalf("expected no error when bypass env is true, got: %v", err)
+	if shouldRunPrestart() {
+		t.Fatalf("expected preStart to be skipped when CATTLE_ENTRYPOINT_BYPASS is true")
 	}
 }
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -63,13 +63,13 @@ func main() {
 	var err error
 	ctx := context.Background()
 
+	configureLogrus()
+
 	if shouldRunPrestart() {
 		if err := preStart(ctx); err != nil {
 			logrus.Fatal(err)
 		}
 	}
-
-	configureLogrus()
 
 	logserver.StartServerWithDefaults()
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -39,9 +39,8 @@ var (
 )
 
 const (
-	Token          = "X-API-Tunnel-Token"
-	Params         = "X-API-Tunnel-Params"
-	caFileLocation = "/etc/kubernetes/ssl/certs/serverca"
+	Token  = "X-API-Tunnel-Token"
+	Params = "X-API-Tunnel-Params"
 )
 
 func main() {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -43,12 +43,31 @@ const (
 	Params = "X-API-Tunnel-Params"
 )
 
+func shouldRunPrestart() bool {
+	for _, arg := range []string{
+		// Explicit entrypoint logic bypass
+		"CATTLE_ENTRYPOINT_BYPASS",
+		// "special modes:
+		"CLUSTER_CLEANUP",
+		"BINDING_CLEANUP",
+		"AD_GUID_CLEANUP",
+	} {
+		if os.Getenv(arg) == "true" {
+			// "special" mode
+			return false
+		}
+	}
+	return true
+}
+
 func main() {
 	var err error
 	ctx := context.Background()
 
-	if err := preStart(ctx); err != nil {
-		logrus.Fatal(err)
+	if shouldRunPrestart() {
+		if err := preStart(ctx); err != nil {
+			logrus.Fatal(err)
+		}
 	}
 
 	configureLogrus()

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -47,13 +47,12 @@ func shouldRunPrestart() bool {
 	for _, arg := range []string{
 		// Explicit entrypoint logic bypass
 		"CATTLE_ENTRYPOINT_BYPASS",
-		// "special modes:
+		// Special modes used in main():
 		"CLUSTER_CLEANUP",
 		"BINDING_CLEANUP",
 		"AD_GUID_CLEANUP",
 	} {
 		if os.Getenv(arg) == "true" {
-			// "special" mode
 			return false
 		}
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -48,6 +48,10 @@ func main() {
 	var err error
 	ctx := context.Background()
 
+	if err := preStart(ctx); err != nil {
+		logrus.Fatal(err)
+	}
+
 	configureLogrus()
 
 	logserver.StartServerWithDefaults()

--- a/package/run.sh
+++ b/package/run.sh
@@ -84,19 +84,6 @@ get_address()
     fi
 }
 
-check_url()
-{
-    local url=$1
-    local err
-    err=$(curl --insecure -sS -fL -o /dev/null --stderr - $url | head -n1 ; exit ${PIPESTATUS[0]})
-    if [ $? -eq 0 ]
-    then
-        echo ""
-    else
-        echo ${err} | sed -e 's/^curl: ([0-9]\+) //'
-    fi
-}
-
 export CATTLE_ADDRESS
 export CATTLE_AGENT_CONNECT
 export CATTLE_INTERNAL_ADDRESS
@@ -190,15 +177,6 @@ info "Environment: $(echo $(printenv | grep CATTLE | sort | sed -e 's/\(CATTLE_T
 info "Using resolv.conf: $(echo $(cat /etc/resolv.conf | grep -v ^#))"
 if grep -E -q '^nameserver 127.*.*.*|^nameserver localhost|^nameserver ::1' /etc/resolv.conf; then
     warn "Loopback address found in /etc/resolv.conf, please refer to the documentation how to configure your cluster to resolve DNS properly"
-fi
-
-CATTLE_SERVER_PING="${CATTLE_SERVER}/ping"
-err=$(check_url $CATTLE_SERVER_PING)
-if [[ $err ]]; then
-    error "${CATTLE_SERVER_PING} is not accessible (${err})"
-    exit 1
-else
-    info "${CATTLE_SERVER_PING} is accessible"
 fi
 
 exec catatonit -- agent

--- a/package/run.sh
+++ b/package/run.sh
@@ -97,19 +97,6 @@ check_url()
     fi
 }
 
-check_x509_cert()
-{
-    local cert=$1
-    local err
-    err=$(openssl x509 -in $cert -noout 2>&1)
-    if [ $? -eq 0 ]
-    then
-        echo ""
-    else
-        echo ${err}
-    fi
-}
-
 export CATTLE_ADDRESS
 export CATTLE_AGENT_CONNECT
 export CATTLE_INTERNAL_ADDRESS
@@ -120,6 +107,7 @@ export CATTLE_TOKEN
 export CATTLE_NODE_LABEL
 export CATTLE_WRITE_CERT_ONLY
 export CATTLE_NODE_TAINTS
+export CATTLE_CA_CHECKSUM
 
 while true; do
     case "$1" in
@@ -215,7 +203,6 @@ fi
 
 # Extract hostname from URL
 CATTLE_SERVER_HOSTNAME=$(echo $CATTLE_SERVER | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/')
-CATTLE_SERVER_HOSTNAME_WITH_PORT=$(echo $CATTLE_SERVER | sed -e 's/[^/]*\/\/\([^@]*@\)\?\(.*\).*/\2/')
 # Resolve IPv4 address(es) from hostname
 RESOLVED_ADDR=$(getent ahostsv4 $CATTLE_SERVER_HOSTNAME | sed -n 's/ *STREAM.*//p')
 
@@ -223,40 +210,5 @@ RESOLVED_ADDR=$(getent ahostsv4 $CATTLE_SERVER_HOSTNAME | sed -n 's/ *STREAM.*//
 if [ "${CATTLE_SERVER_HOSTNAME}" != "${RESOLVED_ADDR}" ]; then
   info "${CATTLE_SERVER_HOSTNAME} resolves to $(echo $RESOLVED_ADDR)"
 fi
-
-if [ -n "$CATTLE_CA_CHECKSUM" ]; then
-    temp=$(mktemp)
-    curl --insecure -s -fL $CATTLE_SERVER/v3/settings/cacerts | jq -r '.value | select(length > 0)' > $temp
-    if [ ! -s $temp ]; then
-      error "The environment variable CATTLE_CA_CHECKSUM is set but there is no CA certificate configured at $CATTLE_SERVER/v3/settings/cacerts"
-      exit 1
-    fi
-    err=$(check_x509_cert $temp)
-    if [[ $err ]]; then
-        error "Value from $CATTLE_SERVER/v3/settings/cacerts does not look like an x509 certificate (${err})"
-        error "Retrieved cacerts:"
-        cat $temp
-        exit 1
-    else
-        info "Value from $CATTLE_SERVER/v3/settings/cacerts is an x509 certificate"
-    fi
-    CATTLE_SERVER_CHECKSUM=$(sha256sum $temp | awk '{print $1}')
-    if [ $CATTLE_SERVER_CHECKSUM != $CATTLE_CA_CHECKSUM ]; then
-        rm -f $temp
-        error "Configured cacerts checksum ($CATTLE_SERVER_CHECKSUM) does not match given --ca-checksum ($CATTLE_CA_CHECKSUM)"
-        error "Please check if the correct certificate is configured at $CATTLE_SERVER/v3/settings/cacerts"
-        exit 1
-    else
-        mkdir -p /etc/kubernetes/ssl/certs
-        mv $temp /etc/kubernetes/ssl/certs/serverca
-        chmod 755 /etc/kubernetes/ssl
-        chmod 700 /etc/kubernetes/ssl/certs
-        chmod 600 /etc/kubernetes/ssl/certs/serverca
-        mkdir -p /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT
-        cp /etc/kubernetes/ssl/certs/serverca /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT/ca.crt
-
-    fi
-fi
-
 exec catatonit -- agent
 

--- a/package/run.sh
+++ b/package/run.sh
@@ -201,14 +201,5 @@ else
     info "${CATTLE_SERVER_PING} is accessible"
 fi
 
-# Extract hostname from URL
-CATTLE_SERVER_HOSTNAME=$(echo $CATTLE_SERVER | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/')
-# Resolve IPv4 address(es) from hostname
-RESOLVED_ADDR=$(getent ahostsv4 $CATTLE_SERVER_HOSTNAME | sed -n 's/ *STREAM.*//p')
-
-# If CATTLE_SERVER_HOSTNAME equals RESOLVED_ADDR, its an IP address and there is nothing to resolve
-if [ "${CATTLE_SERVER_HOSTNAME}" != "${RESOLVED_ADDR}" ]; then
-  info "${CATTLE_SERVER_HOSTNAME} resolves to $(echo $RESOLVED_ADDR)"
-fi
 exec catatonit -- agent
 

--- a/package/run.sh
+++ b/package/run.sh
@@ -32,61 +32,7 @@ if [ "$CLUSTER_CLEANUP" = true ]; then
     exec agent
 fi
 
-get_address()
-{
-    local address=$1
-    # If nothing is given, return empty (it will be automatically determined later if empty)
-    if [ -z $address ]; then
-        echo ""
-    # If given address is a network interface on the system, retrieve configured IP on that interface (only the first configured IP is taken)
-    elif [ -n "$(find /sys/devices -name $address)" ]; then
-        echo $(ip addr show dev $address | grep -w inet | awk '{print $2}' | cut -f1 -d/ | head -1)
-    # Loop through cloud provider options to get IP from metadata, if not found return given value
-    else
-        case $address in
-            awslocal)
-                echo $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-                ;;
-            awspublic)
-                echo $(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
-                ;;
-            doprivate)
-                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
-                ;;
-            dopublic)
-                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
-                ;;
-            azprivate)
-                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text")
-                ;;
-            azpublic)
-                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
-                ;;
-            gceinternal)
-                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
-                ;;
-            gceexternal)
-                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
-                ;;
-            packetlocal)
-                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/local-ipv4)
-                ;;
-            packetpublic)
-                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/public-ipv4)
-                ;;
-            ipify)
-                echo $(curl -s https://api.ipify.org)
-                ;;
-            *)
-                echo $address
-                ;;
-        esac
-    fi
-}
-
-export CATTLE_ADDRESS
 export CATTLE_AGENT_CONNECT
-export CATTLE_INTERNAL_ADDRESS
 export CATTLE_NODE_NAME
 export CATTLE_ROLE
 export CATTLE_SERVER
@@ -108,8 +54,8 @@ while true; do
         -p | --controlplane)            CONTROL=true                ;;
         -n | --node-name)        shift; CATTLE_NODE_NAME=$1         ;;
         -r | --no-register)             CATTLE_AGENT_CONNECT=true   ;;
-        -a | --address)          shift; CATTLE_ADDRESS=$1           ;;
-        -i | --internal-address) shift; CATTLE_INTERNAL_ADDRESS=$1  ;;
+        --address)               shift; ;; # deprecated
+        -i | --internal-address) shift; ;; # deprecated
         -l | --label)            shift; CATTLE_NODE_LABEL+=",$1"    ;;
         -o | --only-write-certs)        CATTLE_WRITE_CERT_ONLY=true ;;
         --taints)                shift; CATTLE_NODE_TAINTS+=",$1"   ;;
@@ -134,22 +80,9 @@ if [ -z "$CATTLE_NODE_NAME" ]; then
     CATTLE_NODE_NAME=$(hostname -s)
 fi
 
-export CATTLE_ADDRESS=$(get_address $CATTLE_ADDRESS)
-export CATTLE_INTERNAL_ADDRESS=$(get_address $CATTLE_INTERNAL_ADDRESS)
-
-if [ -z "$CATTLE_ADDRESS" ]; then
-    # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
-    CATTLE_ADDRESS=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
-fi
-
 if [ "$CATTLE_K8S_MANAGED" != "true" ]; then
     if [ -z "$CATTLE_TOKEN" ]; then
         error -- --token is a required option
-        exit 1
-    fi
-
-    if [ -z "$CATTLE_ADDRESS" ]; then
-        error -- --address is a required option
         exit 1
     fi
 fi

--- a/package/run.sh
+++ b/package/run.sh
@@ -22,11 +22,13 @@ if [ $# -ne 0 ]; then
 fi
 
 if [ "$1" = "--" ]; then
+    export CATTLE_ENTRYPOINT_BYPASS=true
     shift 1
     exec "$@"
 fi
 
 if [ "$CLUSTER_CLEANUP" = true ]; then
+    export CATTLE_ENTRYPOINT_BYPASS=true
     exec agent
 fi
 


### PR DESCRIPTION
## Issue: #55878 
 
## Problems

The entrypoint is too complex and relies on external tool dependencies, while there are alternative available as part of the Go standard library.
- `curl` is used to call `/ping` on the Rancher server. Also for retrieving the "cacerts" `Setting` object, in combination with `jq`.
- `openssl` is used to validate the certificate.
- `sha256sum` is used to verify its integrity.
- There was a public address discovery, also using `curl`, and exposing them via `CATTLE_ADDRESS` and `CATTLE_INTERNAL_ADDRESS`. These can be completely dropped now.
- `getent`,  `ip route` and multiple `grep` and `sed` commands where also used.
 
## Solution

Added a `preStart` to function to the agent's `main()`, replicating the entrypoint behavior using only dependencies from the Go standard library.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_