### PR TITLE
Fix AuditPolicy deny filters

### DIFF
--- a/pkg/apis/auditlog.cattle.io/v1/audit_policy_types.go
+++ b/pkg/apis/auditlog.cattle.io/v1/audit_policy_types.go
@@ -122,14 +122,15 @@ type AuditPolicy struct {
 type AuditPolicySpec struct {
 	Enabled bool `json:"enabled"`
 
-	// Filters described what logs are explicitly allowed and denied. Leave empty if all logs should be allowed. The
-	// Allow action has higher precedence than Deny. So if there are multiple filters that match a log and at least one
-	// Allow, the log will be allowed.
+	// Filters describe what logs are explicitly allowed and denied. Leave empty if all logs should be allowed by
+	// this policy. Within a single AuditPolicy, Allow has higher precedence than Deny when multiple filters match.
+	// Across AuditPolicy objects, an explicit Deny has higher precedence than Allow. If no filter in a policy matches,
+	// that policy has no effect on the log.
 	Filters []Filter `json:"filters,omitempty"`
 
 	// AdditionalRedactions details additional informatino to be redacted. If there are any Filers defined in the same
-	// policy, these Redactions will only be applied to logs that are Allowed by those filters. If there are no
-	// Filters, the redactions will be applied to all logs.
+	// policy, these Redactions will only be applied to logs that are allowed by that policy. If there are no Filters,
+	// the redactions will be applied to all logs.
 	AdditionalRedactions []Redaction `json:"additionalRedactions,omitempty"`
 
 	// Verbosity defines how much data to collect from each log. The end verbosity for a log is calculated as a merge

--- a/pkg/auth/audit/filter.go
+++ b/pkg/auth/audit/filter.go
@@ -24,14 +24,10 @@ func NewFilter(filter auditlogv1.Filter) (*Filter, error) {
 	}, nil
 }
 
-func (m *Filter) Allowed(requestUri string) bool {
-	if m.uri.MatchString(requestUri) {
-		return m.action == auditlogv1.FilterActionAllow
+func (m *Filter) ActionForURI(requestURI string) auditlogv1.FilterAction {
+	if m.uri.MatchString(requestURI) {
+		return m.action
 	}
 
-	return false
-}
-
-func (m *Filter) LogAllowed(log *logEntry) bool {
-	return m.Allowed(log.RequestURI)
+	return auditlogv1.FilterActionUnknown
 }

--- a/pkg/auth/audit/filter_test.go
+++ b/pkg/auth/audit/filter_test.go
@@ -8,55 +8,55 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFilter(t *testing.T) {
-	type testCase struct {
-		Name    string
-		Filter  Filter
-		log     logEntry
-		Allowed bool
-	}
-
-	cases := []testCase{
+func TestFilterActionForURI(t *testing.T) {
+	tests := []struct {
+		name       string
+		filter     Filter
+		requestURI string
+		expected   auditlogv1.FilterAction
+	}{
 		{
-			Name: "Allow All",
-			Filter: Filter{
+			name: "allow filter matches",
+			filter: Filter{
 				action: auditlogv1.FilterActionAllow,
-				uri:    regexp.MustCompile(".*"),
+				uri:    regexp.MustCompile(".*pods.*"),
 			},
-			log: logEntry{
-				RequestURI: "/api/v1/namespaces/default/pods",
-			},
-			Allowed: true,
+			requestURI: "/api/v1/namespaces/default/pods",
+			expected:   auditlogv1.FilterActionAllow,
 		},
 		{
-			Name: "Deny All",
-			Filter: Filter{
+			name: "deny filter matches",
+			filter: Filter{
 				action: auditlogv1.FilterActionDeny,
-				uri:    regexp.MustCompile(".*"),
+				uri:    regexp.MustCompile(".*secrets.*"),
 			},
-			log: logEntry{
-				RequestURI: "/api/v1/namespaces/default/pods",
-			},
-			Allowed: false,
+			requestURI: "/api/v1/namespaces/default/secrets/my-secret",
+			expected:   auditlogv1.FilterActionDeny,
 		},
-
 		{
-			Name: "Block Secret Operations",
-			Filter: Filter{
+			name: "allow filter does not match",
+			filter: Filter{
+				action: auditlogv1.FilterActionAllow,
+				uri:    regexp.MustCompile(".*secrets.*"),
+			},
+			requestURI: "/api/v1/namespaces/default/pods",
+			expected:   auditlogv1.FilterActionUnknown,
+		},
+		{
+			name: "deny filter does not match",
+			filter: Filter{
 				action: auditlogv1.FilterActionDeny,
-				uri:    regexp.MustCompile("/api/v1/namespaces/.*/secrets.*"),
+				uri:    regexp.MustCompile("/healthz"),
 			},
-			log: logEntry{
-				RequestURI: "/api/v1/namespaces/default/secrets/my-secret",
-			},
-			Allowed: false,
+			requestURI: "/api/v1/namespaces/default/pods",
+			expected:   auditlogv1.FilterActionUnknown,
 		},
 	}
 
-	for _, c := range cases {
-		t.Run(c.Name, func(t *testing.T) {
-			actual := c.Filter.LogAllowed(&c.log)
-			assert.Equal(t, c.Allowed, actual)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.filter.ActionForURI(tt.requestURI)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/auth/audit/handler_test.go
+++ b/pkg/auth/audit/handler_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	auditlogv1 "github.com/rancher/rancher/pkg/apis/auditlog.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
@@ -77,4 +79,85 @@ func TestMiddleware(t *testing.T) {
 	}, req)
 
 	assert.Len(t, requests, 1, "handler did not forward request to next handler as expected")
+}
+
+func TestResolveVerbosityUsesOnlyAllowingPolicies(t *testing.T) {
+	tests := []struct {
+		name     string
+		filters  []auditlogv1.Filter
+		level    auditlogv1.Level
+		uri      string
+		expected auditlogv1.Level
+	}{
+		{
+			name:     "filterless policy applies",
+			level:    auditlogv1.LevelRequest,
+			uri:      "/api/v1/pods",
+			expected: auditlogv1.LevelRequest,
+		},
+		{
+			name: "matching allow policy applies",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionAllow, RequestURI: "/detailed"},
+			},
+			level:    auditlogv1.LevelRequestResponse,
+			uri:      "/detailed",
+			expected: auditlogv1.LevelRequestResponse,
+		},
+		{
+			name: "unmatched allow policy is neutral",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionAllow, RequestURI: "/detailed"},
+			},
+			level:    auditlogv1.LevelRequestResponse,
+			uri:      "/api/v1/pods",
+			expected: auditlogv1.LevelNull,
+		},
+		{
+			name: "matched deny policy does not increase verbosity",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: "/healthz"},
+			},
+			level:    auditlogv1.LevelRequestResponse,
+			uri:      "/healthz",
+			expected: auditlogv1.LevelNull,
+		},
+		{
+			name: "unmatched deny policy is neutral",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: "/healthz"},
+			},
+			level:    auditlogv1.LevelRequestResponse,
+			uri:      "/api/v1/pods",
+			expected: auditlogv1.LevelNull,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, w := setup(t, WriterOptions{
+				DefaultPolicyLevel:     auditlogv1.LevelNull,
+				DisableDefaultPolicies: true,
+			})
+
+			err := w.UpdatePolicy(&auditlogv1.AuditPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+				Spec: auditlogv1.AuditPolicySpec{
+					Filters:   tt.filters,
+					Verbosity: auditlogv1.LogVerbosity{Level: tt.level},
+				},
+			})
+			require.NoError(t, err)
+
+			handler := &LoggingHandler{writer: w}
+			actual := handler.ResolveVerbosity(tt.uri)
+
+			// ResolveVerbosity merges verbosities via mergeLogVerbosities, which does not propagate the Level
+			// field (only the Request/Response flags it actually computes from). Normalize Level before
+			// comparing so this test asserts on the flags that matter to callers.
+			expected := verbosityForLevel(tt.expected)
+			expected.Level = auditlogv1.LevelNull
+			assert.Equal(t, expected, actual)
+		})
+	}
 }

