### PR TITLE
Remove broken digestVersion annotations from Dockerfile.installer

### DIFF
--- a/package/Dockerfile.installer
+++ b/package/Dockerfile.installer
@@ -12,9 +12,7 @@ ENV CHART_VERSION=${VERSION}
 # set up helm 4
 # renovate: datasource=github-release-attachments depName=helm/helm
 ENV HELM_VERSION=v4.2.0
-# renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.2.0
 ENV HELM_CHECKSUM_amd64=97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096
-# renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.2.0
 ENV HELM_CHECKSUM_arm64=1f8de130dfbd04de64978e7b852a7a547be1404956a366608276d2520b678670
 
 RUN if [ "${BUILDARCH}" = "amd64" ]; then \
@@ -31,9 +29,7 @@ RUN if [ "${BUILDARCH}" = "amd64" ]; then \
 
 # renovate: datasource=github-release-attachments depName=mikefarah/yq
 ENV YQ_VERSION=v4.44.2
-# renovate: datasource=github-release-attachments depName=mikefarah/yq digestVersion=v4.44.2
 ENV YQ_CHECKSUM_amd64=e4c2570249e3993e33ffa44e592b5eee8545bd807bfbeb596c2986d86cb6c85c
-# renovate: datasource=github-release-attachments depName=mikefarah/yq digestVersion=v4.44.2
 ENV YQ_CHECKSUM_arm64=79c22d98b2ff517cb8b1c20499350cbc1e8c753483c8f72a37a299e6e9872a98
 
 RUN if [ "${BUILDARCH}" = "amd64" ]; then \


### PR DESCRIPTION
The `# renovate: datasource=github-release-attachments digestVersion=` comments before `HELM_CHECKSUM_*` and `YQ_CHECKSUM_*` triggered a manager that returns `newDigest == currentDigest`, leaving checksums stale after every version bump.

The checksum lines are now managed by the new `custom.local` recursive managers in `renovate-config`.

Companion pr for https://github.com/rancher/renovate-config/pull/761