### PR TITLE
Start the auth provider refresh daemon at most once per process

### DIFF
--- a/pkg/auth/providerrefresh/daemon.go
+++ b/pkg/auth/providerrefresh/daemon.go
@@ -2,6 +2,7 @@ package providerrefresh
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,24 +20,32 @@ var (
 	c   = cron.New()
 )
 
+// startOnce guards StartRefreshDaemon so the daemon runs exactly once per
+// process. Rancher wires OnLeader under two distinct lock names (auth server
+// and multi-cluster manager); both fire on the same pod in single-instance
+// deployments and would otherwise race on the package-level `ref` and `c`
+// state, potentially leaking an orphan cron goroutine.
+var startOnce sync.Once
+
 func StartRefreshDaemon(scaledContext *config.ScaledContext, mgmtContext *config.ManagementContext) {
-	extTokenStore := exttokenstore.NewSystemFromWrangler(scaledContext.Wrangler)
-	refreshCronTime := settings.AuthUserInfoResyncCron.Get()
-	maxAge := settings.AuthUserInfoMaxAgeSeconds.Get()
-	ref = &refresher{
-		tokenLister:               mgmtContext.Management.Tokens("").Controller().Lister(),
-		tokens:                    mgmtContext.Management.Tokens(""),
-		userLister:                mgmtContext.Management.Users("").Controller().Lister(),
-		tokenMGR:                  tokens.NewManager(scaledContext.Wrangler),
-		userAttributes:            mgmtContext.Management.UserAttributes(""),
-		userAttributeLister:       mgmtContext.Management.UserAttributes("").Controller().Lister(),
-		extTokenStore:             extTokenStore,
-		ensureAndGetUserAttribute: scaledContext.UserManager.EnsureAndGetUserAttribute,
-	}
+	startOnce.Do(func() {
+		extTokenStore := exttokenstore.NewSystemFromWrangler(scaledContext.Wrangler)
+		refreshCronTime := settings.AuthUserInfoResyncCron.Get()
+		maxAge := settings.AuthUserInfoMaxAgeSeconds.Get()
+		ref = &refresher{
+			tokenLister:               mgmtContext.Management.Tokens("").Controller().Lister(),
+			tokens:                    mgmtContext.Management.Tokens(""),
+			userLister:                mgmtContext.Management.Users("").Controller().Lister(),
+			tokenMGR:                  tokens.NewManager(scaledContext.Wrangler),
+			userAttributes:            mgmtContext.Management.UserAttributes(""),
+			userAttributeLister:       mgmtContext.Management.UserAttributes("").Controller().Lister(),
+			extTokenStore:             extTokenStore,
+			ensureAndGetUserAttribute: scaledContext.UserManager.EnsureAndGetUserAttribute,
+		}
 
-	UpdateRefreshMaxAge(maxAge)
-	UpdateRefreshCronTime(refreshCronTime)
-
+		UpdateRefreshMaxAge(maxAge)
+		UpdateRefreshCronTime(refreshCronTime)
+	})
 }
 
 func UpdateRefreshCronTime(refreshCronTime string) {


### PR DESCRIPTION
## Issue: #55911<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The daemon's startup path is invoked from two separate leader-election callbacks in the same process. Both fire on single-instance Rancher deployments. The two calls race on package-level refresher and cron state. An orphan cron goroutine can be left scheduled with no reference to stop it.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The startup path is now guarded by a sync.Once. Subsequent invocations are a no-op.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
