### PR TITLE
docs: fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Open your browser to https://localhost
 
 ## Installation
 
-See [Installing/Upgrading Rancher]([https://ranchermanager.docs.rancher.com/v2.8/pages-for-subheaders/installation-and-upgrade](https://ranchermanager.docs.rancher.com/v2.14/getting-started/installation-and-upgrade)) for all installation options.
+See [Installing/Upgrading Rancher](https://ranchermanager.docs.rancher.com/v2.14/getting-started/installation-and-upgrade) for all installation options.
 
 ### Minimum Requirements
 

--- a/README.md
+++ b/README.md
@@ -20,24 +20,24 @@ Open your browser to https://localhost
 
 ## Installation
 
-See [Installing/Upgrading Rancher](https://ranchermanager.docs.rancher.com/v2.8/pages-for-subheaders/installation-and-upgrade) for all installation options.
+See [Installing/Upgrading Rancher]([https://ranchermanager.docs.rancher.com/v2.8/pages-for-subheaders/installation-and-upgrade](https://ranchermanager.docs.rancher.com/v2.14/getting-started/installation-and-upgrade)) for all installation options.
 
 ### Minimum Requirements
 
 * Operating Systems
   * Please see [Support Matrix](https://rancher.com/support-matrix/) for specific OS versions for each Rancher version. Note that the link will default to the support matrix for the latest version of Rancher. Use the left navigation menu to select a different Rancher version. 
 * Hardware & Software
-  * Please see [Installation Requirements](https://ranchermanager.docs.rancher.com/v2.8/pages-for-subheaders/installation-requirements) for hardware and software requirements.
+  * Please see [Installation Requirements](https://ranchermanager.docs.rancher.com/v2.14/pages-for-subheaders/installation-requirements) for hardware and software requirements.
 
 ### Using Rancher
 
-To learn more about using Rancher, please refer to our [Rancher Documentation](https://ranchermanager.docs.rancher.com/v2.8).
+To learn more about using Rancher, please refer to our [Rancher Documentation](https://ranchermanager.docs.rancher.com/v2.14).
 
 ## Source Code
 
 This repo is a meta-repo used for packaging and contains the majority of Rancher codebase. For other Rancher projects and modules, [see go.mod](https://github.com/rancher/rancher/blob/release/v2.8/go.mod) for the full list.
 
-Rancher also includes other open source libraries and projects, [see go.mod](https://github.com/rancher/rancher/blob/release/v2.8/go.mod) for the full list.
+Rancher also includes other open source libraries and projects, [see go.mod](https://github.com/rancher/rancher/blob/release/v2.14/go.mod) for the full list.
 
 ## Build configuration
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [Installing/Upgrading Rancher](https://ranchermanager.docs.rancher.com/v2.14
 * Operating Systems
   * Please see [Support Matrix](https://rancher.com/support-matrix/) for specific OS versions for each Rancher version. Note that the link will default to the support matrix for the latest version of Rancher. Use the left navigation menu to select a different Rancher version. 
 * Hardware & Software
-  * Please see [Installation Requirements](https://ranchermanager.docs.rancher.com/v2.14/pages-for-subheaders/installation-requirements) for hardware and software requirements.
+  * Please see [Installation Requirements](https://ranchermanager.docs.rancher.com/v2.14/getting-started/installation-and-upgrade/installation-requirements) for hardware and software requirements.
 
 ### Using Rancher
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Fix broken links in README.md
 
## Problem
Links in the README point to the archived 2.8 version.

## Solution
Reference links to the latest stable version (2.14)
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
I've checked that the links are valid.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: It is a minor change in a README file
* If "None" - GH Issue/PR: n/a

Summary: fix broken links

## QA Testing Considerations
None
 
### Regressions Considerations
None