### PR TITLE
[v2.11] Prune pod IPs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/rancher/aks-operator v1.11.12-rc.2
 	github.com/rancher/apiserver v0.5.2
 	github.com/rancher/channelserver v0.7.0
-	github.com/rancher/dynamiclistener v0.6.4
+	github.com/rancher/dynamiclistener v0.6.5-rc.1
 	github.com/rancher/eks-operator v1.11.12-rc.1
 	github.com/rancher/fleet/pkg/apis v0.12.17
 	github.com/rancher/gke-operator v1.11.12-rc.1

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/rancher/apiserver v0.5.2 h1:K7b+7m8TOyGJGwYwq95O5tSkn/bb/k0PRBtcMqyRe
 github.com/rancher/apiserver v0.5.2/go.mod h1:Tc4+kkh5mO7M1sZYaqlunx4S/YVcz9AapvbScS3hQRg=
 github.com/rancher/channelserver v0.7.0 h1:ZN5o8aD4mD31uhjEEW2e9yQXa3eOb+4Cp6DcWm7W/Lc=
 github.com/rancher/channelserver v0.7.0/go.mod h1:Mwd7hlMSu9X4FnZKj+0mA5ak8nTyJZtZsVX33G62Gzc=
-github.com/rancher/dynamiclistener v0.6.4 h1:Mpm/jNiI03k+HWEkKgz816k9t+EV6xI0off6dd1dSH4=
-github.com/rancher/dynamiclistener v0.6.4/go.mod h1:MqdVm4tlq7jPyd0+PrdVxSROPpvRnlaat65rqtXjCak=
+github.com/rancher/dynamiclistener v0.6.5-rc.1 h1:kfTdvF0qqZybov95U9k+3VaOz/SFX+3PrNCH2sF5HXM=
+github.com/rancher/dynamiclistener v0.6.5-rc.1/go.mod h1:MqdVm4tlq7jPyd0+PrdVxSROPpvRnlaat65rqtXjCak=
 github.com/rancher/eks-operator v1.11.12-rc.1 h1:ViZB3yTPFXMvF+A23GG6t33RcloVYk3o73meF9GNUJU=
 github.com/rancher/eks-operator v1.11.12-rc.1/go.mod h1:hOmdRTtrM9FCBrRxq/2+haEwYS3pIEvuqvzGkAMaF2w=
 github.com/rancher/fleet/pkg/apis v0.12.17 h1:XA6/czzxYl4tMTsyXqJvdqgRxxS5fFTG/zhr4UBH81k=