--- a/pkg/auth/audit/writer.go
+++ b/pkg/auth/audit/writer.go
@@ -27,27 +27,23 @@ func (p Policy) actionForUri(uri string) auditlogv1.FilterAction {
 		return auditlogv1.FilterActionAllow
 	}
 
-	for _, f := range p.Filters {
-		if f.Allowed(uri) {
+	action := auditlogv1.FilterActionUnknown
+	for _, filter := range p.Filters {
+		switch filter.ActionForURI(uri) {
+		case auditlogv1.FilterActionAllow:
+			// Preserve Allow precedence within one AuditPolicy.
 			return auditlogv1.FilterActionAllow
+		case auditlogv1.FilterActionDeny:
+			// Remember the deny, but continue looking for a matching Allow.
+			action = auditlogv1.FilterActionDeny
 		}
 	}
 
-	return auditlogv1.FilterActionDeny
+	return action
 }
 
 func (p Policy) actionForLog(log *logEntry) auditlogv1.FilterAction {
-	if len(p.Filters) == 0 {
-		return auditlogv1.FilterActionAllow
-	}
-
-	for _, f := range p.Filters {
-		if f.LogAllowed(log) {
-			return auditlogv1.FilterActionAllow
-		}
-	}
-
-	return auditlogv1.FilterActionDeny
+	return p.actionForUri(log.RequestURI)
 }
 
 func PolicyFromAuditPolicy(policy *auditlogv1.AuditPolicy) (Policy, error) {
@@ -157,14 +153,16 @@ func (w *Writer) Write(log *logEntry) error {
 	w.policiesMutex.RLock()
 	for _, policy := range w.policies {
 		switch policy.actionForLog(log) {
+		case auditlogv1.FilterActionDeny:
+			action = auditlogv1.FilterActionDeny
 		case auditlogv1.FilterActionAllow:
 			redactors = append(redactors, policy.Redactors...)
 
 			action = auditlogv1.FilterActionAllow
-		case auditlogv1.FilterActionDeny:
-			if action != auditlogv1.FilterActionAllow {
-				action = auditlogv1.FilterActionDeny
-			}
+		}
+
+		if action == auditlogv1.FilterActionDeny {
+			break
 		}
 	}
 	w.policiesMutex.RUnlock()

--- a/pkg/auth/audit/writer_test.go
+++ b/pkg/auth/audit/writer_test.go
@@ -10,6 +10,7 @@ import (
 
 	auditlogv1 "github.com/rancher/rancher/pkg/apis/auditlog.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,63 +42,192 @@ func setup(t *testing.T, opts WriterOptions) (*logWriter, *Writer) {
 	return lw, w
 }
 
-func TestAllowList(t *testing.T) {
+func TestDenyTakesPrecedenceAcrossPolicies(t *testing.T) {
 	logs, w := setup(t, WriterOptions{
 		DefaultPolicyLevel:     auditlogv1.LevelRequestResponse,
 		DisableDefaultPolicies: true,
 	})
 
 	err := w.UpdatePolicy(&auditlogv1.AuditPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "block-all",
-			Namespace: "default",
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "deny-secrets"},
 		Spec: auditlogv1.AuditPolicySpec{
 			Filters: []auditlogv1.Filter{
-				{
-					Action:     auditlogv1.FilterActionDeny,
-					RequestURI: ".*",
-				},
+				{Action: auditlogv1.FilterActionDeny, RequestURI: "/api/v1/secrets"},
 			},
 		},
 	})
-	assert.NoError(t, err)
-
-	expected := []logEntry{}
-
-	err = w.Write(&logEntry{
-		RequestURI: "/api/v1/secrets",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, expected, logs.logs)
+	require.NoError(t, err)
 
 	err = w.UpdatePolicy(&auditlogv1.AuditPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "allow-secrets",
-			Namespace: "default",
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-secrets"},
 		Spec: auditlogv1.AuditPolicySpec{
 			Filters: []auditlogv1.Filter{
-				{
-					Action:     auditlogv1.FilterActionAllow,
-					RequestURI: "/api/v1/secrets",
-				},
+				{Action: auditlogv1.FilterActionAllow, RequestURI: "/api/v1/secrets"},
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	expected = []logEntry{
+	err = w.Write(&logEntry{RequestURI: "/api/v1/secrets"})
+	require.NoError(t, err)
+	assert.Empty(t, logs.logs)
+
+	err = w.Write(&logEntry{RequestURI: "/api/v1/pods"})
+	require.NoError(t, err)
+	require.Len(t, logs.logs, 1)
+	assert.Equal(t, "/api/v1/pods", logs.logs[0].RequestURI)
+}
+
+func TestPolicyActionForURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		filters  []auditlogv1.Filter
+		uri      string
+		expected auditlogv1.FilterAction
+	}{
 		{
-			RequestURI: "/api/v1/secrets",
+			name:     "no filters allow all",
+			uri:      "/api/v1/pods",
+			expected: auditlogv1.FilterActionAllow,
+		},
+		{
+			name: "allow filter matches",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionAllow, RequestURI: ".*secrets.*"},
+			},
+			uri:      "/api/v1/secrets",
+			expected: auditlogv1.FilterActionAllow,
+		},
+		{
+			name: "allow-only policy does not match",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionAllow, RequestURI: ".*secrets.*"},
+			},
+			uri:      "/api/v1/pods",
+			expected: auditlogv1.FilterActionUnknown,
+		},
+		{
+			name: "deny filter matches",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: "/healthz"},
+			},
+			uri:      "/healthz",
+			expected: auditlogv1.FilterActionDeny,
+		},
+		{
+			name: "deny-only policy does not match",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: "/healthz"},
+			},
+			uri:      "/api/v1/pods",
+			expected: auditlogv1.FilterActionUnknown,
+		},
+		{
+			name: "allow overrides deny in same policy - deny first",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: ".*"},
+				{Action: auditlogv1.FilterActionAllow, RequestURI: ".*login.*"},
+			},
+			uri:      "/v3-public/localProviders/local?action=login",
+			expected: auditlogv1.FilterActionAllow,
+		},
+		{
+			name: "allow overrides deny in same policy - allow first",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionAllow, RequestURI: ".*login.*"},
+				{Action: auditlogv1.FilterActionDeny, RequestURI: ".*"},
+			},
+			uri:      "/v3-public/localProviders/local?action=login",
+			expected: auditlogv1.FilterActionAllow,
 		},
 	}
 
