### PR TITLE
Purge expired ext.Tokens hourly

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -145,6 +145,7 @@ func (s *Server) OnLeader(ctx context.Context) error {
 	management := &config.ManagementContext{
 		Management: s.scaledContext.Management,
 		Core:       s.scaledContext.Core,
+		Wrangler:   s.scaledContext.Wrangler,
 	}
 
 	if err := data.AuthConfigs(management); err != nil {

--- a/pkg/auth/tokens/purge_daemon.go
+++ b/pkg/auth/tokens/purge_daemon.go
@@ -2,9 +2,12 @@ package tokens
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/rancher/norman/clientbase"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -14,7 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const intervalSeconds int64 = 3600
+// intervalSeconds defines the interval at which the purge daemon runs.
+const intervalSeconds int64 = 3600 // 1h.
+
+// extTokenPurger deletes expired ext.Tokens.
+type extTokenPurger interface {
+	DeleteExpired() (int, error)
+}
 
 func StartPurgeDaemon(ctx context.Context, mgmt *config.ManagementContext) {
 	p := &purger{
@@ -22,6 +31,7 @@ func StartPurgeDaemon(ctx context.Context, mgmt *config.ManagementContext) {
 		tokens:           mgmt.Management.Tokens(""),
 		samlTokensLister: mgmt.Management.SamlTokens("").Controller().Lister(),
 		samlTokens:       mgmt.Management.SamlTokens(""),
+		extTokenPurger:   exttokenstore.NewSystemFromWrangler(mgmt.Wrangler),
 	}
 	go wait.JitterUntil(p.purge, time.Duration(intervalSeconds)*time.Second, .1, true, ctx.Done())
 }
@@ -31,48 +41,89 @@ type purger struct {
 	tokens           v3.TokenInterface
 	samlTokens       v3.SamlTokenInterface
 	samlTokensLister v3.SamlTokenLister
+	extTokenPurger   extTokenPurger
 }
 
 func (p *purger) purge() {
-	allTokens, err := p.tokenLister.List("", labels.Everything())
+	count, err := p.extTokenPurger.DeleteExpired()
 	if err != nil {
-		logrus.Errorf("Error listing tokens during purge: %v", err)
+		logrus.Errorf("Error purging ext tokens: %v", err)
+	}
+	if count > 0 {
+		logrus.Infof("Purged %v expired ext tokens", count)
 	}
 
-	var count int
-	for _, token := range allTokens {
-		if IsExpired(token) {
-			err = p.tokens.Delete(token.ObjectMeta.Name, &metav1.DeleteOptions{})
-			if err != nil && !clientbase.IsNotFound(err) {
-				logrus.Errorf("Error: while deleting expired token %v: %v", err, token.ObjectMeta.Name)
-				continue
-			}
-			count++
-		}
+	count, err = p.deleteExpiredV3Tokens()
+	if err != nil {
+		logrus.Errorf("Error purging v3 tokens: %v", err)
 	}
 	if count > 0 {
 		logrus.Infof("Purged %v expired tokens", count)
 	}
 
-	// saml tokens store encrypted token for login request from rancher cli
-	samlTokens, err := p.samlTokensLister.List(namespace.GlobalNamespace, labels.Everything())
+	count, err = p.deleteExpiredSamlTokens()
 	if err != nil {
-		return
-	}
-
-	count = 0
-	for _, token := range samlTokens {
-		// avoid delete immediately after creation, login request might be pending
-		if token.CreationTimestamp.Add(15 * time.Minute).Before(time.Now()) {
-			err = p.samlTokens.Delete(token.ObjectMeta.Name, &metav1.DeleteOptions{})
-			if err != nil && !clientbase.IsNotFound(err) {
-				logrus.Errorf("Error: while deleting expired token %v: %v", err, token.Name)
-				continue
-			}
-			count++
-		}
+		logrus.Errorf("Error purging saml tokens: %v", err)
 	}
 	if count > 0 {
 		logrus.Infof("Purged %v saml tokens", count)
 	}
+}
+
+// deleteExpiredV3Tokens removes every v3.Token whose TTL has passed and
+// returns the number of tokens deleted. A failure to list tokens is returned
+// as-is; the returned count is 0 in that case. Per-token delete failures do
+// not stop iteration; each is wrapped with the token name and joined into the
+// returned error, and the count reflects only tokens that were actually
+// deleted (or already gone).
+func (p *purger) deleteExpiredV3Tokens() (int, error) {
+	allV3Tokens, err := p.tokenLister.List("", labels.Everything())
+	if err != nil {
+		return 0, fmt.Errorf("listing v3 tokens: %w", err)
+	}
+
+	var (
+		count int
+		errs  []error
+	)
+	for _, token := range allV3Tokens {
+		if !IsExpired(token) {
+			continue
+		}
+		if err := p.tokens.Delete(token.ObjectMeta.Name, &metav1.DeleteOptions{}); err != nil && !clientbase.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting %s: %w", token.ObjectMeta.Name, err))
+			continue
+		}
+		count++
+	}
+
+	return count, errors.Join(errs...)
+}
+
+// deleteExpiredSamlTokens removes every SamlToken older than 15 minutes and
+// returns the number of tokens deleted. The 15-minute grace period avoids
+// racing with a pending login request from the Rancher CLI. Error semantics
+// match [purger.deleteExpiredV3Tokens].
+func (p *purger) deleteExpiredSamlTokens() (int, error) {
+	samlTokens, err := p.samlTokensLister.List(namespace.GlobalNamespace, labels.Everything())
+	if err != nil {
+		return 0, fmt.Errorf("listing saml tokens: %w", err)
+	}
+
+	var (
+		count int
+		errs  []error
+	)
+	for _, token := range samlTokens {
+		if !token.CreationTimestamp.Add(15 * time.Minute).Before(time.Now()) {
+			continue
+		}
+		if err := p.samlTokens.Delete(token.ObjectMeta.Name, &metav1.DeleteOptions{}); err != nil && !clientbase.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting %s: %w", token.ObjectMeta.Name, err))
+			continue
+		}
+		count++
+	}
+
+	return count, errors.Join(errs...)
 }

--- a/pkg/auth/tokens/purge_daemon.go
+++ b/pkg/auth/tokens/purge_daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/rancher/norman/clientbase"
@@ -25,15 +26,23 @@ type extTokenPurger interface {
 	DeleteExpired() (int, error)
 }
 
+// startOnce guards StartPurgeDaemon so the daemon runs exactly once per
+// process. Rancher wires OnLeader under two distinct lock names (auth server
+// and multi-cluster manager); both fire on the same pod in single-instance
+// deployments and would otherwise spin up two purge goroutines.
+var startOnce sync.Once
+
 func StartPurgeDaemon(ctx context.Context, mgmt *config.ManagementContext) {
-	p := &purger{
-		tokenLister:      mgmt.Management.Tokens("").Controller().Lister(),
-		tokens:           mgmt.Management.Tokens(""),
-		samlTokensLister: mgmt.Management.SamlTokens("").Controller().Lister(),
-		samlTokens:       mgmt.Management.SamlTokens(""),
-		extTokenPurger:   exttokenstore.NewSystemFromWrangler(mgmt.Wrangler),
-	}
-	go wait.JitterUntil(p.purge, time.Duration(intervalSeconds)*time.Second, .1, true, ctx.Done())
+	startOnce.Do(func() {
+		p := &purger{
+			tokenLister:      mgmt.Management.Tokens("").Controller().Lister(),
+			tokens:           mgmt.Management.Tokens(""),
+			samlTokensLister: mgmt.Management.SamlTokens("").Controller().Lister(),
+			samlTokens:       mgmt.Management.SamlTokens(""),
+			extTokenPurger:   exttokenstore.NewSystemFromWrangler(mgmt.Wrangler),
+		}
+		go wait.JitterUntil(p.purge, time.Duration(intervalSeconds)*time.Second, .1, true, ctx.Done())
+	})
 }
 
 type purger struct {

--- a/pkg/auth/tokens/purge_daemon.go
+++ b/pkg/auth/tokens/purge_daemon.go
@@ -18,8 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// intervalSeconds defines the interval at which the purge daemon runs.
-const intervalSeconds int64 = 3600 // 1h.
+// purgeInterval defines the interval at which the purge daemon runs.
+const purgeInterval = time.Hour
 
 // extTokenPurger deletes expired ext.Tokens.
 type extTokenPurger interface {
@@ -41,7 +41,7 @@ func StartPurgeDaemon(ctx context.Context, mgmt *config.ManagementContext) {
 			samlTokens:       mgmt.Management.SamlTokens(""),
 			extTokenPurger:   exttokenstore.NewSystemFromWrangler(mgmt.Wrangler),
 		}
-		go wait.JitterUntil(p.purge, time.Duration(intervalSeconds)*time.Second, .1, true, ctx.Done())
+		go wait.JitterUntil(p.purge, purgeInterval, .1, true, ctx.Done())
 	})
 }
 

--- a/pkg/auth/tokens/purge_daemon_test.go
+++ b/pkg/auth/tokens/purge_daemon_test.go
@@ -1,0 +1,281 @@
+package tokens
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/clientbase"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	testShortTTLMillis = int64(60 * 1000)              // 60s
+	testLongTTLMillis  = int64(365 * 24 * 3600 * 1000) // 1y
+)
+
+func newV3Token(name string, created time.Time, ttlMillis int64) *v3.Token {
+	return &v3.Token{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		TTLMillis: ttlMillis,
+	}
+}
+
+func newSamlToken(name string, created time.Time) *v3.SamlToken {
+	return &v3.SamlToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: metav1.NewTime(created),
+		},
+	}
+}
+
+// clientBaseNotFound returns an error that clientbase.IsNotFound recognises.
+func clientBaseNotFound() error {
+	return &clientbase.APIError{StatusCode: http.StatusNotFound, Msg: "not found"}
+}
+
+func TestPurgerDeleteExpiredV3Tokens(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	longAgo := now.Add(-24 * time.Hour)
+	recent := now.Add(-1 * time.Minute)
+
+	someErr := errors.New("some error")
+
+	cases := []struct {
+		name            string
+		tokens          []*v3.Token
+		listErr         error
+		deleteResults   map[string]error
+		expectedDeletes []string
+		wantCount       int
+		wantErr         bool
+	}{
+		{
+			name: "mix expired + fresh, only expired deleted",
+			tokens: []*v3.Token{
+				newV3Token("expired-1", longAgo, testShortTTLMillis),
+				newV3Token("fresh-1", recent, testLongTTLMillis),
+				newV3Token("expired-2", longAgo, testShortTTLMillis),
+			},
+			expectedDeletes: []string{"expired-1", "expired-2"},
+			wantCount:       2,
+		},
+		{
+			name: "delete returns not found is tolerated",
+			tokens: []*v3.Token{
+				newV3Token("expired-1", longAgo, testShortTTLMillis),
+			},
+			deleteResults: map[string]error{
+				"expired-1": clientBaseNotFound(),
+			},
+			expectedDeletes: []string{"expired-1"},
+			wantCount:       1,
+		},
+		{
+			name: "per-token error surfaced, loop continues",
+			tokens: []*v3.Token{
+				newV3Token("expired-1", longAgo, testShortTTLMillis),
+				newV3Token("expired-2", longAgo, testShortTTLMillis),
+			},
+			deleteResults: map[string]error{
+				"expired-1": someErr,
+			},
+			expectedDeletes: []string{"expired-1", "expired-2"},
+			wantCount:       1,
+			wantErr:         true,
+		},
+		{
+			name:    "list error surfaced, no deletes",
+			listErr: someErr,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deleted := map[string]int{}
+			lister := &fakes.TokenListerMock{
+				ListFunc: func(namespace string, selector labels.Selector) ([]*v3.Token, error) {
+					if tt.listErr != nil {
+						return nil, tt.listErr
+					}
+					return tt.tokens, nil
+				},
+			}
+			iface := &fakes.TokenInterfaceMock{
+				DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+					deleted[name]++
+					return tt.deleteResults[name]
+				},
+			}
+
+			p := &purger{tokenLister: lister, tokens: iface}
+			count, err := p.deleteExpiredV3Tokens()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCount, count)
+			for _, name := range tt.expectedDeletes {
+				assert.Equal(t, 1, deleted[name], "expected exactly one Delete for %s", name)
+			}
+			assert.Len(t, deleted, len(tt.expectedDeletes),
+				"unexpected extra Delete calls: %v", deleted)
+		})
+	}
+}
+
+func TestPurgerDeleteExpiredSamlTokens(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	stale := now.Add(-30 * time.Minute) // past the 15-minute grace period
+	fresh := now.Add(-1 * time.Minute)  // still within grace period
+
+	someErr := errors.New("some error")
+
+	cases := []struct {
+		name            string
+		tokens          []*v3.SamlToken
+		listErr         error
+		deleteResults   map[string]error
+		expectedDeletes []string
+		wantCount       int
+		wantErr         bool
+	}{
+		{
+			name: "mix stale + fresh, only stale deleted",
+			tokens: []*v3.SamlToken{
+				newSamlToken("stale-1", stale),
+				newSamlToken("fresh-1", fresh),
+				newSamlToken("stale-2", stale),
+			},
+			expectedDeletes: []string{"stale-1", "stale-2"},
+			wantCount:       2,
+		},
+		{
+			name: "delete returns not found is tolerated",
+			tokens: []*v3.SamlToken{
+				newSamlToken("stale-1", stale),
+			},
+			deleteResults: map[string]error{
+				"stale-1": clientBaseNotFound(),
+			},
+			expectedDeletes: []string{"stale-1"},
+			wantCount:       1,
+		},
+		{
+			name: "per-token error surfaced, loop continues",
+			tokens: []*v3.SamlToken{
+				newSamlToken("stale-1", stale),
+				newSamlToken("stale-2", stale),
+			},
+			deleteResults: map[string]error{
+				"stale-1": someErr,
+			},
+			expectedDeletes: []string{"stale-1", "stale-2"},
+			wantCount:       1,
+			wantErr:         true,
+		},
+		{
+			name:    "list error surfaced, no deletes",
+			listErr: someErr,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deleted := map[string]int{}
+			lister := &fakes.SamlTokenListerMock{
+				ListFunc: func(namespace string, selector labels.Selector) ([]*v3.SamlToken, error) {
+					if tt.listErr != nil {
+						return nil, tt.listErr
+					}
+					return tt.tokens, nil
+				},
+			}
+			iface := &fakes.SamlTokenInterfaceMock{
+				DeleteFunc: func(name string, options *metav1.DeleteOptions) error {
+					deleted[name]++
+					return tt.deleteResults[name]
+				},
+			}
+
+			p := &purger{samlTokensLister: lister, samlTokens: iface}
+			count, err := p.deleteExpiredSamlTokens()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCount, count)
+			for _, name := range tt.expectedDeletes {
+				assert.Equal(t, 1, deleted[name], "expected exactly one Delete for %s", name)
+			}
+			assert.Len(t, deleted, len(tt.expectedDeletes),
+				"unexpected extra Delete calls: %v", deleted)
+		})
+	}
+}
+
+func TestPurgerPurgeInvokesAll(t *testing.T) {
+	t.Parallel()
+
+	var (
+		v3Called   int
+		samlCalled int
+		extCalled  int
+	)
+
+	p := &purger{
+		tokenLister: &fakes.TokenListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) ([]*v3.Token, error) {
+				v3Called++
+				return nil, nil
+			},
+		},
+		tokens: &fakes.TokenInterfaceMock{},
+		samlTokensLister: &fakes.SamlTokenListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) ([]*v3.SamlToken, error) {
+				samlCalled++
+				return nil, nil
+			},
+		},
+		samlTokens: &fakes.SamlTokenInterfaceMock{},
+		extTokenPurger: extTokenPurgerFunc(func() (int, error) {
+			extCalled++
+			return 0, nil
+		}),
+	}
+
+	p.purge()
+
+	assert.Equal(t, 1, extCalled, "expected extTokenPurger.DeleteExpired to be called once")
+	assert.Equal(t, 1, v3Called, "expected v3 token lister to be called once")
+	assert.Equal(t, 1, samlCalled, "expected saml token lister to be called once")
+}
+
+// extTokenPurgerFunc lets a plain function satisfy the extTokenPurger interface.
+type extTokenPurgerFunc func() (int, error)
+
+func (f extTokenPurgerFunc) DeleteExpired() (int, error) { return f() }

