### PR TITLE
[Backport v2.12] Restrict cluster-impersonation.

### DIFF
--- a/pkg/auth/requests/sar/middleware.go
+++ b/pkg/auth/requests/sar/middleware.go
@@ -3,32 +3,37 @@ package sar
 import (
 	"net/http"
 
+	"github.com/sirupsen/logrus"
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
-	"k8s.io/kubernetes/pkg/apis/authentication"
 
 	"github.com/rancher/rancher/pkg/auth/util"
 )
 
 // NewSubjectAccessReviewHandler provides an HTTP middleware validating that the user has access to the provided resource attributes.
-// User and groups information is taken from Impersonate-User and Impersonate-Group headers from the HTTP request
+// User and groups information is taken from the authenticated user stored in the request context by the authentication layer.
 func NewSubjectAccessReviewHandler(client authorizationv1client.SubjectAccessReviewInterface, resourceAttributes *authv1.ResourceAttributes) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			user := req.Header.Get(authentication.ImpersonateUserHeader)
-			groups := req.Header.Values(authentication.ImpersonateGroupHeader)
+			userInfo, ok := request.UserFrom(req.Context())
+			if !ok {
+				util.ReturnHTTPError(rw, req, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+				return
+			}
 			review := authv1.SubjectAccessReview{
 				Spec: authv1.SubjectAccessReviewSpec{
-					User:               user,
-					Groups:             groups,
+					User:               userInfo.GetName(),
+					Groups:             userInfo.GetGroups(),
 					ResourceAttributes: resourceAttributes,
 				},
 			}
 
 			result, err := client.Create(req.Context(), &review, metav1.CreateOptions{})
 			if err != nil {
-				util.ReturnHTTPError(rw, req, http.StatusInternalServerError, err.Error())
+				logrus.Errorf("[SAR middleware] subject access review failed: %v", err)
+				util.ReturnHTTPError(rw, req, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
 				return
 			}
 

--- a/pkg/auth/requests/sar/middleware_test.go
+++ b/pkg/auth/requests/sar/middleware_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	authV1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 func TestNewSubjectAccessReviewHandler(t *testing.T) {
@@ -83,15 +85,81 @@ func TestNewSubjectAccessReviewHandler(t *testing.T) {
 			}))
 
 			req := httptest.NewRequest(http.MethodGet, "/v1/clusters/c-1", nil)
-			req.Header.Set("Impersonate-User", "user-1")
-			req.Header.Add("Impersonate-Group", "group-1")
-			req.Header.Add("Impersonate-Group", "group-2")
+			req = req.WithContext(request.WithUser(req.Context(), &user.DefaultInfo{
+				Name:   "user-1",
+				Groups: []string{"group-1", "group-2"},
+			}))
 			rr := httptest.NewRecorder()
 
 			handler.ServeHTTP(rr, req)
 
 			assert.Equal(t, test.expectedStatus, rr.Code)
 			assert.Equal(t, test.expectNext, nextCalled)
+		})
+	}
+}
+
+func TestNewSubjectAccessReviewHandlerUntrustedImpersonateHeaders(t *testing.T) {
+	tests := map[string]struct {
+		forgedUser   string
+		forgedGroups []string
+	}{
+		"forged cluster-admin user header": {
+			forgedUser:   "cluster-admin",
+			forgedGroups: nil,
+		},
+		"forged system:masters group header": {
+			forgedUser:   "nobody",
+			forgedGroups: []string{"system:masters"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resourceAttributes := &authV1.ResourceAttributes{
+				Verb:     "get",
+				Resource: "secrets",
+			}
+
+			// The SAR backend would return Allowed: true if ever called — but after
+			// the fix it must never be reached for a request with no auth context.
+			var sarCalled bool
+			client := stubSubjectAccessReviewClient{
+				createFunc: func(_ context.Context, _ *authV1.SubjectAccessReview, _ metav1.CreateOptions) (*authV1.SubjectAccessReview, error) {
+					sarCalled = true
+					return &authV1.SubjectAccessReview{
+						Status: authV1.SubjectAccessReviewStatus{Allowed: true},
+					}, nil
+				},
+			}
+
+			var nextCalled bool
+			handler := NewSubjectAccessReviewHandler(client, resourceAttributes)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				nextCalled = true
+				rw.WriteHeader(http.StatusOK)
+			}))
+
+			// The request carries no real authentication — only forged headers and no
+			// authenticated user in the context.
+			req := httptest.NewRequest(http.MethodGet, "/v1/secrets", nil)
+			req.Header.Set("Impersonate-User", test.forgedUser)
+			for _, g := range test.forgedGroups {
+				req.Header.Add("Impersonate-Group", g)
+			}
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			// The SAR must not be called — the middleware should reject the request
+			// before reaching the authorisation check.
+			assert.False(t, sarCalled,
+				"SAR must not be called when there is no authenticated user in the request context (case %q)", name)
+			assert.False(t, nextCalled,
+				"handler must not admit a request with no authenticated user in context (case %q)", name)
+			assert.Equal(t, http.StatusUnauthorized, rr.Code,
+				"handler must return 401 when there is no authenticated user in context (case %q)", name)
 		})
 	}
 }

