### PR TITLE
fix: workload selector label exceeding 63-character limit

### DIFF
--- a/pkg/api/norman/store/workload/aggregate_store.go
+++ b/pkg/api/norman/store/workload/aggregate_store.go
@@ -1,9 +1,7 @@
 package workload
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -11,6 +9,7 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/rancher/pkg/capr"
 	projectclient "github.com/rancher/rancher/pkg/client/generated/project/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
@@ -145,34 +144,23 @@ func store(registries map[string]projectclient.RegistryCredential, domainToCreds
 	}
 }
 
-func resolveWorkloadID(schemaID string, data map[string]interface{}) string {
-	namespaceID := convert.ToString(data["namespaceId"])
-	name := convert.ToString(data["name"])
+// resolveWorkloadID generates a workload selector label value that respects
+// Kubernetes' 63-character limit. Returns the label value and optionally the
+// full workload ID if truncation occurred (for annotation storage).
+func resolveWorkloadID(schemaID string, namespaceID string, name string) (labelValue string, fullID string) {
+	// Full format: deployment-namespace-name
+	fullID = fmt.Sprintf("%s-%s-%s", schemaID, namespaceID, name)
 
-	// Original format: deployment-namespace-name
-	workloadID := fmt.Sprintf("%s-%s-%s", schemaID, namespaceID, name)
+	// Use SafeConcatName for consistent truncation + hash behavior across Rancher
+	labelValue = capr.SafeConcatName(MaxLabelValueLength, schemaID, namespaceID, name)
 
-	// If within Kubernetes label value limit, use original format
-	if len(workloadID) <= MaxLabelValueLength {
-		return workloadID
+	// If SafeConcatName truncated/hashed the value, return fullID for annotation
+	if labelValue != fullID {
+		return labelValue, fullID
 	}
 
-	// For long names, store full ID in annotation for debugging
-	annotations := convert.ToMapInterface(data["workloadAnnotations"])
-	if annotations == nil {
-		annotations = make(map[string]interface{})
-	}
-	annotations[WorkloadIDAnnotation] = workloadID
-	data["workloadAnnotations"] = annotations
-
-	// Create hash-based identifier to stay within Kubernetes limits
-	// Format: deployment-<12-char-hash>
-	// This allows full 63-character namespace and deployment names
-	hasher := sha256.New()
-	hasher.Write([]byte(workloadID))
-	hash := hex.EncodeToString(hasher.Sum(nil))[:12]
-
-	return fmt.Sprintf("%s-%s", schemaID, hash)
+	// No truncation needed, don't store annotation
+	return labelValue, ""
 }
 
 func (a *AggregateStore) Update(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, id string) (map[string]interface{}, error) {

--- a/pkg/api/norman/store/workload/aggregate_store.go
+++ b/pkg/api/norman/store/workload/aggregate_store.go
@@ -1,7 +1,9 @@
 package workload
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,7 +19,9 @@ import (
 )
 
 const (
-	SelectorLabel = "workload.user.cattle.io/workloadselector"
+	SelectorLabel        = "workload.user.cattle.io/workloadselector"
+	WorkloadIDAnnotation = "workload.user.cattle.io/workload-id-full"
+	MaxLabelValueLength  = 63
 )
 
 type AggregateStore struct {
@@ -142,7 +146,33 @@ func store(registries map[string]projectclient.RegistryCredential, domainToCreds
 }
 
 func resolveWorkloadID(schemaID string, data map[string]interface{}) string {
-	return fmt.Sprintf("%s-%s-%s", schemaID, data["namespaceId"], data["name"])
+	namespaceID := convert.ToString(data["namespaceId"])
+	name := convert.ToString(data["name"])
+
+	// Original format: deployment-namespace-name
+	workloadID := fmt.Sprintf("%s-%s-%s", schemaID, namespaceID, name)
+
+	// If within Kubernetes label value limit, use original format
+	if len(workloadID) <= MaxLabelValueLength {
+		return workloadID
+	}
+
+	// For long names, store full ID in annotation for debugging
+	annotations := convert.ToMapInterface(data["workloadAnnotations"])
+	if annotations == nil {
+		annotations = make(map[string]interface{})
+	}
+	annotations[WorkloadIDAnnotation] = workloadID
+	data["workloadAnnotations"] = annotations
+
+	// Create hash-based identifier to stay within Kubernetes limits
+	// Format: deployment-<12-char-hash>
+	// This allows full 63-character namespace and deployment names
+	hasher := sha256.New()
+	hasher.Write([]byte(workloadID))
+	hash := hex.EncodeToString(hasher.Sum(nil))[:12]
+
+	return fmt.Sprintf("%s-%s", schemaID, hash)
 }
 
 func (a *AggregateStore) Update(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, id string) (map[string]interface{}, error) {

--- a/pkg/api/norman/store/workload/aggregate_store_test.go
+++ b/pkg/api/norman/store/workload/aggregate_store_test.go
@@ -1,247 +1,175 @@
 package workload
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/rancher/norman/types/convert"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestResolveWorkloadID_ShortNames(t *testing.T) {
 	tests := []struct {
-		name        string
-		schemaID    string
-		namespaceID string
+		name         string
+		schemaID     string
+		namespaceID  string
 		workloadName string
-		expected    string
+		expected     string
 	}{
 		{
-			name:        "simple deployment",
-			schemaID:    "deployment",
-			namespaceID: "default",
+			name:         "simple deployment",
+			schemaID:     "deployment",
+			namespaceID:  "default",
 			workloadName: "nginx",
-			expected:    "deployment-default-nginx",
+			expected:     "deployment-default-nginx",
 		},
 		{
-			name:        "statefulset with longer names",
-			schemaID:    "statefulset",
-			namespaceID: "kube-system",
+			name:         "statefulset with longer names",
+			schemaID:     "statefulset",
+			namespaceID:  "kube-system",
 			workloadName: "etcd-cluster",
-			expected:    "statefulset-kube-system-etcd-cluster",
+			expected:     "statefulset-kube-system-etcd-cluster",
 		},
 		{
-			name:        "exactly at limit (63 chars)",
-			schemaID:    "deployment",
-			namespaceID: "test-ns-1234567890123456789012345678901234", // 42 chars
-			workloadName: "dep1", // 4 chars
+			name:         "exactly at limit (63 chars)",
+			schemaID:     "deployment",
+			namespaceID:  "test-ns-1234567890123456789012345678901234", // 42 chars
+			workloadName: "dep1",                                       // 4 chars
 			// Total: deployment(10) + -(1) + namespace(42) + -(1) + name(4) = 58 chars
-			expected:    "deployment-test-ns-1234567890123456789012345678901234-dep1",
+			expected: "deployment-test-ns-1234567890123456789012345678901234-dep1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := map[string]interface{}{
-				"namespaceId": tt.namespaceID,
-				"name":        tt.workloadName,
-			}
+			labelValue, fullID := resolveWorkloadID(tt.schemaID, tt.namespaceID, tt.workloadName)
 
-			result := resolveWorkloadID(tt.schemaID, data)
-			assert.Equal(t, tt.expected, result)
-			assert.LessOrEqual(t, len(result), MaxLabelValueLength, "workload ID should not exceed max label value length")
+			assert.Equal(t, tt.expected, labelValue)
+			assert.LessOrEqual(t, len(labelValue), MaxLabelValueLength, "workload ID should not exceed max label value length")
 
-			// Verify no annotation was added for short names
-			annotations := convert.ToMapInterface(data["workloadAnnotations"])
-			if annotations != nil {
-				_, hasAnnotation := annotations[WorkloadIDAnnotation]
-				assert.False(t, hasAnnotation, "short names should not have annotation")
-			}
+			// Verify no fullID returned for short names (no annotation needed)
+			assert.Empty(t, fullID, "short names should not return fullID")
 		})
 	}
 }
 
 func TestResolveWorkloadID_LongNames(t *testing.T) {
 	tests := []struct {
-		name        string
-		schemaID    string
-		namespaceID string
+		name         string
+		schemaID     string
+		namespaceID  string
 		workloadName string
 	}{
 		{
-			name:        "namespace + deployment > 46 chars",
-			schemaID:    "deployment",
-			namespaceID: "very-long-namespace-name-with-many-characters-12345678",
+			name:         "namespace + deployment > 46 chars",
+			schemaID:     "deployment",
+			namespaceID:  "very-long-namespace-name-with-many-characters-12345678",
 			workloadName: "very-long-deployment-name-with-many-characters",
 		},
 		{
-			name:        "both at max length (63 + 63)",
-			schemaID:    "deployment",
-			namespaceID: strings.Repeat("a", 63),
+			name:         "both at max length (63 + 63)",
+			schemaID:     "deployment",
+			namespaceID:  strings.Repeat("a", 63),
 			workloadName: strings.Repeat("b", 63),
 		},
 		{
-			name:        "replicationcontroller with long names",
-			schemaID:    "replicationcontroller",
-			namespaceID: "namespace-with-a-moderately-long-name",
+			name:         "replicationcontroller with long names",
+			schemaID:     "replicationcontroller",
+			namespaceID:  "namespace-with-a-moderately-long-name",
 			workloadName: "workload-name-that-is-also-quite-long",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := map[string]interface{}{
-				"namespaceId": tt.namespaceID,
-				"name":        tt.workloadName,
-			}
-
-			result := resolveWorkloadID(tt.schemaID, data)
+			labelValue, fullID := resolveWorkloadID(tt.schemaID, tt.namespaceID, tt.workloadName)
 
 			// Verify result is within Kubernetes limits
-			assert.LessOrEqual(t, len(result), MaxLabelValueLength, "workload ID must not exceed 63 characters")
+			assert.LessOrEqual(t, len(labelValue), MaxLabelValueLength, "workload ID must not exceed 63 characters")
 
-			// Verify format is schemaID-hash
-			parts := strings.Split(result, "-")
-			assert.Equal(t, tt.schemaID, parts[0], "first part should be schemaID")
-			assert.Equal(t, 12, len(parts[1]), "hash should be 12 characters")
-
-			// Verify annotation was added with full workload ID
-			annotations := convert.ToMapInterface(data["workloadAnnotations"])
-			assert.NotNil(t, annotations, "annotations should be set for long names")
-
-			fullID, ok := annotations[WorkloadIDAnnotation]
-			assert.True(t, ok, "annotation should contain full workload ID")
+			// Verify fullID was returned (for annotation)
+			assert.NotEmpty(t, fullID, "long names should return fullID for annotation")
 
 			expectedFullID := fmt.Sprintf("%s-%s-%s", tt.schemaID, tt.namespaceID, tt.workloadName)
-			assert.Equal(t, expectedFullID, fullID, "annotation should contain original full ID")
+			assert.Equal(t, expectedFullID, fullID, "fullID should contain original full workload ID")
+
+			// Verify label value starts with schemaID
+			assert.True(t, strings.HasPrefix(labelValue, tt.schemaID+"-"), "label should start with schemaID")
 		})
 	}
 }
 
-func TestResolveWorkloadID_HashDeterminism(t *testing.T) {
-	// Verify that the same input always produces the same hash
+func TestResolveWorkloadID_Determinism(t *testing.T) {
+	// Verify that the same input always produces the same result
 	schemaID := "deployment"
 	namespaceID := strings.Repeat("long-namespace-", 10)
 	workloadName := strings.Repeat("long-workload-", 10)
 
-	data1 := map[string]interface{}{
-		"namespaceId": namespaceID,
-		"name":        workloadName,
-	}
+	result1, fullID1 := resolveWorkloadID(schemaID, namespaceID, workloadName)
+	result2, fullID2 := resolveWorkloadID(schemaID, namespaceID, workloadName)
 
-	data2 := map[string]interface{}{
-		"namespaceId": namespaceID,
-		"name":        workloadName,
-	}
-
-	result1 := resolveWorkloadID(schemaID, data1)
-	result2 := resolveWorkloadID(schemaID, data2)
-
-	assert.Equal(t, result1, result2, "same input should always produce same hash")
+	assert.Equal(t, result1, result2, "same input should always produce same label value")
+	assert.Equal(t, fullID1, fullID2, "same input should always produce same fullID")
 }
 
-func TestResolveWorkloadID_HashUniqueness(t *testing.T) {
-	// Verify that different inputs produce different hashes
+func TestResolveWorkloadID_Uniqueness(t *testing.T) {
+	// Verify that different inputs produce different results
 	schemaID := "deployment"
 
-	data1 := map[string]interface{}{
-		"namespaceId": strings.Repeat("namespace-a-", 10),
-		"name":        strings.Repeat("workload-1-", 10),
-	}
+	result1, _ := resolveWorkloadID(schemaID, strings.Repeat("namespace-a-", 10), strings.Repeat("workload-1-", 10))
+	result2, _ := resolveWorkloadID(schemaID, strings.Repeat("namespace-b-", 10), strings.Repeat("workload-2-", 10))
 
-	data2 := map[string]interface{}{
-		"namespaceId": strings.Repeat("namespace-b-", 10),
-		"name":        strings.Repeat("workload-2-", 10),
-	}
-
-	result1 := resolveWorkloadID(schemaID, data1)
-	result2 := resolveWorkloadID(schemaID, data2)
-
-	assert.NotEqual(t, result1, result2, "different inputs should produce different hashes")
+	assert.NotEqual(t, result1, result2, "different inputs should produce different label values")
 }
 
 func TestResolveWorkloadID_BoundaryCase(t *testing.T) {
-	// Test the exact boundary where we switch from full name to hash
+	// Test the exact boundary where we switch from full name to truncated+hash
 	schemaID := "deployment" // 10 chars
 
-	// Create a workload ID that's exactly 63 chars (should NOT use hash)
+	// Create a workload ID that's exactly 63 chars (should NOT truncate)
 	// deployment(10) + -(1) + namespace(26) + -(1) + name(25) = 63
-	data63 := map[string]interface{}{
-		"namespaceId": strings.Repeat("a", 26),
-		"name":        strings.Repeat("b", 25),
-	}
+	namespaceID63 := strings.Repeat("a", 26)
+	name63 := strings.Repeat("b", 25)
 
-	result63 := resolveWorkloadID(schemaID, data63)
-	expected63 := fmt.Sprintf("deployment-%s-%s", strings.Repeat("a", 26), strings.Repeat("b", 25))
-	assert.Equal(t, expected63, result63, "63-char workload ID should use full format")
-	assert.Equal(t, 63, len(result63))
+	labelValue63, fullID63 := resolveWorkloadID(schemaID, namespaceID63, name63)
+	expected63 := fmt.Sprintf("deployment-%s-%s", namespaceID63, name63)
 
-	// Create a workload ID that's 64 chars (should use hash)
+	assert.Equal(t, expected63, labelValue63, "63-char workload ID should use full format")
+	assert.Equal(t, 63, len(labelValue63))
+	assert.Empty(t, fullID63, "63-char workload ID should not return fullID")
+
+	// Create a workload ID that's 64 chars (should truncate+hash)
 	// deployment(10) + -(1) + namespace(26) + -(1) + name(26) = 64
-	data64 := map[string]interface{}{
-		"namespaceId": strings.Repeat("a", 26),
-		"name":        strings.Repeat("b", 26),
-	}
+	namespaceID64 := strings.Repeat("a", 26)
+	name64 := strings.Repeat("b", 26)
 
-	result64 := resolveWorkloadID(schemaID, data64)
-	assert.NotEqual(t, result64, result63, "64-char workload ID should use hash format")
-	assert.LessOrEqual(t, len(result64), 63)
+	labelValue64, fullID64 := resolveWorkloadID(schemaID, namespaceID64, name64)
 
-	// Verify hash format
-	parts := strings.Split(result64, "-")
-	assert.Equal(t, "deployment", parts[0])
-	assert.Equal(t, 12, len(parts[1]))
+	assert.NotEqual(t, labelValue64, labelValue63, "64-char workload ID should use truncated+hash format")
+	assert.LessOrEqual(t, len(labelValue64), 63)
+	assert.NotEmpty(t, fullID64, "64-char workload ID should return fullID for annotation")
 }
 
-func TestResolveWorkloadID_MatchesExpectedHash(t *testing.T) {
-	// Verify the hash algorithm matches our expectations
-	schemaID := "deployment"
-	namespaceID := "very-long-namespace-name-that-exceeds-limits"
-	workloadName := "very-long-workload-name-that-also-exceeds-limits"
+func TestResolveWorkloadID_DifferentTypes(t *testing.T) {
+	// Verify it works for all workload types
+	namespaceID := strings.Repeat("a", 30)
+	name := strings.Repeat("b", 30)
 
-	data := map[string]interface{}{
-		"namespaceId": namespaceID,
-		"name":        workloadName,
-	}
+	deployment, _ := resolveWorkloadID("deployment", namespaceID, name)
+	statefulset, _ := resolveWorkloadID("statefulset", namespaceID, name)
+	daemonset, _ := resolveWorkloadID("daemonset", namespaceID, name)
 
-	result := resolveWorkloadID(schemaID, data)
+	// All should be within limit
+	assert.LessOrEqual(t, len(deployment), 63)
+	assert.LessOrEqual(t, len(statefulset), 63)
+	assert.LessOrEqual(t, len(daemonset), 63)
 
-	// Calculate expected hash
-	fullID := fmt.Sprintf("%s-%s-%s", schemaID, namespaceID, workloadName)
-	hasher := sha256.New()
-	hasher.Write([]byte(fullID))
-	expectedHash := hex.EncodeToString(hasher.Sum(nil))[:12]
-	expectedResult := fmt.Sprintf("%s-%s", schemaID, expectedHash)
+	// All should start with their respective type
+	assert.True(t, strings.HasPrefix(deployment, "deployment-"))
+	assert.True(t, strings.HasPrefix(statefulset, "statefulset-"))
+	assert.True(t, strings.HasPrefix(daemonset, "daemonset-"))
 
-	assert.Equal(t, expectedResult, result, "hash should match expected SHA256 output")
-}
-
-func TestResolveWorkloadID_PreservesExistingAnnotations(t *testing.T) {
-	// Verify that existing annotations are preserved when adding workload ID annotation
-	schemaID := "deployment"
-	namespaceID := strings.Repeat("long-namespace-", 10)
-	workloadName := strings.Repeat("long-workload-", 10)
-
-	data := map[string]interface{}{
-		"namespaceId": namespaceID,
-		"name":        workloadName,
-		"workloadAnnotations": map[string]interface{}{
-			"existing.annotation/key": "existing-value",
-		},
-	}
-
-	resolveWorkloadID(schemaID, data)
-
-	annotations := convert.ToMapInterface(data["workloadAnnotations"])
-	assert.NotNil(t, annotations)
-
-	// Check existing annotation is preserved
-	assert.Equal(t, "existing-value", annotations["existing.annotation/key"])
-
-	// Check new annotation is added
-	fullID := fmt.Sprintf("%s-%s-%s", schemaID, namespaceID, workloadName)
-	assert.Equal(t, fullID, annotations[WorkloadIDAnnotation])
+	// Different types should produce different results
+	assert.NotEqual(t, deployment, statefulset)
+	assert.NotEqual(t, deployment, daemonset)
 }

--- a/pkg/api/norman/store/workload/aggregate_store_test.go
+++ b/pkg/api/norman/store/workload/aggregate_store_test.go
@@ -1,0 +1,247 @@
+package workload
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rancher/norman/types/convert"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveWorkloadID_ShortNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		schemaID    string
+		namespaceID string
+		workloadName string
+		expected    string
+	}{
+		{
+			name:        "simple deployment",
+			schemaID:    "deployment",
+			namespaceID: "default",
+			workloadName: "nginx",
+			expected:    "deployment-default-nginx",
+		},
+		{
+			name:        "statefulset with longer names",
+			schemaID:    "statefulset",
+			namespaceID: "kube-system",
+			workloadName: "etcd-cluster",
+			expected:    "statefulset-kube-system-etcd-cluster",
+		},
+		{
+			name:        "exactly at limit (63 chars)",
+			schemaID:    "deployment",
+			namespaceID: "test-ns-1234567890123456789012345678901234", // 42 chars
+			workloadName: "dep1", // 4 chars
+			// Total: deployment(10) + -(1) + namespace(42) + -(1) + name(4) = 58 chars
+			expected:    "deployment-test-ns-1234567890123456789012345678901234-dep1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := map[string]interface{}{
+				"namespaceId": tt.namespaceID,
+				"name":        tt.workloadName,
+			}
+
+			result := resolveWorkloadID(tt.schemaID, data)
+			assert.Equal(t, tt.expected, result)
+			assert.LessOrEqual(t, len(result), MaxLabelValueLength, "workload ID should not exceed max label value length")
+
+			// Verify no annotation was added for short names
+			annotations := convert.ToMapInterface(data["workloadAnnotations"])
+			if annotations != nil {
+				_, hasAnnotation := annotations[WorkloadIDAnnotation]
+				assert.False(t, hasAnnotation, "short names should not have annotation")
+			}
+		})
+	}
+}
+
+func TestResolveWorkloadID_LongNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		schemaID    string
+		namespaceID string
+		workloadName string
+	}{
+		{
+			name:        "namespace + deployment > 46 chars",
+			schemaID:    "deployment",
+			namespaceID: "very-long-namespace-name-with-many-characters-12345678",
+			workloadName: "very-long-deployment-name-with-many-characters",
+		},
+		{
+			name:        "both at max length (63 + 63)",
+			schemaID:    "deployment",
+			namespaceID: strings.Repeat("a", 63),
+			workloadName: strings.Repeat("b", 63),
+		},
+		{
+			name:        "replicationcontroller with long names",
+			schemaID:    "replicationcontroller",
+			namespaceID: "namespace-with-a-moderately-long-name",
+			workloadName: "workload-name-that-is-also-quite-long",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := map[string]interface{}{
+				"namespaceId": tt.namespaceID,
+				"name":        tt.workloadName,
+			}
+
+			result := resolveWorkloadID(tt.schemaID, data)
+
+			// Verify result is within Kubernetes limits
+			assert.LessOrEqual(t, len(result), MaxLabelValueLength, "workload ID must not exceed 63 characters")
+
+			// Verify format is schemaID-hash
+			parts := strings.Split(result, "-")
+			assert.Equal(t, tt.schemaID, parts[0], "first part should be schemaID")
+			assert.Equal(t, 12, len(parts[1]), "hash should be 12 characters")
+
+			// Verify annotation was added with full workload ID
+			annotations := convert.ToMapInterface(data["workloadAnnotations"])
+			assert.NotNil(t, annotations, "annotations should be set for long names")
+
+			fullID, ok := annotations[WorkloadIDAnnotation]
+			assert.True(t, ok, "annotation should contain full workload ID")
+
+			expectedFullID := fmt.Sprintf("%s-%s-%s", tt.schemaID, tt.namespaceID, tt.workloadName)
+			assert.Equal(t, expectedFullID, fullID, "annotation should contain original full ID")
+		})
+	}
+}
+
+func TestResolveWorkloadID_HashDeterminism(t *testing.T) {
+	// Verify that the same input always produces the same hash
+	schemaID := "deployment"
+	namespaceID := strings.Repeat("long-namespace-", 10)
+	workloadName := strings.Repeat("long-workload-", 10)
+
+	data1 := map[string]interface{}{
+		"namespaceId": namespaceID,
+		"name":        workloadName,
+	}
+
+	data2 := map[string]interface{}{
+		"namespaceId": namespaceID,
+		"name":        workloadName,
+	}
+
+	result1 := resolveWorkloadID(schemaID, data1)
+	result2 := resolveWorkloadID(schemaID, data2)
+
+	assert.Equal(t, result1, result2, "same input should always produce same hash")
+}
+
+func TestResolveWorkloadID_HashUniqueness(t *testing.T) {
+	// Verify that different inputs produce different hashes
+	schemaID := "deployment"
+
+	data1 := map[string]interface{}{
+		"namespaceId": strings.Repeat("namespace-a-", 10),
+		"name":        strings.Repeat("workload-1-", 10),
+	}
+
+	data2 := map[string]interface{}{
+		"namespaceId": strings.Repeat("namespace-b-", 10),
+		"name":        strings.Repeat("workload-2-", 10),
+	}
+
+	result1 := resolveWorkloadID(schemaID, data1)
+	result2 := resolveWorkloadID(schemaID, data2)
+
+	assert.NotEqual(t, result1, result2, "different inputs should produce different hashes")
+}
+
+func TestResolveWorkloadID_BoundaryCase(t *testing.T) {
+	// Test the exact boundary where we switch from full name to hash
+	schemaID := "deployment" // 10 chars
+
+	// Create a workload ID that's exactly 63 chars (should NOT use hash)
+	// deployment(10) + -(1) + namespace(26) + -(1) + name(25) = 63
+	data63 := map[string]interface{}{
+		"namespaceId": strings.Repeat("a", 26),
+		"name":        strings.Repeat("b", 25),
+	}
+
+	result63 := resolveWorkloadID(schemaID, data63)
+	expected63 := fmt.Sprintf("deployment-%s-%s", strings.Repeat("a", 26), strings.Repeat("b", 25))
+	assert.Equal(t, expected63, result63, "63-char workload ID should use full format")
+	assert.Equal(t, 63, len(result63))
+
+	// Create a workload ID that's 64 chars (should use hash)
+	// deployment(10) + -(1) + namespace(26) + -(1) + name(26) = 64
+	data64 := map[string]interface{}{
+		"namespaceId": strings.Repeat("a", 26),
+		"name":        strings.Repeat("b", 26),
+	}
+
+	result64 := resolveWorkloadID(schemaID, data64)
+	assert.NotEqual(t, result64, result63, "64-char workload ID should use hash format")
+	assert.LessOrEqual(t, len(result64), 63)
+
+	// Verify hash format
+	parts := strings.Split(result64, "-")
+	assert.Equal(t, "deployment", parts[0])
+	assert.Equal(t, 12, len(parts[1]))
+}
+
+func TestResolveWorkloadID_MatchesExpectedHash(t *testing.T) {
+	// Verify the hash algorithm matches our expectations
+	schemaID := "deployment"
+	namespaceID := "very-long-namespace-name-that-exceeds-limits"
+	workloadName := "very-long-workload-name-that-also-exceeds-limits"
+
+	data := map[string]interface{}{
+		"namespaceId": namespaceID,
+		"name":        workloadName,
+	}
+
+	result := resolveWorkloadID(schemaID, data)
+
+	// Calculate expected hash
+	fullID := fmt.Sprintf("%s-%s-%s", schemaID, namespaceID, workloadName)
+	hasher := sha256.New()
+	hasher.Write([]byte(fullID))
+	expectedHash := hex.EncodeToString(hasher.Sum(nil))[:12]
+	expectedResult := fmt.Sprintf("%s-%s", schemaID, expectedHash)
+
+	assert.Equal(t, expectedResult, result, "hash should match expected SHA256 output")
+}
+
+func TestResolveWorkloadID_PreservesExistingAnnotations(t *testing.T) {
+	// Verify that existing annotations are preserved when adding workload ID annotation
+	schemaID := "deployment"
+	namespaceID := strings.Repeat("long-namespace-", 10)
+	workloadName := strings.Repeat("long-workload-", 10)
+
+	data := map[string]interface{}{
+		"namespaceId": namespaceID,
+		"name":        workloadName,
+		"workloadAnnotations": map[string]interface{}{
+			"existing.annotation/key": "existing-value",
+		},
+	}
+
+	resolveWorkloadID(schemaID, data)
+
+	annotations := convert.ToMapInterface(data["workloadAnnotations"])
+	assert.NotNil(t, annotations)
+
+	// Check existing annotation is preserved
+	assert.Equal(t, "existing-value", annotations["existing.annotation/key"])
+
+	// Check new annotation is added
+	fullID := fmt.Sprintf("%s-%s-%s", schemaID, namespaceID, workloadName)
+	assert.Equal(t, fullID, annotations[WorkloadIDAnnotation])
+}