--- a/pkg/auth/tokens/purge_daemon_test.go
+++ b/pkg/auth/tokens/purge_daemon_test.go
@@ -16,17 +16,17 @@ import (
 )
 
 const (
-	testShortTTLMillis = int64(60 * 1000)              // 60s
-	testLongTTLMillis  = int64(365 * 24 * 3600 * 1000) // 1y
+	testShortTTL = time.Minute
+	testLongTTL  = 365 * 24 * time.Hour
 )
 
-func newV3Token(name string, created time.Time, ttlMillis int64) *v3.Token {
+func newV3Token(name string, created time.Time, ttl time.Duration) *v3.Token {
 	return &v3.Token{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
 			CreationTimestamp: metav1.NewTime(created),
 		},
-		TTLMillis: ttlMillis,
+		TTLMillis: ttl.Milliseconds(),
 	}
 }
 
@@ -65,9 +65,9 @@ func TestPurgerDeleteExpiredV3Tokens(t *testing.T) {
 		{
 			name: "mix expired + fresh, only expired deleted",
 			tokens: []*v3.Token{
-				newV3Token("expired-1", longAgo, testShortTTLMillis),
-				newV3Token("fresh-1", recent, testLongTTLMillis),
-				newV3Token("expired-2", longAgo, testShortTTLMillis),
+				newV3Token("expired-1", longAgo, testShortTTL),
+				newV3Token("fresh-1", recent, testLongTTL),
+				newV3Token("expired-2", longAgo, testShortTTL),
 			},
 			expectedDeletes: []string{"expired-1", "expired-2"},
 			wantCount:       2,
@@ -75,7 +75,7 @@ func TestPurgerDeleteExpiredV3Tokens(t *testing.T) {
 		{
 			name: "delete returns not found is tolerated",
 			tokens: []*v3.Token{
-				newV3Token("expired-1", longAgo, testShortTTLMillis),
+				newV3Token("expired-1", longAgo, testShortTTL),
 			},
 			deleteResults: map[string]error{
 				"expired-1": clientBaseNotFound(),
@@ -86,8 +86,8 @@ func TestPurgerDeleteExpiredV3Tokens(t *testing.T) {
 		{
 			name: "per-token error surfaced, loop continues",
 			tokens: []*v3.Token{
-				newV3Token("expired-1", longAgo, testShortTTLMillis),
-				newV3Token("expired-2", longAgo, testShortTTLMillis),
+				newV3Token("expired-1", longAgo, testShortTTL),
+				newV3Token("expired-2", longAgo, testShortTTL),
 			},
 			deleteResults: map[string]error{
 				"expired-1": someErr,

--- a/pkg/ext/stores/tokens/purge.go
+++ b/pkg/ext/stores/tokens/purge.go
@@ -1,0 +1,41 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DeleteExpired removes every ext token whose TTL has passed and returns the
+// number of tokens deleted. TTL-only: idle-expired tokens still within their
+// TTL are rejected by the auth path but not deleted here.
+//
+// A failure to list tokens is returned as-is; the returned count is 0 in that
+// case. Per-token delete failures do not stop iteration; each is wrapped with
+// the token name and joined into the returned error, and the count reflects
+// only tokens that were actually deleted (or already gone).
+func (t *SystemStore) DeleteExpired() (int, error) {
+	tokens, err := t.list(true, "", "", &metav1.ListOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("listing ext tokens: %w", err)
+	}
+
+	var (
+		count int
+		errs  []error
+	)
+	for _, tok := range tokens.Items {
+		if !tok.GetIsExpired() {
+			continue
+		}
+		if err := t.Delete(tok.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting %s: %w", tok.Name, err))
+			continue
+		}
+		count++
+	}
+
+	return count, errors.Join(errs...)
+}

--- a/pkg/ext/stores/tokens/purge_test.go
+++ b/pkg/ext/stores/tokens/purge_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 // makeTokenSecret builds a token-backing Secret with the given name, creation
-// time, and TTL in milliseconds. TTL < 0 encodes an infinite lifetime.
-func makeTokenSecret(t *testing.T, name string, created time.Time, ttlMillis int64) corev1.Secret {
+// time, and TTL. A negative TTL encodes an infinite lifetime.
+func makeTokenSecret(t *testing.T, name string, created time.Time, ttl time.Duration) corev1.Secret {
 	t.Helper()
 	principalBytes, err := json.Marshal(properPrincipal)
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func makeTokenSecret(t *testing.T, name string, created time.Time, ttlMillis int
 			FieldKind:           []byte(IsLogin),
 			FieldLastUpdateTime: []byte("13:00:05"),
 			FieldPrincipal:      principalBytes,
-			FieldTTL:            []byte(strconv.FormatInt(ttlMillis, 10)),
+			FieldTTL:            []byte(strconv.FormatInt(ttl.Milliseconds(), 10)),
 			FieldUID:            []byte("uid-" + name),
 			FieldUserID:         []byte(properUser),
 		},
@@ -56,9 +56,9 @@ func TestSystemStoreDeleteExpired(t *testing.T) {
 	recent := now.Add(-1 * time.Minute)
 
 	const (
-		shortTTLMillis = int64(60 * 1000)              // 60s
-		longTTLMillis  = int64(365 * 24 * 3600 * 1000) // 1y
-		infiniteTTL    = int64(-1)
+		shortTTL    = time.Minute
+		longTTL     = 365 * 24 * time.Hour
+		infiniteTTL = -1 * time.Millisecond // negative TTL encodes infinite
 	)
 
 	someErr := errors.New("some error")
@@ -79,16 +79,16 @@ func TestSystemStoreDeleteExpired(t *testing.T) {
 		{
 			name: "all fresh, no deletes",
 			secrets: []corev1.Secret{
-				makeTokenSecret(t, "fresh-1", recent, longTTLMillis),
-				makeTokenSecret(t, "fresh-2", recent, longTTLMillis),
+				makeTokenSecret(t, "fresh-1", recent, longTTL),
+				makeTokenSecret(t, "fresh-2", recent, longTTL),
 			},
 		},
 		{
 			name: "mix expired + fresh, only expired deleted",
 			secrets: []corev1.Secret{
-				makeTokenSecret(t, "expired-1", longAgo, shortTTLMillis),
-				makeTokenSecret(t, "fresh-1", recent, longTTLMillis),
-				makeTokenSecret(t, "expired-2", longAgo, shortTTLMillis),
+				makeTokenSecret(t, "expired-1", longAgo, shortTTL),
+				makeTokenSecret(t, "fresh-1", recent, longTTL),
+				makeTokenSecret(t, "expired-2", longAgo, shortTTL),
 			},
 			expectedDeletes: []string{"expired-1", "expired-2"},
 			wantCount:       2,
@@ -96,7 +96,7 @@ func TestSystemStoreDeleteExpired(t *testing.T) {
 		{
 			name: "delete returns IsNotFound is tolerated",
 			secrets: []corev1.Secret{
-				makeTokenSecret(t, "expired-1", longAgo, shortTTLMillis),
+				makeTokenSecret(t, "expired-1", longAgo, shortTTL),
 			},
 			deleteResults: map[string]error{
 				"expired-1": apierrors.NewNotFound(GVR.GroupResource(), "expired-1"),
@@ -107,8 +107,8 @@ func TestSystemStoreDeleteExpired(t *testing.T) {
 		{
 			name: "per-token error surfaced, loop continues, count reflects only successes",
 			secrets: []corev1.Secret{
-				makeTokenSecret(t, "expired-1", longAgo, shortTTLMillis),
-				makeTokenSecret(t, "expired-2", longAgo, shortTTLMillis),
+				makeTokenSecret(t, "expired-1", longAgo, shortTTL),
+				makeTokenSecret(t, "expired-2", longAgo, shortTTL),
 			},
 			deleteResults: map[string]error{
 				"expired-1": someErr,

--- a/pkg/ext/stores/tokens/purge_test.go
+++ b/pkg/ext/stores/tokens/purge_test.go
@@ -1,0 +1,181 @@
+package tokens
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// makeTokenSecret builds a token-backing Secret with the given name, creation
+// time, and TTL in milliseconds. TTL < 0 encodes an infinite lifetime.
+func makeTokenSecret(t *testing.T, name string, created time.Time, ttlMillis int64) corev1.Secret {
+	t.Helper()
+	principalBytes, err := json.Marshal(properPrincipal)
+	require.NoError(t, err)
+
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				UserIDLabel:     properUser,
+				SecretKindLabel: SecretKindLabelValue,
+			},
+			UID:               types.UID("uid-" + name),
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		Data: map[string][]byte{
+			FieldDescription:    []byte(""),
+			FieldEnabled:        []byte("false"),
+			FieldHash:           []byte("hash-" + name),
+			FieldKind:           []byte(IsLogin),
+			FieldLastUpdateTime: []byte("13:00:05"),
+			FieldPrincipal:      principalBytes,
+			FieldTTL:            []byte(strconv.FormatInt(ttlMillis, 10)),
+			FieldUID:            []byte("uid-" + name),
+			FieldUserID:         []byte(properUser),
+		},
+	}
+}
+
+func TestSystemStoreDeleteExpired(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	longAgo := now.Add(-24 * time.Hour)
+	recent := now.Add(-1 * time.Minute)
+
+	const (
+		shortTTLMillis = int64(60 * 1000)              // 60s
+		longTTLMillis  = int64(365 * 24 * 3600 * 1000) // 1y
+		infiniteTTL    = int64(-1)
+	)
+
+	someErr := errors.New("some error")
+
+	cases := []struct {
+		name            string
+		secrets         []corev1.Secret
+		listErr         error
+		deleteResults   map[string]error
+		expectedDeletes []string
+		wantCount       int
+		wantErr         bool
+	}{
+		{
+			name:    "empty list, no deletes",
+			secrets: nil,
+		},
+		{
+			name: "all fresh, no deletes",
+			secrets: []corev1.Secret{
+				makeTokenSecret(t, "fresh-1", recent, longTTLMillis),
+				makeTokenSecret(t, "fresh-2", recent, longTTLMillis),
+			},
+		},
+		{
+			name: "mix expired + fresh, only expired deleted",
+			secrets: []corev1.Secret{
+				makeTokenSecret(t, "expired-1", longAgo, shortTTLMillis),
+				makeTokenSecret(t, "fresh-1", recent, longTTLMillis),
+				makeTokenSecret(t, "expired-2", longAgo, shortTTLMillis),
+			},
+			expectedDeletes: []string{"expired-1", "expired-2"},
+			wantCount:       2,
+		},
+		{
+			name: "delete returns IsNotFound is tolerated",
+			secrets: []corev1.Secret{
+				makeTokenSecret(t, "expired-1", longAgo, shortTTLMillis),
+			},
+			deleteResults: map[string]error{
+				"expired-1": apierrors.NewNotFound(GVR.GroupResource(), "expired-1"),
+			},
+			expectedDeletes: []string{"expired-1"},
+			wantCount:       1,
+		},
+		{
+			name: "per-token error surfaced, loop continues, count reflects only successes",
+			secrets: []corev1.Secret{
+				makeTokenSecret(t, "expired-1", longAgo, shortTTLMillis),
+				makeTokenSecret(t, "expired-2", longAgo, shortTTLMillis),
+			},
+			deleteResults: map[string]error{
+				"expired-1": someErr,
+			},
+			expectedDeletes: []string{"expired-1", "expired-2"},
+			wantCount:       1,
+			wantErr:         true,
+		},
+		{
+			name:    "list error surfaced, no deletes",
+			listErr: someErr,
+			wantErr: true,
+		},
+		{
+			name: "infinite TTL never purged",
+			secrets: []corev1.Secret{
+				makeTokenSecret(t, "immortal", longAgo, infiniteTTL),
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+
+			if tt.listErr != nil {
+				secretClient.EXPECT().
+					List(TokenNamespace, gomock.Any()).
+					Return(nil, tt.listErr).
+					Times(1)
+			} else {
+				secretClient.EXPECT().
+					List(TokenNamespace, gomock.Any()).
+					Return(&corev1.SecretList{Items: tt.secrets}, nil).
+					Times(1)
+			}
+
+			deletedNames := map[string]int{}
+			for _, name := range tt.expectedDeletes {
+				resErr := tt.deleteResults[name]
+				secretClient.EXPECT().
+					Delete(TokenNamespace, name, gomock.Any()).
+					DoAndReturn(func(_, gotName string, _ *metav1.DeleteOptions) error {
+						deletedNames[gotName]++
+						return resErr
+					}).
+					Times(1)
+			}
+
+			store := &SystemStore{secretClient: secretClient}
+			count, err := store.DeleteExpired()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCount, count)
+
+			for _, name := range tt.expectedDeletes {
+				assert.Equal(t, 1, deletedNames[name], "expected exactly one Delete for %s", name)
+			}
+			assert.Len(t, deletedNames, len(tt.expectedDeletes),
+				"unexpected extra Delete calls: %v", deletedNames)
+		})
+	}
+}


### PR DESCRIPTION
## Issue: #55881<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Expired ext.Tokens were never cleaned up automatically. The auth path rejected them on use, but their backing Secrets stayed in the cattle-tokens namespace. Rancher already ran an hourly purge for v3.Tokens and SamlTokens but not for ext.Tokens.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The purge daemon now sweeps ext.Tokens on the same hourly schedule alongside v3.Tokens and SamlTokens. Cleanup for each token kind returns a count and an error, and per-token failures are joined and surfaced to the daemon rather than logged inline.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests