### PR TITLE
Fix principal search deduplication and SCIM failures when UserAttribute is missing

### DIFF
--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -135,20 +135,15 @@ func (l *Provider) AuthenticateUser(_ http.ResponseWriter, _ *http.Request, inpu
 }
 
 // isLocalUser reports whether a User resource represents a user that can log
-// in locally. A user is considered local if it has a local login username or a
-// local:// principal ID. SCIM-provisioned users and users created purely as a
-// side effect of external authentication (e.g. SAML/Okta) lack both and must
-// not surface in local principal search results.
+// in locally. A user is local if it has a local login username, or if its only
+// principal is a local:// one. External-auth users (SAML, OAuth, SCIM) always
+// carry an external provider principal such as okta_user://<uid> in addition to
+// the self-referential local://<uid> that the user lifecycle controller appends
+// to every user, so they have more than one principal and are excluded — they
+// must not surface in local principal search results.
 func isLocalUser(user *apiv3.User) bool {
-	if user.Username != "" {
-		return true
-	}
-	for _, p := range user.PrincipalIDs {
-		if strings.HasPrefix(p, Name+"://") {
-			return true
-		}
-	}
-	return false
+	return user.Username != "" ||
+		(len(user.PrincipalIDs) == 1 && strings.HasPrefix(user.PrincipalIDs[0], Name+"://"))
 }
 
 func getLocalPrincipalID(user *apiv3.User) string {

--- a/pkg/auth/providers/local/local_auth_provider_test.go
+++ b/pkg/auth/providers/local/local_auth_provider_test.go
@@ -72,6 +72,26 @@ func TestProviderSearchPrincipal(t *testing.T) {
 			DisplayName:  "testuser2@example.com",
 			PrincipalIDs: []string{"okta_user://abc-uuid-1"},
 		},
+		{
+			// SCIM-provisioned external user after the user lifecycle controller
+			// appended a self-referential local:// principal. The user also
+			// carries an external provider principal, so it must still not
+			// surface as a local principal. Issue rancher/rancher#54022.
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "u-scim2",
+			},
+			DisplayName:  "testuser3@example.com",
+			PrincipalIDs: []string{"okta_user://abc-uuid-2", "local://u-scim2"},
+		},
+		{
+			// Local user with only a self-referential local:// principal and no
+			// username still counts as local.
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "u-local1",
+			},
+			DisplayName:  "Local Only",
+			PrincipalIDs: []string{"local://u-local1"},
+		},
 	}
 
 	provider := Provider{
@@ -169,6 +189,23 @@ func TestProviderSearchPrincipal(t *testing.T) {
 		{
 			searchKey: "testuser2@example.com",
 			want:      nil,
+		},
+		{
+			// SCIM user carrying both an external and a self-referential
+			// local:// principal must not surface as local.
+			// Issue rancher/rancher#54022.
+			searchKey: "testuser3",
+			want:      nil,
+		},
+		{
+			searchKey: "testuser3@example.com",
+			want:      nil,
+		},
+		{
+			// Local-only user (single local:// principal, no username) still
+			// surfaces as a local principal.
+			searchKey: "Local Only",
+			want:      []string{"local://u-local1"},
 		},
 	}
 

--- a/pkg/auth/providers/scim/group.go
+++ b/pkg/auth/providers/scim/group.go
@@ -815,7 +815,7 @@ func (s *SCIMServer) addGroupMember(provider, principalName, displayName string,
 		return fmt.Errorf("failed to get user %s: %w", member.Value, err)
 	}
 
-	attr, err := s.userAttributeCache.Get(user.Name)
+	attr, attrNeedsCreate, err := s.userMGR.EnsureAndGetUserAttribute(user.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get user attributes for %s: %w", user.Name, err)
 	}
@@ -842,9 +842,13 @@ func (s *SCIMServer) addGroupMember(provider, principalName, displayName string,
 	})
 
 	attr.GroupPrincipals[provider] = v3.Principals{Items: principals}
