### PR TITLE
[main] fix management node cache/client usage when mcm is disabled

### DIFF
--- a/pkg/controllers/capr/unmanaged/controller.go
+++ b/pkg/controllers/capr/unmanaged/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/capr/configserver"
 	provcluster "github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
+	"github.com/rancher/rancher/pkg/features"
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta2"
 	mgmtcontroller "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	provcontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
@@ -48,8 +49,6 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigMana
 		unmanagedMachine:  clients.RKE.CustomMachine(),
 		rkeClusterCache:   clients.RKE.RKECluster().Cache(),
 		mgmtClusterCache:  clients.Mgmt.Cluster().Cache(),
-		mgmtNodeClient:    clients.Mgmt.Node(),
-		mgmtNodeCache:     clients.Mgmt.Node().Cache(),
 		clusterCache:      clients.Provisioning.Cluster().Cache(),
 		capiClusterCache:  clients.CAPI.Cluster().Cache(),
 		machineCache:      clients.CAPI.Machine().Cache(),
@@ -68,6 +67,11 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext, kubeconfigMana
 				clients.Core.Secret(),
 			),
 	}
+	if features.MCM.Enabled() {
+		h.mgmtNodeClient = clients.Mgmt.Node()
+		h.mgmtNodeCache = clients.Mgmt.Node().Cache()
+	}
+
 	clients.RKE.CustomMachine().OnRemove(ctx, "unmanaged-machine", h.onUnmanagedMachineOnRemove)
 	clients.RKE.CustomMachine().OnChange(ctx, "unmanaged-health", h.onUnmanagedMachineChange)
 	clients.Core.Secret().OnChange(ctx, "unmanaged-machine-secret", h.onSecretChange)
@@ -206,6 +210,10 @@ func (h *handler) onSecretChange(_ string, secret *corev1.Secret) (*corev1.Secre
 }
 
 func (h *handler) createMachinePlanForImported(secret *corev1.Secret, data data.Object) (*corev1.Secret, error) {
+	if h.mgmtNodeCache == nil || h.mgmtNodeClient == nil {
+		return secret, nil
+	}
+
 	labels := map[string]string{}
 	annotations := map[string]string{}
 

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -180,6 +180,10 @@ func Register(
 		kubeconfigManager: kubeconfigManager,
 	}
 
+	if features.MCM.Enabled() {
+		h.mgmtNodesCache = clients.Mgmt.Node().Cache()
+	}
+
 	clients.Mgmt.Cluster().OnRemove(ctx, "mgmt-cluster-remove", h.OnMgmtClusterRemove)
 	clients.Provisioning.Cluster().OnRemove(ctx, "provisioning-cluster-remove", h.OnClusterRemove)
 }

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -82,10 +82,9 @@ type handler struct {
 }
 
 func handlerWithoutCAPI(clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) *handler {
-	return &handler{
+	h := &handler{
 		mgmtClusterCache:      clients.Mgmt.Cluster().Cache(),
 		mgmtClusters:          clients.Mgmt.Cluster(),
-		mgmtNodesCache:        clients.Mgmt.Node().Cache(),
 		clusterTokenCache:     clients.Mgmt.ClusterRegistrationToken().Cache(),
 		clusterTokens:         clients.Mgmt.ClusterRegistrationToken(),
 		featureCache:          clients.Mgmt.Feature().Cache(),
@@ -97,6 +96,12 @@ func handlerWithoutCAPI(clients *wrangler.Context, kubeconfigManager *kubeconfig
 		secretCache:           clients.Core.Secret().Cache(),
 		kubeconfigManager:     kubeconfigManager,
 	}
+
+	if features.MCM.Enabled() {
+		h.mgmtNodesCache = clients.Mgmt.Node().Cache()
+	}
+
+	return h
 }
 
 func EarlyRegister(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {

--- a/pkg/controllers/provisioningv2/cluster/status.go
+++ b/pkg/controllers/provisioningv2/cluster/status.go
@@ -66,7 +66,7 @@ func (h *handler) updateClusterStatus(key string, cluster *v3.Cluster) (*v3.Clus
 	if cluster.Status.Info != nil {
 		arch = cluster.Status.Info.Arch
 	}
-	if h.getClusterInfoWaitTime(key) == 0 {
+	if h.mgmtNodesCache != nil && h.getClusterInfoWaitTime(key) == 0 {
 		arch, err = h.getArch(cluster)
 		if err != nil {
 			return nil, err
@@ -230,13 +230,6 @@ func (h *handler) getNodeCount(cluster *v3.Cluster, provCluster *v1.Cluster) (in
 }
 
 func (h *handler) getArch(cluster *v3.Cluster) (string, error) {
-	if h.mgmtNodesCache == nil {
-		if cluster.Status.Info != nil {
-			return cluster.Status.Info.Arch, nil
-		}
-		return "", nil
-	}
-
 	machines, err := h.mgmtNodesCache.List(cluster.Name, labels.Everything())
 	if err != nil {
 		return "", err

--- a/pkg/controllers/provisioningv2/cluster/status.go
+++ b/pkg/controllers/provisioningv2/cluster/status.go
@@ -230,6 +230,13 @@ func (h *handler) getNodeCount(cluster *v3.Cluster, provCluster *v1.Cluster) (in
 }
 
 func (h *handler) getArch(cluster *v3.Cluster) (string, error) {
+	if h.mgmtNodesCache == nil {
+		if cluster.Status.Info != nil {
+			return cluster.Status.Info.Arch, nil
+		}
+		return "", nil
+	}
+
 	machines, err := h.mgmtNodesCache.List(cluster.Name, labels.Everything())
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Issue
#56169

## Problem

  With multi-cluster-management=false, Rancher still creates management Node caches in provisioning-v2 and imported Day 2 operations.

  The management Node API is not available in this mode. The cache cannot sync and blocks Rancher controller startup. This prevents Need-A-Cert from recreating capi-webhook-service-cert after CAPIProvider replacement.

  ## Solution

  - Create management Node client and cache objects only when MCM is enabled.
  - When the provisioning-v2 Node cache is unavailable, keep the existing cluster architecture value.
  - Skip imported Day 2 machine plan handling when MCM is disabled. Imported machine plans require MCM and cannot work in this mode.

  ## Testing

  The issue repro steps are valid with MCM disabled.

  ## Engineering Testing

  ### Manual Testing

  Fresh Helm install with:

  multi-cluster-management=false
  multi-cluster-management-agent=false
  imported-day-2-ops=true

  Verified:

  - No nodes.meta.k8s.io cache errors
  - Rancher Service controller starts
  - capi-webhook-service-cert is recreated and owned by the current webhook Service
  - capi-controller-manager becomes Ready
  - CAPIProvider becomes Ready

  ## QA Testing Considerations

 - Test a fresh Rancher install with MCM disabled and imported Day 2 operations enabled.
 - Verify that CAPI installs successfully and capi-webhook-service-cert exists after the CAPIProvider lifecycle completes.
 
