### PR TITLE
Fix CRT indexer

### DIFF
--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/urlbuilder"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
@@ -17,14 +16,15 @@ import (
 	"github.com/rancher/rancher/pkg/systemtemplate"
 	"github.com/rancher/rancher/pkg/tunnelserver/mcmauthorizer"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8scache "k8s.io/client-go/tools/cache"
 )
 
 type ClusterImport struct {
-	Clusters     v3.ClusterInterface
-	SecretLister v1.SecretLister
-	CRTIndexer   k8scache.Indexer
+	Clusters      v3.ClusterInterface
+	SecretLister  v1.SecretLister
+	SecretIndexer k8scache.Indexer
 }
 
 func (ch *ClusterImport) ClusterImportHandler(resp http.ResponseWriter, req *http.Request) {
@@ -110,14 +110,14 @@ func validateAuthImage(authImage string) error {
 }
 
 func (ch *ClusterImport) isValidToken(clusterID, token string) bool {
-	objs, err := ch.CRTIndexer.ByIndex(mcmauthorizer.CRTKeyIndex, token)
+	objs, err := ch.SecretIndexer.ByIndex(mcmauthorizer.SecretTokenIndex, token)
 	if err != nil {
-		logrus.Errorf("[cluster-registration-tokens] CRT index lookup failed: %v", err)
+		logrus.Errorf("[cluster-registration-tokens] CRT token secret index lookup failed: %v", err)
 		return false
 	}
 	for _, obj := range objs {
-		crt, ok := obj.(*v32.ClusterRegistrationToken)
-		if ok && crt.Namespace == clusterID {
+		secret, ok := obj.(*corev1.Secret)
+		if ok && secret.Namespace == clusterID {
 			return true
 		}
 	}

--- a/pkg/api/norman/customization/clusterregistrationtokens/import_test.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import_test.go
@@ -11,18 +11,19 @@ import (
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/rancher/rancher/pkg/tunnelserver/mcmauthorizer"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
-func newTestCRTIndexer(clusterID, token string) cache.Indexer {
+func newTestSecretIndexer(clusterID, token string) cache.Indexer {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-		mcmauthorizer.CRTKeyIndex: func(obj interface{}) ([]string, error) {
+		mcmauthorizer.SecretTokenIndex: func(obj interface{}) ([]string, error) {
 			return []string{token}, nil
 		},
 	})
-	_ = indexer.Add(&apimgmtv3.ClusterRegistrationToken{
-		ObjectMeta: metav1.ObjectMeta{Name: "system", Namespace: clusterID},
+	_ = indexer.Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "crt-token-system", Namespace: clusterID},
 	})
 	return indexer
 }
@@ -34,7 +35,7 @@ func TestClusterImportHandler_ValidateAuthImage(t *testing.T) {
 				return &apimgmtv3.Cluster{}, nil
 			},
 		},
-		CRTIndexer: newTestCRTIndexer("cluster", "token"),
+		SecretIndexer: newTestSecretIndexer("cluster", "token"),
 	}
 
 	tests := []struct {

--- a/pkg/api/steve/proxy/auth.go
+++ b/pkg/api/steve/proxy/auth.go
@@ -4,13 +4,11 @@ import (
 	"net/http"
 	"strings"
 
-	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	crt "github.com/rancher/rancher/pkg/controllers/dashboard/clusterregistrationtoken"
-	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/remotedialer"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
-	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -20,30 +18,16 @@ const (
 )
 
 type clusterProxyAuthorizer struct {
-	tokenCache  v3.ClusterRegistrationTokenCache
 	secretCache corecontrollers.SecretCache
 }
 
 func NewAuthorizer(wrangler *wrangler.Context) remotedialer.Authorizer {
 	secretCache := wrangler.Core.Secret().Cache()
 	a := &clusterProxyAuthorizer{
-		tokenCache:  wrangler.Mgmt.ClusterRegistrationToken().Cache(),
 		secretCache: secretCache,
 	}
-	a.tokenCache.AddIndexer(tokenIndex, func(obj *apimgmtv3.ClusterRegistrationToken) ([]string, error) {
-		current, previous, err := crt.GetTokensFromSecret(secretCache, obj)
-		if err != nil {
-			logrus.Warnf("failed to resolve CRT token for %s/%s: %v", obj.Namespace, obj.Name, err)
-			return nil, nil
-		}
-		if current == "" {
-			return nil, nil
-		}
-		tokens := []string{current}
-		if previous != "" {
-			tokens = append(tokens, previous)
-		}
-		return tokens, nil
+	secretCache.AddIndexer(tokenIndex, func(obj *corev1.Secret) ([]string, error) {
+		return crt.SecretTokenIndexValues(obj), nil
 	})
 
 	return a.Authorize
@@ -54,12 +38,12 @@ func (a *clusterProxyAuthorizer) Authorize(req *http.Request) (string, bool, err
 	if !strings.HasPrefix(auth, Prefix) {
 		return "", false, nil
 	}
-	crts, err := a.tokenCache.GetByIndex(tokenIndex, strings.TrimPrefix(auth, Prefix))
-	if apierror.IsNotFound(err) || len(crts) == 0 {
+	secrets, err := a.secretCache.GetByIndex(tokenIndex, strings.TrimPrefix(auth, Prefix))
+	if apierror.IsNotFound(err) || len(secrets) == 0 {
 		return "", false, nil
 	} else if err != nil {
 		return "", false, err
 	}
 
-	return Prefix + crts[0].Namespace, true, nil
+	return Prefix + secrets[0].Namespace, true, nil
 }

--- a/pkg/api/steve/proxy/auth_test.go
+++ b/pkg/api/steve/proxy/auth_test.go
@@ -1,0 +1,87 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestClusterProxyAuthorizer_Authorize(t *testing.T) {
+	tests := []struct {
+		name          string
+		authHeader    string
+		secrets       []*corev1.Secret
+		getByIndex    []*corev1.Secret
+		getByIndexErr error
+		wantID        string
+		wantOK        bool
+		wantErr       bool
+	}{
+		{
+			name:       "no prefix",
+			authHeader: "Bearer sometoken",
+			wantOK:     false,
+		},
+		{
+			name:       "valid token maps to cluster namespace",
+			authHeader: "Bearer " + Prefix + "tok",
+			getByIndex: []*corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "c-abc", Name: "crt-token-system"}},
+			},
+			wantID: Prefix + "c-abc",
+			wantOK: true,
+		},
+		{
+			name:          "not found error is treated as unauthorized",
+			authHeader:    "Bearer " + Prefix + "tok",
+			getByIndexErr: apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "tok"),
+			wantOK:        false,
+		},
+		{
+			name:       "no matching secret",
+			authHeader: "Bearer " + Prefix + "tok",
+			getByIndex: nil,
+			wantOK:     false,
+		},
+		{
+			name:       "unexpected error with results is propagated",
+			authHeader: "Bearer " + Prefix + "tok",
+			getByIndex: []*corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "c-abc", Name: "crt-token-system"}},
+			},
+			getByIndexErr: assert.AnError,
+			wantOK:        false,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			mockCache.EXPECT().GetByIndex(tokenIndex, gomock.Any()).Return(tt.getByIndex, tt.getByIndexErr).AnyTimes()
+
+			a := &clusterProxyAuthorizer{secretCache: mockCache}
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Authorization", tt.authHeader)
+
+			id, ok, err := a.Authorize(req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}

--- a/pkg/cacerts/handler.go
+++ b/pkg/cacerts/handler.go
@@ -8,43 +8,44 @@ import (
 	"net/http"
 	"strings"
 
-	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	crt "github.com/rancher/rancher/pkg/controllers/dashboard/clusterregistrationtoken"
-	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/tls"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
-	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
 	tokenHash = "tokenByHash"
 )
 
-func Handler(clusterRegistrationToken v3.ClusterRegistrationTokenCache, secretCache corecontrollers.SecretCache) http.HandlerFunc {
-	clusterRegistrationToken.AddIndexer(tokenHash, func(obj *apimgmtv3.ClusterRegistrationToken) ([]string, error) {
-		current, previous, err := crt.GetTokensFromSecret(secretCache, obj)
-		if err != nil {
-			logrus.Warnf("failed to resolve CRT token for %s/%s: %v", obj.Namespace, obj.Name, err)
+// hashToken returns the base64-encoded SHA-256 of a plaintext CRT token, the
+// form agents present in the Authorization header.
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+// Handler indexes CRT token secrets by token hash and serves CA certs,
+// signing responses with an HMAC so agents can verify authenticity.
+func Handler(secretCache corecontrollers.SecretCache) http.HandlerFunc {
+	secretCache.AddIndexer(tokenHash, func(obj *corev1.Secret) ([]string, error) {
+		tokens := crt.SecretTokenIndexValues(obj)
+		if len(tokens) == 0 {
 			return nil, nil
 		}
-		if current == "" {
-			return nil, nil
-		}
-		currentHash := sha256.Sum256([]byte(current))
-		hashes := []string{base64.StdEncoding.EncodeToString(currentHash[:])}
-		if previous != "" {
-			prevHash := sha256.Sum256([]byte(previous))
-			hashes = append(hashes, base64.StdEncoding.EncodeToString(prevHash[:]))
+		hashes := make([]string, 0, len(tokens))
+		for _, token := range tokens {
+			hashes = append(hashes, hashToken(token))
 		}
 		return hashes, nil
 	})
 	return func(rw http.ResponseWriter, req *http.Request) {
-		handler(clusterRegistrationToken, secretCache, rw, req)
+		handler(secretCache, rw, req)
 	}
 }
 
-func handler(clusterRegistrationToken v3.ClusterRegistrationTokenCache, secretCache corecontrollers.SecretCache, rw http.ResponseWriter, req *http.Request) {
+func handler(secretCache corecontrollers.SecretCache, rw http.ResponseWriter, req *http.Request) {
 	ca := settings.CACerts.Get()
 	if v, ok := req.Context().Value(tls.InternalAPI).(bool); ok && v {
 		ca = settings.InternalCACerts.Get()
@@ -63,23 +64,19 @@ func handler(clusterRegistrationToken v3.ClusterRegistrationTokenCache, secretCa
 	authorization := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
 
 	if authorization != "" && nonce != "" {
-		crts, err := clusterRegistrationToken.GetByIndex(tokenHash, authorization)
-		if err == nil && len(crts) > 0 {
-			current, previous, err := crt.GetTokensFromSecret(secretCache, crts[0])
-			if err != nil {
-				logrus.Warnf("failed to resolve CRT token for HMAC: %v", err)
-			} else {
-				// Use whichever token the agent authenticated with.
-				// During grace period both current and previous are indexed;
-				// the HMAC must be keyed with the token that matches the
-				// authorization hash the agent sent.
-				token := current
-				if previous != "" {
-					prevHash := sha256.Sum256([]byte(previous))
-					if authorization == base64.StdEncoding.EncodeToString(prevHash[:]) {
-						token = previous
-					}
+		secrets, err := secretCache.GetByIndex(tokenHash, authorization)
+		if err == nil && len(secrets) > 0 {
+			// During a rotation grace period the secret carries both the
+			// current and previous token; key the HMAC with whichever token
+			// matches the hash the agent authenticated with.
+			var token string
+			for _, t := range crt.SecretTokenIndexValues(secrets[0]) {
+				if authorization == hashToken(t) {
+					token = t
+					break
 				}
+			}
+			if token != "" {
 				digest := hmac.New(sha512.New, []byte(token))
 				digest.Write([]byte(nonce))
 				digest.Write([]byte{0})

--- a/pkg/cacerts/handler_test.go
+++ b/pkg/cacerts/handler_test.go
@@ -1,0 +1,96 @@
+package cacerts
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func expectedHash(token, nonce string, ca []byte) string {
+	digest := hmac.New(sha512.New, []byte(token))
+	digest.Write([]byte(nonce))
+	digest.Write([]byte{0})
+	digest.Write(ca)
+	digest.Write([]byte{0})
+	return base64.StdEncoding.EncodeToString(digest.Sum(nil))
+}
+
+func TestHandler_HMAC(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "c-abc", Name: "crt-token-system"},
+		Data: map[string][]byte{
+			"token":         []byte("current-tok"),
+			"previousToken": []byte("previous-tok"),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		authorization string
+		wantToken     string
+		wantHeader    bool
+	}{
+		{
+			name:          "current token authenticates HMAC with current token",
+			authorization: hashToken("current-tok"),
+			wantToken:     "current-tok",
+			wantHeader:    true,
+		},
+		{
+			name:          "previous token authenticates HMAC with previous token",
+			authorization: hashToken("previous-tok"),
+			wantToken:     "previous-tok",
+			wantHeader:    true,
+		},
+		{
+			name:          "unrecognized hash sets no header",
+			authorization: hashToken("wrong-tok"),
+			wantHeader:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			mockCache.EXPECT().GetByIndex(tokenHash, tt.authorization).Return([]*corev1.Secret{secret}, nil)
+
+			req := httptest.NewRequest(http.MethodGet, "/cacerts", nil)
+			req.Header.Set("Authorization", "Bearer "+tt.authorization)
+			req.Header.Set("X-Cattle-Nonce", "nonce")
+			rw := httptest.NewRecorder()
+
+			handler(mockCache, rw, req)
+
+			if !tt.wantHeader {
+				assert.Empty(t, rw.Header().Get("X-Cattle-Hash"))
+				return
+			}
+			assert.Equal(t, expectedHash(tt.wantToken, "nonce", nil), rw.Header().Get("X-Cattle-Hash"))
+		})
+	}
+}
+
+func TestHandler_NoSecretMatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	mockCache.EXPECT().GetByIndex(tokenHash, gomock.Any()).Return(nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/cacerts", nil)
+	req.Header.Set("Authorization", "Bearer sometoken")
+	req.Header.Set("X-Cattle-Nonce", "nonce")
+	rw := httptest.NewRecorder()
+
+	handler(mockCache, rw, req)
+
+	assert.Empty(t, rw.Header().Get("X-Cattle-Hash"))
+}

--- a/pkg/capr/configserver/custom.go
+++ b/pkg/capr/configserver/custom.go
@@ -38,26 +38,28 @@ func (r *RKE2ConfigServer) findMachineByClusterToken(req *http.Request) (*corev1
 		return nil, nil
 	}
 
-	tokens, err := r.clusterTokenCache.GetByIndex(tokenIndex, token)
+	secrets, err := r.secretsCache.GetByIndex(crtTokenIndex, token)
 	if err != nil {
 		return nil, err
 	}
 
 	data := dataFromHeaders(req)
 
-	if len(tokens) == 0 {
+	if len(secrets) == 0 {
 		return nil, nil
 	}
 
+	namespace := secrets[0].Namespace
+
 	imported := false
-	if mgmtNameRegexp.MatchString(tokens[0].Namespace) {
+	if mgmtNameRegexp.MatchString(namespace) {
 		imported = true
 	}
 
 	secretName := machineRequestSecretName(imported, machineID)
-	secret, err := r.secretsCache.Get(tokens[0].Namespace, secretName)
+	secret, err := r.secretsCache.Get(namespace, secretName)
 	if apierror.IsNotFound(err) {
-		secret, err = r.createSecret(tokens[0].Namespace, secretName, data)
+		secret, err = r.createSecret(namespace, secretName, data)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/capr/configserver/custom_test.go
+++ b/pkg/capr/configserver/custom_test.go
@@ -1,0 +1,86 @@
+package configserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestConfigServer(t *testing.T, tokenSecret *corev1.Secret, readySecret *corev1.Secret) *RKE2ConfigServer {
+	ctrl := gomock.NewController(t)
+
+	secretsCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	secretsCache.EXPECT().GetByIndex(crtTokenIndex, "tok").Return([]*corev1.Secret{tokenSecret}, nil).AnyTimes()
+	secretsCache.EXPECT().Get(readySecret.Namespace, readySecret.Name).Return(readySecret, nil).AnyTimes()
+
+	secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	secrets.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	return &RKE2ConfigServer{
+		secretsCache: secretsCache,
+		secrets:      secrets,
+	}
+}
+
+func readyMachineSecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				capr.MachineNameLabel:      "machine-1",
+				capr.MachineNamespaceLabel: "fleet-default",
+			},
+		},
+	}
+}
+
+func TestFindMachineByClusterToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		wantKind  string
+	}{
+		{
+			name:      "management namespace is treated as imported",
+			namespace: "c-abcde",
+			wantKind:  "Node",
+		},
+		{
+			name:      "non-management namespace is treated as custom",
+			namespace: "fleet-default",
+			wantKind:  "Machine",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: tt.namespace, Name: "crt-token-system"},
+			}
+			secretName := machineRequestSecretName(tt.wantKind == "Node", "machine-1")
+			readySecret := readyMachineSecret(tt.namespace, secretName)
+
+			r := newTestConfigServer(t, tokenSecret, readySecret)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Authorization", "Bearer tok")
+			req.Header.Set(machineIDHeader, "machine-1")
+
+			ref, err := r.findMachineByClusterToken(req)
+			require.NoError(t, err)
+			require.NotNil(t, ref)
+			assert.Equal(t, tt.wantKind, ref.Kind)
+			assert.Equal(t, "fleet-default", ref.Namespace)
+			assert.Equal(t, "machine-1", ref.Name)
+		})
+	}
+}

--- a/pkg/capr/configserver/server.go
+++ b/pkg/capr/configserver/server.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/capr/planner"
 	crt "github.com/rancher/rancher/pkg/controllers/dashboard/clusterregistrationtoken"
@@ -42,11 +41,11 @@ const (
 )
 
 var (
-	tokenIndex = "tokenIndex"
+	tokenIndex    = "tokenIndex"
+	crtTokenIndex = "crtTokenIndex"
 )
 
 type RKE2ConfigServer struct {
-	clusterTokenCache        mgmtcontroller.ClusterRegistrationTokenCache
 	clusterTokens            mgmtcontroller.ClusterRegistrationTokenController
 	serviceAccountsCache     corecontrollers.ServiceAccountCache
 	serviceAccounts          corecontrollers.ServiceAccountClient
@@ -70,29 +69,15 @@ func New(clients *wrangler.Context) *RKE2ConfigServer {
 		return nil, nil
 	})
 
-	clients.Mgmt.ClusterRegistrationToken().Cache().AddIndexer(tokenIndex,
-		func(obj *v3.ClusterRegistrationToken) ([]string, error) {
-			current, previous, err := crt.GetTokensFromSecret(clients.Core.Secret().Cache(), obj)
-			if err != nil {
-				logrus.Warnf("failed to resolve CRT token for %s/%s: %v", obj.Namespace, obj.Name, err)
-				return nil, nil
-			}
-			if current == "" {
-				return nil, nil
-			}
-			tokens := []string{current}
-			if previous != "" {
-				tokens = append(tokens, previous)
-			}
-			return tokens, nil
-		})
+	clients.Core.Secret().Cache().AddIndexer(crtTokenIndex, func(obj *corev1.Secret) ([]string, error) {
+		return crt.SecretTokenIndexValues(obj), nil
+	})
 
 	configSrv := &RKE2ConfigServer{
 		serviceAccountsCache:     clients.Core.ServiceAccount().Cache(),
 		serviceAccounts:          clients.Core.ServiceAccount(),
 		secretsCache:             clients.Core.Secret().Cache(),
 		secrets:                  clients.Core.Secret(),
-		clusterTokenCache:        clients.Mgmt.ClusterRegistrationToken().Cache(),
 		clusterTokens:            clients.Mgmt.ClusterRegistrationToken(),
 		bootstrapCache:           clients.RKE.RKEBootstrap().Cache(),
 		provisioningClusterCache: clients.Provisioning.Cluster().Cache(),

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"strings"
 	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -58,7 +57,6 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 	clients.Mgmt.ClusterRegistrationToken().OnChange(ctx, "cluster-registration-token", h.onChange)
 	clients.Mgmt.ClusterRegistrationToken().OnRemove(ctx, "cluster-registration-token-cleanup", h.onRemove)
 	clients.Mgmt.Cluster().OnChange(ctx, "cluster-registration-token-trigger", h.onClusterChange)
-	clients.Core.Secret().OnChange(ctx, "crt-token-secret-reindex", h.onSecretChange)
 	clients.Mgmt.Feature().OnChange(ctx, "crt-ttl-feature-trigger", h.onFeatureChange)
 	clients.Mgmt.Setting().OnChange(ctx, "crt-ttl-setting-trigger", h.onSettingChange)
 }
@@ -78,24 +76,6 @@ func (h *handler) onClusterChange(key string, obj *v3.Cluster) (*v3.Cluster, err
 	}
 
 	return obj, nil
-}
-
-// onSecretChange watches CRT token secrets and enqueues the owning CRT when
-// the secret data changes. This ensures CRT indexers are refreshed after token
-// rotation, since the indexer runs on CRT events but reads from the secret cache.
-// By the time this handler fires, the secret informer cache is already updated,
-// so the enqueued CRT reconciliation will re-index with correct data.
-func (h *handler) onSecretChange(_ string, secret *corev1.Secret) (*corev1.Secret, error) {
-	if secret == nil || !strings.HasPrefix(secret.Name, secretPrefix) {
-		return secret, nil
-	}
-	for _, ref := range secret.OwnerReferences {
-		if ref.Kind == "ClusterRegistrationToken" {
-			h.clusterRegistrationTokenController.Enqueue(secret.Namespace, ref.Name)
-			break
-		}
-	}
-	return secret, nil
 }
 
 // onFeatureChange re-enqueues all CRTs without an ExpiresAt when the

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -236,6 +236,7 @@ func (h *handler) reconcileExistingCRT(obj *v3.ClusterRegistrationToken) (*v3.Cl
 	}
 
 	obj = obj.DeepCopy()
+	original := obj.DeepCopy()
 
 	if err := h.handleTTL(obj); err != nil {
 		return nil, err
@@ -246,9 +247,10 @@ func (h *handler) reconcileExistingCRT(obj *v3.ClusterRegistrationToken) (*v3.Cl
 		return nil, err
 	}
 
-	if !equality.Semantic.DeepEqual(obj.Status, newStatus) {
-		obj.Status = newStatus
+	if equality.Semantic.DeepEqual(original.Status, newStatus) {
+		return obj, nil
 	}
+	obj.Status = newStatus
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest, err := h.clusterRegistrationTokenController.Get(obj.Namespace, obj.Name, metav1.GetOptions{})
@@ -354,7 +356,10 @@ func (h *handler) rotateToken(obj *v3.ClusterRegistrationToken, ttl int64) error
 	newExpiresAt := now.Add(time.Duration(ttl) * time.Minute).UTC().Format(time.RFC3339)
 	newGracePeriodExpiresAt := now.Add(time.Duration(gracePeriod) * time.Minute).UTC().Format(time.RFC3339)
 
-	newToken, _ := randomtoken.Generate()
+	newToken, err := randomtoken.Generate()
+	if err != nil {
+		return err
+	}
 
 	updated := existing.DeepCopy()
 	updated.Data[previousTokenDataKey] = existing.Data[tokenDataKey]

--- a/pkg/controllers/dashboard/clusterregistrationtoken/token_index_test.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/token_index_test.go
@@ -1,0 +1,73 @@
+package clusterregistrationtoken
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func tokenSecret(name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "c-abcde", Name: name},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       data,
+	}
+}
+
+func TestSecretTokenIndexValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+		want   []string
+	}{
+		{
+			name:   "nil secret",
+			secret: nil,
+			want:   nil,
+		},
+		{
+			name:   "not a token secret",
+			secret: tokenSecret("some-other-secret", map[string][]byte{tokenDataKey: []byte("abc")}),
+			want:   nil,
+		},
+		{
+			name:   "token secret without token data",
+			secret: tokenSecret(SecretName("crt1"), map[string][]byte{"expiresAt": []byte("later")}),
+			want:   nil,
+		},
+		{
+			name:   "token secret with empty token",
+			secret: tokenSecret(SecretName("crt1"), map[string][]byte{tokenDataKey: []byte("")}),
+			want:   nil,
+		},
+		{
+			name:   "current token only",
+			secret: tokenSecret(SecretName("crt1"), map[string][]byte{tokenDataKey: []byte("current-token")}),
+			want:   []string{"current-token"},
+		},
+		{
+			name: "current and previous token (grace period)",
+			secret: tokenSecret(SecretName("crt1"), map[string][]byte{
+				tokenDataKey:         []byte("current-token"),
+				previousTokenDataKey: []byte("previous-token"),
+			}),
+			want: []string{"current-token", "previous-token"},
+		},
+		{
+			name: "empty previous token is ignored",
+			secret: tokenSecret(SecretName("crt1"), map[string][]byte{
+				tokenDataKey:         []byte("current-token"),
+				previousTokenDataKey: []byte(""),
+			}),
+			want: []string{"current-token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SecretTokenIndexValues(tt.secret))
+		})
+	}
+}

--- a/pkg/controllers/dashboard/clusterregistrationtoken/token_secret.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/token_secret.go
@@ -2,6 +2,7 @@ package clusterregistrationtoken
 
 import (
 	"fmt"
+	"strings"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +23,28 @@ const (
 
 func SecretName(crtName string) string {
 	return secretPrefix + crtName
+}
+func IsTokenSecret(secret *corev1.Secret) bool {
+	return secret != nil && strings.HasPrefix(secret.Name, secretPrefix)
+}
+
+// SecretTokenIndexValues returns the plaintext token values stored in a CRT
+// token secret, for use as index keys. Returns the current token and, if
+// present, the previous token (valid during a rotation grace period).
+// Returns nil for non-CRT secrets or secrets with no current token.
+func SecretTokenIndexValues(secret *corev1.Secret) []string {
+	if !IsTokenSecret(secret) {
+		return nil
+	}
+	token, ok := secret.Data[tokenDataKey]
+	if !ok || len(token) == 0 {
+		return nil
+	}
+	values := []string{string(token)}
+	if prev, ok := secret.Data[previousTokenDataKey]; ok && len(prev) > 0 {
+		values = append(values, string(prev))
+	}
+	return values
 }
 
 func GetTokenFromSecret(secrets SecretGetter, crt *v3.ClusterRegistrationToken) (string, error) {
@@ -72,24 +95,4 @@ func NewTokenSecret(crt *v3.ClusterRegistrationToken, token string, expiresAt st
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
 	}
-}
-
-func GetTokensFromSecret(secrets SecretGetter, crt *v3.ClusterRegistrationToken) (current string, previous string, err error) {
-	if crt == nil || crt.Status.TokenSecretName == "" {
-		return "", "", nil
-	}
-
-	secret, err := secrets.Get(crt.Namespace, crt.Status.TokenSecretName)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get token secret %s/%s: %w", crt.Namespace, crt.Status.TokenSecretName, err)
-	}
-
-	if token, ok := secret.Data[tokenDataKey]; ok {
-		current = string(token)
-	}
-	if prev, ok := secret.Data[previousTokenDataKey]; ok {
-		previous = string(prev)
-	}
-
-	return current, previous, nil
 }

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -49,9 +49,8 @@ func router(ctx context.Context, localClusterEnabled bool, scaledContext *config
 		clusterImport  = clusterregistrationtokens.ClusterImport{
 			Clusters:     scaledContext.Management.Clusters(""),
 			SecretLister: scaledContext.Core.Secrets("").Controller().Lister(),
-			// Reuse the CRT token indexer registered by mcmauthorizer.NewAuthorizer,
-			// which is called on the same scaledContext before routing is set up.
-			CRTIndexer: scaledContext.Management.ClusterRegistrationTokens("").Controller().Informer().GetIndexer(),
+			// Reuses the SecretTokenIndex indexer registered by mcmauthorizer.NewAuthorizer.
+			SecretIndexer: scaledContext.Core.Secrets("").Controller().Informer().GetIndexer(),
 		}
 	)
 

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -296,7 +296,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		Controllers:     steveControllers,
 		AccessSetLookup: wranglerContext.ASL,
 		AuthMiddleware:  steveauth.ExistingContext,
-		Next:            ui.New(wranglerContext.Mgmt.Preference().Cache(), wranglerContext.Mgmt.ClusterRegistrationToken().Cache(), wranglerContext.Core.Secret().Cache()),
+		Next:            ui.New(wranglerContext.Mgmt.Preference().Cache(), wranglerContext.Core.Secret().Cache()),
 		ClusterRegistry: opts.ClusterRegistry,
 		SQLCache:        features.UISQLCache.Enabled(),
 		SQLCacheFactoryOptions: factory.CacheFactoryOptions{

--- a/pkg/tunnelserver/mcmauthorizer/tunnel.go
+++ b/pkg/tunnelserver/mcmauthorizer/tunnel.go
@@ -24,6 +24,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
+	k8scorev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -31,9 +32,9 @@ import (
 )
 
 const (
-	CRTKeyIndex  = "crtKeyIndex"
-	crtKeyIndex  = CRTKeyIndex
-	nodeKeyIndex = "nodeKeyIndex"
+	// SecretTokenIndex indexes CRT token secrets by their plaintext token(s).
+	SecretTokenIndex = "crtSecretTokenIndex"
+	nodeKeyIndex     = "nodeKeyIndex"
 
 	Token  = "X-API-Tunnel-Token"
 	Params = "X-API-Tunnel-Params"
@@ -64,7 +65,7 @@ type input struct {
 
 func NewAuthorizer(context *config.ScaledContext) *Authorizer {
 	auth := &Authorizer{
-		crtIndexer:            context.Management.ClusterRegistrationTokens("").Controller().Informer().GetIndexer(),
+		secretIndexer:         context.Core.Secrets("").Controller().Informer().GetIndexer(),
 		clusterLister:         context.Management.Clusters("").Controller().Lister(),
 		nodeIndexer:           context.Management.Nodes("").Controller().Informer().GetIndexer(),
 		machineLister:         context.Management.Nodes("").Controller().Lister(),
@@ -74,9 +75,13 @@ func NewAuthorizer(context *config.ScaledContext) *Authorizer {
 		Secrets:               context.Core.Secrets(""),
 		SecretLister:          context.Core.Secrets("").Controller().Lister(),
 	}
-	context.Management.ClusterRegistrationTokens("").Controller().Informer().AddIndexers(map[string]cache.IndexFunc{
-		crtKeyIndex: auth.crtIndex,
-	})
+	// Registered through wrangler's Cache().AddIndexer (panics via
+	// utilruntime.Must on failure) instead of the raw informer's
+	// AddIndexers, so a registration failure is never silently swallowed.
+	// context.Wrangler.Core.Secret() and context.Core.Secrets("") both resolve
+	// to the same underlying SharedIndexInformer/indexer, since they share
+	// context.Wrangler.ControllerFactory.
+	context.Wrangler.Core.Secret().Cache().AddIndexer(SecretTokenIndex, auth.secretTokenIndex)
 	context.Management.Nodes("").Controller().Informer().AddIndexers(map[string]cache.IndexFunc{
 		nodeKeyIndex: auth.nodeIndex,
 	})
@@ -84,7 +89,7 @@ func NewAuthorizer(context *config.ScaledContext) *Authorizer {
 }
 
 type Authorizer struct {
-	crtIndexer            cache.Indexer
+	secretIndexer         cache.Indexer
 	clusterLister         v3.ClusterLister
 	nodeIndexer           cache.Indexer
 	machineLister         v3.NodeLister
@@ -385,34 +390,31 @@ func machineName(machine *client.Node) string {
 }
 
 func (t *Authorizer) getClusterByToken(token string) (*v3.Cluster, error) {
-	keys, err := t.crtIndexer.ByIndex(crtKeyIndex, token)
+	secrets, err := t.secretIndexer.ByIndex(SecretTokenIndex, token)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, obj := range keys {
-		crt := obj.(*v3.ClusterRegistrationToken)
-		return t.clusterLister.Get("", crt.Spec.ClusterName)
+	for _, obj := range secrets {
+		secret, ok := obj.(*k8scorev1.Secret)
+		if !ok {
+			continue
+		}
+		cluster, err := t.clusterLister.Get("", secret.Namespace)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		return cluster, nil
 	}
 
 	return nil, ErrClusterNotFound
 }
 
-func (t *Authorizer) crtIndex(obj interface{}) ([]string, error) {
-	crt := obj.(*v3.ClusterRegistrationToken)
-	current, previous, err := clusterregistrationtoken.GetTokensFromSecret(t.SecretLister, crt)
-	if err != nil {
-		logrus.Warnf("failed to resolve CRT token for %s/%s: %v", crt.Namespace, crt.Name, err)
-		return nil, nil
-	}
-	if current == "" {
-		return nil, nil
-	}
-	tokens := []string{current}
-	if previous != "" {
-		tokens = append(tokens, previous)
-	}
-	return tokens, nil
+func (t *Authorizer) secretTokenIndex(secret *k8scorev1.Secret) ([]string, error) {
+	return clusterregistrationtoken.SecretTokenIndexValues(secret), nil
 }
 
 func (t *Authorizer) nodeIndex(obj interface{}) ([]string, error) {

--- a/pkg/tunnelserver/mcmauthorizer/tunnel_test.go
+++ b/pkg/tunnelserver/mcmauthorizer/tunnel_test.go
@@ -2,7 +2,115 @@ package mcmauthorizer
 
 import (
 	"testing"
+
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 )
+
+func newTestSecretIndexer(t *testing.T, secrets ...*corev1.Secret) cache.Indexer {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		SecretTokenIndex: func(obj interface{}) ([]string, error) {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return nil, nil
+			}
+			return (&Authorizer{}).secretTokenIndex(secret)
+		},
+	})
+	for _, s := range secrets {
+		if err := indexer.Add(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return indexer
+}
+
+func tokenSecret(namespace, name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data:       data,
+	}
+}
+
+func TestGetClusterByToken(t *testing.T) {
+	cluster := &apimgmtv3.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c-abc"}}
+	clusterLister := &fakes.ClusterListerMock{
+		GetFunc: func(namespace, name string) (*apimgmtv3.Cluster, error) {
+			if name == "c-abc" {
+				return cluster, nil
+			}
+			return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "clusters"}, name)
+		},
+	}
+
+	tests := []struct {
+		name       string
+		secrets    []*corev1.Secret
+		token      string
+		wantResult *apimgmtv3.Cluster
+		wantErr    error
+	}{
+		{
+			name: "current token matches",
+			secrets: []*corev1.Secret{
+				tokenSecret("c-abc", "crt-token-system", map[string][]byte{"token": []byte("tok")}),
+			},
+			token:      "tok",
+			wantResult: cluster,
+		},
+		{
+			name: "previous token matches during rotation",
+			secrets: []*corev1.Secret{
+				tokenSecret("c-abc", "crt-token-system", map[string][]byte{
+					"token":         []byte("new-tok"),
+					"previousToken": []byte("old-tok"),
+				}),
+			},
+			token:      "old-tok",
+			wantResult: cluster,
+		},
+		{
+			name: "non-token secret with matching data is ignored",
+			secrets: []*corev1.Secret{
+				tokenSecret("c-abc", "unrelated-secret", map[string][]byte{"token": []byte("tok")}),
+			},
+			token:   "tok",
+			wantErr: ErrClusterNotFound,
+		},
+		{
+			name: "secret namespace has no matching cluster",
+			secrets: []*corev1.Secret{
+				tokenSecret("c-missing", "crt-token-system", map[string][]byte{"token": []byte("tok")}),
+			},
+			token:   "tok",
+			wantErr: ErrClusterNotFound,
+		},
+		{
+			name:    "no matching secret",
+			token:   "tok",
+			wantErr: ErrClusterNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &Authorizer{
+				secretIndexer: newTestSecretIndexer(t, tt.secrets...),
+				clusterLister: clusterLister,
+			}
+			got, err := auth.getClusterByToken(tt.token)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.wantResult, got)
+		})
+	}
+}
 
 func TestFormatAddress(t *testing.T) {
 	tests := []struct {

--- a/pkg/ui/routes.go
+++ b/pkg/ui/routes.go
@@ -9,11 +9,11 @@ import (
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 )
 
-func New(_ v3.PreferenceCache, clusterRegistrationTokenCache v3.ClusterRegistrationTokenCache, secretCache corecontrollers.SecretCache) http.Handler {
+func New(_ v3.PreferenceCache, secretCache corecontrollers.SecretCache) http.Handler {
 	router := http.NewServeMux()
 
 	router.Handle("/{$}", PreferredIndex())
-	router.Handle("/cacerts", cacerts.Handler(clusterRegistrationTokenCache, secretCache))
+	router.Handle("/cacerts", cacerts.Handler(secretCache))
 	router.Handle("/dashboard", http.RedirectHandler("/dashboard/", http.StatusFound))
 	router.Handle("/humans.txt", vue.ServeAsset())
 	router.Handle("/robots.txt", vue.ServeAsset())

--- a/pkg/ui/routes_test.go
+++ b/pkg/ui/routes_test.go
@@ -7,17 +7,17 @@ import (
 	"path/filepath"
 	"testing"
 
-	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestRoutes_Vue(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockCache := fake.NewMockCacheInterface[*apimgmtv3.ClusterRegistrationToken](ctrl)
-	// cacerts.Handler calls AddIndexer
+	mockCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	// cacerts.Handler calls AddIndexer on the secret cache
 	mockCache.EXPECT().AddIndexer(gomock.Any(), gomock.Any()).AnyTimes()
 
 	tempDir, err := os.MkdirTemp("", "ui-test")
@@ -68,7 +68,7 @@ func TestRoutes_Vue(t *testing.T) {
 		settings.UIOfflinePreferred.Set(origOffline)
 	}()
 
-	handler := New(nil, mockCache, nil)
+	handler := New(nil, mockCache)
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
CRT indexers read from the secret cache at index-build time, but if the CRT informer syncs before the secret informer, the index would be permanently stale. Rework to use secret based indexer and eliminate the cross-cache dependency. 