### PR TITLE
CRT fixes

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -323,9 +323,9 @@ func (c *ClusterRegistrationToken) ObjClusterName() string {
 
 type ClusterRegistrationTokenSpec struct {
 	ClusterName string `json:"clusterName" norman:"required,type=reference[cluster]"`
-	// TTL is the duration in seconds before the token expires and is rotated. Zero disables TTL-based rotation.
+	// TTL is the duration in minutes before the token expires and is rotated. Zero disables TTL-based rotation.
 	TTL *int64 `json:"ttl,omitempty"`
-	// GracePeriod is the duration in seconds during which both the old and new tokens remain valid after
+	// GracePeriod is the duration in minutes during which both the old and new tokens remain valid after
 	// rotation, allowing cluster agents time to restart and pick up the new credential.
 	GracePeriod *int64 `json:"gracePeriod,omitempty"`
 }

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -303,8 +303,7 @@ func (h *handler) handleTTL(obj *v3.ClusterRegistrationToken) error {
 	}
 
 	if obj.Status.ExpiresAt == "" {
-		h.setExpiresAt(obj, ttl)
-		return nil
+		return h.setExpiresAt(obj, ttl)
 	}
 
 	expiry, err := time.Parse(time.RFC3339, obj.Status.ExpiresAt)
@@ -320,7 +319,7 @@ func (h *handler) handleTTL(obj *v3.ClusterRegistrationToken) error {
 	return h.rotateToken(obj, ttl)
 }
 
-func (h *handler) setExpiresAt(obj *v3.ClusterRegistrationToken, ttl int64) {
+func (h *handler) setExpiresAt(obj *v3.ClusterRegistrationToken, ttl int64) error {
 	ttlDuration := time.Duration(ttl) * time.Minute
 	jitter := computeJitter(ttlDuration)
 
@@ -334,6 +333,7 @@ func (h *handler) setExpiresAt(obj *v3.ClusterRegistrationToken, ttl int64) {
 	}
 
 	logrus.Infof("CRT %s/%s: ExpiresAt empty, set to %s", obj.Namespace, obj.Name, obj.Status.ExpiresAt)
+	return nil
 }
 
 func (h *handler) rotateToken(obj *v3.ClusterRegistrationToken, ttl int64) error {
@@ -343,10 +343,15 @@ func (h *handler) rotateToken(obj *v3.ClusterRegistrationToken, ttl int64) error
 		return err
 	}
 
-	if expiresAtBytes, ok := existing.Data["expiresAt"]; ok {
+	if expiresAtBytes, ok := existing.Data[expiresAtDataKey]; ok {
 		expiresAt, err := time.Parse(time.RFC3339, string(expiresAtBytes))
 		if err == nil && expiresAt.After(time.Now()) {
 			obj.Status.ExpiresAt = string(expiresAtBytes)
+			if _, hasPrev := existing.Data[previousTokenDataKey]; hasPrev {
+				if gp, ok := existing.Data[gracePeriodExpiresAtDataKey]; ok && len(gp) > 0 {
+					obj.Status.GracePeriodExpiresAt = string(gp)
+				}
+			}
 			return nil
 		}
 	}
@@ -364,7 +369,8 @@ func (h *handler) rotateToken(obj *v3.ClusterRegistrationToken, ttl int64) error
 	updated := existing.DeepCopy()
 	updated.Data[previousTokenDataKey] = existing.Data[tokenDataKey]
 	updated.Data[tokenDataKey] = []byte(newToken)
-	updated.Data["expiresAt"] = []byte(newExpiresAt)
+	updated.Data[expiresAtDataKey] = []byte(newExpiresAt)
+	updated.Data[gracePeriodExpiresAtDataKey] = []byte(newGracePeriodExpiresAt)
 
 	if _, err = h.secrets.Update(updated); err != nil {
 		return err
@@ -385,6 +391,7 @@ func (h *handler) cleanupGracePeriod(obj *v3.ClusterRegistrationToken) error {
 	if _, hasPrev := existing.Data[previousTokenDataKey]; hasPrev {
 		updated := existing.DeepCopy()
 		delete(updated.Data, previousTokenDataKey)
+		delete(updated.Data, gracePeriodExpiresAtDataKey)
 		if _, err := h.secrets.Update(updated); err != nil {
 			return err
 		}

--- a/pkg/controllers/dashboard/clusterregistrationtoken/token_secret.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/token_secret.go
@@ -19,6 +19,10 @@ const (
 	secretPrefix         = "crt-token-"
 	tokenDataKey         = "token"
 	previousTokenDataKey = "previousToken"
+	// expiresAt and gracePeriodExpiresAt keys store the rotation schedule next to the
+	// token it governs. Required to stay idempotent against duplicate rotation triggers.
+	expiresAtDataKey            = "expiresAt"
+	gracePeriodExpiresAtDataKey = "gracePeriodExpiresAt"
 )
 
 func SecretName(crtName string) string {
@@ -76,7 +80,7 @@ func NewTokenSecret(crt *v3.ClusterRegistrationToken, token string, expiresAt st
 	}
 
 	if expiresAt != "" {
-		data["expiresAt"] = []byte(expiresAt)
+		data[expiresAtDataKey] = []byte(expiresAt)
 	}
 
 	return &corev1.Secret{

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -98,12 +98,6 @@ var (
 		true,
 		true,
 		true)
-	RKE1CustomNodeCleanup = newFeature(
-		"rke1-custom-node-cleanup",
-		"Enable cleanup RKE1 custom cluster nodes when they are deleted",
-		true,
-		true,
-		true)
 	HarvesterBaremetalContainerWorkload = newFeature(
 		"harvester-baremetal-container-workload",
 		"Deploy container workloads to underlying harvester cluster",
@@ -127,12 +121,6 @@ var (
 		"Improve performance by enabling SQLite-backed caching. This also enables server-side pagination and other scaling based performance improvements.",
 		true,
 		false,
-		true)
-	RKE1UI = newFeature(
-		"rke1-ui",
-		"Enable RKE1 provisioning in the Rancher UI",
-		true,
-		true,
 		true)
 	ProvisioningPreBootstrap = newFeature(
 		"provisioningprebootstrap",
@@ -248,7 +236,7 @@ var (
 	CRTTokenTTLRotation = newFeature(
 		"crt-token-ttl-rotation",
 		"Enable TTL-based automatic rotation of ClusterRegistrationToken credentials",
-		true,
+		false,
 		true,
 		true,
 	)


### PR DESCRIPTION
- fix CRT grace-period tracking on rotation 
- mark feature flag false, will enable it after reworking data duplication across both objects  
- removed deprecated RKE1 feature flags, they should have been removed long ago 