### PR TITLE
[v2.14] Update SCC Operator to v0.5.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,5 +5,5 @@ turtlesVersion: 109.0.4+up0.26.4
 cspAdapterMinVersion: 109.0.0+up9.0.0
 defaultShellVersion: rancher/shell:v0.7.1
 fleetVersion: 109.0.5+up0.15.5
-defaultSccOperatorImage: rancher/scc-operator:v0.5.0-rc.3
+defaultSccOperatorImage: rancher/scc-operator:v0.5.0
 chartAuditLogImage: rancher/mirrored-bci-micro:15.6.24.2

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,7 +5,7 @@ package buildconfig
 const (
 	ChartAuditLogImage       = "rancher/mirrored-bci-micro:15.6.24.2"
 	CspAdapterMinVersion     = "109.0.0+up9.0.0"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.0-rc.3"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.0"
 	DefaultShellVersion      = "rancher/shell:v0.7.1"
 	FleetVersion             = "109.0.5+up0.15.5"
 	RemoteDialerProxyVersion = "109.0.4+up0.7.4"


### PR DESCRIPTION
## Summary
Update SCC Operator image to [`v0.5.0`](https://github.com/rancher/scc-operator/releases/tag/v0.5.0)

## Changes
- Updated `defaultSccOperatorImage` in `build.yaml`
- Ran `go generate ./pkg/...` to update generated files