### PR TITLE
Fix Zizmor reports

### DIFF
--- a/.github/actions/images-files/generate/action.yml
+++ b/.github/actions/images-files/generate/action.yml
@@ -14,12 +14,14 @@ runs:
     - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '${{ steps.env.outputs.GO_VERSION }}'
-        cache: ${{ github.event_name == 'pull_request' }}
+        cache: false
     - name: Download data.json
       shell: bash
+      env:
+        CATTLE_KDM_BRANCH: ${{ steps.env.outputs.CATTLE_KDM_BRANCH }}
       run: |
         mkdir -p "$ARTIFACTS_BASE_DIR"
-        curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${{ steps.env.outputs.CATTLE_KDM_BRANCH }}/data.json > "./$ARTIFACTS_BASE_DIR/data.json"
+        curl -sLf "https://releases.rancher.com/kontainer-driver-metadata/$CATTLE_KDM_BRANCH/data.json" > "./$ARTIFACTS_BASE_DIR/data.json"
         cp "./$ARTIFACTS_BASE_DIR/data.json" "./$ARTIFACTS_BASE_DIR/rancher-data.json"
     - name: Create components and images files
       shell: bash

--- a/.github/actions/setup-tag-env/action.yml
+++ b/.github/actions/setup-tag-env/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] -- this action intentionally exports validated tag values for later steps.
         ref_name="${GITHUB_REF_NAME}"
         TAG="v2.16-${GITHUB_SHA}-head"
         prefix="release/"

--- a/.github/workflows/ci-testing-create-pr.yml
+++ b/.github/workflows/ci-testing-create-pr.yml
@@ -51,14 +51,17 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup and create branch
         id: branch-setup
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH_INPUT: ${{ inputs.base_branch }}
         run: |
-          if [[ -n "${{ inputs.base_branch }}" ]]; then
-            BASE_BRANCH="${{ inputs.base_branch }}"
+          if [[ -n "$BASE_BRANCH_INPUT" ]]; then
+            BASE_BRANCH="$BASE_BRANCH_INPUT"
           else
             BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
           fi
@@ -75,11 +78,13 @@ jobs:
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - name: Create and push empty commit
+        env:
+          BRANCH: ${{ steps.branch-setup.outputs.branch }}
         run: |
           touch trigger_ci
           git add trigger_ci
           git commit -m "Add trigger_ci file for CI testing"
-          git push origin ${{ steps.branch-setup.outputs.branch }}
+          git push origin "$BRANCH"
 
       - name: Create draft PR
         env:
@@ -88,6 +93,8 @@ jobs:
           INCLUDE_PATTERNS: ${{ inputs.include_patterns }}
           EXCLUDE_PATTERNS: ${{ inputs.exclude_patterns }}
           MAX_ATTEMPTS: ${{ inputs.max_ci_attempts }}
+          BASE_BRANCH: ${{ steps.branch-setup.outputs.base_branch }}
+          BRANCH: ${{ steps.branch-setup.outputs.branch }}
         run: |
           echo "This PR is for CI testing purposes only and can be ignored." > pr_body.txt
           echo "" >> pr_body.txt
@@ -102,8 +109,8 @@ jobs:
           fi
 
           gh pr create \
-            --base "${{ steps.branch-setup.outputs.base_branch }}" \
-            --head "${{ steps.branch-setup.outputs.branch }}" \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH" \
             --title "CI Testing" \
             --body-file pr_body.txt \
             --draft

--- a/.github/workflows/ci-testing-create-pr.yml
+++ b/.github/workflows/ci-testing-create-pr.yml
@@ -50,9 +50,8 @@ jobs:
           echo "APP_ID=" >> $GITHUB_ENV
 
       - name: Checkout repository
+        # zizmor: ignore[artipacked] -- this job must retain checkout credentials for authenticated branch fetch and push operations.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
 
       - name: Setup and create branch
         id: branch-setup

--- a/.github/workflows/ci-testing-restart-ci.yml
+++ b/.github/workflows/ci-testing-restart-ci.yml
@@ -1,6 +1,6 @@
 name: Restart CI Tests for CI Testing PRs
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] -- this workflow is gated to completed runs from this repository below.
     workflows: ["*"]
     types:
       - completed
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Find CI testing PR
         id: find-pr