-	_, err = s.userAttributes.Update(attr)
+	if attrNeedsCreate {
+		_, err = s.userAttributes.Create(attr)
+	} else {
+		_, err = s.userAttributes.Update(attr)
+	}
 	if err != nil {
-		return fmt.Errorf("failed to update user attributes for %s: %w", user.Name, err)
+		return fmt.Errorf("failed to save user attributes for %s: %w", user.Name, err)
 	}
 
 	return nil
@@ -852,7 +856,7 @@ func (s *SCIMServer) addGroupMember(provider, principalName, displayName string,
 
 // updateGroupMemberDisplayName updates the DisplayName on a member's group principal if it is stale.
 func (s *SCIMServer) updateGroupMemberDisplayName(provider, principalName, displayName, memberID string) error {
-	attr, err := s.userAttributeCache.Get(memberID)
+	attr, _, err := s.userMGR.EnsureAndGetUserAttribute(memberID)
 	if err != nil {
 		return fmt.Errorf("failed to get user attributes for %s: %w", memberID, err)
 	}
@@ -889,7 +893,7 @@ func (s *SCIMServer) removeGroupMember(provider, principalName, value string) er
 		return fmt.Errorf("failed to get user %s: %w", value, err)
 	}
 
-	attr, err := s.userAttributeCache.Get(user.Name)
+	attr, _, err := s.userMGR.EnsureAndGetUserAttribute(user.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get user attributes for %s: %w", user.Name, err)
 	}

--- a/pkg/auth/providers/scim/group_test.go
+++ b/pkg/auth/providers/scim/group_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/user/mocks"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,8 +220,8 @@ func TestSyncGroupMembers(t *testing.T) {
 				provider: {Items: []v3.Principal{}},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-mo773yttt4").Return(existingAttr, false, nil)
 
 		updatedAttr := existingAttr.DeepCopy()
 		updatedAttr.GroupPrincipals[provider] = v3.Principals{
@@ -237,14 +238,57 @@ func TestSyncGroupMembers(t *testing.T) {
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(updatedAttr, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{newMember})
 		require.NoError(t, err)
+	})
+
+	t.Run("adds member that has no attribute yet", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		newMember := scimMember{Value: "u-new", Display: "new.user"}
+		user := &v3.User{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "management.cattle.io/v3", Kind: "User"},
+			ObjectMeta: metav1.ObjectMeta{Name: "u-new", UID: "uid-new"},
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
+		userCache.EXPECT().Get("u-new").Return(user, nil).AnyTimes()
+
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-new").Return(&v3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: "u-new"},
+			GroupPrincipals: map[string]v3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}, true, nil)
+
+		var created *v3.UserAttribute
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(a *v3.UserAttribute) (*v3.UserAttribute, error) {
+			created = a
+			return a, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
+		}
+
+		err := srv.syncGroupMembers(provider, groupPrincipalName(provider, groupName), groupName, []scimMember{newMember})
+		require.NoError(t, err)
+
+		require.NotNil(t, created)
+		items := created.GroupPrincipals[provider].Items
+		require.Len(t, items, 1)
+		assert.Equal(t, groupPrincipalName(provider, groupName), items[0].Name)
 	})
 
 	t.Run("removes members not in new list", func(t *testing.T) {
@@ -272,7 +316,8 @@ func TestSyncGroupMembers(t *testing.T) {
 
 		// Remove the member.
 		userCache.EXPECT().Get("u-mo773yttt4").Return(existingUser, nil)
-		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-mo773yttt4").Return(existingAttr, false, nil)
 
 		updatedAttr := existingAttr.DeepCopy()
 		updatedAttr.GroupPrincipals[provider] = v3.Principals{Items: []v3.Principal{}}
@@ -283,6 +328,7 @@ func TestSyncGroupMembers(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			userAttributes:     userAttrClient,
 			getConfig:          testDefaultGetConfig,
 		}
@@ -388,8 +434,8 @@ func TestUpdateGroupMemberDisplayName(t *testing.T) {
 			},
 		}
 
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(memberID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(memberID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -400,8 +446,8 @@ func TestUpdateGroupMemberDisplayName(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
 		}
 
 		err := srv.updateGroupMemberDisplayName(provider, principalName, "Engineering", memberID)
@@ -422,12 +468,12 @@ func TestUpdateGroupMemberDisplayName(t *testing.T) {
 			},
 		}
 
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(memberID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(memberID).Return(existingAttr, false, nil)
 
 		// No Update call expected.
 		srv := &SCIMServer{
-			userAttributeCache: userAttributeCache,
+			userMGR: userMGR,
 		}
 
 		err := srv.updateGroupMemberDisplayName(provider, principalName, "Engineering", memberID)
@@ -467,6 +513,9 @@ func TestSyncGroupMembersUpdatesStaleDisplayName(t *testing.T) {
 	userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
 	userAttributeCache.EXPECT().Get(memberID).Return(existingAttr, nil).AnyTimes()
 
+	userMGR := mocks.NewMockManager(ctrl)
+	userMGR.EXPECT().EnsureAndGetUserAttribute(memberID).Return(existingAttr, false, nil)
+
 	userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 	userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
 		items := attr.GroupPrincipals[provider].Items
@@ -479,6 +528,7 @@ func TestSyncGroupMembersUpdatesStaleDisplayName(t *testing.T) {
 		userCache:          userCache,
 		userAttributeCache: userAttributeCache,
 		userAttributes:     userAttrClient,
+		userMGR:            userMGR,
 		getConfig:          testDefaultGetConfig,
 	}
 
@@ -809,10 +859,11 @@ func TestPatchGroup(t *testing.T) {
 		userCache.EXPECT().Get("u-mo773yttt4").Return(&v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 		}, nil).Times(2) // Once for pre-flight check, once inside addGroupMember.
-		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-mo773yttt4").Return(&v3.UserAttribute{
 			ObjectMeta:      metav1.ObjectMeta{Name: "u-mo773yttt4"},
 			GroupPrincipals: map[string]v3.Principals{provider: {Items: []v3.Principal{}}},
-		}, nil)
+		}, false, nil)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(&v3.UserAttribute{}, nil)
 
 		// For final getRancherGroupMembers call.
@@ -833,6 +884,7 @@ func TestPatchGroup(t *testing.T) {
 			groupsCache:        groupCache,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			userAttributes:     userAttrClient,
 			getConfig:          testDefaultGetConfig,
 		}
@@ -1037,7 +1089,6 @@ func TestPatchGroup(t *testing.T) {
 
 		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
 		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 
 		existingGroup := &v3.Group{
@@ -1051,23 +1102,24 @@ func TestPatchGroup(t *testing.T) {
 		userCache.EXPECT().Get("u-mo773yttt4").Return(&v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 		}, nil)
-		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-mo773yttt4").Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 			GroupPrincipals: map[string]v3.Principals{
 				provider: {Items: []v3.Principal{{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"}}},
 			},
-		}, nil)
+		}, false, nil)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(&v3.UserAttribute{}, nil)
 
 		// For final getRancherGroupMembers call.
 		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
 
 		srv := &SCIMServer{
-			groupsCache:        groupCache,
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			groupsCache:    groupCache,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -1374,10 +1426,11 @@ func TestPatchGroup(t *testing.T) {
 		userCache.EXPECT().Get("u-mo773yttt4").Return(&v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 		}, nil).Times(2)
-		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-mo773yttt4").Return(&v3.UserAttribute{
 			ObjectMeta:      metav1.ObjectMeta{Name: "u-mo773yttt4"},
 			GroupPrincipals: map[string]v3.Principals{provider: {Items: []v3.Principal{}}},
-		}, nil)
+		}, false, nil)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(&v3.UserAttribute{}, nil)
 
 		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{
@@ -1397,6 +1450,7 @@ func TestPatchGroup(t *testing.T) {
 			groupsCache:        groupCache,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			userAttributes:     userAttrClient,
 			getConfig:          testDefaultGetConfig,
 		}
@@ -1430,7 +1484,6 @@ func TestPatchGroup(t *testing.T) {
 
 		groupCache := fake.NewMockNonNamespacedCacheInterface[*v3.Group](ctrl)
 		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 
 		existingGroup := &v3.Group{
@@ -1443,22 +1496,23 @@ func TestPatchGroup(t *testing.T) {
 		userCache.EXPECT().Get("u-mo773yttt4").Return(&v3.User{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 		}, nil)
-		userAttributeCache.EXPECT().Get("u-mo773yttt4").Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-mo773yttt4").Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: "u-mo773yttt4"},
 			GroupPrincipals: map[string]v3.Principals{
 				provider: {Items: []v3.Principal{{ObjectMeta: metav1.ObjectMeta{Name: groupPrincipalName(provider, "Engineering")}, DisplayName: "Engineering"}}},
 			},
-		}, nil)
+		}, false, nil)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(&v3.UserAttribute{}, nil)
 
 		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{}, nil)
 
 		srv := &SCIMServer{
-			groupsCache:        groupCache,
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			groupsCache:    groupCache,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		payload := map[string]any{
@@ -1862,7 +1916,9 @@ func TestCreateGroup(t *testing.T) {
 			},
 		}
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil).Times(2) // Once for getRancherGroupMembers, once for addGroupMember
+		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil) // getRancherGroupMembers
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-user1").Return(userAttr, false, nil)
 
 		userAttributeClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttributeClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -1878,6 +1934,7 @@ func TestCreateGroup(t *testing.T) {
 			groups:             groupClient,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			userAttributes:     userAttributeClient,
 			getConfig:          testDefaultGetConfig,
 		}
