### PR TITLE
[main] Update SCC Operator to v0.5.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,5 +5,5 @@ turtlesVersion: 110.0.0+up0.27.0
 cspAdapterMinVersion: 110.0.0+up10.0.0
 defaultShellVersion: rancher/shell:v0.8.1-rc.2
 fleetVersion: 110.0.0+up0.16.0-rc.5
-defaultSccOperatorImage: rancher/scc-operator:v0.5.0-rc.3
+defaultSccOperatorImage: rancher/scc-operator:v0.5.0
 chartAuditLogImage: rancher/mirrored-bci-micro:16.0-15.11

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,7 +5,7 @@ package buildconfig
 const (
 	ChartAuditLogImage       = "rancher/mirrored-bci-micro:16.0-15.11"
 	CspAdapterMinVersion     = "110.0.0+up10.0.0"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.0-rc.3"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.0"
 	DefaultShellVersion      = "rancher/shell:v0.8.1-rc.2"
 	FleetVersion             = "110.0.0+up0.16.0-rc.5"
 	RemoteDialerProxyVersion = "110.0.0+up0.8.0-rc.10"


### PR DESCRIPTION
## Summary
Update SCC Operator image to [`v0.5.0`](https://github.com/rancher/scc-operator/releases/tag/v0.5.0)

## Changes
- Updated `defaultSccOperatorImage` in `build.yaml`
- Ran `go generate ./pkg/...` to update generated files