### PR TITLE
[v2.14] Recover recurrent usercontrollers reconciliation every 5s

### DIFF
--- a/pkg/controllers/managementapi/usercontrollers/usercontroller.go
+++ b/pkg/controllers/managementapi/usercontrollers/usercontroller.go
@@ -52,11 +52,17 @@ func Register(ctx context.Context, scaledContext *config.ScaledContext, clusterM
 	scaledContext.Wrangler.Mgmt.Cluster().OnChange(ctx, "user-controllers-controller", u.sync)
 
 	go func() {
+		// temporary measure to recover user controllers not able to successfully start
+		// TODO: find a better way to implement retries for Manager.Start()
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-u.forcedResync():
+			case <-ticker.C:
 			}
 
 			backoff := wait.Backoff{

--- a/pkg/controllers/managementapi/usercontrollers/usercontroller.go
+++ b/pkg/controllers/managementapi/usercontrollers/usercontroller.go
@@ -54,15 +54,16 @@ func Register(ctx context.Context, scaledContext *config.ScaledContext, clusterM
 	go func() {
 		// temporary measure to recover user controllers not able to successfully start
 		// TODO: find a better way to implement retries for Manager.Start()
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
+		const fallbackReconcilePeriod = 30 * time.Second
+		fallbackTimer := time.NewTimer(fallbackReconcilePeriod)
+		defer fallbackTimer.Stop()
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-u.forcedResync():
-			case <-ticker.C:
+			case <-fallbackTimer.C:
 			}
 
 			backoff := wait.Backoff{
@@ -79,6 +80,9 @@ func Register(ctx context.Context, scaledContext *config.ScaledContext, clusterM
 			}); err != nil {
 				logrus.Errorf("Giving up reconciling cluster ownership after %d attempts", backoff.Steps)
 			}
+
+			// Unlike a ticker, we don't need it to run at a fixed rate, just ensure it's executed at least once every X seconds.
+			fallbackTimer.Reset(fallbackReconcilePeriod)
 		}
 	}()
 }


### PR DESCRIPTION
## Issue: #55232
 
## Problem

When some of the Rancher pods get restarted, some of the downstream clusters may get stuck in "Unavailable" state, despite the cattle-cluster-agent being correctly connected to one of the Rancher pods.
This seems to be caused by some of the usercontrollers not succeeding to start and not getting retried.
 
## Solution

Prior to #53475, the code had a mechanism that over-reconciled clusters, which may have helped hiding the need for retrying a failed controller start attempt.
This PR temporarily brings back that periodic reconciliation, while we investigate if a more efficient retry strategy can be applied.