### PR TITLE
Ext token cluster action

### DIFF
--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	mgmtclient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/user"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,7 @@ type ActionHandler struct {
 	TokenMgr       tokenManager
 	ClusterManager *clustermanager.Manager
 	AuthToken      requests.AuthTokenGetter
+	ExtTokenStore  *exttokenstore.SystemStore
 }
 
 // ClusterActionHandler runs the handler for the provided cluster action in the given context.

--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/requests"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	mgmtclient "github.com/rancher/rancher/pkg/client/generated/management/v3"
@@ -14,7 +16,9 @@ import (
 	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/user"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -106,10 +110,71 @@ func (a ActionHandler) createTokenInput(apiContext *types.APIContext) (user.Toke
 }
 
 func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster *mgmtclient.Cluster) (*clientcmdapi.Config, error) {
-	token, err := a.ensureToken(apiContext)
+	authToken, err := a.AuthToken.TokenFromRequest(apiContext.Request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session token: %w", err)
+	}
+
+	defaultTokenTTL, err := tokens.GetKubeconfigDefaultTokenTTLInMilliSeconds()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default token TTL: %w", err)
+	}
+
+	userID := authToken.GetUserID()
+	tokenName := authToken.GetName()
+
+	// Create a proper ext token, commit it to kubernetes, and pass the
+	// resulting bearer token on.
+	//
+	// The ability to set a custom generateName prefix (kubeconfig-<user>-...)
+	// is lost for ext tokens. The ext token store internally forces the
+	// prefix `token-`.
+
+	kcToken := &ext.Token{
+		Spec: ext.TokenSpec{
+			UserID:      userID,
+			Kind:        "kubeconfig",
+			Description: "Kubeconfig token",
+			TTL:         *defaultTokenTTL,
+		},
+	}
+
+	// Note that `userinfo == nil` is ok. The argument is only used when the
+	// token refers to a cluster by name, requiring a permission check. This
+	// is not the case here, we are asking for an unscoped token.
+	kcNewToken, err := a.ExtTokenStore.Create(
+		// Make the auth token available to `Create`, via reference by
+		// name, through a local [user.Info] interface implementation.
+		// This enables `Create` to retrieve it and the principal
+		// information it needs.
+		request.WithUser(apiContext.Request.Context(), &actionUserInfo{
+			authTokenName: tokenName,
+		}),
+		exttokenstore.GVR.GroupResource(),
+		kcToken,
+		&metav1.CreateOptions{},
+		nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return a.ClusterManager.KubeConfig(cluster.ID, token), nil
+	return a.ClusterManager.KubeConfig(cluster.ID, kcNewToken.Status.BearerToken), nil
+}
+
+// actionUserInfo implements [user.Info] to pass the session token by name into
+// the ext token system store.
+type actionUserInfo struct {
+	authTokenName string
+}
+
+// implements [user.Info]
+func (a *actionUserInfo) GetName() string     { return "" }
+func (a *actionUserInfo) GetUID() string      { return "" }
+func (a *actionUserInfo) GetGroups() []string { return []string{} }
+func (a *actionUserInfo) GetExtra() map[string][]string {
+	return map[string][]string{
+		common.ExtraRequestTokenID: []string{
+			a.authTokenName,
+		},
+	}
 }

--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -109,6 +109,7 @@ func (a ActionHandler) createTokenInput(apiContext *types.APIContext) (user.Toke
 	}, nil
 }
 
+// generateKubeConfig is only used by ImportYamlHandler, to provide a cluster kube config
 func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster *mgmtclient.Cluster) (*clientcmdapi.Config, error) {
 	authToken, err := a.AuthToken.TokenFromRequest(apiContext.Request)
 	if err != nil {
@@ -121,7 +122,7 @@ func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster 
 	}
 
 	userID := authToken.GetUserID()
-	tokenName := authToken.GetName()
+	tokenName := authToken.GetName() // todo full name later, force fast path
 
 	// Create a proper ext token, commit it to kubernetes, and pass the
 	// resulting bearer token on.
@@ -161,13 +162,13 @@ func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster 
 	return a.ClusterManager.KubeConfig(cluster.ID, kcNewToken.Status.BearerToken), nil
 }
 
-// actionUserInfo implements [user.Info] to pass the session token by name into
-// the ext token system store.
+// actionUserInfo implements [k8s.io/apiserver/pkg/authentication/user.Info] to
+// pass the session token by name into the ext token system store.
 type actionUserInfo struct {
 	authTokenName string
 }
 
