### PR TITLE
Separated max default ttl

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -82,9 +82,11 @@ type TokenSpec struct {
 	// TTL is the time-to-live of the token, in milliseconds.
 	// Setting a value < 0 represents +infinity, i.e. a token which does not expire.
 	// The default is indicated by the value `0`.
-	// This default is provided by the `auth-token-max-ttl-minutes` setting.
-	// Note that this default is also the maximum specifiable TTL.
-	// A value <= 0 there enables non-expiring tokens.
+	// This default is provided by the `auth-token-default-ttl-minutes` setting.
+	// A value < 0 there enables non-expiring tokens, if not disallowed by the max.
+	// That is, both the ttl here and the default are subject to the
+	// `auth-token-max-ttl-minutes` setting, i.e. will be clamped to it if they
+	// represent a larger value than that.
 	// +optional
 	TTL int64 `json:"ttl"`
 	// Enabled indicates an active token. The default (`null`) indicates an

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -793,3 +793,9 @@ func GetKubeconfigDefaultTokenTTLInMilliSeconds() (*int64, error) {
 	}
 	return &ttlMillis, nil
 }
+
+// GetKubeconfigMaxTokenTTLInMilliSeconds will return the maimum TTL for
+// kubeconfig tokens, in milliseconds
+func GetKubeconfigMaxTokenTTLInMilliSeconds() (int64, error) {
+	return exttokenstore.ParseTTLToMilliseconds(settings.KubeconfigMaxTokenTTLMinutes)
+}

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -101,7 +101,9 @@ func (m *Manager) createDerivedToken(jsonInput clientv3.Token, tokenAuthValue st
 		return apiv3.Token{}, "", http.StatusUnauthorized, err
 	}
 
-	tokenTTL, err := ClampToMaxAuthTTL(time.Duration(int64(jsonInput.TTLMillis)) * time.Millisecond)
+	tokenTTL, err := exttokenstore.IngestTTL(int64(jsonInput.TTLMillis),
+		settings.AuthTokenMaxTTLMinutes,
+		settings.AuthTokenDefaultTTLMinutes)
 	if err != nil {
 		return apiv3.Token{}, "", http.StatusInternalServerError, fmt.Errorf("error validating max-ttl %v", err)
 	}
@@ -110,7 +112,7 @@ func (m *Manager) createDerivedToken(jsonInput clientv3.Token, tokenAuthValue st
 	derivedToken := &apiv3.Token{
 		UserPrincipal: token.GetUserPrincipal(),
 		IsDerived:     true,
-		TTLMillis:     tokenTTL.Milliseconds(),
+		TTLMillis:     tokenTTL,
 		UserID:        token.GetUserID(),
 		AuthProvider:  token.GetAuthProvider(),
 		ProviderInfo:  token.GetProviderInfo(),
@@ -782,68 +784,12 @@ func (m *Manager) GetKubeconfigToken(clusterName, tokenName, description, kind, 
 	return token, createdTokenValue, nil
 }
 
-// ClampToMaxAuthTTL will return the duration of the provided TTL or the
-// duration of settings.AuthTokenMaxTTLMinutes, whichever is smaller.
-func ClampToMaxAuthTTL(ttl time.Duration) (time.Duration, error) {
-	maxTTL, err := maxAuthTTL()
-	if err != nil {
-		return 0, err
-	}
-	return ClampToMaxTTL(ttl, maxTTL), nil
-}
-
-// ClampToMaxTTL will return the duration of the provided TTL or the max TTL, whichever is smaller.
-func ClampToMaxTTL(ttl, max time.Duration) time.Duration {
-	// handle infinities
-	if max == 0 {
-		return ttl
-	}
-	if ttl == 0 {
-		return max
-	}
-	// return minimum
-	if ttl <= max {
-		return ttl
-	}
-	return max
-}
-
 // GetKubeconfigDefaultTokenTTLInMilliSeconds will return the default TTL for
 // kubeconfig tokens, in milliseconds, and clamped to the associated max.
 func GetKubeconfigDefaultTokenTTLInMilliSeconds() (*int64, error) {
-	defaultTTL, err := defaultKubeconfigTTL()
+	ttlMillis, err := exttokenstore.IngestTTL(0, settings.KubeconfigMaxTokenTTLMinutes, settings.KubeconfigDefaultTokenTTLMinutes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate kubeconfig ttl: %w", err)
+		return nil, err
 	}
-	maxTTL, err := maxKubeconfigTTL()
-	if err != nil {
-		return nil, fmt.Errorf("failed to validate kubeconfig ttl: %w", err)
-	}
-
-	ttlMillis := ClampToMaxTTL(defaultTTL, maxTTL).Milliseconds()
 	return &ttlMillis, nil
-}
-
-func maxKubeconfigTTL() (time.Duration, error) {
-	maxKubeconfigTTL, err := exttokenstore.ParseTokenTTL(settings.KubeconfigMaxTokenTTLMinutes.Get())
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.KubeconfigMaxTokenTTLMinutes.Name, err)
-	}
-	return maxKubeconfigTTL, nil
-}
-
-func defaultKubeconfigTTL() (time.Duration, error) {
-	defaultKubeconfigTTL, err := exttokenstore.ParseTokenTTL(settings.KubeconfigDefaultTokenTTLMinutes.Get())
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.KubeconfigDefaultTokenTTLMinutes.Name, err)
-	}
-	return defaultKubeconfigTTL, nil
-}
-
-func maxAuthTTL() (time.Duration, error) {
-	maxAuthTTL, err := exttokenstore.ParseTokenTTL(settings.AuthTokenMaxTTLMinutes.Get())
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.AuthTokenMaxTTLMinutes.Name, err)
-	}
-	return maxAuthTTL, nil
 }

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -105,7 +105,7 @@ func (m *Manager) createDerivedToken(jsonInput clientv3.Token, tokenAuthValue st
 		settings.AuthTokenMaxTTLMinutes,
 		settings.AuthTokenDefaultTTLMinutes)
 	if err != nil {
-		return apiv3.Token{}, "", http.StatusInternalServerError, fmt.Errorf("error validating max-ttl %v", err)
+		return apiv3.Token{}, "", http.StatusInternalServerError, fmt.Errorf("error validating ttl against default and max: %w", err)
 	}
 
 	var unhashedTokenKey string
@@ -794,7 +794,7 @@ func GetKubeconfigDefaultTokenTTLInMilliSeconds() (*int64, error) {
 	return &ttlMillis, nil
 }
 