--- a/pkg/tls/podips.go
+++ b/pkg/tls/podips.go
@@ -1,0 +1,99 @@
+package tls
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+
+	"github.com/rancher/rancher/pkg/namespace"
+	corev1controllers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// podIPTracker watches pods matching the given label selector in a single
+// namespace and maintains a snapshot of their current pod IPs. The snapshot
+// is consumed by filterExistingCN to prune stale IP CNs from the
+// dynamiclistener-managed cert without disturbing other (hostname) CNs.
+type podIPTracker struct {
+	// ips holds *map[string]struct{}. nil before the first list completes:
+	// in that pre-sync state filterExistingCN keeps everything (so we never
+	// prematurely prune the cert at startup).
+	ips atomic.Value
+
+	namespace     string
+	labelSelector string
+	pods          corev1controllers.PodController
+}
+
+// newPodIPTracker registers an OnChange handler that updates the IP set on
+// every relevant pod event. The tracker function it returns is safe to use
+// as a dynamiclistener.Config.FilterExistingCN: non-IP CNs (hostnames) pass
+// through unchanged, IP CNs are kept only if they match a currently-running
+// pod IP.
+func newPodIPTracker(ctx context.Context, ns, labelSelector string, pods corev1controllers.PodController, handlerName string) func(...string) []string {
+	t := &podIPTracker{
+		namespace:     ns,
+		labelSelector: labelSelector,
+		pods:          pods,
+	}
+	pods.OnChange(ctx, handlerName, t.onChange)
+	return t.filterExistingCN
+}
+
+func (t *podIPTracker) onChange(_ string, pod *corev1.Pod) (*corev1.Pod, error) {
+	// Skip pods in other namespaces. On delete events pod is nil; in that
+	// case we proceed and let the List below return the correct live set.
+	if pod != nil && pod.Namespace != t.namespace {
+		return pod, nil
+	}
+	// On every event in our namespace (add/update/delete) re-list and
+	// rebuild the snapshot. Cheap: there are only a handful of rancher pods.
+	list, err := t.pods.List(t.namespace, metav1.ListOptions{LabelSelector: t.labelSelector})
+	if err != nil {
+		return pod, err
+	}
+	ips := make(map[string]struct{}, len(list.Items))
+	for i := range list.Items {
+		p := &list.Items[i]
+		if p.DeletionTimestamp != nil {
+			continue
+		}
+		if p.Status.PodIP != "" {
+			ips[p.Status.PodIP] = struct{}{}
+		}
+	}
+	t.ips.Store(&ips)
+	return pod, nil
+}
+
+func (t *podIPTracker) filterExistingCN(cns ...string) []string {
+	v := t.ips.Load()
+	// Pre-sync: keep everything to avoid pruning legitimate CNs before we
+	// know what the live pod set looks like.
+	if v == nil {
+		return cns
+	}
+	ips := *v.(*map[string]struct{})
+	out := make([]string, 0, len(cns))
+	for _, cn := range cns {
+		// Only prune IP CNs we can positively classify as stale.
+		// Hostnames and any other non-IP CNs pass through — we don't have
+		// enough information here to decide whether they're stale.
+		if net.ParseIP(cn) == nil {
+			out = append(out, cn)
+			continue
+		}
+		if _, ok := ips[cn]; ok {
+			out = append(out, cn)
+		}
+	}
+	return out
+}
+
+// newRancherPodIPFilter wires a podIPTracker to the upstream Rancher
+// server's pods (app=rancher in cattle-system) and returns its
+// FilterExistingCN closure.
+func newRancherPodIPFilter(ctx context.Context, pods corev1controllers.PodController) func(...string) []string {
+	return newPodIPTracker(ctx, namespace.System, "app=rancher", pods, "rancher-podip-tls-internal-filter")
+}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/dynamiclistener/storage/kubernetes"
 	"github.com/rancher/lasso/pkg/metrics"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/apps"
@@ -105,12 +106,12 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 	}
 
 	serverOptions := &server.ListenOpts{
-		Storage:       opts.Storage,
-		Secrets:       opts.Secrets,
-		CAName:        "tls-rancher-internal-ca",
-		CANamespace:   namespace.System,
-		CertNamespace: namespace.System,
-		CertName:      "tls-rancher-internal",
+		Storage:           opts.Storage,
+		Secrets:           opts.Secrets,
+		CAName:            "tls-rancher-internal-ca",
+		CANamespace:       namespace.System,
+		CertNamespace:     namespace.System,
+		CertName:          "tls-rancher-internal",
 		DisplayServerLogs: true,
 	}
 	clusterIP, err := getClusterIP(core.Core().V1().Service())
@@ -127,7 +128,10 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 	}
 	if len(hostIPs) > 0 {
 		serverOptions.TLSListenerConfig = dynamiclistener.Config{
-			SANs: hostIPs,
+			SANs:           hostIPs,
+			MaxSANs:        30,
+			FilterCN:       newRancherPodIPFilter(ctx, core.Core().V1().Pod()),
+			FilterExisting: true,
 		}
 	}
 
