### PR TITLE
[v2.12] Update SCC Operator to v0.5.0-rc.2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,5 +4,5 @@ provisioningCAPIVersion: 107.0.0+up0.8.0
 cspAdapterMinVersion: 107.0.0+up7.0.0
 defaultShellVersion: rancher/shell:v0.5.3
 fleetVersion: 107.0.14+up0.13.14-rc.1
-defaultSccOperatorImage: rancher/scc-operator:v0.4.3
+defaultSccOperatorImage: rancher/scc-operator:v0.5.0-rc.2
 chartAuditLogImage: rancher/mirrored-bci-micro:15.6.24.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,7 +5,7 @@ package buildconfig
 const (
 	ChartAuditLogImage       = "rancher/mirrored-bci-micro:15.6.24.2"
 	CspAdapterMinVersion     = "107.0.0+up7.0.0"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.4.3"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.0-rc.2"
 	DefaultShellVersion      = "rancher/shell:v0.5.3"
 	FleetVersion             = "107.0.14+up0.13.14-rc.1"
 	ProvisioningCAPIVersion  = "107.0.0+up0.8.0"


### PR DESCRIPTION
## Summary
Update SCC Operator image to [`v0.5.0-rc.2`](https://github.com/rancher/scc-operator/releases/tag/v0.5.0-rc.2)

## Changes
- Updated `defaultSccOperatorImage` in `build.yaml`
- Ran `go generate ./pkg/...` to update generated files