### PR TITLE
Update forums URL to forums.suse.com and copyright year to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rancher is an open source container management platform built for organizations 
 <!-- stable v2.14.3 DO NOT REMOVE THIS LINE -->
 * v2.14.3 - `rancher/rancher:v2.14.3` / `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.14.3).
   
-To get automated notifications of our latest release, you can watch the announcements category in our [forums](http://forums.rancher.com/c/announcements), or subscribe to the RSS feed `https://forums.rancher.com/c/announcements.rss`.
+To get automated notifications of our latest release, you can watch the announcements category in our [forums](https://forums.suse.com/c/announcements/12), or subscribe to the RSS feed `https://forums.suse.com/c/announcements/12.rss`.
 
 ## Quick Start
 
@@ -52,7 +52,7 @@ For security issues, please first check our [security policy](https://github.com
 
 # License
 
-Copyright (c) 2014-2025 [SUSE](http://rancher.com)
+Copyright (c) 2014-2026 [SUSE](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Issue: N/A — docs cleanup, no tracked issue
## Problem
README pointed to the old Rancher Forums announcement URLs (`http://forums.rancher.com/c/announcements` and `https://forums.rancher.com/c/announcements.rss`), which no longer reflect where SUSE hosts release announcements. Copyright notice also still said `2014-2025`, out of date for 2026.
## Solution
Updated both forum links in README.md to the current SUSE forums location (`https://forums.suse.com/c/announcements/12` and `.../12.rss`), and bumped the copyright year to `2014-2026`.
## Testing
## Engineering Testing
### Manual Testing
Rendered README.md locally and confirmed links point to the correct SUSE forum category and RSS feed. No application code touched.
### Automated Testing
* Test types added/modified:
    * None
* If "None" - Reason: No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
## QA Testing Considerations
None — documentation-only change, no functional/install/upgrade impact.
### Regressions Considerations
No regression risk: change is limited to two URLs and a copyright year in README.md.
Existing / newly added automated tests that provide evidence there are no regressions:
* N/A (no code paths affected)