### PR TITLE
[v2.14.2-hotfix-64aa] Fix issues with ClusterAuthToken sync diagnostic logging

### DIFF
--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -153,7 +153,7 @@ func Register(ctx context.Context, cluster *config.UserContext, secretsCache cor
 		clusterUserAttribute,
 	}).Sync)
 
-	scheduleStartupCensus(tokenInformer)
+	scheduleStartupCensus(ctx, tokenInformer)
 	logrus.Infof("[clusterauthtoken-sync] cluster=%s v3 Token handlers registered", clusterName)
 
 	cluster.Management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
@@ -170,7 +170,7 @@ func Register(ctx context.Context, cluster *config.UserContext, secretsCache cor
 		}
 		cluster.Cluster.ClusterAuthTokens(namespace).AddHandler(ctx, clusterAuthTokenController, catHandler.sync)
 		logrus.Infof("[clusterauthtoken-sync] cluster=%s ext Token handlers registered", clusterName)
-		scheduleExtStartupCensus(extToken.Informer())
+		scheduleExtStartupCensus(ctx, extToken.Informer())
 	})
 }
 
@@ -179,8 +179,8 @@ var (
 	extCensusOnce sync.Once
 )
 
-// scheduleStartupCensus launches a one-shot goroutine that, once the management
-// v3.Token informer cache has synced, walks the cache exactly once and reports
+// scheduleStartupCensus launches a goroutine that, once the management v3.Token
+// informer cache has synced, walks the cache exactly once and reports
 // per-cluster counts at Info level: total v3.Tokens scoped to each cluster and
 // the subset missing the cat-token-controller lifecycle annotation. The latter
 // equals the per-cluster backlog of tokens that have never been processed by