-	err = w.Write(&logEntry{
-		RequestURI: "/api/v1/secrets",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := PolicyFromAuditPolicy(&auditlogv1.AuditPolicy{
+				Spec: auditlogv1.AuditPolicySpec{Filters: tt.filters},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, policy.actionForUri(tt.uri))
+		})
+	}
+}
+
+func TestAllowTakesPrecedenceWithinPolicy(t *testing.T) {
+	filterOrders := []struct {
+		name    string
+		filters []auditlogv1.Filter
+	}{
+		{
+			name: "deny before allow",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: ".*"},
+				{Action: auditlogv1.FilterActionAllow, RequestURI: ".*login.*"},
+			},
+		},
+		{
+			name: "allow before deny",
+			filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionAllow, RequestURI: ".*login.*"},
+				{Action: auditlogv1.FilterActionDeny, RequestURI: ".*"},
+			},
+		},
+	}
+
+	for _, tt := range filterOrders {
+		t.Run(tt.name, func(t *testing.T) {
+			logs, w := setup(t, WriterOptions{
+				DefaultPolicyLevel:     auditlogv1.LevelRequestResponse,
+				DisableDefaultPolicies: true,
+			})
+
+			err := w.UpdatePolicy(&auditlogv1.AuditPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "login-only"},
+				Spec:       auditlogv1.AuditPolicySpec{Filters: tt.filters},
+			})
+			require.NoError(t, err)
+
+			err = w.Write(&logEntry{RequestURI: "/v3-public/localProviders/local?action=login"})
+			require.NoError(t, err)
+			require.Len(t, logs.logs, 1)
+
+			err = w.Write(&logEntry{RequestURI: "/api/v1/pods"})
+			require.NoError(t, err)
+			require.Len(t, logs.logs, 1)
+		})
+	}
+}
+
+func TestUserDenyOverridesDefaultPolicies(t *testing.T) {
+	logs, w := setup(t, WriterOptions{
+		DefaultPolicyLevel:     auditlogv1.LevelRequestResponse,
+		DisableDefaultPolicies: false,
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, expected, logs.logs)
+
+	err := w.UpdatePolicy(&auditlogv1.AuditPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "deny-healthz"},
+		Spec: auditlogv1.AuditPolicySpec{
+			Filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: "/healthz"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	err = w.Write(&logEntry{RequestURI: "/healthz"})
+	require.NoError(t, err)
+	assert.Empty(t, logs.logs)
+
+	err = w.Write(&logEntry{RequestURI: "/api/v1/pods"})
+	require.NoError(t, err)
+
+	// Also exercise Rancher's allow-only default secrets policy.
+	err = w.Write(&logEntry{RequestURI: "/api/v1/secrets"})
+	require.NoError(t, err)
+
+	require.Len(t, logs.logs, 2)
+	assert.Equal(t, "/api/v1/pods", logs.logs[0].RequestURI)
+	assert.Equal(t, "/api/v1/secrets", logs.logs[1].RequestURI)
 }
 
 func TestBlockList(t *testing.T) {
@@ -142,6 +272,53 @@ func TestBlockList(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, expected, logs.logs)
+
+	expected = append(expected, logEntry{
+		RequestURI: "/api/v1/configmaps",
+		Method:     http.MethodGet,
+	})
+
+	err = w.Write(&logEntry{
+		RequestURI: "/api/v1/configmaps",
+		Method:     http.MethodGet,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, logs.logs)
+}
+
+func TestUnmatchedDenyPolicyDoesNotApplyRedactions(t *testing.T) {
+	logs, w := setup(t, WriterOptions{
+		DefaultPolicyLevel:     auditlogv1.LevelRequestResponse,
+		DisableDefaultPolicies: true,
+	})
+
+	err := w.UpdatePolicy(&auditlogv1.AuditPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "deny-healthz-redact-cache"},
+		Spec: auditlogv1.AuditPolicySpec{
+			Filters: []auditlogv1.Filter{
+				{Action: auditlogv1.FilterActionDeny, RequestURI: "/healthz"},
+			},
+			AdditionalRedactions: []auditlogv1.Redaction{
+				{Headers: []string{"Cache.*"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	err = w.Write(&logEntry{
+		RequestURI: "/api/v1/pods",
+		ResponseHeader: http.Header{
+			"Cache-Control": []string{"no-cache"},
+			"Content-Type":  []string{contentTypeJSON},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, logs.logs, 1)
+	assert.Equal(t, []string{"no-cache"}, logs.logs[0].ResponseHeader["Cache-Control"])
+
+	err = w.Write(&logEntry{RequestURI: "/healthz"})
+	require.NoError(t, err)
+	require.Len(t, logs.logs, 1)
 }
 
 func TestNewWriterDropsImpersonateGroups(t *testing.T) {

--- a/pkg/crds/yaml/generated/auditlog.cattle.io_auditpolicies.yaml
+++ b/pkg/crds/yaml/generated/auditlog.cattle.io_auditpolicies.yaml
@@ -50,8 +50,8 @@ spec:
               additionalRedactions:
                 description: |-
                   AdditionalRedactions details additional informatino to be redacted. If there are any Filers defined in the same
-                  policy, these Redactions will only be applied to logs that are Allowed by those filters. If there are no
-                  Filters, the redactions will be applied to all logs.
+                  policy, these Redactions will only be applied to logs that are allowed by that policy. If there are no Filters,
+                  the redactions will be applied to all logs.
                 items:
                   properties:
                     headers:
@@ -68,9 +68,10 @@ spec:
                 type: boolean
               filters:
                 description: |-
-                  Filters described what logs are explicitly allowed and denied. Leave empty if all logs should be allowed. The
-                  Allow action has higher precedence than Deny. So if there are multiple filters that match a log and at least one
-                  Allow, the log will be allowed.
+                  Filters describe what logs are explicitly allowed and denied. Leave empty if all logs should be allowed by
+                  this policy. Within a single AuditPolicy, Allow has higher precedence than Deny when multiple filters match.
+                  Across AuditPolicy objects, an explicit Deny has higher precedence than Allow. If no filter in a policy matches,
+                  that policy has no effect on the log.
                 items:
                   description: Filter provides values used to filter out audit logs.
                   properties:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/53321
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
AuditPolicy deny filters do not take effect in Rancher audit logging. Requests that explicitly match deny rules (for example /healthz or /version) are still written to the audit log, even when no corresponding allow rule exists in the user-defined policy.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Update audit filter evaluation to explicitly distinguish between Allow, Deny, and Unknown (no match). Enforce deny-takes-precedence across policies while defaulting to allow when no policy matches. This ensures deny rules are respected without breaking default audit logging behavior and preserves policy-specific redactions.




## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Manual verification performed.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_