### PR TITLE
[2.16] Fix provisioning cluster may not be deleted on rancher restart

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/cluster.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster.go
@@ -28,7 +28,7 @@ func (h *handler) OnCluster(key string, cluster *v1.Cluster) (*v1.Cluster, error
 	}
 
 	// Ensure the finalizer is present on all provisioning clusters
-	if !slices.Contains(cluster.Finalizers, capiResourcesCleanupFinalizer) {
+	if cluster.DeletionTimestamp == nil && !slices.Contains(cluster.Finalizers, capiResourcesCleanupFinalizer) {
 		clusterCopy := cluster.DeepCopy()
 		clusterCopy.Finalizers = append(clusterCopy.Finalizers, capiResourcesCleanupFinalizer)
 		return h.clusterController.Update(clusterCopy)

--- a/pkg/controllers/management/authprovisioningv2/cluster.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster.go
@@ -27,7 +27,7 @@ func (h *handler) OnCluster(key string, cluster *v1.Cluster) (*v1.Cluster, error
 		return cluster, nil
 	}
 
-	// Ensure the finalizer is present on all provisioning clusters
+	// Ensure the finalizer is present on all non-deleting provisioning clusters
 	if cluster.DeletionTimestamp == nil && !slices.Contains(cluster.Finalizers, capiResourcesCleanupFinalizer) {
 		clusterCopy := cluster.DeepCopy()
 		clusterCopy.Finalizers = append(clusterCopy.Finalizers, capiResourcesCleanupFinalizer)

--- a/pkg/controllers/management/authprovisioningv2/cluster_test.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster_test.go
@@ -80,9 +80,14 @@ func TestOnCluster(t *testing.T) {
 		crtbMock           func(*gomock.Controller) mgmtcontrollers.ClusterRoleTemplateBindingController
 		prtbCacheMock      func(*gomock.Controller, string) mgmtcontrollers.ProjectRoleTemplateBindingCache
 		prtbMock           func(*gomock.Controller) mgmtcontrollers.ProjectRoleTemplateBindingController
+		setupHandler       func(*handler)
 		expectedErr        error
 		expectedFinalizers []string
 	}{
+		"nil cluster no-op": {
+			cluster:     nil,
+			expectedErr: nil,
+		},
 		"role exists, don't enqueue CRTBs nor PRTBs": {
 			cluster: &v1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -302,8 +307,64 @@ func TestOnCluster(t *testing.T) {
 				})
 				return mock
 			},
+			setupHandler: func(h *handler) {
+				// Ensure deletion flow executes the updated cluster-index scan logic.
+				// Using provisioningClusterGVK here exercises the self-skip branch and avoids dynamic calls.
+				h.provisioningClusterGVK = schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Cluster",
+				}
+				h.resourcesList = []resourceMatch{{GVK: h.provisioningClusterGVK, Resource: "clusters"}}
+			},
 			expectedErr:        nil,
 			expectedFinalizers: []string{},
+		},
+		"deleting cluster without finalizer still processes cleanup": {
+			cluster: &v1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "Cluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster",
+					Namespace: "fleet-default",
+					Labels: map[string]string{
+						kubernetesprovider.ProviderKey: providers.K3s, // distro is irrelevant here
+					},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			},
+			roleBindingMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) wranglerrbacv1.RoleBindingController {
+				mock := fake.NewMockControllerInterface[*rbacv1.RoleBinding, *rbacv1.RoleBindingList](ctrl)
+				mock.EXPECT().List(cluster.Namespace, metav1.ListOptions{}).Return(&rbacv1.RoleBindingList{}, nil)
+				return mock
+			},
+			roleCacheMock: func(ctrl *gomock.Controller, cluster *v1.Cluster) wranglerrbacv1.RoleCache {
+				mock := fake.NewMockCacheInterface[*rbacv1.Role](ctrl)
+				mock.EXPECT().Get(cluster.Namespace, clusterViewName(cluster)).Return(&rbacv1.Role{
+					Rules: []rbacv1.PolicyRule{{
+						APIGroups:     []string{cluster.GroupVersionKind().Group},
+						Resources:     []string{"clusters"},
+						ResourceNames: []string{cluster.Name},
+						Verbs:         []string{"get"},
+					}},
+				}, nil)
+				return mock
+			},
+			clusterMock: func(ctrl *gomock.Controller, _ *v1.Cluster) provisioningcontrollers.ClusterController {
+				return fake.NewMockControllerInterface[*v1.Cluster, *v1.ClusterList](ctrl)
+			},
+			setupHandler: func(h *handler) {
+				h.provisioningClusterGVK = schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Cluster",
+				}
+				h.resourcesList = []resourceMatch{{GVK: h.provisioningClusterGVK, Resource: "clusters"}}
+			},
+			expectedErr:        nil,
+			expectedFinalizers: nil,
 		},
 		"missing finalizer updates cluster before role handling": {
 			cluster: &v1.Cluster{
@@ -388,13 +449,18 @@ func TestOnCluster(t *testing.T) {
 				roleBindingController:                roleBindingController,
 				clusterController:                    clusterController,
 			}
+			if test.setupHandler != nil {
+				test.setupHandler(&h)
+			}
 
 			result, err := h.OnCluster("", test.cluster)
 
-			assert.Equal(t, err, test.expectedErr)
-			if test.cluster != nil {
-				assert.Equal(t, test.expectedFinalizers, result.Finalizers)
+			assert.Equal(t, test.expectedErr, err)
+			if test.cluster == nil {
+				assert.Nil(t, result)
+				return
 			}
+			assert.Equal(t, test.expectedFinalizers, result.Finalizers)
 		})
 	}
 }

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -77,7 +77,7 @@ type handler struct {
 	kubeconfigManager     *kubeconfig.Manager
 
 	capiClustersCache capicontrollers.ClusterCache
-	capiClusters      capicontrollers.ClusterClient
+	capiClusters      capicontrollers.ClusterController
 	capiMachinesCache capicontrollers.MachineCache
 }
 

