### PR TITLE
[v2.14] Add Go toolchain directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 replace (
 	github.com/crewjam/saml => github.com/rancher/saml v0.4.14-rancher3

--- a/gotools/controller-gen/go.mod
+++ b/gotools/controller-gen/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/gotools/controller-gen
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 tool sigs.k8s.io/controller-tools/cmd/controller-gen
 

--- a/gotools/mockery/go.mod
+++ b/gotools/mockery/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/gotools/mockery
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 tool github.com/vektra/mockery/v2
 

--- a/gotools/mockgen/go.mod
+++ b/gotools/mockgen/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/gotools/mockgen
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 tool go.uber.org/mock/mockgen
 

--- a/hack/airgap/go.mod
+++ b/hack/airgap/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/airgap
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.7.32 // CVE-2026-46680

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/pkg/apis
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 replace (
 	k8s.io/api => k8s.io/api v0.35.6

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/rancher/pkg/client
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 require (
 	github.com/rancher/norman v0.8.8


### PR DESCRIPTION
Set each module's `go` directive to `1.25.0` and add `toolchain go1.25.11`.