### PR TITLE
Improve the namespace handling for projects so namespaces access is correct.

### DIFF
--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -39,6 +39,7 @@ import (
 	rbacv1controllers "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	"github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -894,8 +895,10 @@ func (s *Operations) createRoleAndRoleBindings(op *catalog.Operation, user strin
 
 // createNamespace creates a new k8s namespace and returns its object.
 // It can also set the field.cattle.io/projectId annotation on the namespace if a non-empty projectID is provided.
-// It creates a watch on the namespace and waits for the v3.ProjectConditionInitialRolesPopulated condition
-// If the condition is not met within 30 seconds, it returns an error
+// It creates a watch on the namespace and waits for the v3.ProjectConditionInitialRolesPopulated condition.
+// If the condition is not met within 30 seconds, it logs a warning and returns the namespace anyway; the
+// condition may never be reachable (e.g. a PRTB referencing a deleted role template), and the actual
+// permission check happens later when the operation pod's impersonated helm/kubectl calls run.
 func (s *Operations) createNamespace(ctx context.Context, namespace, projectID string) (*corev1.Namespace, error) {
 	apiContext := types.GetAPIContext(ctx)
 	client, err := s.cg.K8sInterface(apiContext)
@@ -954,7 +957,13 @@ func (s *Operations) createNamespace(ctx context.Context, namespace, projectID s
 		}
 	}
 
-	return nil, fmt.Errorf("failed to wait for roles to be populated")
+	// The watch ended before InitialRolesPopulated was observed - this can happen if the project's
+	// RBAC can never fully converge (e.g. a PRTB referencing a deleted role template). Proceed with
+	// the namespace as-is rather than failing the install outright; the RBAC controller keeps
+	// reconciling roles for it in the background, and any permission gap will surface when the
+	// operation pod's impersonated helm/kubectl calls run against the namespace.
+	logrus.Warnf("[helmop] timed out waiting for roles to be populated in namespace %s, proceeding anyway", namespace)
+	return adminClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 }
 
 // createPod creates the struct of the pod for the operation to run in. It also mounts a secret with the secretdata provided.

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -168,6 +168,7 @@ func Register(ctx context.Context, workload *config.UserContext) error {
 
 	// Re-evaluate a namespace's InitialRolesPopulated condition when the project RBAC it waits for
 	// appears: PRTB-owned RoleBindings (project-member access) and project-namespace ClusterRoles.
+	// ClusterRoleBindings don't have a similar watch, but will be caught by the 5 second retry timer in the InitialRolesPopulated condition handler.
 	relatedresource.WatchClusterScoped(ctx, "enqueue-namespace-by-rolebinding", roleBindingEnqueueNamespace, workload.Corew.Namespace(), workload.RBACw.RoleBinding())
 	relatedresource.WatchClusterScoped(ctx, "enqueue-namespace-by-clusterrole", clusterRoleEnqueueNamespace, workload.Corew.Namespace(), workload.RBACw.ClusterRole())
 

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -166,6 +166,11 @@ func Register(ctx context.Context, workload *config.UserContext) error {
 	}
 	relatedresource.WatchClusterScoped(ctx, "enqueue-namespaces-by-roletemplate", nsEnqueuer.RoleTemplateEnqueueNamespace, workload.Corew.Namespace(), management.Wrangler.Mgmt.RoleTemplate())
 
+	// Re-evaluate a namespace's InitialRolesPopulated condition when the project RBAC it waits for
+	// appears: PRTB-owned RoleBindings (project-member access) and project-namespace ClusterRoles.
+	relatedresource.WatchClusterScoped(ctx, "enqueue-namespace-by-rolebinding", roleBindingEnqueueNamespace, workload.Corew.Namespace(), workload.RBACw.RoleBinding())
+	relatedresource.WatchClusterScoped(ctx, "enqueue-namespace-by-clusterrole", clusterRoleEnqueueNamespace, workload.Corew.Namespace(), workload.RBACw.ClusterRole())
+
 	// Register GlobalRole and GlobalRoleBinding Enqueuers
 	grEnqueuer := globalRoleEnqueuer{
 		grbLister: management.Wrangler.Mgmt.GlobalRoleBinding().Cache(),
@@ -222,7 +227,7 @@ type manager struct {
 	rbLister            wrbacv1.RoleBindingCache
 	roleBindings        wrbacv1.RoleBindingClient
 	nsLister            corew.NamespaceCache
-	namespaces          corew.NamespaceClient
+	namespaces          corew.NamespaceController
 	clusterLister       v3.ClusterLister
 	projectLister       v3.ProjectLister
 	userLister          v3.UserLister

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -14,9 +14,10 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
 	"github.com/rancher/rancher/pkg/features"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/project"
+	"github.com/rancher/rancher/pkg/rbac"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -235,150 +236,188 @@ func IsFleetNamespace(ns *v1.Namespace) bool {
 	return ns.Name == fleetconst.ClustersLocalNamespace || ns.Name == fleetconst.ClustersDefaultNamespace || ns.Name == fleetconst.ReleaseClustersNamespace || ns.Labels["fleet.cattle.io/managed"] == "true"
 }
 
+// ensurePRTBAddToNamespace reconciles the per-namespace PRTB RoleBindings for the project the
+// namespace currently belongs to. Under the legacy RBAC model it creates the bindings that should
+// exist; in all cases it removes bindings that should not (e.g. left behind when the namespace was
+// moved between projects, or when it belongs to no project at all). It returns whether the
+// namespace's project has any PRTBs, which the caller uses to gate the initial-roles status.
 func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
-	// Get project that contain this namespace
 	projectID := ns.Annotations[projectIDAnnotation]
-	if len(projectID) == 0 {
-		logrus.Debugf("Namespace %s does not belong to a project - deleting rolebindings", ns.Name)
-		// if namespace does not belong to a project, delete all rolebindings from that namespace that were created for a PRTB
-		// such rolebindings will have the label "authz.cluster.cattle.io/rtb-owner" prior to 2.5 and
-		// "authz.cluster.cattle.io/rtb-owner-updated" 2.5 onwards
-		rbs, err := n.m.rbLister.List(ns.Name, labels.Everything())
-		if err != nil {
-			return false, errors.Wrapf(err, "couldn't list role bindings in %s", ns.Name)
-		}
-		client := n.m.workload.RBACw.RoleBinding()
-		for _, rb := range rbs {
-			for _, ownerLabel := range []string{
-				rtbOwnerLabelLegacy,
-				rtbOwnerLabel,
-			} {
-				if uid := convert.ToString(rb.Labels[ownerLabel]); uid != "" {
-					logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
-					if err := client.Delete(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-						return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
-					}
-				}
-			}
-		}
-		return false, nil
-	}
 
-	prtbs, err := n.m.prtbIndexer.ByIndex(prtbByProjectIndex, projectID)
-	if err != nil {
-		return false, errors.Wrapf(err, "couldn't get project role binding templates associated with project id %s", projectID)
+	var prtbs []any
+	if projectID != "" {
+		var err error
+		prtbs, err = n.m.prtbIndexer.ByIndex(prtbByProjectIndex, projectID)
+		if err != nil {
+			return false, errors.Wrapf(err, "couldn't get project role binding templates associated with project id %s", projectID)
+		}
 	}
 	hasPRTBs := len(prtbs) > 0
 
-	// When aggregation is enabled, the per-namespace RoleBindings for PRTBs are owned by the
-	// roletemplate-aggregation controllers, which create them with aggregation labels and remove
-	// them when the PRTB is deleted. Creating the legacy bindings here would leak RoleBindings that
-	// the aggregation removal handler does not clean up, leaving stale namespace access behind.
-	if !features.AggregatedRoleTemplates.Enabled() {
-		for _, obj := range prtbs {
-			prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
-			if !ok {
-				return false, errors.Wrapf(err, "object %v is not valid project role template binding", obj)
-			}
-
-			if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {
-				continue
-			}
-
-			if prtb.RoleTemplateName == "" {
-				logrus.Warnf("ProjectRoleTemplateBinding %v has no role template set. Skipping.", prtb.Name)
-				continue
-			}
-
-			rt, err := n.m.rtLister.Get(prtb.RoleTemplateName)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", prtb.Name, prtb.RoleTemplateName)
-					continue
-				}
-				return false, err
-			}
-
-			roles := map[string]*v3.RoleTemplate{}
-			if err := n.m.gatherRoles(rt, roles, 0); err != nil {
-				return false, err
-			}
-
-			if err := n.m.ensureRoles(roles); err != nil {
-				return false, errors.Wrap(err, "couldn't ensure roles")
-			}
-
-			if err := n.m.ensureProjectRoleBindings(ns.Name, roles, prtb); err != nil {
-				return false, errors.Wrapf(err, "couldn't ensure binding %v in %v", prtb.Name, ns.Name)
-			}
+	// Under the legacy RBAC model the per-namespace PRTB RoleBindings are created here. Under
+	// aggregation they are owned by the roletemplate-aggregation controllers, which create them with
+	// aggregation labels and remove them when the PRTB is deleted; creating the legacy bindings here
+	// would leak RoleBindings the aggregation removal handler does not clean up.
+	if projectID != "" && !features.AggregatedRoleTemplates.Enabled() {
+		if err := n.createLegacyProjectRoleBindings(ns.Name, prtbs); err != nil {
+			return false, err
 		}
 	}
 
-	var namespace string
-	if parts := strings.SplitN(projectID, ":", 2); len(parts) == 2 && len(parts[1]) > 0 {
-		project, err := n.rq.ProjectCache.Get(parts[0], parts[1])
+	// Remove any PRTB RoleBinding (legacy or aggregation) that doesn't belong to the namespace's
+	// current project - e.g. bindings left behind when the namespace was moved between projects, or
+	// when it belongs to no project at all.
+	if err := n.removePRTBRoleBindingsNotInProject(ns.Name, projectID, prtbs); err != nil {
+		return hasPRTBs, err
+	}
+
+	return hasPRTBs, nil
+}
+
+// createLegacyProjectRoleBindings ensures a RoleBinding exists in the namespace for each PRTB in the
+// namespace's project. Only used under the legacy RBAC model; under aggregation these bindings are
+// owned by the roletemplate-aggregation controllers.
+func (n *nsLifecycle) createLegacyProjectRoleBindings(nsName string, prtbs []any) error {
+	for _, obj := range prtbs {
+		prtb, ok := obj.(*apisV3.ProjectRoleTemplateBinding)
+		if !ok {
+			return fmt.Errorf("expected *v3.ProjectRoleTemplateBinding, got %T", obj)
+		}
+
+		if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {
+			continue
+		}
+
+		if prtb.RoleTemplateName == "" {
+			logrus.Warnf("ProjectRoleTemplateBinding %v has no role template set. Skipping.", prtb.Name)
+			continue
+		}
+
+		rt, err := n.m.rtLister.Get(prtb.RoleTemplateName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				logrus.Warnf("Namespace %s references project %s in namespace %s which does not exist", ns.Name, parts[1], parts[0])
-				return hasPRTBs, nil
+				logrus.Warnf("ProjectRoleTemplateBinding %q sets a non-existing role template %q. Skipping.", prtb.Name, prtb.RoleTemplateName)
+				continue
 			}
-			return hasPRTBs, err
+			return err
 		}
-		namespace = project.GetProjectBackingNamespace()
-	} else {
-		return hasPRTBs, nil
+
+		roles := map[string]*apisV3.RoleTemplate{}
+		if err := n.m.gatherRoles(rt, roles, 0); err != nil {
+			return err
+		}
+
+		if err := n.m.ensureRoles(roles); err != nil {
+			return errors.Wrap(err, "couldn't ensure roles")
+		}
+
+		if err := n.m.ensureProjectRoleBindings(nsName, roles, prtb); err != nil {
+			return errors.Wrapf(err, "couldn't ensure binding %v in %v", prtb.Name, nsName)
+		}
+	}
+	return nil
+}
+
+// legacyOwnerIndexes maps each legacy rtb-owner RoleBinding label to the PRTB indexer that resolves
+// its value to the owning PRTB: the pre-2.5 label carries the PRTB UID, the 2.5+ label carries the
+// PRTB's namespace_name key. Only the legacy cleanup branch consults these; the whole map and its
+// use in prtbOwnerInCurrentProject can be removed with the legacy RBAC model.
+var legacyOwnerIndexes = map[string]string{
+	rtbOwnerLabelLegacy: prtbByUIDIndex,
+	rtbOwnerLabel:       prtbByNsAndNameIndex,
+}
+
+// removePRTBRoleBindingsNotInProject removes every PRTB-owned RoleBinding in the namespace whose
+// owning PRTB does not belong to the namespace's current project, handling legacy (rtb-owner
+// labelled) and aggregation (prtb-owner labelled) bindings in a single pass. Bindings left behind
+// when a namespace moves between projects are the main target; when the namespace belongs to no
+// project, no owner is valid so every PRTB-owned binding is removed.
+//
+// This closes the gap where moving a namespace between projects leaves a user with access to it: the
+// aggregation handler reconciles bindings by iterating a project's current namespaces, so once a
+// namespace leaves the project the owning PRTB's reconcile can no longer reach it to clean up.
+func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectID string, prtbs []any) error {
+	var backingNamespace string
+	if projectID != "" {
+		clusterID, projectID, found := strings.Cut(projectID, ":")
+		if !found {
+			return nil
+		}
+		project, err := n.rq.ProjectCache.Get(clusterID, projectID)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Warnf("Namespace %s references project %s in namespace %s which does not exist", nsName, projectID, clusterID)
+				return nil
+			}
+			return err
+		}
+		backingNamespace = project.GetProjectBackingNamespace()
 	}
 
-	rbs, err := n.m.rbLister.List(ns.Name, labels.Everything())
+	// allowedOwnerLabels is the set of prtb-owner label keys valid for the current project, against
+	// which aggregation bindings are matched. Empty when the namespace belongs to no project.
+	allowedOwnerLabels := make(map[string]bool, len(prtbs))
+	for _, obj := range prtbs {
+		if prtb, ok := obj.(*apisV3.ProjectRoleTemplateBinding); ok {
+			allowedOwnerLabels[pkgrbac.GetPRTBOwnerLabel(prtb.Name)] = true
+		}
+	}
+
+	rbs, err := n.m.rbLister.List(nsName, labels.Everything())
 	if err != nil {
-		return false, errors.Wrapf(err, "couldn't list role bindings in %s", ns.Name)
+		return errors.Wrapf(err, "couldn't list role bindings in %s", nsName)
 	}
-	client := n.m.workload.RBACw.RoleBinding()
-
 	for _, rb := range rbs {
-		if uid := convert.ToString(rb.Labels[rtbOwnerLabelLegacy]); uid != "" {
-			prtbs, err := n.m.prtbIndexer.ByIndex(prtbByUIDIndex, uid)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-
-				return false, errors.Wrapf(err, "couldn't find prtb for %s", rb.Name)
-			}
-			for _, prtb := range prtbs {
-				if prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding); ok {
-					if prtb.Namespace != namespace {
-						logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
-						if err := client.Delete(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-							return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
-						}
-					}
-				}
-			}
+		owned, inProject, err := n.prtbOwnerInCurrentProject(rb, backingNamespace, allowedOwnerLabels)
+		if err != nil {
+			return err
 		}
-
-		if nsAndName := convert.ToString(rb.Labels[rtbOwnerLabel]); nsAndName != "" {
-			prtbs, err := n.m.prtbIndexer.ByIndex(prtbByNsAndNameIndex, nsAndName)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-
-				return false, errors.Wrapf(err, "couldn't find prtb for %s", rb.Name)
-			}
-			for _, prtb := range prtbs {
-				if prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding); ok {
-					if prtb.Namespace != namespace {
-						logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
-						if err := client.Delete(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-							return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
-						}
-					}
-				}
+		// Only touch PRTB-owned bindings; leave CRTB-owned (or unrelated) bindings alone.
+		if owned && !inProject {
+			if err := rbac.DeleteNamespacedResource(nsName, rb.Name, n.m.roleBindings); err != nil {
+				return err
 			}
 		}
 	}
-	return hasPRTBs, nil
+	return nil
+}
+
+// prtbOwnerInCurrentProject reports whether rb is owned by a PRTB and if so, whether that
+// PRTB belongs to the namespace's current project.
+//
+// Aggregation bindings encode their owning PRTB in a prtb-owner-<name> label key, matched against
+// allowedOwnerLabels (the owner labels of the current project's PRTBs). Legacy bindings reference
+// their owning PRTB by the rtb-owner label value, which is resolved through the PRTB indexer and
+// matched against the current project's backing namespace. The legacy branch can be dropped once the
+// legacy RBAC model is removed.
+func (n *nsLifecycle) prtbOwnerInCurrentProject(rb *rbacv1.RoleBinding, backingNamespace string, allowedOwnerLabels map[string]bool) (owned, inProject bool, err error) {
+	for key := range rb.Labels {
+		if strings.HasPrefix(key, pkgrbac.PrtbOwnerLabel+"-") {
+			owned = true
+			if allowedOwnerLabels[key] {
+				inProject = true
+			}
+		}
+	}
+
+	for label, index := range legacyOwnerIndexes {
+		value := convert.ToString(rb.Labels[label])
+		if value == "" {
+			continue
+		}
+		owned = true
+		prtbs, lookupErr := n.m.prtbIndexer.ByIndex(index, value)
+		if lookupErr != nil {
+			return owned, inProject, errors.Wrapf(lookupErr, "couldn't find prtb for %s", rb.Name)
+		}
+		for _, obj := range prtbs {
+			if prtb, ok := obj.(*apisV3.ProjectRoleTemplateBinding); ok && prtb.Namespace == backingNamespace {
+				inProject = true
+			}
+		}
+	}
+
+	return owned, inProject, nil
 }
 
 // To ensure that all users in a project can do a GET on the namespaces in that project, this

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -286,7 +286,7 @@ func (n *nsLifecycle) createLegacyProjectRoleBindings(nsName string, prtbs []any
 	for _, obj := range prtbs {
 		prtb, ok := obj.(*apisV3.ProjectRoleTemplateBinding)
 		if !ok {
-			return fmt.Errorf("expected *v3.ProjectRoleTemplateBinding, got %T", obj)
+			return fmt.Errorf("expected *apisv3.ProjectRoleTemplateBinding, got %T", obj)
 		}
 
 		if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {
@@ -394,7 +394,11 @@ func (n *nsLifecycle) prtbOwnerInCurrentProject(rb *rbacv1.RoleBinding, backingN
 	}
 
 	for label, index := range legacyOwnerIndexes {
-		value := convert.ToString(rb.Labels[label])
+		raw, ok := rb.Labels[label]
+		if !ok {
+			continue
+		}
+		value := convert.ToString(raw)
 		if value == "" {
 			continue
 		}

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -17,7 +17,6 @@ import (
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/rbac"
-	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -359,7 +358,7 @@ func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectID strin
 	allowedOwnerLabels := make(map[string]bool, len(prtbs))
 	for _, obj := range prtbs {
 		if prtb, ok := obj.(*apisV3.ProjectRoleTemplateBinding); ok {
-			allowedOwnerLabels[pkgrbac.GetPRTBOwnerLabel(prtb.Name)] = true
+			allowedOwnerLabels[rbac.GetPRTBOwnerLabel(prtb.Name)] = true
 		}
 	}
 
@@ -392,7 +391,7 @@ func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectID strin
 // legacy RBAC model is removed.
 func (n *nsLifecycle) prtbOwnerInCurrentProject(rb *rbacv1.RoleBinding, backingNamespace string, allowedOwnerLabels map[string]bool) (owned, inProject bool, err error) {
 	for key := range rb.Labels {
-		if strings.HasPrefix(key, pkgrbac.PrtbOwnerLabel+"-") {
+		if strings.HasPrefix(key, rbac.PrtbOwnerLabel+"-") {
 			owned = true
 			if allowedOwnerLabels[key] {
 				inProject = true

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -335,10 +335,10 @@ var legacyOwnerIndexes = map[string]string{
 // owning PRTB does not belong to the namespace's current project. Bindings left behind
 // when a namespace moves between projects are the main target; when the namespace belongs to no
 // project, no owner is valid so every PRTB-owned binding is removed.
-func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectID string, prtbs []any) error {
+func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectLabel string, prtbs []any) error {
 	var backingNamespace string
-	if projectID != "" {
-		clusterID, projectID, found := strings.Cut(projectID, ":")
+	if projectLabel != "" {
+		clusterID, projectID, found := strings.Cut(projectLabel, ":")
 		if !found {
 			return nil
 		}
@@ -384,12 +384,12 @@ func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectID strin
 // prtbOwnerInCurrentProject reports whether rb is owned by a PRTB and if so, whether that
 // PRTB belongs to the namespace's current project.
 func (n *nsLifecycle) prtbOwnerInCurrentProject(rb *rbacv1.RoleBinding, backingNamespace string, allowedOwnerLabels map[string]bool) (owned, inProject bool, err error) {
+	owned = isPRTBOwnedRoleBinding(rb)
+
 	for key := range rb.Labels {
-		if strings.HasPrefix(key, rbac.PrtbOwnerLabel+"-") {
-			owned = true
-			if allowedOwnerLabels[key] {
-				inProject = true
-			}
+		if allowedOwnerLabels[key] {
+			inProject = true
+			break
 		}
 	}
 
@@ -402,7 +402,6 @@ func (n *nsLifecycle) prtbOwnerInCurrentProject(rb *rbacv1.RoleBinding, backingN
 		if value == "" {
 			continue
 		}
-		owned = true
 		prtbs, lookupErr := n.m.prtbIndexer.ByIndex(index, value)
 		if lookupErr != nil {
 			return owned, inProject, errors.Wrapf(lookupErr, "couldn't find prtb for %s", rb.Name)
@@ -426,9 +425,10 @@ func (n *nsLifecycle) reconcileNamespaceProjectClusterRole(ns *v1.Namespace) err
 		var desiredRole string
 		var projectName string
 		if ns.DeletionTimestamp == nil {
-			if parts := strings.SplitN(ns.Annotations[projectIDAnnotation], ":", 2); len(parts) == 2 && len(parts[1]) > 0 {
-				projectName = parts[1]
-				desiredRole = fmt.Sprintf(projectNSGetClusterRoleNameFmt, parts[1], name)
+			var found bool
+			_, projectName, found = strings.Cut(ns.Annotations[projectIDAnnotation], ":")
+			if found {
+				desiredRole = fmt.Sprintf(projectNSGetClusterRoleNameFmt, projectName, name)
 			}
 		}
 
@@ -705,7 +705,11 @@ func (n *nsLifecycle) initialRolesReady(ns *v1.Namespace) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("getting role bindings for namespace %s: %w", ns.Name, err)
 		}
-		if len(bindings) == 0 {
+
+		found := slices.ContainsFunc(bindings, func(rb *rbacv1.RoleBinding) bool {
+			return isPRTBOwnedRoleBinding(rb)
+		})
+		if !found {
 			return false, nil
 		}
 	}
@@ -746,6 +750,9 @@ func isPRTBOwnedRoleBinding(rb *rbacv1.RoleBinding) bool {
 // so InitialRolesPopulated is re-evaluated when those ClusterRoles appear. crByNS already filters to
 // the relevant ClusterRoles and extracts the namespaces they reference.
 func clusterRoleEnqueueNamespace(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
 	nsNames, err := crByNS(obj)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -393,15 +393,13 @@ func (n *nsLifecycle) prtbOwnerInCurrentProject(rb *rbacv1.RoleBinding, backingN
 		}
 	}
 
+	// empty legacy values naturally miss the index lookup, so no special-casing needed here.
 	for label, index := range legacyOwnerIndexes {
 		raw, ok := rb.Labels[label]
 		if !ok {
 			continue
 		}
 		value := convert.ToString(raw)
-		if value == "" {
-			continue
-		}
 		prtbs, lookupErr := n.m.prtbIndexer.ByIndex(index, value)
 		if lookupErr != nil {
 			return owned, inProject, errors.Wrapf(lookupErr, "couldn't find prtb for %s", rb.Name)
@@ -427,7 +425,7 @@ func (n *nsLifecycle) reconcileNamespaceProjectClusterRole(ns *v1.Namespace) err
 		if ns.DeletionTimestamp == nil {
 			var found bool
 			_, projectName, found = strings.Cut(ns.Annotations[projectIDAnnotation], ":")
-			if found {
+			if found && projectName != "" {
 				desiredRole = fmt.Sprintf(projectNSGetClusterRoleNameFmt, projectName, name)
 			}
 		}

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -17,12 +17,14 @@ import (
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/rbac"
+	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -32,6 +34,10 @@ const (
 	initialRoleCondition           = "InitialRolesPopulated"
 	manageNSVerb                   = "manage-namespaces"
 	projectNSEditVerb              = "*"
+
+	// initialRolesRequeueInterval is the backstop delay for re-checking whether a namespace's
+	// project RBAC has materialized, used when no watch wakes the reconcile sooner.
+	initialRolesRequeueInterval = 5 * time.Second
 
 	// compatibility with previous norman lifecycle implementation, now implemented inside OnChange's handler
 	normanLifecycleAnnotation = "lifecycle.cattle.io/create.namespace-auth"
@@ -76,12 +82,20 @@ func (n *nsLifecycle) onChange(_ string, obj *v1.Namespace) (*v1.Namespace, erro
 		return n.onRemove(obj)
 	}
 
+	var err error
 	if obj.Annotations[normanLifecycleAnnotation] != "true" {
-		return n.onCreate(obj)
+		obj, err = n.onCreate(obj)
+	} else {
+		err = n.syncNS(obj)
+	}
+	if err != nil {
+		return obj, err
 	}
 
-	_, err := n.syncNS(obj)
-	return obj, err
+	// Level-triggered: reconcile the InitialRolesPopulated condition every pass, based on the
+	// namespace's final project assignment. The RB/CR enqueuers re-trigger this handler when the
+	// awaited RBAC appears; until then reconcileInitialRolesCondition requeues via EnqueueAfter.
+	return n.reconcileInitialRolesCondition(obj)
 }
 
 func (n *nsLifecycle) removeFinalizer(obj *v1.Namespace) (*v1.Namespace, error) {
@@ -102,8 +116,7 @@ func (n *nsLifecycle) onCreate(obj *v1.Namespace) (*v1.Namespace, error) {
 		return nil, err
 	}
 
-	hasPRTBs, err := n.syncNS(obj)
-	if err != nil {
+	if err := n.syncNS(obj); err != nil {
 		return nil, err
 	}
 
@@ -122,8 +135,6 @@ func (n *nsLifecycle) onCreate(obj *v1.Namespace) (*v1.Namespace, error) {
 		return nil, err
 	}
 
-	go updateStatusAnnotation(hasPRTBs, obj.DeepCopy(), n.m)
-
 	return obj, nil
 }
 
@@ -141,7 +152,7 @@ func (n *nsLifecycle) onRemove(obj *v1.Namespace) (*v1.Namespace, error) {
 	return obj, nil
 }
 
-func (n *nsLifecycle) syncNS(obj *v1.Namespace) (bool, error) {
+func (n *nsLifecycle) syncNS(obj *v1.Namespace) error {
 	// add fleet namespace to system project
 	if IsFleetNamespace(obj) &&
 		// If this is the local cluster, then only move the namespace to ths system project if the projectIDAnnotation is
@@ -153,7 +164,7 @@ func (n *nsLifecycle) syncNS(obj *v1.Namespace) (bool, error) {
 
 		systemProjectName, err := n.GetSystemProjectName()
 		if err != nil {
-			return false, errors.Wrapf(err, "failed to add namespace %s to system project", obj.Name)
+			return errors.Wrapf(err, "failed to add namespace %s to system project", obj.Name)
 		}
 
 		// When there is no system project, we should not set this annotation as a result because the project name
@@ -166,16 +177,15 @@ func (n *nsLifecycle) syncNS(obj *v1.Namespace) (bool, error) {
 		}
 	}
 
-	hasPRTBs, err := n.ensurePRTBAddToNamespace(obj)
-	if err != nil {
-		return false, fmt.Errorf("ensuring PRTBs are added to namespace %s: %w", obj.Name, err)
+	if err := n.ensurePRTBAddToNamespace(obj); err != nil {
+		return fmt.Errorf("ensuring PRTBs are added to namespace %s: %w", obj.Name, err)
 	}
 
 	if err := n.reconcileNamespaceProjectClusterRole(obj); err != nil {
-		return false, fmt.Errorf("reconciling namespace %s project cluster roles: %w", obj.Name, err)
+		return fmt.Errorf("reconciling namespace %s project cluster roles: %w", obj.Name, err)
 	}
 
-	return hasPRTBs, nil
+	return nil
 }
 
 func (n *nsLifecycle) assignToInitialProject(ns *v1.Namespace) error {
@@ -238,9 +248,8 @@ func IsFleetNamespace(ns *v1.Namespace) bool {
 // ensurePRTBAddToNamespace reconciles the per-namespace PRTB RoleBindings for the project the
 // namespace currently belongs to. Under the legacy RBAC model it creates the bindings that should
 // exist; in all cases it removes bindings that should not (e.g. left behind when the namespace was
-// moved between projects, or when it belongs to no project at all). It returns whether the
-// namespace's project has any PRTBs, which the caller uses to gate the initial-roles status.
-func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
+// moved between projects, or when it belongs to no project at all).
+func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) error {
 	projectID := ns.Annotations[projectIDAnnotation]
 
 	var prtbs []any
@@ -248,18 +257,16 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 		var err error
 		prtbs, err = n.m.prtbIndexer.ByIndex(prtbByProjectIndex, projectID)
 		if err != nil {
-			return false, errors.Wrapf(err, "couldn't get project role binding templates associated with project id %s", projectID)
+			return errors.Wrapf(err, "couldn't get project role binding templates associated with project id %s", projectID)
 		}
 	}
-	hasPRTBs := len(prtbs) > 0
 
 	// Under the legacy RBAC model the per-namespace PRTB RoleBindings are created here. Under
 	// aggregation they are owned by the roletemplate-aggregation controllers, which create them with
-	// aggregation labels and remove them when the PRTB is deleted; creating the legacy bindings here
-	// would leak RoleBindings the aggregation removal handler does not clean up.
+	// aggregation labels and remove them when the PRTB is deleted.
 	if projectID != "" && !features.AggregatedRoleTemplates.Enabled() {
 		if err := n.createLegacyProjectRoleBindings(ns.Name, prtbs); err != nil {
-			return false, err
+			return err
 		}
 	}
 
@@ -267,15 +274,14 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 	// current project - e.g. bindings left behind when the namespace was moved between projects, or
 	// when it belongs to no project at all.
 	if err := n.removePRTBRoleBindingsNotInProject(ns.Name, projectID, prtbs); err != nil {
-		return hasPRTBs, err
+		return err
 	}
 
-	return hasPRTBs, nil
+	return nil
 }
 
 // createLegacyProjectRoleBindings ensures a RoleBinding exists in the namespace for each PRTB in the
-// namespace's project. Only used under the legacy RBAC model; under aggregation these bindings are
-// owned by the roletemplate-aggregation controllers.
+// namespace's project. Only used under the non-aggregation RBAC model.
 func (n *nsLifecycle) createLegacyProjectRoleBindings(nsName string, prtbs []any) error {
 	for _, obj := range prtbs {
 		prtb, ok := obj.(*apisV3.ProjectRoleTemplateBinding)
@@ -319,22 +325,16 @@ func (n *nsLifecycle) createLegacyProjectRoleBindings(nsName string, prtbs []any
 
 // legacyOwnerIndexes maps each legacy rtb-owner RoleBinding label to the PRTB indexer that resolves
 // its value to the owning PRTB: the pre-2.5 label carries the PRTB UID, the 2.5+ label carries the
-// PRTB's namespace_name key. Only the legacy cleanup branch consults these; the whole map and its
-// use in prtbOwnerInCurrentProject can be removed with the legacy RBAC model.
+// PRTB's namespace_name key.
 var legacyOwnerIndexes = map[string]string{
 	rtbOwnerLabelLegacy: prtbByUIDIndex,
 	rtbOwnerLabel:       prtbByNsAndNameIndex,
 }
 
 // removePRTBRoleBindingsNotInProject removes every PRTB-owned RoleBinding in the namespace whose
-// owning PRTB does not belong to the namespace's current project, handling legacy (rtb-owner
-// labelled) and aggregation (prtb-owner labelled) bindings in a single pass. Bindings left behind
+// owning PRTB does not belong to the namespace's current project. Bindings left behind
 // when a namespace moves between projects are the main target; when the namespace belongs to no
 // project, no owner is valid so every PRTB-owned binding is removed.
-//
-// This closes the gap where moving a namespace between projects leaves a user with access to it: the
-// aggregation handler reconciles bindings by iterating a project's current namespaces, so once a
-// namespace leaves the project the owning PRTB's reconcile can no longer reach it to clean up.
 func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectID string, prtbs []any) error {
 	var backingNamespace string
 	if projectID != "" {
@@ -383,12 +383,6 @@ func (n *nsLifecycle) removePRTBRoleBindingsNotInProject(nsName, projectID strin
 
 // prtbOwnerInCurrentProject reports whether rb is owned by a PRTB and if so, whether that
 // PRTB belongs to the namespace's current project.
-//
-// Aggregation bindings encode their owning PRTB in a prtb-owner-<name> label key, matched against
-// allowedOwnerLabels (the owner labels of the current project's PRTBs). Legacy bindings reference
-// their owning PRTB by the rtb-owner label value, which is resolved through the PRTB indexer and
-// matched against the current project's backing namespace. The legacy branch can be dropped once the
-// legacy RBAC model is removed.
 func (n *nsLifecycle) prtbOwnerInCurrentProject(rb *rbacv1.RoleBinding, backingNamespace string, allowedOwnerLabels map[string]bool) (owned, inProject bool, err error) {
 	for key := range rb.Labels {
 		if strings.HasPrefix(key, rbac.PrtbOwnerLabel+"-") {
@@ -609,7 +603,7 @@ func addUpdatepsaClusterRole(projectName string) *rbacv1.ClusterRole {
 	return clusterRole
 }
 
-func crByNS(obj interface{}) ([]string, error) {
+func crByNS(obj any) ([]string, error) {
 	cr, ok := obj.(*rbacv1.ClusterRole)
 	if !ok {
 		return []string{}, nil
@@ -628,68 +622,135 @@ func crByNS(obj interface{}) ([]string, error) {
 	return result, nil
 }
 
-func updateStatusAnnotation(hasPRTBs bool, namespace *v1.Namespace, mgr *manager) {
-	if _, ok := namespace.Annotations[projectIDAnnotation]; ok {
-		for i := 0; i < 10; i++ {
-			time.Sleep(time.Millisecond * 500)
-			clusterRoles, err := mgr.crIndexer.ByIndex(crByNSIndex, namespace.Name)
+// reconcileInitialRolesCondition sets the InitialRolesPopulated condition once the namespace's
+// project RBAC has been created. Until then, it requeues the namespace via EnqueueAfter.
+// The condition is write-once: after it is set, this returns early on every subsequent reconcile.
+func (n *nsLifecycle) reconcileInitialRolesCondition(ns *v1.Namespace) (*v1.Namespace, error) {
+	set, err := namespaceutil.IsNamespaceConditionSet(ns, initialRoleCondition, true)
+	if err != nil {
+		return ns, fmt.Errorf("checking %s condition on namespace %s: %w", initialRoleCondition, ns.Name, err)
+	}
+	if set {
+		return ns, nil
+	}
+
+	ready, err := n.initialRolesReady(ns)
+	if err != nil {
+		return ns, err
+	}
+	if !ready {
+		// The RB/CR enqueuers usually wake us sooner when the awaited objects appear; this is the
+		// backstop for transitions no watch covers (e.g. a just-assigned project, dropped events).
+		n.m.namespaces.EnqueueAfter(ns.Name, initialRolesRequeueInterval)
+		return ns, nil
+	}
+
+	ns = ns.DeepCopy()
+	if err := namespaceutil.SetNamespaceCondition(ns, time.Second, initialRoleCondition, true, ""); err != nil {
+		return ns, fmt.Errorf("setting %s condition on namespace %s: %w", initialRoleCondition, ns.Name, err)
+	}
+	return n.m.namespaces.Update(ns)
+}
+
+// initialRolesReady reports whether the RBAC that InitialRolesPopulated gates has materialized: the
+// project's namespace ClusterRoles exist, the namespace creator (if any) has a binding to one of
+// them, and - when the project has PRTBs - at least one project RoleBinding exists in the namespace.
+// A namespace that belongs to no project has no per-project roles to wait for and is always ready.
+func (n *nsLifecycle) initialRolesReady(ns *v1.Namespace) (bool, error) {
+	projectID := ns.Annotations[projectIDAnnotation]
+	if projectID == "" {
+		return true, nil
+	}
+
+	clusterRoles, err := n.m.crIndexer.ByIndex(crByNSIndex, ns.Name)
+	if err != nil {
+		return false, fmt.Errorf("getting cluster roles for namespace %s: %w", ns.Name, err)
+	}
+	if len(clusterRoles) < 2 {
+		return false, nil
+	}
+
+	if creator := ns.Annotations["field.cattle.io/creatorId"]; creator != "" {
+		found := false
+		for _, crx := range clusterRoles {
+			cr, ok := crx.(*rbacv1.ClusterRole)
+			if !ok {
+				continue
+			}
+			crbKey := rbRoleSubjectKey(cr.Name, rbacv1.Subject{Kind: "User", Name: creator})
+			crbs, err := n.m.crbIndexer.ByIndex(crbByRoleAndSubjectIndex, crbKey)
 			if err != nil {
-				logrus.Warnf("error getting cluster roles for ns %v for status update: %v", namespace.Name, err)
-				continue
+				return false, fmt.Errorf("getting cluster role bindings for namespace %s: %w", ns.Name, err)
 			}
-			if len(clusterRoles) < 2 {
-				continue
+			if len(crbs) > 0 {
+				found = true
+				break
 			}
-
-			creator := namespace.Annotations["field.cattle.io/creatorId"]
-			if creator != "" {
-				found := false
-				for _, crx := range clusterRoles {
-					cr, _ := crx.(*rbacv1.ClusterRole)
-					crbKey := rbRoleSubjectKey(cr.Name, rbacv1.Subject{Kind: "User", Name: creator})
-					crbs, _ := mgr.crbIndexer.ByIndex(crbByRoleAndSubjectIndex, crbKey)
-					if len(crbs) > 0 {
-						found = true
-						break
-					}
-				}
-				if !found {
-					continue
-				}
-			}
-
-			if hasPRTBs {
-				bindings, err := mgr.rbLister.List(namespace.Name, labels.Everything())
-				if err != nil {
-					logrus.Warnf("error getting bindings for ns %v for status update: %v", namespace.Name, err)
-					continue
-				}
-				if len(bindings) > 0 {
-					break
-				}
-			}
+		}
+		if !found {
+			return false, nil
 		}
 	}
 
-	for i := 0; i < 10; i++ {
-		ns, err := mgr.namespaces.Get(namespace.Name, metav1.GetOptions{})
+	prtbs, err := n.m.prtbIndexer.ByIndex(prtbByProjectIndex, projectID)
+	if err != nil {
+		return false, fmt.Errorf("getting PRTBs for project %s: %w", projectID, err)
+	}
+	if len(prtbs) > 0 {
+		bindings, err := n.m.rbLister.List(ns.Name, labels.Everything())
 		if err != nil {
-			logrus.Errorf("error getting ns %v for status update: %v", namespace.Name, err)
-			return
+			return false, fmt.Errorf("getting role bindings for namespace %s: %w", ns.Name, err)
 		}
-		if err := namespaceutil.SetNamespaceCondition(ns, time.Second*1, initialRoleCondition, true, ""); err != nil {
-			logrus.Warnf("fail to set %v condition on ns %v: %v", initialRoleCondition, namespace.Name, err)
-			continue
-		}
-		_, err = mgr.namespaces.Update(ns)
-		if err == nil {
-			break
-		}
-		if !apierrors.IsConflict(err) {
-			logrus.Warnf("error updating ns %v status: %v", ns.Name, err)
+		if len(bindings) == 0 {
+			return false, nil
 		}
 	}
 
+	return true, nil
+}
+
+// roleBindingEnqueueNamespace enqueues the namespace a PRTB-owned RoleBinding lives in, so its
+// InitialRolesPopulated condition is re-evaluated as soon as project-member bindings appear.
+func roleBindingEnqueueNamespace(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	rb, ok := obj.(*rbacv1.RoleBinding)
+	if !ok || rb == nil {
+		return nil, nil
+	}
+	if !isPRTBOwnedRoleBinding(rb) {
+		return nil, nil
+	}
+	return []relatedresource.Key{{Name: rb.Namespace}}, nil
+}
+
+// isPRTBOwnedRoleBinding reports whether rb is owned by a ProjectRoleTemplateBinding, under either
+// the aggregation model (prtb-owner-<name> label) or the legacy model (rtb-owner labels).
+func isPRTBOwnedRoleBinding(rb *rbacv1.RoleBinding) bool {
+	for key := range rb.Labels {
+		if strings.HasPrefix(key, rbac.PrtbOwnerLabel+"-") {
+			return true
+		}
+	}
+	for label := range legacyOwnerIndexes {
+		if _, ok := rb.Labels[label]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// clusterRoleEnqueueNamespace enqueues every namespace a project-namespaces ClusterRole authorizes,
+// so InitialRolesPopulated is re-evaluated when those ClusterRoles appear. crByNS already filters to
+// the relevant ClusterRoles and extracts the namespaces they reference.
+func clusterRoleEnqueueNamespace(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	nsNames, err := crByNS(obj)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]relatedresource.Key, 0, len(nsNames))
+	for _, name := range nsNames {
+		keys = append(keys, relatedresource.Key{Name: name})
+	}
+	return keys, nil
 }
 
 // asyncCleanupRBAC will wait for a Terminating namespace to be fully deleted before removing the associated RBAC.

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
 	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	wfakes "github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -741,6 +743,278 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 				},
 			})
 			assert.Equal(t, test.wantHasPRTBs, hasPRTBs)
+			if test.wantError != "" {
+				assert.ErrorContains(t, err, test.wantError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// aggregationRoleBinding builds a RoleBinding carrying the aggregation feature label plus the given
+// owner label, mirroring what the roletemplate-aggregation PRTB handler creates in each namespace.
+func aggregationRoleBinding(name, namespace, ownerLabel string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				pkgrbac.AggregationFeatureLabel: "true",
+				ownerLabel:                      "true",
+			},
+		},
+	}
+}
+
+// legacyRoleBinding builds a RoleBinding carrying a single legacy rtb-owner label (key/value),
+// mirroring what the legacy PRTB handler creates in each namespace.
+func legacyRoleBinding(name, namespace, label, value string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{label: value},
+		},
+	}
+}
+
+// prtb builds a minimal PRTB; only its Namespace matters for legacy owner resolution.
+func prtb(namespace, name string) *v3.ProjectRoleTemplateBinding {
+	return &v3.ProjectRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	}
+}
+
+// multiIndexPRTBIndexer is a cache.Indexer that resolves PRTBs by (indexName, indexKey), supporting
+// the multiple indexes the unified cleanup consults (prtbByUIDIndex, prtbByNsAndNameIndex). Only
+// ByIndex is implemented; the other cache.Indexer methods are never called by the code under test.
+type multiIndexPRTBIndexer struct {
+	cache.Indexer
+	byIndex map[string]map[string][]*v3.ProjectRoleTemplateBinding
+	err     error
+}
+
+func (m *multiIndexPRTBIndexer) ByIndex(indexName, indexKey string) ([]interface{}, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	var out []interface{}
+	for _, p := range m.byIndex[indexName][indexKey] {
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func TestRemovePRTBRoleBindingsNotInProject(t *testing.T) {
+	const (
+		namespaceName    = "test-ns"
+		projectID        = "c-123xyz:p-current"
+		backingNamespace = "p-current"
+		otherNamespace   = "p-other"
+	)
+	currentPRTBLabel := pkgrbac.GetPRTBOwnerLabel("current-prtb")
+	otherPRTBLabel := pkgrbac.GetPRTBOwnerLabel("other-prtb")
+	crtbLabel := pkgrbac.GetCRTBOwnerLabel("some-crtb")
+
+	currentProject := &apisV3.Project{
+		Status: apisV3.ProjectStatus{BackingNamespace: backingNamespace},
+	}
+
+	tests := []struct {
+		name          string
+		projectID     string
+		project       *apisV3.Project
+		projectGetErr error
+		currentPRTBs  []*v3.ProjectRoleTemplateBinding
+		existingRBs   []*rbacv1.RoleBinding
+		prtbsByUID    map[string][]*v3.ProjectRoleTemplateBinding
+		prtbsByNsName map[string][]*v3.ProjectRoleTemplateBinding
+		indexerErr    error
+		listError     error
+		deleteError   error
+
+		wantDeleted []string
+		wantError   string
+	}{
+		{
+			name:         "aggregation: stale binding from another project deleted, current kept",
+			projectID:    projectID,
+			project:      currentProject,
+			currentPRTBs: []*v3.ProjectRoleTemplateBinding{prtb(backingNamespace, "current-prtb")},
+			existingRBs: []*rbacv1.RoleBinding{
+				aggregationRoleBinding("rb-keep", namespaceName, currentPRTBLabel),
+				aggregationRoleBinding("rb-stale", namespaceName, otherPRTBLabel),
+			},
+			wantDeleted: []string{"rb-stale"},
+		},
+		{
+			name:      "legacy: stale binding from another project deleted, current kept",
+			projectID: projectID,
+			project:   currentProject,
+			existingRBs: []*rbacv1.RoleBinding{
+				legacyRoleBinding("rb-legkeep", namespaceName, rtbOwnerLabelLegacy, "uid-current"),
+				legacyRoleBinding("rb-legstale", namespaceName, rtbOwnerLabelLegacy, "uid-other"),
+			},
+			prtbsByUID: map[string][]*v3.ProjectRoleTemplateBinding{
+				"uid-current": {prtb(backingNamespace, "cur")},
+				"uid-other":   {prtb(otherNamespace, "oth")},
+			},
+			wantDeleted: []string{"rb-legstale"},
+		},
+		{
+			name:      "legacy: rtb-owner-updated label resolved via ns-and-name index",
+			projectID: projectID,
+			project:   currentProject,
+			existingRBs: []*rbacv1.RoleBinding{
+				legacyRoleBinding("rb-updstale", namespaceName, rtbOwnerLabel, "p-other_oth"),
+			},
+			prtbsByNsName: map[string][]*v3.ProjectRoleTemplateBinding{
+				"p-other_oth": {prtb(otherNamespace, "oth")},
+			},
+			wantDeleted: []string{"rb-updstale"},
+		},
+		{
+			name:      "legacy: orphaned binding whose PRTB no longer exists is deleted",
+			projectID: projectID,
+			project:   currentProject,
+			existingRBs: []*rbacv1.RoleBinding{
+				legacyRoleBinding("rb-orphan", namespaceName, rtbOwnerLabelLegacy, "uid-gone"),
+			},
+			// uid-gone resolves to nothing: the owning PRTB is gone, so the binding is stale.
+			wantDeleted: []string{"rb-orphan"},
+		},
+		{
+			name:         "crtb-owned aggregation binding is left alone",
+			projectID:    projectID,
+			project:      currentProject,
+			currentPRTBs: []*v3.ProjectRoleTemplateBinding{prtb(backingNamespace, "current-prtb")},
+			existingRBs: []*rbacv1.RoleBinding{
+				aggregationRoleBinding("rb-crtb", namespaceName, crtbLabel),
+			},
+			wantDeleted: nil,
+		},
+		{
+			name:      "no project: every prtb-owned binding (legacy and aggregation) deleted",
+			projectID: "",
+			existingRBs: []*rbacv1.RoleBinding{
+				aggregationRoleBinding("rb-agg", namespaceName, otherPRTBLabel),
+				legacyRoleBinding("rb-leg", namespaceName, rtbOwnerLabelLegacy, "uid-any"),
+			},
+			prtbsByUID: map[string][]*v3.ProjectRoleTemplateBinding{
+				"uid-any": {prtb(otherNamespace, "any")},
+			},
+			wantDeleted: []string{"rb-agg", "rb-leg"},
+		},
+		{
+			name:          "project not found: cleanup skipped",
+			projectID:     projectID,
+			projectGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "management.cattle.io", Resource: "projects"}, "p-current"),
+			existingRBs: []*rbacv1.RoleBinding{
+				aggregationRoleBinding("rb-stale", namespaceName, otherPRTBLabel),
+			},
+			wantDeleted: nil,
+		},
+		{
+			name:      "malformed project id: cleanup skipped",
+			projectID: "no-colon",
+			existingRBs: []*rbacv1.RoleBinding{
+				aggregationRoleBinding("rb-stale", namespaceName, otherPRTBLabel),
+			},
+			wantDeleted: nil,
+		},
+		{
+			name:          "project get error is surfaced",
+			projectID:     projectID,
+			projectGetErr: fmt.Errorf("boom"),
+			wantError:     "boom",
+		},
+		{
+			name:         "list error is surfaced",
+			projectID:    projectID,
+			project:      currentProject,
+			currentPRTBs: []*v3.ProjectRoleTemplateBinding{prtb(backingNamespace, "current-prtb")},
+			listError:    fmt.Errorf("boom"),
+			wantError:    "couldn't list role bindings",
+		},
+		{
+			name:      "prtb lookup error is surfaced",
+			projectID: projectID,
+			project:   currentProject,
+			existingRBs: []*rbacv1.RoleBinding{
+				legacyRoleBinding("rb-leg", namespaceName, rtbOwnerLabelLegacy, "uid-any"),
+			},
+			indexerErr: fmt.Errorf("boom"),
+			wantError:  "couldn't find prtb",
+		},
+		{
+			name:         "delete error is surfaced",
+			projectID:    projectID,
+			project:      currentProject,
+			currentPRTBs: []*v3.ProjectRoleTemplateBinding{prtb(backingNamespace, "current-prtb")},
+			existingRBs: []*rbacv1.RoleBinding{
+				aggregationRoleBinding("rb-stale", namespaceName, otherPRTBLabel),
+			},
+			wantDeleted: []string{"rb-stale"},
+			deleteError: fmt.Errorf("boom"),
+			wantError:   "couldn't delete role binding",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			wellFormed := false
+			if test.projectID != "" {
+				parts := strings.SplitN(test.projectID, ":", 2)
+				wellFormed = len(parts) == 2 && parts[1] != ""
+			}
+			// The project is only resolved when a well-formed project id is set; cleanup only reaches
+			// the RoleBinding list when there's no project or the project resolved successfully.
+			reachedList := test.projectID == "" || (wellFormed && test.projectGetErr == nil)
+
+			pGetter := wfakes.NewMockCacheInterface[*apisV3.Project](ctrl)
+			if wellFormed {
+				pGetter.EXPECT().Get(gomock.Any(), gomock.Any()).Return(test.project, test.projectGetErr)
+			}
+
+			rbLister := wfakes.NewMockCacheInterface[*rbacv1.RoleBinding](ctrl)
+			if reachedList {
+				rbLister.EXPECT().List(namespaceName, gomock.Any()).Return(test.existingRBs, test.listError)
+			}
+
+			roleBindings := wfakes.NewMockControllerInterface[*rbacv1.RoleBinding, *rbacv1.RoleBindingList](ctrl)
+			for _, name := range test.wantDeleted {
+				roleBindings.EXPECT().Delete(namespaceName, name, gomock.Any()).Return(test.deleteError)
+			}
+
+			prtbIndexer := &multiIndexPRTBIndexer{
+				byIndex: map[string]map[string][]*v3.ProjectRoleTemplateBinding{
+					prtbByUIDIndex:       test.prtbsByUID,
+					prtbByNsAndNameIndex: test.prtbsByNsName,
+				},
+				err: test.indexerErr,
+			}
+
+			var prtbs []interface{}
+			for _, p := range test.currentPRTBs {
+				prtbs = append(prtbs, p)
+			}
+
+			lifecycle := nsLifecycle{
+				m: &manager{
+					rbLister:     rbLister,
+					roleBindings: roleBindings,
+					prtbIndexer:  prtbIndexer,
+				},
+				rq: &resourcequota.SyncController{
+					ProjectCache: pGetter,
+				},
+			}
+
+			err := lifecycle.removePRTBRoleBindingsNotInProject(namespaceName, test.projectID, prtbs)
 			if test.wantError != "" {
 				assert.ErrorContains(t, err, test.wantError)
 			} else {

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
 	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	wfakes "github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -636,8 +638,7 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 		deleteError         error
 		getError            error
 
-		wantError    string
-		wantHasPRTBs bool
+		wantError string
 	}{
 		{
 			name:                "update namespace with missing namespace",
@@ -657,7 +658,6 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 					RoleTemplateName: "test-rt",
 				},
 			},
-			wantHasPRTBs: true,
 		},
 		{
 			name:                "aggregation enabled skips legacy binding creation",
@@ -677,7 +677,6 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 					RoleTemplateName: "test-rt",
 				},
 			},
-			wantHasPRTBs: true,
 		},
 	}
 	for _, test := range tests {
@@ -734,7 +733,7 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 					ProjectCache: pGetter,
 				},
 			}
-			hasPRTBs, err := lifecycle.ensurePRTBAddToNamespace(&corev1.Namespace{
+			err := lifecycle.ensurePRTBAddToNamespace(&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespaceName,
 					Annotations: map[string]string{
@@ -742,7 +741,6 @@ func TestEnsurePRTBAddToNamespace(t *testing.T) {
 					},
 				},
 			})
-			assert.Equal(t, test.wantHasPRTBs, hasPRTBs)
 			if test.wantError != "" {
 				assert.ErrorContains(t, err, test.wantError)
 			} else {
@@ -1022,4 +1020,273 @@ func TestRemovePRTBRoleBindingsNotInProject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsPRTBOwnedRoleBinding(t *testing.T) {
+	const namespaceName = "test-ns"
+	prtbLabel := pkgrbac.GetPRTBOwnerLabel("some-prtb")
+	crtbLabel := pkgrbac.GetCRTBOwnerLabel("some-crtb")
+
+	tests := []struct {
+		name string
+		rb   *rbacv1.RoleBinding
+		want bool
+	}{
+		{
+			name: "aggregation prtb-owner labelled binding is owned",
+			rb:   aggregationRoleBinding("rb", namespaceName, prtbLabel),
+			want: true,
+		},
+		{
+			name: "legacy rtb-owner labelled binding is owned",
+			rb:   legacyRoleBinding("rb", namespaceName, rtbOwnerLabelLegacy, "uid-1"),
+			want: true,
+		},
+		{
+			name: "legacy rtb-owner-updated labelled binding is owned",
+			rb:   legacyRoleBinding("rb", namespaceName, rtbOwnerLabel, "p-proj_name"),
+			want: true,
+		},
+		{
+			name: "crtb-owner labelled binding is not owned",
+			rb:   aggregationRoleBinding("rb", namespaceName, crtbLabel),
+			want: false,
+		},
+		{
+			name: "unlabelled binding is not owned",
+			rb:   &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: namespaceName}},
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isPRTBOwnedRoleBinding(test.rb))
+		})
+	}
+}
+
+func TestRoleBindingEnqueueNamespace(t *testing.T) {
+	const namespaceName = "test-ns"
+	prtbLabel := pkgrbac.GetPRTBOwnerLabel("some-prtb")
+
+	t.Run("prtb-owned binding enqueues its namespace", func(t *testing.T) {
+		keys, err := roleBindingEnqueueNamespace("", "", aggregationRoleBinding("rb", namespaceName, prtbLabel))
+		assert.NoError(t, err)
+		assert.Equal(t, []relatedresource.Key{{Name: namespaceName}}, keys)
+	})
+
+	t.Run("non-prtb binding enqueues nothing", func(t *testing.T) {
+		keys, err := roleBindingEnqueueNamespace("", "", &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: namespaceName},
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, keys)
+	})
+
+	t.Run("non-rolebinding object enqueues nothing", func(t *testing.T) {
+		keys, err := roleBindingEnqueueNamespace("", "", &rbacv1.ClusterRole{})
+		assert.NoError(t, err)
+		assert.Empty(t, keys)
+	})
+}
+
+func TestClusterRoleEnqueueNamespace(t *testing.T) {
+	const (
+		namespaceName = "test-ns"
+		projectName   = "p-123xyz"
+	)
+
+	t.Run("project namespace cluster role enqueues its namespaces", func(t *testing.T) {
+		cr := createClusterRoleForProject(projectName, namespaceName, "get")
+		keys, err := clusterRoleEnqueueNamespace("", "", cr)
+		assert.NoError(t, err)
+		assert.Contains(t, keys, relatedresource.Key{Name: namespaceName})
+	})
+
+	t.Run("unrelated cluster role enqueues nothing", func(t *testing.T) {
+		keys, err := clusterRoleEnqueueNamespace("", "", &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "unrelated"},
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, keys)
+	})
+}
+
+func TestInitialRolesReady(t *testing.T) {
+	const (
+		namespaceName = "test-ns"
+		projectID     = "c-123xyz:p-123xyz"
+		creator       = "creator-user"
+	)
+	twoRoles := []*rbacv1.ClusterRole{
+		{ObjectMeta: metav1.ObjectMeta{Name: "p-123xyz-namespaces-readonly"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "p-123xyz-namespaces-edit"}},
+	}
+
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		clusterRoles  []*rbacv1.ClusterRole
+		creatorCRBs   []*rbacv1.ClusterRoleBinding
+		prtbs         []*v3.ProjectRoleTemplateBinding
+		bindings      []*rbacv1.RoleBinding
+		expectListRBs bool
+		want          bool
+	}{
+		{
+			name:        "no project is always ready",
+			annotations: map[string]string{},
+			want:        true,
+		},
+		{
+			name:         "fewer than two cluster roles is not ready",
+			annotations:  map[string]string{projectIDAnnotation: projectID},
+			clusterRoles: twoRoles[:1],
+			want:         false,
+		},
+		{
+			name:         "two cluster roles, no creator, no prtbs is ready",
+			annotations:  map[string]string{projectIDAnnotation: projectID},
+			clusterRoles: twoRoles,
+			want:         true,
+		},
+		{
+			name:         "creator without a binding is not ready",
+			annotations:  map[string]string{projectIDAnnotation: projectID, "field.cattle.io/creatorId": creator},
+			clusterRoles: twoRoles,
+			creatorCRBs:  nil,
+			want:         false,
+		},
+		{
+			name:         "creator with a binding, no prtbs is ready",
+			annotations:  map[string]string{projectIDAnnotation: projectID, "field.cattle.io/creatorId": creator},
+			clusterRoles: twoRoles,
+			creatorCRBs:  []*rbacv1.ClusterRoleBinding{{ObjectMeta: metav1.ObjectMeta{Name: "crb"}}},
+			want:         true,
+		},
+		{
+			name:          "project has prtbs but no bindings yet is not ready",
+			annotations:   map[string]string{projectIDAnnotation: projectID},
+			clusterRoles:  twoRoles,
+			prtbs:         []*v3.ProjectRoleTemplateBinding{prtb("p-123xyz", "member-prtb")},
+			bindings:      nil,
+			expectListRBs: true,
+			want:          false,
+		},
+		{
+			name:          "project has prtbs and a binding is ready",
+			annotations:   map[string]string{projectIDAnnotation: projectID},
+			clusterRoles:  twoRoles,
+			prtbs:         []*v3.ProjectRoleTemplateBinding{prtb("p-123xyz", "member-prtb")},
+			bindings:      []*rbacv1.RoleBinding{{ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: namespaceName}}},
+			expectListRBs: true,
+			want:          true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			crIndexer := &FakeResourceIndexer[*rbacv1.ClusterRole]{
+				resources: map[string][]*rbacv1.ClusterRole{namespaceName: test.clusterRoles},
+				index:     crByNSIndex,
+			}
+			crbKey := rbRoleSubjectKey(twoRoles[0].Name, rbacv1.Subject{Kind: "User", Name: creator})
+			crbIndexer := &FakeResourceIndexer[*rbacv1.ClusterRoleBinding]{
+				resources: map[string][]*rbacv1.ClusterRoleBinding{crbKey: test.creatorCRBs},
+				index:     crbByRoleAndSubjectIndex,
+			}
+			prtbIndexer := &FakeResourceIndexer[*v3.ProjectRoleTemplateBinding]{
+				resources: map[string][]*v3.ProjectRoleTemplateBinding{projectID: test.prtbs},
+				index:     prtbByProjectIndex,
+			}
+			rbLister := wfakes.NewMockCacheInterface[*rbacv1.RoleBinding](ctrl)
+			if test.expectListRBs {
+				rbLister.EXPECT().List(namespaceName, gomock.Any()).Return(test.bindings, nil)
+			}
+
+			lifecycle := nsLifecycle{m: &manager{
+				crIndexer:   crIndexer,
+				crbIndexer:  crbIndexer,
+				prtbIndexer: prtbIndexer,
+				rbLister:    rbLister,
+			}}
+
+			ready, err := lifecycle.initialRolesReady(&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceName, Annotations: test.annotations},
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, test.want, ready)
+		})
+	}
+}
+
+func TestReconcileInitialRolesCondition(t *testing.T) {
+	const (
+		namespaceName = "test-ns"
+		projectID     = "c-123xyz:p-123xyz"
+	)
+
+	newNS := func() *corev1.Namespace {
+		return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:        namespaceName,
+			Annotations: map[string]string{projectIDAnnotation: projectID},
+		}}
+	}
+	twoRoles := []*rbacv1.ClusterRole{
+		{ObjectMeta: metav1.ObjectMeta{Name: "readonly"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "edit"}},
+	}
+
+	t.Run("already-set condition short-circuits without lookups or writes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ns := newNS()
+		assert.NoError(t, namespaceutil.SetNamespaceCondition(ns, time.Second, initialRoleCondition, true, ""))
+		// nil indexers/namespaces client would panic if the readiness path or an update ran.
+		namespaces := wfakes.NewMockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList](ctrl)
+
+		lifecycle := nsLifecycle{m: &manager{namespaces: namespaces}}
+		got, err := lifecycle.reconcileInitialRolesCondition(ns)
+		assert.NoError(t, err)
+		assert.Same(t, ns, got)
+	})
+
+	t.Run("not ready requeues via EnqueueAfter and does not update", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		crIndexer := &FakeResourceIndexer[*rbacv1.ClusterRole]{
+			resources: map[string][]*rbacv1.ClusterRole{namespaceName: twoRoles[:1]}, // <2 => not ready
+			index:     crByNSIndex,
+		}
+		namespaces := wfakes.NewMockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList](ctrl)
+		namespaces.EXPECT().EnqueueAfter(namespaceName, initialRolesRequeueInterval)
+
+		lifecycle := nsLifecycle{m: &manager{crIndexer: crIndexer, namespaces: namespaces}}
+		_, err := lifecycle.reconcileInitialRolesCondition(newNS())
+		assert.NoError(t, err)
+	})
+
+	t.Run("ready sets the condition and updates the namespace", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		crIndexer := &FakeResourceIndexer[*rbacv1.ClusterRole]{
+			resources: map[string][]*rbacv1.ClusterRole{namespaceName: twoRoles},
+			index:     crByNSIndex,
+		}
+		prtbIndexer := &FakeResourceIndexer[*v3.ProjectRoleTemplateBinding]{
+			resources: map[string][]*v3.ProjectRoleTemplateBinding{projectID: nil}, // no prtbs => no binding wait
+			index:     prtbByProjectIndex,
+		}
+		namespaces := wfakes.NewMockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList](ctrl)
+		namespaces.EXPECT().Update(gomock.Any()).DoAndReturn(func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+			set, err := namespaceutil.IsNamespaceConditionSet(ns, initialRoleCondition, true)
+			assert.NoError(t, err)
+			assert.True(t, set, "expected %s condition set to true on the updated namespace", initialRoleCondition)
+			return ns, nil
+		})
+
+		lifecycle := nsLifecycle{m: &manager{crIndexer: crIndexer, prtbIndexer: prtbIndexer, namespaces: namespaces}}
+		_, err := lifecycle.reconcileInitialRolesCondition(newNS())
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -1179,9 +1179,18 @@ func TestInitialRolesReady(t *testing.T) {
 			annotations:   map[string]string{projectIDAnnotation: projectID},
 			clusterRoles:  twoRoles,
 			prtbs:         []*v3.ProjectRoleTemplateBinding{prtb("p-123xyz", "member-prtb")},
-			bindings:      []*rbacv1.RoleBinding{{ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: namespaceName}}},
+			bindings:      []*rbacv1.RoleBinding{aggregationRoleBinding("rb", namespaceName, pkgrbac.GetPRTBOwnerLabel("member-prtb"))},
 			expectListRBs: true,
 			want:          true,
+		},
+		{
+			name:          "project has prtbs but only an unrelated binding is not ready",
+			annotations:   map[string]string{projectIDAnnotation: projectID},
+			clusterRoles:  twoRoles,
+			prtbs:         []*v3.ProjectRoleTemplateBinding{prtb("p-123xyz", "member-prtb")},
+			bindings:      []*rbacv1.RoleBinding{{ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: namespaceName}}},
+			expectListRBs: true,
+			want:          false,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/controllers/managementuser/rbac/namespace_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler_test.go
@@ -957,7 +957,7 @@ func TestRemovePRTBRoleBindingsNotInProject(t *testing.T) {
 			},
 			wantDeleted: []string{"rb-stale"},
 			deleteError: fmt.Errorf("boom"),
-			wantError:   "couldn't delete role binding",
+			wantError:   "failed to delete",
 		},
 	}
 


### PR DESCRIPTION
## Issue: Addresses this https://github.com/rancher/rancher/issues/49259 and other issues.
 
## Problem
When a namespace gets moved between projects, a project member can see namespaces that get moved out of projects they are a member of. They should not be able to see those namespaces since they don't have project access.
 
## Solution
I ended up refactoring the namespace handler quite a bit, but in essence it now performs a few checks:
1. Create legacy role bindings
    - The legacy (non-aggregation) controllers would provide Roles and RoleBindings in each namespace. The aggregation controllers no longer do that, instead relying on the roletemplate controller to handle the roles, but we need to handle both for now so we keep the legacy path.
2. Remove any role bindings that aren't part of a project.
    - This is where the bug existed. Prior to this change, the aggregation controllers search through each namespace owned by a project and create the right bindings. But in the case where a namespace is no longer in a project, the binding wasn't being found to be cleaned up.
    - Now we go through the bindings in the namespace, identify which claim to be owned by a PRTB and delete anything that doesn't belong anymore  
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_