@@ -371,6 +375,12 @@ func collectNodeIPs(nodeController corev1controllers.NodeController) ([]string, 
 }
 
 func filterCN(cns ...string) []string {
+	// In the embedded agent Rancher, reject all dynamic CN additions.
+	// The static Config.SANs (short-circuited by allowDefaultSANs) cover all
+	// legitimate access; anything dynamic is attacker-supplied SNI noise.
+	if features.MCMAgent.Enabled() {
+		return nil
+	}
 	serverURL := settings.ServerURL.Get()
 	if serverURL == "" {
 		return cns

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,85 @@
+package tls
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+// TestFilterCN covers all branches of filterCN, which gates dynamic CN
+// additions to the serving-cert (:443) listener.
+//
+// filterCN is the func(...string)[]string passed to dynamiclistener as
+// FilterCN.  allowDefaultSANs (inside dynamiclistener) already short-circuits
+// CNs that are in Config.SANs, so filterCN only ever receives the *unknown*
+// (dynamically presented) ones.
+func TestFilterCN(t *testing.T) {
+	tests := []struct {
+		name      string
+		mcmAgent  bool
+		serverURL string
+		input     []string
+		expected  []string
+	}{
+		{
+			name:     "MCMAgent enabled — reject all dynamic CNs regardless of serverURL",
+			mcmAgent: true,
+			input:    []string{"attacker.evil.com", "10.0.0.5"},
+			expected: nil,
+		},
+		{
+			name:      "MCMAgent enabled, empty serverURL — still returns nil",
+			mcmAgent:  true,
+			serverURL: "",
+			input:     []string{"anything.com"},
+			expected:  nil,
+		},
+		{
+			name:      "MCMAgent disabled, empty serverURL — pass-through (pre-bootstrap)",
+			mcmAgent:  false,
+			serverURL: "",
+			input:     []string{"anything.com", "10.0.0.5"},
+			expected:  []string{"anything.com", "10.0.0.5"},
+		},
+		{
+			name:      "MCMAgent disabled, serverURL set — only server hostname allowed",
+			mcmAgent:  false,
+			serverURL: "https://rancher.example.com",
+			input:     []string{"attacker.evil.com"},
+			expected:  []string{"rancher.example.com"},
+		},
+		{
+			name:      "MCMAgent disabled, serverURL with port — hostname without port returned",
+			mcmAgent:  false,
+			serverURL: "https://rancher.example.com:8443",
+			input:     []string{"attacker.evil.com"},
+			expected:  []string{"rancher.example.com"},
+		},
+		{
+			name:      "MCMAgent disabled, unparseable serverURL — pass-through",
+			mcmAgent:  false,
+			serverURL: "://bad-url",
+			input:     []string{"attacker.evil.com"},
+			expected:  []string{"attacker.evil.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// filterCN reads global state; do not run subtests in parallel.
+			features.MCMAgent.Set(tt.mcmAgent)
+			t.Cleanup(func() { features.MCMAgent.Set(false) })
+
+			_ = settings.ServerURL.Set(tt.serverURL)
+			t.Cleanup(func() { _ = settings.ServerURL.Set("") })
+
+			got := filterCN(tt.input...)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("filterCN(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Backport of #56007 to `release/v2.11`.

For the `tls-rancher-internal` listener (`:444`), pod IPs enter the cert legitimately via the `Accept()` `LocalAddr` fallback when connections arrive at a pod's IP directly. After a rolling restart the old pod IPs remain indefinitely, causing the cert to grow unboundedly.

This PR sets `FilterCN` to a pod-IP-aware closure backed by a watcher on pods labeled `app=rancher` in `cattle-system`, and sets `PruneExistingCN=true` so that dynamiclistener applies the same filter to existing cert annotations on every cert operation (Merge, AddCN, Renew, Regenerate). Dead pod IPs are pruned on the next cert write without a delete-and-regenerate. `MaxSANs=30` is set as a backstop.

`PruneExistingCN` is a new boolean added to `dynamiclistener.Config`. When true, `FilterCN` is also applied to the stored CN annotation set, allowing callers to trim stale entries that accumulated before the filter was in place.

`go.mod` is updated to reference the fork commit that introduces `PruneExistingCN`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)