--- a/pkg/api/norman/store/workload/workload_store.go
+++ b/pkg/api/norman/store/workload/workload_store.go
@@ -169,7 +169,21 @@ func setSelector(schemaID string, data map[string]interface{}) {
 		setSelector = true
 	}
 	if setSelector {
-		workloadID := resolveWorkloadID(schemaID, data)
+		namespaceID := convert.ToString(data["namespaceId"])
+		name := convert.ToString(data["name"])
+
+		workloadID, fullWorkloadID := resolveWorkloadID(schemaID, namespaceID, name)
+
+		// If fullWorkloadID is set, the label was truncated - store full ID in annotation
+		if fullWorkloadID != "" {
+			annotations := convert.ToMapInterface(data["workloadAnnotations"])
+			if annotations == nil {
+				annotations = make(map[string]interface{})
+			}
+			annotations[WorkloadIDAnnotation] = fullWorkloadID
+			data["workloadAnnotations"] = annotations
+		}
+
 		// set selector
 		data["selector"] = map[string]interface{}{
 			"matchLabels": map[string]interface{}{


### PR DESCRIPTION
## Issue

When creating deployments via Rancher, the automatically generated label `workload.user.cattle.io/workloadselector` can exceed Kubernetes' 63-character limit for label values, causing deployment creation to fail.

## Problem

Rancher generates workload selector labels using the format `<type>-<namespace>-<deployment>` (e.g., `deployment-my-namespace-my-app`). This creates a hard limit where namespace + deployment name cannot exceed 46 characters combined, even though Kubernetes allows up to 63 characters for both namespace and deployment names individually.

Root cause: The label generation in `resolveWorkloadID()` didn't account for Kubernetes' 63-character label value limit, and there was no truncation or validation logic.

## Solution

Updated the workload selector label generation to use `SafeConcatName` from `pkg/capr/common.go`:

- Short names (≤63 chars): No change, uses original format `deployment-namespace-name`
- Long names (>63 chars): Truncates and appends hash, e.g., `deployment-very-long-namespace-very-long-dep-a1b2c`
- Stores full workload ID in annotation `workload.user.cattle.io/workload-id-full` when truncation occurs

## Testing

### Manual Testing

1. **Short names (baseline)**: Created deployment with namespace `test-short` + name `nginx` → label: `deployment-test-short-nginx` 
2. **Boundary case (63 chars)**: Created deployment with 26-char namespace + 25-char name → label: full 63-char format 
3. **Over limit (64+ chars)**: Created deployment with 63-char namespace + 63-char name → label: truncated with hash, ≤63 chars 
4. **Annotation verification**: Long names correctly stored full ID in annotation 
5. **Pod selector**: Verified pods match deployment selector with hash-based labels 
6. **Determinism**: Same namespace+name produces identical hash across recreations 

Before fix: Deployments with namespace+deployment > 46 chars failed with "must be no more than 63 bytes"

After fix: Can create deployments with full 63-char namespace and deployment names

### Automated Testing

**Unit Tests**: Added comprehensive test suite in `aggregate_store_test.go`:
- `TestResolveWorkloadID_ShortNames`: Verifies backward compatibility
- `TestResolveWorkloadID_LongNames`: Verifies truncation + hash for long names
- `TestResolveWorkloadID_Determinism`: Verifies consistent hash generation
- `TestResolveWorkloadID_Uniqueness`: Verifies different inputs produce different hashes
- `TestResolveWorkloadID_BoundaryCase`: Tests exact 63/64 char boundary
- `TestResolveWorkloadID_DifferentTypes`: Tests all workload types

## Related PRs

Dashboard PR: https://github.com/rancher/dashboard/pull/18242 (must be deployed together)