@@ -2878,7 +2935,9 @@ func TestUpdateGroup(t *testing.T) {
 			},
 		}
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil).Times(2)
+		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-user1").Return(userAttr, false, nil)
 
 		userAttributeClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttributeClient.EXPECT().Update(gomock.Any()).Return(userAttr, nil)
@@ -2887,6 +2946,7 @@ func TestUpdateGroup(t *testing.T) {
 			groupsCache:        groupsCache,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			userAttributes:     userAttributeClient,
 			getConfig:          testDefaultGetConfig,
 		}
@@ -3092,7 +3152,9 @@ func TestUpdateGroup(t *testing.T) {
 			},
 		}
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil).Times(2)
+		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-user1").Return(userAttr, false, nil)
 
 		userAttributeClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttributeClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -3106,6 +3168,7 @@ func TestUpdateGroup(t *testing.T) {
 			groupsCache:        groupsCache,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			userAttributes:     userAttributeClient,
 			getConfig:          testDefaultGetConfig,
 		}
@@ -3203,7 +3266,9 @@ func TestDeleteGroup(t *testing.T) {
 			},
 		}
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil).Times(2)
+		userAttributeCache.EXPECT().Get("u-user1").Return(userAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute("u-user1").Return(userAttr, false, nil)
 
 		userAttributeClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttributeClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -3218,6 +3283,7 @@ func TestDeleteGroup(t *testing.T) {
 			groups:             groupClient,
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			userAttributes:     userAttributeClient,
 			getConfig:          testDefaultGetConfig,
 		}

--- a/pkg/auth/providers/scim/user.go
+++ b/pkg/auth/providers/scim/user.go
@@ -455,9 +455,9 @@ func (s *SCIMServer) GetUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	attr, err := s.userAttributeCache.Get(user.Name)
+	attr, _, err := s.userMGR.EnsureAndGetUserAttribute(user.Name)
 	if err != nil {
-		logrus.Errorf("scim::GetUsers: failed to get user attributes for %s: %s", user.Name, err)
+		logrus.Errorf("scim::GetUser: failed to get user attributes for %s: %s", user.Name, err)
 		writeError(w, NewInternalError())
 		return
 	}
@@ -562,9 +562,9 @@ func (s *SCIMServer) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	attr, err := s.userAttributeCache.Get(user.Name)
+	attr, attrNeedsCreate, err := s.userMGR.EnsureAndGetUserAttribute(user.Name)
 	if err != nil {
-		logrus.Errorf("scim::UpdateUsers: failed to get user attributes for %s: %s", user.Name, err)
+		logrus.Errorf("scim::UpdateUser: failed to get user attributes for %s: %s", user.Name, err)
 		writeError(w, NewInternalError())
 		return
 	}
@@ -620,8 +620,13 @@ func (s *SCIMServer) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		shouldUpdateUser = true
 	}
 	if shouldUpdateAttr {
-		if attr, err = s.userAttributes.Update(attr); err != nil {
-			logrus.Errorf("scim::UpdateUser: failed to update user attributes for %s: %s", user.Name, err)
+		if attrNeedsCreate {
+			attr, err = s.userAttributes.Create(attr)
+		} else {
+			attr, err = s.userAttributes.Update(attr)
+		}
+		if err != nil {
+			logrus.Errorf("scim::UpdateUser: failed to save user attributes for %s: %s", user.Name, err)
 			writeError(w, NewInternalError())
 			return
 		}
@@ -745,7 +750,7 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	attr, err := s.userAttributeCache.Get(user.Name)
+	attr, attrNeedsCreate, err := s.userMGR.EnsureAndGetUserAttribute(user.Name)
 	if err != nil {
 		logrus.Errorf("scim::PatchUser: failed to get user attributes for %s: %s", user.Name, err)
 		writeError(w, NewInternalError())
@@ -800,8 +805,13 @@ func (s *SCIMServer) PatchUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if shouldUpdateAttr {
-		if attr, err = s.userAttributes.Update(attr); err != nil {
-			logrus.Errorf("scim::PatchUser: failed to update user attributes for %s: %s", user.Name, err)
+		if attrNeedsCreate {
+			attr, err = s.userAttributes.Create(attr)
+		} else {
+			attr, err = s.userAttributes.Update(attr)
+		}
+		if err != nil {
+			logrus.Errorf("scim::PatchUser: failed to save user attributes for %s: %s", user.Name, err)
 			writeError(w, NewInternalError())
 			return
 		}

--- a/pkg/auth/providers/scim/user_test.go
+++ b/pkg/auth/providers/scim/user_test.go
@@ -529,8 +529,8 @@ func TestGetUser(t *testing.T) {
 			Enabled:    &enabled,
 		}, nil)
 
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			ExtraByProvider: map[string]map[string][]string{
 				provider: {
@@ -540,11 +540,11 @@ func TestGetUser(t *testing.T) {
 					"email":       {"john.doe@example.com"},
 				},
 			},
-		}, nil)
+		}, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
+			userCache: userCache,
+			userMGR:   userMGR,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
@@ -590,8 +590,8 @@ func TestGetUser(t *testing.T) {
 			Enabled:    &disabled,
 		}, nil)
 
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			ExtraByProvider: map[string]map[string][]string{
 				provider: {
@@ -600,11 +600,11 @@ func TestGetUser(t *testing.T) {
 					"principalid": {provider + "_user://inactive.user"},
 				},
 			},
-		}, nil)
+		}, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
+			userCache: userCache,
+			userMGR:   userMGR,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
@@ -686,7 +686,7 @@ func TestGetUser(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, resp.Status)
 	})
 
