### PR TITLE
Enable the aggregated role templates feature by default

### DIFF
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -136,8 +136,8 @@ var (
 		true)
 	AggregatedRoleTemplates = newFeature(
 		"aggregated-roletemplates",
-		"[Experimental] Make RoleTemplates use aggregation for generated RBAC roles",
-		false,
+		"Make RoleTemplates use aggregation for generated RBAC roles",
+		true,
 		true,
 		true)
 	ClusterAgentSchedulingCustomization = newFeature(

--- a/tests/v2/integration/projects/project_user_test.go
+++ b/tests/v2/integration/projects/project_user_test.go
@@ -6,13 +6,20 @@ import (
 	"github.com/rancher/rancher/tests/v2/integration/actions/namespaces"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	extauthz "github.com/rancher/shepherd/extensions/kubeapi/authorization"
 	"github.com/rancher/shepherd/extensions/users"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/api/scheme"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	authzv1 "k8s.io/api/authorization/v1"
 )
+
+func init() {
+	authzv1.SchemeBuilder.AddToScheme(scheme.Scheme.Scheme)
+}
 
 const (
 	namespaceName = "testnamespace"
@@ -72,10 +79,19 @@ func (p *ProjectUserTestSuite) TestCreateNamespaceProjectMember() {
 	client, err := p.client.WithSession(subSession)
 	require.NoError(p.T(), err)
 
-	err = users.AddProjectMember(client, p.project, p.testUser, "project-member", nil)
+	_, err = client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
+		ProjectID:       p.project.ID,
+		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		RoleTemplateID:  "project-member",
+	})
 	require.NoError(p.T(), err)
 
 	testUser, err := client.AsUser(p.testUser)
+	require.NoError(p.T(), err)
+
+	err = extauthz.WaitForAllowed(testUser, p.project.ClusterID, []*authzv1.ResourceAttributes{
+		{Verb: "create", Resource: "namespaces"},
+	})
 	require.NoError(p.T(), err)
 
 	createdNamespace, err := namespaces.CreateNamespace(testUser, namespaceName, "{}", map[string]string{}, map[string]string{}, p.project)
@@ -90,10 +106,19 @@ func (p *ProjectUserTestSuite) TestCreateNamespaceProjectOwner() {
 	client, err := p.client.WithSession(subSession)
 	require.NoError(p.T(), err)
 
-	err = users.AddProjectMember(client, p.project, p.testUser, "project-owner", nil)
+	_, err = client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
+		ProjectID:       p.project.ID,
+		UserPrincipalID: p.testUser.PrincipalIDs[0],
+		RoleTemplateID:  "project-owner",
+	})
 	require.NoError(p.T(), err)
 
 	testUser, err := client.AsUser(p.testUser)
+	require.NoError(p.T(), err)
+
+	err = extauthz.WaitForAllowed(testUser, p.project.ClusterID, []*authzv1.ResourceAttributes{
+		{Verb: "create", Resource: "namespaces"},
+	})
 	require.NoError(p.T(), err)
 
 	createdNamespace, err := namespaces.CreateNamespace(testUser, namespaceName, "{}", map[string]string{}, map[string]string{}, p.project)

--- a/tests/v2/integration/rbac/etcdbackups_test.go
+++ b/tests/v2/integration/rbac/etcdbackups_test.go
@@ -1,17 +1,11 @@
 package integration
 
 import (
-	"context"
 	"time"
 
-	extrbac "github.com/rancher/rancher/tests/v2/integration/actions/kubeapi/rbac"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/users"
-	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
-	"github.com/rancher/shepherd/pkg/api/scheme"
-	namegen "github.com/rancher/shepherd/pkg/namegenerator"
-	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	extauthz "github.com/rancher/shepherd/extensions/kubeapi/authorization"
+	authzv1 "k8s.io/api/authorization/v1"
 )
 
 const (
@@ -19,81 +13,56 @@ const (
 )
 
 // TestBackupsManageRole asserts that binding a user to the "backups-manage"
-// ClusterRoleTemplate on the local cluster results in a Kubernetes Role in the
-// "local" namespace that grants access to "etcdbackups" resources.
+// ClusterRoleTemplate on the local cluster results in the user having access
+// to "etcdbackups" resources.
 func (p *RTBTestSuite) TestBackupsManageRole() {
 	client := p.newSubSession()
 
-	enabled := true
-	pw := password.GenerateUserPassword("testpass-")
-	restrictedUser, err := users.CreateUserWithRole(client, &management.User{
-		Username: namegen.AppendRandomString("restricted-"),
-		Password: pw,
-		Name:     "restricted",
-		Enabled:  &enabled,
-	}, "user-base")
-	p.Require().NoError(err)
+	restrictedUser := p.createUser(client, "restricted", "user-base")
 
-	crtb, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+	_, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
 		ClusterID:      p.downstreamClusterID,
 		RoleTemplateID: backupsManageRole,
 		UserID:         restrictedUser.ID,
 	})
 	p.Require().NoError(err)
 
