### PR TITLE
 Refactor CRT TTL logic

### DIFF
--- a/pkg/api/norman/customization/setting/setting.go
+++ b/pkg/api/norman/customization/setting/setting.go
@@ -2,7 +2,6 @@ package setting
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
@@ -12,12 +11,6 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	v3client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/settings"
-)
-
-const (
-	minTTLMinutes         = 30 // 30 minutes
-	minGracePeriodMinutes = 10 // 10 minutes
 )
 
 var ReadOnlySettings = []string{
@@ -74,48 +67,10 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 		_, err = providerrefresh.ParseMaxAge(newValueString)
 	case "auth-user-info-resync-cron":
 		_, err = providerrefresh.ParseCron(newValueString)
-	case "crt-default-ttl-minutes":
-		err = validateCRTTTL(request, newValueString)
-	case "crt-default-grace-period-minutes":
-		err = validateCRTGracePeriod(request, newValueString)
 	}
 
 	if err != nil {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("%v", err))
-	}
-
-	return nil
-}
-
-func validateCRTTTL(request *types.APIContext, value string) error {
-	ttl, err := strconv.Atoi(value)
-	if err != nil {
-		return fmt.Errorf("crt-default-ttl-minutes must be a valid integer: %v", err)
-	}
-	if ttl < minTTLMinutes {
-		return fmt.Errorf("crt-default-ttl-minutes must be >= %d", minTTLMinutes)
-	}
-	// validate TTL > grace period
-	gp := settings.CRTDefaultGracePeriod.GetInt()
-	if ttl <= gp {
-		return fmt.Errorf("crt-default-ttl-minutes (%d) must be greater than crt-default-grace-period-minutes (%d)", ttl, gp)
-	}
-
-	return nil
-}
-
-func validateCRTGracePeriod(request *types.APIContext, value string) error {
-	gp, err := strconv.Atoi(value)
-	if err != nil {
-		return fmt.Errorf("crt-default-grace-period-minutes must be a valid integer: %v", err)
-	}
-	if gp < minGracePeriodMinutes {
-		return fmt.Errorf("crt-default-grace-period-minutes must be >= %d", minGracePeriodMinutes)
-	}
-	// validate TTL > grace period
-	ttl := settings.CRTDefaultTTL.GetInt()
-	if ttl <= gp {
-		return fmt.Errorf("crt-default-grace-period-minutes (%d) must be less than crt-default-ttl-minutes (%d)", gp, ttl)
 	}
 
 	return nil

--- a/pkg/api/norman/store/cluster/cluster_registration_store.go
+++ b/pkg/api/norman/store/cluster/cluster_registration_store.go
@@ -6,12 +6,25 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/v3/pkg/randomtoken"
 	"github.com/sirupsen/logrus"
 )
 
 type RegistrationTokenStore struct {
 	types.Store
 	SecretCache corecontrollers.SecretCache
+}
+
+func (r *RegistrationTokenStore) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	if data != nil {
+		token, err := randomtoken.Generate()
+		if err != nil {
+			return nil, err
+		}
+		data["token"] = token
+	}
+
+	return r.Store.Create(apiContext, schema, data)
 }
 
 func (r *RegistrationTokenStore) ByID(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -138,7 +138,7 @@ func (h *handler) onRemove(_ string, obj *v3.ClusterRegistrationToken) (*v3.Clus
 }
 
 func (h *handler) onChange(key string, obj *v3.ClusterRegistrationToken) (_ *v3.ClusterRegistrationToken, err error) {
-	if obj == nil {
+	if obj == nil || obj.DeletionTimestamp != nil {
 		return obj, nil
 	}
 
@@ -164,7 +164,7 @@ func (h *handler) onChange(key string, obj *v3.ClusterRegistrationToken) (_ *v3.
 		var expiresAt string
 		ttl := getTTL(obj)
 		if ttl > 0 && isTTLRotationEnabled() {
-			expiresAt = computeExpiresAt(obj.CreationTimestamp.Time, ttl)
+			expiresAt = computeExpiresAt(obj.CreationTimestamp.Time, ttl, time.Now())
 		}
 
 		if err := h.ensureTokenSecret(obj, token, expiresAt); err != nil {
@@ -265,8 +265,9 @@ func computeTTLDecision(now time.Time, obj *v3.ClusterRegistrationToken, data ma
 		}
 
 		d.gracePeriodExpiresAt = ""
+		d.deleteKeys = []string{gracePeriodExpiresAtDataKey}
 		if _, hasPrev := data[previousTokenDataKey]; hasPrev {
-			d.deleteKeys = []string{previousTokenDataKey, gracePeriodExpiresAtDataKey}
+			d.deleteKeys = append(d.deleteKeys, previousTokenDataKey)
 		}
 		return d, nil
 	}
@@ -277,7 +278,7 @@ func computeTTLDecision(now time.Time, obj *v3.ClusterRegistrationToken, data ma
 
 	ea, ok := data[expiresAtDataKey]
 	if !ok || len(ea) == 0 {
-		expiresAt := computeExpiresAt(creationTime, ttl)
+		expiresAt := computeExpiresAt(creationTime, ttl, now)
 		d.setData = map[string][]byte{expiresAtDataKey: []byte(expiresAt)}
 		d.expiresAt = expiresAt
 		return d, nil
@@ -303,10 +304,17 @@ func computeTTLDecision(now time.Time, obj *v3.ClusterRegistrationToken, data ma
 	newGracePeriodExpiresAt := now.Add(time.Duration(gracePeriod) * time.Minute).UTC().Format(time.RFC3339)
 
 	d.setData = map[string][]byte{
-		previousTokenDataKey:        data[tokenDataKey],
 		tokenDataKey:                []byte(newToken),
 		expiresAtDataKey:            []byte(newExpiresAt),
 		gracePeriodExpiresAtDataKey: []byte(newGracePeriodExpiresAt),
+	}
+	if oldToken, ok := data[tokenDataKey]; ok && len(oldToken) > 0 {
+		d.setData[previousTokenDataKey] = oldToken
+	} else {
+		// tokenDataKey should always be populated once the token secret exists; reaching rotation without one
+		// indicates the secret was corrupted.
+		logrus.Warnf("CRT %s/%s: %s is missing a valid token at rotation time; proceeding without a previousToken",
+			obj.Namespace, obj.Name, obj.Status.TokenSecretName)
 	}
 	d.expiresAt = newExpiresAt
 	d.gracePeriodExpiresAt = newGracePeriodExpiresAt
@@ -314,7 +322,7 @@ func computeTTLDecision(now time.Time, obj *v3.ClusterRegistrationToken, data ma
 }
 
 func (h *handler) handleTTL(obj *v3.ClusterRegistrationToken) (time.Duration, error) {
-	secret, err := h.secretCache.Get(obj.Namespace, SecretName(obj.Name))
+	secret, err := h.secretCache.Get(obj.Namespace, obj.Status.TokenSecretName)
 	if err != nil {
 		return 0, err
 	}
@@ -449,12 +457,11 @@ func (h *handler) ensureTokenSecret(crt *v3.ClusterRegistrationToken, token stri
 
 // computeExpiresAt computes a jittered expiry from creationTime + ttl,
 // falling back to now + jitter if that candidate is already in the past.
-func computeExpiresAt(creationTime time.Time, ttl int64) string {
+func computeExpiresAt(creationTime time.Time, ttl int64, now time.Time) string {
 	ttlDuration := time.Duration(ttl) * time.Minute
 	jitter := ComputeJitter(ttlDuration)
 
 	candidate := creationTime.Add(ttlDuration).Add(jitter)
-	now := time.Now()
 	if candidate.After(now) {
 		return candidate.UTC().Format(time.RFC3339)
 	}

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -96,12 +96,10 @@ func (h *handler) onSettingChange(_ string, obj *v3.Setting) (*v3.Setting, error
 	return obj, h.enqueueCRTsWithoutExpiry()
 }
 
-// enqueueCRTsWithoutExpiry enqueues all CRTs that have no ExpiresAt set.
-// This is used when the feature flag or TTL setting changes, to ensure existing
-// CRTs without a scheduled expiry are reconciled and get ExpiresAt assigned.
-// No-ops if the TTL rotation feature flag is not enabled.
+// enqueueCRTsWithoutExpiry re-enqueues CRTs whose token Secret has no expiresAt yet.
+// Called on TTL flag/setting changes so they pick up a schedule.
 func (h *handler) enqueueCRTsWithoutExpiry() error {
-	if !h.isTTLRotationEnabled() {
+	if !isTTLRotationEnabled() {
 		return nil
 	}
 	crts, err := h.clusterRegistrationTokenCache.List("", labels.Everything())
@@ -109,7 +107,17 @@ func (h *handler) enqueueCRTsWithoutExpiry() error {
 		return err
 	}
 	for _, crt := range crts {
-		if crt.Status.ExpiresAt == "" {
+		if crt.Status.TokenSecretName == "" {
+			continue
+		}
+		secret, err := h.secretCache.Get(crt.Namespace, crt.Status.TokenSecretName)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				logrus.Warnf("CRT %s/%s: failed to get token secret %s: %v", crt.Namespace, crt.Name, crt.Status.TokenSecretName, err)
+			}
+			continue
+		}
+		if expiresAt, ok := secret.Data[expiresAtDataKey]; !ok || len(expiresAt) == 0 {
 			h.clusterRegistrationTokenController.Enqueue(crt.Namespace, crt.Name)
 		}
 	}
@@ -134,112 +142,48 @@ func (h *handler) onChange(key string, obj *v3.ClusterRegistrationToken) (_ *v3.
 		return obj, nil
 	}
 
-	// Case 1: New CRT - TokenSecretName not set, generate token
-	if obj.Status.TokenSecretName == "" {
-		if obj.Status.Token != "" {
-			logrus.Warnf("CRT %s/%s has Status.Token set but no TokenSecretName - this should have been migrated. Migrating now as fallback.",
-				obj.Namespace, obj.Name)
-			return h.migrateCRTFallback(obj)
-		}
-
-		// New CRT - generate token and create secret
-		return h.createNewCRT(obj)
-	}
-
-	// Handle TTL rotation and status updates
-	return h.reconcileExistingCRT(obj)
-}
-
-// migrateCRTFallback handles the case where migration didn't run or failed
-// This is a safety net - normal migration happens in migrations.go
-func (h *handler) migrateCRTFallback(obj *v3.ClusterRegistrationToken) (*v3.ClusterRegistrationToken, error) {
-	obj = obj.DeepCopy()
-
-	var expiresAt string
-	ttl := h.getTTL(obj)
-	if ttl > 0 && h.isTTLRotationEnabled() {
-		ttlDuration := time.Duration(ttl) * time.Minute
-		jitter := computeJitter(ttlDuration)
-
-		candidate := obj.CreationTimestamp.Time.Add(ttlDuration).Add(jitter)
-		now := time.Now()
-
-		if candidate.After(now) {
-			expiresAt = candidate.UTC().Format(time.RFC3339)
-		} else {
-			expiresAt = now.Add(jitter).UTC().Format(time.RFC3339)
-		}
-	}
-
-	if err := h.ensureTokenSecret(obj, obj.Status.Token, expiresAt); err != nil {
-		return nil, err
-	}
-
-	obj.Status.Token = ""
-	obj.Status.TokenSecretName = SecretName(obj.Name)
-
-	newStatus, err := h.assignStatus(obj)
-	if err != nil {
-		return nil, err
-	}
-	obj.Status = newStatus
-
-	if expiresAt != "" {
-		obj.Status.ExpiresAt = expiresAt
-	}
-
-	logrus.Infof("Fallback migration completed for CRT %s/%s", obj.Namespace, obj.Name)
-	return h.clusterRegistrationTokenController.Update(obj)
-}
-
-// createNewCRT generates a token for a new CRT and stores it in a secret
-func (h *handler) createNewCRT(obj *v3.ClusterRegistrationToken) (*v3.ClusterRegistrationToken, error) {
-	token, err := randomtoken.Generate()
-	if err != nil {
-		return nil, err
-	}
-
-	obj = obj.DeepCopy()
-
-	// Calculate expiresAt once for consistency between secret and status
-	var expiresAt string
-	ttl := h.getTTL(obj)
-	if ttl > 0 && h.isTTLRotationEnabled() {
-		expiresAt = time.Now().Add(time.Duration(ttl) * time.Minute).UTC().Format(time.RFC3339)
-	}
-
-	if err := h.ensureTokenSecret(obj, token, expiresAt); err != nil {
-		return nil, err
-	}
-
-	obj.Status.Token = ""
-
-	obj.Status.TokenSecretName = SecretName(obj.Name)
-
-	newStatus, err := h.assignStatus(obj)
-	if err != nil {
-		return nil, err
-	}
-	obj.Status = newStatus
-
-	if expiresAt != "" {
-		obj.Status.ExpiresAt = expiresAt
-	}
-
-	return h.clusterRegistrationTokenController.Update(obj)
-}
-
-// reconcileExistingCRT handles TTL rotation and status updates for existing CRTs
-func (h *handler) reconcileExistingCRT(obj *v3.ClusterRegistrationToken) (*v3.ClusterRegistrationToken, error) {
-	if err := h.ensureCRTTokenReaderRole(obj.Namespace); err != nil {
-		return nil, err
-	}
-
 	obj = obj.DeepCopy()
 	original := obj.DeepCopy()
+	var requeueAfter time.Duration
 
-	if err := h.handleTTL(obj); err != nil {
-		return nil, err
+	// Runs only once, on first creation (or as fallback migration for a
+	// pre-Secret CRT). The Status update below re-triggers onChange with
+	// TokenSecretName set, entering the else branch for TTL handling.
+	if obj.Status.TokenSecretName == "" {
+		token := obj.Status.Token
+		if token != "" {
+			logrus.Warnf("CRT %s/%s has Status.Token set but no TokenSecretName - this should have been migrated. Migrating now as fallback.",
+				obj.Namespace, obj.Name)
+		} else {
+			token, err = randomtoken.Generate()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		var expiresAt string
+		ttl := getTTL(obj)
+		if ttl > 0 && isTTLRotationEnabled() {
+			expiresAt = computeExpiresAt(obj.CreationTimestamp.Time, ttl)
+		}
+
+		if err := h.ensureTokenSecret(obj, token, expiresAt); err != nil {
+			return nil, err
+		}
+
+		obj.Status.Token = ""
+		obj.Status.TokenSecretName = SecretName(obj.Name)
+		obj.Status.ExpiresAt = expiresAt
+		obj.Status.GracePeriodExpiresAt = ""
+	} else {
+		if err := h.ensureCRTTokenReaderRole(obj.Namespace); err != nil {
+			return nil, err
+		}
+
+		requeueAfter, err = h.handleTTL(obj)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	newStatus, err := h.assignStatus(obj)
@@ -247,163 +191,162 @@ func (h *handler) reconcileExistingCRT(obj *v3.ClusterRegistrationToken) (*v3.Cl
 		return nil, err
 	}
 
-	if equality.Semantic.DeepEqual(original.Status, newStatus) {
-		return obj, nil
-	}
-	obj.Status = newStatus
+	if !equality.Semantic.DeepEqual(original.Status, newStatus) {
+		obj.Status = newStatus
 
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest, err := h.clusterRegistrationTokenController.Get(obj.Namespace, obj.Name, metav1.GetOptions{})
-		if err != nil {
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, err := h.clusterRegistrationTokenController.Get(obj.Namespace, obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			latest = latest.DeepCopy()
+			latest.Status = obj.Status
+
+			updated, err := h.clusterRegistrationTokenController.Update(latest)
+			if err == nil {
+				obj = updated
+			}
 			return err
+		})
+
+		if err != nil {
+			return nil, err
 		}
+	}
 
-		latest = latest.DeepCopy()
-		latest.Status = obj.Status
-
-		updated, err := h.clusterRegistrationTokenController.Update(latest)
-		if err == nil {
-			obj = updated
-		}
-		return err
-	})
-
-	if err != nil {
-		return nil, err
+	if requeueAfter > 0 {
+		h.clusterRegistrationTokenController.EnqueueAfter(obj.Namespace, obj.Name, requeueAfter)
 	}
 
 	return obj, nil
 }
 
-func (h *handler) handleTTL(obj *v3.ClusterRegistrationToken) error {
-	now := time.Now()
+type ttlDecision struct {
+	setData              map[string][]byte
+	deleteKeys           []string
+	expiresAt            string
+	gracePeriodExpiresAt string
+	requeueAfter         time.Duration
+}
 
-	// Handle grace period cleanup FIRST - always enforce grace period deadline
-	// even when feature flag is disabled. This ensures previousToken expires
-	// at the promised time.
-	if obj.Status.GracePeriodExpiresAt != "" {
-		gpExpiry, err := time.Parse(time.RFC3339, obj.Status.GracePeriodExpiresAt)
+func (d ttlDecision) writesSecret() bool {
+	return len(d.setData) > 0 || len(d.deleteKeys) > 0
+}
+
+func computeTTLDecision(now time.Time, obj *v3.ClusterRegistrationToken, data map[string][]byte) (ttlDecision, error) {
+	ttl := getTTL(obj)
+	gracePeriod := getGracePeriod(obj, ttl)
+	ttlEnabled := isTTLRotationEnabled()
+	creationTime := obj.CreationTimestamp.Time
+	currentExpiresAt := obj.Status.ExpiresAt
+	currentGracePeriodExpiresAt := obj.Status.GracePeriodExpiresAt
+
+	d := ttlDecision{
+		expiresAt:            currentExpiresAt,
+		gracePeriodExpiresAt: currentGracePeriodExpiresAt,
+	}
+
+	// Grace period is checked first, even if TTL is disabled: a promised
+	// previousToken expiry must still fire regardless of the feature flag.
+	if gp, ok := data[gracePeriodExpiresAtDataKey]; ok && len(gp) > 0 {
+		gpExpiry, err := time.Parse(time.RFC3339, string(gp))
 		if err != nil {
-			return err
+			return ttlDecision{}, err
 		}
+
 		if now.Before(gpExpiry) {
-			h.clusterRegistrationTokenController.EnqueueAfter(obj.Namespace, obj.Name, time.Until(gpExpiry))
-			return nil
+			d.gracePeriodExpiresAt = string(gp)
+			if ea, ok := data[expiresAtDataKey]; ok && len(ea) > 0 {
+				d.expiresAt = string(ea)
+			}
+			d.requeueAfter = gpExpiry.Sub(now)
+			return d, nil
 		}
-		return h.cleanupGracePeriod(obj)
+
+		d.gracePeriodExpiresAt = ""
+		if _, hasPrev := data[previousTokenDataKey]; hasPrev {
+			d.deleteKeys = []string{previousTokenDataKey, gracePeriodExpiresAtDataKey}
+		}
+		return d, nil
 	}
 
-	if !h.isTTLRotationEnabled() {
-		return nil
+	if !ttlEnabled || ttl <= 0 {
+		return d, nil
 	}
 
-	ttl := h.getTTL(obj)
-	if ttl <= 0 {
-		return nil
+	ea, ok := data[expiresAtDataKey]
+	if !ok || len(ea) == 0 {
+		expiresAt := computeExpiresAt(creationTime, ttl)
+		d.setData = map[string][]byte{expiresAtDataKey: []byte(expiresAt)}
+		d.expiresAt = expiresAt
+		return d, nil
 	}
 
-	if obj.Status.ExpiresAt == "" {
-		return h.setExpiresAt(obj, ttl)
-	}
-
-	expiry, err := time.Parse(time.RFC3339, obj.Status.ExpiresAt)
+	expiry, err := time.Parse(time.RFC3339, string(ea))
 	if err != nil {
-		return err
+		return ttlDecision{}, err
 	}
 
 	if now.Before(expiry) {
-		h.clusterRegistrationTokenController.EnqueueAfter(obj.Namespace, obj.Name, time.Until(expiry))
-		return nil
+		d.expiresAt = string(ea)
+		d.requeueAfter = expiry.Sub(now)
+		return d, nil
 	}
-
-	return h.rotateToken(obj, ttl)
-}
-
-func (h *handler) setExpiresAt(obj *v3.ClusterRegistrationToken, ttl int64) error {
-	ttlDuration := time.Duration(ttl) * time.Minute
-	jitter := computeJitter(ttlDuration)
-
-	candidate := obj.CreationTimestamp.Time.Add(ttlDuration).Add(jitter)
-	now := time.Now()
-
-	if candidate.After(now) {
-		obj.Status.ExpiresAt = candidate.UTC().Format(time.RFC3339)
-	} else {
-		obj.Status.ExpiresAt = now.Add(jitter).UTC().Format(time.RFC3339)
-	}
-
-	logrus.Infof("CRT %s/%s: ExpiresAt empty, set to %s", obj.Namespace, obj.Name, obj.Status.ExpiresAt)
-	return nil
-}
-
-func (h *handler) rotateToken(obj *v3.ClusterRegistrationToken, ttl int64) error {
-	secretName := SecretName(obj.Name)
-	existing, err := h.secretCache.Get(obj.Namespace, secretName)
-	if err != nil {
-		return err
-	}
-
-	if expiresAtBytes, ok := existing.Data[expiresAtDataKey]; ok {
-		expiresAt, err := time.Parse(time.RFC3339, string(expiresAtBytes))
-		if err == nil && expiresAt.After(time.Now()) {
-			obj.Status.ExpiresAt = string(expiresAtBytes)
-			if _, hasPrev := existing.Data[previousTokenDataKey]; hasPrev {
-				if gp, ok := existing.Data[gracePeriodExpiresAtDataKey]; ok && len(gp) > 0 {
-					obj.Status.GracePeriodExpiresAt = string(gp)
-				}
-			}
-			return nil
-		}
-	}
-
-	now := time.Now()
-	gracePeriod := h.getGracePeriod(obj)
-	newExpiresAt := now.Add(time.Duration(ttl) * time.Minute).UTC().Format(time.RFC3339)
-	newGracePeriodExpiresAt := now.Add(time.Duration(gracePeriod) * time.Minute).UTC().Format(time.RFC3339)
 
 	newToken, err := randomtoken.Generate()
 	if err != nil {
-		return err
+		return ttlDecision{}, err
 	}
 
-	updated := existing.DeepCopy()
-	updated.Data[previousTokenDataKey] = existing.Data[tokenDataKey]
-	updated.Data[tokenDataKey] = []byte(newToken)
-	updated.Data[expiresAtDataKey] = []byte(newExpiresAt)
-	updated.Data[gracePeriodExpiresAtDataKey] = []byte(newGracePeriodExpiresAt)
+	newExpiresAt := now.Add(time.Duration(ttl) * time.Minute).UTC().Format(time.RFC3339)
+	newGracePeriodExpiresAt := now.Add(time.Duration(gracePeriod) * time.Minute).UTC().Format(time.RFC3339)
 
-	if _, err = h.secrets.Update(updated); err != nil {
-		return err
+	d.setData = map[string][]byte{
+		previousTokenDataKey:        data[tokenDataKey],
+		tokenDataKey:                []byte(newToken),
+		expiresAtDataKey:            []byte(newExpiresAt),
+		gracePeriodExpiresAtDataKey: []byte(newGracePeriodExpiresAt),
 	}
-
-	obj.Status.ExpiresAt = newExpiresAt
-	obj.Status.GracePeriodExpiresAt = newGracePeriodExpiresAt
-	return nil
+	d.expiresAt = newExpiresAt
+	d.gracePeriodExpiresAt = newGracePeriodExpiresAt
+	return d, nil
 }
 
-func (h *handler) cleanupGracePeriod(obj *v3.ClusterRegistrationToken) error {
-	secretName := SecretName(obj.Name)
-	existing, err := h.secretCache.Get(obj.Namespace, secretName)
+func (h *handler) handleTTL(obj *v3.ClusterRegistrationToken) (time.Duration, error) {
+	secret, err := h.secretCache.Get(obj.Namespace, SecretName(obj.Name))
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	if _, hasPrev := existing.Data[previousTokenDataKey]; hasPrev {
-		updated := existing.DeepCopy()
-		delete(updated.Data, previousTokenDataKey)
-		delete(updated.Data, gracePeriodExpiresAtDataKey)
+	decision, err := computeTTLDecision(time.Now(), obj, secret.Data)
+	if err != nil {
+		return 0, err
+	}
+
+	if decision.writesSecret() {
+		updated := secret.DeepCopy()
+		if updated.Data == nil {
+			updated.Data = make(map[string][]byte)
+		}
+		for k, v := range decision.setData {
+			updated.Data[k] = v
+		}
+		for _, k := range decision.deleteKeys {
+			delete(updated.Data, k)
+		}
 		if _, err := h.secrets.Update(updated); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	obj.Status.GracePeriodExpiresAt = ""
+	obj.Status.ExpiresAt = decision.expiresAt
+	obj.Status.GracePeriodExpiresAt = decision.gracePeriodExpiresAt
 
-	logrus.Infof("CRT %s/%s: grace period expired, previous token removed", obj.Namespace, obj.Name)
-	return nil
+	return decision.requeueAfter, nil
 }
 
-func (h *handler) getTTL(obj *v3.ClusterRegistrationToken) int64 {
+func getTTL(obj *v3.ClusterRegistrationToken) int64 {
 	var ttl int64
 	if obj.Spec.TTL == nil {
 		ttl = int64(settings.CRTDefaultTTL.GetInt())
@@ -414,22 +357,27 @@ func (h *handler) getTTL(obj *v3.ClusterRegistrationToken) int64 {
 	return ClampTTL(ttl, obj.Namespace, obj.Name)
 }
 
-// ClampTTL clamps the TTL to the minimum value and logs a warning if clamping occurs.
+// ClampTTL clamps the TTL to the minimum value and logs (at trace level, since this can fire on
+// every reconcile) if clamping occurs. ttl <= 0 is treated as an explicit "never expire" sentinel
+// and is left untouched.
 // This is exported for use by migration code.
 func ClampTTL(ttl int64, namespace, name string) int64 {
+	if ttl <= 0 {
+		return ttl
+	}
 	if ttl < MinTTLMinutes {
-		logrus.Warnf("CRT %s/%s: TTL %d is below minimum %d, clamping to minimum",
+		logrus.Tracef("CRT %s/%s: TTL %d is below minimum %d, clamping to minimum",
 			namespace, name, ttl, MinTTLMinutes)
 		return MinTTLMinutes
 	}
 	return ttl
 }
 
-func (h *handler) isTTLRotationEnabled() bool {
+func isTTLRotationEnabled() bool {
 	return features.CRTTokenTTLRotation.Enabled()
 }
 
-func (h *handler) getGracePeriod(obj *v3.ClusterRegistrationToken) int64 {
+func getGracePeriod(obj *v3.ClusterRegistrationToken, ttl int64) int64 {
 	var gracePeriod int64
 	if obj.Spec.GracePeriod == nil {
 		gracePeriod = int64(settings.CRTDefaultGracePeriod.GetInt())
@@ -437,16 +385,18 @@ func (h *handler) getGracePeriod(obj *v3.ClusterRegistrationToken) int64 {
 		gracePeriod = *obj.Spec.GracePeriod
 	}
 
-	ttl := h.getTTL(obj)
 	return ClampGracePeriod(gracePeriod, ttl, obj.Namespace, obj.Name)
 }
 
 // ClampGracePeriod clamps the grace period to the minimum value and ensures it's less than TTL.
-// This is exported for use by migration code.
 func ClampGracePeriod(gracePeriod, ttl int64, namespace, name string) int64 {
+	if ttl <= 0 {
+		return gracePeriod
+	}
+
 	// Clamp to minimum - defensive check in case setting validation is bypassed
 	if gracePeriod < MinGracePeriodMinutes {
-		logrus.Warnf("CRT %s/%s: grace period %d is below minimum %d, clamping to minimum",
+		logrus.Tracef("CRT %s/%s: grace period %d is below minimum %d, clamping to minimum",
 			namespace, name, gracePeriod, MinGracePeriodMinutes)
 		gracePeriod = MinGracePeriodMinutes
 	}
@@ -458,7 +408,7 @@ func ClampGracePeriod(gracePeriod, ttl int64, namespace, name string) int64 {
 		if newGracePeriod < MinGracePeriodMinutes {
 			newGracePeriod = MinGracePeriodMinutes
 		}
-		logrus.Warnf("CRT %s/%s: grace period %d must be less than TTL %d, clamping to %d",
+		logrus.Tracef("CRT %s/%s: grace period %d must be less than TTL %d, clamping to %d",
 			namespace, name, gracePeriod, ttl, newGracePeriod)
 		gracePeriod = newGracePeriod
 	}
@@ -482,6 +432,8 @@ func (h *handler) ensureTokenSecret(crt *v3.ClusterRegistrationToken, token stri
 		return h.ensureCRTTokenReaderRole(crt.Namespace)
 	}
 
+	// Only reached during initial/legacy migration - a live token's Secret
+	// should never be overwritten after that.
 	if string(existing.Data[tokenDataKey]) != token {
 		updated := existing.DeepCopy()
 		if updated.Data == nil {
@@ -495,7 +447,23 @@ func (h *handler) ensureTokenSecret(crt *v3.ClusterRegistrationToken, token stri
 	return nil
 }
 
-func computeJitter(ttl time.Duration) time.Duration {
+// computeExpiresAt computes a jittered expiry from creationTime + ttl,
+// falling back to now + jitter if that candidate is already in the past.
+func computeExpiresAt(creationTime time.Time, ttl int64) string {
+	ttlDuration := time.Duration(ttl) * time.Minute
+	jitter := ComputeJitter(ttlDuration)
+
+	candidate := creationTime.Add(ttlDuration).Add(jitter)
+	now := time.Now()
+	if candidate.After(now) {
+		return candidate.UTC().Format(time.RFC3339)
+	}
+	return now.Add(jitter).UTC().Format(time.RFC3339)
+}
+
+// ComputeJitter returns a random duration up to 10% of ttl (capped at 24h),
+// used to avoid synchronized expiry/rotation across CRTs.
+func ComputeJitter(ttl time.Duration) time.Duration {
 	tenPercent := ttl / 10
 	maxJitter := 24 * time.Hour
 	if tenPercent > maxJitter {

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -152,7 +153,7 @@ func (h *handler) onChange(key string, obj *v3.ClusterRegistrationToken) (_ *v3.
 	if obj.Status.TokenSecretName == "" {
 		token := obj.Status.Token
 		if token != "" {
-			logrus.Warnf("CRT %s/%s has Status.Token set but no TokenSecretName - this should have been migrated. Migrating now as fallback.",
+			logrus.Warnf("CRT %s/%s has Status.Token set but no TokenSecretName - migrating to secret",
 				obj.Namespace, obj.Name)
 		} else {
 			token, err = randomtoken.Generate()
@@ -176,7 +177,7 @@ func (h *handler) onChange(key string, obj *v3.ClusterRegistrationToken) (_ *v3.
 		obj.Status.ExpiresAt = expiresAt
 		obj.Status.GracePeriodExpiresAt = ""
 	} else {
-		if err := h.ensureCRTTokenReaderRole(obj.Namespace); err != nil {
+		if err := h.ensureCRTTokenReaderRoleForSecret(obj.Namespace, obj.Status.TokenSecretName); err != nil {
 			return nil, err
 		}
 
@@ -480,6 +481,23 @@ func ComputeJitter(ttl time.Duration) time.Duration {
 		return 0
 	}
 	return time.Duration(rand.Int63n(int64(tenPercent)))
+}
+
+func (h *handler) ensureCRTTokenReaderRoleForSecret(namespace, secretName string) error {
+	existing, err := h.roleCache.Get(namespace, crtTokenReaderRole)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if existing != nil {
+		for _, rule := range existing.Rules {
+			if slices.Contains(rule.ResourceNames, secretName) {
+				return nil
+			}
+		}
+	}
+
+	return h.ensureCRTTokenReaderRole(namespace)
 }
 
 // ensureCRTTokenReaderRole creates or updates the crt-token-reader Role in the given namespace.

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken_test.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken_test.go
@@ -1,0 +1,273 @@
+package clusterregistrationtoken
+
+import (
+	"testing"
+	"time"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// test helpers
+const (
+	staleCurrentExpiresAt            = "stale-current-expires-at"
+	staleCurrentGracePeriodExpiresAt = "stale-current-grace-period-expires-at"
+)
+
+func ptrInt64(v int64) *int64 { return &v }
+
+func newTestCRT(creationTime time.Time, ttl, gracePeriod *int64, currentExpiresAt, currentGracePeriodExpiresAt string) *v3.ClusterRegistrationToken {
+	return &v3.ClusterRegistrationToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "c-test",
+			Name:              "test-crt",
+			CreationTimestamp: metav1.NewTime(creationTime),
+		},
+		Spec: v3.ClusterRegistrationTokenSpec{
+			TTL:         ttl,
+			GracePeriod: gracePeriod,
+		},
+		Status: v3.ClusterRegistrationTokenStatus{
+			ExpiresAt:            currentExpiresAt,
+			GracePeriodExpiresAt: currentGracePeriodExpiresAt,
+		},
+	}
+}
+
+func setTTLEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	features.CRTTokenTTLRotation.Set(enabled)
+	t.Cleanup(features.CRTTokenTTLRotation.Unset)
+}
+
+// newHandlerForSecret builds a *handler backed by mock SecretCache/SecretClient
+// that serve the given Secret and capture the single expected Update call.
+// The returned func retrieves whatever was passed to Update (nil if never called).
+func newHandlerForSecret(t *testing.T, secret *corev1.Secret) (*handler, func() *corev1.Secret) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	secretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	secretCache.EXPECT().Get(secret.Namespace, secret.Name).Return(secret, nil)
+	secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	var updated *corev1.Secret
+	secretClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(s *corev1.Secret) (*corev1.Secret, error) {
+		updated = s
+		return s, nil
+	})
+	h := &handler{secretCache: secretCache, secrets: secretClient}
+	return h, func() *corev1.Secret { return updated }
+}
+
+// Grace period cleanup must fire even when TTL rotation is disabled - a
+// promised previousToken expiry must still be honored.
+func TestComputeTTLDecision_GracePeriodOrderingBeforeTTLGate(t *testing.T) {
+	setTTLEnabled(t, false)
+	now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+
+	data := map[string][]byte{
+		tokenDataKey:                []byte("tok"),
+		previousTokenDataKey:        []byte("old-tok"),
+		gracePeriodExpiresAtDataKey: []byte(past),
+	}
+
+	obj := newTestCRT(now, ptrInt64(60), ptrInt64(10), staleCurrentExpiresAt, staleCurrentGracePeriodExpiresAt)
+	d, err := computeTTLDecision(now, obj, data)
+	require.NoError(t, err)
+	require.Contains(t, d.deleteKeys, previousTokenDataKey)
+	require.Contains(t, d.deleteKeys, gracePeriodExpiresAtDataKey)
+}
+
+// When there's nothing to do (TTL disabled, or ttl<=0 "never expire"), the
+// current status must be carried forward untouched - never silently cleared.
+func TestComputeTTLDecision_NeverSilentlyClearsCurrentStatus(t *testing.T) {
+	now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	future := now.Add(1 * time.Hour).UTC().Format(time.RFC3339)
+
+	cases := []struct {
+		name       string
+		data       map[string][]byte
+		ttlEnabled bool
+		ttl        int64
+	}{
+		{name: "ttl disabled, no schedule", data: map[string][]byte{tokenDataKey: []byte("tok")}, ttlEnabled: false, ttl: 60},
+		{name: "ttl disabled, expiresAt present", data: map[string][]byte{tokenDataKey: []byte("tok"), expiresAtDataKey: []byte(future)}, ttlEnabled: false, ttl: 60},
+		{name: "ttl<=0 means never expire", data: map[string][]byte{tokenDataKey: []byte("tok")}, ttlEnabled: true, ttl: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setTTLEnabled(t, tc.ttlEnabled)
+			obj := newTestCRT(now.Add(-time.Hour), ptrInt64(tc.ttl), ptrInt64(10), staleCurrentExpiresAt, staleCurrentGracePeriodExpiresAt)
+			d, err := computeTTLDecision(now, obj, tc.data)
+			require.NoError(t, err)
+			require.False(t, d.writesSecret(), "no Secret write should happen when nothing was decided")
+			require.Equal(t, staleCurrentExpiresAt, d.expiresAt)
+			require.Equal(t, staleCurrentGracePeriodExpiresAt, d.gracePeriodExpiresAt)
+		})
+	}
+}
+
+// Feeds computeTTLDecision's own output back into itself across a full
+// lifecycle (stamp -> wait -> rotate -> grace wait -> cleanup -> next
+// window), asserting requeue timing is correct at each step and nothing
+// ever rotates or writes twice for the same instant.
+func TestTTLDecisionConvergesAndIsIdempotent(t *testing.T) {
+	setTTLEnabled(t, true)
+	const ttl = int64(60)
+	const gracePeriod = int64(10)
+	creationTime := time.Now().Add(-48 * time.Hour)
+	now := time.Now()
+
+	data := map[string][]byte{tokenDataKey: []byte("initial-token")}
+	obj := newTestCRT(creationTime, ptrInt64(ttl), ptrInt64(gracePeriod), "", "")
+
+	apply := func(d ttlDecision) {
+		for k, v := range d.setData {
+			data[k] = v
+		}
+		for _, k := range d.deleteKeys {
+			delete(data, k)
+		}
+		obj.Status.ExpiresAt = d.expiresAt
+		obj.Status.GracePeriodExpiresAt = d.gracePeriodExpiresAt
+	}
+
+	// Initial stamp: no schedule yet, one gets assigned, no requeue (the
+	// resulting Secret write triggers the next reconcile).
+	d1, err := computeTTLDecision(now, obj, data)
+	require.NoError(t, err)
+	require.NotEmpty(t, d1.expiresAt)
+	require.Zero(t, d1.requeueAfter)
+	apply(d1)
+
+	// Immediate re-reconcile: must be a no-op write, and must schedule the
+	// wakeup at expiry.
+	d2, err := computeTTLDecision(now, obj, data)
+	require.NoError(t, err)
+	require.Empty(t, d2.setData, "immediate re-reconcile at the same instant must be a no-op write")
+	require.Equal(t, obj.Status.ExpiresAt, d2.expiresAt)
+	require.Greater(t, d2.requeueAfter, time.Duration(0))
+	apply(d2)
+
+	// Expiry reached: rotate. New token issued, old token preserved as
+	// previousToken, no requeue (rotation itself doesn't requeue).
+	expiredNow := now.Add(time.Duration(ttl)*time.Minute + 20*time.Minute)
+	oldToken := string(data[tokenDataKey])
+	d3, err := computeTTLDecision(expiredNow, obj, data)
+	require.NoError(t, err)
+	require.NotEmpty(t, d3.setData[tokenDataKey])
+	require.NotEqual(t, oldToken, string(d3.setData[tokenDataKey]))
+	require.Equal(t, []byte(oldToken), d3.setData[previousTokenDataKey])
+	require.Zero(t, d3.requeueAfter)
+	apply(d3)
+
+	// Right after rotation: no further write, grace period wakeup scheduled.
+	d4, err := computeTTLDecision(expiredNow, obj, data)
+	require.NoError(t, err)
+	require.Empty(t, d4.setData)
+	require.Empty(t, d4.deleteKeys)
+	require.Greater(t, d4.requeueAfter, time.Duration(0))
+	apply(d4)
+
+	// Repeated reconciles while grace period is still active: must never
+	// rotate again.
+	rotatedToken := string(data[tokenDataKey])
+	for i := 0; i < 3; i++ {
+		dRepeat, err := computeTTLDecision(expiredNow, obj, data)
+		require.NoError(t, err)
+		require.Empty(t, dRepeat.setData, "must not rotate again while grace period is still active")
+		require.Equal(t, rotatedToken, string(data[tokenDataKey]))
+	}
+
+	// Grace period expires: previousToken and gracePeriodExpiresAt are
+	// cleaned up, ExpiresAt carried forward unchanged, no requeue.
+	graceExpiredNow := expiredNow.Add(time.Duration(gracePeriod)*time.Minute + time.Minute)
+	d5, err := computeTTLDecision(graceExpiredNow, obj, data)
+	require.NoError(t, err)
+	require.Contains(t, d5.deleteKeys, previousTokenDataKey)
+	require.Contains(t, d5.deleteKeys, gracePeriodExpiresAtDataKey)
+	require.Zero(t, d5.requeueAfter)
+	require.Equal(t, obj.Status.ExpiresAt, d5.expiresAt)
+	apply(d5)
+	require.NotContains(t, data, previousTokenDataKey)
+	require.NotContains(t, data, gracePeriodExpiresAtDataKey)
+	require.Empty(t, obj.Status.GracePeriodExpiresAt)
+
+	// After cleanup: no-op write, next rotation window's wakeup is scheduled.
+	d6, err := computeTTLDecision(graceExpiredNow, obj, data)
+	require.NoError(t, err)
+	require.Empty(t, d6.setData)
+	require.Greater(t, d6.requeueAfter, time.Duration(0))
+}
+
+// A stale CRT.Status.ExpiresAt (e.g. left over from before the feature was
+// disabled) must never be reused; handleTTL should stamp a fresh schedule there.
+func TestHandleTTL_ReadsFromSecretNotStaleStatus(t *testing.T) {
+	features.CRTTokenTTLRotation.Set(true)
+	defer features.CRTTokenTTLRotation.Unset()
+
+	secretName := SecretName("system")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "c-abc", Name: secretName},
+		Data: map[string][]byte{
+			tokenDataKey: []byte("tok"),
+			// No expiresAtDataKey: Secret has no schedule yet.
+		},
+	}
+
+	h, updated := newHandlerForSecret(t, secret)
+
+	crt := &v3.ClusterRegistrationToken{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "c-abc", Name: "system", CreationTimestamp: metav1.NewTime(time.Now().Add(-48 * time.Hour))},
+		Status: v3.ClusterRegistrationTokenStatus{
+			TokenSecretName: secretName,
+			// Stale: leftover from before the feature was disabled.
+			ExpiresAt: "2020-01-01T00:00:00Z",
+		},
+	}
+
+	_, err := h.handleTTL(crt)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated(), "a fresh expiresAt must be persisted to the Secret")
+	require.NotEqual(t, "2020-01-01T00:00:00Z", string(updated().Data[expiresAtDataKey]), "stale Status.ExpiresAt must not be reused as the new schedule")
+	require.NotEmpty(t, updated().Data[expiresAtDataKey])
+}
+
+// When the feature is disabled, handleTTL must not assign a new expiresAt,
+// but must still clean up an already-expired grace period from the Secret.
+func TestHandleTTL_DisabledFeatureHonorsExistingGracePeriod(t *testing.T) {
+	features.CRTTokenTTLRotation.Set(false)
+	defer features.CRTTokenTTLRotation.Unset()
+
+	secretName := SecretName("system")
+	graceAt := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339) // already expired
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "c-abc", Name: secretName},
+		Data: map[string][]byte{
+			tokenDataKey:                []byte("tok"),
+			previousTokenDataKey:        []byte("old-tok"),
+			gracePeriodExpiresAtDataKey: []byte(graceAt),
+		},
+	}
+
+	h, updated := newHandlerForSecret(t, secret)
+
+	crt := &v3.ClusterRegistrationToken{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "c-abc", Name: "system"},
+		Status:     v3.ClusterRegistrationTokenStatus{TokenSecretName: secretName},
+	}
+
+	_, err := h.handleTTL(crt)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated(), "expired grace period must be cleaned up from the Secret even when the feature is disabled")
+	require.Empty(t, updated().Data[gracePeriodExpiresAtDataKey])
+	require.Empty(t, updated().Data[expiresAtDataKey], "feature disabled: no new expiry should be assigned")
+}

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -236,7 +236,7 @@ var (
 	CRTTokenTTLRotation = newFeature(
 		"crt-token-ttl-rotation",
 		"Enable TTL-based automatic rotation of ClusterRegistrationToken credentials",
-		false,
+		true,
 		true,
 		true,
 	)


### PR DESCRIPTION
- Decoupled TTL/grace-period state from CRT.Status - CRT.Status is now just a projection of latest computed timestamps from secret. Fixes edge cases where a stale/out-of-sync status could cause reconcile to be skipped or an invalid token to not be revoked correctly. 
- Refactored the TTL/grace-period logic into a single pure decision function, so it can be unit tested directly.
- Fixed TTL=0  being silently clamped to the minimum, will add validation for minimum values in webhook for v2.15.1. 
- Enable feature by default 
- Other minor cleanup (log level, duplicate computation removed, etc) 

https://github.com/rancher/rancher/issues/56071 