@@ -67,8 +68,10 @@ jobs:
       - name: Get settings from PR
         id: pr-settings
         if: steps.find-pr.outputs.pr_number
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
         run: |
-          PR_BODY=$(gh pr view "${{ steps.find-pr.outputs.pr_number }}" --json body -q '.body')
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
 
           MAX_ATTEMPTS=$(echo "$PR_BODY" | grep -o "MAX_CI_ATTEMPTS: \`[0-9]*\`" | sed "s/MAX_CI_ATTEMPTS: \`//; s/\`$//")
           echo "Extracted MAX_ATTEMPTS: $MAX_ATTEMPTS"
@@ -94,11 +97,13 @@ jobs:
       - name: Get current workflow attempt
         id: current-attempt
         if: steps.find-pr.outputs.pr_number
+        env:
+          WORKFLOW_NAME: ${{ steps.find-pr.outputs.workflow_name }}
+          RUN_ID: ${{ steps.find-pr.outputs.run_id }}
+          MAX_ATTEMPTS: ${{ steps.pr-settings.outputs.max_attempts }}
         run: |
-          WORKFLOW_NAME="${{ steps.find-pr.outputs.workflow_name }}"
-          CURRENT_ATTEMPT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ steps.find-pr.outputs.run_id }}" --jq '.run_attempt')
+          CURRENT_ATTEMPT=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '.run_attempt')
           echo "value=$CURRENT_ATTEMPT" >> $GITHUB_OUTPUT
-          MAX_ATTEMPTS=${{ steps.pr-settings.outputs.max_attempts }}
 
           if (( CURRENT_ATTEMPT >= MAX_ATTEMPTS )); then
             echo "✅ Workflow '$WORKFLOW_NAME' reached limit: $CURRENT_ATTEMPT of $MAX_ATTEMPTS attempts"
@@ -113,9 +118,11 @@ jobs:
         env:
           # Needs write permissions to Actions
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          WORKFLOW_NAME: ${{ steps.find-pr.outputs.workflow_name }}
+          RUN_ID: ${{ steps.find-pr.outputs.run_id }}
         run: |
-          echo "Restart workflow '${{ steps.find-pr.outputs.workflow_name }}'"
-          gh api --method POST "repos/${{ github.repository }}/actions/runs/${{ steps.find-pr.outputs.run_id }}/rerun"
+          echo "Restart workflow '$WORKFLOW_NAME'"
+          gh api --method POST "repos/${{ github.repository }}/actions/runs/$RUN_ID/rerun"
 
       - name: Check if all workflows have reached limit
         if: steps.find-pr.outputs.pr_number && steps.current-attempt.outputs.reached_limit == 'true'
