### PR TITLE
Improve namespace creation logic to handle transient errors during Rancher startup

### DIFF
--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -445,13 +445,22 @@ func getSQLCacheGCValues(wranglerContext *wrangler.Context) (time.Duration, int)
 
 func (r *Rancher) Start(ctx context.Context) error {
 	if r.opts.LocalUserPasswordsNamespace {
-		// ensure namespace for storing local users password is created
-		if _, err := r.Wrangler.Core.Namespace().Create(&v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: pbkdf2.LocalUserPasswordsNamespace},
-		}); err != nil && !apierrors.IsAlreadyExists(err) {
+		// ensure namespace for storing local users password is created, retrying on transient errors
+		// instead of failing Rancher startup outright (e.g. API server not fully ready yet).
+		if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 3*time.Minute, true, func(context.Context) (bool, error) {
+			_, err := r.Wrangler.Core.Namespace().Create(&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: pbkdf2.LocalUserPasswordsNamespace},
+			})
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				logrus.WithError(err).Warnf("creating namespace %s failed; retrying", pbkdf2.LocalUserPasswordsNamespace)
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
 			return err
 		}
 	}
+
 	if err := dashboardapi.Register(ctx, r.Wrangler); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Related PR:
https://github.com/rancher/rancher/pull/55257

## Issue: 
https://github.com/rancher/rancher/issues/53053

https://github.com/rancher/rancher/issues/42699
https://github.com/rancher/rancher/issues/53053
https://github.com/rancher/rancher/issues/54739
https://github.com/rancher/rancher/issues/54906

## Problem
During Rancher startup, `Start()` creates the namespace used to store local user passwords (`pbkdf2.LocalUserPasswordsNamespace`) via a single, non-retried `Namespace().Create()` call. If this call fails for a transient reason (e.g. the API server isn't fully ready yet right after startup, a brief connectivity blip, etc.), Rancher startup fails outright and the process exits/crashes instead of recovering, even though the underlying condition is temporary and would resolve itself shortly after.

## Solution
Wrapped the namespace creation call in `wait.PollUntilContextTimeout` (10s interval, 3 minute timeout) so transient errors are retried instead of immediately failing startup. `AlreadyExists` errors are still treated as success (idempotent). On each retry a warning is logged via `logrus.WithError(err).Warnf(...)` so the transient failure is visible without aborting startup. If the namespace still cannot be created after the timeout window, `Start()` returns the error as before.

This change is scoped to the `r.opts.LocalUserPasswordsNamespace` guarded block in [`pkg/rancher/rancher.go`](pkg/rancher/rancher.go) and does not change any other startup behavior.

## Testing

## Engineering Testing
### Manual Testing
Manually verified `Start()` still creates the namespace successfully in the normal case, and that pre-existing namespaces (`AlreadyExists`) are treated as success without retrying.

### Automated Testing
- None

## QA Testing Considerations
- Verify a fresh install still creates the local-user-passwords namespace and starts up normally.
- Verify upgrade scenario where the namespace already exists — startup should proceed without retrying or logging warnings.
- If possible, simulate a transient API server unavailability window right at startup (e.g. delay API server readiness) and confirm Rancher now retries and eventually starts successfully instead of crashing.

### Regressions Considerations
Low risk of regression. The change only adds retry/backoff around a single `Create()` call and preserves the original error-handling semantics (`AlreadyExists` treated as success, other errors returned after retries are exhausted). No other startup logic was touched.

Existing / newly added automated tests that provide evidence there are no regressions:
- None