### PR TITLE
Add Go toolchain directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 replace (
 	github.com/crewjam/saml => github.com/rancher/saml v0.4.14-rancher3

--- a/gotools/controller-gen/go.mod
+++ b/gotools/controller-gen/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/gotools/controller-gen
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 tool sigs.k8s.io/controller-tools/cmd/controller-gen
 

--- a/gotools/mockery/go.mod
+++ b/gotools/mockery/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/gotools/mockery
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 tool github.com/vektra/mockery/v2
 

--- a/gotools/mockgen/go.mod
+++ b/gotools/mockgen/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/gotools/mockgen
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 tool go.uber.org/mock/mockgen
 

--- a/hack/airgap/go.mod
+++ b/hack/airgap/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/airgap
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.7.33 // CVE-2024-40635

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/pkg/apis
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 replace (
 	github.com/rancher/rancher/pkg/plan => ../plan

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/pkg/client
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/rancher/norman v0.9.7

--- a/pkg/plan/go.mod
+++ b/pkg/plan/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/pkg/plan
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 replace (
 	k8s.io/api => k8s.io/api v0.36.2


### PR DESCRIPTION
Set each module's `go` directive to `1.26.0` and add `toolchain go1.26.4`.