--- a/pkg/auth/requests/sar/sar.go
+++ b/pkg/auth/requests/sar/sar.go
@@ -2,15 +2,16 @@ package sar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	authV1 "k8s.io/api/authorization/v1"
+	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
-	v1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
 // SubjectAccessReview checks if a user can impersonate as another user or group
@@ -25,62 +26,45 @@ type SubjectAccessReview interface {
 	UserCanImpersonateServiceAccount(req *http.Request, user string, groups []string, sa string) (bool, error)
 }
 
+// subjectAccessReview implements SubjectAccessReview interface.
 type subjectAccessReview struct {
-	sarClientGetter SubjectAccessReviewClientGetter
+	sarClient authorizationv1.SubjectAccessReviewInterface
 }
 
-type SubjectAccessReviewClientGetter interface {
-	SubjectAccessReviewForCluster(request *http.Request) (v1.SubjectAccessReviewInterface, error)
-}
-
-func NewSubjectAccessReview(getter SubjectAccessReviewClientGetter) SubjectAccessReview {
+// NewSubjectAccessReview creates a new SubjectAccessReview with the given
+// SubjectAccessReviewInterface client for performing SAR checks.
+func NewSubjectAccessReview(sarClient authorizationv1.SubjectAccessReviewInterface) SubjectAccessReview {
 	return subjectAccessReview{
-		sarClientGetter: getter,
+		sarClient: sarClient,
 	}
 }
 
 // UserCanImpersonateUser checks if user can impersonate as impUser
-func (sar subjectAccessReview) UserCanImpersonateUser(req *http.Request, user string, groups []string, impUser string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateUser(req.Context(), userContext, user, groups, impUser)
+func (s subjectAccessReview) UserCanImpersonateUser(req *http.Request, user string, groups []string, impUser string) (bool, error) {
+	return s.checkUserCanImpersonateUser(req.Context(), user, groups, impUser)
 }
 
 // UserCanImpersonateGroup checks if user can impersonate as the group
-func (sar subjectAccessReview) UserCanImpersonateGroup(req *http.Request, user string, groups []string, group string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateGroup(req.Context(), userContext, user, groups, group)
+func (s subjectAccessReview) UserCanImpersonateGroup(req *http.Request, user string, groups []string, group string) (bool, error) {
+	return s.checkUserCanImpersonateGroup(req.Context(), user, groups, group)
 }
 
 // UserCanImpersonateExtras checks if user can impersonate extras
-func (sar subjectAccessReview) UserCanImpersonateExtras(req *http.Request, user string, groups []string, impExtras map[string][]string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateExtras(req.Context(), userContext, user, groups, impExtras)
+func (s subjectAccessReview) UserCanImpersonateExtras(req *http.Request, user string, groups []string, impExtras map[string][]string) (bool, error) {
+	return s.checkUserCanImpersonateExtras(req.Context(), user, groups, impExtras)
 }
 
 // UserCanImpersonateServiceAccount checks if user can impersonate as the service account
-func (sar subjectAccessReview) UserCanImpersonateServiceAccount(req *http.Request, user string, groups []string, sa string) (bool, error) {
-	userContext, err := sar.sarClientGetter.SubjectAccessReviewForCluster(req)
-	if err != nil {
-		return false, err
-	}
-	return sar.checkUserCanImpersonateServiceAccount(req.Context(), userContext, user, groups, sa)
+func (s subjectAccessReview) UserCanImpersonateServiceAccount(req *http.Request, user string, groups []string, sa string) (bool, error) {
+	return s.checkUserCanImpersonateServiceAccount(req.Context(), user, groups, sa)
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user string, groups []string, impUser string) (bool, error) {
-	review := authV1.SubjectAccessReview{
-		Spec: authV1.SubjectAccessReviewSpec{
+func (s subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, user string, groups []string, impUser string) (bool, error) {
+	review := authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			User:   user,
 			Groups: groups,
-			ResourceAttributes: &authV1.ResourceAttributes{
+			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:     "impersonate",
 				Resource: "users",
 				Name:     impUser,
@@ -88,7 +72,7 @@ func (sar subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, 
 		},
 	}
 
-	result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+	result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -96,12 +80,12 @@ func (sar subjectAccessReview) checkUserCanImpersonateUser(ctx context.Context, 
 	return result.Status.Allowed, nil
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user string, groups []string, group string) (bool, error) {
-	review := authV1.SubjectAccessReview{
-		Spec: authV1.SubjectAccessReviewSpec{
+func (s subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context, user string, groups []string, group string) (bool, error) {
+	review := authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			User:   user,
 			Groups: groups,
-			ResourceAttributes: &authV1.ResourceAttributes{
+			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:     "impersonate",
 				Resource: "groups",
 				Name:     group,
@@ -109,7 +93,7 @@ func (sar subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context,
 		},
 	}
 
-	result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+	result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -118,14 +102,17 @@ func (sar subjectAccessReview) checkUserCanImpersonateGroup(ctx context.Context,
 	return result.Status.Allowed, nil
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user string, groups []string, extras map[string][]string) (bool, error) {
+func (s subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context, user string, groups []string, extras map[string][]string) (bool, error) {
 	for name, values := range extras {
+		if err := validateExtraKey(name); err != nil {
+			return false, err
+		}
 		for _, value := range values {
-			review := authV1.SubjectAccessReview{
-				Spec: authV1.SubjectAccessReviewSpec{
+			review := authv1.SubjectAccessReview{
+				Spec: authv1.SubjectAccessReviewSpec{
 					User:   user,
 					Groups: groups,
-					ResourceAttributes: &authV1.ResourceAttributes{
+					ResourceAttributes: &authv1.ResourceAttributes{
 						Verb:     "impersonate",
 						Resource: "userextras/" + name,
 						Name:     value,
@@ -133,7 +120,7 @@ func (sar subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context
 				},
 			}
 
-			result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+			result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -147,16 +134,16 @@ func (sar subjectAccessReview) checkUserCanImpersonateExtras(ctx context.Context
 	return true, nil
 }
 
-func (sar subjectAccessReview) checkUserCanImpersonateServiceAccount(ctx context.Context, sarClient v1.SubjectAccessReviewInterface, user string, groups []string, sa string) (bool, error) {
+func (s subjectAccessReview) checkUserCanImpersonateServiceAccount(ctx context.Context, user string, groups []string, sa string) (bool, error) {
 	saNamespace, saName, err := parseServiceAccountUsername(sa)
 	if err != nil {
 		return false, err
 	}
-	review := authV1.SubjectAccessReview{
-		Spec: authV1.SubjectAccessReviewSpec{
+	review := authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			User:   user,
 			Groups: groups,
-			ResourceAttributes: &authV1.ResourceAttributes{
+			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:      "impersonate",
 				Resource:  "serviceaccounts",
 				Namespace: saNamespace,
@@ -165,7 +152,7 @@ func (sar subjectAccessReview) checkUserCanImpersonateServiceAccount(ctx context
 		},
 	}
 
-	result, err := sarClient.Create(ctx, &review, metav1.CreateOptions{})
+	result, err := s.sarClient.Create(ctx, &review, metav1.CreateOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -182,4 +169,14 @@ func parseServiceAccountUsername(username string) (namespace string, name string
 	namespace = tokens[0]
 	name = tokens[1]
 	return namespace, name, nil
+}
+
+func validateExtraKey(name string) error {
+	if name == "" {
+		return errors.New("extra key must not be empty")
+	}
+	if strings.Contains(name, "/") {
+		return fmt.Errorf("extra key %q must not contain '/'", name)
+	}
+	return nil
 }

--- a/pkg/auth/requests/sar/sar_test.go
+++ b/pkg/auth/requests/sar/sar_test.go
@@ -1,6 +1,7 @@
 package sar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -11,24 +12,23 @@ import (
 	"go.uber.org/mock/gomock"
 	authV1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
 func TestUserCanImpersonateUser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	err := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, user string, groups []string, impUser string) SubjectAccessReviewClientGetter
-		user                string
-		groups              []string
-		impUser             string
-		expectedAuthed      bool
-		expectedErr         error
+		sarClientFunc  func(req *http.Request, user string, groups []string, impUser string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		groups         []string
+		impUser        string
+		expectedAuthed bool
+		expectedErr    error
 	}{
 		"can impersonate": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impUser string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impUser string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -47,7 +47,7 @@ func TestUserCanImpersonateUser(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -56,11 +56,8 @@ func TestUserCanImpersonateUser(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"can impersonate with group permission": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impUser string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impUser string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
-
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
 						User:   user,
@@ -72,13 +69,13 @@ func TestUserCanImpersonateUser(t *testing.T) {
 						},
 					},
 				}
-				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
+				sarClientMock.EXPECT().Create(gomock.Any(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
 					Status: authV1.SubjectAccessReviewStatus{
 						Allowed: true,
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         []string{"azuread_group://a1cc05b8-d30b-454c-be77-0830ce1eae94", "system:authenticated"},
@@ -87,11 +84,8 @@ func TestUserCanImpersonateUser(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impUser string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
-
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
 						User:   user,
@@ -99,17 +93,17 @@ func TestUserCanImpersonateUser(t *testing.T) {
 						ResourceAttributes: &authV1.ResourceAttributes{
 							Verb:     "impersonate",
 							Resource: "users",
-							Name:     impUser,
+							Name:     "impUser",
 						},
 					},
 				}
-				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
+				sarClientMock.EXPECT().Create(gomock.Any(), &sar, metav1.CreateOptions{}).Return(&authV1.SubjectAccessReview{
 					Status: authV1.SubjectAccessReviewStatus{
 						Allowed: false,
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -118,10 +112,8 @@ func TestUserCanImpersonateUser(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impUser string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impUser string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -136,7 +128,7 @@ func TestUserCanImpersonateUser(t *testing.T) {
 				}
 				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(nil, err)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -150,7 +142,7 @@ func TestUserCanImpersonateUser(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.user, test.groups, test.impUser))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.user, test.groups, test.impUser))
 
 			authed, err := sar.UserCanImpersonateUser(req, test.user, test.groups, test.impUser)
 			assert.Equal(t, test.expectedErr, err)
@@ -163,18 +155,16 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	err := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, user string, groups []string, impGroup string) SubjectAccessReviewClientGetter
-		user                string
-		groups              []string
-		group               string
-		expectedAuthed      bool
-		expectedErr         error
+		sarClientFunc  func(req *http.Request, user string, groups []string, impGroup string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		groups         []string
+		group          string
+		expectedAuthed bool
+		expectedErr    error
 	}{
 		"can impersonate": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impGroup string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -193,7 +183,7 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -202,10 +192,8 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"can impersonate with group permission": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impGroup string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -224,7 +212,7 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "u-tifl6nuj5i",
 			groups:         []string{"azuread_group://a1cc05b8-d30b-454c-be77-0830ce1eae94", "system:authenticated"},
@@ -233,10 +221,8 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impGroup string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -255,7 +241,7 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -264,11 +250,8 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impGroup string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impGroup string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
-
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
 						User:   user,
@@ -282,7 +265,7 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 				}
 				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(nil, err)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -296,7 +279,7 @@ func TestUserCanImpersonateGroup(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.user, test.groups, test.group))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.user, test.groups, test.group))
 
 			authed, err := sar.UserCanImpersonateGroup(req, test.user, test.groups, test.group)
 			assert.Equal(t, test.expectedErr, err)
@@ -309,18 +292,16 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	err := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, impExtras map[string][]string, user string, groups []string) SubjectAccessReviewClientGetter
-		user                string
-		groups              []string
-		extras              map[string][]string
-		expectedAuthed      bool
-		expectedErr         error
+		sarClientFunc  func(req *http.Request, impExtras map[string][]string, user string, groups []string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		groups         []string
+		extras         map[string][]string
+		expectedAuthed bool
+		expectedErr    error
 	}{
 		"can impersonate": {
-			sarClientGetterMock: func(req *http.Request, impExtras map[string][]string, user string, groups []string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string, groups []string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				for name, values := range impExtras {
 					for _, value := range values {
@@ -344,7 +325,7 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 					}
 				}
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -353,10 +334,8 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"can impersonate with group permission": {
-			sarClientGetterMock: func(req *http.Request, impExtras map[string][]string, user string, groups []string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string, groups []string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				for name, values := range impExtras {
 					for _, value := range values {
@@ -380,7 +359,7 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 					}
 				}
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "u-tifl6nuj5i",
 			groups:         []string{"azuread_group://a1cc05b8-d30b-454c-be77-0830ce1eae94", "system:authenticated"},
@@ -389,10 +368,8 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, impExtras map[string][]string, user string, groups []string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string, groups []string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				for name, values := range impExtras {
 					for _, value := range values {
@@ -416,7 +393,7 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 					}
 				}
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -425,10 +402,8 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, impExtras map[string][]string, user string, groups []string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, impExtras map[string][]string, user string, groups []string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				for name, values := range impExtras {
 					for _, value := range values {
@@ -447,7 +422,7 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 					}
 				}
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -461,7 +436,7 @@ func TestUserCanImpersonateExtras(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.extras, test.user, test.groups))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.extras, test.user, test.groups))
 
 			authed, err := sar.UserCanImpersonateExtras(req, test.user, test.groups, test.extras)
 			assert.Equal(t, test.expectedErr, err)
@@ -474,20 +449,18 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	err := errors.New("unexpected error")
 	tests := map[string]struct {
-		sarClientGetterMock func(req *http.Request, user string, groups []string, impSA string, ns string, name string) SubjectAccessReviewClientGetter
-		user                string
-		groups              []string
-		impSA               string
-		saNs                string
-		saName              string
-		expectedAuthed      bool
-		expectedErr         error
+		sarClientFunc  func(req *http.Request, user string, groups []string, impSA string, ns string, name string) authorizationv1.SubjectAccessReviewInterface
+		user           string
+		groups         []string
+		impSA          string
+		saNs           string
+		saName         string
+		expectedAuthed bool
+		expectedErr    error
 	}{
 		"can impersonate with direct user permission": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -507,7 +480,7 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -518,10 +491,8 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"can impersonate with group permission (Azure AD group)": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -541,7 +512,7 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "u-tifl6nuj5i",
 			groups:         []string{"azuread_group://a1cc05b8-d30b-454c-be77-0830ce1eae94", "system:authenticated"},
@@ -552,10 +523,8 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate not allowed": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -575,7 +544,7 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 					},
 				}, nil)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -586,10 +555,8 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 			expectedErr:    nil,
 		},
 		"impersonate error": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) SubjectAccessReviewClientGetter {
+			sarClientFunc: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) authorizationv1.SubjectAccessReviewInterface {
 				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
 
 				sar := authV1.SubjectAccessReview{
 					Spec: authV1.SubjectAccessReviewSpec{
@@ -605,7 +572,7 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 				}
 				sarClientMock.EXPECT().Create(req.Context(), &sar, metav1.CreateOptions{}).Return(nil, err)
 
-				return sarMock
+				return sarClientMock
 			},
 			user:           "user",
 			groups:         nil,
@@ -616,11 +583,8 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 			expectedErr:    err,
 		},
 		"impersonate parsing error": {
-			sarClientGetterMock: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) SubjectAccessReviewClientGetter {
-				sarClientMock := mocks.NewMockSubjectAccessReviewInterface(ctrl)
-				sarMock := mocks.NewMockSubjectAccessReviewClientGetter(ctrl)
-				sarMock.EXPECT().SubjectAccessReviewForCluster(req).Return(sarClientMock, nil)
-				return sarMock
+			sarClientFunc: func(req *http.Request, user string, groups []string, impSA string, ns string, name string) authorizationv1.SubjectAccessReviewInterface {
+				return mocks.NewMockSubjectAccessReviewInterface(ctrl)
 			},
 			user:           "user",
 			groups:         nil,
@@ -636,7 +600,7 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{}
-			sar := NewSubjectAccessReview(test.sarClientGetterMock(req, test.user, test.groups, test.impSA, test.saNs, test.saName))
+			sar := NewSubjectAccessReview(test.sarClientFunc(req, test.user, test.groups, test.impSA, test.saNs, test.saName))
 
 			authed, err := sar.UserCanImpersonateServiceAccount(req, test.user, test.groups, test.impSA)
 			if test.expectedErr != nil {
@@ -645,6 +609,45 @@ func TestUserCanImpersonateServiceAccount(t *testing.T) {
 				assert.Nil(t, err)
 			}
 			assert.Equal(t, test.expectedAuthed, authed)
+		})
+	}
+}
+
+func TestUserCanImpersonateExtrasWithMaliciousKey(t *testing.T) {
+	tests := map[string]struct {
+		extras map[string][]string
+	}{
+		"path traversal via dotdot-slash in key": {
+			extras: map[string][]string{"../users": {"admin"}},
+		},
+		"forward slash splits resource path": {
+			extras: map[string][]string{"some/key": {"value"}},
+		},
+		"empty key": {
+			extras: map[string][]string{"": {"value"}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// The stub always returns Allowed: true so that if the key is not validated
+			// the call succeeds — causing authed=true and err=nil, which fails the
+			// assertions below and proves the vulnerability is present.
+			getter := &stubSubjectAccessReviewClient{
+				createFunc: func(_ context.Context, _ *authV1.SubjectAccessReview, _ metav1.CreateOptions) (*authV1.SubjectAccessReview, error) {
+					return &authV1.SubjectAccessReview{
+						Status: authV1.SubjectAccessReviewStatus{Allowed: true},
+					}, nil
+				},
+			}
+
+			req := &http.Request{}
+			s := NewSubjectAccessReview(getter)
+
+			authed, err := s.UserCanImpersonateExtras(req, "user", nil, test.extras)
+			assert.False(t, authed, "impersonation should be denied for malicious extra key in case %q", name)
+			assert.Error(t, err, "expected an error for malicious extra key in case %q", name)
 		})
 	}
 }

--- a/pkg/auth/requests/service_account.go
+++ b/pkg/auth/requests/service_account.go
@@ -131,6 +131,11 @@ func (t *ServiceAccountAuth) Authenticate(req *http.Request) (user.Info, bool, e
 		return info, false, nil
 	}
 
+	if tokenReview.Status.Error != "" {
+		logrus.Debugf("saauth: tokenReview returned an error: %s", tokenReview.Status.Error)
+		return info, false, nil
+	}
+
 	// Let others know that this request is authenticated using a service account.
 	*req = *req.WithContext(authcontext.SetSAAuthenticated(req.Context()))
 

--- a/pkg/auth/requests/service_account_test.go
+++ b/pkg/auth/requests/service_account_test.go
@@ -70,17 +70,18 @@ func TestIsTokenExpired(t *testing.T) {
 func TestServiceAccountAuthAuthenticate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name                  string
-		startUser             string
-		expectedUser          string
-		settingEnabled        bool
-		token                 string
-		tokenReviewAuthStatus bool
-		downstreamRequest     *http.Request
-		clusterID             string
-		isAuthenticated       bool
-		expectedError         bool
-		omitProxyConfig       bool
+		name                   string
+		startUser              string
+		expectedUser           string
+		settingEnabled         bool
+		token                  string
+		tokenReviewAuthStatus  bool
+		tokenReviewStatusError string
+		downstreamRequest      *http.Request
+		clusterID              string
+		isAuthenticated        bool
+		expectedError          bool
+		omitProxyConfig        bool
 	}{
 		{
 			name: "everything valid auth succeeds secure mode",
@@ -223,6 +224,43 @@ func TestServiceAccountAuthAuthenticate(t *testing.T) {
 			isAuthenticated:       true,
 			expectedError:         false,
 		},
+		// A successful HTTP response from the downstream cluster can still carry a
+		// non-empty Status.Error. The authenticator should treat this as a failure
+		// and return unauthenticated, not trust the Status.User or Status.Authenticated fields.
+		{
+			name: "token review status error should not authenticate",
+			token: makeJWT(jwtv4.MapClaims{
+				"sub": "system:serviceaccount:vault:token-reviewer",
+				"exp": time.Now().Add(time.Hour).Unix(),
+			}),
+			startUser:              "system:cattle:error",
+			expectedUser:           "system:cattle:error",
+			settingEnabled:         true,
+			tokenReviewAuthStatus:  false,
+			tokenReviewStatusError: "token has been revoked",
+			downstreamRequest:      generateDownstreamRequest("POST", "testclusterid"+tokenReviewSuffix),
+			clusterID:              "testclusterid",
+			isAuthenticated:        false,
+			expectedError:          false,
+		},
+		{
+			name: "token review status error with authenticated true should not authenticate",
+			// Kubernetes should never set Authenticated=true alongside a non-empty
+			// Error, but a defensive implementation must handle this edge case.
+			token: makeJWT(jwtv4.MapClaims{
+				"sub": "system:serviceaccount:vault:token-reviewer",
+				"exp": time.Now().Add(time.Hour).Unix(),
+			}),
+			startUser:              "system:cattle:error",
+			expectedUser:           "system:cattle:error",
+			settingEnabled:         true,
+			tokenReviewAuthStatus:  true,
+			tokenReviewStatusError: "token lookup failed",
+			downstreamRequest:      generateDownstreamRequest("POST", "testclusterid"+tokenReviewSuffix),
+			clusterID:              "testclusterid",
+			isAuthenticated:        false,
+			expectedError:          false,
+		},
 	}
 
 	for _, test := range tests {
@@ -263,6 +301,7 @@ func TestServiceAccountAuthAuthenticate(t *testing.T) {
 							},
 							Status: v1.TokenReviewStatus{
 								Authenticated: test.tokenReviewAuthStatus,
+								Error:         test.tokenReviewStatusError,
 								Audiences:     []string{},
 								User: v1.UserInfo{
 									Username: test.expectedUser,

--- a/pkg/auth/requests/token_review.go
+++ b/pkg/auth/requests/token_review.go
@@ -55,6 +55,11 @@ func (t *TokenReviewAuth) Authenticate(req *http.Request) (user.Info, bool, erro
 		return info, false, nil
 	}
 
+	if tokenReview.Status.Error != "" {
+		logrus.Debugf("tokenReview returned an error: %s", tokenReview.Status.Error)
+		return info, false, nil
+	}
+
 	tokenReviewUserInfo := &user.DefaultInfo{
 		Name:   tokenReview.Status.User.Username,
 		UID:    tokenReview.Status.User.UID,

--- a/pkg/auth/requests/token_review_test.go
+++ b/pkg/auth/requests/token_review_test.go
@@ -43,6 +43,28 @@ func TestTokenReviewAuthAuthenticate(t *testing.T) {
 			wantGroups:  []string{"devs"},
 			wantHasAuth: true,
 		},
+		"when the authenticated user is the error user a token review is done": {
+			userInfo: &user.DefaultInfo{
+				Name: errorUserName,
+			},
+			authorization:    "Bearer token-review-token",
+			wantReviewCalled: true,
+			wantReviewToken:  "token-review-token",
+			reviewResponse: &authenticationv1.TokenReview{
+				Status: authenticationv1.TokenReviewStatus{
+					Authenticated: false,
+					User: authenticationv1.UserInfo{
+						Username: "u-123",
+						UID:      "u-123",
+						Groups:   []string{"devs"},
+					},
+				},
+			},
+			wantName:    "u-123",
+			wantUID:     "u-123",
+			wantGroups:  []string{"devs"},
+			wantHasAuth: false,
+		},
 		"failed auth and token review return error": {
 			userInfo: &user.DefaultInfo{
 				Name: "system:cattle:error",
@@ -50,6 +72,7 @@ func TestTokenReviewAuthAuthenticate(t *testing.T) {
 			authorization:    "Bearer token-review-token",
 			reviewErr:        "token review create failed",
 			wantName:         "system:cattle:error",
+			wantHasAuth:      false,
 			wantReviewCalled: true,
 			wantReviewToken:  "token-review-token",
 		},
@@ -75,14 +98,14 @@ func TestTokenReviewAuthAuthenticate(t *testing.T) {
 			wantReviewCalled: true,
 			wantReviewToken:  "review-success-token",
 		},
-		"failed auth and token review success with unauthenticated status returns not authenticated": {
+		"failed auth and token review success with unauthenticated status still returns review user": {
 			userInfo: &user.DefaultInfo{
-				Name: "system:cattle:error",
+				Name: errorUserName,
 			},
 			authorization: "Bearer review-not-authenticated-token",
 			reviewResponse: &authenticationv1.TokenReview{
 				Status: authenticationv1.TokenReviewStatus{
-					// The token review returns Not Authenticated
+					// The token review has returns Not Authenticated
 					Authenticated: false,
 					User: authenticationv1.UserInfo{
 						Username: "impersonated-user",
@@ -94,8 +117,45 @@ func TestTokenReviewAuthAuthenticate(t *testing.T) {
 			wantName:         "impersonated-user",
 			wantUID:          "uid-2",
 			wantGroups:       []string{"group-a"},
+			wantHasAuth:      false,
 			wantReviewCalled: true,
 			wantReviewToken:  "review-not-authenticated-token",
+		},
+		"token review status error with unauthenticated status should not authenticate": {
+			userInfo: &user.DefaultInfo{
+				Name: errorUserName,
+			},
+			authorization: "Bearer some-token",
+			reviewResponse: &authenticationv1.TokenReview{
+				Status: authenticationv1.TokenReviewStatus{
+					Authenticated: false,
+					Error:         "token has been revoked",
+				},
+			},
+			wantName:         errorUserName,
+			wantHasAuth:      false,
+			wantReviewCalled: true,
+			wantReviewToken:  "some-token",
+		},
+		"token review status error with authenticated true should not authenticate": {
+			userInfo: &user.DefaultInfo{
+				Name: errorUserName,
+			},
+			authorization: "Bearer some-token",
+			reviewResponse: &authenticationv1.TokenReview{
+				Status: authenticationv1.TokenReviewStatus{
+					Authenticated: true,
+					Error:         "token lookup failed",
+					User: authenticationv1.UserInfo{
+						Username: "some-user",
+						UID:      "uid-3",
+					},
+				},
+			},
+			wantName:         errorUserName,
+			wantHasAuth:      false,
+			wantReviewCalled: true,
+			wantReviewToken:  "some-token",
 		},
 	}
 
@@ -103,13 +163,13 @@ func TestTokenReviewAuthAuthenticate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			var reviewCalled bool
+			reviewCalled := 0
 			var reviewToken string
 
 			authClient := &fakeAuthenticationV1{
 				tokenReviews: &fakeTokenReviewInterface{
 					create: func(_ context.Context, createdReview *authenticationv1.TokenReview, _ metav1.CreateOptions) (*authenticationv1.TokenReview, error) {
-						reviewCalled = true
+						reviewCalled++
 						reviewToken = createdReview.Spec.Token
 
 						if tt.reviewErr != "" {
@@ -139,8 +199,13 @@ func TestTokenReviewAuthAuthenticate(t *testing.T) {
 			assert.Equal(t, tt.wantName, respUser.GetName())
 			assert.Equal(t, tt.wantUID, respUser.GetUID())
 			assert.Equal(t, tt.wantGroups, respUser.GetGroups())
-			assert.Equal(t, tt.wantReviewCalled, reviewCalled)
-			assert.Equal(t, tt.wantReviewToken, reviewToken)
+
+			if tt.wantReviewCalled {
+				require.Equal(t, 1, reviewCalled)
+				assert.Equal(t, tt.wantReviewToken, reviewToken)
+			} else {
+				assert.Equal(t, 0, reviewCalled)
+			}
 		})
 	}
 }

--- a/pkg/clusterrouter/lookup.go
+++ b/pkg/clusterrouter/lookup.go
@@ -4,13 +4,14 @@ import (
 	"net/http"
 	"strings"
 
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 )
 
 type ClusterLookup interface {
 	Lookup(req *http.Request) (*v3.Cluster, error)
 }
 
+// GetClusterID extracts the cluster ID from the request URL path.
 func GetClusterID(req *http.Request) string {
 	parts := strings.Split(req.URL.Path, "/")
 	if len(parts) > 3 &&

--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -41,7 +41,7 @@ type ClusterContextGetter interface {
 type RemoteService struct {
 	sync.Mutex
 
-	cluster   *v3.Cluster
+	cluster   *v32.Cluster
 	transport transportGetter
 	url       urlGetter
 
@@ -77,14 +77,14 @@ func prefix(cluster *v3.Cluster) string {
 	return "/k8s/clusters/" + cluster.Name
 }
 
-func New(localConfig *rest.Config, cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
+func New(localConfig *rest.Config, cluster *v32.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
 	if cluster.Spec.Internal {
 		return NewLocal(localConfig, cluster)
 	}
 	return NewRemote(cluster, clusterLister, factory, clusterContextGetter)
 }
 
-func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, error) {
+func NewLocal(localConfig *rest.Config, cluster *v32.Cluster) (*RemoteService, error) {
 	// the gvk is ignored by us, so just pass in any gvk
 	hostURL, _, err := rest.DefaultServerURL(localConfig.Host, localConfig.APIPath, schema.GroupVersion{}, true)
 	if err != nil {
@@ -116,7 +116,7 @@ func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, er
 	return rs, nil
 }
 
-func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
+func NewRemote(cluster *v32.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
 	if !v32.ClusterConditionProvisioned.IsTrue(cluster) {
 		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, "cluster not provisioned")
 	}
@@ -217,7 +217,7 @@ func (r *RemoteService) getTransport() (http.RoundTripper, error) {
 	return transport, nil
 }
 
-func (r *RemoteService) cacertChanged(cluster *v3.Cluster) bool {
+func (r *RemoteService) cacertChanged(cluster *v32.Cluster) bool {
 	return r.caCert != cluster.Status.CACert
 }
 
@@ -310,7 +310,7 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	httpProxy.ServeHTTP(rw, req)
 }
 
-func (r *RemoteService) Cluster() *v3.Cluster {
+func (r *RemoteService) Cluster() *v32.Cluster {
 	return r.cluster
 }
 

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -103,7 +103,10 @@ func router(ctx context.Context, localClusterEnabled bool, tunnelAuthorizer *mcm
 	unauthed.PathPrefix("/v3-public").Handler(publicAPI)
 
 	// Authenticated routes
-	impersonatingAuth := requests.NewImpersonatingAuth(scaledContext.Wrangler, sar.NewSubjectAccessReview(clusterManager))
+	handler := sar.NewSubjectAccessReview(
+		scaledContext.K8sClient.AuthorizationV1().SubjectAccessReviews())
+
+	impersonatingAuth := requests.NewImpersonatingAuth(scaledContext.Wrangler, handler)
 	saAuth := auth.ToMiddleware(requests.NewServiceAccountAuth(scaledContext, clustermanager.ToRESTConfig))
 	accessControlHandler := rbac.NewAccessControlHandler()
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The user principal wasn't used in requests to external clusters - only impersonation headers.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This drops support for impersonation headers when making requests to the cluster.

Verification of permissions is now only done via the management cluster.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_