-// GetKubeconfigMaxTokenTTLInMilliSeconds will return the maimum TTL for
+// GetKubeconfigMaxTokenTTLInMilliSeconds will return the maximum TTL for
 // kubeconfig tokens, in milliseconds
 func GetKubeconfigMaxTokenTTLInMilliSeconds() (int64, error) {
 	return exttokenstore.ParseTTLToMilliseconds(settings.KubeconfigMaxTokenTTLMinutes)

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -101,7 +101,7 @@ func (m *Manager) createDerivedToken(jsonInput clientv3.Token, tokenAuthValue st
 		return apiv3.Token{}, "", http.StatusUnauthorized, err
 	}
 
-	tokenTTL, err := ClampToMaxTTL(time.Duration(int64(jsonInput.TTLMillis)) * time.Millisecond)
+	tokenTTL, err := ClampToMaxAuthTTL(time.Duration(int64(jsonInput.TTLMillis)) * time.Millisecond)
 	if err != nil {
 		return apiv3.Token{}, "", http.StatusInternalServerError, fmt.Errorf("error validating max-ttl %v", err)
 	}
@@ -782,47 +782,68 @@ func (m *Manager) GetKubeconfigToken(clusterName, tokenName, description, kind, 
 	return token, createdTokenValue, nil
 }
 
-// ClampToMaxTTL will return the duration of the provided TTL or the duration of settings.AuthTokenMaxTTLMinutes whichever is smaller.
-func ClampToMaxTTL(ttl time.Duration) (time.Duration, error) {
-	maxTTL, err := ParseTokenTTL(settings.AuthTokenMaxTTLMinutes.Get())
+// ClampToMaxAuthTTL will return the duration of the provided TTL or the
+// duration of settings.AuthTokenMaxTTLMinutes, whichever is smaller.
+func ClampToMaxAuthTTL(ttl time.Duration) (time.Duration, error) {
+	maxTTL, err := maxAuthTTL()
+	if err != nil {
+		return 0, err
+	}
+	return ClampToMaxTTL(ttl, maxTTL), nil
+}
+
+// ClampToMaxTTL will return the duration of the provided TTL or the max TTL, whichever is smaller.
+func ClampToMaxTTL(ttl, max time.Duration) time.Duration {
+	// handle infinities
+	if max == 0 {
+		return ttl
+	}
+	if ttl == 0 {
+		return max
+	}
+	// return minimum
+	if ttl <= max {
+		return ttl
+	}
+	return max
+}
+
+// GetKubeconfigDefaultTokenTTLInMilliSeconds will return the default TTL for
+// kubeconfig tokens, in milliseconds, and clamped to the associated max.
+func GetKubeconfigDefaultTokenTTLInMilliSeconds() (*int64, error) {
+	defaultTTL, err := defaultKubeconfigTTL()
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate kubeconfig ttl: %w", err)
+	}
+	maxTTL, err := maxKubeconfigTTL()
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate kubeconfig ttl: %w", err)
+	}
+
+	ttlMillis := ClampToMaxTTL(defaultTTL, maxTTL).Milliseconds()
+	return &ttlMillis, nil
+}
+
+func maxKubeconfigTTL() (time.Duration, error) {
+	maxKubeconfigTTL, err := exttokenstore.ParseTokenTTL(settings.KubeconfigMaxTokenTTLMinutes.Get())
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.KubeconfigMaxTokenTTLMinutes.Name, err)
+	}
+	return maxKubeconfigTTL, nil
+}
+
+func defaultKubeconfigTTL() (time.Duration, error) {
+	defaultKubeconfigTTL, err := exttokenstore.ParseTokenTTL(settings.KubeconfigDefaultTokenTTLMinutes.Get())
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.KubeconfigDefaultTokenTTLMinutes.Name, err)
+	}
+	return defaultKubeconfigTTL, nil
+}
+
+func maxAuthTTL() (time.Duration, error) {
+	maxAuthTTL, err := exttokenstore.ParseTokenTTL(settings.AuthTokenMaxTTLMinutes.Get())
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.AuthTokenMaxTTLMinutes.Name, err)
 	}