-	t.Run("returns error when user attribute cache fails", func(t *testing.T) {
+	t.Run("returns error when the attribute lookup fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
 		userID := "u-error"
@@ -698,12 +698,12 @@ func TestGetUser(t *testing.T) {
 			Enabled:    &enabled,
 		}, nil)
 
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(nil, fmt.Errorf("cache error"))
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(nil, false, fmt.Errorf("cache error"))
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
+			userCache: userCache,
+			userMGR:   userMGR,
 		}
 
 		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
@@ -719,6 +719,94 @@ func TestGetUser(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, resp.Schemas, errorSchemaID)
 		assert.Equal(t, http.StatusInternalServerError, resp.Status)
+	})
+
+	t.Run("missing user attribute returns user with empty attribute fields", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-noattr"
+		enabled := true
+
+		user := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(user, nil).AnyTimes()
+
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
+			ObjectMeta:      metav1.ObjectMeta{Name: userID},
+			GroupPrincipals: map[string]v3.Principals{},
+			ExtraByProvider: map[string]map[string][]string{},
+		}, true, nil)
+
+		srv := &SCIMServer{
+			userCache: userCache,
+			userMGR:   userMGR,
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.GetUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, userID, resp["id"])
+		assert.Equal(t, true, resp["active"])
+		assert.Equal(t, "", resp["userName"])
+		assert.Equal(t, "", resp["externalId"])
+		assert.NotContains(t, resp, "emails")
+	})
+
+	t.Run("resolves attributes via the manager", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-lag"
+		enabled := true
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(&v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}, nil).AnyTimes()
+
+		attr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":   {"john.doe"},
+					"externalid": {"ext-12345"},
+				},
+			},
+		}
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(attr, false, nil)
+
+		srv := &SCIMServer{
+			userCache: userCache,
+			userMGR:   userMGR,
+		}
+
+		r := httptest.NewRequest(http.MethodGet, "/v1-scim/"+provider+"/Users/"+userID, nil)
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.GetUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "john.doe", resp["userName"])
+		assert.Equal(t, "ext-12345", resp["externalId"])
 	})
 }
 
