### PR TITLE
[main] change up logging when serving connection information and CAPI isn't available yet

### DIFF
--- a/pkg/capr/configserver/server.go
+++ b/pkg/capr/configserver/server.go
@@ -97,15 +97,15 @@ func (r *RKE2ConfigServer) DeferCAPIResources(clients *wrangler.Context) {
 		r.machines = clients.CAPI.Machine()
 		r.capiClusterCache = clients.CAPI.Cluster().Cache()
 		r.capiAvailable = true
-		logrus.Debug("[rke2configserver] Initialized CAPI clients after deferred func execution")
+		logrus.Info("[rke2configserver] Initialized CAPI clients after deferred func execution")
 	})
 }
 
 func (r *RKE2ConfigServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if !r.capiAvailable {
-		logrus.Debug("[rke2configserver] CAPI not ready yet")
-		rw.WriteHeader(http.StatusServiceUnavailable)
+		logrus.Warn("[rke2configserver] CAPI not ready yet")
 		rw.Header().Set("Retry-After", "5")
+		http.Error(rw, "CAPI not ready yet", http.StatusServiceUnavailable)
 		return
 	}
 


### PR DESCRIPTION
## Issue: #56013
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

## Problem
When Rancher's CAPI clients haven't finished initializing, `ServeHTTP` in `pkg/capr/configserver/server.go` returns a 503 with an **empty body**. This gives the `system-agent-install.sh` script (and operators reading logs) no actionable information - the script retries indefinitely with only `503 received while downloading Rancher connection information`, and Rancher's own logs emit only a `DEBUG`-level message that is invisible at default log levels. The root cause (CAPI not yet ready) is entirely opaque from both the client and the server side.

> **Note:** This PR does **not** fix the underlying cause of CAPI being unavailable - if CAPI is down or stuck for an unrelated reason, node registration will still fail with a 503. This change only improves observability so that the cause is no longer opaque when that situation occurs.

## Solution
Two targeted changes to `pkg/capr/configserver/server.go`:

1. **Elevate the server-side log message from `Debug` to `Warn`** so the "CAPI not ready yet" condition is visible at default log levels without requiring debug logging to be enabled.
2. **Return the error string `"CAPI not ready yet"` as the 503 response body** (via `http.Error`) instead of an empty body, so `system-agent-install.sh` output and any operator watching the client side gets an actionable hint rather than a silent failure.

Additionally, the "Initialized CAPI clients" message is elevated from `Debug` to `Info` so operators can confirm when CAPI becomes available.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
- Reproduced the 503-with-empty-body condition by registering a new node before CAPI clients finish initializing.
- After the change, confirmed the 503 response body contains `"CAPI not ready yet"` and a `WARN`-level log line appears in Rancher logs during the startup window before CAPI is ready.
- Confirmed that once CAPI is available, registration proceeds normally and an `INFO`-level log line confirms CAPI client initialization.

### Automated Testing
* Test types added/modified:
    * None

Summary: Elevates CAPI-not-ready log messages from Debug -> Warn/Info and returns the error string in the 503 response body so node registration failures are actionable from both the client and server side.

## QA Testing Considerations
- Test new node registration against a Rancher instance that is still starting up (CAPI not yet ready) and verify the agent install script output now includes `"CAPI not ready yet"` rather than a blank 503.
- Verify normal node registration still succeeds once Rancher is fully initialized.
- Confirm Rancher logs show `WARN [rke2configserver] CAPI not ready yet` during the startup window and `INFO [rke2configserver] Initialized CAPI clients after deferred func execution` once ready.

### Regressions Considerations
Very low regression risk. The only behavioral changes are:
- The 503 response body changes from empty -> `"CAPI not ready yet\n"` (standard `http.Error` format). No callers are known to parse the body of this error response.
- Log levels for two existing messages are elevated (`Debug -> Warn` and `Debug -> Info`). No logic paths are modified.

Probability of regression: very low to none. this is just a logging change.