### PR TITLE
[v2.15] add localhost and rancher-internal.cattle-system.svc as default …

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -124,6 +124,15 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 		return err
 	}
 
+	// Always include localhost and the in-cluster DNS name for the
+	// rancher-internal Service as default SANs, alongside the dynamic
+	// pod/cluster IPs below. These are admin-controlled Config.SANs
+	// (short-circuited by dynamiclistener's allowDefaultSANs before
+	// FilterCN ever runs), so they're always present regardless of what
+	// the pod-IP/Service-allowlist filter would otherwise decide -- and
+	// unlike those IPs, they don't change across restarts.
+	hostIPs = append(hostIPs, "localhost", apiservice.RancherInternalServiceName+"."+namespace.System+".svc")
+
 	if clusterIP != "" {
 		hostIPs = append(hostIPs, clusterIP)
 	}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -124,14 +124,16 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 		return err
 	}
 
-	// Always include localhost and the in-cluster DNS name for the
-	// rancher-internal Service as default SANs, alongside the dynamic
-	// pod/cluster IPs below. These are admin-controlled Config.SANs
-	// (short-circuited by dynamiclistener's allowDefaultSANs before
-	// FilterCN ever runs), so they're always present regardless of what
-	// the pod-IP/Service-allowlist filter would otherwise decide -- and
-	// unlike those IPs, they don't change across restarts.
-	hostIPs = append(hostIPs, "localhost", apiservice.RancherInternalServiceName+"."+namespace.System+".svc")
+	// Always include localhost, 127.0.0.1, and the in-cluster DNS names
+	// (short and FQDN forms) for the rancher-internal Service as default
+	// SANs, alongside the dynamic pod/cluster IPs below. These are
+	// admin-controlled Config.SANs (short-circuited by dynamiclistener's
+	// allowDefaultSANs before FilterCN ever runs), so they're always
+	// present regardless of what the pod-IP/Service-allowlist filter
+	// would otherwise decide -- and unlike those IPs, they don't change
+	// across restarts.
+	internalSvcName := apiservice.RancherInternalServiceName + "." + namespace.System + ".svc"
+	hostIPs = append(hostIPs, "localhost", "127.0.0.1", internalSvcName, internalSvcName+".cluster.local")
 
 	if clusterIP != "" {
 		hostIPs = append(hostIPs, clusterIP)


### PR DESCRIPTION
…SANs

The tls-rancher-internal (:444) listener's default SANs (Config.SANs, fed by hostIPs) previously only ever contained IPs: node IPs (when the deployment uses hostPort) and the rancher-internal Service's ClusterIP. localhost and the Service's in-cluster DNS name (rancher-internal.cattle- system.svc) were both missing, even though the main :443 listener already includes localhost/127.0.0.1/rancher.cattle-system as defaults.

Add both. These are handled by dynamiclistener's allowDefaultSANs wrapper upstream of FilterCN, so they're unaffected by the CN-filtering fix in a889302df5 (still rejects any non-default hostname) and by the pod-IP/ Service-allowlist filter -- they're always present regardless of pod churn or admin configuration.

As a side effect, this also ensures the internal listener always gets a TLSListenerConfig even in the edge case where clusterIP and getHostIPs both come back empty (previously that left serverOptions.TLSListenerConfig unset entirely).

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_