### PR TITLE
[2.13] fix the updatecli config for wins and system-agent

### DIFF
--- a/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
+++ b/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
@@ -34,29 +34,117 @@ actions:
       description: 'Bump patch versions of Wins to {{ source "wins-release" }} and System Agent to {{ source "system-agent-release" }}.'
 
 sources:
+  wins-current-version:
+    name: 'Get current Wins version from package/Dockerfile'
+    kind: file
+    scmid: 'default'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: 'ENV[\s\t]+CATTLE_WINS_AGENT_VERSION[=\s]\S+'
+    transformers:
+      - find: 'v\S+'
+
+  system-agent-current-version:
+    name: 'Get current System Agent version from package/Dockerfile'
+    kind: file
+    scmid: 'default'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: 'ENV[\s\t]+CATTLE_SYSTEM_AGENT_VERSION[=\s]\S+'
+    transformers:
+      - find: 'v\S+'
+
   wins-release:
     name: 'Get latest upstream Wins version'
     kind: githubrelease
+    dependson:
+      - 'wins-current-version'
     spec:
       owner: '{{ .repos.wins.owner }}'
       repository: '{{ .repos.wins.repo }}'
       key: tagname
       typefilter:
-        latest: true
+        release: true
+        prerelease: true
       username: '{{ .scm.username }}'
       token: '{{ requiredEnv .scm.token }}'
+      versionfilter:
+        kind: semver
+        pattern: '~{{ source "wins-current-version" }}'
 
   system-agent-release:
     name: 'Get latest upstream System Agent version'
     kind: githubrelease
+    dependson:
+      - 'system-agent-current-version'
     spec:
       owner: '{{ .repos.system_agent.owner }}'
       repository: '{{ .repos.system_agent.repo }}'
       key: tagname
       typefilter:
-        latest: true
+        release: true
+        prerelease: true
       username: '{{ .scm.username }}'
       token: '{{ requiredEnv .scm.token }}'
+      versionfilter:
+        kind: semver
+        pattern: '~{{ source "system-agent-current-version" }}'
+
+  wins-checksum:
+    name: 'Get sha256 for wins.exe from {{ source "wins-release" }}'
+    kind: shell
+    dependson:
+      - 'wins-release'
+    spec:
+      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256.txt | grep " wins.exe$" | cut -d " " -f1'
+
+  wins-checksum-install:
+    name: 'Get sha256 for install.ps1 from {{ source "wins-release" }}'
+    kind: shell
+    dependson:
+      - 'wins-release'
+    spec:
+      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256.txt | grep " install.ps1$" | cut -d " " -f1'
+
+  wins-checksum-uninstall:
+    name: 'Get sha256 for uninstall.ps1 from {{ source "wins-release" }}'
+    kind: shell
+    dependson:
+      - 'wins-release'
+    spec:
+      command: 'curl -sLf https://github.com/{{ .repos.wins.owner }}/{{ .repos.wins.repo }}/releases/download/{{ source "wins-release" }}/sha256.txt | grep " uninstall.ps1$" | cut -d " " -f1'
+
+  system-agent-checksum-amd64:
+    name: 'Get sha256 for rancher-system-agent-amd64 from {{ source "system-agent-release" }}'
+    kind: shell
+    dependson:
+      - 'system-agent-release'
+    spec:
+      command: 'curl -sLf https://github.com/{{ .repos.system_agent.owner }}/{{ .repos.system_agent.repo }}/releases/download/{{ source "system-agent-release" }}/sha256sum.txt | grep " rancher-system-agent-amd64$" | cut -d " " -f1'
+
+  system-agent-checksum-arm64:
+    name: 'Get sha256 for rancher-system-agent-arm64 from {{ source "system-agent-release" }}'
+    kind: shell
+    dependson:
+      - 'system-agent-release'
+    spec:
+      command: 'curl -sLf https://github.com/{{ .repos.system_agent.owner }}/{{ .repos.system_agent.repo }}/releases/download/{{ source "system-agent-release" }}/sha256sum.txt | grep " rancher-system-agent-arm64$" | cut -d " " -f1'
+
+  system-agent-checksum-install:
+    name: 'Get sha256 for install.sh from {{ source "system-agent-release" }}'
+    kind: shell
+    dependson:
+      - 'system-agent-release'
+    spec:
+      command: 'curl -sLf https://github.com/{{ .repos.system_agent.owner }}/{{ .repos.system_agent.repo }}/releases/download/{{ source "system-agent-release" }}/sha256sum.txt | grep " install.sh$" | cut -d " " -f1'
+
+  system-agent-checksum-uninstall:
+    name: 'Get sha256 for system-agent-uninstall.sh from {{ source "system-agent-release" }}'
+    kind: shell
+    dependson:
+      - 'system-agent-release'
+    spec:
+      command: 'curl -sLf https://github.com/{{ .repos.system_agent.owner }}/{{ .repos.system_agent.repo }}/releases/download/{{ source "system-agent-release" }}/sha256sum.txt | grep " system-agent-uninstall.sh$" | cut -d " " -f1'
 
 conditions:
   check-dockerfile-wins-version:
