### PR TITLE
[main] Implement Rancher assets image

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ defaultShellVersion: rancher/shell:v0.8.1
 defaultSccOperatorImage: rancher/scc-operator:v0.5.1-rc.2
 
 # Notes: ClusterRepo asset and branch versions
-defaultChartsImage: rancher/rancher-assets:v2.16-20260805T1815Z-dev
+defaultAssetsImage: rancher/rancher-assets:v2.16-20260805T1815Z-dev
 chartDefaultBranch: dev-v2.16
 partnerChartDefaultBranch: main
 rke2ChartDefaultBranch: main

--- a/build.yaml
+++ b/build.yaml
@@ -2,6 +2,13 @@
 chartAuditLogImage: rancher/mirrored-bci-micro:16.0-15.11
 defaultShellVersion: rancher/shell:v0.8.1
 defaultSccOperatorImage: rancher/scc-operator:v0.5.1-rc.2
+
+# Notes: ClusterRepo asset and branch versions
+defaultChartsImage: rancher/rancher-assets:v2.16-20260805T1815Z-dev
+chartDefaultBranch: dev-v2.16
+partnerChartDefaultBranch: main
+rke2ChartDefaultBranch: main
+
 # Charts Versions
 cspAdapterMinVersion: 110.0.0+up10.0.0
 fleetVersion: 110.0.0+up0.16.0-rc.5

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -70,21 +70,21 @@ Prepare the Rancher Image Pull Policy value w/ new fields as opt-in for now.
 Prepare the Rancher Image repo value w/ new fields as opt-in for now.
 */}}
 {{ define "rancherCharts.imageRepo" -}}
-{{ default "rancher/rancher-assets" .Values.chartsImage.repository -}}
+{{ default "rancher/rancher-assets" .Values.assetsImage.repository -}}
 {{ end -}}
 
 {{/*
 Prepare the Rancher Image value w/ new fields as opt-in for now.
 */}}
 {{ define "rancherCharts.image" -}}
-{{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . (default "" .Values.chartsImage.registry))) (include "rancherCharts.imageRepo" .) -}}
+{{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . (default "" .Values.assetsImage.registry))) (include "rancherCharts.imageRepo" .) -}}
 {{ end -}}
 
 {{/*
 Prepare the Rancher Image Pull Policy value w/ new fields as opt-in for now.
 */}}
 {{ define "rancherCharts.imagePullPolicy" -}}