@@ -124,11 +131,10 @@ jobs:
           INCLUDE_PATTERNS: ${{ steps.pr-settings.outputs.include_patterns }}
           EXCLUDE_PATTERNS: ${{ steps.pr-settings.outputs.exclude_patterns }}
           MAX_CI_ATTEMPTS: ${{ steps.pr-settings.outputs.max_attempts }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
+          BRANCH: ${{ steps.find-pr.outputs.branch }}
+          MAX_ATTEMPTS: ${{ steps.pr-settings.outputs.max_attempts }}
         run: |
-          PR_NUMBER="${{ steps.find-pr.outputs.pr_number }}"
-          BRANCH="${{ steps.find-pr.outputs.branch }}"
-          MAX_ATTEMPTS=${{ steps.pr-settings.outputs.max_attempts }}
-
           INCOMPLETE_WORKFLOWS=0
 
           BRANCH_WORKFLOW_RUNS=$(gh api "repos/${{ github.repository }}/actions/runs" \

--- a/.github/workflows/ci-testing-restart-ci.yml
+++ b/.github/workflows/ci-testing-restart-ci.yml
@@ -98,11 +98,12 @@ jobs:
         id: current-attempt
         if: steps.find-pr.outputs.pr_number
         env:
+          REPOSITORY: ${{ github.repository }}
           WORKFLOW_NAME: ${{ steps.find-pr.outputs.workflow_name }}
           RUN_ID: ${{ steps.find-pr.outputs.run_id }}
           MAX_ATTEMPTS: ${{ steps.pr-settings.outputs.max_attempts }}
         run: |
-          CURRENT_ATTEMPT=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '.run_attempt')
+          CURRENT_ATTEMPT=$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID" --jq '.run_attempt')
           echo "value=$CURRENT_ATTEMPT" >> $GITHUB_OUTPUT
 
           if (( CURRENT_ATTEMPT >= MAX_ATTEMPTS )); then
@@ -116,13 +117,14 @@ jobs:
       - name: Restart workflow if under limit
         if: steps.find-pr.outputs.pr_number && steps.current-attempt.outputs.reached_limit != 'true'
         env:
+          REPOSITORY: ${{ github.repository }}
           # Needs write permissions to Actions
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WORKFLOW_NAME: ${{ steps.find-pr.outputs.workflow_name }}
           RUN_ID: ${{ steps.find-pr.outputs.run_id }}
         run: |
           echo "Restart workflow '$WORKFLOW_NAME'"
-          gh api --method POST "repos/${{ github.repository }}/actions/runs/$RUN_ID/rerun"
+          gh api --method POST "repos/$REPOSITORY/actions/runs/$RUN_ID/rerun"
 
       - name: Check if all workflows have reached limit
         if: steps.find-pr.outputs.pr_number && steps.current-attempt.outputs.reached_limit == 'true'
@@ -137,7 +139,7 @@ jobs:
         run: |
           INCOMPLETE_WORKFLOWS=0
 
-          BRANCH_WORKFLOW_RUNS=$(gh api "repos/${{ github.repository }}/actions/runs" \
+          BRANCH_WORKFLOW_RUNS=$(gh api "repos/$REPOSITORY/actions/runs" \
             -X GET \
             -f branch="$BRANCH" \
             --paginate \

--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.4.0
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
-          cache: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+          cache: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }} # zizmor: ignore[cache-poisoning] -- test-only dependency cache; release workflows are separate.
       - name: Run Integration Tests
         env:
           ENVTEST_K8S_VERSION: "1.30"

--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.4.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
           cache: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }} # zizmor: ignore[cache-poisoning] -- test-only dependency cache; release workflows are separate.

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -15,7 +15,7 @@ jobs:
   promote-docker-image:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/rancher/ci-image/go1.26
+      image: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: read
       id-token: write
@@ -35,7 +35,7 @@ jobs:
   promote-chart:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/rancher/ci-image/go1.26
+      image: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: read
       id-token: write
@@ -72,7 +72,7 @@ jobs:
     needs: [promote-docker-image, promote-chart]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/rancher/ci-image/go1.26
+      image: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -117,7 +117,7 @@ jobs:
     name: Convert test report to xml
     needs: [provisioning_tests]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     steps:
       - name: Fetch plaintext test output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -139,7 +139,7 @@ jobs:
   event-file:
     name: Upload event file
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     steps:
       - name: Upload GH Event File
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/publish-provisioning-test-results.yaml
+++ b/.github/workflows/publish-provisioning-test-results.yaml
@@ -1,6 +1,6 @@
 name: Publish Provisioning Tests Results
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] -- artifacts are published only for successful or failed runs from this repository.
     workflows: ["Build Pull Request"]
     types:
       - completed
@@ -9,8 +9,10 @@ permissions: {}
 jobs:
   publish-provisioning-test-results:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: registry.suse.com/bci/bci-base:15.7
-    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
+    container: registry.suse.com/bci/bci-base@sha256:d691028312b5d68e5b2d7cf494f8bbc2311f80fae556520e5f5e03b78ce7d5f9 # 15.7
+    if: >-
+      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/unit-test.yml
   build-chart:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: read
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -82,7 +82,7 @@ jobs:
   build-publish-chart:
     needs: [push-images]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/rcs-release.yml
+++ b/.github/workflows/rcs-release.yml
@@ -89,7 +89,7 @@ jobs:
   build-publish-chart:
     needs: [push-images]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: read
       id-token: write
@@ -186,7 +186,7 @@ jobs:
         uses: ./.github/actions/merge-manifests
   create-images-files:
     runs-on: runs-on,runner=2cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
   build-publish-chart:
     needs: [push-images]
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     permissions:
       contents: read
       id-token: write
@@ -177,7 +177,7 @@ jobs:
         uses: ./.github/actions/merge-manifests
   create-images-files:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26:latest
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # latest
     permissions:
       contents: read
     env:
