### PR TITLE
[Backport v2.11] Restrict cluster-impersonation.

### DIFF
--- a/pkg/auth/requests/sar/middleware.go
+++ b/pkg/auth/requests/sar/middleware.go
@@ -3,31 +3,37 @@ package sar
 import (
 	"net/http"
 
+	"github.com/sirupsen/logrus"
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 
 	"github.com/rancher/rancher/pkg/auth/util"
 )
 
 // NewSubjectAccessReviewHandler provides an HTTP middleware validating that the user has access to the provided resource attributes.
-// User and groups information is taken from Impersonate-User and Impersonate-Group headers from the HTTP request
+// User and groups information is taken from the authenticated user stored in the request context by the authentication layer.
 func NewSubjectAccessReviewHandler(client authorizationv1client.SubjectAccessReviewInterface, resourceAttributes *authv1.ResourceAttributes) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			user := req.Header.Get("Impersonate-User")
-			groups := req.Header["Impersonate-Groups"]
+			userInfo, ok := request.UserFrom(req.Context())
+			if !ok {
+				util.ReturnHTTPError(rw, req, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+				return
+			}
 			review := authv1.SubjectAccessReview{
 				Spec: authv1.SubjectAccessReviewSpec{
-					User:               user,
-					Groups:             groups,
+					User:               userInfo.GetName(),
+					Groups:             userInfo.GetGroups(),
 					ResourceAttributes: resourceAttributes,
 				},
 			}
 
 			result, err := client.Create(req.Context(), &review, metav1.CreateOptions{})
 			if err != nil {
-				util.ReturnHTTPError(rw, req, http.StatusInternalServerError, err.Error())
+				logrus.Errorf("[SAR middleware] subject access review failed: %v", err)
+				util.ReturnHTTPError(rw, req, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
 				return
 			}
 

--- a/pkg/auth/requests/sar/middleware_test.go
+++ b/pkg/auth/requests/sar/middleware_test.go
@@ -1,0 +1,173 @@
+package sar
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	authV1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func TestNewSubjectAccessReviewHandler(t *testing.T) {
+	tests := map[string]struct {
+		result         *authV1.SubjectAccessReview
+		createErr      error
+		expectedStatus int
+		expectNext     bool
+		assertReview   func(t *testing.T, review *authV1.SubjectAccessReview)
+	}{
+		"allowed request": {
+			result: &authV1.SubjectAccessReview{
+				Status: authV1.SubjectAccessReviewStatus{Allowed: true},
+			},
+			expectedStatus: http.StatusTeapot,
+			expectNext:     true,
+			assertReview: func(t *testing.T, review *authV1.SubjectAccessReview) {
+				assert.Equal(t, "user-1", review.Spec.User)
+				assert.Equal(t, []string{"group-1", "group-2"}, review.Spec.Groups)
+				if assert.NotNil(t, review.Spec.ResourceAttributes) {
+					assert.Equal(t, "get", review.Spec.ResourceAttributes.Verb)
+					assert.Equal(t, "clusters", review.Spec.ResourceAttributes.Resource)
+					assert.Equal(t, "c-1", review.Spec.ResourceAttributes.Name)
+				}
+			},
+		},
+		"denied request": {
+			result: &authV1.SubjectAccessReview{
+				Status: authV1.SubjectAccessReviewStatus{Allowed: false},
+			},
+			expectedStatus: http.StatusUnauthorized,
+			expectNext:     false,
+			assertReview: func(t *testing.T, review *authV1.SubjectAccessReview) {
+				assert.Equal(t, "user-1", review.Spec.User)
+				assert.Equal(t, []string{"group-1", "group-2"}, review.Spec.Groups)
+			},
+		},
+		"create error": {
+			createErr:      errors.New("backend unavailable"),
+			expectedStatus: http.StatusInternalServerError,
+			expectNext:     false,
+			assertReview: func(t *testing.T, review *authV1.SubjectAccessReview) {
+				assert.Equal(t, "user-1", review.Spec.User)
+				assert.Equal(t, []string{"group-1", "group-2"}, review.Spec.Groups)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resourceAttributes := &authV1.ResourceAttributes{
+				Verb:     "get",
+				Resource: "clusters",
+				Name:     "c-1",
+			}
+
+			var nextCalled bool
+			client := stubSubjectAccessReviewClient{
+				createFunc: func(ctx context.Context, review *authV1.SubjectAccessReview, opts metav1.CreateOptions) (*authV1.SubjectAccessReview, error) {
+					assert.Equal(t, metav1.CreateOptions{}, opts)
+					test.assertReview(t, review)
+					return test.result, test.createErr
+				},
+			}
+
+			handler := NewSubjectAccessReviewHandler(client, resourceAttributes)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				nextCalled = true
+				rw.WriteHeader(http.StatusTeapot)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/v1/clusters/c-1", nil)
+			req = req.WithContext(request.WithUser(req.Context(), &user.DefaultInfo{
+				Name:   "user-1",
+				Groups: []string{"group-1", "group-2"},
+			}))
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, test.expectedStatus, rr.Code)
+			assert.Equal(t, test.expectNext, nextCalled)
+		})
+	}
+}
+
+func TestNewSubjectAccessReviewHandlerUntrustedImpersonateHeaders(t *testing.T) {
+	tests := map[string]struct {
+		forgedUser   string
+		forgedGroups []string
+	}{
+		"forged cluster-admin user header": {
+			forgedUser:   "cluster-admin",
+			forgedGroups: nil,
+		},
+		"forged system:masters group header": {
+			forgedUser:   "nobody",
+			forgedGroups: []string{"system:masters"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resourceAttributes := &authV1.ResourceAttributes{
+				Verb:     "get",
+				Resource: "secrets",
+			}
+
+			// The SAR backend would return Allowed: true if ever called — but after
+			// the fix it must never be reached for a request with no auth context.
+			var sarCalled bool
+			client := stubSubjectAccessReviewClient{
+				createFunc: func(_ context.Context, _ *authV1.SubjectAccessReview, _ metav1.CreateOptions) (*authV1.SubjectAccessReview, error) {
+					sarCalled = true
+					return &authV1.SubjectAccessReview{
+						Status: authV1.SubjectAccessReviewStatus{Allowed: true},
+					}, nil
+				},
+			}
+
+			var nextCalled bool
+			handler := NewSubjectAccessReviewHandler(client, resourceAttributes)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				nextCalled = true
+				rw.WriteHeader(http.StatusOK)
+			}))
+
+			// The request carries no real authentication — only forged headers and no
+			// authenticated user in the context.
+			req := httptest.NewRequest(http.MethodGet, "/v1/secrets", nil)
+			req.Header.Set("Impersonate-User", test.forgedUser)
+			for _, g := range test.forgedGroups {
+				req.Header.Add("Impersonate-Group", g)
+			}
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			// The SAR must not be called — the middleware should reject the request
+			// before reaching the authorisation check.
+			assert.False(t, sarCalled,
+				"SAR must not be called when there is no authenticated user in the request context (case %q)", name)
+			assert.False(t, nextCalled,
+				"handler must not admit a request with no authenticated user in context (case %q)", name)
+			assert.Equal(t, http.StatusUnauthorized, rr.Code,
+				"handler must return 401 when there is no authenticated user in context (case %q)", name)
+		})
+	}
+}
+
+type stubSubjectAccessReviewClient struct {
+	createFunc func(ctx context.Context, review *authV1.SubjectAccessReview, opts metav1.CreateOptions) (*authV1.SubjectAccessReview, error)
+}
+
+func (s stubSubjectAccessReviewClient) Create(ctx context.Context, review *authV1.SubjectAccessReview, opts metav1.CreateOptions) (*authV1.SubjectAccessReview, error) {
+	return s.createFunc(ctx, review, opts)
+}