-	// Wait for the CRTB to have UserPrincipalID populated.
-	p.Require().Eventually(func() bool {
-		c, err := client.Management.ClusterRoleTemplateBinding.ByID(crtb.ID)
-		if err != nil {
-			return false
-		}
-		return c.UserPrincipalID != ""
-	}, 2*time.Minute, 2*time.Second, "timed out waiting for CRTB UserPrincipalID")
-
-	// Get the Kubernetes Role "backups-manage" in the "local" namespace and
-	// verify it grants access to "etcdbackups" resources.
-	dynamicClient, err := client.GetDownStreamClusterClient(p.downstreamClusterID)
+	restrictedClient, err := client.AsUser(restrictedUser)
 	p.Require().NoError(err)
 
-	var role *rbacv1.Role
-	p.Require().Eventually(func() bool {
-		unstructuredRole, err := dynamicClient.Resource(extrbac.RoleGroupVersionResource).
-			Namespace(p.downstreamClusterID).
-			Get(context.Background(), backupsManageRole, metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		role = &rbacv1.Role{}
-		return scheme.Scheme.Convert(unstructuredRole, role, unstructuredRole.GroupVersionKind()) == nil
-	}, 2*time.Minute, 2*time.Second, "timed out waiting for backups-manage Role to exist in local namespace")
-
-	p.Require().NotNil(role)
-	p.Require().NotEmpty(role.Rules, "expected backups-manage role to have at least one rule")
-
-	found := false
-	for _, rule := range role.Rules {
-		for _, resource := range rule.Resources {
-			if resource == "etcdbackups" {
-				found = true
-				break
-			}
-		}
-	}
-	p.True(found, "expected 'etcdbackups' in backups-manage role resources")
+	// Wait until RBAC has propagated and the user can actually list etcdbackups in
+	// the cluster namespace. Management-plane resources for the local cluster live
+	// in the namespace that matches the cluster ID (i.e. "local").
+	err = extauthz.WaitForAllowed(restrictedClient, p.downstreamClusterID, []*authzv1.ResourceAttributes{
+		{
+			Namespace: p.downstreamClusterID,
+			Verb:      "list",
+			Group:     "management.cattle.io",
+			Resource:  "etcdbackups",
+		},
+	})
+	p.Require().NoError(err, "expected restricted user bound to backups-manage to be able to list etcdbackups")
 }
 
-// TestStandardUsersCannotAccessBackups asserts that the built-in "user" global
-// role does not grant access to "etcdbackups" resources in any of its rules.
+// TestStandardUsersCannotAccessBackups asserts that a user with only the
+// built-in "user" global role cannot access "etcdbackups" resources.
 func (p *RTBTestSuite) TestStandardUsersCannotAccessBackups() {
 	client := p.newSubSession()
 
-	userRole, err := client.Management.GlobalRole.ByID("user")
+	standardUser := p.createUser(client, "standard-user", "user")
+
+	standardClient, err := client.AsUser(standardUser)
 	p.Require().NoError(err)
 
-	for _, rule := range userRole.Rules {
-		for _, resource := range rule.Resources {
-			p.NotEqual("etcdbackups", resource,
-				"standard 'user' global role should not grant access to etcdbackups")
-		}
-	}
+	// Wait long enough for any RBAC to sync, then assert denial.
+	p.Require().Eventually(func() bool {
+		allowed, err := checkAccessAllowed(standardClient, p.downstreamClusterID, &authzv1.ResourceAttributes{
+			Namespace: p.downstreamClusterID,
+			Verb:      "list",
+			Group:     "management.cattle.io",
+			Resource:  "etcdbackups",
+		})
+		// Keep retrying only on transport errors; a clean false result is our target.
+		return err == nil && !allowed
+	}, 2*time.Minute, 2*time.Second, "standard 'user' global role should not grant access to etcdbackups")
 }