@@ -208,7 +208,7 @@ jobs:
           path: /tmp/artifacts
   docker-image-digests:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     needs: [create-images-files, merge-server-agent-installer-manifests]
     env:
       ARTIFACTS_BASE_DIR: "dist"
@@ -240,7 +240,7 @@ jobs:
           path: /tmp/artifacts
   publish-artifacts:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     needs: [merge-server-agent-installer-manifests, create-images-files, docker-image-digests]
     permissions:
       contents: write
@@ -304,7 +304,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
   notify-release:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
-    container: ghcr.io/rancher/ci-image/go1.26
+    container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26
     needs: [publish-artifacts, merge-server-agent-installer-manifests, docker-image-digests]
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,18 +272,6 @@ jobs:
           path: /tmp/artifacts
           name: images-digests
           merge-multiple: true
-      - name: Read App Secrets
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
-            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY ;
-      - name: Create App Token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-        id: app-token
-        with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.PRIVATE_KEY }}
       - name: create draft release
         shell: bash
         run: |
@@ -301,7 +289,7 @@ jobs:
 
           gh release create "${TAG}" -R "${GITHUB_REPOSITORY}" --draft --prerelease --title "${TAG}" --notes-file /tmp/artifacts/rancher-components.txt  "${ALL_ARTIFACTS[@]}"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
   notify-release:
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     container: ghcr.io/rancher/ci-image/go1.26@sha256:a491bffcf6fce8e242fa2a64df51375f2d0400ddbfb7a6649365f808eb11abca # go1.26

--- a/.github/workflows/system-agent-upgrade.yml
+++ b/.github/workflows/system-agent-upgrade.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
       - name: Update system agent in files
         run:  ./scripts/system-agent-upgrade
       - name: Check for repository changes

--- a/.github/workflows/system-agent-upgrade.yml
+++ b/.github/workflows/system-agent-upgrade.yml
@@ -40,10 +40,10 @@ jobs:
           permission-pull-requests: write
 
       - name: Check out repository code
+        # zizmor: ignore[artipacked] -- this job must retain the App token for its authenticated branch push.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
       - name: Update system agent in files
         run:  ./scripts/system-agent-upgrade
       - name: Check for repository changes

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Install updatecli
         uses: updatecli/updatecli-action@4b17f4ea784de29f71f85f9bc4955402ba1ae53c # v2.100.0

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -30,9 +30,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
+        # zizmor: ignore[artipacked] -- this job must retain checkout credentials for authenticated branch cleanup pushes.
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: false
 
       - name: Install updatecli
         uses: updatecli/updatecli-action@4b17f4ea784de29f71f85f9bc4955402ba1ae53c # v2.100.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,14 +25,14 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "${{ env.GOLANG_VERSION }}"
-          cache: ${{ github.event_name == 'pull_request' }}
+          cache: ${{ github.event_name == 'pull_request' }} # zizmor: ignore[cache-poisoning] -- validation-only dependency cache; release workflows are separate.
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: ${{ env.GOLANG_CI_LINT_VERSION }}
           args: -v
           only-new-issues: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000') }}
-          skip-cache: false
+          skip-cache: false # zizmor: ignore[cache-poisoning] -- validation-only linter cache; release workflows are separate.
         # only use cache on pull requests
       - name: Validate (modules)
         run: ./scripts/validate

--- a/.github/workflows/verify-generated-code-changes.yml
+++ b/.github/workflows/verify-generated-code-changes.yml
@@ -28,9 +28,10 @@ jobs:
       - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.4.0
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
-          cache: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+          cache: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }} # zizmor: ignore[cache-poisoning] -- test-only dependency cache; release workflows are separate.
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        # zizmor: ignore[cache-poisoning] -- test-only dependency cache; release workflows are separate.
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/verify-generated-code-changes.yml
+++ b/.github/workflows/verify-generated-code-changes.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.4.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
           cache: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }} # zizmor: ignore[cache-poisoning] -- test-only dependency cache; release workflows are separate.


### PR DESCRIPTION
## Summary

- Harden GitHub Actions workflows against zizmor findings.
- Pin workflow container images to immutable digests.
- Prevent shell template injection from workflow expressions.
- Restrict `workflow_run` artifact processing to trusted repository runs.
- Disable unnecessary checkout credential persistence.
- Retain dependency caching for test and validation workflows with scoped zizmor exceptions.
- Remove redundant Vault-backed GitHub App credentials from the release workflow.