### PR TITLE
fix: checking out bundled charts

### DIFF
--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -19,7 +19,9 @@ func Ensure(secret *corev1.Secret, namespace, name, gitURL, commit string, insec
 	// If the repositories are rancher managed and if bundled is set
 	// don't fetch anything from upstream.
 	if IsBundled(git.Directory) && settings.SystemCatalog.Get() == "bundled" {
-		return nil
+		if err := git.reset("HEAD"); err != nil {
+			return fmt.Errorf("ensure failure: %w", err)
+		}
 	}
 
 	if err := git.clone(""); err != nil {

--- a/pkg/catalogv2/git/download_test.go
+++ b/pkg/catalogv2/git/download_test.go
@@ -3,15 +3,20 @@ package git
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
-const chartsSmallForkURL = "https://github.com/rancher/charts-small-fork"
-const mainBranch = "main"
-const lastBranch = "test-1"
+const (
+	chartsSmallForkURL = "https://github.com/rancher/charts-small-fork"
+	mainBranch         = "main"
+	lastBranch         = "test-1"
+)
 
 func TestMain(m *testing.M) {
 	// Run all the tests
@@ -179,7 +184,7 @@ func Test_Update(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.dir != "" {
-				err := os.MkdirAll(tc.dir, 0755)
+				err := os.MkdirAll(tc.dir, 0o755)
 				assert.NoError(t, err)
 			}
 
@@ -192,4 +197,179 @@ func Test_Update(t *testing.T) {
 			}
 		})
 	}
+}
+
+const (
+	bundledNamespace = ""
+	bundledName      = "fake-charts"
+	bundledURL       = "https://git.fake.io/charts"
+)
+
+// Test_Ensure_Bundled_NotCheckedOut covers Ensure against the repository as the images ship it: a
+// clone with no working tree, holding the single commit it was bundled with, and no way to reach
+// upstream.
+func Test_Ensure_Bundled_NotCheckedOut(t *testing.T) {
+	testCases := []struct {
+		test          string
+		systemCatalog string
+		commit        string
+		expectedError string
+	}{
+		{
+			test:          "#1 TestCase: Success - Bundled Commit Is Checked Out Without Reaching Upstream",
+			systemCatalog: "bundled",
+			commit:        "v1",
+		},
+		{
+			test:          "#2 TestCase: Failure - Any Other Commit Has To Be Fetched",
+			systemCatalog: "bundled",
+			commit:        "missing-commit", // outside the --depth 1 clone, so it can only come from upstream
+			expectedError: "ensure failure",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			setSystemCatalog(t, tc.systemCatalog)
+			f := newFixture(t)
+
+			err := Ensure(nil, bundledNamespace, bundledName, bundledURL, f.commits[tc.commit], false, nil)
+
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+			// either way the repository is left on the bundled commit, the reset to HEAD comes first
+			assert.Equal(t, f.commits["v1"], f.headCommit(t, f.dir), "unexpected commit checked out")
+			chart, err := os.ReadFile(filepath.Join(f.dir, "chart.yaml"))
+			require.NoError(t, err)
+			assert.Equal(t, "v1", string(chart), "the working tree should have been restored")
+		})
+	}
+}
+
+// Test_Update_Bundled_NotCheckedOut covers the same shipped state through Update.
+func Test_Update_Bundled_NotCheckedOut(t *testing.T) {
+	testCases := []struct {
+		test           string
+		systemCatalog  string
+		branch         string
+		expectedCommit string
+	}{
+		{
+			test:           "#1 TestCase: Success - Working Tree Restored Without Reaching Upstream",
+			systemCatalog:  "bundled",
+			branch:         "main",
+			expectedCommit: "v1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			setSystemCatalog(t, tc.systemCatalog)
+			f := newFixture(t)
+
+			commit, err := Update(nil, bundledNamespace, bundledName, bundledURL, tc.branch, false, nil)
+
+			require.NoError(t, err)
+			assert.Equal(t, f.commits[tc.expectedCommit], commit, "unexpected commit returned")
+			chart, err := os.ReadFile(filepath.Join(f.dir, "chart.yaml"))
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedCommit, string(chart), "the working tree should have been restored")
+		})
+	}
+}
+
+// fixture is the repository a test case runs against.
+type fixture struct {
+	dir        string
+	mockRemote string
+	commits    map[string]string
+	git        *git
+}
+
+// newWorkspace moves the test into a temporary working directory - so that the relative directories
+// RepoDir resolves to (localDir and stateDir) end up inside it instead of polluting the source
+// tree - and creates the bundled catalog directory along with the upstream repository the clone
+// comes from, holding the commits "missing-commit" and "v1". The two constructors below clone it into
+// that directory, each leaving the clone in a different state.
+//
+// Every commit writes its own name into chart.yaml, so the file tells which commit is checked out.
+func newWorkspace(t *testing.T) *fixture {
+	t.Helper()
+	root := t.TempDir()
+	work := filepath.Join(root, "work")
+	require.NoError(t, os.MkdirAll(work, 0o755))
+	t.Chdir(work)
+
+	g := createBundledGitDirectory(t)
+
+	f := &fixture{
+		dir:        g.Directory,
+		mockRemote: filepath.Join(root, "upstream"),
+		commits:    map[string]string{},
+		git:        g,
+	}
+	require.NoError(t, os.MkdirAll(f.mockRemote, 0o755))
+	require.NoError(t, f.git.gitCmd(nil, "-C", f.mockRemote, "init", "-b", "main"))
+	f.commits["missing-commit"] = f.mockCommitRemote(t, "missing-commit")
+	f.commits["v1"] = f.mockCommitRemote(t, "v1")
+
+	return f
+}
+
+func createBundledGitDirectory(t *testing.T) *git {
+	require.NoError(t, os.MkdirAll(filepath.Join(localDir, bundledNamespace, bundledName, Hash(bundledURL)), 0o755))
+	g, err := gitForRepo(nil, bundledNamespace, bundledName, bundledURL, false, nil)
+	require.NoError(t, err)
+	require.True(t, IsBundled(g.Directory))
+	require.Equal(t, filepath.Join(localDir, bundledName, Hash(bundledURL)), g.Directory)
+
+	return g
+}
+
+// newFixture clones the upstream the way package/Dockerfile does, with --no-checkout and
+// --depth 1, leaving a .git holding only "v1" and no working tree at all.
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	f := newWorkspace(t)
+
+	// a file:// URL rather than a path, git ignores --depth on a plain local clone
+	require.NoError(t, f.git.gitCmd(nil, "clone", "--no-checkout", "--depth", "1", "--branch", "main",
+		"--", "file://"+f.mockRemote, f.dir))
+	require.NoFileExists(t, filepath.Join(f.dir, "chart.yaml"), "the clone should have no working tree")
+	depth, err := f.git.gitOutput("-C", f.dir, "rev-list", "--count", "HEAD")
+	require.NoError(t, err)
+	require.Equal(t, "1", depth, `the clone should hold "v1" and nothing else`)
+	require.NoError(t, os.RemoveAll(f.mockRemote))
+
+	return f
+}
+
+// mockCommitRemote writes the commit name into chart.yaml in the mockRemote repository and commits it.
+func (f *fixture) mockCommitRemote(t *testing.T, name string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(f.mockRemote, "chart.yaml"), []byte(name), 0o644))
+	require.NoError(t, f.git.gitCmd(nil, "-C", f.mockRemote, "add", "chart.yaml"))
+	require.NoError(t, f.git.gitCmd(nil, "-C", f.mockRemote, "-c", "user.name=rancher",
+		"-c", "user.email=rancher@suse.com", "-c", "commit.gpgsign=false", "commit", "-m", name))
+	return f.headCommit(t, f.mockRemote)
+}
+
+// headCommit returns the commit checked out in dir.
+func (f *fixture) headCommit(t *testing.T, dir string) string {
+	t.Helper()
+	commit, err := f.git.gitOutput("-C", dir, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	return commit
+}
+
+func setSystemCatalog(t *testing.T, value string) {
+	t.Helper()
+	previous := settings.SystemCatalog.Get()
+	require.NoError(t, settings.SystemCatalog.Set(value))
+	t.Cleanup(func() {
+		require.NoError(t, settings.SystemCatalog.Set(previous))
+	})
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/56260

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 rancher-charts and partner-charts git directories do not get checked out in both cattle-cluster-agent Pods when system-catalog setting is set to bundled in the downstream cluster in Rancher v2.12+. This results in failure to deploy/update charts with failed to find chartName <name>:<version>: NotFound 404 errors
In v2.12 the bundled charts were changed so that the git repositories are not checked out in the rancher and rancher-agent docker images, reducing image size, per https://github.com/rancher/rancher/pull/49556

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR addresses that by checking out the charts so the git repositories are available again on `bundled` airgapped environments.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
- On a airgapped downstream cluster with the agent environment variable CATTLE_SYSTEM_CATALOG=bundle configured, check if charts are available on the UI and if the repositories are checked out  on the `cattle-cluster-agent` pods.
- On a airgapped downstream cluster **_without_** the agent environment variable CATTLE_SYSTEM_CATALOG=bundle configured, check if charts are available on the UI and if the repositories are checked out  on the `cattle-cluster-agent` pods.

### Automated Testing
* Test types added/modified:
    * Unit

The automated test is to create a temporary workspace and git repository as https://github.com/rancher/rancher/pull/49556, then validating a successful reset on said workspace.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_