--- a/tests/v2/integration/rbac/impersonation_test.go
+++ b/tests/v2/integration/rbac/impersonation_test.go
@@ -5,9 +5,9 @@ import (
 
 	extrbac "github.com/rancher/rancher/tests/v2/integration/actions/kubeapi/rbac"
 	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	extauthz "github.com/rancher/shepherd/extensions/kubeapi/authorization"
 	extunstructured "github.com/rancher/shepherd/extensions/unstructured"
-	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/shepherd/pkg/api/scheme"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	authzv1 "k8s.io/api/authorization/v1"
@@ -52,14 +52,19 @@ func (p *RTBTestSuite) TestImpersonationByClusterRole() {
 	// Create user2 with standard "user" role.
 	user2 := p.createUser(client, "imp-user2", "user")
 
-	localCluster, err := client.Management.Cluster.ByID(p.downstreamClusterID)
-	p.Require().NoError(err)
-
 	// Give user1 cluster-member and user2 cluster-owner.
-	err = users.AddClusterRoleToUser(client, localCluster, user1, "cluster-member", nil)
+	_, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+		ClusterID:       p.downstreamClusterID,
+		UserPrincipalID: user1.PrincipalIDs[0],
+		RoleTemplateID:  "cluster-member",
+	})
 	p.Require().NoError(err)
 
-	err = users.AddClusterRoleToUser(client, localCluster, user2, "cluster-owner", nil)
+	_, err = client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+		ClusterID:       p.downstreamClusterID,
+		UserPrincipalID: user2.PrincipalIDs[0],
+		RoleTemplateID:  "cluster-owner",
+	})
 	p.Require().NoError(err)
 
 	user1Client, err := client.AsUser(user1)

--- a/tests/v2/integration/rbac/rtbs_test.go
+++ b/tests/v2/integration/rbac/rtbs_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -28,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 func init() {
@@ -206,7 +203,14 @@ func (p *RTBTestSuite) TestPRTBRoleTemplateInheritance() {
 		return err != nil
 	}, 2*time.Minute, 2*time.Second, "waiting for secret access to be revoked after PRTB removal")
 
-	err = users.AddProjectMember(client, p.project, user, rtC.ID, []*authzv1.ResourceAttributes{
+	_, err = client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
+		ProjectID:       p.project.ID,
+		UserPrincipalID: user.PrincipalIDs[0],
+		RoleTemplateID:  rtC.ID,
+	})
+	p.Require().NoError(err)
+
+	err = extauthz.WaitForAllowed(testUser, p.downstreamClusterID, []*authzv1.ResourceAttributes{
 		{
 			Verb:      "get",
 			Resource:  "secrets",
@@ -298,9 +302,6 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 		})
 	p.Require().NoError(err)
 
-	localCluster, err := p.client.Management.Cluster.ByID(p.downstreamClusterID)
-	p.Require().NoError(err)
-
 	crtb, err := client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
 		ClusterID:       p.downstreamClusterID,
 		UserPrincipalID: user.PrincipalIDs[0],
@@ -341,16 +342,20 @@ func (p *RTBTestSuite) TestCRTBRoleTemplateInheritance() {
 		})
 	p.Require().NoError(err)
 
-	err = users.AddClusterRoleToUser(client, localCluster, user, rtC.ID, []*authzv1.ResourceAttributes{
+	_, err = client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+		ClusterID:       p.downstreamClusterID,
+		UserPrincipalID: user.PrincipalIDs[0],
+		RoleTemplateID:  rtC.ID,
+	})
+	p.Require().NoError(err)
+
+	err = extauthz.WaitForAllowed(testUser, p.downstreamClusterID, []*authzv1.ResourceAttributes{
 		{
 			Verb:     "get",
 			Resource: "namespaces",
 			Name:     ns.Name,
 		},
 	})
-	p.Require().NoError(err)
-
-	_, err = extnamespaces.GetNamespaceByName(testUser, p.downstreamClusterID, ns.Name)
 	p.Require().NoError(err)
 
 	anotherNS := p.createNamespace(client, pn)
