### PR TITLE
Fix support for OCI charts referenced from git-based clusterrepos

### DIFF
--- a/pkg/catalogv2/content/content.go
+++ b/pkg/catalogv2/content/content.go
@@ -233,9 +233,9 @@ func (c *Manager) Chart(namespace, name, chartName, version string, skipFilter b
 		return nil, err
 	}
 
-	// If the commit status of the repository is not an empty string
-	// Return the Chart through Git without checking the secret
-	if repo.status.Commit != "" {
+	if repo.status.Commit != "" && !isRemoteChart(chart) {
+		// Git-based ClusterRepos can include the chart tarballs as part of the repository.
+		// Retrieve the chart from the local file.
 		return git.Chart(namespace, name, repo.status.URL, chart)
 	}
 
@@ -261,6 +261,14 @@ func (c *Manager) Chart(namespace, name, chartName, version string, skipFilter b
 	default:
 		return helmhttp.Chart(secret, repo.status.URL, repo.spec.CABundle, repo.spec.InsecureSkipTLSverify, repo.spec.DisableSameOriginCheck, chart)
 	}
+}
+
+func isRemoteChart(chart *repo.ChartVersion) bool {
+	if len(chart.URLs) == 0 {
+		return false
+	}
+	location := chart.URLs[0]
+	return strings.Contains(chart.URLs[0], "://") && !strings.HasSuffix(location, "file://")
 }
 
 // Info retrieves detailed information about a specific Helm chart from a Helm repository.

--- a/pkg/catalogv2/content/content.go
+++ b/pkg/catalogv2/content/content.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -225,7 +224,10 @@ func (c *Manager) Chart(namespace, name, chartName, version string, skipFilter b
 	chart, err := index.Get(chartName, version)
 	if err != nil {
 		return nil, err
+	} else if len(chart.URLs) == 0 {
+		return nil, fmt.Errorf("failed to find chartName %s version %s: %w", chart.Name, chart.Version, validation.NotFound)
 	}
+	chartURL := chart.URLs[0]
 
 	// Retrieve the clusterRepo
 	repo, err := c.getRepo(namespace, name)
@@ -233,7 +235,7 @@ func (c *Manager) Chart(namespace, name, chartName, version string, skipFilter b
 		return nil, err
 	}
 
-	if repo.status.Commit != "" && !isRemoteChart(chart) {
+	if repo.status.Commit != "" && !isRemoteChart(chartURL, repo.status.URL) {
 		// Git-based ClusterRepos can include the chart tarballs as part of the repository.
 		// Retrieve the chart from the local file.
 		return git.Chart(namespace, name, repo.status.URL, chart)
@@ -242,14 +244,6 @@ func (c *Manager) Chart(namespace, name, chartName, version string, skipFilter b
 	secret, err := catalogv2.GetSecret(c.secrets, repo.spec, repo.metadata.Namespace)
 	if err != nil {
 		return nil, err
-	}
-
-	// Check if chart is nil and has at least one URL
-	if chart == nil {
-		return nil, errors.New("chart is nil")
-	}
-	if len(chart.URLs) <= 0 {
-		return nil, errors.New("chart has no urls specified")
 	}
 
 	switch {
@@ -263,12 +257,11 @@ func (c *Manager) Chart(namespace, name, chartName, version string, skipFilter b
 	}
 }
 
-func isRemoteChart(chart *repo.ChartVersion) bool {
-	if len(chart.URLs) == 0 {
+func isRemoteChart(chartURL, gitURL string) bool {
+	if strings.HasSuffix(chartURL, "file://") || strings.HasSuffix(chartURL, gitURL) {
 		return false
 	}
-	location := chart.URLs[0]
-	return strings.Contains(chart.URLs[0], "://") && !strings.HasSuffix(location, "file://")
+	return strings.Contains(chartURL, "://")
 }
 
 // Info retrieves detailed information about a specific Helm chart from a Helm repository.


### PR DESCRIPTION
## Issue: _TBD_
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem

Git-based ClusterRepos assume all charts will be present within the Git repository.
 
## Solution

Remove this assumption, at least when the chart URL clearly contains an protocol schema (e.g. `oci://`).
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_