@@ -1489,8 +1577,8 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -1499,9 +1587,9 @@ func TestUpdateUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},
@@ -1538,6 +1626,70 @@ func TestUpdateUser(t *testing.T) {
 		assert.Contains(t, w.Header().Get("Location"), wantLocation)
 	})
 
+	t.Run("updates via the attribute from the manager", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		userID := "u-abc123"
+		enabled := true
+
+		existingUser := &v3.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			Enabled:    &enabled,
+		}
+
+		userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+		userCache.EXPECT().Get(userID).Return(existingUser, nil)
+		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser}, nil)
+
+		existingAttr := &v3.UserAttribute{
+			ObjectMeta: metav1.ObjectMeta{Name: userID},
+			ExtraByProvider: map[string]map[string][]string{
+				provider: {
+					"username":    {"old.name"},
+					"externalid":  {"ext-12345"},
+					"principalid": {provider + "_user://old.name"},
+				},
+			},
+		}
+
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
+
+		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
+		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
+			assert.Equal(t, "new.name", first(attr.ExtraByProvider[provider]["username"]))
+			return attr, nil
+		})
+
+		srv := &SCIMServer{
+			userCache:      userCache,
+			userAttributes: userAttrClient,
+			userMGR:        userMGR,
+			getConfig: func(string) providerConfig {
+				return providerConfig{UserIDAttribute: UserIDExternalID}
+			},
+		}
+
+		body := `{
+			"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+			"userName": "new.name",
+			"externalId": "ext-12345",
+			"active": true
+		}`
+		r := httptest.NewRequest(http.MethodPut, "/v1-scim/"+provider+"/Users/"+userID, bytes.NewBufferString(body))
+		r.SetPathValue("provider", provider)
+		r.SetPathValue("id", userID)
+		w := httptest.NewRecorder()
+
+		srv.UpdateUser(w, r)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "new.name", resp["userName"])
+	})
+
 	t.Run("rejects userName change with default config", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
@@ -1559,13 +1711,13 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1610,12 +1762,12 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
+			userCache: userCache,
+			userMGR:   userMGR,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},
@@ -1663,8 +1815,8 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -1673,10 +1825,10 @@ func TestUpdateUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1721,8 +1873,8 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -1731,10 +1883,10 @@ func TestUpdateUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1779,14 +1931,14 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		// No Update calls expected since nothing changed.
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1841,15 +1993,15 @@ func TestUpdateUser(t *testing.T) {
 			PrincipalIDs: []string{"system://local"},
 		}, nil)
 
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
 			ObjectMeta:      metav1.ObjectMeta{Name: userID},
 			ExtraByProvider: map[string]map[string][]string{},