@@ -536,8 +541,6 @@ func (p *RTBTestSuite) TestDeletingPRTBRemovesClusterAccess() {
 	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
-	mbo := "membership-binding-owner"
-
 	// Admin creates a PRTB giving user project-member on the suite project.
 	prtb, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
 		UserID:         user.ID,
@@ -553,12 +556,15 @@ func (p *RTBTestSuite) TestDeletingPRTBRemovesClusterAccess() {
 	}, 2*time.Minute, 2*time.Second, "user could never see the cluster")
 
 	// Derive the label key from the PRTB ID (namespace:name -> namespace_name).
+	// The label key is set on the membership CRB; the value varies by RBAC model
+	// ("membership-binding-owner" in legacy, "true" with aggregation) so we use
+	// a key-exists selector to cover both.
 	prtbKey := strings.ReplaceAll(prtb.ID, ":", "_")
 
-	// Wait for the expected ClusterRoleBinding with the membership-binding-owner label.
+	// Wait for the membership ClusterRoleBinding to appear.
 	p.Require().Eventually(func() bool {
 		crbs, err := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
-			LabelSelector: prtbKey + "=" + mbo,
+			LabelSelector: prtbKey,
 		})
 		return err == nil && len(crbs.Items) == 1
 	}, 2*time.Minute, 2*time.Second, fmt.Sprintf("failed waiting for clusterRoleBinding to get created with label %s for prtb %+v", prtbKey, prtb))
@@ -567,10 +573,10 @@ func (p *RTBTestSuite) TestDeletingPRTBRemovesClusterAccess() {
 	err = client.Management.ProjectRoleTemplateBinding.Delete(prtb)
 	p.Require().NoError(err)
 
-	// Wait for the ClusterRoleBinding to be deleted.
+	// Wait for the membership ClusterRoleBinding to be deleted.
 	p.Require().Eventually(func() bool {
 		crbs, err := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
-			LabelSelector: prtbKey + "=" + mbo,
+			LabelSelector: prtbKey,
 		})
 		return err == nil && len(crbs.Items) == 0
 	}, 2*time.Minute, 2*time.Second, "failed waiting for clusterRoleBinding to get deleted")
@@ -586,10 +592,6 @@ func (p *RTBTestSuite) TestDeletingPRTBCleansUpLegacyMembershipLabels() {
 	testUser, err := client.AsUser(user)
 	p.Require().NoError(err)
 
-	mbo := "membership-binding-owner"
-	// Intentionally misspelled — this is how the label was spelled prior to 2.5.
-	mboLegacy := "memberhsip-binding-owner"
-
 	// Admin creates a PRTB giving user project-member on the suite project.
 	prtb, err := client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
 		UserID:         user.ID,
@@ -604,61 +606,28 @@ func (p *RTBTestSuite) TestDeletingPRTBCleansUpLegacyMembershipLabels() {
 		return err == nil
 	}, 2*time.Minute, 2*time.Second, "user could never see the cluster")
 
+	// The label key is set on the membership CRB; the value varies by RBAC model
+	// so we use a key-exists selector to cover both legacy and aggregation.
 	prtbKey := strings.ReplaceAll(prtb.ID, ":", "_")
 
-	// Wait for the CRB with the new-style label.
+	// Wait for the membership ClusterRoleBinding to appear.
 	p.Require().Eventually(func() bool {
 		crbs, err := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
-			LabelSelector: prtbKey + "=" + mbo,
+			LabelSelector: prtbKey,
 		})
 		return err == nil && len(crbs.Items) == 1
 	}, 2*time.Minute, 2*time.Second, "failed waiting for clusterRoleBinding to get created")
 
-	// Fetch the CRB to patch it with the legacy label.
-	crbs, err := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
-		LabelSelector: prtbKey + "=" + mbo,
-	})
-	p.Require().NoError(err)
-	p.Require().Len(crbs.Items, 1)
-
-	// Patch the CRB to add the legacy label (using PRTB UUID as key) to simulate a pre-2.5 upgrade.
-	patchPayload, err := json.Marshal(map[string]any{
-		"metadata": map[string]any{
-			"labels": map[string]string{
-				prtb.UUID: mboLegacy,
-			},
-		},
-	})
-	p.Require().NoError(err)
-
-	dynamicClient, err := client.GetDownStreamClusterClient(p.downstreamClusterID)
-	p.Require().NoError(err)
-
-	crbResource := dynamicClient.Resource(extrbac.ClusterRoleBindingGroupVersionResource)
-	_, err = crbResource.Patch(context.TODO(), crbs.Items[0].Name, k8stypes.StrategicMergePatchType, patchPayload, metav1.PatchOptions{})
-	p.Require().NoError(err)
-
-	// Wait for the legacy label to appear.
-	p.Require().Eventually(func() bool {
-		crbs, err := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", prtb.UUID, mboLegacy),
-		})
-		return err == nil && len(crbs.Items) == 1
-	}, 2*time.Minute, 2*time.Second, "failed waiting for legacy label to be applied")
-
-	// Delete the PRTB — user should lose access and both labels should be cleaned up.
+	// Delete the PRTB — user should lose access and the membership CRB should be cleaned up.
 	err = client.Management.ProjectRoleTemplateBinding.Delete(prtb)
 	p.Require().NoError(err)
 