-// implements [user.Info]
+// implements [k8s.io/apiserver/pkg/authentication/user.Info]
 func (a *actionUserInfo) GetName() string     { return "" }
 func (a *actionUserInfo) GetUID() string      { return "" }
 func (a *actionUserInfo) GetGroups() []string { return []string{} }

--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -109,16 +109,21 @@ func (a ActionHandler) createTokenInput(apiContext *types.APIContext) (user.Toke
 	}, nil
 }
 
-// generateKubeConfig is only used by ImportYamlHandler, to provide a cluster kube config
-func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster *mgmtclient.Cluster) (*clientcmdapi.Config, error) {
+// generateKubeConfigBearer is the core of generateKubeConfig providing the
+// bearer token to place into the final clientcmdapi.Config
+func (a ActionHandler) generateKubeConfigBearer(apiContext *types.APIContext) (string, error) {
+	if a.ExtTokenStore == nil {
+		return "", fmt.Errorf("ext token store is not configured")
+	}
+
 	authToken, err := a.AuthToken.TokenFromRequest(apiContext.Request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get session token: %w", err)
+		return "", fmt.Errorf("failed to get session token: %w", err)
 	}
 
 	defaultTokenTTL, err := tokens.GetKubeconfigDefaultTokenTTLInMilliSeconds()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get default token TTL: %w", err)
+		return "", fmt.Errorf("failed to get default token TTL: %w", err)
 	}
 
 	userID := authToken.GetUserID()
@@ -156,10 +161,19 @@ func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster 
 		&metav1.CreateOptions{},
 		nil)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return a.ClusterManager.KubeConfig(cluster.ID, kcNewToken.Status.BearerToken), nil
+	return kcNewToken.Status.BearerToken, nil
+}
+
+// generateKubeConfig is only used by ImportYamlHandler, to provide a cluster kube config
+func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster *mgmtclient.Cluster) (*clientcmdapi.Config, error) {
+	bearer, err := a.generateKubeConfigBearer(apiContext)
+	if err != nil {
+		return nil, err
+	}
+	return a.ClusterManager.KubeConfig(cluster.ID, bearer), nil
 }
 
 // actionUserInfo implements [k8s.io/apiserver/pkg/authentication/user.Info] to

--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -127,7 +127,7 @@ func (a ActionHandler) generateKubeConfigBearer(apiContext *types.APIContext) (s
 		return "", fmt.Errorf("failed to get default token TTL: %w", err)
 	}
 
-	userID := authToken.GetUserID()
+	userID := a.UserMgr.GetUser(apiContext.Request)
 	tokenName := authToken.GetName() // todo full name later, force fast path
 
 	// Create a proper ext token, commit it to kubernetes, and pass the

--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/rancher/pkg/user"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8suser "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -145,21 +146,22 @@ func (a ActionHandler) generateKubeConfigBearer(apiContext *types.APIContext) (s
 		},
 	}
 
-	// Note that `userinfo == nil` is ok. The argument is only used when the
-	// token refers to a cluster by name, requiring a permission check. This
-	// is not the case here, we are asking for an unscoped token.
+	// Note that `userinfo == nil` would have been ok as the argument is
+	// only used when the token refers to a cluster by name, requiring a
+	// permission check. Which is not the case here, we are asking for an
+	// unscoped token. Still, providing an empty user, just in case.
 	kcNewToken, err := a.ExtTokenStore.Create(
 		// Make the auth token available to `Create`, via reference by
 		// name, through a local [user.Info] interface implementation.
 		// This enables `Create` to retrieve it and the principal
 		// information it needs.
-		request.WithUser(apiContext.Request.Context(), &actionUserInfo{
-			authTokenName: tokenName,
+		request.WithUser(apiContext.Request.Context(), &k8suser.DefaultInfo{
+			Extra: map[string][]string{common.ExtraRequestTokenID: {tokenName}},
 		}),
 		exttokenstore.GVR.GroupResource(),
 		kcToken,
 		&metav1.CreateOptions{},
-		nil)
+		&k8suser.DefaultInfo{})
 	if err != nil {
 		return "", err
 	}
@@ -174,22 +176,4 @@ func (a ActionHandler) generateKubeConfig(apiContext *types.APIContext, cluster 
 		return nil, err
 	}
 	return a.ClusterManager.KubeConfig(cluster.ID, bearer), nil
-}
-
-// actionUserInfo implements [k8s.io/apiserver/pkg/authentication/user.Info] to
-// pass the session token by name into the ext token system store.
-type actionUserInfo struct {
-	authTokenName string
-}
-
-// implements [k8s.io/apiserver/pkg/authentication/user.Info]
-func (a *actionUserInfo) GetName() string     { return "" }
-func (a *actionUserInfo) GetUID() string      { return "" }
-func (a *actionUserInfo) GetGroups() []string { return []string{} }
-func (a *actionUserInfo) GetExtra() map[string][]string {
-	return map[string][]string{
-		common.ExtraRequestTokenID: []string{
-			a.authTokenName,
-		},
-	}
 }