-	if maxTTL == 0 {
-		return ttl, nil
-	}
-	if ttl == 0 {
-		return maxTTL, nil
-	}
-	// return min(ttl, maxTTL)
-	if ttl <= maxTTL {
-		return ttl, nil
-	}
-	return maxTTL, nil
-}
-
-// ParseTokenTTL parses an integer representing minutes as a string and returns its duration.
-// See also pkg/ext/stores/tokens/tokens.go
-func ParseTokenTTL(ttl string) (time.Duration, error) {
-	durString := fmt.Sprintf("%vm", ttl)
-	dur, err := time.ParseDuration(durString)
-	if err != nil {
-		return 0, fmt.Errorf("error parsing token ttl: %v", err)
-	}
-	return dur, nil
-}
-
-// GetKubeconfigDefaultTokenTTLInMilliSeconds will return the default TTL for kubeconfig tokens
-func GetKubeconfigDefaultTokenTTLInMilliSeconds() (*int64, error) {
-	defaultTokenTTL, err := exttokenstore.ParseTokenTTL(settings.KubeconfigDefaultTokenTTLMinutes.Get())
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse setting '%s': %w", settings.KubeconfigDefaultTokenTTLMinutes.Name, err)
-	}
-
-	tokenTTL, err := ClampToMaxTTL(defaultTokenTTL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to validate token ttl: %w", err)
-	}
-	ttlMilli := tokenTTL.Milliseconds()
-	return &ttlMilli, nil
+	return maxAuthTTL, nil
 }

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -293,7 +293,7 @@ func (s *Store) Create(
 
 	defaultTTLPtr, err := s.getDefaultTTL()
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting default token TTL: %v", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting default token TTL: %w", err))
 	}
 	maxTTL, err := s.getMaxTTL()
 	if err != nil {
@@ -305,10 +305,10 @@ func (s *Store) Create(
 	ttlMilliseconds := kubeconfig.Spec.TTL * 1000
 	switch {
 	case ttlMilliseconds < 0:
-		return nil, apierrors.NewBadRequest("spec.ttl can't be negative")
+		return nil, apierrors.NewBadRequest("spec.ttl can't be negative (infinite)")
 	case ttlMilliseconds == 0:
 		if defaultTTL < 0 {
-			return nil, apierrors.NewBadRequest("spec.ttl can't be made negative")
+			return nil, apierrors.NewBadRequest("spec.ttl can't be negative (infinite), please fix the default")
 		}
 		ttlMilliseconds = defaultTTL
 		kubeconfig.Spec.TTL = defaultTTLSeconds

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -291,25 +291,30 @@ func (s *Store) Create(
 		return nil, apierrors.NewBadRequest("at least one cluster is required when includeDefaultEntry is false")
 	}
 
-	defaultTTL, err := s.getDefaultTTL()
+	defaultTTLPtr, err := s.getDefaultTTL()
 	if err != nil {
 		return nil, apierrors.NewInternalError(fmt.Errorf("error getting default token TTL: %v", err))
 	}
-	defaultTTLSeconds := *defaultTTL / 1000
 	maxTTL, err := s.getMaxTTL()
 	if err != nil {
-		return nil, fmt.Errorf("error getting max token TTL: %w", err)
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting max token TTL: %w", err))
 	}
+	defaultTTL := exttokens.ClampToMaxTTL(exttokens.DefaultTTL(*defaultTTLPtr, maxTTL), maxTTL)
+	defaultTTLSeconds := defaultTTL / 1000
 
 	ttlMilliseconds := kubeconfig.Spec.TTL * 1000
 	switch {
 	case ttlMilliseconds < 0:
 		return nil, apierrors.NewBadRequest("spec.ttl can't be negative")
 	case ttlMilliseconds == 0:
-		ttlMilliseconds = *defaultTTL
+		if defaultTTL < 0 {
+			return nil, apierrors.NewBadRequest("spec.ttl can't be made negative")
+		}
+		ttlMilliseconds = defaultTTL
 		kubeconfig.Spec.TTL = defaultTTLSeconds
-	case ttlMilliseconds > maxTTL:
+	case maxTTL >= 1 && ttlMilliseconds > maxTTL:
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("spec.ttl %d exceeds max ttl %d", kubeconfig.Spec.TTL, maxTTL/1000))
+	case maxTTL < 1: // max is infinity, valid ttl
 	default: // Valid TTL.
 	}
 

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -137,6 +137,7 @@ type Store struct {
 	tokenMgr            tokenCreator
 	getCACert           func() string
 	getDefaultTTL       func() (*int64, error)
+	getMaxTTL           func() (int64, error)
 	getServerURL        func() string
 	shouldGenerateToken func() bool
 	tableConverter      rest.TableConvertor
@@ -159,6 +160,7 @@ func New(mcmEnabled bool, wranglerContext *wrangler.Context, authorizer authoriz
 		authorizer:      authorizer,
 		getCACert:       settings.CACerts.Get,
 		getDefaultTTL:   tokens.GetKubeconfigDefaultTokenTTLInMilliSeconds,
+		getMaxTTL:       tokens.GetKubeconfigMaxTokenTTLInMilliSeconds,
 		getServerURL:    settings.ServerURL.Get,
 		shouldGenerateToken: func() bool {
 			return strings.EqualFold(settings.KubeconfigGenerateToken.Get(), "true")
@@ -294,6 +296,10 @@ func (s *Store) Create(
 		return nil, apierrors.NewInternalError(fmt.Errorf("error getting default token TTL: %v", err))
 	}
 	defaultTTLSeconds := *defaultTTL / 1000
+	maxTTL, err := s.getMaxTTL()
+	if err != nil {
+		return nil, fmt.Errorf("error getting max token TTL: %w", err)
+	}
 
 	ttlMilliseconds := kubeconfig.Spec.TTL * 1000
 	switch {
@@ -302,8 +308,8 @@ func (s *Store) Create(
 	case ttlMilliseconds == 0:
 		ttlMilliseconds = *defaultTTL
 		kubeconfig.Spec.TTL = defaultTTLSeconds
-	case ttlMilliseconds > *defaultTTL:
-		return nil, apierrors.NewBadRequest(fmt.Sprintf("spec.ttl %d exceeds max ttl %d", kubeconfig.Spec.TTL, defaultTTLSeconds))
+	case ttlMilliseconds > maxTTL:
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("spec.ttl %d exceeds max ttl %d", kubeconfig.Spec.TTL, maxTTL/1000))
 	default: // Valid TTL.
 	}
 

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -464,6 +464,11 @@ func TestStoreCreate(t *testing.T) {
 		millis := defaultTTLSeconds * 1000
 		return &millis, nil
 	}
+	maxTTLSeconds := int64(41760)
+	getMaxTTL := func() (int64, error) {
+		millis := maxTTLSeconds * 1000
+		return millis, nil
+	}
 	shouldGenerateToken := func() bool { return true }
 	options := &metav1.CreateOptions{}
 	tokenManager := &fakeTokenManager{}
@@ -509,6 +514,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -650,6 +656,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return "" },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -736,6 +743,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return "" },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -856,6 +864,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: func() bool { return false },
 		}
@@ -941,6 +950,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return "" },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -1050,6 +1060,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -1209,6 +1220,7 @@ func TestStoreCreate(t *testing.T) {
 			getDefaultTTL: func() (*int64, error) {
 				return nil, fmt.Errorf("setting unavailable")
 			},
+			getMaxTTL: getMaxTTL,
 		}
 
 		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
@@ -1232,6 +1244,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenStore:    tokenStore,
 			tokenMgr:      tokenManager,
 			getDefaultTTL: getDefaultTTL,
+			getMaxTTL:     getMaxTTL,
 		}
 
 		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
@@ -1261,6 +1274,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenStore:    tokenStore,
 			tokenMgr:      tokenManager,
 			getDefaultTTL: getDefaultTTL,
+			getMaxTTL:     getMaxTTL,
 		}
 
 		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
@@ -1290,6 +1304,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenStore:    tokenStore,
 			tokenMgr:      tokenManager,
 			getDefaultTTL: getDefaultTTL,
+			getMaxTTL:     getMaxTTL,
 		}
 
 		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