@@ -90,6 +178,36 @@ targets:
       matchpattern: '(ENV|ARG)[\s\t]+CATTLE_WINS_AGENT_VERSION[=\s]\S+'
       replacepattern: '$1 CATTLE_WINS_AGENT_VERSION={{ source "wins-release" }}'
 
+  update-dockerfile-wins-checksum:
+    name: 'Update ENV CATTLE_WINS_AGENT_CHECKSUM in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'wins-checksum'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_WINS_AGENT_CHECKSUM[=\s]\S+'
+      replacepattern: '$1 CATTLE_WINS_AGENT_CHECKSUM={{ source "wins-checksum" }}'
+
+  update-dockerfile-wins-checksum-install:
+    name: 'Update ENV CATTLE_WINS_AGENT_CHECKSUM_install in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'wins-checksum-install'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_WINS_AGENT_CHECKSUM_install[=\s]\S+'
+      replacepattern: '$1 CATTLE_WINS_AGENT_CHECKSUM_install={{ source "wins-checksum-install" }}'
+
+  update-dockerfile-wins-checksum-uninstall:
+    name: 'Update ENV CATTLE_WINS_AGENT_CHECKSUM_uninstall in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'wins-checksum-uninstall'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_WINS_AGENT_CHECKSUM_uninstall[=\s]\S+'
+      replacepattern: '$1 CATTLE_WINS_AGENT_CHECKSUM_uninstall={{ source "wins-checksum-uninstall" }}'
+
   update-dockerfile-system-agent-release:
     name: 'Update ENV CATTLE_SYSTEM_AGENT_VERSION to {{ source "system-agent-release" }} in Dockerfile'
     kind: file
@@ -99,6 +217,46 @@ targets:
       file: 'package/Dockerfile'
       matchpattern: '(ENV|ARG)[\s\t]+CATTLE_SYSTEM_AGENT_VERSION[=\s]\S+'
       replacepattern: '$1 CATTLE_SYSTEM_AGENT_VERSION={{ source "system-agent-release" }}'
+
+  update-dockerfile-system-agent-checksum-amd64:
+    name: 'Update ENV CATTLE_SYSTEM_AGENT_CHECKSUM_amd64 in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'system-agent-checksum-amd64'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_SYSTEM_AGENT_CHECKSUM_amd64[=\s]\S+'
+      replacepattern: '$1 CATTLE_SYSTEM_AGENT_CHECKSUM_amd64={{ source "system-agent-checksum-amd64" }}'
+
+  update-dockerfile-system-agent-checksum-arm64:
+    name: 'Update ENV CATTLE_SYSTEM_AGENT_CHECKSUM_arm64 in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'system-agent-checksum-arm64'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_SYSTEM_AGENT_CHECKSUM_arm64[=\s]\S+'
+      replacepattern: '$1 CATTLE_SYSTEM_AGENT_CHECKSUM_arm64={{ source "system-agent-checksum-arm64" }}'
+
+  update-dockerfile-system-agent-checksum-install:
+    name: 'Update ENV CATTLE_SYSTEM_AGENT_CHECKSUM_install in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'system-agent-checksum-install'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_SYSTEM_AGENT_CHECKSUM_install[=\s]\S+'
+      replacepattern: '$1 CATTLE_SYSTEM_AGENT_CHECKSUM_install={{ source "system-agent-checksum-install" }}'
+
+  update-dockerfile-system-agent-checksum-uninstall:
+    name: 'Update ENV CATTLE_SYSTEM_AGENT_CHECKSUM_uninstall in Dockerfile'
+    kind: file
+    scmid: 'default'
+    sourceid: 'system-agent-checksum-uninstall'
+    spec:
+      file: 'package/Dockerfile'
+      matchpattern: '(ENV|ARG)[\s\t]+CATTLE_SYSTEM_AGENT_CHECKSUM_uninstall[=\s]\S+'
+      replacepattern: '$1 CATTLE_SYSTEM_AGENT_CHECKSUM_uninstall={{ source "system-agent-checksum-uninstall" }}'
 
   update-pkg-settings-wins-release:
     name: 'Update Wins to {{ source "wins-release" }} in pkg/settings/setting.go'


### PR DESCRIPTION
Issue: 
- https://github.com/rancher/rancher/issues/55769

Backports of:
- https://github.com/rancher/rancher/pull/55948
- https://github.com/rancher/rancher/pull/55994

Changes:
- add support for checking and updating the checksum values for wins and system-agent in the Dockerfile
- fix the issue that versions are downgraded because it checks for the latest tag 

We cannot test the changes locally because updatecli is deeply integrated with GH Actions, so we will validate them by checking the PRs generated or updated after the PR is merged.