### PR TITLE
Adapt to the dynamiclistener NeedsUpdate receiver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,6 +247,7 @@ require (
 	github.com/google/go-github/v67 v67.0.0 // indirect
 	github.com/google/go-github/v72 v72.0.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/renameio/v2 v2.0.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
@@ -437,3 +438,5 @@ require (
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 )
+
+replace github.com/rancher/dynamiclistener => github.com/rohitsuse/dynamiclistener v0.6.2-rc2.0.20260729013640-a29e623326d8

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oXJCETMO23COyaKGP6fHVpkpWpg=
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
+github.com/google/renameio/v2 v2.0.2 h1:qKZs+tfn+arruZZhQ7TKC/ergJunuJicWS6gLDt/dGw=
+github.com/google/renameio/v2 v2.0.2/go.mod h1:OX+G6WHHpHq3NVj7cAOleLOwJfcQ1s3uUJQCrr78SWo=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -689,6 +691,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rohitsuse/dynamiclistener v0.6.2-rc2.0.20260729013640-a29e623326d8 h1:SBRFPk0fB4ElH+HZMv64BqGTckdoH8VjXsKRWswcSSw=
+github.com/rohitsuse/dynamiclistener v0.6.2-rc2.0.20260729013640-a29e623326d8/go.mod h1:bQ4AJIuI/ghhuo8NuO2nUAEmqEXCJLWqPymOUbipzWM=
 github.com/rubenv/sql-migrate v1.8.1 h1:EPNwCvjAowHI3TnZ+4fQu3a915OpnQoPAjTXCGOy2U0=
 github.com/rubenv/sql-migrate v1.8.1/go.mod h1:BTIKBORjzyxZDS6dzoiw6eAFYJ1iNlGAtjn4LGeVjS8=
 github.com/russellhaering/goxmldsig v1.6.0 h1:8fdWXEPh2k/NZNQBPFNoVfS3JmzS4ZprY/sAOpKQLks=

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -486,7 +486,8 @@ func ensureInternalCertSANs(secrets corev1controllers.SecretController, clusterI
 	}
 
 	// If the clusterIP is already recorded in the SAN annotations, nothing to do.
-	if !factory.NeedsUpdate(0, secret, clusterIP) {
+	var tlsFactory factory.TLS
+	if !tlsFactory.NeedsUpdate(0, secret, clusterIP) {
 		return nil
 	}
 


### PR DESCRIPTION
Companion to rancher/dynamiclistener#325, where `NeedsUpdate` becomes a method on `*factory.TLS`. A zero-value `TLS` applies no filter, so the check is unchanged.

Blocked on #325 being released — the `replace` must be swapped for the released version first.