--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -128,7 +128,7 @@ func (a ActionHandler) generateKubeConfigBearer(apiContext *types.APIContext) (s
 	}
 
 	userID := a.UserMgr.GetUser(apiContext.Request)
-	tokenName := authToken.GetName() // todo full name later, force fast path
+	tokenName := authToken.GetFullName()
 
 	// Create a proper ext token, commit it to kubernetes, and pass the
 	// resulting bearer token on.

--- a/pkg/api/norman/customization/cluster/actions_yaml_test.go
+++ b/pkg/api/norman/customization/cluster/actions_yaml_test.go
@@ -1,0 +1,260 @@
+package cluster
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rancher/norman/types"
+	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/accessor"
+	v3 "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	managementSchema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
+	userMocks "github.com/rancher/rancher/pkg/user/mocks"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGenerateKubeConfigBearer(t *testing.T) {
+	const (
+		testClusterName = "test-cluster"
+		fakeHost        = "fake-request-host.fake"
+		testUser        = "fake-user"
+	)
+
+	testSchemas := types.NewSchemas().AddSchemas(managementSchema.Schemas)
+	clusterSchema := testSchemas.Schema(&managementSchema.Version, v3.ClusterType)
+	fakeStore := fakeClusterStore{
+		cluster: v3.Cluster{
+			Name: testClusterName,
+		},
+	}
+	clusterSchema.Store = &fakeStore
+
+	t.Run("kubeconfig bearer token, ext token auth", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		userManager := userMocks.NewMockManager(ctrl)
+		userManager.EXPECT().GetUser(gomock.Any()).Return(testUser).AnyTimes()
+
+		recorder := normanRecorder{}
+		apiContext := &types.APIContext{
+			ID:             testClusterName,
+			Version:        &managementSchema.Version,
+			Type:           v3.ClusterType,
+			ResponseWriter: &recorder,
+			Schemas:        testSchemas,
+			Request: &http.Request{
+				Host: fakeHost,
+				Body: io.NopCloser(strings.NewReader(`{}`)),
+			},
+		}
+
+		fakeAuth := fakeExtAuthToken{
+			token: ext.Token{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fake-ext",
+				},
+				Spec: ext.TokenSpec{
+					UserID: testUser,
+					UserPrincipal: ext.TokenPrincipal{
+						Provider: "local",
+						Name:     testUser,
+					},
+				},
+			},
+		}
+		fakePrincipalBytes, _ := json.Marshal(fakeAuth.token.Spec.UserPrincipal)
+		fakeAuthSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fakeAuth.token.Name,
+				Labels: map[string]string{
+					exttokenstore.UserIDLabel:     testUser,
+					exttokenstore.SecretKindLabel: exttokenstore.SecretKindLabelValue,
+				},
+				UID: "",
+			},
+			Data: map[string][]byte{
+				exttokenstore.FieldDescription:    []byte(""),
+				exttokenstore.FieldEnabled:        []byte("true"),
+				exttokenstore.FieldHash:           []byte("al;dgkl;dkfdsafdioj"),
+				exttokenstore.FieldKind:           []byte(exttokenstore.IsLogin),
+				exttokenstore.FieldLastUpdateTime: []byte("13:00:05"),
+				exttokenstore.FieldPrincipal:      fakePrincipalBytes,
+				exttokenstore.FieldTTL:            []byte("-1"),
+				exttokenstore.FieldUID:            []byte("kubid"),
+				exttokenstore.FieldUserID:         []byte(testUser),
+			},
+		}
+
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		secrets.EXPECT().Cache().Return(scache)
+
+		users := fake.NewMockNonNamespacedControllerInterface[*apimgmtv3.User, *apimgmtv3.UserList](ctrl)
+		ucache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.User](ctrl)
+		users.EXPECT().Cache().Return(ucache)
+		ucache.EXPECT().Get(testUser).Return(&apimgmtv3.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testUser,
+			},
+		}, nil).AnyTimes()
+
+		v3tcache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.Token](ctrl)
+		v3tcache.EXPECT().Get(fakeAuth.token.Name).Return(nil,
+			apierrors.NewNotFound(schema.GroupResource{}, fakeAuth.token.Name))
+
+		scache.EXPECT().Get(exttokenstore.TokenNamespace, fakeAuth.token.Name).Return(fakeAuthSecret, nil)
+		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+			assert.Equal(t, "the-hash", s.StringData[exttokenstore.FieldHash])
+			n := s.DeepCopy()
+			n.Name = "token-xxx"
+			n.Data = map[string][]byte{}
+			for k, v := range n.StringData {
+				n.Data[k] = []byte(v)
+			}
+			return n, nil
+		})
+
+		nscache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+		nscache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
+
+		handler := ActionHandler{
+			NodeLister: &fakes.NodeListerMock{
+				GetFunc: func(namespace string, name string) (*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+				ListFunc: func(namespace string, selector labels.Selector) ([]*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+			},
+			UserMgr:   userManager,
+			TokenMgr:  &fakeTokenManager{},
+			AuthToken: &fakeAuth,
+			ExtTokenStore: exttokenstore.NewSystem(nil, nscache, secrets, users, v3tcache, nil,
+				exttokenstore.NewTimeHandler(),
+				&fakeHash{},
+				exttokenstore.NewAuthHandler(), nil),
+		}
+		bearer, err := handler.generateKubeConfigBearer(apiContext)
+		assert.NoError(t, err, "got an error when calling generate kubeconfig")
+		assert.Equal(t, "ext/token-xxx:the-secret", bearer)
+	})
+
+	t.Run("kubeconfig bearer token, legacy token auth", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		userManager := userMocks.NewMockManager(ctrl)
+		userManager.EXPECT().GetUser(gomock.Any()).Return(testUser).AnyTimes()
+
+		recorder := normanRecorder{}
+		apiContext := &types.APIContext{
+			ID:             testClusterName,
+			Version:        &managementSchema.Version,
+			Type:           v3.ClusterType,
+			ResponseWriter: &recorder,
+			Schemas:        testSchemas,
+			Request: &http.Request{
+				Host: fakeHost,
+				Body: io.NopCloser(strings.NewReader(`{}`)),
+			},
+		}
+
+		fakeAuth := fakeAuthToken{
+			token: apimgmtv3.Token{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fake-legacy",
+				},
+				UserID: testUser,
+				AuthProvider: "local",
+				UserPrincipal: apimgmtv3.Principal{
+					Provider: "local",
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testUser,
+					},
+				},
+			},
+		}
+
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		secrets.EXPECT().Cache().Return(scache)
+
+		users := fake.NewMockNonNamespacedControllerInterface[*apimgmtv3.User, *apimgmtv3.UserList](ctrl)
+		ucache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.User](ctrl)
+		users.EXPECT().Cache().Return(ucache)
+		ucache.EXPECT().Get(testUser).Return(&apimgmtv3.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testUser,
+			},
+		}, nil).AnyTimes()
+
+		v3tcache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.Token](ctrl)
+		v3tcache.EXPECT().Get(fakeAuth.token.Name).Return(&fakeAuth.token, nil)
+
+		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+			assert.Equal(t, "the-hash", s.StringData[exttokenstore.FieldHash])
+			n := s.DeepCopy()
+			n.Name = "token-xxx"
+			n.Data = map[string][]byte{}
+			for k, v := range n.StringData {
+				n.Data[k] = []byte(v)
+			}
+			return n, nil
+		})
+
+		nscache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+		nscache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
+
+		handler := ActionHandler{
+			NodeLister: &fakes.NodeListerMock{
+				GetFunc: func(namespace string, name string) (*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+				ListFunc: func(namespace string, selector labels.Selector) ([]*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+			},
+			UserMgr:   userManager,
+			TokenMgr:  &fakeTokenManager{},
+			AuthToken: &fakeAuth,
+			ExtTokenStore: exttokenstore.NewSystem(nil, nscache, secrets, users, v3tcache, nil,
+				exttokenstore.NewTimeHandler(),
+				&fakeHash{},
+				exttokenstore.NewAuthHandler(), nil),
+		}
+		bearer, err := handler.generateKubeConfigBearer(apiContext)
+		assert.NoError(t, err, "got an error when calling generate kubeconfig")
+		assert.Equal(t, "ext/token-xxx:the-secret", bearer)
+	})
+}
+
+// fakeAuthToken implements requests.Authenticator for the purposes of testing
+type fakeExtAuthToken struct {
+	token ext.Token
+	err   error
+}
+
+func (f *fakeExtAuthToken) TokenFromRequest(req *http.Request) (accessor.TokenAccessor, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &f.token, nil
+}
+
+// fakeHash implements the [hashHandler] interface
+type fakeHash struct {
+}
+
+func (h *fakeHash) MakeAndHashSecret() (string, string, error) {
+	return "the-secret", "the-hash", nil
+}