--- a/pkg/auth/requests/sar/sar.go
+++ b/pkg/auth/requests/sar/sar.go
@@ -2,12 +2,15 @@ package sar
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/sirupsen/logrus"
-	authV1 "k8s.io/api/authorization/v1"
+	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
 // SubjectAccessReview checks if a user can impersonate as another user or group
@@ -22,61 +25,44 @@ type SubjectAccessReview interface {
 	UserCanImpersonateServiceAccount(req *http.Request, user string, sa string) (bool, error)
 }
 
+// subjectAccessReview implements SubjectAccessReview interface.
 type subjectAccessReview struct {
-	sarClientGetter SubjectAccessReviewClientGetter
+	sarClient authorizationv1.SubjectAccessReviewInterface
 }
 
-type SubjectAccessReviewClientGetter interface {
-	SubjectAccessReviewForCluster(request *http.Request) (v1.SubjectAccessReviewInterface, error)
-}
-
-func NewSubjectAccessReview(getter SubjectAccessReviewClientGetter) SubjectAccessReview {
+// NewSubjectAccessReview creates a new SubjectAccessReview with the given
+// SubjectAccessReviewInterface client for performing SAR checks.
+func NewSubjectAccessReview(sarClient authorizationv1.SubjectAccessReviewInterface) SubjectAccessReview {
 	return subjectAccessReview{
-		sarClientGetter: getter,
+		sarClient: sarClient,
 	}
 }
 
 // UserCanImpersonateUser checks if user can impersonate as impUser
 func (sar subjectAccessReview) UserCanImpersonateUser(req *http.Request, user, impUser string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateUser(req.Context(), userContext, user, impUser)
-}
-
-// UserCanImpersonateGroup checks if user can impersonate as the group
-func (sar subjectAccessReview) UserCanImpersonateGroup(req *http.Request, user string, group string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateGroup(req.Context(), userContext, user, group)
-}
-
-// UserCanImpersonateExtras checks if user can impersonate extras
-func (sar subjectAccessReview) UserCanImpersonateExtras(req *http.Request, user string, impExtras map[string][]string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateExtras(req.Context(), userContext, user, impExtras)
+	return sar.checkUserCanImpersonateUser(req.Context(), user, impUser)
 }
 
 // UserCanImpersonateServiceAccount checks if user can impersonate as the service account
 func (sar subjectAccessReview) UserCanImpersonateServiceAccount(req *http.Request, user string, sa string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateServiceAccount(req.Context(), userContext, user, sa)
+	return sar.checkUserCanImpersonateServiceAccount(req.Context(), user, sa)
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user, impUser string) (bool, error) {
-	review := authV1.SubjectAccessReview{
-		Spec: authV1.SubjectAccessReviewSpec{
+// UserCanImpersonateGroup checks if user can impersonate as the group
+func (s subjectAccessReview) UserCanImpersonateGroup(req *http.Request, user string, group string) (bool, error) {
+	return s.checkUserCanImpersonateGroup(req.Context(), user, group)
+}
+
+// UserCanImpersonateExtras checks if user can impersonate extras
+func (s subjectAccessReview) UserCanImpersonateExtras(req *http.Request, user string, impExtras map[string][]string) (bool, error) {
+	return s.checkUserCanImpersonateExtras(req.Context(), user, impExtras)
+}
+
+func (s subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, user, impUser string) (bool, error) {
+	review := authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			User: user,
-			ResourceAttributes: &authV1.ResourceAttributes{
+			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:     "impersonate",
 				Resource: "users",
 				Name:     impUser,
@@ -84,7 +70,7 @@ func (sar subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, 
 		},
 	}
 
-	result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+	result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -92,11 +78,11 @@ func (sar subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, 
 	return result.Status.Allowed, nil
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user string, group string) (bool, error) {
-	review := authV1.SubjectAccessReview{
-		Spec: authV1.SubjectAccessReviewSpec{
+func (s subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context, user, group string) (bool, error) {
+	review := authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			User: user,
-			ResourceAttributes: &authV1.ResourceAttributes{
+			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:     "impersonate",
 				Resource: "groups",
 				Name:     group,
@@ -104,7 +90,7 @@ func (sar subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context,
 		},
 	}
 
-	result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+	result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -113,13 +99,16 @@ func (sar subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context,
 	return result.Status.Allowed, nil
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user string, extras map[string][]string) (bool, error) {
+func (s subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context, user string, extras map[string][]string) (bool, error) {
 	for name, values := range extras {
+		if err := validateExtraKey(name); err != nil {
+			return false, err
+		}
 		for _, value := range values {
-			review := authV1.SubjectAccessReview{
-				Spec: authV1.SubjectAccessReviewSpec{
+			review := authv1.SubjectAccessReview{
+				Spec: authv1.SubjectAccessReviewSpec{
 					User: user,
-					ResourceAttributes: &authV1.ResourceAttributes{
+					ResourceAttributes: &authv1.ResourceAttributes{
 						Verb:     "impersonate",
 						Resource: "userextras/" + name,
 						Name:     value,
@@ -127,7 +116,7 @@ func (sar subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context
 				},
 			}
 
-			result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+			result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -141,11 +130,11 @@ func (sar subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context
 	return true, nil
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateServiceAccount(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user string, sa string) (bool, error) {
-	review := authV1.SubjectAccessReview{
-		Spec: authV1.SubjectAccessReviewSpec{
+func (s subjectAccessReview) checkUserCanImpersonateServiceAccount(ctx context.Context, user, sa string) (bool, error) {
+	review := authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			User: user,
-			ResourceAttributes: &authV1.ResourceAttributes{
+			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:     "impersonate",
 				Resource: "serviceaccounts",
 				Name:     sa,
@@ -153,10 +142,20 @@ func (sar subjectAccessReview) checkUserCanImpersonateServiceAccount(ctx context
 		},
 	}
 
-	result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+	result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 	if err != nil {
 		return false, err
 	}
 	logrus.Debugf("Impersonate sa check result: %v", result)
 	return result.Status.Allowed, nil
+}
+
+func validateExtraKey(name string) error {
+	if name == "" {
+		return errors.New("extra key must not be empty")
+	}
+	if strings.Contains(name, "/") {
+		return fmt.Errorf("extra key %q must not contain '/'", name)
+	}
+	return nil
 }

--- a/pkg/auth/requests/sar/sar_test.go
+++ b/pkg/auth/requests/sar/sar_test.go
@@ -1,6 +1,7 @@
 package sar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -10,23 +11,22 @@ import (
 	"go.uber.org/mock/gomock"
 	authV1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
 func TestUserCanImpersonateUser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	err := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, user string, impUser string) SubjectAccessReviewClientGetter
-		user                string
-		impUser             string
-		expectedAuthed      bool
-		expecterErr         error
+		sarClientFunc  func(req *http.Request, user, impGroup string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		impUser        string
+		expectedAuthed bool
+		expecterErr    error
 	}{
 		"can impersonate": {
-			sarClientGetterMock: func(req *http.Request, user string, impUser string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, impUser string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -44,19 +44,15 @@ func TestUserCanImpersonateUser(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			impUser:        "impUser",
 			expectedAuthed: true,
-			expecterErr:    nil,
 		},
-		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, user string, impUser string) SubjectAccessReviewClientGetter {
+		"can impersonate with group permission": {
+			sarClientFunc: func(req *http.Request, user, impUser string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
-
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
 						User: user,
@@ -67,13 +63,38 @@ func TestUserCanImpersonateUser(t *testing.T) {
 						},
 					},
 				}
-				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
+				sarClientMock.EXPECT().Create(gomock.Any(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
+					Status: authV1.SubjectAccessReviewStatus{
+						Allowed: true,
+					},
+				}, nil)
+
+				return sarClientMock
+			},
+			user:           "user",
+			impUser:        "impUser",
+			expectedAuthed: true,
+		},
+		"impersonate not allowed": {
+			sarClientFunc: func(req *http.Request, user, impGroup string) authorizationv1.SubjectAccessReviewInterface {
+				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
+				sar := authV1.SubjectAccessReview{
+					Spec: authV1.SubjectAccessReviewSpec{
+						User: user,
+						ResourceAttributes: &authV1.ResourceAttributes{
+							Verb:     "impersonate",
+							Resource: "users",
+							Name:     "impUser",
+						},
+					},
+				}
+				sarClientMock.EXPECT().Create(gomock.Any(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
 					Status: authV1.SubjectAccessReviewStatus{
 						Allowed: false,
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			impUser:        "impUser",
@@ -81,10 +102,8 @@ func TestUserCanImpersonateUser(t *testing.T) {
 			expecterErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, user string, impUser string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, impUser string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -98,7 +117,7 @@ func TestUserCanImpersonateUser(t *testing.T) {
 				}
 				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(nil, err)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			impUser:        "impUser",
@@ -111,7 +130,7 @@ func TestUserCanImpersonateUser(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.user, test.impUser))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.user, test.impUser))
 
 			authed, err := sar.UserCanImpersonateUser(req, test.user, test.impUser)
 			assert.Equal(t, test.expecterErr, err)
@@ -122,19 +141,17 @@ func TestUserCanImpersonateUser(t *testing.T) {
 
 func TestUserCanImpersonateGroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	err := errors.New("unexpected error")
+	unexpectedErr := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, user string, impGroup string) SubjectAccessReviewClientGetter
-		user                string
-		group               string
-		expectedAuthed      bool
-		expecterErr         error
+		sarClientFunc  func(req *http.Request, user, impGroup string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		group          string
+		expectedAuthed bool
+		expectedErr    error
 	}{
 		"can impersonate": {
-			sarClientGetterMock: func(req *http.Request, user string, impGroup string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -152,18 +169,42 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			group:          "admin",
 			expectedAuthed: true,
-			expecterErr:    nil,
+		},
+		"can impersonate with group permission": {
+			sarClientFunc: func(req *http.Request, user, impGroup string) authorizationv1.SubjectAccessReviewInterface {
+				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
+
+				sar := authV1.SubjectAccessReview{
+					Spec: authV1.SubjectAccessReviewSpec{
+						User: user,
+						ResourceAttributes: &authV1.ResourceAttributes{
+							Verb:     "impersonate",
+							Resource: "groups",
+							Name:     impGroup,
+						},
+					},
+				}
+				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
+					Status: authV1.SubjectAccessReviewStatus{
+						Allowed: true,
+					},
+				}, nil)
+
+				return sarClientMock
+			},
+			user:           "u-tifl6nuj5i",
+			group:          "admin",
+			expectedAuthed: true,
+			expectedErr:    nil,
 		},
 		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, user string, impGroup string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -181,19 +222,15 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			group:          "admin",
 			expectedAuthed: false,
-			expecterErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, user string, impGroup string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
-
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
 						User: user,
@@ -204,14 +241,14 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 						},
 					},
 				}
-				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(nil, err)
+				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(nil, unexpectedErr)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			group:          "admin",
 			expectedAuthed: false,
-			expecterErr:    err,
+			expectedErr:    unexpectedErr,
 		},
 	}
 
@@ -219,10 +256,10 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.user, test.group))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.user, test.group))
 
 			authed, err := sar.UserCanImpersonateGroup(req, test.user, test.group)
-			assert.Equal(t, test.expecterErr, err)
+			assert.Equal(t, err, test.expectedErr)
 			assert.Equal(t, test.expectedAuthed, authed)
 		})
 	}
@@ -232,17 +269,15 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	err := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, impExtras map[string][]string, user string) SubjectAccessReviewClientGetter
-		user                string
-		extras              map[string][]string
-		expectedAuthed      bool
-		expecterErr         error
+		sarClientFunc  func(req *http.Request, impExtras map[string][]string, user string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		extras         map[string][]string
+		expectedAuthed bool
+		expectedErr    error
 	}{
 		"can impersonate": {
-			sarClientGetterMock: func(req *http.Request, impExtras map[string][]string, user string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				for name, values := range impExtras {
 					for _, value := range values {
@@ -265,18 +300,47 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 					}
 				}
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			extras:         map[string][]string{"extra": {"extra1", "extra2"}},
 			expectedAuthed: true,
-			expecterErr:    nil,
+		},
+		"can impersonate with group permission": {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string) authorizationv1.SubjectAccessReviewInterface {
+				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
+
+				for name, values := range impExtras {
+					for _, value := range values {
+						sar := authV1.SubjectAccessReview{
+							Spec: authV1.SubjectAccessReviewSpec{
+								User: user,
+								ResourceAttributes: &authV1.ResourceAttributes{
+									Verb:     "impersonate",
+									Resource: "userextras/" + name,
+									Name:     value,
+								},
+							},
+						}
+						sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
+							Status: authV1.SubjectAccessReviewStatus{
+								Allowed: true,
+							},
+						}, nil)
+
+					}
+				}
+
+				return sarClientMock
+			},
+			user:           "u-tifl6nuj5i",
+			extras:         map[string][]string{"extra": {"extra1"}},
+			expectedAuthed: true,
+			expectedErr:    nil,
 		},
 		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, impExtras map[string][]string, user string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				for name, values := range impExtras {
 					for _, value := range values {
@@ -299,18 +363,15 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 					}
 				}
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			extras:         map[string][]string{"extra": {"extra1"}},
 			expectedAuthed: false,
-			expecterErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, impExtras map[string][]string, user string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				for name, values := range impExtras {
 					for _, value := range values {
@@ -328,12 +389,12 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 					}
 				}
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			extras:         map[string][]string{"extra": {"extra1"}},
 			expectedAuthed: false,
-			expecterErr:    err,
+			expectedErr:    err,
 		},
 	}
 
@@ -341,10 +402,10 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.extras, test.user))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.extras, test.user))
 
 			authed, err := sar.UserCanImpersonateExtras(req, test.user, test.extras)
-			assert.Equal(t, test.expecterErr, err)
+			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedAuthed, authed)
 		})
 	}
@@ -354,17 +415,16 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	err := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, user string, impSA string) SubjectAccessReviewClientGetter
-		user                string
-		impSA               string
-		expectedAuthed      bool
-		expecterErr         error
+		sarClientFunc  func(req *http.Request, user, impSA string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		impSA          string
+		saName         string
+		expectedAuthed bool
+		expectedErr    error
 	}{
-		"can impersonate": {
-			sarClientGetterMock: func(req *http.Request, user string, impSA string) SubjectAccessReviewClientGetter {
+		"can impersonate with direct user permission": {
+			sarClientFunc: func(req *http.Request, user string, impSA string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -382,18 +442,43 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			impSA:          "impSA",
 			expectedAuthed: true,
-			expecterErr:    nil,
+		},
+		"can impersonate with group permission (Azure AD group)": {
+			sarClientFunc: func(req *http.Request, user string, impSA string) authorizationv1.SubjectAccessReviewInterface {
+				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
+
+				sar := authV1.SubjectAccessReview{
+					Spec: authV1.SubjectAccessReviewSpec{
+						User: user,
+						ResourceAttributes: &authV1.ResourceAttributes{
+							Verb:     "impersonate",
+							Resource: "serviceaccounts",
+							Name:     impSA,
+						},
+					},
+				}
+				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
+					Status: authV1.SubjectAccessReviewStatus{
+						Allowed: true,
+					},
+				}, nil)
+
+				return sarClientMock
+			},
+			user:           "u-tifl6nuj5i",
+			impSA:          "system:serviceaccount:example-ns:example-test",
+			saName:         "system:serviceaccount:example-ns:example-test",
+			expectedAuthed: true,
+			expectedErr:    nil,
 		},
 		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, user string, impSA string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user, impSA string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -411,18 +496,15 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			impSA:          "impSA",
 			expectedAuthed: false,
-			expecterErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, user string, impSA string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user, impSA string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -436,12 +518,12 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 				}
 				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(nil, err)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			impSA:          "impUser",
 			expectedAuthed: false,
-			expecterErr:    err,
+			expectedErr:    err,
 		},
 	}
 
