### PR TITLE
Handles cluster NotFound error during nodesSync

### DIFF
--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -141,6 +141,10 @@ func (n *nodeSyncer) sync(key string, node *corev1.Node) (*corev1.Node, error) {
 
 	cluster, err := n.nodesSyncer.clusterLister.Get("", n.clusterNamespace)
 	if err != nil {
+		// if cluster no longer exists; nothing to sync
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -261,6 +265,10 @@ func (m *nodesSyncer) reconcileAll() error {
 		if restoring, err := m.isClusterRestoring(); restoring {
 			return nil
 		} else if err != nil {
+			// if cluster no longer exists; nothing to reconcile
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
 			return err
 		}
 	}

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer_test.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer_test.go
@@ -1,11 +1,86 @@
 package nodesyncer
 
 import (
+	"errors"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+type MockClusterLister struct {
+	mock.Mock
+}
+
+func (m *MockClusterLister) Get(namespace, name string) (*v3.Cluster, error) {
+	args := m.Called(namespace, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*v3.Cluster), args.Error(1)
+}
+
+func (m *MockClusterLister) List(namespace string, selector labels.Selector) (ret []*v3.Cluster, err error) {
+	args := m.Called(namespace, selector)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*v3.Cluster), args.Error(1)
+}
+
+func TestReconcileAll_ClusterStatusEdgeCases(t *testing.T) {
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "cluster", Resource: "clusters"}, "c-testc")
+	genericErr := errors.New("api connection timeout")
+	testClusterNS := "ds-cluster"
+
+	testCases := []struct {
+		name             string
+		clusterNamespace string
+		setupMock        func(m *MockClusterLister)
+		expectedErr      error
+	}{
+		{
+			name:             "Cluster is not found, should return nil gracefully",
+			clusterNamespace: testClusterNS,
+			setupMock: func(m *MockClusterLister) {
+				m.On("Get", "", testClusterNS).Return(nil, notFoundErr)
+			},
+			expectedErr: nil,
+		},
+		{
+			name:             "Generic error occurs during restoration check, should bubble up error",
+			clusterNamespace: testClusterNS,
+			setupMock: func(m *MockClusterLister) {
+				m.On("Get", "", testClusterNS).Return(nil, genericErr)
+			},
+			expectedErr: genericErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClusterLister := new(MockClusterLister)
+			defer mockClusterLister.AssertExpectations(t)
+			tc.setupMock(mockClusterLister)
+
+			syncer := nodesSyncer{
+				clusterNamespace: tc.clusterNamespace,
+				clusterLister:    mockClusterLister,
+			}
+
+			err := syncer.reconcileAll()
+			if tc.expectedErr != nil {
+				assert.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestDetermineNodeRole(t *testing.T) {
 	var tests = []struct {


### PR DESCRIPTION
## Issue: #55901 
 
## Problem
When a cluster is deleted, the _machine_all_ sync key can still be enqueued/processed. [isClusterRestoring()](https://github.com/rancher/rancher/blob/main/pkg/controllers/managementuser/nodesyncer/nodessyncer.go#L703) calls clusterLister.Get(), which returns a NotFound error since the parent Cluster object no longer exists. This raw error is propagated up through reconcileAll → sync, causing it to repeat indefinitely.
 
## Solution
Added an explicit `NotFound` check where `isClusterRestoring()`'s error is handled in [reconcileAll](https://github.com/rancher/rancher/blob/main/pkg/controllers/managementuser/nodesyncer/nodessyncer.go#L256), so a deleted cluster short-circuits the reconcile instead of propagating an error.
 
## Testing
The repro steps in GitHub issue are relevant.

## Engineering Testing
### Manual Testing
- Tested manually following the documented steps in the GH issue.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_