### PR TITLE
[v2.13] Update SCC Operator to v0.5.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,7 +5,7 @@ turtlesVersion: 108.0.6+up0.25.6
 cspAdapterMinVersion: 108.0.0+up8.0.0
 defaultShellVersion: rancher/shell:v0.6.4
 fleetVersion: 108.0.9+up0.14.9
-defaultSccOperatorImage: rancher/scc-operator:v0.5.0-rc.3
+defaultSccOperatorImage: rancher/scc-operator:v0.5.0
 # NOTE: when updating this version, you will also need to update the hardcoded
 # k8s minor <-> image tag mapping in pkg/controllers/capr/autoscaler/fleet.go (imageTagVersions variable).
 # if adding support for a new k8s minor release (e.g. new rancher release)

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -6,7 +6,7 @@ const (
 	ChartAuditLogImage            = "rancher/mirrored-bci-micro:15.6.24.2"
 	ClusterAutoscalerChartVersion = "9.50.1"
 	CspAdapterMinVersion          = "108.0.0+up8.0.0"
-	DefaultSccOperatorImage       = "rancher/scc-operator:v0.5.0-rc.3"
+	DefaultSccOperatorImage       = "rancher/scc-operator:v0.5.0"
 	DefaultShellVersion           = "rancher/shell:v0.6.4"
 	FleetVersion                  = "108.0.9+up0.14.9"
 	ProvisioningCAPIVersion       = "108.0.0+up0.9.0"


### PR DESCRIPTION
## Summary
Update SCC Operator image to [`v0.5.0`](https://github.com/rancher/scc-operator/releases/tag/v0.5.0)

## Changes
- Updated `defaultSccOperatorImage` in `build.yaml`
- Ran `go generate ./pkg/...` to update generated files