### PR TITLE
Allow retry workflow for fork PR runs

### DIFF
--- a/.github/workflows/retry-failed-jobs.yml
+++ b/.github/workflows/retry-failed-jobs.yml
@@ -1,7 +1,7 @@
 name: Retry failed jobs once
 
 on:
-  workflow_run: # zizmor: ignore[dangerous-triggers] -- guarded by head_repository.full_name == github.repository
+  workflow_run: # zizmor: ignore[dangerous-triggers] -- only calls rerun-failed-jobs API, does not run untrusted code
     workflows:
       - "Build Pull Request"
       - "Push to release branches"
@@ -12,13 +12,15 @@ permissions:
 
 jobs:
   retry:
-    # Only retry once, only on failure, and only for PR/release push runs.
+    # Only retry once, only on failure.
+    # For PRs, allow forks because CI runs live in this repository.
+    # For push workflows, restrict to this repository.
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.run_attempt == 1 &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
       (github.event.workflow_run.event == 'pull_request' ||
-       github.event.workflow_run.event == 'push')
+       (github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed jobs


### PR DESCRIPTION
Allow `pull_request`-based `workflow_run` events from forks to trigger retries for failed jobs, because most of our prs are created from forks.
Keep `push`-based retries restricted to runs from this repository.