-		}, nil)
+		}, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
+			userCache: userCache,
+			userMGR:   userMGR,
 		}
 
 		body := `{
@@ -1888,13 +2040,13 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -1992,16 +2144,16 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("update failed"))
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},
@@ -2043,17 +2195,17 @@ func TestUpdateUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("update failed"))
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2092,7 +2244,8 @@ func TestUpdateUser(t *testing.T) {
 		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
 
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			ExtraByProvider: map[string]map[string][]string{
 				provider: {
@@ -2100,7 +2253,7 @@ func TestUpdateUser(t *testing.T) {
 					"externalid": {"ext-111"},
 				},
 			},
-		}, nil)
+		}, false, nil)
 		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
 			ExtraByProvider: map[string]map[string][]string{
@@ -2114,6 +2267,7 @@ func TestUpdateUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			getConfig:          testDefaultGetConfig,
 		}
 
@@ -2153,7 +2307,8 @@ func TestUpdateUser(t *testing.T) {
 		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
 
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			ExtraByProvider: map[string]map[string][]string{
 				provider: {
@@ -2161,7 +2316,7 @@ func TestUpdateUser(t *testing.T) {
 					"externalid": {"ext-111"},
 				},
 			},
-		}, nil)
+		}, false, nil)
 		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
 			ExtraByProvider: map[string]map[string][]string{
@@ -2175,6 +2330,7 @@ func TestUpdateUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},
@@ -2381,8 +2537,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -2391,10 +2547,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2444,8 +2600,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -2454,10 +2610,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		// We deliberately use a string "True" here to verify that we handle string booleans.
@@ -2503,8 +2659,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -2513,10 +2669,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2559,8 +2715,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -2569,10 +2725,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2622,8 +2778,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(existingAttr, nil)
@@ -2634,11 +2790,11 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			userCache:      userCache,
+			users:          userClient,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2675,8 +2831,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -2685,10 +2841,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2724,8 +2880,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -2734,10 +2890,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2773,8 +2929,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -2783,10 +2939,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2831,8 +2987,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -2841,9 +2997,9 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},
@@ -2887,13 +3043,13 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2934,13 +3090,13 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -2977,12 +3133,12 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
+			userCache: userCache,
+			userMGR:   userMGR,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},
@@ -3028,12 +3184,12 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
+			userCache: userCache,
+			userMGR:   userMGR,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},
@@ -3078,14 +3234,14 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		// No Update calls expected since nothing changed.
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3175,13 +3331,13 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3217,13 +3373,13 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3259,13 +3415,13 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3327,13 +3483,13 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3373,17 +3529,17 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("update failed"))
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3419,17 +3575,17 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("update failed"))
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3466,8 +3622,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userClient := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
 		userClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(u *v3.User) (*v3.User, error) {
@@ -3476,10 +3632,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			users:              userClient,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			users:     userClient,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3524,8 +3680,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -3534,10 +3690,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3579,13 +3735,13 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			getConfig:          testDefaultGetConfig,
+			userCache: userCache,
+			userMGR:   userMGR,
+			getConfig: testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3623,8 +3779,8 @@ func TestPatchUser(t *testing.T) {
 				},
 			},
 		}
-		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(existingAttr, nil)
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(existingAttr, false, nil)
 
 		userAttrClient := fake.NewMockNonNamespacedClientInterface[*v3.UserAttribute, *v3.UserAttributeList](ctrl)
 		userAttrClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(attr *v3.UserAttribute) (*v3.UserAttribute, error) {
@@ -3633,10 +3789,10 @@ func TestPatchUser(t *testing.T) {
 		})
 
 		srv := &SCIMServer{
-			userCache:          userCache,
-			userAttributeCache: userAttributeCache,
-			userAttributes:     userAttrClient,
-			getConfig:          testDefaultGetConfig,
+			userCache:      userCache,
+			userMGR:        userMGR,
+			userAttributes: userAttrClient,
+			getConfig:      testDefaultGetConfig,
 		}
 
 		body := `{
@@ -3682,7 +3838,8 @@ func TestPatchUser(t *testing.T) {
 		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
 
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			ExtraByProvider: map[string]map[string][]string{
 				provider: {
@@ -3690,7 +3847,7 @@ func TestPatchUser(t *testing.T) {
 					"externalid": {"ext-111"},
 				},
 			},
-		}, nil)
+		}, false, nil)
 		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
 			ExtraByProvider: map[string]map[string][]string{
@@ -3704,6 +3861,7 @@ func TestPatchUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			getConfig:          testDefaultGetConfig,
 		}
 