@@ -191,22 +191,28 @@ var (
 //
 // The walk is process-wide, not per UserContext: the management Token informer
 // cache is shared across all clusters, so a single walk is sufficient. The
-// goroutine runs at most once per process (guarded by sync.Once); subsequent
-// calls from other clusters' Register are no-ops.
-func scheduleStartupCensus(mgmtTokenInformer cache.SharedIndexInformer) {
-	censusOnce.Do(func() {
-		go runStartupCensus(mgmtTokenInformer)
-	})
+// sync.Once guard is consumed only after WaitForCacheSync succeeds, so a
+// timeout on one caller leaves the gate open for the next cluster's Register
+// to retry.
+func scheduleStartupCensus(ctx context.Context, mgmtTokenInformer cache.SharedIndexInformer) {
+	go func() {
+		waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		if !cache.WaitForCacheSync(waitCtx.Done(), mgmtTokenInformer.HasSynced) {
+			if err := ctx.Err(); err != nil {
+				logrus.Warnf("[clusterauthtoken-sync] startup census skipped: %v before management v3.Token cache synced", err)
+			} else {
+				logrus.Warnf("[clusterauthtoken-sync] startup census skipped: management v3.Token cache did not sync within timeout")
+			}
+			return
+		}
+
+		censusOnce.Do(func() { walkV3StartupCensus(mgmtTokenInformer) })
+	}()
 }
 
-func runStartupCensus(mgmtTokenInformer cache.SharedIndexInformer) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	if !cache.WaitForCacheSync(ctx.Done(), mgmtTokenInformer.HasSynced) {
-		logrus.Warnf("[clusterauthtoken-sync] startup census skipped: management v3.Token cache did not sync within timeout")
-		return
-	}
-
+func walkV3StartupCensus(mgmtTokenInformer cache.SharedIndexInformer) {
 	type counts struct{ total, missing int }
 	byCluster := map[string]*counts{}
 	for _, obj := range mgmtTokenInformer.GetStore().List() {
@@ -214,13 +220,16 @@ func runStartupCensus(mgmtTokenInformer cache.SharedIndexInformer) {
 		if !ok || t.ClusterName == "" {
 			continue
 		}
+
 		c, ok := byCluster[t.ClusterName]
 		if !ok {
 			c = &counts{}
 			byCluster[t.ClusterName] = c
 		}
+
 		c.total++
-		annotation := "lifecycle.cattle.io/create.cat-token-controller_" + t.ClusterName
+
+		annotation := "lifecycle.cattle.io/create." + tokenController + "_" + t.ClusterName
 		if t.Annotations[annotation] != "true" {
 			c.missing++
 		}
@@ -231,27 +240,34 @@ func runStartupCensus(mgmtTokenInformer cache.SharedIndexInformer) {
 	}
 }
 
-// scheduleExtStartupCensus mirrors scheduleStartupCensus for ext.Tokens. Called
-// from the EXT API DeferFunc once per UserContext; sync.Once ensures the walk
-// runs exactly once per process across all clusters. ext.Tokens are managed by
-// wrangler OnChange/OnRemove rather than Norman lifecycle, so they carry no
-// stuck-state annotation. The census reports inventory only — total ext.Tokens
-// per cluster. The actual drain is observable via the per-token "ext create"
-// Info events emitted by the sync handler.
-func scheduleExtStartupCensus(extTokenInformer cache.SharedIndexInformer) {
-	extCensusOnce.Do(func() {
-		go runExtStartupCensus(extTokenInformer)
-	})
+// scheduleExtStartupCensus mirrors scheduleStartupCensus for ext.Tokens.
+// ext.Tokens are managed by wrangler OnChange/OnRemove rather than Norman
+// lifecycle, so they carry no stuck-state annotation. The census reports
+// inventory only — total ext.Tokens per cluster. Drain of stuck tokens
+// (no existing ClusterAuthToken) is observable per-token via the success
+// Info events emitted by createClusterAuthToken; ongoing updates to
+// already-present ClusterAuthTokens are not logged at Info. The sync.Once
+// guard is consumed only after WaitForCacheSync succeeds, so a timeout on
+// one caller leaves the gate open for the next cluster's DeferFunc to retry.
+func scheduleExtStartupCensus(ctx context.Context, extTokenInformer cache.SharedIndexInformer) {
+	go func() {
+		waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		if !cache.WaitForCacheSync(waitCtx.Done(), extTokenInformer.HasSynced) {
+			if err := ctx.Err(); err != nil {
+				logrus.Warnf("[clusterauthtoken-sync] ext startup census skipped: %v before ext.Token cache synced", err)
+			} else {
+				logrus.Warnf("[clusterauthtoken-sync] ext startup census skipped: ext.Token cache did not sync within timeout")
+			}
+			return
+		}
+
+		extCensusOnce.Do(func() { walkExtStartupCensus(extTokenInformer) })
+	}()
 }
 
-func runExtStartupCensus(extTokenInformer cache.SharedIndexInformer) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	if !cache.WaitForCacheSync(ctx.Done(), extTokenInformer.HasSynced) {
-		logrus.Warnf("[clusterauthtoken-sync] ext startup census skipped: ext.Token cache did not sync within timeout")
-		return
-	}
-
+func walkExtStartupCensus(extTokenInformer cache.SharedIndexInformer) {
 	byCluster := map[string]int{}
 	for _, obj := range extTokenInformer.GetStore().List() {
 		t, ok := obj.(*extv1.Token)

--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -63,8 +63,6 @@ func (h *tokenHandler) extCreate(token *extv1.Token) (*extv1.Token, error) {
 	if err := validateToken(token.GetName(), token.Spec.UserID); err != nil {
 		return token, err
 	}
-	logrus.Infof("[clusterauthtoken-sync] cluster=%s token=%s ext create", token.Spec.ClusterName, token.Name)
-
 	_, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
 	if !errors.IsNotFound(err) {
 		return h.ExtUpdated(token)
@@ -212,8 +210,6 @@ func (h *tokenHandler) Create(token *mgmtapiv3.Token) (runtime.Object, error) {
 	if err := validateToken(token.Name, token.UserID); err != nil {
 		return token, err
 	}
-	logrus.Infof("[clusterauthtoken-sync] cluster=%s token=%s v3 create", token.ClusterName, token.Name)
-
 	_, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name)
 	if !errors.IsNotFound(err) {
 		return h.Updated(token)
@@ -284,7 +280,6 @@ func (h *tokenHandler) createClusterAuthToken(token accessor.TokenAccessor, hash
 		// Overwrite an existing secret.
 		existing, err := h.clusterSecret.Get(clusterAuthTokenSecret.Namespace, clusterAuthTokenSecret.Name, metav1.GetOptions{})
 		if err != nil {
-			logrus.Errorf("error migrating clusterAuthToken's secret %s: %s", clusterAuthTokenSecret.Name, err)
 			return err
 		}
 		existing = existing.DeepCopy()


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The once-only guard was consumed before cache-sync success, so a timeout permanently disabled the census. The lifecycle annotation key in the census walk was hardcoded rather than derived from the controller-name constant. The census goroutines used an empty background context, unlinked from shutdown. The v3.Token and ext.Token create entry Info logs fired on every retry while the token-hashing path waited for a hash. A pre-existing inline error log in the secret migration path duplicated the boundary Error log on the downstream upsert path.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The once-only guard is now consumed only after the informer cache syncs. The annotation key is composed from the controller-name constant. The census goroutines derive their timeout from the caller's context and distinguish parent cancellation from sync timeout in the warning text. The token create entry Info logs are removed; the per-token outcome is still visible via the existing defer log on the downstream upsert path. The redundant inline error log is removed. The ext census comment clarifies that the per-token success log covers drain of stuck tokens with no existing ClusterAuthToken, not ongoing updates to already-present ClusterAuthTokens.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