--- a/pkg/api/norman/customization/cluster/actions_yaml_test.go
+++ b/pkg/api/norman/customization/cluster/actions_yaml_test.go
@@ -129,6 +129,9 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 		nscache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
 		nscache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
 
+		fakeHash := exttokenstore.NewMockhashHandler(ctrl)
+		fakeHash.EXPECT().MakeAndHashSecret().Return("the-secret", "the-hash", nil)
+
 		handler := ActionHandler{
 			NodeLister: &fakes.NodeListerMock{
 				GetFunc: func(namespace string, name string) (*apimgmtv3.Node, error) {
@@ -143,7 +146,7 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 			AuthToken: &fakeAuth,
 			ExtTokenStore: exttokenstore.NewSystem(nil, nscache, secrets, users, v3tcache, nil,
 				exttokenstore.NewTimeHandler(),
-				&fakeHash{},
+				fakeHash,
 				exttokenstore.NewAuthHandler(), nil),
 		}
 		bearer, err := handler.generateKubeConfigBearer(apiContext)
@@ -174,7 +177,7 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "fake-legacy",
 				},
-				UserID: testUser,
+				UserID:       testUser,
 				AuthProvider: "local",
 				UserPrincipal: apimgmtv3.Principal{
 					Provider: "local",
@@ -215,6 +218,9 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 		nscache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
 		nscache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
 
+		fakeHash := exttokenstore.NewMockhashHandler(ctrl)
+		fakeHash.EXPECT().MakeAndHashSecret().Return("the-secret", "the-hash", nil)
+
 		handler := ActionHandler{
 			NodeLister: &fakes.NodeListerMock{
 				GetFunc: func(namespace string, name string) (*apimgmtv3.Node, error) {
@@ -229,7 +235,7 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 			AuthToken: &fakeAuth,
 			ExtTokenStore: exttokenstore.NewSystem(nil, nscache, secrets, users, v3tcache, nil,
 				exttokenstore.NewTimeHandler(),
-				&fakeHash{},
+				fakeHash,
 				exttokenstore.NewAuthHandler(), nil),
 		}
 		bearer, err := handler.generateKubeConfigBearer(apiContext)
@@ -249,12 +255,4 @@ func (f *fakeExtAuthToken) TokenFromRequest(req *http.Request) (accessor.TokenAc
 		return nil, f.err
 	}
 	return &f.token, nil
-}
-
-// fakeHash implements the [hashHandler] interface
-type fakeHash struct {
-}
-
-func (h *fakeHash) MakeAndHashSecret() (string, string, error) {
-	return "the-secret", "the-hash", nil
 }

--- a/pkg/api/norman/customization/cluster/actions_yaml_test.go
+++ b/pkg/api/norman/customization/cluster/actions_yaml_test.go
@@ -20,10 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestGenerateKubeConfigBearer(t *testing.T) {
@@ -111,8 +109,6 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 		}, nil).AnyTimes()
 
 		v3tcache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.Token](ctrl)
-		v3tcache.EXPECT().Get(fakeAuth.token.Name).Return(nil,
-			apierrors.NewNotFound(schema.GroupResource{}, fakeAuth.token.Name))
 
 		scache.EXPECT().Get(exttokenstore.TokenNamespace, fakeAuth.token.Name).Return(fakeAuthSecret, nil)
 		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {

--- a/pkg/api/norman/customization/cluster/actions_yaml_test.go
+++ b/pkg/api/norman/customization/cluster/actions_yaml_test.go
@@ -113,6 +113,7 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 		scache.EXPECT().Get(exttokenstore.TokenNamespace, fakeAuth.token.Name).Return(fakeAuthSecret, nil)
 		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
 			assert.Equal(t, "the-hash", s.StringData[exttokenstore.FieldHash])
+			assert.Equal(t, testUser, s.StringData[exttokenstore.FieldUserID])
 			n := s.DeepCopy()
 			n.Name = "token-xxx"
 			n.Data = map[string][]byte{}
@@ -202,6 +203,7 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 
 		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
 			assert.Equal(t, "the-hash", s.StringData[exttokenstore.FieldHash])
+			assert.Equal(t, testUser, s.StringData[exttokenstore.FieldUserID])
 			n := s.DeepCopy()
 			n.Name = "token-xxx"
 			n.Data = map[string][]byte{}

--- a/pkg/api/norman/customization/cluster/actions_yaml_test.go
+++ b/pkg/api/norman/customization/cluster/actions_yaml_test.go
@@ -26,9 +26,10 @@ import (
 
 func TestGenerateKubeConfigBearer(t *testing.T) {
 	const (
-		testClusterName = "test-cluster"
-		fakeHost        = "fake-request-host.fake"
-		testUser        = "fake-user"
+		testClusterName      = "test-cluster"
+		fakeHost             = "fake-request-host.fake"
+		testUser             = "fake-user"
+		testImpersonatedUser = "impersonated-user" // Impersonate-User header target
 	)
 
 	testSchemas := types.NewSchemas().AddSchemas(managementSchema.Schemas)
@@ -204,6 +205,207 @@ func TestGenerateKubeConfigBearer(t *testing.T) {
 		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
 			assert.Equal(t, "the-hash", s.StringData[exttokenstore.FieldHash])
 			assert.Equal(t, testUser, s.StringData[exttokenstore.FieldUserID])
+			n := s.DeepCopy()
+			n.Name = "token-xxx"
+			n.Data = map[string][]byte{}
+			for k, v := range n.StringData {
+				n.Data[k] = []byte(v)
+			}
+			return n, nil
+		})
+
+		nscache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+		nscache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
+
+		fakeHash := exttokenstore.NewMockhashHandler(ctrl)
+		fakeHash.EXPECT().MakeAndHashSecret().Return("the-secret", "the-hash", nil)
+
+		handler := ActionHandler{
+			NodeLister: &fakes.NodeListerMock{
+				GetFunc: func(namespace string, name string) (*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+				ListFunc: func(namespace string, selector labels.Selector) ([]*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+			},
+			UserMgr:   userManager,
+			TokenMgr:  &fakeTokenManager{},
+			AuthToken: &fakeAuth,
+			ExtTokenStore: exttokenstore.NewSystem(nil, nscache, secrets, users, v3tcache, nil,
+				exttokenstore.NewTimeHandler(),
+				fakeHash,
+				exttokenstore.NewAuthHandler(), nil),
+		}
+		bearer, err := handler.generateKubeConfigBearer(apiContext)
+		assert.NoError(t, err, "got an error when calling generate kubeconfig")
+		assert.Equal(t, "ext/token-xxx:the-secret", bearer)
+	})
+
+	t.Run("kubeconfig bearer token, impersonation, ext token auth", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		userManager := userMocks.NewMockManager(ctrl)
+		userManager.EXPECT().GetUser(gomock.Any()).Return(testImpersonatedUser).AnyTimes()
+
+		recorder := normanRecorder{}
+		apiContext := &types.APIContext{
+			ID:             testClusterName,
+			Version:        &managementSchema.Version,
+			Type:           v3.ClusterType,
+			ResponseWriter: &recorder,
+			Schemas:        testSchemas,
+			Request: &http.Request{
+				Host: fakeHost,
+				Body: io.NopCloser(strings.NewReader(`{}`)),
+			},
+		}
+
+		fakeAuth := fakeExtAuthToken{
+			token: ext.Token{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fake-ext",
+				},
+				Spec: ext.TokenSpec{
+					UserID: testUser, // session owner, distinct from impersonated target
+					UserPrincipal: ext.TokenPrincipal{
+						Provider: "local",
+						Name:     testUser,
+					},
+				},
+			},
+		}
+		fakePrincipalBytes, _ := json.Marshal(fakeAuth.token.Spec.UserPrincipal)
+		fakeAuthSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fakeAuth.token.Name,
+				Labels: map[string]string{
+					exttokenstore.UserIDLabel:     testUser,
+					exttokenstore.SecretKindLabel: exttokenstore.SecretKindLabelValue,
+				},
+				UID: "",
+			},
+			Data: map[string][]byte{
+				exttokenstore.FieldDescription:    []byte(""),
+				exttokenstore.FieldEnabled:        []byte("true"),
+				exttokenstore.FieldHash:           []byte("al;dgkl;dkfdsafdioj"),
+				exttokenstore.FieldKind:           []byte(exttokenstore.IsLogin),
+				exttokenstore.FieldLastUpdateTime: []byte("13:00:05"),
+				exttokenstore.FieldPrincipal:      fakePrincipalBytes,
+				exttokenstore.FieldTTL:            []byte("-1"),
+				exttokenstore.FieldUID:            []byte("kubid"),
+				exttokenstore.FieldUserID:         []byte(testUser),
+			},
+		}
+
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		secrets.EXPECT().Cache().Return(scache)
+
+		users := fake.NewMockNonNamespacedControllerInterface[*apimgmtv3.User, *apimgmtv3.UserList](ctrl)
+		ucache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.User](ctrl)
+		users.EXPECT().Cache().Return(ucache)
+		ucache.EXPECT().Get(testImpersonatedUser).Return(&apimgmtv3.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testImpersonatedUser,
+			},
+		}, nil).AnyTimes()
+
+		v3tcache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.Token](ctrl)
+
+		scache.EXPECT().Get(exttokenstore.TokenNamespace, fakeAuth.token.Name).Return(fakeAuthSecret, nil)
+		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+			assert.Equal(t, "the-hash", s.StringData[exttokenstore.FieldHash])
+			assert.Equal(t, testImpersonatedUser, s.StringData[exttokenstore.FieldUserID])
+			n := s.DeepCopy()
+			n.Name = "token-xxx"
+			n.Data = map[string][]byte{}
+			for k, v := range n.StringData {
+				n.Data[k] = []byte(v)
+			}
+			return n, nil
+		})
+
+		nscache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+		nscache.EXPECT().Get(exttokenstore.TokenNamespace).AnyTimes()
+
+		fakeHash := exttokenstore.NewMockhashHandler(ctrl)
+		fakeHash.EXPECT().MakeAndHashSecret().Return("the-secret", "the-hash", nil)
+
+		handler := ActionHandler{
+			NodeLister: &fakes.NodeListerMock{
+				GetFunc: func(namespace string, name string) (*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+				ListFunc: func(namespace string, selector labels.Selector) ([]*apimgmtv3.Node, error) {
+					return nil, nil
+				},
+			},
+			UserMgr:   userManager,
+			TokenMgr:  &fakeTokenManager{},
+			AuthToken: &fakeAuth,
+			ExtTokenStore: exttokenstore.NewSystem(nil, nscache, secrets, users, v3tcache, nil,
+				exttokenstore.NewTimeHandler(),
+				fakeHash,
+				exttokenstore.NewAuthHandler(), nil),
+		}
+		bearer, err := handler.generateKubeConfigBearer(apiContext)
+		assert.NoError(t, err, "got an error when calling generate kubeconfig")
+		assert.Equal(t, "ext/token-xxx:the-secret", bearer)
+	})
+
+	t.Run("kubeconfig bearer token, impersonation, legacy token auth", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		userManager := userMocks.NewMockManager(ctrl)
+		userManager.EXPECT().GetUser(gomock.Any()).Return(testImpersonatedUser).AnyTimes()
+
+		recorder := normanRecorder{}
+		apiContext := &types.APIContext{
+			ID:             testClusterName,
+			Version:        &managementSchema.Version,
+			Type:           v3.ClusterType,
+			ResponseWriter: &recorder,
+			Schemas:        testSchemas,
+			Request: &http.Request{
+				Host: fakeHost,
+				Body: io.NopCloser(strings.NewReader(`{}`)),
+			},
+		}
+
+		fakeAuth := fakeAuthToken{
+			token: apimgmtv3.Token{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fake-legacy",
+				},
+				UserID:       testUser, // session owner, distinct from impersonated target
+				AuthProvider: "local",
+				UserPrincipal: apimgmtv3.Principal{
+					Provider: "local",
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testUser,
+					},
+				},
+			},
+		}
+
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		secrets.EXPECT().Cache().Return(scache)
+
+		users := fake.NewMockNonNamespacedControllerInterface[*apimgmtv3.User, *apimgmtv3.UserList](ctrl)
+		ucache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.User](ctrl)
+		users.EXPECT().Cache().Return(ucache)
+		ucache.EXPECT().Get(testImpersonatedUser).Return(&apimgmtv3.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testImpersonatedUser,
+			},
+		}, nil).AnyTimes()
+
+		v3tcache := fake.NewMockNonNamespacedCacheInterface[*apimgmtv3.Token](ctrl)
+		v3tcache.EXPECT().Get(fakeAuth.token.Name).Return(&fakeAuth.token, nil)
+
+		secrets.EXPECT().Create(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+			assert.Equal(t, "the-hash", s.StringData[exttokenstore.FieldHash])
+			assert.Equal(t, testImpersonatedUser, s.StringData[exttokenstore.FieldUserID])
 			n := s.DeepCopy()
 			n.Name = "token-xxx"
 			n.Data = map[string][]byte{}

--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -40,6 +40,7 @@ import (
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/clusterrouter"
 	"github.com/rancher/rancher/pkg/encryptedstore"
+	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	md "github.com/rancher/rancher/pkg/kontainerdrivermetadata"
 	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	projectschema "github.com/rancher/rancher/pkg/schemas/project.cattle.io/v3"
@@ -165,6 +166,7 @@ func Clusters(ctx context.Context, schemas *types.Schemas, managementContext *co
 		TokenMgr:       tokens.NewManager(managementContext.Wrangler),
 		ClusterManager: clusterManager,
 		AuthToken:      authToken,
+		ExtTokenStore:  exttokenstore.NewSystemFromWrangler(managementContext.Wrangler),
 	}
 
 	clusterValidator := ccluster.Validator{

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1364,7 +1364,7 @@ func (t *SystemStore) Fetch(tokenID string) (accessor.TokenAccessor, error) {
 		if err == nil {
 			return ext, nil
 		}
-		return nil, fmt.Errorf("unable to fetch token %s: %w", tokenID, err)
+		return nil, fmt.Errorf("unable to fetch token %q: %w", tokenID, err)
 	}
 
 	// checking for a v3 Token first, as it is the currently more common
@@ -1386,7 +1386,8 @@ func (t *SystemStore) Fetch(tokenID string) (accessor.TokenAccessor, error) {
 	if errExt == nil {
 		return ext, nil
 	}
-	return nil, fmt.Errorf("unable to fetch token %s: %w", tokenID, errExt)
+
+	return nil, fmt.Errorf("unable to fetch token %q: %w", tokenID, errExt)
 }
 
 // timeHandler is a helper interface hiding the details of timestamp generation from

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -1151,7 +1151,7 @@ func TestStoreCreate(t *testing.T) {
 		},
 		{
 			name: "provider/principal retrieval error",
-			err:  fmt.Errorf("unable to fetch token session-token: %w", sessionNotFoundError),
+			err:  fmt.Errorf("unable to fetch token \"session-token\": %w", sessionNotFoundError),
 			tok: &ext.Token{
 				Spec: ext.TokenSpec{
 					UserID: "world",
@@ -1186,7 +1186,7 @@ func TestStoreCreate(t *testing.T) {
 		},
 		{
 			name: "provider/principal retrieval error, not found",
-			err: fmt.Errorf("unable to fetch token session-token: %w",
+			err: fmt.Errorf("unable to fetch token \"session-token\": %w",
 				apierrors.NewNotFound(GVR.GroupResource(), "session-token")),
 			tok: &ext.Token{
 				Spec: ext.TokenSpec{
@@ -1214,7 +1214,7 @@ func TestStoreCreate(t *testing.T) {
 				token.EXPECT().Get("session-token").
 					Return(nil, apierrors.NewNotFound(GVR.GroupResource(), "session-token"))
 				scache.EXPECT().Get("cattle-tokens", "session-token").
-					Return(nil, apierrors.NewNotFound(GVR.GroupResource(), "session-token"))
+					Return(nil, sessionNotFoundError)
 
 				users.EXPECT().Get("world").
 					Return(enabledUser, nil)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#55237 
 
## Problem

The import yaml action still creates and uses legacy tokens.
 
## Solution

Reworked the internals of the action to create an ext token.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_