### PR TITLE
[roletemplate-aggregation] Namespaces created after a PRTB issues

### DIFF
--- a/pkg/controllers/management/auth/roletemplates/register.go
+++ b/pkg/controllers/management/auth/roletemplates/register.go
@@ -46,6 +46,7 @@ func RegisterIndexers(wranglerContext *wrangler.Context) {
 	wranglerContext.Mgmt.ClusterRoleTemplateBinding().Cache().AddIndexer(rbac.CRTBByRoleTemplateNameIndex, getCRTBByRoleTemplateName)
 	wranglerContext.Mgmt.ProjectRoleTemplateBinding().Cache().AddIndexer(rbac.PRTBByClusterAndRoleTemplateNameIndex, getPRTBByClusterAndRoleTemplateName)
 	wranglerContext.Mgmt.ClusterRoleTemplateBinding().Cache().AddIndexer(rbac.CRTBByClusterAndRoleTemplateNameIndex, getCRTBByClusterAndRoleTemplateName)
+	wranglerContext.Mgmt.ProjectRoleTemplateBinding().Cache().AddIndexer(rbac.PRTBByProjectNameIndex, getPRTBByProjectName)
 }
 
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
@@ -252,6 +253,16 @@ func getCRTBByRoleTemplateName(crtb *v3.ClusterRoleTemplateBinding) ([]string, e
 		return []string{crtb.RoleTemplateName}, nil
 	}
 	return []string{}, nil
+}
+
+// getPRTBByProjectName indexes a PRTB by its ProjectName (<cluster-name>:<project-name>). This value
+// matches the field.cattle.io/projectId annotation set on namespaces, so the aggregation namespace
+// enqueuer can resolve the PRTBs belonging to a namespace's project.
+func getPRTBByProjectName(prtb *v3.ProjectRoleTemplateBinding) ([]string, error) {
+	if prtb == nil || prtb.ProjectName == "" {
+		return []string{}, nil
+	}
+	return []string{prtb.ProjectName}, nil
 }
 
 // getPRTBByClusterAndRoleTemplateName indexes a PRTB by <cluster-name>/<roletemplate-name> so the

--- a/pkg/controllers/management/auth/roletemplates/register.go
+++ b/pkg/controllers/management/auth/roletemplates/register.go
@@ -255,7 +255,7 @@ func getCRTBByRoleTemplateName(crtb *v3.ClusterRoleTemplateBinding) ([]string, e
 	return []string{}, nil
 }
 
-// getPRTBByProjectName indexes a PRTB by its ProjectName (<cluster-name>:<project-name>). This value
+// getPRTBByProjectName indexes a PRTB by its ProjectName (<cluster-id>:<project-id>). This value
 // matches the field.cattle.io/projectId annotation set on namespaces, so the aggregation namespace
 // enqueuer can resolve the PRTBs belonging to a namespace's project.
 func getPRTBByProjectName(prtb *v3.ProjectRoleTemplateBinding) ([]string, error) {

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -275,10 +275,10 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 	// them when the PRTB is deleted. Creating the legacy bindings here would leak RoleBindings that
 	// the aggregation removal handler does not clean up, leaving stale namespace access behind.
 	if !features.AggregatedRoleTemplates.Enabled() {
-		for _, prtb := range prtbs {
-			prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding)
+		for _, obj := range prtbs {
+			prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
 			if !ok {
-				return false, errors.Wrapf(err, "object %v is not valid project role template binding", prtb)
+				return false, errors.Wrapf(err, "object %v is not valid project role template binding", obj)
 			}
 
 			if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
+	"github.com/rancher/rancher/pkg/features"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
@@ -269,41 +270,47 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 	}
 	hasPRTBs := len(prtbs) > 0
 
-	for _, prtb := range prtbs {
-		prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding)
-		if !ok {
-			return false, errors.Wrapf(err, "object %v is not valid project role template binding", prtb)
-		}
+	// When aggregation is enabled, the per-namespace RoleBindings for PRTBs are owned by the
+	// roletemplate-aggregation controllers, which create them with aggregation labels and remove
+	// them when the PRTB is deleted. Creating the legacy bindings here would leak RoleBindings that
+	// the aggregation removal handler does not clean up, leaving stale namespace access behind.
+	if !features.AggregatedRoleTemplates.Enabled() {
+		for _, prtb := range prtbs {
+			prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding)
+			if !ok {
+				return false, errors.Wrapf(err, "object %v is not valid project role template binding", prtb)
+			}
 
-		if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {
-			continue
-		}
-
-		if prtb.RoleTemplateName == "" {
-			logrus.Warnf("ProjectRoleTemplateBinding %v has no role template set. Skipping.", prtb.Name)
-			continue
-		}
-
-		rt, err := n.m.rtLister.Get(prtb.RoleTemplateName)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", prtb.Name, prtb.RoleTemplateName)
+			if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {
 				continue
 			}
-			return false, err
-		}
 
-		roles := map[string]*v3.RoleTemplate{}
-		if err := n.m.gatherRoles(rt, roles, 0); err != nil {
-			return false, err
-		}
+			if prtb.RoleTemplateName == "" {
+				logrus.Warnf("ProjectRoleTemplateBinding %v has no role template set. Skipping.", prtb.Name)
+				continue
+			}
 
-		if err := n.m.ensureRoles(roles); err != nil {
-			return false, errors.Wrap(err, "couldn't ensure roles")
-		}
+			rt, err := n.m.rtLister.Get(prtb.RoleTemplateName)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", prtb.Name, prtb.RoleTemplateName)
+					continue
+				}
+				return false, err
+			}
 
-		if err := n.m.ensureProjectRoleBindings(ns.Name, roles, prtb); err != nil {
-			return false, errors.Wrapf(err, "couldn't ensure binding %v in %v", prtb.Name, ns.Name)
+			roles := map[string]*v3.RoleTemplate{}
+			if err := n.m.gatherRoles(rt, roles, 0); err != nil {
+				return false, err
+			}
+
+			if err := n.m.ensureRoles(roles); err != nil {
+				return false, errors.Wrap(err, "couldn't ensure roles")
+			}
+
+			if err := n.m.ensureProjectRoleBindings(ns.Name, roles, prtb); err != nil {
+				return false, errors.Wrapf(err, "couldn't ensure binding %v in %v", prtb.Name, ns.Name)
+			}
 		}
 	}
 

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher/pkg/apis/management.cattle.io"
 	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
+	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	wfakes "github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
@@ -626,6 +627,7 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 		currentRoles        []*rbacv1.ClusterRole
 		indexedPRTBs        []*v3.ProjectRoleTemplateBinding
 		projectNSAnnotation string
+		aggregationEnabled  bool
 		indexerError        error
 		updateError         error
 		createError         error
@@ -655,10 +657,34 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 			},
 			wantHasPRTBs: true,
 		},
+		{
+			name:                "aggregation enabled skips legacy binding creation",
+			projectNSAnnotation: "c-123xyz:p-123xyz",
+			aggregationEnabled:  true,
+			indexedRoles: []*rbacv1.ClusterRole{
+				createClusterRoleForProject("p-123xyz", namespaceName, "*"),
+			},
+			indexedPRTBs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      "test-prtb",
+					},
+					UserName:         "test-user",
+					ProjectName:      "test-cluster:test-project",
+					RoleTemplateName: "test-rt",
+				},
+			},
+			wantHasPRTBs: true,
+		},
 	}
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			prev := features.AggregatedRoleTemplates.Enabled()
+			features.AggregatedRoleTemplates.Set(test.aggregationEnabled)
+			t.Cleanup(func() { features.AggregatedRoleTemplates.Set(prev) })
+
 			crIndexer := &FakeResourceIndexer[*rbacv1.ClusterRole]{
 				resources: map[string][]*rbacv1.ClusterRole{
 					namespaceName: test.indexedRoles,
@@ -675,14 +701,18 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 			}
 
 			rtLister := wfakes.NewMockNonNamespacedCacheInterface[*v3.RoleTemplate](ctrl)
-			rtLister.EXPECT().Get(gomock.Any()).DoAndReturn(
-				func(name string) (*v3.RoleTemplate, error) {
-					return nil, apierrors.NewNotFound(schema.GroupResource{
-						Group:    "management.cattle.io",
-						Resource: "roletemplates",
-					}, name)
-				},
-			)
+			// When aggregation is enabled, the legacy binding creation loop is skipped,
+			// so the RoleTemplate lister is never consulted.
+			if !test.aggregationEnabled {
+				rtLister.EXPECT().Get(gomock.Any()).DoAndReturn(
+					func(name string) (*v3.RoleTemplate, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{
+							Group:    "management.cattle.io",
+							Resource: "roletemplates",
+						}, name)
+					},
+				)
+			}
 			pGetter := wfakes.NewMockCacheInterface[*apisV3.Project](ctrl)
 			pGetter.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(namespace string, name string) (*v3.Project, error) {

--- a/pkg/controllers/managementuser/rbac/roletemplates/register.go
+++ b/pkg/controllers/managementuser/rbac/roletemplates/register.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -24,6 +25,11 @@ const (
 	// RoleTemplate enqueues the referencing PRTBs/CRTBs on the same workqueue the handlers run on.
 	prtbRoleTemplateEnqueuer = "aggregation-prtb-roletemplate-enqueuer"
 	crtbRoleTemplateEnqueuer = "aggregation-crtb-roletemplate-enqueuer"
+
+	// Namespace-side enqueuer that re-triggers the PRTB handler when a namespace in a project
+	// changes. reconcileBindings creates the per-namespace RoleBindings by iterating the project's
+	// namespaces, so a namespace created after its PRTB would otherwise never receive a binding.
+	prtbNamespaceEnqueuer = "aggregation-prtb-namespace-enqueuer"
 )
 
 func Register(ctx context.Context, workload *config.UserContext) error {
@@ -57,6 +63,8 @@ func Register(ctx context.Context, workload *config.UserContext) error {
 		management.Wrangler.Mgmt.ProjectRoleTemplateBinding(), management.Wrangler.Mgmt.RoleTemplate())
 	relatedresource.Watch(ctx, crtbRoleTemplateEnqueuer, enqueuer.enqueueCRTBs,
 		management.Wrangler.Mgmt.ClusterRoleTemplateBinding(), management.Wrangler.Mgmt.RoleTemplate())
+	relatedresource.Watch(ctx, prtbNamespaceEnqueuer, enqueuer.enqueuePRTBsForNamespace,
+		management.Wrangler.Mgmt.ProjectRoleTemplateBinding(), workload.Corew.Namespace())
 
 	return nil
 }
@@ -78,6 +86,29 @@ func (e *roleTemplateEnqueuer) enqueuePRTBs(_, name string, obj runtime.Object) 
 	prtbs, err := e.prtbCache.GetByIndex(rbac.PRTBByClusterAndRoleTemplateNameIndex, rbac.RoleTemplateClusterIndexKey(e.clusterName, name))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list ProjectRoleTemplateBindings for roletemplate %s: %w", name, err)
+	}
+	var keys []relatedresource.Key
+	for _, prtb := range prtbs {
+		keys = append(keys, relatedresource.Key{Namespace: prtb.Namespace, Name: prtb.Name})
+	}
+	return keys, nil
+}
+
+// enqueuePRTBsForNamespace enqueues every PRTB in the changed namespace's project so their
+// per-namespace RoleBindings are reconciled. Without this, a namespace created after its PRTB never
+// receives a binding, because reconcileBindings only runs on PRTB and RoleTemplate changes.
+func (e *roleTemplateEnqueuer) enqueuePRTBsForNamespace(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok || ns == nil {
+		return nil, nil
+	}
+	projectID := ns.Annotations[projectIDAnnotation]
+	if projectID == "" {
+		return nil, nil
+	}
+	prtbs, err := e.prtbCache.GetByIndex(rbac.PRTBByProjectNameIndex, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list ProjectRoleTemplateBindings for project %s: %w", projectID, err)
 	}
 	var keys []relatedresource.Key
 	for _, prtb := range prtbs {

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -58,7 +58,7 @@ const (
 	// the RoleTemplate across all clusters.
 	PRTBByClusterAndRoleTemplateNameIndex = "auth.management.cattle.io/prtb-by-cluster-and-roletemplate-name"
 	CRTBByClusterAndRoleTemplateNameIndex = "auth.management.cattle.io/crtb-by-cluster-and-roletemplate-name"
-	// PRTBByProjectNameIndex keys PRTBs by their ProjectName (<cluster-name>:<project-name>), which
+	// PRTBByProjectNameIndex keys PRTBs by their ProjectName (<cluster-id>:<project-id>), which
 	// matches the field.cattle.io/projectId annotation on namespaces. Used by the aggregation
 	// namespace enqueuer to reconcile the PRTBs of a project when one of its namespaces changes.
 	PRTBByProjectNameIndex              = "auth.management.cattle.io/prtb-by-project-name"

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -58,11 +58,15 @@ const (
 	// the RoleTemplate across all clusters.
 	PRTBByClusterAndRoleTemplateNameIndex = "auth.management.cattle.io/prtb-by-cluster-and-roletemplate-name"
 	CRTBByClusterAndRoleTemplateNameIndex = "auth.management.cattle.io/crtb-by-cluster-and-roletemplate-name"
-	CrbGlobalRoleAnnotation               = "authz.cluster.cattle.io/globalrole"
-	CrbGlobalRoleBindingAnnotation        = "authz.cluster.cattle.io/globalrolebinding"
-	CrbAdminGlobalRoleCheckedAnnotation   = "authz.cluster.cattle.io/admin-globalrole-checked"
-	AggregationManagementFeatureLabel     = "management.cattle.io/roletemplate-aggregation-mgmt"
-	AggregationFeatureLabel               = "management.cattle.io/roletemplate-aggregation"
+	// PRTBByProjectNameIndex keys PRTBs by their ProjectName (<cluster-name>:<project-name>), which
+	// matches the field.cattle.io/projectId annotation on namespaces. Used by the aggregation
+	// namespace enqueuer to reconcile the PRTBs of a project when one of its namespaces changes.
+	PRTBByProjectNameIndex              = "auth.management.cattle.io/prtb-by-project-name"
+	CrbGlobalRoleAnnotation             = "authz.cluster.cattle.io/globalrole"
+	CrbGlobalRoleBindingAnnotation      = "authz.cluster.cattle.io/globalrolebinding"
+	CrbAdminGlobalRoleCheckedAnnotation = "authz.cluster.cattle.io/admin-globalrole-checked"
+	AggregationManagementFeatureLabel   = "management.cattle.io/roletemplate-aggregation-mgmt"
+	AggregationFeatureLabel             = "management.cattle.io/roletemplate-aggregation"
 	// GRDownstreamNSIndex is the cache index name for looking up GlobalRoles by the namespaces in InheritedNamespacedRules.
 	GRDownstreamNSIndex = "mgmt-auth-gr-downstream-ns-index"
 )

--- a/tests/v2/integration/rbac/projects_test.go
+++ b/tests/v2/integration/rbac/projects_test.go
@@ -77,29 +77,36 @@ func (p *RTBTestSuite) TestProjectCreatorGetsOwnerBindings() {
 	// User creates a namespace in the project.
 	ns := p.createNamespace(testUser, p.projectName(project))
 
-	// Verify user can list pods in the namespace (proves basic access).
-	dynamicClient, err := testUser.GetDownStreamClusterClient(p.downstreamClusterID)
+	// Verify user can list pods in the namespace (proves basic access). The per-namespace bindings
+	// are created asynchronously by the roletemplate controllers, so wait for the permission to
+	// propagate rather than checking once.
+	err = extauthz.WaitForAllowed(testUser, p.downstreamClusterID, []*authzv1.ResourceAttributes{
+		{
+			Verb:      "list",
+			Resource:  "pods",
+			Group:     "",
+			Namespace: ns.Name,
+		},
+	})
 	p.Require().NoError(err)
 
-	podGVR := corev1.SchemeGroupVersion.WithResource("pods")
-	_, err = dynamicClient.Resource(podGVR).Namespace(ns.Name).List(context.TODO(), metav1.ListOptions{})
-	p.Require().NoError(err)
-
-	// Verify user has both 'project-owner' and 'admin' role bindings in the namespace.
-	rbs, err := extrbac.ListRoleBindings(client, p.downstreamClusterID, ns.Name, metav1.ListOptions{})
-	p.Require().NoError(err)
-
-	rbRoles := []string{}
-	for _, rb := range rbs.Items {
-		for _, subject := range rb.Subjects {
-			if subject.Name == user.ID {
-				rbRoles = append(rbRoles, rb.RoleRef.Name)
+	// Verify the user has a project-owner RoleBinding in the namespace. The RoleRef name depends on
+	// the RBAC model ("project-owner" in the legacy model, "project-owner-aggregator" when the
+	// aggregated-roletemplates feature is enabled), so match by prefix and wait for it to appear.
+	p.Require().Eventually(func() bool {
+		rbs, err := extrbac.ListRoleBindings(client, p.downstreamClusterID, ns.Name, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		for _, rb := range rbs.Items {
+			for _, subject := range rb.Subjects {
+				if subject.Name == user.ID && strings.HasPrefix(rb.RoleRef.Name, "project-owner") {
+					return true
+				}
 			}
 		}
-	}
-
-	p.Require().Contains(rbRoles, "project-owner", "expected project-owner role binding for user")
-	p.Require().Contains(rbRoles, "admin", "expected admin role binding for user")
+		return false
+	}, 2*time.Minute, 2*time.Second, "expected a project-owner role binding for the user")
 
 	// Verify user can create deployments (extensions group) in the namespace.
 	err = extauthz.WaitForAllowed(testUser, p.downstreamClusterID, []*authzv1.ResourceAttributes{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56155
 
> [!NOTE]
> This is for the roletemplate aggregation feature.

## Problem
There are 2 problems solved by this PR

1. When a namespace is added to a project, any user that had access to that project via PRTB is provided a rolebinding created in that namespace. The problem is that it is a legacy binding, which does not get cleaned up when the PRTB is deleted, so the user retains access to that new namespace even though they no longer have their project access.

2. After the above issue is resolved, when you create a new namespace the PRTB does not update to provide access within that new namespace. So the namespace is available in the UI, but any permissions within the namespace (ex. GET pods) don't exist.
 
## Solution
1. The first solution is to feature gate the legacy namespace handler
2. Next we have to introduce an enqueuer to reconcile the PRTB when a new namespace is created. We filter based on the project annotation so we aren't checking too many PRTBs.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Tested both changes manually. These were originally discovered when running the integration tests with the feature enabled https://github.com/rancher/rancher/pull/56132

### Automated Testing
* Test types added/modified:
    * Unit
    * Integration (Go Framework)

Summary: Added unit tests for coverage, and modified some integration tests in projects_tests.go. Those integration checks are checking for specific resources when really they should be checking for permissions.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_