@@ -1342,6 +1357,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -1418,6 +1434,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -1485,6 +1502,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -1554,6 +1572,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -1611,6 +1630,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return "" },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}
@@ -1663,6 +1683,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:            tokenManager,
 			getCACert:           func() string { return rancherCACert },
 			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
 			getServerURL:        getServerURL,
 			shouldGenerateToken: shouldGenerateToken,
 		}

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -547,7 +547,7 @@ func TestStoreCreate(t *testing.T) {
 		created := obj.(*ext.Kubeconfig)
 		assert.NotEmpty(t, created.Name)
 		assert.Empty(t, created.Namespace) // Kubeconfig is a cluster scoped resource.
-		assert.Equal(t, defaultTTLSeconds, created.Spec.TTL)
+		assert.Equal(t, maxTTLSeconds, created.Spec.TTL)
 		assert.Equal(t, kubeconfig.Spec.Description, created.Spec.Description)
 		assert.NotEmpty(t, created.Spec.CurrentContext)
 		assert.Equal(t, kubeconfig.Spec.Clusters, created.Spec.Clusters)
@@ -561,7 +561,7 @@ func TestStoreCreate(t *testing.T) {
 		require.NotNil(t, configMap.Annotations)
 		assert.NotEmpty(t, configMap.Annotations[UIDAnnotation])
 		require.NotNil(t, configMap.Data)
-		assert.Equal(t, strconv.FormatInt(defaultTTLSeconds, 10), configMap.Data[TTLField])
+		assert.Equal(t, strconv.FormatInt(maxTTLSeconds, 10), configMap.Data[TTLField])
 		assert.Equal(t, kubeconfig.Spec.Description, configMap.Data[DescriptionField])
 		assert.Equal(t, created.Spec.CurrentContext, configMap.Data[CurrentContextField]) // Check against the created Kubeconfig instance.
 		clustersValue, err := json.Marshal(kubeconfig.Spec.Clusters)
@@ -587,7 +587,7 @@ func TestStoreCreate(t *testing.T) {
 			case 2:
 				assert.Equal(t, "# createdTimestamp: "+configMap.CreationTimestamp.Time.Format(time.RFC3339), line)
 			case 3:
-				assert.Equal(t, "# ttl: "+strconv.FormatInt(defaultTTLSeconds, 10), line)
+				assert.Equal(t, "# ttl: "+strconv.FormatInt(maxTTLSeconds, 10), line)
 			default:
 			}
 			lines++
@@ -688,7 +688,7 @@ func TestStoreCreate(t *testing.T) {
 		created := obj.(*ext.Kubeconfig)
 		assert.NotEmpty(t, created.Name)
 		assert.Empty(t, created.Namespace) // Kubeconfig is a cluster scoped resource.
-		assert.Equal(t, defaultTTLSeconds, created.Spec.TTL)
+		assert.Equal(t, maxTTLSeconds, created.Spec.TTL)
 		assert.Equal(t, kubeconfig.Spec.Description, created.Spec.Description)
 		assert.Empty(t, kubeconfig.Spec.CurrentContext)
 		assert.Len(t, created.Spec.Clusters, 0)
@@ -702,7 +702,7 @@ func TestStoreCreate(t *testing.T) {
 		require.NotNil(t, configMap.Annotations)
 		assert.NotEmpty(t, configMap.Annotations[UIDAnnotation])
 		require.NotNil(t, configMap.Data)
-		assert.Equal(t, strconv.FormatInt(defaultTTLSeconds, 10), configMap.Data[TTLField])
+		assert.Equal(t, strconv.FormatInt(maxTTLSeconds, 10), configMap.Data[TTLField])
 		assert.Equal(t, kubeconfig.Spec.Description, configMap.Data[DescriptionField])
 		assert.Equal(t, created.Spec.CurrentContext, configMap.Data[CurrentContextField]) // Check against the created Kubeconfig instance.
 		assert.Empty(t, configMap.Data[ClustersField])
@@ -781,7 +781,7 @@ func TestStoreCreate(t *testing.T) {
 		created := obj.(*ext.Kubeconfig)
 		assert.NotEmpty(t, created.Name)
 		assert.Empty(t, created.Namespace) // Kubeconfig is a cluster scoped resource.
-		assert.Equal(t, defaultTTLSeconds, created.Spec.TTL)
+		assert.Equal(t, maxTTLSeconds, created.Spec.TTL)
 		assert.Equal(t, kubeconfig.Spec.Description, created.Spec.Description)
 		assert.Equal(t, downstream1, kubeconfig.Spec.CurrentContext)
 		require.Len(t, created.Spec.Clusters, 2)
@@ -983,7 +983,7 @@ func TestStoreCreate(t *testing.T) {
 		created := obj.(*ext.Kubeconfig)
 		assert.NotEmpty(t, created.Name)
 		assert.Empty(t, created.Namespace) // Kubeconfig is a cluster scoped resource.
-		assert.Equal(t, defaultTTLSeconds, created.Spec.TTL)
+		assert.Equal(t, maxTTLSeconds, created.Spec.TTL)
 		assert.Equal(t, kubeconfig.Spec.Description, created.Spec.Description)
 		assert.Empty(t, kubeconfig.Spec.CurrentContext)
 		require.Len(t, created.Spec.Clusters, 1)
@@ -998,7 +998,7 @@ func TestStoreCreate(t *testing.T) {
 		require.NotNil(t, configMap.Annotations)
 		assert.NotEmpty(t, configMap.Annotations[UIDAnnotation])
 		require.NotNil(t, configMap.Data)
-		assert.Equal(t, strconv.FormatInt(defaultTTLSeconds, 10), configMap.Data[TTLField])
+		assert.Equal(t, strconv.FormatInt(maxTTLSeconds, 10), configMap.Data[TTLField])
 		assert.Equal(t, kubeconfig.Spec.Description, configMap.Data[DescriptionField])
 		assert.Equal(t, created.Spec.CurrentContext, configMap.Data[CurrentContextField]) // Check against the created Kubeconfig instance.
 		assert.Equal(t, "[\"*\"]", configMap.Data[ClustersField])
@@ -1092,7 +1092,7 @@ func TestStoreCreate(t *testing.T) {
 		created := obj.(*ext.Kubeconfig)
 		assert.NotEmpty(t, created.Name)
 		assert.Empty(t, created.Namespace) // Kubeconfig is a cluster scoped resource.
-		assert.Equal(t, defaultTTLSeconds, created.Spec.TTL)
+		assert.Equal(t, maxTTLSeconds, created.Spec.TTL)
 		assert.Equal(t, kubeconfig.Spec.Description, created.Spec.Description)
 		assert.NotEmpty(t, created.Spec.CurrentContext)
 		assert.Equal(t, kubeconfig.Spec.Clusters, created.Spec.Clusters)
@@ -1106,7 +1106,7 @@ func TestStoreCreate(t *testing.T) {
 		require.NotNil(t, configMap.Annotations)
 		assert.NotEmpty(t, configMap.Annotations[UIDAnnotation])
 		require.NotNil(t, configMap.Data)
-		assert.Equal(t, strconv.FormatInt(defaultTTLSeconds, 10), configMap.Data[TTLField])
+		assert.Equal(t, strconv.FormatInt(maxTTLSeconds, 10), configMap.Data[TTLField])
 		assert.Equal(t, kubeconfig.Spec.Description, configMap.Data[DescriptionField])
 		assert.Equal(t, created.Spec.CurrentContext, configMap.Data[CurrentContextField]) // Check against the created Kubeconfig instance.
 		clustersValue, err := json.Marshal(kubeconfig.Spec.Clusters)

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1835,11 +1835,8 @@ func ClampToMaxTTL(ttl, max int64) int64 {
 		// maximum is infinity, ttl is always smaller or equal
 		return ttl
 	}
-	// for a finite maximum we can do simple comparison
-	if ttl > max {
-		return max
-	}
-	return ttl
+	// for a finite maximum we can do a simple
+	return min(ttl, max)
 }
 
 // ttlGreater compares the two TTL a and b. It returns true if a is greater than b.

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1785,31 +1785,54 @@ func clampMaxTTL(ttl int64) (int64, error) {
 	}
 
 	// decision table
-	// max | ttl         | note                                        | result
-	// --- + ----------- + ------------------------------------------- + ----------------
-	// < 1 | < 0         | max, ttl = +inf, no clamp                   | ttl
-	// < 1 | = 0         | max = +inf = default, ttl default requested | -1 = +inf
-	// < 1 | > 0         | max = +inf, ttl is regular, less than max   | ttl
-	// --- + ----------- + ------------------------------------------- + ----------------
-	// > 0 | < 0         | ttl = +inf, clamp to max                    | max
-	// > 0 | = 0         | ttl default requested, this is max          | max
-	// > 0 | > 0, <= max | less than max                               | ttl
-	// > 0 | > max       | clamp to max                                | max
+	//   | max | ttl         | note                                         | result
+	// - + --- + ----------- + ------------------------------------------- + ----------------
+	// a | < 1 | < 0         | max, ttl = +inf, no clamp                   | ttl
+	// b | < 1 | = 0         | max = +inf, ttl default requested, no clamp | default
+	// c | < 1 | > 0         | max = +inf, ttl is regular, less than max   | ttl
+	// - + --- + ----------- + ------------------------------------------- + ----------------
+	// d | > 0 | < 0         | ttl = +inf, clamp to max                    | max
+	// e | > 0 | = 0         | ttl default requested, clamp it to max      | clamp (default)
+	// f | > 0 | > 0, <= max | less than max                               | ttl
+	// g | > 0 | > max       | clamp to max                                | max
 
 	if max < 1 {
+		// a,b,c
 		if ttl == 0 {
-			return -1, nil
+			// b
+			defaultvalue, err := defaultTTL()
+			if err != nil {
+				return 0, err
+			}
+			return defaultvalue, nil
 		}
+		// a,c
 		return ttl, nil
 	}
-	if ttl > max || ttl <= 0 {
+	// d,e,f,g
+	if ttl > max || ttl < 0 {
+		// d,g
 		return max, nil
 	}
+	if ttl == 0 {
+		// e
+		defaultvalue, err := defaultTTL()
+		if err != nil {
+			return 0, err
+		}
+		// inlined clampMaxTTL(default), simplified, a,b,c irrelevant
+		if defaultvalue > max || defaultvalue < 0 {
+			// d,g
+			return max, nil
+		}
+		// e,f
+		return defaultvalue, nil
+	}
+	// f
 	return ttl, nil
 }
 
-// ParseTokenTTL parses an integer representing minutes as a string and returns its duration.
-// See also pkg/auth/tokens/manager.go
+// ParseTokenTTL parses an integer representing minutes as a string and returns it as a duration.
 func ParseTokenTTL(ttl string) (time.Duration, error) {
 	durString := fmt.Sprintf("%vm", ttl)
 	dur, err := time.ParseDuration(durString)
@@ -1827,6 +1850,16 @@ func maxTTL() (int64, error) {
 	}
 
 	return maxTTL.Milliseconds(), nil
+}
+
+func defaultTTL() (int64, error) {
+	defaultTTL, err := ParseTokenTTL(settings.AuthTokenDefaultTTLMinutes.Get())
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.AuthTokenDefaultTTLMinutes.Name, err)
+	}
+
+	return defaultTTL.Milliseconds(), nil
 }
 
 // ttlGreater compares the two TTL a and b. It returns true if a is greater than b.

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1020,7 +1020,7 @@ func (t *SystemStore) update(authTokenID string, fullPermission bool, oldToken, 
 	if !fullPermission {
 		ttl, err := IngestTTL(token.Spec.TTL, settings.AuthTokenMaxTTLMinutes, settings.AuthTokenDefaultTTLMinutes)
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("failed to clamp token time-to-live: %w", err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("failed to ingest token time-to-live: %w", err))
 		}
 		token.Spec.TTL = ttl
 		if ttlGreater(ttl, oldToken.Spec.TTL) {
@@ -1814,7 +1814,7 @@ func ParseTTLToMilliseconds(ttlSetting settings.Setting) (int64, error) {
 func ParseTTLToDuration(ttl string) (time.Duration, error) {
 	dur, err := time.ParseDuration(fmt.Sprintf("%vm", ttl))
 	if err != nil {
-		return 0, fmt.Errorf("error parsing ttl minutes: %v", err)
+		return 0, fmt.Errorf("error parsing ttl minutes: %w", err)
 	}
 	return dur, nil
 }
@@ -1850,7 +1850,7 @@ func ClampToMaxTTL(ttl, max int64) int64 {
 // Important special cases for TTL:
 // Any value < 0 represents +infinity.
 // A value > 0 is that many milliseconds.
-// The default of `0` cannot arrive here. `clampMaxTTL` resolved that already.
+// The default of `0` cannot arrive here. `IngestTTL` resolved that already.
 func ttlGreater(a, b int64) bool {
 	// Decision table
 	//

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1018,7 +1018,7 @@ func (t *SystemStore) update(authTokenID string, fullPermission bool, oldToken, 
 
 	// Regular users are not allowed to extend the TTL.
 	if !fullPermission {
-		ttl, err := clampMaxTTL(token.Spec.TTL)
+		ttl, err := IngestTTL(token.Spec.TTL, settings.AuthTokenMaxTTLMinutes, settings.AuthTokenDefaultTTLMinutes)
 		if err != nil {
 			return nil, apierrors.NewInternalError(fmt.Errorf("failed to clamp token time-to-live: %w", err))
 		}
@@ -1627,7 +1627,7 @@ func toSecret(token *ext.Token) (*corev1.Secret, error) {
 
 	// spec values
 	// injects default on creation and update
-	ttl, err := clampMaxTTL(token.Spec.TTL)
+	ttl, err := IngestTTL(token.Spec.TTL, settings.AuthTokenMaxTTLMinutes, settings.AuthTokenDefaultTTLMinutes)
 	if err != nil {
 		return nil, err
 	}
@@ -1778,88 +1778,68 @@ func setExpired(token *ext.Token) error {
 	return nil
 }
 
-func clampMaxTTL(ttl int64) (int64, error) {
-	max, err := maxTTL()
+// IngestTTL returns the input ttl (milliseconds) with requests for defaults
+// resolved, and further limited to the maximum allowed, as per the given
+// settings.
+func IngestTTL(ttl int64, maxSetting, defaultSetting settings.Setting) (int64, error) {
+	maxValue, err := ParseTTLToMilliseconds(maxSetting)
+	if err != nil {
+		return 0, err
+	}
+	defaultValue, err := ParseTTLToMilliseconds(defaultSetting)
 	if err != nil {
 		return 0, err
 	}
 
-	// decision table
-	//   | max | ttl         | note                                         | result
-	// - + --- + ----------- + ------------------------------------------- + ----------------
-	// a | < 1 | < 0         | max, ttl = +inf, no clamp                   | ttl
-	// b | < 1 | = 0         | max = +inf, ttl default requested, no clamp | default
-	// c | < 1 | > 0         | max = +inf, ttl is regular, less than max   | ttl
-	// - + --- + ----------- + ------------------------------------------- + ----------------
-	// d | > 0 | < 0         | ttl = +inf, clamp to max                    | max
-	// e | > 0 | = 0         | ttl default requested, clamp it to max      | clamp (default)
-	// f | > 0 | > 0, <= max | less than max                               | ttl
-	// g | > 0 | > max       | clamp to max                                | max
+	// We fall back to the maximum when the default value requests a default itself
+	defaultValue = DefaultTTL(defaultValue, maxValue)
 
-	if max < 1 {
-		// a,b,c
-		if ttl == 0 {
-			// b
-			defaultvalue, err := defaultTTL()
-			if err != nil {
-				return 0, err
-			}
-			return defaultvalue, nil
-		}
-		// a,c
-		return ttl, nil
-	}
-	// d,e,f,g
-	if ttl > max || ttl < 0 {
-		// d,g
-		return max, nil
-	}
-	if ttl == 0 {
-		// e
-		defaultvalue, err := defaultTTL()
-		if err != nil {
-			return 0, err
-		}
-		// inlined clampMaxTTL(default), simplified, a,b,c irrelevant
-		if defaultvalue > max || defaultvalue < 0 {
-			// d,g
-			return max, nil
-		}
-		// e,f
-		return defaultvalue, nil
-	}
-	// f
-	return ttl, nil
+	// Then resolve a default request in the input and clamp
+	return ClampToMaxTTL(DefaultTTL(ttl, defaultValue), maxValue), nil
 }
 
-// ParseTokenTTL parses an integer representing minutes as a string and returns it as a duration.
-func ParseTokenTTL(ttl string) (time.Duration, error) {
-	durString := fmt.Sprintf("%vm", ttl)
-	dur, err := time.ParseDuration(durString)
+// ParseTTLToMilliseconds retrieves a ttl setting (in minutes) and returns it as milliseconds
+func ParseTTLToMilliseconds(ttlSetting settings.Setting) (int64, error) {
+	ttl, err := ParseTTLToDuration(ttlSetting.Get())
 	if err != nil {
-		return 0, fmt.Errorf("error parsing token ttl: %v", err)
+		return 0, fmt.Errorf("failed to process setting '%s': %w", ttlSetting.Name, err)
+	}
+	return ttl.Milliseconds(), nil
+}
+
+// ParseTTLToDuration parses an integer representing minutes as a string and returns it as a duration.
+func ParseTTLToDuration(ttl string) (time.Duration, error) {
+	dur, err := time.ParseDuration(fmt.Sprintf("%vm", ttl))
+	if err != nil {
+		return 0, fmt.Errorf("error parsing ttl minutes: %v", err)
 	}
 	return dur, nil
 }
 
-func maxTTL() (int64, error) {
-	maxTTL, err := ParseTokenTTL(settings.AuthTokenMaxTTLMinutes.Get())
-
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.AuthTokenMaxTTLMinutes.Name, err)
+// DefaultTTL returns the default ttl, if such was requested by the input
+// (`value == 0`), or else the input as is.
+func DefaultTTL(ttl, defaultValue int64) int64 {
+	if ttl == 0 {
+		return defaultValue
 	}
-
-	return maxTTL.Milliseconds(), nil
+	return ttl
 }
 
-func defaultTTL() (int64, error) {
-	defaultTTL, err := ParseTokenTTL(settings.AuthTokenDefaultTTLMinutes.Get())
-
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse setting '%s': %w", settings.AuthTokenDefaultTTLMinutes.Name, err)
+// ClampToMaxTTL ensures that the returned ttl is smaller than the specified
+// maximum. In other words, it returns the minimum of the 2 inputs, taking into
+// account the special encoding of `infinity` (`value < 0`). The function
+// assumes that `ttl` is not `0`, i.e. that a request for the default has been
+// resolved already.
+func ClampToMaxTTL(ttl, max int64) int64 {
+	if max < 1 {
+		// maximum is infinity, ttl is always smaller or equal
+		return ttl
 	}
-
-	return defaultTTL.Milliseconds(), nil
+	// for a finite maximum we can do simple comparison
+	if ttl > max {
+		return max
+	}
+	return ttl
 }
 
 // ttlGreater compares the two TTL a and b. It returns true if a is greater than b.

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -1786,6 +1786,9 @@ func IngestTTL(ttl int64, maxSetting, defaultSetting settings.Setting) (int64, e
 	if err != nil {
 		return 0, err
 	}
+	if maxValue < 1 {
+		maxValue = -1 // "0" means no max — use the real "never expires" value.
+	}
 	defaultValue, err := ParseTTLToMilliseconds(defaultSetting)
 	if err != nil {
 		return 0, err
@@ -1827,13 +1830,17 @@ func DefaultTTL(ttl, defaultValue int64) int64 {
 
 // ClampToMaxTTL ensures that the returned ttl is smaller than the specified
 // maximum. In other words, it returns the minimum of the 2 inputs, taking into
-// account the special encoding of `infinity` (`value < 0`). The function
-// assumes that `ttl` is not `0`, i.e. that a request for the default has been
-// resolved already.
+// account the special encoding of `infinity` (`value < 0`) for both max and
+// ttl. The function assumes that `ttl` is not `0`, i.e. that a request for the
+// default has been resolved already.
 func ClampToMaxTTL(ttl, max int64) int64 {
 	if max < 1 {
 		// maximum is infinity, ttl is always smaller or equal
 		return ttl
+	}
+	if ttl < 0 {
+		// ttl asked for infinity, but max is finite — cap it at max.
+		return max
 	}
 	// for a finite maximum we can do a simple
 	return min(ttl, max)

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -11,6 +11,7 @@ import (
 
 	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1061,6 +1062,7 @@ func TestStoreCreate(t *testing.T) {
 		tok        *ext.Token            // token input
 		rtok       *ext.Token            // expected op result, created token
 		opts       *metav1.CreateOptions // create options
+		defaultmin string                // not empty --> use as modified default ttl setting
 		storeSetup func(                 // configure store backend clients
 			space *fake.MockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList],
 			secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
@@ -1415,7 +1417,7 @@ func TestStoreCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "created secret ok",
+			name: "created secret ok, ttl == default == max",
 			err:  nil,
 			tok: &ext.Token{
 				Spec: ext.TokenSpec{
@@ -1459,10 +1461,319 @@ func TestStoreCreate(t *testing.T) {
 				// Fake current time
 				timer.EXPECT().Now().Return("this is a fake now")
 
-				// note: returning an arbitrary good secret here.
-				// no connection to the token spec which went into create
 				secrets.EXPECT().Create(gomock.Any()).
-					Return(&properSecret, nil)
+					DoAndReturn(func(have *corev1.Secret) (*corev1.Secret, error) {
+						// the uid of the input is not fixed, and we cannot use
+						// Any() on the field. as solution we simply copy this
+						// field from have to want, ensuring that this particular
+						// comparison is a no-op, effectively any.
+						want := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:    TokenNamespace,
+								GenerateName: GeneratePrefix,
+								Labels: map[string]string{
+									KindLabel:       "",
+									SecretKindLabel: SecretKindLabelValue,
+									UserIDLabel:     "world",
+								},
+							},
+							StringData: map[string]string{
+								FieldClusterName:      "",
+								FieldDescription:      "",
+								FieldEnabled:          "true",
+								FieldHash:             "",
+								FieldKind:             "",
+								FieldLastActivitySeen: "",
+								FieldLastUpdateTime:   "this is a fake now",
+								FieldLastUsedAt:       "",
+								FieldPrincipal:        `{"name":"local://world"}`,
+								FieldTTL:              "7776000000",
+								FieldUID:              have.StringData[FieldUID],
+								FieldUserID:           "world",
+							},
+						}
+
+						assert.Equal(t, want, have)
+						// note: returning an arbitrary good secret here.
+						// no connection to the token spec which went into create
+						return &properSecret, nil
+					})
+			},
+			rtok: func() *ext.Token {
+				copy := properToken.DeepCopy()
+				copy.Status.Hash = ""
+				copy.Status.Value = "94084kdlafj43"
+				copy.Status.BearerToken = fmt.Sprintf("ext/%s:%s", copy.Name, copy.Status.Value)
+				return copy
+			}(),
+		},
+		{
+			name: "created secret ok, ttl > max, clamped",
+			err:  nil,
+			tok: &ext.Token{
+				Spec: ext.TokenSpec{
+					UserID: "world",
+					TTL:    8776000000,
+				},
+			},
+			opts: &metav1.CreateOptions{},
+			storeSetup: func( // configure store backend clients
+				space *fake.MockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				scache *fake.MockCacheInterface[*corev1.Secret],
+				users *fake.MockNonNamespacedCacheInterface[*v3.User],
+				token *fake.MockNonNamespacedCacheInterface[*v3.Token],
+				cluster *fake.MockNonNamespacedCacheInterface[*v3.Cluster],
+				timer *MocktimeHandler,
+				hasher *MockhashHandler,
+				auth *MockauthHandler) {
+
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&mockUser{name: "world"}, false, true, nil)
+
+				// session token fetch for user principal
+				auth.EXPECT().SessionID(gomock.Any()).
+					Return("session-token", nil)
+				token.EXPECT().Get("session-token").Return(&v3.Token{
+					AuthProvider: "local",
+					UserPrincipal: v3.Principal{
+						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
+					}}, nil)
+
+				users.EXPECT().Get("world").
+					Return(&v3.User{
+						DisplayName: "worldwide",
+						Username:    "wide",
+						Enabled:     ptr.To(true),
+					}, nil)
+
+				// Fake value and hash -- See rtok below
+				hasher.EXPECT().MakeAndHashSecret().Return("94084kdlafj43", "", nil)
+
+				// Fake current time
+				timer.EXPECT().Now().Return("this is a fake now")
+
+				secrets.EXPECT().Create(gomock.Any()).
+					DoAndReturn(func(have *corev1.Secret) (*corev1.Secret, error) {
+						// the uid of the input is not fixed, and we cannot use
+						// Any() on the field. as solution we simply copy this
+						// field from have to want, ensuring that this particular
+						// comparison is a no-op, effectively any.
+						want := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:    TokenNamespace,
+								GenerateName: GeneratePrefix,
+								Labels: map[string]string{
+									KindLabel:       "",
+									SecretKindLabel: SecretKindLabelValue,
+									UserIDLabel:     "world",
+								},
+							},
+							StringData: map[string]string{
+								FieldClusterName:      "",
+								FieldDescription:      "",
+								FieldEnabled:          "true",
+								FieldHash:             "",
+								FieldKind:             "",
+								FieldLastActivitySeen: "",
+								FieldLastUpdateTime:   "this is a fake now",
+								FieldLastUsedAt:       "",
+								FieldPrincipal:        `{"name":"local://world"}`,
+								FieldTTL:              "7776000000",
+								FieldUID:              have.StringData[FieldUID],
+								FieldUserID:           "world",
+							},
+						}
+
+						assert.Equal(t, want, have)
+						// note: returning an arbitrary good secret here.
+						// no connection to the token spec which went into create
+						return &properSecret, nil
+					})
+			},
+			rtok: func() *ext.Token {
+				copy := properToken.DeepCopy()
+				copy.Status.Hash = ""
+				copy.Status.Value = "94084kdlafj43"
+				copy.Status.BearerToken = fmt.Sprintf("ext/%s:%s", copy.Name, copy.Status.Value)
+				return copy
+			}(),
+		},
+		{
+			name:       "created secret ok, ttl == default > max, clamped",
+			err:        nil,
+			defaultmin: "146266",
+			tok: &ext.Token{
+				Spec: ext.TokenSpec{
+					UserID: "world",
+				},
+			},
+			opts: &metav1.CreateOptions{},
+			storeSetup: func( // configure store backend clients
+				space *fake.MockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				scache *fake.MockCacheInterface[*corev1.Secret],
+				users *fake.MockNonNamespacedCacheInterface[*v3.User],
+				token *fake.MockNonNamespacedCacheInterface[*v3.Token],
+				cluster *fake.MockNonNamespacedCacheInterface[*v3.Cluster],
+				timer *MocktimeHandler,
+				hasher *MockhashHandler,
+				auth *MockauthHandler) {
+
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&mockUser{name: "world"}, false, true, nil)
+
+				// session token fetch for user principal
+				auth.EXPECT().SessionID(gomock.Any()).
+					Return("session-token", nil)
+				token.EXPECT().Get("session-token").Return(&v3.Token{
+					AuthProvider: "local",
+					UserPrincipal: v3.Principal{
+						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
+					}}, nil)
+
+				users.EXPECT().Get("world").
+					Return(&v3.User{
+						DisplayName: "worldwide",
+						Username:    "wide",
+						Enabled:     ptr.To(true),
+					}, nil)
+
+				// Fake value and hash -- See rtok below
+				hasher.EXPECT().MakeAndHashSecret().Return("94084kdlafj43", "", nil)
+
+				// Fake current time
+				timer.EXPECT().Now().Return("this is a fake now")
+
+				secrets.EXPECT().Create(gomock.Any()).
+					DoAndReturn(func(have *corev1.Secret) (*corev1.Secret, error) {
+						// the uid of the input is not fixed, and we cannot use
+						// Any() on the field. as solution we simply copy this
+						// field from have to want, ensuring that this particular
+						// comparison is a no-op, effectively any.
+						want := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:    TokenNamespace,
+								GenerateName: GeneratePrefix,
+								Labels: map[string]string{
+									KindLabel:       "",
+									SecretKindLabel: SecretKindLabelValue,
+									UserIDLabel:     "world",
+								},
+							},
+							StringData: map[string]string{
+								FieldClusterName:      "",
+								FieldDescription:      "",
+								FieldEnabled:          "true",
+								FieldHash:             "",
+								FieldKind:             "",
+								FieldLastActivitySeen: "",
+								FieldLastUpdateTime:   "this is a fake now",
+								FieldLastUsedAt:       "",
+								FieldPrincipal:        `{"name":"local://world"}`,
+								FieldTTL:              "7776000000",
+								FieldUID:              have.StringData[FieldUID],
+								FieldUserID:           "world",
+							},
+						}
+
+						assert.Equal(t, want, have)
+						// note: returning an arbitrary good secret here.
+						// no connection to the token spec which went into create
+						return &properSecret, nil
+					})
+			},
+			rtok: func() *ext.Token {
+				copy := properToken.DeepCopy()
+				copy.Status.Hash = ""
+				copy.Status.Value = "94084kdlafj43"
+				copy.Status.BearerToken = fmt.Sprintf("ext/%s:%s", copy.Name, copy.Status.Value)
+				return copy
+			}(),
+		},
+		{
+			name:       "created secret ok, ttl == default < max",
+			err:        nil,
+			defaultmin: "112933",
+			tok: &ext.Token{
+				Spec: ext.TokenSpec{
+					UserID: "world",
+				},
+			},
+			opts: &metav1.CreateOptions{},
+			storeSetup: func( // configure store backend clients
+				space *fake.MockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				scache *fake.MockCacheInterface[*corev1.Secret],
+				users *fake.MockNonNamespacedCacheInterface[*v3.User],
+				token *fake.MockNonNamespacedCacheInterface[*v3.Token],
+				cluster *fake.MockNonNamespacedCacheInterface[*v3.Cluster],
+				timer *MocktimeHandler,
+				hasher *MockhashHandler,
+				auth *MockauthHandler) {
+
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&mockUser{name: "world"}, false, true, nil)
+
+				// session token fetch for user principal
+				auth.EXPECT().SessionID(gomock.Any()).
+					Return("session-token", nil)
+				token.EXPECT().Get("session-token").Return(&v3.Token{
+					AuthProvider: "local",
+					UserPrincipal: v3.Principal{
+						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
+					}}, nil)
+
+				users.EXPECT().Get("world").
+					Return(&v3.User{
+						DisplayName: "worldwide",
+						Username:    "wide",
+						Enabled:     ptr.To(true),
+					}, nil)
+
+				// Fake value and hash -- See rtok below
+				hasher.EXPECT().MakeAndHashSecret().Return("94084kdlafj43", "", nil)
+
+				// Fake current time
+				timer.EXPECT().Now().Return("this is a fake now")
+
+				secrets.EXPECT().Create(gomock.Any()).
+					DoAndReturn(func(have *corev1.Secret) (*corev1.Secret, error) {
+						// the uid of the input is not fixed, and we cannot use
+						// Any() on the field. as solution we simply copy this
+						// field from have to want, ensuring that this particular
+						// comparison is a no-op, effectively any.
+						want := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:    TokenNamespace,
+								GenerateName: GeneratePrefix,
+								Labels: map[string]string{
+									KindLabel:       "",
+									SecretKindLabel: SecretKindLabelValue,
+									UserIDLabel:     "world",
+								},
+							},
+							StringData: map[string]string{
+								FieldClusterName:      "",
+								FieldDescription:      "",
+								FieldEnabled:          "true",
+								FieldHash:             "",
+								FieldKind:             "",
+								FieldLastActivitySeen: "",
+								FieldLastUpdateTime:   "this is a fake now",
+								FieldLastUsedAt:       "",
+								FieldPrincipal:        `{"name":"local://world"}`,
+								FieldTTL:              "6775980000",
+								FieldUID:              have.StringData[FieldUID],
+								FieldUserID:           "world",
+							},
+						}
+
+						assert.Equal(t, want, have)
+						// note: returning an arbitrary good secret here.
+						// no connection to the token spec which went into create
+						return &properSecret, nil
+					})
 			},
 			rtok: func() *ext.Token {
 				copy := properToken.DeepCopy()
@@ -1498,6 +1809,15 @@ func TestStoreCreate(t *testing.T) {
 
 			store := New(nil, nil, nsCache, secrets, users, tcache, ccache, timer, hasher, auth)
 			test.storeSetup(nil, secrets, scache, ucache, tcache, ccache, timer, hasher, auth)
+
+			// inject a modified auth-token-default-ttl-minutes setting
+			if test.defaultmin != "" {
+				prior := settings.AuthTokenDefaultTTLMinutes.Get()
+				assert.NoError(t, settings.AuthTokenDefaultTTLMinutes.Set(test.defaultmin))
+				t.Cleanup(func() {
+					assert.NoError(t, settings.AuthTokenDefaultTTLMinutes.Set(prior))
+				})
+			}
 
 			// perform test and validate results
 			tok, err := store.create(context.TODO(), test.tok, test.opts)

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -1019,7 +1019,7 @@ func schema_pkg_apis_extcattleio_v1_TokenSpec(ref common.ReferenceCallback) comm
 					},
 					"ttl": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TTL is the time-to-live of the token, in milliseconds. Setting a value < 0 represents +infinity, i.e. a token which does not expire. The default is indicated by the value `0`. This default is provided by the `auth-token-max-ttl-minutes` setting. Note that this default is also the maximum specifiable TTL. A value <= 0 there enables non-expiring tokens.",
+							Description: "TTL is the time-to-live of the token, in milliseconds. Setting a value < 0 represents +infinity, i.e. a token which does not expire. The default is indicated by the value `0`. This default is provided by the `auth-token-default-ttl-minutes` setting. A value < 0 there enables non-expiring tokens, if not disallowed by the max. That is, both the ttl here and the default are subject to the `auth-token-max-ttl-minutes` setting, i.e. will be clamped to it if they represent a larger value than that.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -183,6 +183,9 @@ var (
 	// AuthTokenMaxTTLMinutes is the max allowable time to live for tokens. Excluding those created for UI sessions which is controlled by AuthUserSessionTTLMinutes.
 	AuthTokenMaxTTLMinutes = NewSetting("auth-token-max-ttl-minutes", "129600") // 90 days
 
+	// AuthTokenDefaultTTLMinutes is the default allowable time to live for tokens. Excluding those created for UI sessions which is controlled by AuthUserSessionTTLMinutes.
+	AuthTokenDefaultTTLMinutes = NewSetting("auth-token-default-ttl-minutes", "129600") // 90 days
+
 	// AuthUserInfoMaxAgeSeconds represents the maximum age of a users auth tokens before an auth provider group membership sync will be performed.
 	AuthUserInfoMaxAgeSeconds = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour
 
@@ -257,6 +260,10 @@ var (
 	// KubeconfigDefaultTokenTTLMinutes is the default time to live applied to kubeconfigs created for users.
 	// This setting will take effect regardless of the kubeconfig-generate-token status.
 	KubeconfigDefaultTokenTTLMinutes = NewSetting("kubeconfig-default-token-ttl-minutes", "43200") // 30 days
+
+	// KubeconfigMaxTokenTTLMinutes is the max time to live applied to kubeconfigs created for users.
+	// This setting will take effect regardless of the kubeconfig-generate-token status.
+	KubeconfigMaxTokenTTLMinutes = NewSetting("kubeconfig-max-token-ttl-minutes", "129600") // 90 days
 
 	// KubeconfigGenerateToken determines whether the UI will return a generate token with kubeconfigs.
 	// If set to false the kubeconfig will contain a command to login to Rancher.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#45924 
 
## Problem

User-request to separate the max and default values for various token life-times.
 
## Solution

Added the missing default and max settings (1) and updated the backend code to use them in the appropriate places.

1. auth token had a max setting, gained default. kubeconfig token had a default setting, gained a max.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_