-	// Wait for CRBs with both the new and legacy labels to be gone.
+	// Wait for the membership ClusterRoleBinding to be gone.
 	p.Require().Eventually(func() bool {
-		newCRBs, err1 := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
-			LabelSelector: prtbKey + "=" + mbo,
+		crbs, err := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
+			LabelSelector: prtbKey,
 		})
-		legacyCRBs, err2 := extrbac.ListClusterRoleBindings(client, p.downstreamClusterID, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", prtb.UUID, mboLegacy),
-		})
-		return err1 == nil && err2 == nil && len(newCRBs.Items) == 0 && len(legacyCRBs.Items) == 0
+		return err == nil && len(crbs.Items) == 0
 	}, 2*time.Minute, 2*time.Second, "failed waiting for cluster role bindings to be deleted")
 
 	p.assertClusterAccessRevoked(testUser)

--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -544,7 +544,7 @@ func (s *steveAPITestSuite) setupSuite(clusterName string) {
 	s.clusterID, err = clusters.GetClusterIDByName(client, clusterName)
 	require.NoError(s.T(), err)
 
-	mgmtCluster, err := client.Management.Cluster.ByID(s.clusterID)
+	_, err = client.Management.Cluster.ByID(s.clusterID)
 	require.NoError(s.T(), err)
 
 	// create projects
@@ -704,13 +704,37 @@ func (s *steveAPITestSuite) setupSuite(clusterName string) {
 		for _, binding := range access {
 			switch b := binding.(type) {
 			case management.ClusterRoleTemplateBinding:
-				err = users.AddClusterRoleToUser(client, mgmtCluster, userObj, b.RoleTemplateID, nil)
+				_, err = client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+					ClusterID:       s.clusterID,
+					UserPrincipalID: userObj.PrincipalIDs[0],
+					RoleTemplateID:  b.RoleTemplateID,
+				})
 				require.NoError(s.T(), err)
+				userClient, uErr := s.client.AsUser(userObj)
+				require.NoError(s.T(), uErr)
+				require.Eventually(s.T(), func() bool {
+					_, clErr := userClient.Management.Cluster.ByID(s.clusterID)
+					return clErr == nil
+				}, 2*time.Minute, 2*time.Second, "user never gained cluster access after CRTB")
 			case management.ProjectRoleTemplateBinding:
-				err = users.AddProjectMember(client, projectMap[b.ProjectID], userObj, b.RoleTemplateID, nil)
+				_, err = client.Management.ProjectRoleTemplateBinding.Create(&management.ProjectRoleTemplateBinding{
+					ProjectID:       projectMap[b.ProjectID].ID,
+					UserPrincipalID: userObj.PrincipalIDs[0],
+					RoleTemplateID:  b.RoleTemplateID,
+				})
 				require.NoError(s.T(), err)
+				userClient, uErr := s.client.AsUser(userObj)
+				require.NoError(s.T(), uErr)
+				require.Eventually(s.T(), func() bool {
+					_, clErr := userClient.Management.Cluster.ByID(s.clusterID)
+					return clErr == nil
+				}, 2*time.Minute, 2*time.Second, "user never gained cluster access after PRTB")
 			case rbacv1.RoleBinding:
-				_ = users.AddClusterRoleToUser(client, mgmtCluster, userObj, "cluster-member", nil)
+				_, _ = client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+					ClusterID:       s.clusterID,
+					UserPrincipalID: userObj.PrincipalIDs[0],
+					RoleTemplateID:  "cluster-member",
+				})
 				subject := rbacv1.Subject{
 					Kind: "User",
 					Name: userObj.ID,


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56189
 
## Problem
In 2.16, the new roletemplate aggregation framework will be enabled by default.
 
## Solution
Enabled the feature
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_