-{{ default "IfNotPresent" .Values.chartsImage.pullPolicy }}
+{{ default "IfNotPresent" .Values.assetsImage.pullPolicy }}
 {{ end -}}
 
 {{/*

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -67,6 +67,27 @@ Prepare the Rancher Image Pull Policy value w/ new fields as opt-in for now.
 {{ end -}}
 
 {{/*
+Prepare the Rancher Image repo value w/ new fields as opt-in for now.
+*/}}
+{{ define "rancherCharts.imageRepo" -}}
+{{ default "rancher/rancher-assets" .Values.chartsImage.repository -}}
+{{ end -}}
+
+{{/*
+Prepare the Rancher Image value w/ new fields as opt-in for now.
+*/}}
+{{ define "rancherCharts.image" -}}
+{{ printf "%s%s" (include "defaultOrOverrideRegistry" (list . (default "" .Values.chartsImage.registry))) (include "rancherCharts.imageRepo" .) -}}
+{{ end -}}
+
+{{/*
+Prepare the Rancher Image Pull Policy value w/ new fields as opt-in for now.
+*/}}
+{{ define "rancherCharts.imagePullPolicy" -}}
+{{ default "IfNotPresent" .Values.chartsImage.pullPolicy }}
+{{ end -}}
+
+{{/*
 Render Values in configurationSnippet
 */}}
 {{- define "configurationSnippet" -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -74,6 +74,13 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
+      initContainers:
+        - name: rancher-charts-copy
+          image: "{{ template "rancherCharts.image" . }}:{{ .Values.chartsImage.tag }}"
+          imagePullPolicy: {{ include "rancherCharts.imagePullPolicy" . }}
+          volumeMounts:
+            - name: rancher-charts
+              mountPath: /charts
       containers:
       - image: "{{ template "rancher.image" . }}:{{ template "rancher.imageTag" . }}"
         imagePullPolicy: {{ include "rancher.imagePullPolicy" . }}
@@ -177,6 +184,8 @@ spec:
         - name: CATTLE_BASE_REGISTRY_PULL_SECRETS
           value: "{{ range $i, $v := .Values.imagePullSecrets }}{{- if $i }},{{ end }}{{ $v.name }}{{ end }}"
 {{- end }}
+        - name: CATTLE_CHARTS_IMAGE_DEFAULT
+          value: "{{ template "rancherCharts.image" . }}:{{ default .Chart.appVersion .Values.chartsImage.tag }}"
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}
@@ -211,6 +220,8 @@ spec:
         resources: {{- toYaml .Values.resources | nindent 10 }}
         {{- end }}
         volumeMounts:
+        - mountPath: /var/lib/rancher-data/local-catalogs/v2
+          name: rancher-charts
 {{- if .Values.additionalTrustedCAs }}
         - mountPath: /etc/pki/trust/anchors/ca-additional.pem
           name: tls-ca-additional-volume
@@ -258,6 +269,8 @@ spec:
   {{- end }}
 {{- end }}
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
 {{- if .Values.additionalTrustedCAs }}
       - name: tls-ca-additional-volume
         secret:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -185,7 +185,7 @@ spec:
           value: "{{ range $i, $v := .Values.imagePullSecrets }}{{- if $i }},{{ end }}{{ $v.name }}{{ end }}"
 {{- end }}
         - name: CATTLE_CHARTS_IMAGE_DEFAULT
-          value: "{{ template "rancherCharts.image" . }}:{{ default .Chart.appVersion .Values.chartsImage.tag }}"
+          value: "{{ template "rancherCharts.image" . }}:{{ .Values.chartsImage.tag }}"
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -184,7 +184,7 @@ spec:
         - name: CATTLE_BASE_REGISTRY_PULL_SECRETS
           value: "{{ range $i, $v := .Values.imagePullSecrets }}{{- if $i }},{{ end }}{{ $v.name }}{{ end }}"
 {{- end }}
-        - name: CATTLE_CHARTS_IMAGE_DEFAULT
+        - name: CATTLE_CHARTS_IMAGE
           value: "{{ template "rancherCharts.image" . }}:{{ .Values.chartsImage.tag }}"
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
 {{- end }}
       initContainers:
         - name: rancher-charts-copy
-          image: "{{ template "rancherCharts.image" . }}:{{ .Values.chartsImage.tag }}"
+          image: "{{ template "rancherCharts.image" . }}:{{ .Values.assetsImage.tag }}"
           imagePullPolicy: {{ include "rancherCharts.imagePullPolicy" . }}
           volumeMounts:
             - name: rancher-charts
@@ -185,7 +185,7 @@ spec:
           value: "{{ range $i, $v := .Values.imagePullSecrets }}{{- if $i }},{{ end }}{{ $v.name }}{{ end }}"
 {{- end }}
         - name: CATTLE_CHARTS_IMAGE
-          value: "{{ template "rancherCharts.image" . }}:{{ .Values.chartsImage.tag }}"
+          value: "{{ template "rancherCharts.image" . }}:{{ .Values.assetsImage.tag }}"
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -44,7 +44,7 @@ tests:
 - it: should Just have default env vars with default values.yaml
   set:
     systemDefaultRegistry: ""
-    chartsImage.tag: "stable-tag"
+    assetsImage.tag: "stable-tag"
   asserts:
     - equal:
         path: spec.template.spec.containers[0].env
@@ -62,7 +62,7 @@ tests:
 - it: should have systemDefaultRegistry env var set when value is not empty
   set:
     systemDefaultRegistry: "suseregistry"
-    chartsImage.tag: "stable-tag"
+    assetsImage.tag: "stable-tag"
   asserts:
     - equal:
         path: spec.template.spec.containers[0].env
@@ -714,7 +714,7 @@ tests:
   set:
     systemDefaultRegistry: ""
     cacheSyncTimeout: 10m
-    chartsImage.tag: stable-tag
+    assetsImage.tag: stable-tag
   asserts:
   - equal:
       path: spec.template.spec.containers[0].env
@@ -749,7 +749,7 @@ tests:
         path: spec.template.spec.dnsPolicy
 - it: should configure rancher deployments with namespace options
   set:
-    chartsImage.tag: stable-tag
+    assetsImage.tag: stable-tag
     rancherNamespaces:
       enabled: true
       labels:

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -57,7 +57,7 @@ tests:
             value: "true"
           - name: IMPERATIVE_API_APP_SELECTOR
             value: RELEASE-NAME-rancher
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+          - name: CATTLE_CHARTS_IMAGE
             value: rancher/rancher-assets:stable-tag
 - it: should have systemDefaultRegistry env var set when value is not empty
   set:
@@ -77,7 +77,7 @@ tests:
             value: "true"
           - name: IMPERATIVE_API_APP_SELECTOR
             value: RELEASE-NAME-rancher
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+          - name: CATTLE_CHARTS_IMAGE
             value: suseregistry/rancher/rancher-assets:stable-tag
 - it: should default imagePullPolicy to IfNotPresent
   asserts:
@@ -729,7 +729,7 @@ tests:
           value: RELEASE-NAME-rancher
         - name: CACHE_SYNC_TIMEOUT
           value: 10m
-        - name: CATTLE_CHARTS_IMAGE_DEFAULT
+        - name: CATTLE_CHARTS_IMAGE
           value: rancher/rancher-assets:stable-tag
 - it: should enable hostNetwork and set dnsPolicy when hostNetwork is true
   set:
@@ -770,7 +770,7 @@ tests:
             value: RELEASE-NAME-rancher
           - name: RANCHER_NAMESPACES_OPTIONS
             value: "{\"annotations\":{\"foo\":\"bar\"},\"enabled\":true,\"labels\":{\"foo\":\"bar\"}}"
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+          - name: CATTLE_CHARTS_IMAGE
             value: rancher/rancher-assets:stable-tag
 - it: should not add CATTLE_BASE_REGISTRY_PULL_SECRETS to env when imagePullSecrets is empty
   asserts:

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -44,6 +44,7 @@ tests:
 - it: should Just have default env vars with default values.yaml
   set:
     systemDefaultRegistry: ""
+    chartsImage.tag: "stable-tag"
   asserts:
     - equal:
         path: spec.template.spec.containers[0].env
@@ -56,9 +57,12 @@ tests:
             value: "true"
           - name: IMPERATIVE_API_APP_SELECTOR
             value: RELEASE-NAME-rancher
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:stable-tag
 - it: should have systemDefaultRegistry env var set when value is not empty
   set:
     systemDefaultRegistry: "suseregistry"
+    chartsImage.tag: "stable-tag"
   asserts:
     - equal:
         path: spec.template.spec.containers[0].env
@@ -73,6 +77,8 @@ tests:
             value: "true"
           - name: IMPERATIVE_API_APP_SELECTOR
             value: RELEASE-NAME-rancher
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: suseregistry/rancher/rancher-assets:stable-tag
 - it: should default imagePullPolicy to IfNotPresent
   asserts:
   - equal:
@@ -199,14 +205,18 @@ tests:
     customLogos.enabled: true
     customLogos.volumeKind: configMap
   asserts:
-  - isNullOrEmpty:
+  - notContains:
       path: spec.template.spec.volumes
+      content:
+        name: custom-logos
 - it: should not create custom-logos volume if not customLogos.enabled
   set:
     customLogos.enabled: false
   asserts:
-  - isNullOrEmpty:
+  - notContains:
       path: spec.template.spec.volumes
+      content:
+        name: custom-logos
 - it: should mount custom-logos volume with default subpaths if customLogos.enabled and customLogos.volumeKind=persistentVolumeClaim
   set:
     customLogos.enabled: true
@@ -325,14 +335,18 @@ tests:
     customLogos.enabled: true
     customLogos.volumeKind: configMap
   asserts:
-  - isNullOrEmpty:
+  - notContains:
       path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: custom-logos
 - it: should not mount custom-logos volume if not customLogos.enabled
   set:
     customLogos.enabled: false
   asserts:
-  - isNullOrEmpty:
+  - notContains:
       path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: custom-logos
 - it: should set priorityClassName=system-node-critical
   set:
     priorityClassName: "system-node-critical"
@@ -700,6 +714,7 @@ tests:
   set:
     systemDefaultRegistry: ""
     cacheSyncTimeout: 10m
+    chartsImage.tag: stable-tag
   asserts:
   - equal:
       path: spec.template.spec.containers[0].env
@@ -714,6 +729,8 @@ tests:
           value: RELEASE-NAME-rancher
         - name: CACHE_SYNC_TIMEOUT
           value: 10m
+        - name: CATTLE_CHARTS_IMAGE_DEFAULT
+          value: rancher/rancher-assets:stable-tag
 - it: should enable hostNetwork and set dnsPolicy when hostNetwork is true
   set:
     hostNetwork: true
@@ -732,6 +749,7 @@ tests:
         path: spec.template.spec.dnsPolicy
 - it: should configure rancher deployments with namespace options
   set:
+    chartsImage.tag: stable-tag
     rancherNamespaces:
       enabled: true
       labels:
@@ -752,6 +770,8 @@ tests:
             value: RELEASE-NAME-rancher
           - name: RANCHER_NAMESPACES_OPTIONS
             value: "{\"annotations\":{\"foo\":\"bar\"},\"enabled\":true,\"labels\":{\"foo\":\"bar\"}}"
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:stable-tag
 - it: should not add CATTLE_BASE_REGISTRY_PULL_SECRETS to env when imagePullSecrets is empty
   asserts:
     - notContains:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -221,6 +221,12 @@ systemRegistryInheritsPullSecrets: false
 # Set to use the packaged system charts
 useBundledSystemChart: false
 
+# Charts image used for bundled Helm charts
+# Important: update build.yaml when this default image needs to be changed, then run `go generate`.
+chartsImage:
+  repository: rancher/rancher-assets
+  tag: v2.16-20260805T1815Z-dev
+
 # Certmanager version compatibility
 certmanager:
   version: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -223,7 +223,7 @@ useBundledSystemChart: false
 
 # Charts image used for bundled Helm charts
 # Important: update build.yaml when this default image needs to be changed, then run `go generate`.
-chartsImage:
+assetsImage:
   repository: rancher/rancher-assets
   tag: v2.16-20260805T1815Z-dev
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -68,32 +68,6 @@ ENV CGO_ENABLED=$CGO_ENABLED
 ENV GOMODCACHE=/root/.cache/go/modcache
 ENV GOCACHE=/root/.cache/go/cache
 
-FROM builder AS rancher-charts
-ARG CHART_DEFAULT_BRANCH
-RUN mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
-    # Temporarily clone from our GitHub's main repo, to avoid unnecessary load in git.rancher.io
-    git config --global url."https://github.com/rancher/".insteadOf https://git.rancher.io/ && \
-    # Charts need to be copied into the sha256 value of git url computed in https://github.com/rancher/rancher/blob/5ebda9ac23c06e9647b586ec38aa51cc9ff9b031/pkg/catalogv2/git/download.go#L102 to create a unique folder per url
-    git clone --no-checkout -b $CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/charts /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721
-
-FROM builder AS partner-charts
-ARG PARTNER_CHART_DEFAULT_BRANCH
-RUN mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
-    # Temporarily clone from our GitHub's main repo, to avoid unnecessary load in git.rancher.io
-    git config --global url."https://github.com/rancher/".insteadOf https://git.rancher.io/ && \
-    # Charts need to be copied into the sha256 value of git url computed in https://github.com/rancher/rancher/blob/5ebda9ac23c06e9647b586ec38aa51cc9ff9b031/pkg/catalogv2/git/download.go#L102 to create a unique folder per url
-    git clone --no-checkout -b $PARTNER_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974
-
-
-FROM builder AS rke2-charts
-ARG RKE2_CHART_DEFAULT_BRANCH
-RUN mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
-    # Temporarily clone from our GitHub's main repo, to avoid unnecessary load in git.rancher.io
-    git config --global url."https://github.com/rancher/".insteadOf https://git.rancher.io/ && \
-    # Charts need to be copied into the sha256 value of git url computed in https://github.com/rancher/rancher/blob/5ebda9ac23c06e9647b586ec38aa51cc9ff9b031/pkg/catalogv2/git/download.go#L102 to create a unique folder per url
-    git clone --no-checkout -b $RKE2_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9
-
-
 FROM builder AS kdm
 ARG CATTLE_KDM_BRANCH
 RUN mkdir -p /var/lib/rancher-data/driver-metadata && \
@@ -186,10 +160,6 @@ ARG CATTLE_GKE_OPERATOR_VERSION
 ENV CATTLE_GKE_OPERATOR_VERSION=$CATTLE_GKE_OPERATOR_VERSION
 ARG CATTLE_ALI_OPERATOR_VERSION
 ENV CATTLE_ALI_OPERATOR_VERSION=$CATTLE_ALI_OPERATOR_VERSION
-
-COPY --from=rancher-charts /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721 /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721
-COPY --from=partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974 /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974
-COPY --from=rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9
 
 
 RUN case "${ARCH}" in \
@@ -534,9 +504,6 @@ ARG VERSION
 ENV AGENT_IMAGE=${RANCHER_REPO}/rancher-agent:${VERSION}
 
 ENV SSL_CERT_DIR=/etc/kubernetes/ssl/certs
-COPY --from=rancher-charts /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721 /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721
-COPY --from=partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974 /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974
-COPY --from=rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9
 COPY --from=kdm /var/lib/rancher-data/driver-metadata/data.json /var/lib/rancher-data/driver-metadata/data.json
 COPY --from=agent-build /app/agent /usr/bin/
 COPY package/loglevel package/run.sh /usr/bin/

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -444,6 +444,9 @@ ENV CATTLE_BASE_CLUSTER_AUTOSCALER_CHART_REPOSITORY=$CATTLE_BASE_CLUSTER_AUTOSCA
 ENV CATTLE_BASE_CLUSTER_AUTOSCALER_IMAGE=$CATTLE_BASE_CLUSTER_AUTOSCALER_IMAGE
 ENV CATTLE_BASE_RKE2_PROVISIONING_PRIME_DEFAULT=$CATTLE_BASE_RKE2_PROVISIONING_PRIME_DEFAULT
 
+# We still create the catalogs dir
+RUN mkdir -p /var/lib/rancher-data/local-catalogs
+
 COPY --chown=root:root --chmod=0755 \
     --from=server-build /app/rancher /usr/bin/
 COPY --chown=root:root --chmod=0755 \
@@ -453,6 +456,7 @@ COPY --chown=root:root --chmod=0755 \
     package/entrypoint.sh \
     package/jailer.sh /usr/bin/
 
+VOLUME /var/lib/rancher-data/local-catalogs
 VOLUME /var/lib/rancher
 VOLUME /var/lib/kubelet
 VOLUME /var/lib/cni
@@ -508,6 +512,11 @@ COPY --from=kdm /var/lib/rancher-data/driver-metadata/data.json /var/lib/rancher
 COPY --from=agent-build /app/agent /usr/bin/
 COPY package/loglevel package/run.sh /usr/bin/
 WORKDIR /var/lib/rancher
+
+# We still create the catalogs dir
+RUN mkdir -p /var/lib/rancher-data/local-catalogs
+
+VOLUME /var/lib/rancher-data/local-catalogs
 
 LABEL "io.artifacthub.package.logo-url"="https://raw.githubusercontent.com/rancher/dashboard/master/shell/static/welcome-cow.svg" \
     "io.artifacthub.package.readme-url"="https://raw.githubusercontent.com/rancher/rancher/${VERSION}/README.md" \

--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -80,11 +80,11 @@ func (ch *ClusterImport) ClusterImportHandler(resp http.ResponseWriter, req *htt
 	}
 
 	agentImage := image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
-	chartsImage := image.ResolveWithCluster(settings.ChartsImage.Get(), cluster)
+	assetsImage := image.ResolveWithCluster(settings.AssetsImage.Get(), cluster)
 	ops := &systemtemplate.TemplateOps{
 		AgentImage:     agentImage,
 		AuthImage:      authImage,
-		ChartsImage:    chartsImage,
+		AssetsImage:    assetsImage,
 		Namespace:      "",
 		Token:          token,
 		URL:            url,

--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -80,9 +80,11 @@ func (ch *ClusterImport) ClusterImportHandler(resp http.ResponseWriter, req *htt
 	}
 
 	agentImage := image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
+	chartsImage := image.ResolveWithCluster(settings.ChartsImage.Get(), cluster)
 	ops := &systemtemplate.TemplateOps{
 		AgentImage:     agentImage,
 		AuthImage:      authImage,
+		ChartsImage:    chartsImage,
 		Namespace:      "",
 		Token:          token,
 		URL:            url,

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -191,6 +191,7 @@ type ClusterStatus struct {
 	Driver                     string                    `json:"driver"`
 	Provider                   string                    `json:"provider"`
 	AgentImage                 string                    `json:"agentImage"`
+	ChartsImage                string                    `json:"chartsImage"`
 	AppliedAgentEnvVars        []v1.EnvVar               `json:"appliedAgentEnvVars,omitempty"`
 	AgentFeatures              map[string]bool           `json:"agentFeatures,omitempty"`
 	AuthImage                  string                    `json:"authImage"`

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -110,6 +110,8 @@ type ClusterSpecBase struct {
 	DesiredAuthImage                                     string                          `json:"desiredAuthImage"`
 	AgentImageOverride                                   string                          `json:"agentImageOverride"`
 	AgentEnvVars                                         []v1.EnvVar                     `json:"agentEnvVars,omitempty"`
+	DesiredChartsImage                                   string                          `json:"desiredChartsImage"`
+	ChartsImageOverride                                  string                          `json:"chartsImageOverride"`
 	DefaultPodSecurityAdmissionConfigurationTemplateName string                          `json:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty"`
 	DefaultClusterRoleForProjectMembers                  string                          `json:"defaultClusterRoleForProjectMembers,omitempty" norman:"type=reference[roleTemplate]"`
 	DockerRootDir                                        string                          `json:"dockerRootDir,omitempty" norman:"default=/var/lib/docker"`

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -110,8 +110,8 @@ type ClusterSpecBase struct {
 	DesiredAuthImage                                     string                          `json:"desiredAuthImage"`
 	AgentImageOverride                                   string                          `json:"agentImageOverride"`
 	AgentEnvVars                                         []v1.EnvVar                     `json:"agentEnvVars,omitempty"`
-	DesiredChartsImage                                   string                          `json:"desiredChartsImage"`
-	ChartsImageOverride                                  string                          `json:"chartsImageOverride"`
+	DesiredAssetsImage                                   string                          `json:"desiredAssetsImage"`
+	AssetsImageOverride                                  string                          `json:"assetsImageOverride"`
 	DefaultPodSecurityAdmissionConfigurationTemplateName string                          `json:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty"`
 	DefaultClusterRoleForProjectMembers                  string                          `json:"defaultClusterRoleForProjectMembers,omitempty" norman:"type=reference[roleTemplate]"`
 	DockerRootDir                                        string                          `json:"dockerRootDir,omitempty" norman:"default=/var/lib/docker"`
@@ -191,7 +191,7 @@ type ClusterStatus struct {
 	Driver                     string                    `json:"driver"`
 	Provider                   string                    `json:"provider"`
 	AgentImage                 string                    `json:"agentImage"`
-	ChartsImage                string                    `json:"chartsImage"`
+	AssetsImage                string                    `json:"assetsImage"`
 	AppliedAgentEnvVars        []v1.EnvVar               `json:"appliedAgentEnvVars,omitempty"`
 	AgentFeatures              map[string]bool           `json:"agentFeatures,omitempty"`
 	AuthImage                  string                    `json:"authImage"`

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,7 +6,7 @@ const (
 	ChartAuditLogImage        = "rancher/mirrored-bci-micro:16.0-15.11"
 	ChartDefaultBranch        = "dev-v2.16"
 	CspAdapterMinVersion      = "110.0.0+up10.0.0"
-	DefaultChartsImage        = "rancher/rancher-assets:v2.16-20260805T1815Z-dev"
+	DefaultAssetsImage        = "rancher/rancher-assets:v2.16-20260805T1815Z-dev"
 	DefaultSccOperatorImage   = "rancher/scc-operator:v0.5.1-rc.2"
 	DefaultShellVersion       = "rancher/shell:v0.8.1"
 	FleetVersion              = "110.0.0+up0.16.0-rc.5"

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,12 +3,16 @@
 package buildconfig
 
 const (
-	ChartAuditLogImage       = "rancher/mirrored-bci-micro:16.0-15.11"
-	CspAdapterMinVersion     = "110.0.0+up10.0.0"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.1-rc.2"
-	DefaultShellVersion      = "rancher/shell:v0.8.1"
-	FleetVersion             = "110.0.0+up0.16.0-rc.5"
-	RemoteDialerProxyVersion = "110.0.0+up0.8.0-rc.10"
-	TurtlesVersion           = "110.0.0+up0.27.0"
-	WebhookVersion           = "111.0.0+up0.12.1-rc.1"
+	ChartAuditLogImage        = "rancher/mirrored-bci-micro:16.0-15.11"
+	ChartDefaultBranch        = "dev-v2.16"
+	CspAdapterMinVersion      = "110.0.0+up10.0.0"
+	DefaultChartsImage        = "rancher/rancher-assets:v2.16-20260805T1815Z-dev"
+	DefaultSccOperatorImage   = "rancher/scc-operator:v0.5.1-rc.2"
+	DefaultShellVersion       = "rancher/shell:v0.8.1"
+	FleetVersion              = "110.0.0+up0.16.0-rc.5"
+	PartnerChartDefaultBranch = "main"
+	RemoteDialerProxyVersion  = "110.0.0+up0.8.0-rc.10"
+	Rke2ChartDefaultBranch    = "main"
+	TurtlesVersion            = "110.0.0+up0.27.0"
+	WebhookVersion            = "111.0.0+up0.12.1-rc.1"
 )

--- a/pkg/client/generated/management/v3/zz_generated_cluster.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster.go
@@ -30,6 +30,7 @@ const (
 	ClusterFieldCapabilities                                         = "capabilities"
 	ClusterFieldCapacity                                             = "capacity"
 	ClusterFieldCertificatesExpiration                               = "certificatesExpiration"
+	ClusterFieldChartsImage                                          = "chartsImage"
 	ClusterFieldChartsImageOverride                                  = "chartsImageOverride"
 	ClusterFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterFieldClusterSecrets                                       = "clusterSecrets"
@@ -115,6 +116,7 @@ type Cluster struct {
 	Capabilities                                         *Capabilities                   `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Capacity                                             map[string]string               `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration                               map[string]CertExpiration       `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
+	ChartsImage                                          string                          `json:"chartsImage,omitempty" yaml:"chartsImage,omitempty"`
 	ChartsImageOverride                                  string                          `json:"chartsImageOverride,omitempty" yaml:"chartsImageOverride,omitempty"`
 	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization   `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                 `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster.go
@@ -30,6 +30,7 @@ const (
 	ClusterFieldCapabilities                                         = "capabilities"
 	ClusterFieldCapacity                                             = "capacity"
 	ClusterFieldCertificatesExpiration                               = "certificatesExpiration"
+	ClusterFieldChartsImageOverride                                  = "chartsImageOverride"
 	ClusterFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterFieldClusterSecrets                                       = "clusterSecrets"
 	ClusterFieldComponentStatuses                                    = "componentStatuses"
@@ -42,6 +43,7 @@ const (
 	ClusterFieldDescription                                          = "description"
 	ClusterFieldDesiredAgentImage                                    = "desiredAgentImage"
 	ClusterFieldDesiredAuthImage                                     = "desiredAuthImage"
+	ClusterFieldDesiredChartsImage                                   = "desiredChartsImage"
 	ClusterFieldDockerRootDir                                        = "dockerRootDir"
 	ClusterFieldDriver                                               = "driver"
 	ClusterFieldEKSConfig                                            = "eksConfig"
@@ -113,6 +115,7 @@ type Cluster struct {
 	Capabilities                                         *Capabilities                   `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Capacity                                             map[string]string               `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration                               map[string]CertExpiration       `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
+	ChartsImageOverride                                  string                          `json:"chartsImageOverride,omitempty" yaml:"chartsImageOverride,omitempty"`
 	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization   `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                 `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	ComponentStatuses                                    []ClusterComponentStatus        `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
@@ -125,6 +128,7 @@ type Cluster struct {
 	Description                                          string                          `json:"description,omitempty" yaml:"description,omitempty"`
 	DesiredAgentImage                                    string                          `json:"desiredAgentImage,omitempty" yaml:"desiredAgentImage,omitempty"`
 	DesiredAuthImage                                     string                          `json:"desiredAuthImage,omitempty" yaml:"desiredAuthImage,omitempty"`
+	DesiredChartsImage                                   string                          `json:"desiredChartsImage,omitempty" yaml:"desiredChartsImage,omitempty"`
 	DockerRootDir                                        string                          `json:"dockerRootDir,omitempty" yaml:"dockerRootDir,omitempty"`
 	Driver                                               string                          `json:"driver,omitempty" yaml:"driver,omitempty"`
 	EKSConfig                                            *EKSClusterConfigSpec           `json:"eksConfig,omitempty" yaml:"eksConfig,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster.go
@@ -25,13 +25,13 @@ const (
 	ClusterFieldAppliedEnableNetworkPolicy                           = "appliedEnableNetworkPolicy"
 	ClusterFieldAppliedSpec                                          = "appliedSpec"
 	ClusterFieldAppliedWebhookDeploymentCustomization                = "appliedWebhookDeploymentCustomization"
+	ClusterFieldAssetsImage                                          = "assetsImage"
+	ClusterFieldAssetsImageOverride                                  = "assetsImageOverride"
 	ClusterFieldAuthImage                                            = "authImage"
 	ClusterFieldCACert                                               = "caCert"
 	ClusterFieldCapabilities                                         = "capabilities"
 	ClusterFieldCapacity                                             = "capacity"
 	ClusterFieldCertificatesExpiration                               = "certificatesExpiration"
-	ClusterFieldChartsImage                                          = "chartsImage"
-	ClusterFieldChartsImageOverride                                  = "chartsImageOverride"
 	ClusterFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterFieldClusterSecrets                                       = "clusterSecrets"
 	ClusterFieldComponentStatuses                                    = "componentStatuses"
@@ -43,8 +43,8 @@ const (
 	ClusterFieldDefaultPodSecurityAdmissionConfigurationTemplateName = "defaultPodSecurityAdmissionConfigurationTemplateName"
 	ClusterFieldDescription                                          = "description"
 	ClusterFieldDesiredAgentImage                                    = "desiredAgentImage"
+	ClusterFieldDesiredAssetsImage                                   = "desiredAssetsImage"
 	ClusterFieldDesiredAuthImage                                     = "desiredAuthImage"
-	ClusterFieldDesiredChartsImage                                   = "desiredChartsImage"
 	ClusterFieldDockerRootDir                                        = "dockerRootDir"
 	ClusterFieldDriver                                               = "driver"
 	ClusterFieldEKSConfig                                            = "eksConfig"
@@ -111,13 +111,13 @@ type Cluster struct {
 	AppliedEnableNetworkPolicy                           bool                            `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
 	AppliedSpec                                          *ClusterSpec                    `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`
 	AppliedWebhookDeploymentCustomization                *WebhookDeploymentCustomization `json:"appliedWebhookDeploymentCustomization,omitempty" yaml:"appliedWebhookDeploymentCustomization,omitempty"`
+	AssetsImage                                          string                          `json:"assetsImage,omitempty" yaml:"assetsImage,omitempty"`
+	AssetsImageOverride                                  string                          `json:"assetsImageOverride,omitempty" yaml:"assetsImageOverride,omitempty"`
 	AuthImage                                            string                          `json:"authImage,omitempty" yaml:"authImage,omitempty"`
 	CACert                                               string                          `json:"caCert,omitempty" yaml:"caCert,omitempty"`
 	Capabilities                                         *Capabilities                   `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Capacity                                             map[string]string               `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration                               map[string]CertExpiration       `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
-	ChartsImage                                          string                          `json:"chartsImage,omitempty" yaml:"chartsImage,omitempty"`
-	ChartsImageOverride                                  string                          `json:"chartsImageOverride,omitempty" yaml:"chartsImageOverride,omitempty"`
 	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization   `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                 `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	ComponentStatuses                                    []ClusterComponentStatus        `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
@@ -129,8 +129,8 @@ type Cluster struct {
 	DefaultPodSecurityAdmissionConfigurationTemplateName string                          `json:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty" yaml:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty"`
 	Description                                          string                          `json:"description,omitempty" yaml:"description,omitempty"`
 	DesiredAgentImage                                    string                          `json:"desiredAgentImage,omitempty" yaml:"desiredAgentImage,omitempty"`
+	DesiredAssetsImage                                   string                          `json:"desiredAssetsImage,omitempty" yaml:"desiredAssetsImage,omitempty"`
 	DesiredAuthImage                                     string                          `json:"desiredAuthImage,omitempty" yaml:"desiredAuthImage,omitempty"`
-	DesiredChartsImage                                   string                          `json:"desiredChartsImage,omitempty" yaml:"desiredChartsImage,omitempty"`
 	DockerRootDir                                        string                          `json:"dockerRootDir,omitempty" yaml:"dockerRootDir,omitempty"`
 	Driver                                               string                          `json:"driver,omitempty" yaml:"driver,omitempty"`
 	EKSConfig                                            *EKSClusterConfigSpec           `json:"eksConfig,omitempty" yaml:"eksConfig,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_spec.go
@@ -8,6 +8,7 @@ const (
 	ClusterSpecFieldAliConfig                                            = "aliConfig"
 	ClusterSpecFieldAmazonElasticContainerServiceConfig                  = "amazonElasticContainerServiceConfig"
 	ClusterSpecFieldAzureKubernetesServiceConfig                         = "azureKubernetesServiceConfig"
+	ClusterSpecFieldChartsImageOverride                                  = "chartsImageOverride"
 	ClusterSpecFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterSpecFieldClusterSecrets                                       = "clusterSecrets"
 	ClusterSpecFieldDefaultClusterRoleForProjectMembers                  = "defaultClusterRoleForProjectMembers"
@@ -15,6 +16,7 @@ const (
 	ClusterSpecFieldDescription                                          = "description"
 	ClusterSpecFieldDesiredAgentImage                                    = "desiredAgentImage"
 	ClusterSpecFieldDesiredAuthImage                                     = "desiredAuthImage"
+	ClusterSpecFieldDesiredChartsImage                                   = "desiredChartsImage"
 	ClusterSpecFieldDisplayName                                          = "displayName"
 	ClusterSpecFieldDockerRootDir                                        = "dockerRootDir"
 	ClusterSpecFieldEKSConfig                                            = "eksConfig"
@@ -40,6 +42,7 @@ type ClusterSpec struct {
 	AliConfig                                            *AliClusterConfigSpec           `json:"aliConfig,omitempty" yaml:"aliConfig,omitempty"`
 	AmazonElasticContainerServiceConfig                  map[string]interface{}          `json:"amazonElasticContainerServiceConfig,omitempty" yaml:"amazonElasticContainerServiceConfig,omitempty"`
 	AzureKubernetesServiceConfig                         map[string]interface{}          `json:"azureKubernetesServiceConfig,omitempty" yaml:"azureKubernetesServiceConfig,omitempty"`
+	ChartsImageOverride                                  string                          `json:"chartsImageOverride,omitempty" yaml:"chartsImageOverride,omitempty"`
 	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization   `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                 `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	DefaultClusterRoleForProjectMembers                  string                          `json:"defaultClusterRoleForProjectMembers,omitempty" yaml:"defaultClusterRoleForProjectMembers,omitempty"`
@@ -47,6 +50,7 @@ type ClusterSpec struct {
 	Description                                          string                          `json:"description,omitempty" yaml:"description,omitempty"`
 	DesiredAgentImage                                    string                          `json:"desiredAgentImage,omitempty" yaml:"desiredAgentImage,omitempty"`
 	DesiredAuthImage                                     string                          `json:"desiredAuthImage,omitempty" yaml:"desiredAuthImage,omitempty"`
+	DesiredChartsImage                                   string                          `json:"desiredChartsImage,omitempty" yaml:"desiredChartsImage,omitempty"`
 	DisplayName                                          string                          `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	DockerRootDir                                        string                          `json:"dockerRootDir,omitempty" yaml:"dockerRootDir,omitempty"`
 	EKSConfig                                            *EKSClusterConfigSpec           `json:"eksConfig,omitempty" yaml:"eksConfig,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_spec.go
@@ -7,16 +7,16 @@ const (
 	ClusterSpecFieldAgentImageOverride                                   = "agentImageOverride"
 	ClusterSpecFieldAliConfig                                            = "aliConfig"
 	ClusterSpecFieldAmazonElasticContainerServiceConfig                  = "amazonElasticContainerServiceConfig"
+	ClusterSpecFieldAssetsImageOverride                                  = "assetsImageOverride"
 	ClusterSpecFieldAzureKubernetesServiceConfig                         = "azureKubernetesServiceConfig"
-	ClusterSpecFieldChartsImageOverride                                  = "chartsImageOverride"
 	ClusterSpecFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterSpecFieldClusterSecrets                                       = "clusterSecrets"
 	ClusterSpecFieldDefaultClusterRoleForProjectMembers                  = "defaultClusterRoleForProjectMembers"
 	ClusterSpecFieldDefaultPodSecurityAdmissionConfigurationTemplateName = "defaultPodSecurityAdmissionConfigurationTemplateName"
 	ClusterSpecFieldDescription                                          = "description"
 	ClusterSpecFieldDesiredAgentImage                                    = "desiredAgentImage"
+	ClusterSpecFieldDesiredAssetsImage                                   = "desiredAssetsImage"
 	ClusterSpecFieldDesiredAuthImage                                     = "desiredAuthImage"
-	ClusterSpecFieldDesiredChartsImage                                   = "desiredChartsImage"
 	ClusterSpecFieldDisplayName                                          = "displayName"
 	ClusterSpecFieldDockerRootDir                                        = "dockerRootDir"
 	ClusterSpecFieldEKSConfig                                            = "eksConfig"
@@ -41,16 +41,16 @@ type ClusterSpec struct {
 	AgentImageOverride                                   string                          `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	AliConfig                                            *AliClusterConfigSpec           `json:"aliConfig,omitempty" yaml:"aliConfig,omitempty"`
 	AmazonElasticContainerServiceConfig                  map[string]interface{}          `json:"amazonElasticContainerServiceConfig,omitempty" yaml:"amazonElasticContainerServiceConfig,omitempty"`
+	AssetsImageOverride                                  string                          `json:"assetsImageOverride,omitempty" yaml:"assetsImageOverride,omitempty"`
 	AzureKubernetesServiceConfig                         map[string]interface{}          `json:"azureKubernetesServiceConfig,omitempty" yaml:"azureKubernetesServiceConfig,omitempty"`
-	ChartsImageOverride                                  string                          `json:"chartsImageOverride,omitempty" yaml:"chartsImageOverride,omitempty"`
 	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization   `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                 `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	DefaultClusterRoleForProjectMembers                  string                          `json:"defaultClusterRoleForProjectMembers,omitempty" yaml:"defaultClusterRoleForProjectMembers,omitempty"`
 	DefaultPodSecurityAdmissionConfigurationTemplateName string                          `json:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty" yaml:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty"`
 	Description                                          string                          `json:"description,omitempty" yaml:"description,omitempty"`
 	DesiredAgentImage                                    string                          `json:"desiredAgentImage,omitempty" yaml:"desiredAgentImage,omitempty"`
+	DesiredAssetsImage                                   string                          `json:"desiredAssetsImage,omitempty" yaml:"desiredAssetsImage,omitempty"`
 	DesiredAuthImage                                     string                          `json:"desiredAuthImage,omitempty" yaml:"desiredAuthImage,omitempty"`
-	DesiredChartsImage                                   string                          `json:"desiredChartsImage,omitempty" yaml:"desiredChartsImage,omitempty"`
 	DisplayName                                          string                          `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	DockerRootDir                                        string                          `json:"dockerRootDir,omitempty" yaml:"dockerRootDir,omitempty"`
 	EKSConfig                                            *EKSClusterConfigSpec           `json:"eksConfig,omitempty" yaml:"eksConfig,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_status.go
@@ -21,6 +21,7 @@ const (
 	ClusterStatusFieldCapabilities                               = "capabilities"
 	ClusterStatusFieldCapacity                                   = "capacity"
 	ClusterStatusFieldCertificatesExpiration                     = "certificatesExpiration"
+	ClusterStatusFieldChartsImage                                = "chartsImage"
 	ClusterStatusFieldComponentStatuses                          = "componentStatuses"
 	ClusterStatusFieldConditions                                 = "conditions"
 	ClusterStatusFieldCurrentCisRunName                          = "currentCisRunName"
@@ -68,6 +69,7 @@ type ClusterStatus struct {
 	Capabilities                               *Capabilities                   `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Capacity                                   map[string]string               `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration                     map[string]CertExpiration       `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
+	ChartsImage                                string                          `json:"chartsImage,omitempty" yaml:"chartsImage,omitempty"`
 	ComponentStatuses                          []ClusterComponentStatus        `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
 	Conditions                                 []ClusterCondition              `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	CurrentCisRunName                          string                          `json:"currentCisRunName,omitempty" yaml:"currentCisRunName,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_status.go
@@ -16,12 +16,12 @@ const (
 	ClusterStatusFieldAppliedEnableNetworkPolicy                 = "appliedEnableNetworkPolicy"
 	ClusterStatusFieldAppliedSpec                                = "appliedSpec"
 	ClusterStatusFieldAppliedWebhookDeploymentCustomization      = "appliedWebhookDeploymentCustomization"
+	ClusterStatusFieldAssetsImage                                = "assetsImage"
 	ClusterStatusFieldAuthImage                                  = "authImage"
 	ClusterStatusFieldCACert                                     = "caCert"
 	ClusterStatusFieldCapabilities                               = "capabilities"
 	ClusterStatusFieldCapacity                                   = "capacity"
 	ClusterStatusFieldCertificatesExpiration                     = "certificatesExpiration"
-	ClusterStatusFieldChartsImage                                = "chartsImage"
 	ClusterStatusFieldComponentStatuses                          = "componentStatuses"
 	ClusterStatusFieldConditions                                 = "conditions"
 	ClusterStatusFieldCurrentCisRunName                          = "currentCisRunName"
@@ -64,12 +64,12 @@ type ClusterStatus struct {
 	AppliedEnableNetworkPolicy                 bool                            `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
 	AppliedSpec                                *ClusterSpec                    `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`
 	AppliedWebhookDeploymentCustomization      *WebhookDeploymentCustomization `json:"appliedWebhookDeploymentCustomization,omitempty" yaml:"appliedWebhookDeploymentCustomization,omitempty"`
+	AssetsImage                                string                          `json:"assetsImage,omitempty" yaml:"assetsImage,omitempty"`
 	AuthImage                                  string                          `json:"authImage,omitempty" yaml:"authImage,omitempty"`
 	CACert                                     string                          `json:"caCert,omitempty" yaml:"caCert,omitempty"`
 	Capabilities                               *Capabilities                   `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Capacity                                   map[string]string               `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration                     map[string]CertExpiration       `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
-	ChartsImage                                string                          `json:"chartsImage,omitempty" yaml:"chartsImage,omitempty"`
 	ComponentStatuses                          []ClusterComponentStatus        `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
 	Conditions                                 []ClusterCondition              `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	CurrentCisRunName                          string                          `json:"currentCisRunName,omitempty" yaml:"currentCisRunName,omitempty"`

--- a/pkg/codegen/buildconfig/chart_writer.go
+++ b/pkg/codegen/buildconfig/chart_writer.go
@@ -148,6 +148,19 @@ func (w *ChartValuesWriter) collectReplacements(root *yaml.Node, replacements ma
 		}
 	}
 
+	// Update Charts asset image from defaultChartsImage
+	if chartAssetsImage, ok := w.Config["defaultChartsImage"]; ok {
+		parts := strings.SplitN(chartAssetsImage, ":", 2)
+		if len(parts) == 2 {
+			if err := w.recordReplacement(chart, []string{"chartsImage", "repository"}, parts[0], replacements); err != nil {
+				return fmt.Errorf("failed to set auditLog.image.repository: %w", err)
+			}
+			if err := w.recordReplacement(chart, []string{"chartsImage", "tag"}, parts[1], replacements); err != nil {
+				return fmt.Errorf("failed to set auditLog.image.tag: %w", err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/codegen/buildconfig/chart_writer.go
+++ b/pkg/codegen/buildconfig/chart_writer.go
@@ -148,15 +148,15 @@ func (w *ChartValuesWriter) collectReplacements(root *yaml.Node, replacements ma
 		}
 	}
 
-	// Update Charts asset image from defaultChartsImage
-	if chartAssetsImage, ok := w.Config["defaultChartsImage"]; ok {
+	// Update Charts asset image from defaultAssetsImage
+	if chartAssetsImage, ok := w.Config["defaultAssetsImage"]; ok {
 		parts := strings.SplitN(chartAssetsImage, ":", 2)
 		if len(parts) == 2 {
-			if err := w.recordReplacement(chart, []string{"chartsImage", "repository"}, parts[0], replacements); err != nil {
-				return fmt.Errorf("failed to set chartsImage.repository: %w", err)
+			if err := w.recordReplacement(chart, []string{"assetsImage", "repository"}, parts[0], replacements); err != nil {
+				return fmt.Errorf("failed to set assetsImage.repository: %w", err)
 			}
-			if err := w.recordReplacement(chart, []string{"chartsImage", "tag"}, parts[1], replacements); err != nil {
-				return fmt.Errorf("failed to set chartsImage.tag: %w", err)
+			if err := w.recordReplacement(chart, []string{"assetsImage", "tag"}, parts[1], replacements); err != nil {
+				return fmt.Errorf("failed to set assetsImage.tag: %w", err)
 			}
 		}
 	}

--- a/pkg/codegen/buildconfig/chart_writer.go
+++ b/pkg/codegen/buildconfig/chart_writer.go
@@ -153,10 +153,10 @@ func (w *ChartValuesWriter) collectReplacements(root *yaml.Node, replacements ma
 		parts := strings.SplitN(chartAssetsImage, ":", 2)
 		if len(parts) == 2 {
 			if err := w.recordReplacement(chart, []string{"chartsImage", "repository"}, parts[0], replacements); err != nil {
-				return fmt.Errorf("failed to set auditLog.image.repository: %w", err)
+				return fmt.Errorf("failed to set chartsImage.repository: %w", err)
 			}
 			if err := w.recordReplacement(chart, []string{"chartsImage", "tag"}, parts[1], replacements); err != nil {
-				return fmt.Errorf("failed to set auditLog.image.tag: %w", err)
+				return fmt.Errorf("failed to set chartsImage.tag: %w", err)
 			}
 		}
 	}

--- a/pkg/codegen/buildconfig/chart_writer_test.go
+++ b/pkg/codegen/buildconfig/chart_writer_test.go
@@ -15,6 +15,7 @@ func TestChartValuesWriterRun(t *testing.T) {
 
 	cfg := map[string]string{
 		"chartAuditLogImage":  "rancher/mirrored-bci-micro:16.0-15.11",
+		"defaultChartsImage":  "rancher/rancher-charts:v0.1.0-rc.1",
 		"defaultShellVersion": "rancher/shell:v0.8.0-rc.2",
 	}
 
@@ -23,6 +24,10 @@ func TestChartValuesWriterRun(t *testing.T) {
   image:
     repository: "rancher/old-audit"
     tag: old-tag
+
+chartsImage:
+  repository: rancher/old-charts
+  tag: v0.0.1
 
 postDelete:
   enabled: true
@@ -41,6 +46,10 @@ preUpgrade:
   image:
     repository: "rancher/mirrored-bci-micro"
     tag: 16.0-15.11
+
+chartsImage:
+  repository: rancher/rancher-charts
+  tag: v0.1.0-rc.1
 
 postDelete:
   enabled: true

--- a/pkg/codegen/buildconfig/chart_writer_test.go
+++ b/pkg/codegen/buildconfig/chart_writer_test.go
@@ -15,7 +15,7 @@ func TestChartValuesWriterRun(t *testing.T) {
 
 	cfg := map[string]string{
 		"chartAuditLogImage":  "rancher/mirrored-bci-micro:16.0-15.11",
-		"defaultChartsImage":  "rancher/rancher-charts:v0.1.0-rc.1",
+		"defaultAssetsImage":  "rancher/rancher-charts:v0.1.0-rc.1",
 		"defaultShellVersion": "rancher/shell:v0.8.0-rc.2",
 	}
 
@@ -25,7 +25,7 @@ func TestChartValuesWriterRun(t *testing.T) {
     repository: "rancher/old-audit"
     tag: old-tag
 
-chartsImage:
+assetsImage:
   repository: rancher/old-charts
   tag: v0.0.1
 
@@ -47,7 +47,7 @@ preUpgrade:
     repository: "rancher/mirrored-bci-micro"
     tag: 16.0-15.11
 
-chartsImage:
+assetsImage:
   repository: rancher/rancher-charts
   tag: v0.1.0-rc.1
 

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -133,7 +133,7 @@ func (cd *clusterDeploy) sync(key string, cluster *apimgmtv3.Cluster) (runtime.O
 		toUpdate.Status.AgentImage = modified.Status.AgentImage
 		toUpdate.Status.AgentFeatures = modified.Status.AgentFeatures
 		toUpdate.Status.AuthImage = modified.Status.AuthImage
-		toUpdate.Status.ChartsImage = modified.Status.ChartsImage
+		toUpdate.Status.AssetsImage = modified.Status.AssetsImage
 		toUpdate.Status.AppliedAgentEnvVars = modified.Status.AppliedAgentEnvVars
 		toUpdate.Status.AppliedClusterAgentDeploymentCustomization = modified.Status.AppliedClusterAgentDeploymentCustomization
 		toUpdate.Status.AppliedClusterAgentImagePullSecretsHash = modified.Status.AppliedClusterAgentImagePullSecretsHash
@@ -246,7 +246,7 @@ func redeployAgent(cluster *apimgmtv3.Cluster, desiredAgent, desiredAuth, desire
 		return true
 	}
 	forceDeploy := cluster.Annotations[AgentForceDeployAnn] == "true"
-	imageChange := cluster.Status.AgentImage != desiredAgent || cluster.Status.AuthImage != desiredAuth || cluster.Status.ChartsImage != desiredCharts
+	imageChange := cluster.Status.AgentImage != desiredAgent || cluster.Status.AuthImage != desiredAuth || cluster.Status.AssetsImage != desiredCharts
 	agentFeaturesChanged := agentFeaturesChanged(desiredFeatures, cluster.Status.AgentFeatures)
 
 	if forceDeploy || imageChange || agentFeaturesChanged {
@@ -255,7 +255,7 @@ func redeployAgent(cluster *apimgmtv3.Cluster, desiredAgent, desiredAuth, desire
 			agentFeaturesChanged)
 		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.AgentImage: [%s], desiredAgent: [%s]", cluster.Status.AgentImage, desiredAgent)
 		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.AuthImage [%s], desiredAuth: [%s]", cluster.Status.AuthImage, desiredAuth)
-		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.ChartsImage [%s], desiredCharts: [%s]", cluster.Status.ChartsImage, desiredCharts)
+		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.AssetsImage [%s], desiredCharts: [%s]", cluster.Status.AssetsImage, desiredCharts)
 		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.AgentFeatures [%v], desiredFeatures: [%v]", cluster.Status.AgentFeatures, desiredFeatures)
 		return true
 	}
@@ -519,7 +519,7 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 
 	desiredAgent := systemtemplate.GetDesiredAgentImage(cluster)
 	desiredAuth := systemtemplate.GetDesiredAuthImage(cluster)
-	desiredCharts := systemtemplate.GetDesiredChartsImage(cluster)
+	desiredCharts := systemtemplate.GetDesiredAssetsImage(cluster)
 	desiredFeatures := systemtemplate.GetDesiredFeatures(cluster)
 
 	logrus.Tracef("clusterDeploy: deployAgent: desiredFeatures is [%v] for cluster [%s]", desiredFeatures, cluster.Name)
@@ -645,9 +645,9 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 	if cluster.Spec.DesiredAuthImage == "fixed" {
 		cluster.Spec.DesiredAuthImage = desiredAuth
 	}
-	cluster.Status.ChartsImage = desiredCharts
-	if cluster.Spec.DesiredChartsImage == "fixed" {
-		cluster.Spec.DesiredChartsImage = desiredCharts
+	cluster.Status.AssetsImage = desiredCharts
+	if cluster.Spec.DesiredAssetsImage == "fixed" {
+		cluster.Spec.DesiredAssetsImage = desiredCharts
 	}
 
 	if cluster.Annotations[AgentForceDeployAnn] == "true" {
@@ -682,10 +682,10 @@ func (cd *clusterDeploy) getKubeConfig(cluster *apimgmtv3.Cluster) (*clientcmdap
 	return cd.clusterManager.KubeConfig(cluster.Name, token), tokenName, nil
 }
 
-func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authImage, chartsImage string, features map[string]bool, taints []corev1.Taint, priorityClassExists bool) ([]byte, error) {
+func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authImage, assetsImage string, features map[string]bool, taints []corev1.Taint, priorityClassExists bool) ([]byte, error) {
 	logrus.Tracef("clusterDeploy: getYAML: Desired agent image is [%s] for cluster [%s]", agentImage, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired auth image is [%s] for cluster [%s]", authImage, cluster.Name)
-	logrus.Tracef("clusterDeploy: getYAML: Desired charts assets image is [%s] for cluster [%s]", chartsImage, cluster.Name)
+	logrus.Tracef("clusterDeploy: getYAML: Desired charts assets image is [%s] for cluster [%s]", assetsImage, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired features are [%v] for cluster [%s]", features, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired taints are [%v] for cluster [%s]", taints, cluster.Name)
 
@@ -703,7 +703,7 @@ func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authIma
 	ops := &systemtemplate.TemplateOps{
 		AgentImage:     agentImage,
 		AuthImage:      authImage,
-		ChartsImage:    chartsImage,
+		AssetsImage:    assetsImage,
 		Namespace:      cluster.Name,
 		Token:          token,
 		URL:            url,

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -133,6 +133,7 @@ func (cd *clusterDeploy) sync(key string, cluster *apimgmtv3.Cluster) (runtime.O
 		toUpdate.Status.AgentImage = modified.Status.AgentImage
 		toUpdate.Status.AgentFeatures = modified.Status.AgentFeatures
 		toUpdate.Status.AuthImage = modified.Status.AuthImage
+		toUpdate.Status.ChartsImage = modified.Status.ChartsImage
 		toUpdate.Status.AppliedAgentEnvVars = modified.Status.AppliedAgentEnvVars
 		toUpdate.Status.AppliedClusterAgentDeploymentCustomization = modified.Status.AppliedClusterAgentDeploymentCustomization
 		toUpdate.Status.AppliedClusterAgentImagePullSecretsHash = modified.Status.AppliedClusterAgentImagePullSecretsHash
@@ -239,13 +240,13 @@ func agentFeaturesChanged(desired, actual map[string]bool) bool {
 	return false
 }
 
-func redeployAgent(cluster *apimgmtv3.Cluster, desiredAgent, desiredAuth string, desiredFeatures map[string]bool, desiredTaints []corev1.Taint) bool {
+func redeployAgent(cluster *apimgmtv3.Cluster, desiredAgent, desiredAuth, desiredCharts string, desiredFeatures map[string]bool, desiredTaints []corev1.Taint) bool {
 	logrus.Tracef("clusterDeploy: redeployAgent called for cluster [%s]", cluster.Name)
 	if !apimgmtv3.ClusterConditionAgentDeployed.IsTrue(cluster) {
 		return true
 	}
 	forceDeploy := cluster.Annotations[AgentForceDeployAnn] == "true"
-	imageChange := cluster.Status.AgentImage != desiredAgent || cluster.Status.AuthImage != desiredAuth
+	imageChange := cluster.Status.AgentImage != desiredAgent || cluster.Status.AuthImage != desiredAuth || cluster.Status.ChartsImage != desiredCharts
 	agentFeaturesChanged := agentFeaturesChanged(desiredFeatures, cluster.Status.AgentFeatures)
 
 	if forceDeploy || imageChange || agentFeaturesChanged {
@@ -254,6 +255,7 @@ func redeployAgent(cluster *apimgmtv3.Cluster, desiredAgent, desiredAuth string,
 			agentFeaturesChanged)
 		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.AgentImage: [%s], desiredAgent: [%s]", cluster.Status.AgentImage, desiredAgent)
 		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.AuthImage [%s], desiredAuth: [%s]", cluster.Status.AuthImage, desiredAuth)
+		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.ChartsImage [%s], desiredCharts: [%s]", cluster.Status.ChartsImage, desiredCharts)
 		logrus.Tracef("clusterDeploy: redeployAgent: cluster.Status.AgentFeatures [%v], desiredFeatures: [%v]", cluster.Status.AgentFeatures, desiredFeatures)
 		return true
 	}
@@ -517,6 +519,7 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 
 	desiredAgent := systemtemplate.GetDesiredAgentImage(cluster)
 	desiredAuth := systemtemplate.GetDesiredAuthImage(cluster)
+	desiredCharts := systemtemplate.GetDesiredChartsImage(cluster)
 	desiredFeatures := systemtemplate.GetDesiredFeatures(cluster)
 
 	logrus.Tracef("clusterDeploy: deployAgent: desiredFeatures is [%v] for cluster [%s]", desiredFeatures, cluster.Name)
@@ -542,7 +545,7 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 		return err
 	}
 
-	shouldRedeployAgent := redeployAgent(cluster, desiredAgent, desiredAuth, desiredFeatures, desiredTaints)
+	shouldRedeployAgent := redeployAgent(cluster, desiredAgent, desiredAuth, desiredCharts, desiredFeatures, desiredTaints)
 	agentManifestChanged := shouldRedeployAgent || pcDeleted || pcCreated || hashChanged || tokenHashChanged
 
 	if !agentManifestChanged && !pcChanged {
@@ -642,6 +645,11 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 	if cluster.Spec.DesiredAuthImage == "fixed" {
 		cluster.Spec.DesiredAuthImage = desiredAuth
 	}
+	cluster.Status.ChartsImage = desiredCharts
+	if cluster.Spec.DesiredChartsImage == "fixed" {
+		cluster.Spec.DesiredChartsImage = desiredCharts
+	}
+
 	if cluster.Annotations[AgentForceDeployAnn] == "true" {
 		cluster.Annotations[AgentForceDeployAnn] = "false"
 	}

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -592,7 +592,7 @@ func (cd *clusterDeploy) deployAgent(cluster *apimgmtv3.Cluster) error {
 	}
 
 	if _, err = apimgmtv3.ClusterConditionAgentDeployed.Do(cluster, func() (runtime.Object, error) {
-		yaml, err := cd.getYAML(cluster, desiredAgent, desiredAuth, desiredFeatures, desiredTaints, pcExists)
+		yaml, err := cd.getYAML(cluster, desiredAgent, desiredAuth, desiredCharts, desiredFeatures, desiredTaints, pcExists)
 		if err != nil {
 			return cluster, err
 		}
@@ -682,9 +682,10 @@ func (cd *clusterDeploy) getKubeConfig(cluster *apimgmtv3.Cluster) (*clientcmdap
 	return cd.clusterManager.KubeConfig(cluster.Name, token), tokenName, nil
 }
 
-func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authImage string, features map[string]bool, taints []corev1.Taint, priorityClassExists bool) ([]byte, error) {
+func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authImage, chartsImage string, features map[string]bool, taints []corev1.Taint, priorityClassExists bool) ([]byte, error) {
 	logrus.Tracef("clusterDeploy: getYAML: Desired agent image is [%s] for cluster [%s]", agentImage, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired auth image is [%s] for cluster [%s]", authImage, cluster.Name)
+	logrus.Tracef("clusterDeploy: getYAML: Desired charts assets image is [%s] for cluster [%s]", chartsImage, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired features are [%v] for cluster [%s]", features, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired taints are [%v] for cluster [%s]", taints, cluster.Name)
 
@@ -702,6 +703,7 @@ func (cd *clusterDeploy) getYAML(cluster *apimgmtv3.Cluster, agentImage, authIma
 	ops := &systemtemplate.TemplateOps{
 		AgentImage:     agentImage,
 		AuthImage:      authImage,
+		ChartsImage:    chartsImage,
 		Namespace:      cluster.Name,
 		Token:          token,
 		URL:            url,

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -529,6 +529,7 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.EnableNetworkPolicy = cluster.Spec.EnableNetworkPolicy
 	spec.DesiredAgentImage = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
 	spec.DesiredAuthImage = image.ResolveWithCluster(settings.AuthImage.Get(), cluster)
+	spec.DesiredChartsImage = image.ResolveWithCluster(settings.ChartsImage.Get(), cluster)
 
 	spec.ClusterSecrets.PrivateRegistrySecret, _ = image.GetPrivateRepoSecretFromCluster(cluster)
 	spec.ClusterSecrets.PrivateRegistryURL, _ = image.GetPrivateRepoURLFromCluster(cluster)

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -529,7 +529,7 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.EnableNetworkPolicy = cluster.Spec.EnableNetworkPolicy
 	spec.DesiredAgentImage = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
 	spec.DesiredAuthImage = image.ResolveWithCluster(settings.AuthImage.Get(), cluster)
-	spec.DesiredChartsImage = image.ResolveWithCluster(settings.ChartsImage.Get(), cluster)
+	spec.DesiredAssetsImage = image.ResolveWithCluster(settings.AssetsImage.Get(), cluster)
 
 	spec.ClusterSecrets.PrivateRegistrySecret, _ = image.GetPrivateRepoSecretFromCluster(cluster)
 	spec.ClusterSecrets.PrivateRegistryURL, _ = image.GetPrivateRepoURLFromCluster(cluster)

--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -261,6 +261,7 @@ var OriginMap = map[string]string{
 	"pushprox":                                                "https://github.com/rancher/PushProx",
 	"rancher":                                                 "https://github.com/rancher/rancher",
 	"rancher-agent":                                           "https://github.com/rancher/rancher",
+	"rancher-assets":                                          "https://github.com/rancher/rancher-assets",
 	"rancher-csp-adapter":                                     "https://github.com/rancher/csp-adapter",
 	"rancher-webhook":                                         "https://github.com/rancher/webhook",
 	"remotedialer-proxy":                                      "https://github.com/rancher/remotedialer",

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -138,8 +138,9 @@ func IsValidSemver(version string) bool {
 
 func setRequiredImages(osType OSType, imagesSet map[string]map[string]struct{}) {
 	if osType == Linux {
-		addSourceToImage(imagesSet, settings.SCCOperatorImage.Get(), imageSourceCore)
-		addSourceToImage(imagesSet, settings.ShellImage.Get(), imageSourceCore)
+		addSourceToImage(imagesSet, buildconfig.DefaultChartsImage, imageSourceCore)
+		addSourceToImage(imagesSet, buildconfig.DefaultSccOperatorImage, imageSourceCore)
+		addSourceToImage(imagesSet, buildconfig.DefaultShellVersion, imageSourceCore)
 		addSourceToImage(imagesSet, settings.MachineProvisionImage.Get(), imageSourceCore)
 		// Used by Audit Log feature - sourced from build.yaml
 		addSourceToImage(imagesSet, buildconfig.ChartAuditLogImage, imageSourceCore)

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -138,7 +138,7 @@ func IsValidSemver(version string) bool {
 
 func setRequiredImages(osType OSType, imagesSet map[string]map[string]struct{}) {
 	if osType == Linux {
-		addSourceToImage(imagesSet, buildconfig.DefaultChartsImage, imageSourceCore)
+		addSourceToImage(imagesSet, buildconfig.DefaultAssetsImage, imageSourceCore)
 		addSourceToImage(imagesSet, buildconfig.DefaultSccOperatorImage, imageSourceCore)
 		addSourceToImage(imagesSet, buildconfig.DefaultShellVersion, imageSourceCore)
 		addSourceToImage(imagesSet, settings.MachineProvisionImage.Get(), imageSourceCore)

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -451,6 +451,9 @@ var (
 	ExpireSCIMTokensAfter = NewSetting("expire-scim-tokens-after", "720h") // 30 days
 
 	ImportedClusterDay2OpsEnabledDefault = NewSetting("imported-cluster-day2-ops-enabled", "true")
+
+	// ChartsImage is the image used for Rancher's `ClusterRepo` assets on downstream clusters.
+	ChartsImage = NewSetting("charts-image", buildconfig.DefaultChartsImage)
 )
 
 // FullShellImage returns the full private registry name of the rancher shell image.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -452,8 +452,8 @@ var (
 
 	ImportedClusterDay2OpsEnabledDefault = NewSetting("imported-cluster-day2-ops-enabled", "true")
 
-	// ChartsImage is the image used for Rancher's `ClusterRepo` assets on downstream clusters.
-	ChartsImage = NewSetting("charts-image", buildconfig.DefaultChartsImage)
+	// AssetsImage is the image used for Rancher's `ClusterRepo` assets on downstream clusters.
+	AssetsImage = NewSetting("charts-image", buildconfig.DefaultAssetsImage)
 )
 
 // FullShellImage returns the full private registry name of the rancher shell image.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -147,7 +147,7 @@ var (
 	InitialDockerRootDir                = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
 	// ATTENTION: This file and the following line are used in the rancher/webhook CI to extract the default branch they need
-	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.16")
+	ChartDefaultBranch                  = NewSetting("chart-default-branch", buildconfig.ChartDefaultBranch)
 	SystemManagedChartsOperationTimeout = NewSetting("system-managed-charts-operation-timeout", "300s")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none
 	ShellImage                          = NewSetting("shell-image", buildconfig.DefaultShellVersion)
@@ -263,7 +263,7 @@ var (
 	KubeconfigGenerateToken = NewSetting("kubeconfig-generate-token", "true")
 
 	// PartnerChartDefaultBranch represents the default branch for the partner charts repo.
-	PartnerChartDefaultBranch = NewSetting("partner-chart-default-branch", "main")
+	PartnerChartDefaultBranch = NewSetting("partner-chart-default-branch", buildconfig.PartnerChartDefaultBranch)
 
 	// PartnerChartDefaultURL represents the default URL for the partner charts repo. It should only be set for test
 	// or debug purposes.
@@ -286,7 +286,7 @@ var (
 	ClusterAutoscalerImage = NewSetting("cluster-autoscaler-image", "").WithEnvDefault("CATTLE_BASE_CLUSTER_AUTOSCALER_IMAGE")
 
 	// RKE2ChartDefaultBranch represents the default branch for the RKE2 charts repo.
-	RKE2ChartDefaultBranch = NewSetting("rke2-chart-default-branch", "main")
+	RKE2ChartDefaultBranch = NewSetting("rke2-chart-default-branch", buildconfig.Rke2ChartDefaultBranch)
 
 	// RKE2ChartDefaultURL represents the default URL for the RKE2 charts repo. It should only be set for test or
 	// debug purposes.

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -146,6 +146,7 @@ func PodDisruptionBudgetTemplate(cluster *apimgmtv3.Cluster) ([]byte, error) {
 type TemplateOps struct {
 	AgentImage     string
 	AuthImage      string
+	ChartsImage    string
 	Namespace      string
 	Token          string
 	URL            string
@@ -165,6 +166,10 @@ func SystemTemplate(resp io.Writer, ops *TemplateOps) error {
 
 	if ops.AuthImage == "fixed" {
 		ops.AuthImage = settings.AuthImage.Get()
+	}
+
+	if ops.ChartsImage == "fixed" {
+		ops.ChartsImage = settings.ChartsImage.Get()
 	}
 
 	var registryURL string
@@ -274,7 +279,7 @@ func SystemTemplate(resp io.Writer, ops *TemplateOps) error {
 		AgentImage:                 ops.AgentImage,
 		AgentEnvVars:               agentEnvVars,
 		AuthImage:                  ops.AuthImage,
-		ChartsImage:                GetDesiredChartsImage(ops.Cluster),
+		ChartsImage:                ops.ChartsImage,
 		TokenKey:                   tokenKey,
 		Token:                      base64.StdEncoding.EncodeToString([]byte(ops.Token)),
 		URL:                        base64.StdEncoding.EncodeToString([]byte(ops.URL)),
@@ -350,6 +355,7 @@ func ForCluster(cluster *apimgmtv3.Cluster, token string, taints []corev1.Taint,
 	err := SystemTemplate(buf, &TemplateOps{
 		AgentImage:     GetDesiredAgentImage(cluster),
 		AuthImage:      GetDesiredAuthImage(cluster),
+		ChartsImage:    GetDesiredChartsImage(cluster),
 		Namespace:      cluster.Name,
 		Token:          token,
 		URL:            settings.ServerURL.Get(),

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -40,6 +40,7 @@ type clusterAgentContext struct {
 	AgentImage           string
 	AgentEnvVars         string
 	AuthImage            string
+	ChartsImage          string
 	TokenKey             string
 	Token                string
 	URL                  string
@@ -273,6 +274,7 @@ func SystemTemplate(resp io.Writer, ops *TemplateOps) error {
 		AgentImage:                 ops.AgentImage,
 		AgentEnvVars:               agentEnvVars,
 		AuthImage:                  ops.AuthImage,
+		ChartsImage:                GetDesiredChartsImage(ops.Cluster),
 		TokenKey:                   tokenKey,
 		Token:                      base64.StdEncoding.EncodeToString([]byte(ops.Token)),
 		URL:                        base64.StdEncoding.EncodeToString([]byte(ops.URL)),
@@ -409,6 +411,19 @@ func GetDesiredAuthImage(cluster *apimgmtv3.Cluster) string {
 	}
 	logrus.Tracef("clusterDeploy: deployAgent: desiredAuth is [%s] for cluster [%s]", desiredAuth, cluster.Name)
 	return desiredAuth
+}
+
+func GetDesiredChartsImage(cluster *apimgmtv3.Cluster) string {
+	logrus.Tracef("clusterDeploy: getting desired charts image for [%s]", cluster.Name)
+	desiredCharts := cluster.Spec.DesiredChartsImage
+	if cluster.Spec.ChartsImageOverride != "" {
+		desiredCharts = cluster.Spec.ChartsImageOverride
+	}
+	if desiredCharts == "" || desiredCharts == "fixed" {
+		desiredCharts = image.ResolveWithCluster(settings.ChartsImage.Get(), cluster)
+	}
+	logrus.Tracef("clusterDeploy: desiredCharts is [%s] for cluster [%s]", desiredCharts, cluster.Name)
+	return desiredCharts
 }
 
 func toYAML(v interface{}) string {

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -40,7 +40,7 @@ type clusterAgentContext struct {
 	AgentImage           string
 	AgentEnvVars         string
 	AuthImage            string
-	ChartsImage          string
+	AssetsImage          string
 	TokenKey             string
 	Token                string
 	URL                  string
@@ -146,7 +146,7 @@ func PodDisruptionBudgetTemplate(cluster *apimgmtv3.Cluster) ([]byte, error) {
 type TemplateOps struct {
 	AgentImage     string
 	AuthImage      string
-	ChartsImage    string
+	AssetsImage    string
 	Namespace      string
 	Token          string
 	URL            string
@@ -168,8 +168,8 @@ func SystemTemplate(resp io.Writer, ops *TemplateOps) error {
 		ops.AuthImage = settings.AuthImage.Get()
 	}
 
-	if ops.ChartsImage == "fixed" {
-		ops.ChartsImage = settings.ChartsImage.Get()
+	if ops.AssetsImage == "fixed" {
+		ops.AssetsImage = settings.AssetsImage.Get()
 	}
 
 	var registryURL string
@@ -279,7 +279,7 @@ func SystemTemplate(resp io.Writer, ops *TemplateOps) error {
 		AgentImage:                 ops.AgentImage,
 		AgentEnvVars:               agentEnvVars,
 		AuthImage:                  ops.AuthImage,
-		ChartsImage:                ops.ChartsImage,
+		AssetsImage:                ops.AssetsImage,
 		TokenKey:                   tokenKey,
 		Token:                      base64.StdEncoding.EncodeToString([]byte(ops.Token)),
 		URL:                        base64.StdEncoding.EncodeToString([]byte(ops.URL)),
@@ -355,7 +355,7 @@ func ForCluster(cluster *apimgmtv3.Cluster, token string, taints []corev1.Taint,
 	err := SystemTemplate(buf, &TemplateOps{
 		AgentImage:     GetDesiredAgentImage(cluster),
 		AuthImage:      GetDesiredAuthImage(cluster),
-		ChartsImage:    GetDesiredChartsImage(cluster),
+		AssetsImage:    GetDesiredAssetsImage(cluster),
 		Namespace:      cluster.Name,
 		Token:          token,
 		URL:            settings.ServerURL.Get(),
@@ -419,14 +419,14 @@ func GetDesiredAuthImage(cluster *apimgmtv3.Cluster) string {
 	return desiredAuth
 }
 
-func GetDesiredChartsImage(cluster *apimgmtv3.Cluster) string {
+func GetDesiredAssetsImage(cluster *apimgmtv3.Cluster) string {
 	logrus.Tracef("clusterDeploy: getting desired charts image for [%s]", cluster.Name)
-	desiredCharts := cluster.Spec.DesiredChartsImage
-	if cluster.Spec.ChartsImageOverride != "" {
-		desiredCharts = cluster.Spec.ChartsImageOverride
+	desiredCharts := cluster.Spec.DesiredAssetsImage
+	if cluster.Spec.AssetsImageOverride != "" {
+		desiredCharts = cluster.Spec.AssetsImageOverride
 	}
 	if desiredCharts == "" || desiredCharts == "fixed" {
-		desiredCharts = image.ResolveWithCluster(settings.ChartsImage.Get(), cluster)
+		desiredCharts = image.ResolveWithCluster(settings.AssetsImage.Get(), cluster)
 	}
 	logrus.Tracef("clusterDeploy: desiredCharts is [%s] for cluster [%s]", desiredCharts, cluster.Name)
 	return desiredCharts

--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -43,7 +43,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 		pcExists       bool
 		agentImage     string
 		authImage      string
-		chartsImage    string
+		assetsImage    string
 		namespace      string
 		token          string
 		url            string
@@ -163,7 +163,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 			url:         "some-dummy-url",
 			token:       "some-dummy-token",
 			agentImage:  "my/agent:image",
-			chartsImage: "rancher/assets:charts",
+			assetsImage: "rancher/assets:charts",
 		},
 		{
 			name: "test-rancher-namespace-options-enabled",
@@ -190,7 +190,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:  "my/agent:image",
-			chartsImage: "rancher/assets:charts",
+			assetsImage: "rancher/assets:charts",
 		},
 		{
 			name: "test-rancher-namespace-options-enabled-no-labels",
@@ -215,7 +215,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				Labels: map[string]string{},
 			},
 			agentImage:  "my/agent:image",
-			chartsImage: "rancher/assets:charts",
+			assetsImage: "rancher/assets:charts",
 		},
 		{
 			name: "test-rancher-namespace-options-enabled-no-annotations",
@@ -240,7 +240,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:  "my/agent:image",
-			chartsImage: "rancher/assets:charts",
+			assetsImage: "rancher/assets:charts",
 		},
 		{
 			name: "imported cluster with pull secrets renders imagePullSecrets and secret resources",
@@ -261,7 +261,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:  "rancher/rancher-agent:v2.8.0",
-			chartsImage: "rancher/assets:charts",
+			assetsImage: "rancher/assets:charts",
 			token:       "test-token",
 			url:         "https://rancher.example.com",
 			secrets: map[string]*corev1.Secret{
@@ -293,7 +293,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:  "rancher-agent:v2.8.0",
-			chartsImage: "rancher/assets:charts",
+			assetsImage: "rancher/assets:charts",
 			token:       "test-token",
 			url:         "https://rancher.example.com",
 			secrets: map[string]*corev1.Secret{
@@ -329,7 +329,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:  "rancher-agent:v2.8.0",
-			chartsImage: "rancher/assets:charts",
+			assetsImage: "rancher/assets:charts",
 			token:       "test-token",
 			url:         "https://rancher.example.com",
 			secrets: map[string]*corev1.Secret{
@@ -376,7 +376,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:    "my-registry.example.com/rancher/rancher-agent:v2.8.0",
-			chartsImage:   "rancher/assets:charts",
+			assetsImage:   "rancher/assets:charts",
 			token:         "test-token",
 			url:           "https://rancher.example.com",
 			expectedError: "\"fleet-default:nonexistent-secret\" not found",
@@ -395,7 +395,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:     "rancher/rancher-agent:v2.8.0",
-			chartsImage:    "rancher/assets:charts",
+			assetsImage:    "rancher/assets:charts",
 			token:          "test-token",
 			url:            "https://rancher.example.com",
 			isPreBootstrap: true,
@@ -414,7 +414,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 			err := SystemTemplate(&b, &TemplateOps{
 				AgentImage:     tt.agentImage,
 				AuthImage:      tt.authImage,
-				ChartsImage:    tt.chartsImage,
+				AssetsImage:    tt.assetsImage,
 				Namespace:      tt.namespace,
 				Token:          tt.token,
 				URL:            tt.url,

--- a/pkg/systemtemplate/import_test.go
+++ b/pkg/systemtemplate/import_test.go
@@ -43,6 +43,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 		pcExists       bool
 		agentImage     string
 		authImage      string
+		chartsImage    string
 		namespace      string
 		token          string
 		url            string
@@ -159,9 +160,10 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					Provider: "rke2",
 				},
 			},
-			url:        "some-dummy-url",
-			token:      "some-dummy-token",
-			agentImage: "my/agent:image",
+			url:         "some-dummy-url",
+			token:       "some-dummy-token",
+			agentImage:  "my/agent:image",
+			chartsImage: "rancher/assets:charts",
 		},
 		{
 			name: "test-rancher-namespace-options-enabled",
@@ -187,7 +189,8 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					"baz": "quz",
 				},
 			},
-			agentImage: "my/agent:image",
+			agentImage:  "my/agent:image",
+			chartsImage: "rancher/assets:charts",
 		},
 		{
 			name: "test-rancher-namespace-options-enabled-no-labels",
@@ -211,7 +214,8 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 				Labels: map[string]string{},
 			},
-			agentImage: "my/agent:image",
+			agentImage:  "my/agent:image",
+			chartsImage: "rancher/assets:charts",
 		},
 		{
 			name: "test-rancher-namespace-options-enabled-no-annotations",
@@ -235,7 +239,8 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					"baz": "quz",
 				},
 			},
-			agentImage: "my/agent:image",
+			agentImage:  "my/agent:image",
+			chartsImage: "rancher/assets:charts",
 		},
 		{
 			name: "imported cluster with pull secrets renders imagePullSecrets and secret resources",
@@ -255,9 +260,10 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					Provider: "rke2",
 				},
 			},
-			agentImage: "rancher/rancher-agent:v2.8.0",
-			token:      "test-token",
-			url:        "https://rancher.example.com",
+			agentImage:  "rancher/rancher-agent:v2.8.0",
+			chartsImage: "rancher/assets:charts",
+			token:       "test-token",
+			url:         "https://rancher.example.com",
 			secrets: map[string]*corev1.Secret{
 				"fleet-default:my-pull-secret": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -286,9 +292,10 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					},
 				},
 			},
-			agentImage: "rancher-agent:v2.8.0",
-			token:      "test-token",
-			url:        "https://rancher.example.com",
+			agentImage:  "rancher-agent:v2.8.0",
+			chartsImage: "rancher/assets:charts",
+			token:       "test-token",
+			url:         "https://rancher.example.com",
 			secrets: map[string]*corev1.Secret{
 				"fleet-default:my-pull-secret-rancher-managed-pull-secret": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -321,9 +328,10 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 					Provider: "rke2",
 				},
 			},
-			agentImage: "rancher-agent:v2.8.0",
-			token:      "test-token",
-			url:        "https://rancher.example.com",
+			agentImage:  "rancher-agent:v2.8.0",
+			chartsImage: "rancher/assets:charts",
+			token:       "test-token",
+			url:         "https://rancher.example.com",
 			secrets: map[string]*corev1.Secret{
 				"fleet-default:secret-one": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -368,6 +376,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:    "my-registry.example.com/rancher/rancher-agent:v2.8.0",
+			chartsImage:   "rancher/assets:charts",
 			token:         "test-token",
 			url:           "https://rancher.example.com",
 			expectedError: "\"fleet-default:nonexistent-secret\" not found",
@@ -386,6 +395,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 				},
 			},
 			agentImage:     "rancher/rancher-agent:v2.8.0",
+			chartsImage:    "rancher/assets:charts",
 			token:          "test-token",
 			url:            "https://rancher.example.com",
 			isPreBootstrap: true,
@@ -404,6 +414,7 @@ func TestSystemTemplate_systemtemplate(t *testing.T) {
 			err := SystemTemplate(&b, &TemplateOps{
 				AgentImage:     tt.agentImage,
 				AuthImage:      tt.authImage,
+				ChartsImage:    tt.chartsImage,
 				Namespace:      tt.namespace,
 				Token:          tt.token,
 				URL:            tt.url,

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -187,6 +187,20 @@ spec:
       {{- if .EnablePriorityClass }}
       priorityClassName: cattle-cluster-agent-priority-class
       {{- end }}
+      initContainers:
+      - name: rancher-charts-copy
+        image: {{.ChartsImage}}
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -228,11 +242,15 @@ spec:
           - name: CATTLE_AGENT_PULL_SECRETS
             value: "{{range $i, $s := .AgentDeploymentPullSecrets}}{{if $i}},{{end}}{{$s.Name}}{{end}}"
           {{- end }}
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: {{.ChartsImage}}
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}
       {{- end }}
           image: "{{.AgentImage}}"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
@@ -247,6 +265,8 @@ spec:
       hostNetwork: true
       {{- end }}
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-{{.TokenKey}}

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -191,13 +191,6 @@ spec:
       - name: rancher-charts-copy
         image: {{.ChartsImage}}
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -235,8 +235,6 @@ spec:
           - name: CATTLE_AGENT_PULL_SECRETS
             value: "{{range $i, $s := .AgentDeploymentPullSecrets}}{{if $i}},{{end}}{{$s.Name}}{{end}}"
           {{- end }}
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: {{.ChartsImage}}
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}
       {{- end }}

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -189,7 +189,7 @@ spec:
       {{- end }}
       initContainers:
       - name: rancher-charts-copy
-        image: {{.ChartsImage}}
+        image: {{.AssetsImage}}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/imported-cluster-with-multiple-pull-secrets.yaml
+++ b/pkg/systemtemplate/testdata/imported-cluster-with-multiple-pull-secrets.yaml
@@ -187,13 +187,6 @@ spec:
       - name: rancher-charts-copy
         image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -219,8 +212,6 @@ spec:
             value: "secret-one-rancher-managed-pull-secret,secret-two-rancher-managed-pull-secret"
           - name: CATTLE_AGENT_PULL_SECRETS
             value: "secret-one-rancher-managed-pull-secret,secret-two-rancher-managed-pull-secret"
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/imported-cluster-with-multiple-pull-secrets.yaml
+++ b/pkg/systemtemplate/testdata/imported-cluster-with-multiple-pull-secrets.yaml
@@ -185,7 +185,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/imported-cluster-with-multiple-pull-secrets.yaml
+++ b/pkg/systemtemplate/testdata/imported-cluster-with-multiple-pull-secrets.yaml
@@ -183,6 +183,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -205,6 +219,8 @@ spec:
             value: "secret-one-rancher-managed-pull-secret,secret-two-rancher-managed-pull-secret"
           - name: CATTLE_AGENT_PULL_SECRETS
             value: "secret-one-rancher-managed-pull-secret,secret-two-rancher-managed-pull-secret"
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -214,6 +230,8 @@ spec:
             value: "true"
           image: "my-registry.example.com/rancher/rancher-agent:v2.8.0"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
@@ -221,6 +239,8 @@ spec:
       - name: "secret-one-rancher-managed-pull-secret"
       - name: "secret-two-rancher-managed-pull-secret"
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-a15c1b308a

--- a/pkg/systemtemplate/testdata/imported-cluster-with-pull-secrets-renders-imagepullsecrets-and-secret-resources.yaml
+++ b/pkg/systemtemplate/testdata/imported-cluster-with-pull-secrets-renders-imagepullsecrets-and-secret-resources.yaml
@@ -173,7 +173,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/imported-cluster-with-pull-secrets-renders-imagepullsecrets-and-secret-resources.yaml
+++ b/pkg/systemtemplate/testdata/imported-cluster-with-pull-secrets-renders-imagepullsecrets-and-secret-resources.yaml
@@ -175,13 +175,6 @@ spec:
       - name: rancher-charts-copy
         image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -207,8 +200,6 @@ spec:
             value: "my-pull-secret-rancher-managed-pull-secret"
           - name: CATTLE_AGENT_PULL_SECRETS
             value: "my-pull-secret-rancher-managed-pull-secret"
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/imported-cluster-with-pull-secrets-renders-imagepullsecrets-and-secret-resources.yaml
+++ b/pkg/systemtemplate/testdata/imported-cluster-with-pull-secrets-renders-imagepullsecrets-and-secret-resources.yaml
@@ -171,6 +171,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -193,6 +207,8 @@ spec:
             value: "my-pull-secret-rancher-managed-pull-secret"
           - name: CATTLE_AGENT_PULL_SECRETS
             value: "my-pull-secret-rancher-managed-pull-secret"
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -202,12 +218,16 @@ spec:
             value: "true"
           image: "my-registry.example.com/rancher/rancher-agent:v2.8.0"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       imagePullSecrets:
       - name: "my-pull-secret-rancher-managed-pull-secret"
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-a15c1b308a

--- a/pkg/systemtemplate/testdata/pre-bootstrap-renders-bootstrap-deployment-with-hostnetwork.yaml
+++ b/pkg/systemtemplate/testdata/pre-bootstrap-renders-bootstrap-deployment-with-hostnetwork.yaml
@@ -165,6 +165,20 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -184,6 +198,8 @@ spec:
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-test-preboot-managed-system-upgrade-controller"
           # since we're on the host network, talk to the apiserver over localhost
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -193,12 +209,16 @@ spec:
             value: "true"
           image: "rancher/rancher-agent:v2.8.0"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       # use hostNetwork since the CNI (and coreDNS) is not up yet
       hostNetwork: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-a15c1b308a

--- a/pkg/systemtemplate/testdata/pre-bootstrap-renders-bootstrap-deployment-with-hostnetwork.yaml
+++ b/pkg/systemtemplate/testdata/pre-bootstrap-renders-bootstrap-deployment-with-hostnetwork.yaml
@@ -169,13 +169,6 @@ spec:
       - name: rancher-charts-copy
         image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -198,8 +191,6 @@ spec:
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-test-preboot-managed-system-upgrade-controller"
           # since we're on the host network, talk to the apiserver over localhost
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/pre-bootstrap-renders-bootstrap-deployment-with-hostnetwork.yaml
+++ b/pkg/systemtemplate/testdata/pre-bootstrap-renders-bootstrap-deployment-with-hostnetwork.yaml
@@ -167,7 +167,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/provisioned-cluster-name-does-not-get-system-default-pull-secrets-env-var.yaml
+++ b/pkg/systemtemplate/testdata/provisioned-cluster-name-does-not-get-system-default-pull-secrets-env-var.yaml
@@ -163,13 +163,6 @@ spec:
       - name: rancher-charts-copy
         image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -191,8 +184,6 @@ spec:
             value: cattle-credentials-a15c1b308a
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: ""
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/provisioned-cluster-name-does-not-get-system-default-pull-secrets-env-var.yaml
+++ b/pkg/systemtemplate/testdata/provisioned-cluster-name-does-not-get-system-default-pull-secrets-env-var.yaml
@@ -161,7 +161,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/provisioned-cluster-name-does-not-get-system-default-pull-secrets-env-var.yaml
+++ b/pkg/systemtemplate/testdata/provisioned-cluster-name-does-not-get-system-default-pull-secrets-env-var.yaml
@@ -159,6 +159,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -177,6 +191,8 @@ spec:
             value: cattle-credentials-a15c1b308a
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: ""
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: my-registry.example.com/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -186,10 +202,14 @@ spec:
             value: "true"
           image: "my-registry.example.com/rancher/rancher-agent:v2.8.0"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-a15c1b308a

--- a/pkg/systemtemplate/testdata/test-provisioned-import-custom-agent.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-custom-agent.yaml
@@ -159,6 +159,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: localhost:5001/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -177,6 +191,8 @@ spec:
             value: cattle-credentials-d23bc3c633
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: localhost:5001/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -186,10 +202,14 @@ spec:
             value: "true"
           image: "localhost:5001/my/agent:image"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-d23bc3c633

--- a/pkg/systemtemplate/testdata/test-provisioned-import-custom-agent.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-custom-agent.yaml
@@ -163,13 +163,6 @@ spec:
       - name: rancher-charts-copy
         image: localhost:5001/rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -191,8 +184,6 @@ spec:
             value: cattle-credentials-d23bc3c633
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: localhost:5001/rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/test-provisioned-import-custom-agent.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-custom-agent.yaml
@@ -161,7 +161,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: localhost:5001/rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-cluster-deploy-creation.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-cluster-deploy-creation.yaml
@@ -175,7 +175,7 @@ spec:
       priorityClassName: cattle-cluster-agent-priority-class
       initContainers:
       - name: rancher-charts-copy
-        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: 
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-cluster-deploy-creation.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-cluster-deploy-creation.yaml
@@ -173,6 +173,20 @@ spec:
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
       priorityClassName: cattle-cluster-agent-priority-class
+      initContainers:
+      - name: rancher-charts-copy
+        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -191,6 +205,8 @@ spec:
             value: cattle-credentials-5ec1f7e700
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -200,10 +216,14 @@ spec:
             value: "true"
           image: ""
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-5ec1f7e700

--- a/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-cluster-deploy-creation.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-cluster-deploy-creation.yaml
@@ -177,13 +177,6 @@ spec:
       - name: rancher-charts-copy
         image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -205,8 +198,6 @@ spec:
             value: cattle-credentials-5ec1f7e700
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-initial-registration.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-initial-registration.yaml
@@ -172,6 +172,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -190,6 +204,8 @@ spec:
             value: cattle-credentials-5ec1f7e700
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -199,10 +215,14 @@ spec:
             value: "true"
           image: ""
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-5ec1f7e700

--- a/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-initial-registration.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-initial-registration.yaml
@@ -174,7 +174,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: 
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-initial-registration.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import-with-scheduling-customization-initial-registration.yaml
@@ -176,13 +176,6 @@ spec:
       - name: rancher-charts-copy
         image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -204,8 +197,6 @@ spec:
             value: cattle-credentials-5ec1f7e700
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/test-provisioned-import.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import.yaml
@@ -160,6 +160,20 @@ spec:
       - effect: PreferNoSchedule
         key: key2
         operator: Exists
+      initContainers:
+      - name: rancher-charts-copy
+        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -178,6 +192,8 @@ spec:
             value: cattle-credentials-5ec1f7e700
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -187,10 +203,14 @@ spec:
             value: "true"
           image: ""
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-5ec1f7e700

--- a/pkg/systemtemplate/testdata/test-provisioned-import.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import.yaml
@@ -162,7 +162,7 @@ spec:
         operator: Exists
       initContainers:
       - name: rancher-charts-copy
-        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: 
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/test-provisioned-import.yaml
+++ b/pkg/systemtemplate/testdata/test-provisioned-import.yaml
@@ -164,13 +164,6 @@ spec:
       - name: rancher-charts-copy
         image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -192,8 +185,6 @@ spec:
             value: cattle-credentials-5ec1f7e700
           - name: CATTLE_SUC_APP_NAME_OVERRIDE
             value: "mcc-testing-rke2-managed-system-upgrade-controller"
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-annotations.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-annotations.yaml
@@ -165,13 +165,6 @@ spec:
       - name: rancher-charts-copy
         image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -195,8 +188,6 @@ spec:
             value: "mcc-testing-namesapce-opotions-managed-system-94546d"
           - name: RANCHER_NAMESPACE_OPTIONS
             value: '{"enabled":true,"annotations":{},"labels":{"baz":"quz"}}'
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-annotations.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-annotations.yaml
@@ -163,7 +163,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-annotations.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-annotations.yaml
@@ -161,6 +161,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -181,6 +195,8 @@ spec:
             value: "mcc-testing-namesapce-opotions-managed-system-94546d"
           - name: RANCHER_NAMESPACE_OPTIONS
             value: '{"enabled":true,"annotations":{},"labels":{"baz":"quz"}}'
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -190,10 +206,14 @@ spec:
             value: "true"
           image: "my/agent:image"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-5ec1f7e700

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-labels.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-labels.yaml
@@ -163,7 +163,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-labels.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-labels.yaml
@@ -161,6 +161,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -181,6 +195,8 @@ spec:
             value: "mcc-testing-namesapce-opotions-managed-system-94546d"
           - name: RANCHER_NAMESPACE_OPTIONS
             value: '{"enabled":true,"annotations":{"foo":"bar"},"labels":{}}'
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -190,10 +206,14 @@ spec:
             value: "true"
           image: "my/agent:image"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-5ec1f7e700

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-labels.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled-no-labels.yaml
@@ -165,13 +165,6 @@ spec:
       - name: rancher-charts-copy
         image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -195,8 +188,6 @@ spec:
             value: "mcc-testing-namesapce-opotions-managed-system-94546d"
           - name: RANCHER_NAMESPACE_OPTIONS
             value: '{"enabled":true,"annotations":{"foo":"bar"},"labels":{}}'
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled.yaml
@@ -165,7 +165,7 @@ spec:
         operator: "Exists"
       initContainers:
       - name: rancher-charts-copy
-        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        image: rancher/assets:charts
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: rancher-charts

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled.yaml
@@ -167,13 +167,6 @@ spec:
       - name: rancher-charts-copy
         image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
         imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          echo "Copying charts to shared volume..."
-          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
-          echo "Charts copied successfully"
         volumeMounts:
         - name: rancher-charts
           mountPath: /charts
@@ -197,8 +190,6 @@ spec:
             value: "mcc-testing-namesapce-opotions-managed-system-94546d"
           - name: RANCHER_NAMESPACE_OPTIONS
             value: '{"enabled":true,"annotations":{"foo":"bar"},"labels":{"baz":"quz"}}'
-          - name: CATTLE_CHARTS_IMAGE_DEFAULT
-            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID

--- a/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled.yaml
+++ b/pkg/systemtemplate/testdata/test-rancher-namespace-options-enabled.yaml
@@ -163,6 +163,20 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
+      initContainers:
+      - name: rancher-charts-copy
+        image: rancher/rancher-assets:v2.15-20260727T1556Z-dev
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Copying charts to shared volume..."
+          cp -r /var/lib/rancher-data/local-catalogs/v2/* /charts/
+          echo "Charts copied successfully"
+        volumeMounts:
+        - name: rancher-charts
+          mountPath: /charts
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -183,6 +197,8 @@ spec:
             value: "mcc-testing-namesapce-opotions-managed-system-94546d"
           - name: RANCHER_NAMESPACE_OPTIONS
             value: '{"enabled":true,"annotations":{"foo":"bar"},"labels":{"baz":"quz"}}'
+          - name: CATTLE_CHARTS_IMAGE_DEFAULT
+            value: rancher/rancher-assets:v2.15-20260727T1556Z-dev
           - name: CATTLE_SERVER_VERSION
             value: dev
           - name: CATTLE_INSTALL_UUID
@@ -192,10 +208,14 @@ spec:
             value: "true"
           image: "my/agent:image"
           volumeMounts:
+          - name: rancher-charts
+            mountPath: /var/lib/rancher-data/local-catalogs/v2
           - name: cattle-credentials
             mountPath: /cattle-credentials
             readOnly: true
       volumes:
+      - name: rancher-charts
+        emptyDir: {}
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-5ec1f7e700

--- a/scripts/package-env
+++ b/scripts/package-env
@@ -4,7 +4,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 ARCH=${ARCH:-"amd64"}
 CHART_REPO_DIR=build/charts
-CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.16"}
+
+build_file="$(git rev-parse --show-toplevel)/build.yaml"
+CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-$(grep -m1 'chartDefaultBranch' "$build_file" | cut -d ' ' -f2)}
 
 REGISTRY=${REGISTRY/:-""}
 IMAGE=${REGISTRY}${REPO}/rancher:${TAG}


### PR DESCRIPTION
# Overview

Adds the new rancher assets image to `build.yaml`, Rancher's chart and downstream deployment templates.

Depends on: https://github.com/rancher/rancher-assets

Related to: https://github.com/rancher/rancher/issues/56270