### PR TITLE
[v2.13] Backport Immediately sync git clusterrepos after bootstrap

### DIFF
--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -276,6 +276,12 @@ func (r *repoHandler) download(repository *catalog.ClusterRepo, newStatus *catal
 			newStatus.URL = repoSpec.GitRepo
 			newStatus.Branch = repoSpec.GitBranch
 			index, err = git.BuildOrGetIndex(metadata.Namespace, metadata.Name, repoSpec.GitRepo)
+
+			// Bootstrap succeeded via git.Head() and BuildOrGetIndex(), which initialises the repository from the current local checkout. Set ShouldNotSkip to force exactly one immediate follow-up reconcile
+			// so shouldSkip() bypasses the refresh-interval gate and the next reconcile runs git.Update(), synchronising the repository with the latest upstream commit instead of waiting for RefreshInterval.
+			if err == nil {
+				newStatus.ShouldNotSkip = true
+			}
 		}
 	} else if repoSpec.GitRepo != "" {
 		commit, err = git.Update(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch, repoSpec.InsecureSkipTLSverify, repoSpec.CABundle)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56034 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Rancher initialised system-managed repositories vs user-created repositories

For a user created git clusterrepo, the controller follows the normal reconciliation lifecycle. The repository is cloned, and after the initial bootstrap, the controller proceeds thru the normal update path git.Update(), which checks the remote repository and fetches the latest commit when changes are detected. As a result, user created repos quickly gets to the current/latest commit.

But, for rancher managed repositories, such as rancher-rke2-charts, behave differently... They are initialised from the catalog bundled with the rancher image. During the initial reconciliation, the controller calls git.Head(), which simply records the commit currently checked out in the bundled repository and builds the chart index from that revision...

This explains the difference in behavior:

A user created Git repository quickly sync to the latest upstream commit.
A rancher managed repository initially reports the bundled commit, even though the remote repository is reachable and already contains a newer commit.
This suggests the issue is not that git.Update() is failing. Rather, the initial bootstrap flow for bundled system catalogs never transitions directly from git.Head() to git.Update(). As a result, the repository remains on the bundled commit until the next periodic reconciliation.
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
After successfully completing the initial bootstrap (git.Head() + BuildOrGetIndex()), mark the repository with
newStatus.ShouldNotSkip = true before updating the status.

This change only affects the initial bootstrap of git based clusterrepos. After the repository is initialised with git.Head(), the controller performs one immediate follow-up reconciliation to execute git.Update() instead of waiting for the configured refresh interval. Once this reconciliation completes, the controller resumes its normal refresh schedule...
It happens only once per clusterrepo lifecycle (or whenever the repository is bootstrapped again), not on every refresh...
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Initial bootstrap yaml:
```
Every 2.0s: kubectl get clusterrepo rancher-rke2-charts -o yaml                                                                                                                                                                                 ip-172-31-46-120: Wed Jul  8 12:14:50 2026
apiVersion: catalog.cattle.io/v1
kind: ClusterRepo
metadata:
  creationTimestamp: "2026-07-08T12:13:30Z"
  generation: 1
  name: rancher-rke2-charts
  resourceVersion: "7817318"
  uid: 12928e5c-4e33-42f6-8fdd-6b6fb11019d6
spec:
  gitBranch: main
  gitRepo: https://git.rancher.io/rke2-charts
status:
  branch: main
  commit: 3f4445d9b094fc3fd91b1910148f2a8a39f2793d              <<<---------- Initial bootstrap commit
  conditions:
  **- lastUpdateTime: "2026-07-08T12:14:27Z"**
    status: "True"
    type: Downloaded
  downloadTime: "2026-07-08T12:13:31Z"
  indexConfigMapName: rancher-rke2-charts-0-12928e5c-4e33-42f6-8fdd-6b6fb11019d6
  indexConfigMapNamespace: cattle-system
  observedGeneration: 1
  shouldNotSkip: true                                <<<<<<<------------
  url: https://git.rancher.io/rke2-charts
```
After bootstrap `ShouldNotSkip: true` , yaml
```
Every 2.0s: kubectl get clusterrepo rancher-rke2-charts -o yaml                                                                                                                                                                                 ip-172-31-46-120: Wed Jul  8 12:15:17 2026
apiVersion: catalog.cattle.io/v1
kind: ClusterRepo
metadata:
  creationTimestamp: "2026-07-08T12:13:30Z"
  generation: 1
  name: rancher-rke2-charts
  resourceVersion: "7817576"
  uid: 12928e5c-4e33-42f6-8fdd-6b6fb11019d6
spec:
  gitBranch: main
  gitRepo: https://git.rancher.io/rke2-charts
status:
  branch: main
  commit: a2cf2abba28d3b135ac0d7b5606f9f84974fa2d5              <<<<<-------- latest commit
  conditions:
  **- lastUpdateTime: "2026-07-08T12:14:56Z"**
    status: "True"
    type: Downloaded
  downloadTime: "2026-07-08T12:14:28Z"
  indexConfigMapName: rancher-rke2-charts-0-12928e5c-4e33-42f6-8fdd-6b6fb11019d6
  indexConfigMapNamespace: cattle-system
  observedGeneration: 1
  url: https://git.rancher.io/rke2-charts
```
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_