@@ -449,11 +531,50 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.user, test.impSA))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.user, test.impSA))
 
 			authed, err := sar.UserCanImpersonateServiceAccount(req, test.user, test.impSA)
-			assert.Equal(t, test.expecterErr, err)
+			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedAuthed, authed)
+		})
+	}
+}
+
+func TestUserCanImpersonateExtrasWithMaliciousKey(t *testing.T) {
+	tests := map[string]struct {
+		extras map[string][]string
+	}{
+		"path traversal via dotdot-slash in key": {
+			extras: map[string][]string{"../users": {"admin"}},
+		},
+		"forward slash splits resource path": {
+			extras: map[string][]string{"some/key": {"value"}},
+		},
+		"empty key": {
+			extras: map[string][]string{"": {"value"}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// The stub always returns Allowed: true so that if the key is not validated
+			// the call succeeds — causing authed=true and err=nil, which fails the
+			// assertions below and proves the vulnerability is present.
+			getter := &stubSubjectAccessReviewClient{
+				createFunc: func(_ context.Context, _ *authV1.SubjectAccessReview, _ metav1.CreateOptions) (*authV1.SubjectAccessReview, error) {
+					return &authV1.SubjectAccessReview{
+						Status: authV1.SubjectAccessReviewStatus{Allowed: true},
+					}, nil
+				},
+			}
+
+			req := &http.Request{}
+			s := NewSubjectAccessReview(getter)
+
+			authed, err := s.UserCanImpersonateExtras(req, "user", test.extras)
+			assert.False(t, authed, "impersonation should be denied for malicious extra key in case %q", name)
+			assert.Error(t, err, "expected an error for malicious extra key in case %q", name)
 		})
 	}
 }