--- a/pkg/controllers/provisioningv2/cluster/remove.go
+++ b/pkg/controllers/provisioningv2/cluster/remove.go
@@ -96,7 +96,7 @@ func (h *handler) doClusterRemove(cluster *v1.Cluster) func() (string, error) {
 		if capiClusterErr != nil && !apierrors.IsNotFound(capiClusterErr) {
 			return "", capiClusterErr
 		}
-		// Cache can be not up-to-date right after Rancher restart, so fall back to direct API read.
+		// Cache may not be up to date immediately after a Rancher restart, so fall back to a direct API read.
 		if apierrors.IsNotFound(capiClusterErr) {
 			capiCluster, capiClusterErr = h.capiClusters.Get(cluster.Namespace, cluster.Name, metav1.GetOptions{})
 			if capiClusterErr != nil {

--- a/pkg/controllers/provisioningv2/cluster/remove.go
+++ b/pkg/controllers/provisioningv2/cluster/remove.go
@@ -92,21 +92,20 @@ func (h *handler) doClusterRemove(cluster *v1.Cluster) func() (string, error) {
 			}
 		}
 
+		// The CAPI cluster informer cache may not be synced yet immediately after a
+		// Rancher restart, which would produce a false "not found" below and cause us
+		// to release this finalizer without ever deleting the CAPI cluster. If the
+		// cache is not synced, re-enqueue the provisioning cluster and try again later.
+		if !h.capiClusters.Informer().HasSynced() {
+			h.clusters.EnqueueAfter(cluster.Namespace, cluster.Name, 5*time.Second)
+			return "", generic.ErrSkip
+		}
+
 		capiCluster, capiClusterErr := h.capiClustersCache.Get(cluster.Namespace, cluster.Name)
 		if capiClusterErr != nil && !apierrors.IsNotFound(capiClusterErr) {
 			return "", capiClusterErr
 		}
-		// Cache may not be up to date immediately after a Rancher restart, so fall back to a direct API read.
-		if apierrors.IsNotFound(capiClusterErr) {
-			capiCluster, capiClusterErr = h.capiClusters.Get(cluster.Namespace, cluster.Name, metav1.GetOptions{})
-			if capiClusterErr != nil {
-				if apierrors.IsNotFound(capiClusterErr) {
-					capiCluster = nil
-				} else {
-					return "", capiClusterErr
-				}
-			}
-		}
+
 		if capiCluster != nil {
 			if capiCluster.DeletionTimestamp == nil {
 				// Deleting the CAPI cluster will start the process of deleting Machines, Bootstraps, etc.

--- a/pkg/controllers/provisioningv2/cluster/remove.go
+++ b/pkg/controllers/provisioningv2/cluster/remove.go
@@ -96,7 +96,17 @@ func (h *handler) doClusterRemove(cluster *v1.Cluster) func() (string, error) {
 		if capiClusterErr != nil && !apierrors.IsNotFound(capiClusterErr) {
 			return "", capiClusterErr
 		}
-
+		// Cache can be not up-to-date right after Rancher restart, so fall back to direct API read.
+		if apierrors.IsNotFound(capiClusterErr) {
+			capiCluster, capiClusterErr = h.capiClusters.Get(cluster.Namespace, cluster.Name, metav1.GetOptions{})
+			if capiClusterErr != nil {
+				if apierrors.IsNotFound(capiClusterErr) {
+					capiCluster = nil
+				} else {
+					return "", capiClusterErr
+				}
+			}
+		}
 		if capiCluster != nil {
 			if capiCluster.DeletionTimestamp == nil {
 				// Deleting the CAPI cluster will start the process of deleting Machines, Bootstraps, etc.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- https://github.com/rancher/rancher/issues/55939

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The "provisioning-cluster-remove" handler is the only function that triggers the deletion of CAPI clusters.
When Rancher starts, the "provisioning-cluster-remove" handler could begin processing provisioning cluster deletion events before the cache for CAPI Clusters is fully populated. In this case, the cache returns a not-found error for the target CAPI cluster, resulting in the target CAPI cluster NOT being deleted. Then, the `clusterIndexedResourcesExist` function always returns true, causing the `auth.cattle.io/capi-resources-cleanup` finalizer to never be removed from the provisioning cluster. 

There is no consistent way to reproduce the bug. I managed to reproduce it by creating a node-driver cluster and deleting it right after the creation, and had to try a few times. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This PR contains the following change:
-  Fix the `doClusterRemove` function to fall back to a direct API call to get the CPAI cluster if it is not found in the cache. The chance of this happening is low. As soon as being fully synced, the cache will return the CAPI cluster. 
- Avoid adding a finalizer to a provisioning cluster that has been deleted ( ie. has the DeletionTimestamp set). 


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Changes are tested by using an image built from this branch. It is confirmed that the reported issue is resolved.

### Automated Testing
 
Unit tests are updated. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Creating and deleting node-driver clusters rapidly a few times, and the provisioning clusters should be deleted successfully. 


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 
The provisioning clusters can not be deleted, because of the  `auth.cattle.io/capi-resources-cleanup` finalizer. 

Existing / newly added automated tests that provide evidence there are no regressions:
 
N/A 