@@ -3741,7 +3899,8 @@ func TestPatchUser(t *testing.T) {
 		userCache.EXPECT().List(labels.Everything()).Return([]*v3.User{existingUser, otherUser}, nil)
 
 		userAttributeCache := fake.NewMockNonNamespacedCacheInterface[*v3.UserAttribute](ctrl)
-		userAttributeCache.EXPECT().Get(userID).Return(&v3.UserAttribute{
+		userMGR := mocks.NewMockManager(ctrl)
+		userMGR.EXPECT().EnsureAndGetUserAttribute(userID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: userID},
 			ExtraByProvider: map[string]map[string][]string{
 				provider: {
@@ -3749,7 +3908,7 @@ func TestPatchUser(t *testing.T) {
 					"externalid": {"ext-111"},
 				},
 			},
-		}, nil)
+		}, false, nil)
 		userAttributeCache.EXPECT().Get(otherUserID).Return(&v3.UserAttribute{
 			ObjectMeta: metav1.ObjectMeta{Name: otherUserID},
 			ExtraByProvider: map[string]map[string][]string{
@@ -3763,6 +3922,7 @@ func TestPatchUser(t *testing.T) {
 		srv := &SCIMServer{
 			userCache:          userCache,
 			userAttributeCache: userAttributeCache,
+			userMGR:            userMGR,
 			getConfig: func(string) providerConfig {
 				return providerConfig{UserIDAttribute: UserIDExternalID}
 			},


### PR DESCRIPTION
## Issue: #54022 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

- Principal search returned external-auth users (SCIM, SAML, OAuth) as Local in /v3/principals alongside their external provider entry, so the same person appeared twice in cluster member search. The user lifecycle controller appends a local:// principal id to every user, so a prior fix which assumed external users have no local:// principal, didn't hold.

- SCIM reads and writes failed with a 500 when a user's UserAttribute was missing.
GetUser, UpdateUser, PatchUser, and the group-membership helpers read the attribute straight from the cache and turned a not-found into an internal error.
The attribute is created on first login or refresh and can also lag in the cache right after provisioning, so a user read or updated before the attribute existed could not be served. A recurring 500 on a SCIM read risks the provisioning connector marking the sync as broken.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- A user is treated as local only when it has a local login username, or when its single principal is a local:// one. External users also carry an external
provider principal, so they have more than one principal and no longer surface as local.

- The SCIM handlers resolve the attribute through the user manager's EnsureAndGetUserAttribute, which reads the cache, falls back to the client on a miss, and builds a fresh attribute when none exists. Reads return the real values during cache lag and an empty result when the attribute is genuinely absent. Writes create the attribute when it was built and update it otherwise, so adding a not-yet-provisioned user to a group records the membership instead of failing. The group display-name and member-removal helpers treat a missing attribute as nothing to do.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests