### PR TITLE
Synchronize NodeDriver download and install on all replicas

### DIFF
--- a/pkg/controllers/management/drivers/base_driver.go
+++ b/pkg/controllers/management/drivers/base_driver.go
@@ -121,6 +121,9 @@ func (d *BaseDriver) stage(forceUpdate bool) error {
 	defer tempFile.Close()
 
 	hasher := d.getHasher()
+	if len(d.DriverHash) > 0 && hasher == nil {
+		return fmt.Errorf("invalid hash format: %s", d.DriverHash)
+	}
 	downloadDest := io.Writer(tempFile)
 	if hasher != nil {
 		downloadDest = io.MultiWriter(tempFile, hasher)

--- a/pkg/controllers/management/drivers/base_driver.go
+++ b/pkg/controllers/management/drivers/base_driver.go
@@ -120,11 +120,7 @@ func (d *BaseDriver) stage(forceUpdate bool) error {
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
-	hasher, err := d.getHasher()
-	if err != nil {
-		return err
-	}
-
+	hasher := d.getHasher()
 	downloadDest := io.Writer(tempFile)
 	if hasher != nil {
 		downloadDest = io.MultiWriter(tempFile, hasher)
@@ -307,22 +303,19 @@ func compare(hash hash.Hash, value string) (string, bool) {
 	return got, got == expected
 }
 
-func (d *BaseDriver) getHasher() (hash.Hash, error) {
+func (d *BaseDriver) getHasher() hash.Hash {
 	switch len(d.DriverHash) {
-	case 0:
-		return nil, nil
 	case 32:
 		logrus.Warnf("[%s] md5 is unsupported and will be removed in a future version of Rancher", d.Name())
-		return md5.New(), nil
+		return md5.New()
 	case 40:
-		return sha1.New(), nil
+		return sha1.New()
 	case 64:
-		return sha256.New(), nil
+		return sha256.New()
 	case 128:
-		return sha512.New(), nil
+		return sha512.New()
 	}
-
-	return nil, fmt.Errorf("invalid hash format: %s", d.DriverHash)
+	return nil
 }
 
 func (d *BaseDriver) download(dest io.Writer) error {

--- a/pkg/controllers/management/drivers/dynamic_driver.go
+++ b/pkg/controllers/management/drivers/dynamic_driver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -56,7 +57,11 @@ func (d *DynamicDriver) Install() error {
 		return nil
 	}
 
-	return d.copyTo(fmt.Sprintf("%s/assets/%s", settings.UIDashboardPath.Get(), d.DriverName))
+	return d.copyTo(d.assetPath())
+}
+
+func (d *DynamicDriver) assetPath() string {
+	return filepath.Join(settings.UIDashboardPath.Get(), "assets", d.DriverName)
 }
 
 func (d *BaseDriver) copyTo(dest string) error {

--- a/pkg/controllers/management/drivers/dynamic_driver.go
+++ b/pkg/controllers/management/drivers/dynamic_driver.go
@@ -64,6 +64,30 @@ func (d *DynamicDriver) assetPath() string {
 	return filepath.Join(settings.UIDashboardPath.Get(), "assets", d.DriverName)
 }
 
+// Valid returns whether the driver binary is correctly downloaded and matches the expected checksum
+func (d *DynamicDriver) Valid() bool {
+	if !d.Exists() {
+		return false
+	}
+
+	hasher := d.getHasher()
+	if hasher == nil {
+		return true
+	}
+
+	f, err := os.Open(d.assetPath())
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(hasher, f); err != nil {
+		return false
+	}
+	_, matches := compare(hasher, d.DriverHash)
+	return matches
+}
+
 func (d *BaseDriver) copyTo(dest string) error {
 	binaryPath := d.binName()
 	tmpPath := binaryPath + "-tmp"

--- a/pkg/controllers/management/drivers/dynamic_driver.go
+++ b/pkg/controllers/management/drivers/dynamic_driver.go
@@ -24,7 +24,7 @@ var DockerMachineDriverPrefix = "docker-machine-driver-"
 
 const ExecutionTimeout = time.Second * 5
 
-func NewDynamicDriver(builtin bool, name, url, hash string) *DynamicDriver {
+func NewDynamicDriver(builtin bool, name, url, hash string) (*DynamicDriver, error) {
 	d := &DynamicDriver{
 		BaseDriver{
 			Builtin:      builtin,
@@ -37,7 +37,10 @@ func NewDynamicDriver(builtin bool, name, url, hash string) *DynamicDriver {
 	if !strings.HasPrefix(d.DriverName, DockerMachineDriverPrefix) {
 		d.DriverName = DockerMachineDriverPrefix + d.DriverName
 	}
-	return d
+	if len(hash) > 0 && d.getHasher() == nil {
+		return nil, fmt.Errorf("invalid hash format: %s", hash)
+	}
+	return d, nil
 }
 
 func (d *DynamicDriver) Install() error {

--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	errs "github.com/pkg/errors"
 	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
@@ -83,12 +82,6 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 		return obj, nil
 	}
 
-	forceUpdate := m.checkDriverVersion(obj)
-	if v32.NodeDriverConditionDownloaded.GetStatus(obj) == "" || v32.NodeDriverConditionInstalled.GetStatus(obj) == "" {
-		forceUpdate = true
-	}
-
-	err := errs.New("not found")
 	// if node driver was created, we also activate the driver by default
 	driver, err := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
 	if err != nil {
@@ -96,21 +89,35 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 		v32.NodeDriverConditionDownloaded.False(obj)
 		v32.NodeDriverConditionDownloaded.Reason(obj, err.Error())
 		return obj, controller.ErrIgnore
-	}
-	schemaName := obj.Spec.DisplayName + "config"
-	var existingSchema *v32.DynamicSchema
-	if obj.Spec.DisplayName != "" {
-		existingSchema, err = m.schemaLister.Get("", schemaName)
+	} else if !driver.Valid() {
+		v32.NodeDriverConditionDownloaded.Unknown(obj)
+		v32.NodeDriverConditionInstalled.Unknown(obj)
+		return obj, fmt.Errorf("node driver binary is not ready")
 	}
 
-	if driver.Exists() && err == nil && !forceUpdate {
+	driverName := strings.TrimPrefix(driver.Name(), drivers.DockerMachineDriverPrefix)
+	obj.Spec.DisplayName = driverName
+	v32.NodeDriverConditionDownloaded.True(obj)
+	v32.NodeDriverConditionInstalled.True(obj)
+
+	needsUpdate := m.checkDriverVersion(obj)
+
+	schemaName := driverName + "config"
+	existingSchema, err := m.schemaLister.Get("", schemaName)
+	if err != nil {
+		logrus.Errorf("failed to get schema %q: %v", schemaName, err)
+		needsUpdate = true
+	}
+
+	// If dynamic schema exists already, and this specific version of the driver was already evaluated, only update the schema
+	if !needsUpdate {
 		// add credential schema
 		credFields := map[string]v32.Field{}
 		pubCredFields, privateCredFields, passwordFields, defaults, optionals := getCredFields(obj.Annotations)
 		for name, field := range existingSchema.Spec.ResourceFields {
 			if SSHKeyFields[name] || passwordFields[name] || privateCredFields[name] {
 				if field.Type != "password" {
-					forceUpdate = true
+					needsUpdate = true
 					break
 				}
 			}
@@ -124,55 +131,14 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 				credFields[name] = credField
 			}
 		}
-		if !forceUpdate {
+		if !needsUpdate {
 			return m.createCredSchema(obj, credFields)
 		}
 	}
 
-	if !driver.Exists() || forceUpdate {
-		v32.NodeDriverConditionDownloaded.Unknown(obj)
-		v32.NodeDriverConditionInstalled.Unknown(obj)
-	}
-
-	newObj, err := v32.NodeDriverConditionDownloaded.Once(obj, func() (runtime.Object, error) {
-		// update status
-		obj, err = m.nodeDriverClient.Update(obj)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := driver.Stage(forceUpdate); err != nil {
-			return nil, err
-		}
-		return obj, nil
-	})
-	if err != nil {
-		return obj, err
-	}
-
-	obj = newObj.(*v32.NodeDriver)
-	newObj, err = v32.NodeDriverConditionInstalled.Once(obj, func() (runtime.Object, error) {
-		if err := driver.Install(); err != nil {
-			return nil, err
-		}
-		if err = driver.Executable(); err != nil {
-			return nil, err
-		}
-		obj.Spec.DisplayName = strings.TrimPrefix(driver.Name(), drivers.DockerMachineDriverPrefix)
-		return obj, nil
-	})
-	if err != nil {
-		return newObj.(*v32.NodeDriver), err
-	}
-
-	obj = newObj.(*v32.NodeDriver)
-	driverName := strings.TrimPrefix(driver.Name(), drivers.DockerMachineDriverPrefix)
-
-	obj = m.addVersionInfo(obj)
-
-	obj, err = m.addUIHintsAnno(obj)
-	if err != nil {
-		return obj, errs.Wrap(err, "failed JSON in addUIHintsAnno")
+	m.addVersionInfo(obj)
+	if err := m.addUIHintsAnno(obj); err != nil {
+		return nil, fmt.Errorf("failed JSON in addUIHintsAnno: %w", err)
 	}
 
 	flags, err := getCreateFlagsForDriver(driverName)
@@ -295,7 +261,7 @@ func (m *Lifecycle) createCredSchema(obj *v32.NodeDriver, credFields map[string]
 }
 
 func (m *Lifecycle) checkDriverVersion(obj *v32.NodeDriver) bool {
-	if v32.NodeDriverConditionDownloaded.IsUnknown(obj) || v32.NodeDriverConditionInstalled.IsUnknown(obj) {
+	if !v32.NodeDriverConditionDownloaded.IsTrue(obj) || !v32.NodeDriverConditionInstalled.IsTrue(obj) {
 		return true
 	}
 
@@ -317,17 +283,16 @@ func (m *Lifecycle) checkDriverVersion(obj *v32.NodeDriver) bool {
 	return false
 }
 
-func (m *Lifecycle) addVersionInfo(obj *v32.NodeDriver) *v32.NodeDriver {
+func (m *Lifecycle) addVersionInfo(obj *v32.NodeDriver) {
 	if obj.Spec.Builtin {
 		obj.Status.AppliedDockerMachineVersion = m.dockerMachineVersion
 	} else {
 		obj.Status.AppliedURL = obj.Spec.URL
 		obj.Status.AppliedChecksum = obj.Spec.Checksum
 	}
-	return obj
 }
 
-func (m *Lifecycle) addUIHintsAnno(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
+func (m *Lifecycle) addUIHintsAnno(obj *v32.NodeDriver) error {
 	if aliasedField, ok := obj.Annotations[FileToFieldAliasesAnno]; ok {
 		anno := make(map[string]map[string]string)
 		aliases := ParseKeyValueString(aliasedField)
@@ -339,7 +304,7 @@ func (m *Lifecycle) addUIHintsAnno(obj *v32.NodeDriver) (*v32.NodeDriver, error)
 
 		jsonAnno, err := json.Marshal(anno)
 		if err != nil {
-			return obj, err
+			return err
 		}
 
 		if obj.Annotations == nil {
@@ -348,7 +313,7 @@ func (m *Lifecycle) addUIHintsAnno(obj *v32.NodeDriver) (*v32.NodeDriver, error)
 
 		obj.Annotations[uiFieldHintsAnno] = string(jsonAnno)
 	}
-	return obj, nil
+	return nil
 }
 
 func (m *Lifecycle) Updated(obj *v32.NodeDriver) (runtime.Object, error) {

--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	errs "github.com/pkg/errors"
+	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -89,7 +90,13 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 
 	err := errs.New("not found")
 	// if node driver was created, we also activate the driver by default
-	driver := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
+	driver, err := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
+	if err != nil {
+		// Configuration is incorrect, no point on retrying until it's changed
+		v32.NodeDriverConditionDownloaded.False(obj)
+		v32.NodeDriverConditionDownloaded.Reason(obj, err.Error())
+		return obj, controller.ErrIgnore
+	}
 	schemaName := obj.Spec.DisplayName + "config"
 	var existingSchema *v32.DynamicSchema
 	if obj.Spec.DisplayName != "" {

--- a/pkg/controllers/nodedriver/nodedriver.go
+++ b/pkg/controllers/nodedriver/nodedriver.go
@@ -36,7 +36,8 @@ func onChange(_ string, obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 		return obj, generic.ErrSkip
 	}
 
-	if driver.Exists() {
+	if driver.Valid() {
+		// driver binary already downloaded and matches the expected hash
 		return obj, nil
 	}
 

--- a/pkg/controllers/nodedriver/nodedriver.go
+++ b/pkg/controllers/nodedriver/nodedriver.go
@@ -2,7 +2,6 @@ package nodedriver
 
 import (
 	"context"
-	"sync/atomic"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/drivers"
@@ -12,16 +11,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var leader = atomic.Bool{}
-
 func Register(ctx context.Context, wrangler *wrangler.Context) {
+	// This handler ensures all Rancher pods have an up-to-date version of the driver binaries inside the UIPath/assets directory.
+	// This acts as a cache for rancher/machine (runs in a separate Job/Pod), which downloads the drivers from Rancher instead of the Internet.
+	// Given those requests could be load-balanced to any of the Pods, all replicas must have the same data.
 	wrangler.Mgmt.NodeDriver().OnChange(ctx, "custom-node-driver-handler", onChange)
-
-	// when this pod becomes the leader, do not run the onChange code
-	wrangler.OnLeaderOrDie("nodedriver-register", func(ctx context.Context) error {
-		leader.Store(true)
-		return nil
-	})
 }
 
 func onChange(_ string, obj *v3.NodeDriver) (*v3.NodeDriver, error) {

--- a/pkg/controllers/nodedriver/nodedriver.go
+++ b/pkg/controllers/nodedriver/nodedriver.go
@@ -7,6 +7,9 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/drivers"
 	"github.com/rancher/rancher/pkg/wrangler"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	"github.com/sirupsen/logrus"
 )
 
 var leader = atomic.Bool{}
@@ -22,25 +25,17 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 }
 
 func onChange(_ string, obj *v3.NodeDriver) (*v3.NodeDriver, error) {
-	if obj == nil {
-		return obj, nil
-	}
-
-	// if leader, no need to sync
-	if leader.Load() {
-		return obj, nil
-	}
-
-	if !obj.Spec.Active {
-		return obj, nil
-	}
-
 	// only cache drivers which are not built-in to rancher image
-	if obj.Spec.Builtin {
+	if obj == nil || obj.Spec.Builtin || !obj.Spec.Active {
 		return obj, nil
 	}
 
-	driver := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
+	driver, err := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
+	if err != nil {
+		logrus.Errorf("failed initializing NodeDriver %q: %v", obj.Name, err)
+		return obj, generic.ErrSkip
+	}
+
 	if driver.Exists() {
 		return obj, nil
 	}


### PR DESCRIPTION
## Issue: #56191
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Follower pods may not react to NodeDriver updates, ending up not serving the correct version of the driver binaries.

## Solution
This PR decouples the download+installation of the drivers (should happen on every replica) from the processing and schema discovery (only on the leader replica).
 
## Testing

I may need help testing this, since I can't seem to activate any of the drivers in my local environment (probably because it's ARM based). It seems the `CATTLE_DEV_MODE` seems to also interfere with these results.