--- a/pkg/auth/requests/service_account.go
+++ b/pkg/auth/requests/service_account.go
@@ -131,6 +131,11 @@ func (t *ServiceAccountAuth) Authenticate(req *http.Request) (user.Info, bool, e
 		return info, false, nil
 	}
 
+	if tokenReview.Status.Error != "" {
+		logrus.Debugf("saauth: tokenReview returned an error: %s", tokenReview.Status.Error)
+		return info, false, nil
+	}
+
 	// Let others know that this request is authenticated using a service account.
 	*req = *req.WithContext(authcontext.SetSAAuthenticated(req.Context()))
 

--- a/pkg/auth/requests/service_account_test.go
+++ b/pkg/auth/requests/service_account_test.go
@@ -70,17 +70,18 @@ func TestIsTokenExpired(t *testing.T) {
 func TestServiceAccountAuthAuthenticate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name                  string
-		startUser             string
-		expectedUser          string
-		settingEnabled        bool
-		token                 string
-		tokenReviewAuthStatus bool
-		downstreamRequest     *http.Request
-		clusterID             string
-		isAuthenticated       bool
-		expectedError         bool
-		omitProxyConfig       bool
+		name                   string
+		startUser              string
+		expectedUser           string
+		settingEnabled         bool
+		token                  string
+		tokenReviewAuthStatus  bool
+		tokenReviewStatusError string
+		downstreamRequest      *http.Request
+		clusterID              string
+		isAuthenticated        bool
+		expectedError          bool
+		omitProxyConfig        bool
 	}{
 		{
 			name: "everything valid auth succeeds secure mode",
@@ -223,6 +224,43 @@ func TestServiceAccountAuthAuthenticate(t *testing.T) {
 			isAuthenticated:       true,
 			expectedError:         false,
 		},
+		// A successful HTTP response from the downstream cluster can still carry a
+		// non-empty Status.Error. The authenticator should treat this as a failure
+		// and return unauthenticated, not trust the Status.User or Status.Authenticated fields.
+		{
+			name: "token review status error should not authenticate",
+			token: makeJWT(jwtv4.MapClaims{
+				"sub": "system:serviceaccount:vault:token-reviewer",
+				"exp": time.Now().Add(time.Hour).Unix(),
+			}),
+			startUser:              "system:cattle:error",
+			expectedUser:           "system:cattle:error",
+			settingEnabled:         true,
+			tokenReviewAuthStatus:  false,
+			tokenReviewStatusError: "token has been revoked",
+			downstreamRequest:      generateDownstreamRequest("POST", "testclusterid"+tokenReviewSuffix),
+			clusterID:              "testclusterid",
+			isAuthenticated:        false,
+			expectedError:          false,
+		},
+		{
+			name: "token review status error with authenticated true should not authenticate",
+			// Kubernetes should never set Authenticated=true alongside a non-empty
+			// Error, but a defensive implementation must handle this edge case.
+			token: makeJWT(jwtv4.MapClaims{
+				"sub": "system:serviceaccount:vault:token-reviewer",
+				"exp": time.Now().Add(time.Hour).Unix(),
+			}),
+			startUser:              "system:cattle:error",
+			expectedUser:           "system:cattle:error",
+			settingEnabled:         true,
+			tokenReviewAuthStatus:  true,
+			tokenReviewStatusError: "token lookup failed",
+			downstreamRequest:      generateDownstreamRequest("POST", "testclusterid"+tokenReviewSuffix),
+			clusterID:              "testclusterid",
+			isAuthenticated:        false,
+			expectedError:          false,
+		},
 	}
 
 	for _, test := range tests {
@@ -263,6 +301,7 @@ func TestServiceAccountAuthAuthenticate(t *testing.T) {
 							},
 							Status: v1.TokenReviewStatus{
 								Authenticated: test.tokenReviewAuthStatus,
+								Error:         test.tokenReviewStatusError,
 								Audiences:     []string{},
 								User: v1.UserInfo{
 									Username: test.expectedUser,

--- a/pkg/auth/requests/token_review.go
+++ b/pkg/auth/requests/token_review.go
@@ -13,6 +13,8 @@ import (
 	authv1 "k8s.io/client-go/kubernetes/typed/authentication/v1"
 )
 
+const errorUserName string = "system:cattle:error"
+
 type TokenReviewAuth struct {
 	AuthClient authv1.AuthenticationV1Interface
 }
@@ -28,7 +30,7 @@ func NewTokenReviewAuth(authClient authv1.AuthenticationV1Interface) auth.Authen
 // review to authenticate token and extract user info.
 func (t *TokenReviewAuth) Authenticate(req *http.Request) (user.Info, bool, error) {
 	info, hasAuth := request.UserFrom(req.Context())
-	if info.GetName() != "system:cattle:error" {
+	if info.GetName() != errorUserName {
 		// auth has succeeded
 		return info, hasAuth, nil
 	}
@@ -46,6 +48,11 @@ func (t *TokenReviewAuth) Authenticate(req *http.Request) (user.Info, bool, erro
 	tokenReview, err := t.AuthClient.TokenReviews().Create(req.Context(), tokenReview, metav1.CreateOptions{})
 	if err != nil {
 		logrus.Debugf("tokenReview failed: %v", err)
+		return info, false, nil
+	}
+
+	if tokenReview.Status.Error != "" {
+		logrus.Debugf("tokenReview returned an error: %s", tokenReview.Status.Error)
 		return info, false, nil
 	}
 

--- a/pkg/auth/requests/token_review_test.go
+++ b/pkg/auth/requests/token_review_test.go
@@ -1,0 +1,222 @@
+package requests
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+	authv1client "k8s.io/client-go/kubernetes/typed/authentication/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestTokenReviewAuthAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		userInfo         user.Info
+		authorization    string
+		reviewResponse   *authenticationv1.TokenReview
+		reviewErr        string
+		wantName         string
+		wantUID          string
+		wantGroups       []string
+		wantHasAuth      bool
+		wantReviewCalled bool
+		wantReviewToken  string
+	}{
+		"already authenticated user bypasses token review": {
+			userInfo: &user.DefaultInfo{
+				Name:   "u-123",
+				UID:    "u-123",
+				Groups: []string{"devs"},
+			},
+			wantName:    "u-123",
+			wantUID:     "u-123",
+			wantGroups:  []string{"devs"},
+			wantHasAuth: true,
+		},
+		"when the authenticated user is the error user a token review is done": {
+			userInfo: &user.DefaultInfo{
+				Name: errorUserName,
+			},
+			authorization:    "Bearer token-review-token",
+			wantReviewCalled: true,
+			wantReviewToken:  "token-review-token",
+			wantHasAuth:      true,
+		},
+		"failed auth and token review return error": {
+			userInfo: &user.DefaultInfo{
+				Name: "system:cattle:error",
+			},
+			authorization:    "Bearer token-review-token",
+			reviewErr:        "token review create failed",
+			wantName:         "system:cattle:error",
+			wantHasAuth:      false,
+			wantReviewCalled: true,
+			wantReviewToken:  "token-review-token",
+		},
+		"failed auth and token review success returns review user as authenticated": {
+			userInfo: &user.DefaultInfo{
+				Name: "system:cattle:error",
+			},
+			authorization: "Bearer review-success-token",
+			reviewResponse: &authenticationv1.TokenReview{
+				Status: authenticationv1.TokenReviewStatus{
+					Authenticated: true,
+					User: authenticationv1.UserInfo{
+						Username: "system:serviceaccount:default:my-sa",
+						UID:      "uid-1",
+						Groups:   []string{"system:serviceaccounts", "system:authenticated"},
+					},
+				},
+			},
+			wantName:         "system:serviceaccount:default:my-sa",
+			wantUID:          "uid-1",
+			wantGroups:       []string{"system:serviceaccounts", "system:authenticated"},
+			wantHasAuth:      true,
+			wantReviewCalled: true,
+			wantReviewToken:  "review-success-token",
+		},
+		"failed auth and token review success with unauthenticated status still returns review user": {
+			userInfo: &user.DefaultInfo{
+				Name: "system:cattle:error",
+			},
+			authorization: "Bearer review-not-authenticated-token",
+			reviewResponse: &authenticationv1.TokenReview{
+				Status: authenticationv1.TokenReviewStatus{
+					// The token review has returns Not Authenticated
+					Authenticated: false,
+					User: authenticationv1.UserInfo{
+						Username: "impersonated-user",
+						UID:      "uid-2",
+						Groups:   []string{"group-a"},
+					},
+				},
+			},
+			wantName:         "impersonated-user",
+			wantUID:          "uid-2",
+			wantGroups:       []string{"group-a"},
+			wantHasAuth:      true,
+			wantReviewCalled: true,
+			wantReviewToken:  "review-not-authenticated-token",
+		},
+		"token review status error with unauthenticated status should not authenticate": {
+			userInfo: &user.DefaultInfo{
+				Name: errorUserName,
+			},
+			authorization: "Bearer some-token",
+			reviewResponse: &authenticationv1.TokenReview{
+				Status: authenticationv1.TokenReviewStatus{
+					Authenticated: false,
+					Error:         "token has been revoked",
+				},
+			},
+			wantName:         errorUserName,
+			wantHasAuth:      false,
+			wantReviewCalled: true,
+			wantReviewToken:  "some-token",
+		},
+		"token review status error with authenticated true should not authenticate": {
+			userInfo: &user.DefaultInfo{
+				Name: errorUserName,
+			},
+			authorization: "Bearer some-token",
+			reviewResponse: &authenticationv1.TokenReview{
+				Status: authenticationv1.TokenReviewStatus{
+					Authenticated: true,
+					Error:         "token lookup failed",
+					User: authenticationv1.UserInfo{
+						Username: "some-user",
+						UID:      "uid-3",
+					},
+				},
+			},
+			wantName:         errorUserName,
+			wantHasAuth:      false,
+			wantReviewCalled: true,
+			wantReviewToken:  "some-token",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			reviewCalled := 0
+			var reviewToken string
+
+			authClient := &fakeAuthenticationV1{
+				tokenReviews: &fakeTokenReviewInterface{
+					create: func(_ context.Context, createdReview *authenticationv1.TokenReview, _ metav1.CreateOptions) (*authenticationv1.TokenReview, error) {
+						reviewCalled++
+						reviewToken = createdReview.Spec.Token
+
+						if tt.reviewErr != "" {
+							return nil, errors.New(tt.reviewErr)
+						}
+
+						if tt.reviewResponse != nil {
+							return tt.reviewResponse, nil
+						}
+
+						return &authenticationv1.TokenReview{}, nil
+					}},
+			}
+
+			authenticator := &TokenReviewAuth{AuthClient: authClient}
+
+			req := httptest.NewRequest(http.MethodGet, "/v1/test", nil)
+			if tt.authorization != "" {
+				req.Header.Set("Authorization", tt.authorization)
+			}
+			req = req.WithContext(k8srequest.WithUser(req.Context(), tt.userInfo))
+
+			respUser, respHasAuth, err := authenticator.Authenticate(req)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantHasAuth, respHasAuth)
+			assert.Equal(t, tt.wantName, respUser.GetName())
+			assert.Equal(t, tt.wantUID, respUser.GetUID())
+			assert.Equal(t, tt.wantGroups, respUser.GetGroups())
+
+			if tt.wantReviewCalled {
+				require.Equal(t, 1, reviewCalled)
+				assert.Equal(t, tt.wantReviewToken, reviewToken)
+			} else {
+				assert.Equal(t, 0, reviewCalled)
+			}
+		})
+	}
+}
+
+type fakeAuthenticationV1 struct {
+	tokenReviews authv1client.TokenReviewInterface
+}
+
+func (f *fakeAuthenticationV1) RESTClient() rest.Interface {
+	return nil
+}
+
+func (f *fakeAuthenticationV1) SelfSubjectReviews() authv1client.SelfSubjectReviewInterface {
+	return nil
+}
+
+func (f *fakeAuthenticationV1) TokenReviews() authv1client.TokenReviewInterface {
+	return f.tokenReviews
+}
+
+type fakeTokenReviewInterface struct {
+	create func(ctx context.Context, tokenReview *authenticationv1.TokenReview, opts metav1.CreateOptions) (*authenticationv1.TokenReview, error)
+}
+
+func (f *fakeTokenReviewInterface) Create(ctx context.Context, tokenReview *authenticationv1.TokenReview, opts metav1.CreateOptions) (*authenticationv1.TokenReview, error) {
+	return f.create(ctx, tokenReview, opts)
+}

--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -41,7 +41,7 @@ type ClusterContextGetter interface {
 type RemoteService struct {
 	sync.Mutex
 
-	cluster   *v3.Cluster
+	cluster   *v32.Cluster
 	transport transportGetter
 	url       urlGetter
 
@@ -77,14 +77,14 @@ func prefix(cluster *v3.Cluster) string {
 	return "/k8s/clusters/" + cluster.Name
 }
 
-func New(localConfig *rest.Config, cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
+func New(localConfig *rest.Config, cluster *v32.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
 	if cluster.Spec.Internal {
 		return NewLocal(localConfig, cluster)
 	}
 	return NewRemote(cluster, clusterLister, factory, clusterContextGetter)
 }
 
-func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, error) {
+func NewLocal(localConfig *rest.Config, cluster *v32.Cluster) (*RemoteService, error) {
 	// the gvk is ignored by us, so just pass in any gvk
 	hostURL, _, err := rest.DefaultServerURL(localConfig.Host, localConfig.APIPath, schema.GroupVersion{}, true)
 	if err != nil {
@@ -116,7 +116,7 @@ func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, er
 	return rs, nil
 }
 
-func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
+func NewRemote(cluster *v32.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
 	if !v32.ClusterConditionProvisioned.IsTrue(cluster) {
 		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, "cluster not provisioned")
 	}
@@ -217,7 +217,7 @@ func (r *RemoteService) getTransport() (http.RoundTripper, error) {
 	return transport, nil
 }
 
-func (r *RemoteService) cacertChanged(cluster *v3.Cluster) bool {
+func (r *RemoteService) cacertChanged(cluster *v32.Cluster) bool {
 	return r.caCert != cluster.Status.CACert
 }
 
@@ -310,7 +310,7 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	httpProxy.ServeHTTP(rw, req)
 }
 
-func (r *RemoteService) Cluster() *v3.Cluster {
+func (r *RemoteService) Cluster() *v32.Cluster {
 	return r.cluster
 }
 

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -104,7 +104,10 @@ func router(ctx context.Context, localClusterEnabled bool, tunnelAuthorizer *mcm
 	unauthed.PathPrefix("/v3-public").Handler(publicAPI)
 
 	// Authenticated routes
-	impersonatingAuth := requests.NewImpersonatingAuth(scaledContext.Wrangler, sar.NewSubjectAccessReview(clusterManager))
+	handler := sar.NewSubjectAccessReview(
+		scaledContext.K8sClient.AuthorizationV1().SubjectAccessReviews())
+
+	impersonatingAuth := requests.NewImpersonatingAuth(scaledContext.Wrangler, handler)
 	saAuth := auth.ToMiddleware(requests.NewServiceAccountAuth(scaledContext, clustermanager.ToRESTConfig))
 	accessControlHandler := rbac.NewAccessControlHandler()
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The user principal wasn't used in requests to external clusters - only impersonation headers.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This drops support for impersonation headers when making requests to the cluster.

Verification of permissions is now only done via the management cluster.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_