### PR TITLE
Correct the wins checksum filename in the updatecli config

### DIFF
--- a/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
+++ b/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
@@ -96,7 +96,7 @@ sources:
     dependson:
       - 'wins-release'
     spec:
-      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256sum.txt | grep " wins.exe$" | cut -d " " -f1'
+      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256.txt | grep " wins.exe$" | cut -d " " -f1'
 
   wins-checksum-install:
     name: 'Get sha256 for install.ps1 from {{ source "wins-release" }}'
@@ -104,7 +104,7 @@ sources:
     dependson:
       - 'wins-release'
     spec:
-      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256sum.txt | grep " install.ps1$" | cut -d " " -f1'
+      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256.txt | grep " install.ps1$" | cut -d " " -f1'
 
   wins-checksum-uninstall:
     name: 'Get sha256 for uninstall.ps1 from {{ source "wins-release" }}'
@@ -112,7 +112,7 @@ sources:
     dependson:
       - 'wins-release'
     spec:
-      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256sum.txt | grep " uninstall.ps1$" | cut -d " " -f1'
+      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256.txt | grep " uninstall.ps1$" | cut -d " " -f1'
 
   system-agent-checksum-amd64:
     name: 'Get sha256 for rancher-system-agent-amd64 from {{ source "system-agent-release" }}'


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/55769 
  

The [updatecli-generated PR](https://github.com/rancher/rancher/pull/55699) fails to find the checksum file for rancher/wins because the filename is incorrect: it looks for `sha256sum.txt`, but the correct name is `sha256.txt` (see https://github.com/rancher/wins/releases/tag/v0.15.0-rc.3) . This PR fixes the wrong filename. 

Side note: rancher/system-agent release uses the `sha256sum.txt` filename. 

We cannot test the changes locally because updatecli is deeply integrated with GH Actions, so we will validate them by checking the PRs generated or updated after the PR is merged.

