### PR TITLE
Align ext.Kubeconfig store with the standard k8s API behavior

### DIFF
--- a/pkg/apis/ext.cattle.io/v1/types.go
+++ b/pkg/apis/ext.cattle.io/v1/types.go
@@ -236,6 +236,19 @@ func (t *Token) GetIsExpired() bool {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Kubeconfig allows creating v1.Config kubeconfig files for interacting with Rancher and clusters managed by Rancher.
+//
+// Name generation: the server always assigns a name with the "kubeconfig-" prefix. Any
+// metadata.name or metadata.generateName supplied by the client is silently ignored — it
+// is not rejected, but it has no effect.
+//
+// Token requirement: Create must be called by a Rancher user authenticated with a Rancher
+// token — a UI session token or a user-created API token both work; the derived kubeconfig
+// tokens are minted against the authenticating token. Requests authenticated by other
+// means (for example, a service account) return Forbidden (403).
+//
+// Value availability: status.value is populated only in the Create response. It is empty
+// on all subsequent Get or List reads. Clients must capture the value from the Create
+// response; it cannot be retrieved again.
 type Kubeconfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
@@ -255,7 +268,7 @@ type KubeconfigSpec struct {
 	// Clusters is a list of cluster names.
 	// +listType=set
 	// +optional
-	Clusters []string `json:"clusters"`
+	Clusters []string `json:"clusters,omitempty"`
 	// CurrentContext is the cluster ID default context for which will be set as the current context.
 	// If omitted, the first cluster in the list is considered for setting the current context.
 	// +optional
@@ -283,10 +296,11 @@ type KubeconfigStatus struct {
 	// +patchMergeKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
-	// Summary of the Kubeconfig status. Can be "Complete" or "Error".
+	// Summary of the Kubeconfig status. Can be "Pending", "Complete", or "Error".
 	// +optional
 	Summary string `json:"summary,omitempty"`
 	// Tokens is a list of Kubeconfig tokens.
+	// +listType=atomic
 	// +optional
 	Tokens []string `json:"tokens,omitempty"`
 	// Value contains the generated content of the kubeconfig.

--- a/pkg/ext/stores/kubeconfig/errors.go
+++ b/pkg/ext/stores/kubeconfig/errors.go
@@ -78,9 +78,10 @@ func mapBackingError(err error, resource string) error {
 	}
 }
 
-// toListOptionsErr classifies a toListOptions error: APIStatus errors pass through;
-// all other errors become InternalError.
-func toListOptionsErr(err error) error {
+// apiStatusOrInternalError returns err unchanged when it already carries an
+// APIStatus (so a deliberate 4xx keeps its code) and wraps anything else as an
+// InternalError.
+func apiStatusOrInternalError(err error) error {
 	if _, ok := err.(apierrors.APIStatus); ok {
 		return err
 	}

--- a/pkg/ext/stores/kubeconfig/errors.go
+++ b/pkg/ext/stores/kubeconfig/errors.go
@@ -1,0 +1,88 @@
+package kubeconfig
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	registry "k8s.io/apiserver/pkg/registry/generic/registry"
+)
+
+// statusDetails extracts the StatusDetails from an API error, seeing through
+// wrapping via errors.As so that wrapped status errors are handled the same as
+// direct ones.
+func statusDetails(err error) *metav1.StatusDetails {
+	var status apierrors.APIStatus
+	if !errors.As(err, &status) {
+		return nil
+	}
+	return status.Status().Details
+}
+
+// mapBackingError re-scopes an error from a backing object (ConfigMap or token)
+// to the Kubeconfig GroupResource, preserving the apierrors classification so
+// clients see 404/409/403/422 instead of an opaque 500. Every branch rebuilds
+// the error: a backing error passed through verbatim would leak the backing
+// resource's identity in its details and message. Unexpected errors are logged
+// at Error level; client-side errors (Invalid, BadRequest) at Warn level.
+func mapBackingError(err error, resource string) error {
+	switch {
+	case err == nil:
+		return nil
+	case apierrors.IsNotFound(err):
+		return apierrors.NewNotFound(gvr.GroupResource(), resource)
+	case apierrors.IsConflict(err):
+		return apierrors.NewConflict(gvr.GroupResource(), resource,
+			errors.New(registry.OptimisticLockErrorMsg))
+	case apierrors.IsAlreadyExists(err):
+		return apierrors.NewAlreadyExists(gvr.GroupResource(), resource)
+	case apierrors.IsForbidden(err):
+		rebuilt := apierrors.NewForbidden(gvr.GroupResource(), resource, errors.New("backing store denied the request"))
+		if details := statusDetails(err); details != nil && len(details.Causes) > 0 {
+			rebuilt.ErrStatus.Details.Causes = details.Causes
+		}
+		return rebuilt
+	case apierrors.IsInvalid(err):
+		logrus.Warnf("invalid backing object for kubeconfig %s: %v", resource, err)
+		var errs field.ErrorList
+		if details := statusDetails(err); details != nil {
+			for _, c := range details.Causes {
+				errs = append(errs, &field.Error{
+					Type:   field.ErrorType(c.Type),
+					Field:  c.Field,
+					Detail: c.Message,
+				})
+			}
+		}
+		return apierrors.NewInvalid(schema.GroupKind{Group: gvr.Group, Kind: Kind}, resource, errs)
+	case apierrors.IsBadRequest(err):
+		logrus.Warnf("bad request on backing object for kubeconfig %s: %v", resource, err)
+		return apierrors.NewBadRequest(fmt.Sprintf("invalid request for kubeconfig %s", resource))
+	case apierrors.IsTooManyRequests(err):
+		var retryAfter int32
+		if details := statusDetails(err); details != nil {
+			retryAfter = details.RetryAfterSeconds
+		}
+		logrus.Warnf("backing store throttled for kubeconfig %s: %v", resource, err)
+		return apierrors.NewTooManyRequests(fmt.Sprintf("too many requests for kubeconfig %s", resource), int(retryAfter))
+	case apierrors.IsServiceUnavailable(err):
+		logrus.Warnf("backing store unavailable for kubeconfig %s: %v", resource, err)
+		return apierrors.NewServiceUnavailable(fmt.Sprintf("backing store unavailable for kubeconfig %s", resource))
+	default:
+		logrus.Errorf("backing store error for kubeconfig %s: %v", resource, err)
+		return apierrors.NewInternalError(errors.New("error accessing backing object for kubeconfig " + resource))
+	}
+}
+
+// toListOptionsErr classifies a toListOptions error: APIStatus errors pass through;
+// all other errors become InternalError.
+func toListOptionsErr(err error) error {
+	if _, ok := err.(apierrors.APIStatus); ok {
+		return err
+	}
+	return apierrors.NewInternalError(err)
+}

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -248,7 +248,7 @@ func (s *Store) Create(
 ) (runtime.Object, error) {
 	userInfo, _, isRancherUser, err := s.userFrom(ctx, "create")
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %v", err))
 	}
 
 	if !isRancherUser {
@@ -264,7 +264,7 @@ func (s *Store) Create(
 
 	authToken, err := s.tokenStore.Fetch(authTokenID)
 	if err != nil {
-		return nil, apierrors.NewForbidden(gvr.GroupResource(), "", fmt.Errorf("error getting request token %s: %w", authTokenID, err))
+		return nil, apierrors.NewForbidden(gvr.GroupResource(), "", fmt.Errorf("error getting request token %s: %v", authTokenID, err))
 	}
 
 	kubeconfig, ok := obj.(*ext.Kubeconfig)
@@ -291,7 +291,7 @@ func (s *Store) Create(
 
 	defaultTTL, err := s.getDefaultTTL()
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting default token TTL: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting default token TTL: %v", err))
 	}
 	defaultTTLSeconds := *defaultTTL / 1000
 
@@ -330,7 +330,7 @@ func (s *Store) Create(
 
 	localCluster, err := s.clusterCache.Get("local")
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting local cluster: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting local cluster: %v", err))
 	}
 
 	if len(kubeconfig.Spec.Clusters) > 0 {
@@ -338,7 +338,7 @@ func (s *Store) Create(
 			// The first id in the spec.clusters "*" means all clusters.
 			clusters, err = s.clusterCache.List(labels.Everything())
 			if err != nil {
-				return nil, apierrors.NewInternalError(fmt.Errorf("error listing clusters: %w", err))
+				return nil, apierrors.NewInternalError(fmt.Errorf("error listing clusters: %v", err))
 			}
 		} else {
 			// Individually listed clusters.
@@ -353,7 +353,7 @@ func (s *Store) Create(
 					if apierrors.IsNotFound(err) {
 						return nil, apierrors.NewBadRequest(fmt.Sprintf("cluster %s not found", clusterID))
 					}
-					return nil, apierrors.NewInternalError(fmt.Errorf("error getting cluster %s: %w", clusterID, err))
+					return nil, apierrors.NewInternalError(fmt.Errorf("error getting cluster %s: %v", clusterID, err))
 				}
 
 				clusters = append(clusters, cluster)
@@ -377,7 +377,7 @@ func (s *Store) Create(
 			Name:            clusters[i].Name,
 		})
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("error checking if user %s has access to cluster %s: %w", userInfo.GetName(), clusters[i].Name, err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("error checking if user %s has access to cluster %s: %v", userInfo.GetName(), clusters[i].Name, err))
 		}
 
 		if decision != authorizer.DecisionAllow {
@@ -430,7 +430,7 @@ func (s *Store) Create(
 
 	configMap, err := s.toConfigMap(kubeconfigToStore)
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error converting kubeconfig to configmap: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error converting kubeconfig to configmap: %v", err))
 	}
 	configMap.GenerateName = namePrefix
 
@@ -440,7 +440,7 @@ func (s *Store) Create(
 		configMap.Name = kubeConfigID
 	} else {
 		if err = s.ensureNamespace(); err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("error ensuring namespace %s: %w", namespace, err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("error ensuring namespace %s: %v", namespace, err))
 		}
 
 		configMap, err = s.configMapClient.Create(configMap)
@@ -452,7 +452,7 @@ func (s *Store) Create(
 
 	kubeconfigToStore, err = s.fromConfigMap(configMap)
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", kubeConfigID, err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %v", kubeConfigID, err))
 	}
 
 	var (
@@ -490,13 +490,13 @@ func (s *Store) Create(
 					LastTransitionTime: metav1.NewTime(time.Now()),
 				})
 
-				return apierrors.NewInternalError(fmt.Errorf("error creating kubeconfig token: %w", err))
+				return apierrors.NewInternalError(fmt.Errorf("error creating kubeconfig token: %v", err))
 			}
 
 			sharedTokenKey = sharedToken.Status.BearerToken
 			ownerRef, err := s.secretOwnerRef(sharedToken.Name)
 			if err != nil {
-				return apierrors.NewInternalError(fmt.Errorf("error getting owner reference for shared token: %w", err))
+				return apierrors.NewInternalError(fmt.Errorf("error getting owner reference for shared token: %v", err))
 			}
 			ownerRefs = append(ownerRefs, ownerRef)
 			tokenIDs = append(tokenIDs, sharedToken.Name)
@@ -581,13 +581,13 @@ func (s *Store) Create(
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					})
 
-					return apierrors.NewInternalError(fmt.Errorf("error creating kubeconfig token for cluster %s: %w", cluster.Name, err))
+					return apierrors.NewInternalError(fmt.Errorf("error creating kubeconfig token for cluster %s: %v", cluster.Name, err))
 				}
 
 				tokenKey = clusterToken.Status.BearerToken
 				ownerRef, err := s.secretOwnerRef(clusterToken.Name)
 				if err != nil {
-					return apierrors.NewInternalError(fmt.Errorf("error getting owner reference for token: %w", err))
+					return apierrors.NewInternalError(fmt.Errorf("error getting owner reference for token: %v", err))
 				}
 				ownerRefs = append(ownerRefs, ownerRef)
 				tokenIDs = append(tokenIDs, clusterToken.Name)
@@ -646,7 +646,7 @@ func (s *Store) Create(
 						LastTransitionTime: metav1.NewTime(time.Now()),
 					})
 
-					return apierrors.NewInternalError(fmt.Errorf("error listing nodes for cluster %s: %w", cluster.Name, err))
+					return apierrors.NewInternalError(fmt.Errorf("error listing nodes for cluster %s: %v", cluster.Name, err))
 				}
 
 				clusterCerts := kconfig.FormatCertString(cluster.Status.CACert) // Already base64 encoded.
@@ -686,7 +686,7 @@ func (s *Store) Create(
 				LastTransitionTime: metav1.NewTime(time.Now()),
 			}}
 
-			return apierrors.NewInternalError(fmt.Errorf("error generating kubeconfig content: %w", err))
+			return apierrors.NewInternalError(fmt.Errorf("error generating kubeconfig content: %v", err))
 		}
 
 		return nil
@@ -716,7 +716,7 @@ func (s *Store) Create(
 		}
 	} else {
 		if err == nil {
-			err = apierrors.NewInternalError(fmt.Errorf("error converting kubeconfig %s to configmap: %w", kubeConfigID, convertErr))
+			err = apierrors.NewInternalError(fmt.Errorf("error converting kubeconfig %s to configmap: %v", kubeConfigID, convertErr))
 		} // else preserve the original error.
 	}
 
@@ -726,7 +726,7 @@ func (s *Store) Create(
 
 	kubeconfig, err = s.fromConfigMap(configMap)
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig after saving: %w", kubeConfigID, err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig after saving: %v", kubeConfigID, err))
 	}
 
 	// Note: Status.Value contains tokens' secret keys and mustn't be persisted.
@@ -958,7 +958,7 @@ func (s *Store) Get(
 ) (runtime.Object, error) {
 	userInfo, isAdmin, _, err := s.userFrom(ctx, "get")
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %v", err))
 	}
 
 	var emptyGetOptions metav1.GetOptions
@@ -976,7 +976,7 @@ func (s *Store) Get(
 
 	kubeconfig, err := s.fromConfigMap(configMap)
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", name, err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %v", name, err))
 	}
 
 	return kubeconfig, nil
@@ -1014,7 +1014,7 @@ func toListOptions(options *metainternalversion.ListOptions, userInfo k8suser.In
 	if !isAdmin {
 		userReq, err := labels.NewRequirement(UserIDLabel, selection.Equals, []string{userInfo.GetName()})
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("user ID %q is not a valid label value: %w", userInfo.GetName(), err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("user ID %q is not a valid label value: %v", userInfo.GetName(), err))
 		}
 		reqs = append(reqs, *userReq)
 	}
@@ -1031,12 +1031,12 @@ func (s *Store) List(
 ) (runtime.Object, error) {
 	userInfo, isAdmin, _, err := s.userFrom(ctx, "list")
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %v", err))
 	}
 
 	listOptions, err := toListOptions(options, userInfo, isAdmin)
 	if err != nil {
-		return nil, toListOptionsErr(err)
+		return nil, apiStatusOrInternalError(err)
 	}
 
 	configMapList, err := s.configMapClient.List(namespace, *listOptions)
@@ -1044,7 +1044,7 @@ func (s *Store) List(
 		if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) { // Continue token expired.
 			return nil, apierrors.NewResourceExpired(err.Error())
 		}
-		return nil, apierrors.NewInternalError(fmt.Errorf("error listing configmaps for kubeconfigs: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error listing configmaps for kubeconfigs: %v", err))
 	}
 
 	list := &ext.KubeconfigList{
@@ -1058,7 +1058,7 @@ func (s *Store) List(
 	for _, configMap := range configMapList.Items {
 		kubeconfig, err := s.fromConfigMap(&configMap)
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", configMap.Name, err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %v", configMap.Name, err))
 		}
 
 		list.Items = append(list.Items, *kubeconfig)
@@ -1074,12 +1074,12 @@ func (s *Store) Watch(
 ) (watch.Interface, error) {
 	userInfo, isAdmin, _, err := s.userFrom(ctx, "watch")
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %v", err))
 	}
 
 	listOptions, err := toListOptions(options, userInfo, isAdmin)
 	if err != nil {
-		return nil, toListOptionsErr(err)
+		return nil, apiStatusOrInternalError(err)
 	}
 
 	if !features.FeatureGates().Enabled(features.WatchListClient) {
@@ -1090,7 +1090,7 @@ func (s *Store) Watch(
 	configMapWatch, err := s.configMapClient.Watch(namespace, *listOptions)
 	if err != nil {
 		logrus.Errorf("kubeconfig: watch: error starting watch: %s", err)
-		return nil, apierrors.NewInternalError(fmt.Errorf("kubeconfig: watch: error starting watch: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("kubeconfig: watch: error starting watch: %v", err))
 	}
 
 	kubeconfigWatch := &watcher{
@@ -1304,12 +1304,12 @@ func (s *Store) DeleteCollection(
 ) (runtime.Object, error) {
 	userInfo, isAdmin, _, err := s.userFrom(ctx, "delete")
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting user info: %v", err))
 	}
 
 	lOptions, err := toListOptions(listOptions, userInfo, isAdmin)
 	if err != nil {
-		return nil, toListOptionsErr(err)
+		return nil, apiStatusOrInternalError(err)
 	}
 
 	configMapList, err := s.configMapClient.List(namespace, *lOptions)
@@ -1317,7 +1317,7 @@ func (s *Store) DeleteCollection(
 		if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) { // Continue token expired.
 			return nil, apierrors.NewResourceExpired(err.Error())
 		}
-		return nil, apierrors.NewInternalError(fmt.Errorf("error listing configmaps for kubeconfigs: %w", err))
+		return nil, apierrors.NewInternalError(fmt.Errorf("error listing configmaps for kubeconfigs: %v", err))
 	}
 
 	list := &ext.KubeconfigList{
@@ -1336,7 +1336,7 @@ func (s *Store) DeleteCollection(
 		// so it aborts the whole collection and is surfaced verbatim.
 		kubeconfig, err := s.fromConfigMap(&configMap)
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", configMap.Name, err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %v", configMap.Name, err))
 		}
 		if deleteValidation != nil {
 			if err := deleteValidation(ctx, kubeconfig); err != nil {
@@ -1374,7 +1374,7 @@ func (s *Store) Delete(
 ) (runtime.Object, bool, error) {
 	userInfo, isAdmin, _, err := s.userFrom(ctx, "delete")
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting user info: %w", err))
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting user info: %v", err))
 	}
 
 	useCache := false
@@ -1391,7 +1391,7 @@ func (s *Store) Delete(
 
 	kubeconfig, err := s.fromConfigMap(configMap)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", configMap.Name, err))
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %v", configMap.Name, err))
 	}
 	return s.delete(ctx, kubeconfig, configMap, deleteValidation, options)
 }
@@ -1523,7 +1523,7 @@ func (s *Store) Update(
 ) (runtime.Object, bool, error) {
 	userInfo, isAdmin, _, err := s.userFrom(ctx, "update")
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting user info: %w", err))
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting user info: %v", err))
 	}
 
 	useCache := false
@@ -1540,12 +1540,12 @@ func (s *Store) Update(
 
 	oldKubeconfig, err := s.fromConfigMap(oldConfigMap)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", name, err))
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %v", name, err))
 	}
 
 	newObj, err := objInfo.UpdatedObject(ctx, oldKubeconfig)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting updated object for kubeconfig %s: %w", name, err))
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting updated object for kubeconfig %s: %v", name, err))
 	}
 
 	newKubeconfig, ok := newObj.(*ext.Kubeconfig)
@@ -1609,7 +1609,7 @@ func (s *Store) Update(
 	// Note: [Store.toConfigMap] takes care of enforcing [KindLabel] label and [UIDAnnotation] annotation.
 	newConfigMap, err := s.toConfigMap(newKubeconfig)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting kubeconfig %s to configmap: %w", name, err))
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting kubeconfig %s to configmap: %v", name, err))
 	}
 
 	dryRun := options != nil && len(options.DryRun) > 0
@@ -1631,7 +1631,7 @@ func (s *Store) Update(
 
 	newKubeconfig, err = s.fromConfigMap(newConfigMap)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", name, err))
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %v", name, err))
 	}
 
 	return newKubeconfig, false, nil

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -290,7 +291,7 @@ func (s *Store) Create(
 
 	defaultTTL, err := s.getDefaultTTL()
 	if err != nil {
-		return nil, fmt.Errorf("error getting default token TTL: %w", err)
+		return nil, apierrors.NewInternalError(fmt.Errorf("error getting default token TTL: %w", err))
 	}
 	defaultTTLSeconds := *defaultTTL / 1000
 
@@ -1118,12 +1119,25 @@ func (s *Store) Watch(
 						continue
 					}
 
-					obj = &ext.Kubeconfig{
-						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: configMap.ResourceVersion,
-							Annotations:     configMap.Annotations,
-						},
+					// Rebuild the bookmark's metadata as an allowlist instead of
+					// copying the backing ConfigMap's annotations: passing them
+					// through leaked internal bookkeeping (the cattle.io/uid
+					// annotation) that every other event type strips, and a
+					// copy-and-delete approach would silently leak any internal
+					// annotation added later. Only two things are justified on a
+					// bookmark: the resourceVersion resume point, and the
+					// k8s.io/initial-events-end marker that tells a WatchList
+					// (sendInitialEvents) client the initial-state replay is
+					// complete — dropping the marker would leave such a client
+					// waiting forever.
+					anns := map[string]string{}
+					if v, ok := configMap.Annotations["k8s.io/initial-events-end"]; ok {
+						anns["k8s.io/initial-events-end"] = v
 					}
+					obj = &ext.Kubeconfig{ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: configMap.ResourceVersion,
+						Annotations:     anns,
+					}}
 				case watch.Error:
 					// Pass through the errors e.g. 410 Expired.
 					obj = event.Object
@@ -1139,7 +1153,8 @@ func (s *Store) Watch(
 						logrus.Errorf("kubeconfig: watch: error converting configmap %s to kubeconfig: %s", configMap.Name, err)
 						continue
 					}
-				default: // watch.Error
+				default:
+					// watch.EventType is an open string type; unknown types pass through untranslated.
 					obj = event.Object
 				}
 
@@ -1578,12 +1593,18 @@ func (s *Store) Update(
 	newKubeconfig.Labels[UserIDLabel] = oldKubeconfig.Labels[UserIDLabel]
 	newKubeconfig.Status = oldKubeconfig.Status // Carry over the status.
 
-	newKubeconfig.Status.Conditions = append(newKubeconfig.Status.Conditions, metav1.Condition{
-		Type:               UpdatedCond,
-		Status:             metav1.ConditionTrue,
-		Reason:             UpdatedCond,
-		LastTransitionTime: metav1.NewTime(time.Now()),
+	meta.SetStatusCondition(&newKubeconfig.Status.Conditions, metav1.Condition{
+		Type:   UpdatedCond,
+		Status: metav1.ConditionTrue,
+		Reason: UpdatedCond,
 	})
+	// Updated records the time of the latest modification, not a status transition.
+	// Advance LastTransitionTime unconditionally so clients can use it as a
+	// last-modified timestamp — restoring the observable behavior from before the
+	// single-condition upsert was introduced.
+	if c := meta.FindStatusCondition(newKubeconfig.Status.Conditions, UpdatedCond); c != nil {
+		c.LastTransitionTime = metav1.NewTime(time.Now())
+	}
 
 	// Note: [Store.toConfigMap] takes care of enforcing [KindLabel] label and [UIDAnnotation] annotation.
 	newConfigMap, err := s.toConfigMap(newKubeconfig)

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -43,6 +44,7 @@ import (
 	k8suser "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/features"
@@ -93,6 +95,10 @@ const (
 )
 
 var gvr = ext.SchemeGroupVersion.WithResource(ext.KubeconfigResourceName)
+
+// kindRequirement filters ConfigMaps to those that back Kubeconfig resources.
+// It is built once at init time rather than per request.
+var kindRequirement = mustRequirement(KindLabel, selection.Equals, KindLabelValue)
 
 // tokenFetcher abstracts the ext token store operations needed by the kubeconfig store.
 type tokenFetcher interface {
@@ -199,6 +205,12 @@ func (s *Store) userFrom(ctx context.Context, verb string) (k8suser.Info, bool, 
 		return nil, false, false, fmt.Errorf("missing user info")
 	}
 
+	// Resource: "*" is a deliberate superuser heuristic, matching the pattern
+	// used by the sibling token and useractivity stores. Scoping this check to
+	// ext.KubeconfigResourceName would make every default Rancher user an admin
+	// because the built-in User/User Base GlobalRoles grant all verbs on
+	// ext.cattle.io/kubeconfigs, which would bypass per-user scoping in
+	// Get/List/Watch/Delete/Update.
 	decision, _, err := s.authorizer.Authorize(ctx, &authorizer.AttributesRecord{
 		User:            userInfo,
 		Verb:            verb,
@@ -432,7 +444,7 @@ func (s *Store) Create(
 
 		configMap, err = s.configMapClient.Create(configMap)
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("error creating configmap for kubeconfig: %w", err))
+			return nil, mapBackingError(err, namePrefix)
 		}
 		kubeConfigID = configMap.Name
 	}
@@ -697,7 +709,7 @@ func (s *Store) Create(
 			configMap, updateErr = s.configMapClient.Update(configMap)
 			if updateErr != nil {
 				if err == nil {
-					err = apierrors.NewInternalError(fmt.Errorf("error updating configmap for kubeconfig %s: %w", kubeConfigID, updateErr))
+					err = mapBackingError(updateErr, kubeConfigID)
 				} // else preserve the original error.
 			}
 		}
@@ -974,27 +986,39 @@ func (s *Store) NewList() runtime.Object {
 	return &ext.KubeconfigList{}
 }
 
+func mustRequirement(key string, op selection.Operator, val string) labels.Requirement {
+	r, err := labels.NewRequirement(key, op, []string{val})
+	if err != nil {
+		panic(fmt.Sprintf("kubeconfig: invalid label requirement %s %s %s: %v", key, op, val, err))
+	}
+	return *r
+}
+
 func toListOptions(options *metainternalversion.ListOptions, userInfo k8suser.Info, isAdmin bool) (*metav1.ListOptions, error) {
 	listOptions, err := extapi.ConvertListOptions(options)
 	if err != nil {
 		return nil, fmt.Errorf("error converting list options: %w", err)
 	}
 
-	labelSet, err := labels.ConvertSelectorToLabelsMap(listOptions.LabelSelector)
-	if err != nil {
-		return nil, fmt.Errorf("error converting label selector: %w", err)
+	selector := labels.Everything()
+	if listOptions.LabelSelector != "" {
+		parsed, err := labels.Parse(listOptions.LabelSelector)
+		if err != nil {
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid label selector: %s", err))
+		}
+		selector = parsed
 	}
 
-	configMapLabels := labels.Set{
-		KindLabel: KindLabelValue,
-	}
-
+	reqs := []labels.Requirement{kindRequirement}
 	if !isAdmin {
-		configMapLabels[UserIDLabel] = userInfo.GetName()
+		userReq, err := labels.NewRequirement(UserIDLabel, selection.Equals, []string{userInfo.GetName()})
+		if err != nil {
+			return nil, apierrors.NewInternalError(fmt.Errorf("user ID %q is not a valid label value: %w", userInfo.GetName(), err))
+		}
+		reqs = append(reqs, *userReq)
 	}
-
-	labelSet = labels.Merge(labelSet, configMapLabels)
-	listOptions.LabelSelector = labelSet.AsSelector().String()
+	selector = selector.Add(reqs...)
+	listOptions.LabelSelector = selector.String()
 
 	return listOptions, nil
 }
@@ -1011,7 +1035,7 @@ func (s *Store) List(
 
 	listOptions, err := toListOptions(options, userInfo, isAdmin)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, toListOptionsErr(err)
 	}
 
 	configMapList, err := s.configMapClient.List(namespace, *listOptions)
@@ -1054,7 +1078,7 @@ func (s *Store) Watch(
 
 	listOptions, err := toListOptions(options, userInfo, isAdmin)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, toListOptionsErr(err)
 	}
 
 	if !features.FeatureGates().Enabled(features.WatchListClient) {
@@ -1069,7 +1093,8 @@ func (s *Store) Watch(
 	}
 
 	kubeconfigWatch := &watcher{
-		ch: make(chan watch.Event, 100),
+		ch:   make(chan watch.Event, 100),
+		done: make(chan struct{}),
 	}
 
 	go func() {
@@ -1133,22 +1158,26 @@ func (s *Store) Watch(
 
 // watcher implements [watch.Interface].
 type watcher struct {
-	mu     sync.RWMutex
-	closed bool
-	ch     chan watch.Event
+	mu       sync.RWMutex
+	closed   bool
+	ch       chan watch.Event
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // Stop tells the producer that the consumer is done watching, so the
 // producer should stop sending events and close the result channel.
 func (w *watcher) Stop() {
+	// Close done BEFORE taking the write lock: a blocked add holds RLock
+	// until done closes, so taking Lock first would deadlock — the exact
+	// bug this change fixes.
+	w.stopOnce.Do(func() { close(w.done) })
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
-
-	// no operation if called multiple times.
 	if w.closed {
 		return
 	}
-
 	close(w.ch)
 	w.closed = true
 }
@@ -1162,13 +1191,15 @@ func (w *watcher) ResultChan() <-chan watch.Event {
 func (w *watcher) add(event watch.Event) bool {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-
 	if w.closed {
 		return false
 	}
-
-	w.ch <- event
-	return true
+	select {
+	case w.ch <- event:
+		return true
+	case <-w.done:
+		return false
+	}
 }
 
 // translateTimestampSince returns the elapsed time since timestamp in
@@ -1263,7 +1294,7 @@ func (s *Store) DeleteCollection(
 
 	lOptions, err := toListOptions(listOptions, userInfo, isAdmin)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, toListOptionsErr(err)
 	}
 
 	configMapList, err := s.configMapClient.List(namespace, *lOptions)
@@ -1284,17 +1315,36 @@ func (s *Store) DeleteCollection(
 	}
 
 	for _, configMap := range configMapList.Items {
-		obj, _, err := s.delete(ctx, &configMap, deleteValidation, options)
+		// Convert to Kubeconfig first and run deleteValidation against it directly.
+		// Any error from deleteValidation (including a NotFound-classified one) is
+		// provably from the caller's validation logic, not from a concurrent delete,
+		// so it aborts the whole collection and is surfaced verbatim.
+		kubeconfig, err := s.fromConfigMap(&configMap)
 		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("error deleting kubeconfig %s: %w", configMap.Name, err))
+			return nil, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", configMap.Name, err))
 		}
-
-		kubeconfig, ok := obj.(*ext.Kubeconfig)
-		if !ok { // Sanity check.
+		if deleteValidation != nil {
+			if err := deleteValidation(ctx, kubeconfig); err != nil {
+				if _, ok := err.(apierrors.APIStatus); ok {
+					return nil, err
+				}
+				return nil, apierrors.NewBadRequest(fmt.Sprintf("delete validation for kubeconfig %s failed: %s", configMap.Name, err))
+			}
+		}
+		// Pass nil deleteValidation: validation already ran above, so an IsNotFound
+		// from s.delete is provably the backing concurrent-delete race.
+		obj, _, err := s.delete(ctx, kubeconfig, &configMap, nil, options)
+		if apierrors.IsNotFound(err) {
+			continue // backing ConfigMap was concurrently deleted — skip
+		}
+		if err != nil {
+			return nil, err // already Kubeconfig-scoped via mapBackingError
+		}
+		kc, ok := obj.(*ext.Kubeconfig)
+		if !ok {
 			return nil, apierrors.NewInternalError(fmt.Errorf("expected kubeconfig object, got %T", obj))
 		}
-
-		list.Items = append(list.Items, *kubeconfig)
+		list.Items = append(list.Items, *kc)
 	}
 
 	return list, nil
@@ -1324,21 +1374,64 @@ func (s *Store) Delete(
 		return nil, false, apierrors.NewNotFound(gvr.GroupResource(), name)
 	}
 
-	return s.delete(ctx, configMap, deleteValidation, options)
-}
-
-// delete a kubeconfig's configmap and associated tokens.
-func (s *Store) delete(
-	ctx context.Context,
-	configMap *corev1.ConfigMap,
-	deleteValidation rest.ValidateObjectFunc,
-	options *metav1.DeleteOptions,
-) (runtime.Object, bool, error) {
 	kubeconfig, err := s.fromConfigMap(configMap)
 	if err != nil {
 		return nil, false, apierrors.NewInternalError(fmt.Errorf("error converting configmap %s to kubeconfig: %w", configMap.Name, err))
 	}
+	return s.delete(ctx, kubeconfig, configMap, deleteValidation, options)
+}
 
+// checkPreconditions verifies the caller's UID and ResourceVersion preconditions
+// against the stored values. It returns a Conflict if a check fails and nil when
+// all checks pass or preconditions is nil.
+//
+// The UID precondition passes if the submitted UID equals ANY of the accepted
+// UIDs: callers may pass both the Kubeconfig's virtual UID and the backing
+// ConfigMap's real UID so a client holding either identity can enforce uniqueness.
+//
+// Note: the default apiserver UpdatedObjectInfo only ever populates the UID
+// precondition; the ResourceVersion branch is defensive for non-default
+// rest.UpdatedObjectInfo implementations, but kept for the standard
+// Preconditions contract.
+func checkPreconditions(preconditions *metav1.Preconditions, name, rv string, uids ...types.UID) error {
+	if preconditions == nil {
+		return nil
+	}
+	if preconditions.UID != nil {
+		var matched bool
+		for _, uid := range uids {
+			if *preconditions.UID == uid {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			var recordUID types.UID
+			if len(uids) > 0 {
+				recordUID = uids[0]
+			}
+			return apierrors.NewConflict(gvr.GroupResource(), name,
+				fmt.Errorf("the UID in the precondition (%s) does not match the UID in record (%s)",
+					*preconditions.UID, recordUID))
+		}
+	}
+	if preconditions.ResourceVersion != nil && *preconditions.ResourceVersion != rv {
+		return apierrors.NewConflict(gvr.GroupResource(), name,
+			fmt.Errorf("the ResourceVersion in the precondition (%s) does not match the ResourceVersion in record (%s)",
+				*preconditions.ResourceVersion, rv))
+	}
+	return nil
+}
+
+// delete a kubeconfig's configmap and associated tokens.
+// kubeconfig must be the already-converted form of configMap (callers convert once).
+func (s *Store) delete(
+	ctx context.Context,
+	kubeconfig *ext.Kubeconfig,
+	configMap *corev1.ConfigMap,
+	deleteValidation rest.ValidateObjectFunc,
+	options *metav1.DeleteOptions,
+) (runtime.Object, bool, error) {
 	if deleteValidation != nil {
 		err := deleteValidation(ctx, kubeconfig)
 		if err != nil {
@@ -1349,53 +1442,56 @@ func (s *Store) delete(
 		}
 	}
 
-	if options.Preconditions != nil {
-		// If the UID precondition matches the kubeconfig's UID, we need
-		// to replace it with the corresponding configmap's UID.
-		if options.Preconditions.UID != nil && *options.Preconditions.UID == kubeconfig.UID {
-			options.Preconditions.UID = &configMap.UID
-		}
+	// Enforce the client's preconditions before any destructive step, so a
+	// failing precondition leaves both the tokens and the ConfigMap untouched.
+	// The backing ConfigMap delete below re-enforces them authoritatively; the
+	// window between the token loop and that delete is the inherent
+	// non-transactional gap of this multi-object design. On this gap: if the
+	// backing delete returns a Conflict after tokens have been deleted, the
+	// caller receives a Conflict that explicitly names this state — signaling
+	// that the delete is safe to retry (the tokens are gone; only the ConfigMap
+	// record remains to be removed).
+	if err := checkPreconditions(options.Preconditions, configMap.Name, configMap.ResourceVersion, kubeconfig.UID, configMap.UID); err != nil {
+		return nil, false, err
+	}
+	if options.Preconditions != nil && options.Preconditions.UID != nil {
+		// Rewrite to the ConfigMap UID so the backing delete can enforce
+		// it — on a copy, so a caller retrying with the same DeleteOptions
+		// still submits its original precondition.
+		preconditions := *options.Preconditions
+		preconditions.UID = &configMap.UID
+		optionsCopy := *options
+		optionsCopy.Preconditions = &preconditions
+		options = &optionsCopy
 	}
 
-	err = s.configMapClient.Delete(namespace, configMap.Name, options)
-	switch {
-	case err == nil:
-	case apierrors.IsNotFound(err):
-		return nil, false, apierrors.NewNotFound(gvr.GroupResource(), configMap.Name)
-	case apierrors.IsConflict(err):
-		// Massage the err details to refer to Kubeconfigs instead of ConfigMaps.
-		var errMessage string
-		conflictErr, ok := err.(*apierrors.StatusError)
-		if ok {
-			_, errMessage, ok = strings.Cut(conflictErr.ErrStatus.Message, `ConfigMap "`+configMap.Name+`": `)
-			if !ok {
-				errMessage = ""
-			}
-		}
-		return nil, false, apierrors.NewConflict(gvr.GroupResource(), configMap.Name, errors.New(errMessage))
-	default:
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting configmap for kubeconfig %s: %w", configMap.Name, err))
-	}
-
-	// Token IDs are tracked in status.tokens. Delete each token, falling back
-	// to the v3 token client for pre-migration kubeconfigs that reference v3 tokens.
+	// Delete tokens first so the ConfigMap (which holds the token ID list)
+	// survives a partial failure and the whole delete stays retryable.
+	tokensDeleteAttempted := len(options.DryRun) == 0 && len(kubeconfig.Status.Tokens) > 0
 	for _, tokenName := range kubeconfig.Status.Tokens {
 		delOptions := &metav1.DeleteOptions{
 			GracePeriodSeconds: options.GracePeriodSeconds,
 			PropagationPolicy:  options.PropagationPolicy,
-			DryRun:             options.DryRun, // Pass through the dry run flag instead of handling it explicitly.
+			DryRun:             options.DryRun,
 		}
-
 		err := s.tokenStore.Delete(tokenName, delOptions)
 		if apierrors.IsNotFound(err) {
-			// Not an ext token — try v3 token for backward compatibility.
 			err = s.v3Tokens.Delete(tokenName, delOptions)
 		}
 		if err != nil && !apierrors.IsNotFound(err) {
-			return nil, false, apierrors.NewInternalError(fmt.Errorf("error deleting token %s for kubeconfig %s: %w", tokenName, configMap.Name, err))
+			return nil, false, mapBackingError(err, configMap.Name)
 		}
 	}
 
+	err := s.configMapClient.Delete(namespace, configMap.Name, options)
+	if err != nil {
+		mapped := mapBackingError(err, configMap.Name)
+		if apierrors.IsConflict(mapped) && tokensDeleteAttempted {
+			return nil, false, apierrors.NewConflict(gvr.GroupResource(), configMap.Name,
+				fmt.Errorf("%s; this attempt has already revoked the kubeconfig's tokens and the delete should be retried to remove the record", genericregistry.OptimisticLockErrorMsg))
+		}
+		return nil, false, mapped
+	}
 	return kubeconfig, true, nil
 }
 
@@ -1440,6 +1536,15 @@ func (s *Store) Update(
 	newKubeconfig, ok := newObj.(*ext.Kubeconfig)
 	if !ok {
 		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("invalid object type %T", newObj))
+	}
+
+	// Enforce a UID or ResourceVersion precondition supplied by the caller via
+	// objInfo.Preconditions(). This mirrors the Delete path and must run before
+	// any write so dry-run also predicts the conflict outcome.
+	if prec := objInfo.Preconditions(); prec != nil {
+		if err := checkPreconditions(prec, name, oldKubeconfig.ResourceVersion, oldKubeconfig.UID, oldConfigMap.UID); err != nil {
+			return nil, false, err
+		}
 	}
 
 	if updateValidation != nil {
@@ -1487,10 +1592,19 @@ func (s *Store) Update(
 	}
 
 	dryRun := options != nil && len(options.DryRun) > 0
+
+	// Enforce the client's resourceVersion precondition even on dry-run, so a
+	// preview predicts the real conflict outcome.
+	if newKubeconfig.ResourceVersion != "" &&
+		newKubeconfig.ResourceVersion != oldKubeconfig.ResourceVersion {
+		return nil, false, apierrors.NewConflict(gvr.GroupResource(), name,
+			errors.New(genericregistry.OptimisticLockErrorMsg))
+	}
+
 	if !dryRun {
 		newConfigMap, err = s.configMapClient.Update(newConfigMap)
 		if err != nil {
-			return nil, false, apierrors.NewInternalError(fmt.Errorf("error updating configmap for kubeconfig %s: %w", name, err))
+			return nil, false, mapBackingError(err, name)
 		}
 	}
 

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -36,7 +37,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/watch"
 	k8suser "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -265,6 +270,63 @@ func TestStoreUserFrom(t *testing.T) {
 			Name: "error",
 		}), "get")
 		require.Error(t, err)
+	})
+}
+
+func TestUserFromAdminScoping(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	userCache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+	userCache.EXPECT().Get(gomock.Any()).Return(nil, apierrors.NewNotFound(gvr.GroupResource(), "")).AnyTimes()
+
+	ctxSomeUser := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+		Name: userID,
+	})
+
+	t.Run("star resource grants admin", func(t *testing.T) {
+		t.Parallel()
+
+		starAuthorizer := authorizer.AuthorizerFunc(func(_ context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			if a.GetResource() == "*" {
+				return authorizer.DecisionAllow, "", nil
+			}
+			return authorizer.DecisionDeny, "", nil
+		})
+		s := &Store{authorizer: starAuthorizer, userCache: userCache}
+		_, isAdmin, _, err := s.userFrom(ctxSomeUser, "get")
+		require.NoError(t, err)
+		assert.True(t, isAdmin)
+	})
+
+	t.Run("kubeconfigs resource does not grant admin", func(t *testing.T) {
+		t.Parallel()
+
+		// Simulates the built-in User/User Base GlobalRoles, which grant all verbs
+		// on ext.cattle.io/kubeconfigs. This must never result in isAdmin=true, or
+		// every default Rancher user would bypass per-user scoping.
+		kcAuthorizer := authorizer.AuthorizerFunc(func(_ context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			if a.GetResource() == ext.KubeconfigResourceName && a.GetAPIGroup() == gvr.Group {
+				return authorizer.DecisionAllow, "", nil
+			}
+			return authorizer.DecisionDeny, "", nil
+		})
+		s := &Store{authorizer: kcAuthorizer, userCache: userCache}
+		_, isAdmin, _, err := s.userFrom(ctxSomeUser, "get")
+		require.NoError(t, err)
+		assert.False(t, isAdmin)
+	})
+
+	t.Run("deny everything results in no admin and no error", func(t *testing.T) {
+		t.Parallel()
+
+		denyAuthorizer := authorizer.AuthorizerFunc(func(_ context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionDeny, "", nil
+		})
+		s := &Store{authorizer: denyAuthorizer, userCache: userCache}
+		_, isAdmin, _, err := s.userFrom(ctxSomeUser, "get")
+		require.NoError(t, err)
+		assert.False(t, isAdmin)
 	})
 }
 
@@ -1498,6 +1560,106 @@ func TestStoreCreate(t *testing.T) {
 		assert.Contains(t, config.Contexts, defaultClusterName)
 		assert.Contains(t, config.AuthInfos, defaultClusterName)
 	})
+	t.Run("one-shot status value", func(t *testing.T) {
+		tokenManager := &fakeTokenManager{}
+		var capturedCM *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			capturedCM = obj.DeepCopy()
+			capturedCM.Name = names.SimpleNameGenerator.GenerateName(obj.GenerateName)
+			return capturedCM, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			capturedCM = obj.DeepCopy()
+			return capturedCM, nil
+		}).Times(1)
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          commonAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return "" },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: adminID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+
+		obj, err := store.Create(ctx, &ext.Kubeconfig{}, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+		created := obj.(*ext.Kubeconfig)
+		assert.NotEmpty(t, created.Status.Value, "Create must return the rendered kubeconfig in Status.Value")
+
+		require.NotNil(t, capturedCM)
+
+		configMapCache := fake.NewMockCacheInterface[*corev1.ConfigMap](ctrl)
+		configMapCache.EXPECT().Get(namespace, capturedCM.Name).Return(capturedCM, nil).Times(1)
+		store.configMapCache = configMapCache
+
+		got, err := store.Get(ctx, capturedCM.Name, &metav1.GetOptions{})
+		require.NoError(t, err)
+		fetched := got.(*ext.Kubeconfig)
+		assert.Empty(t, fetched.Status.Value, "Status.Value must be empty on Get (write-once invariant)")
+	})
+	t.Run("backing configmap create returns Forbidden surfaces as Forbidden", func(t *testing.T) {
+		// mapBackingError must be applied to the configMapClient.Create call so
+		// that a quota-exceeded or webhook-rejected Forbidden reaches the client
+		// as 403, not wrapped as a 500 InternalError.
+		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		})
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).Return(nil,
+			apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("quota exceeded")),
+		).Times(1)
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters: []string{downstream1},
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsForbidden(err), "backing Forbidden must surface as 403, got %v", err)
+		assert.False(t, apierrors.IsInternalError(err), "must not be wrapped as InternalError, got %v", err)
+	})
 }
 
 func generateCAKeyAndCert() (*ecdsa.PrivateKey, string, error) {
@@ -1532,7 +1694,8 @@ func TestWatcherStop(t *testing.T) {
 
 	t.Run("safe to call Stop more than once", func(t *testing.T) {
 		w := &watcher{
-			ch: make(chan watch.Event, 1),
+			ch:   make(chan watch.Event, 1),
+			done: make(chan struct{}),
 		}
 
 		var wg sync.WaitGroup
@@ -1547,11 +1710,27 @@ func TestWatcherStop(t *testing.T) {
 	})
 }
 
+func TestWatcherStopUnderBackpressure(t *testing.T) {
+	w := &watcher{ch: make(chan watch.Event, 100), done: make(chan struct{})}
+	for i := 0; i < 100; i++ {
+		require.True(t, w.add(watch.Event{Type: watch.Added}))
+	}
+	go func() { _ = w.add(watch.Event{Type: watch.Added}) }() // would block on a full buffer
+	stopped := make(chan struct{})
+	go func() { w.Stop(); close(stopped) }()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop deadlocked under a full buffer")
+	}
+}
+
 func TestWatcherAdd(t *testing.T) {
 	t.Parallel()
 
 	w := &watcher{
-		ch: make(chan watch.Event, 3),
+		ch:   make(chan watch.Event, 3),
+		done: make(chan struct{}),
 	}
 
 	var wg sync.WaitGroup
@@ -2051,7 +2230,8 @@ func TestStoreWatch(t *testing.T) {
 
 	t.Run("admin watches kubeconfigs", func(t *testing.T) {
 		configMapWatcher := &watcher{
-			ch: make(chan watch.Event),
+			ch:   make(chan watch.Event),
+			done: make(chan struct{}),
 		}
 		defer configMapWatcher.Stop()
 
@@ -2182,7 +2362,8 @@ func TestStoreWatch(t *testing.T) {
 
 	t.Run("user watches kubeconfigs", func(t *testing.T) {
 		configMapWatcher := &watcher{
-			ch: make(chan watch.Event),
+			ch:   make(chan watch.Event),
+			done: make(chan struct{}),
 		}
 		defer configMapWatcher.Stop()
 
@@ -2225,12 +2406,13 @@ func TestStoreWatch(t *testing.T) {
 }
 
 type fakeUpdatedObjectInfo struct {
-	obj runtime.Object
-	err error
+	obj           runtime.Object
+	err           error
+	preconditions *metav1.Preconditions
 }
 
 func (i *fakeUpdatedObjectInfo) Preconditions() *metav1.Preconditions {
-	return nil
+	return i.preconditions
 }
 
 func (i *fakeUpdatedObjectInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (newObj runtime.Object, err error) {
@@ -2640,6 +2822,220 @@ func TestStoreUpdate(t *testing.T) {
 		assert.Equal(t, "bar", newKubeconfig.Annotations["foo"])
 		assert.Equal(t, "updated", newKubeconfig.Spec.Description)
 	})
+	t.Run("backing configmap conflict returns 409", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+			return oldConfigMap.DeepCopy(), nil
+		})
+		configMapClient.EXPECT().Update(gomock.Any()).Return(nil, apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, kubeconfigID, errors.New("rv stale")))
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+		})
+
+		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
+		require.NoError(t, err)
+
+		update := oldKubeconfig.DeepCopy()
+		update.Spec.Description = "updated"
+		objInfo := &fakeUpdatedObjectInfo{obj: update}
+
+		options := &metav1.UpdateOptions{}
+
+		obj, isCreated, err := store.Update(ctx, kubeconfigID, objInfo, nil, nil, false, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.False(t, isCreated)
+		assert.True(t, apierrors.IsConflict(err), "expected Conflict, got %v", err)
+		assert.False(t, apierrors.IsInternalError(err), "expected not InternalError, got %v", err)
+	})
+	t.Run("stale resourceVersion yields conflict", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+			return oldConfigMap.DeepCopy(), nil
+		})
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+		})
+
+		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
+		require.NoError(t, err)
+
+		update := oldKubeconfig.DeepCopy()
+		update.ResourceVersion = "stale" // differs from oldConfigMap.ResourceVersion ("")
+		update.Spec.Description = "updated"
+		objInfo := &fakeUpdatedObjectInfo{obj: update}
+
+		obj, isCreated, err := store.Update(ctx, kubeconfigID, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.False(t, isCreated)
+		assert.True(t, apierrors.IsConflict(err), "stale resourceVersion must yield 409 Conflict, got %v", err)
+		assert.False(t, apierrors.IsInternalError(err), "expected not InternalError, got %v", err)
+	})
+	t.Run("stale UID precondition yields conflict", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+			return oldConfigMap.DeepCopy(), nil
+		})
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+		})
+
+		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
+		require.NoError(t, err)
+
+		update := oldKubeconfig.DeepCopy()
+		update.Spec.Description = "updated"
+		staleUID := types.UID("stale-uid")
+		objInfo := &fakeUpdatedObjectInfo{
+			obj:           update,
+			preconditions: &metav1.Preconditions{UID: &staleUID},
+		}
+
+		obj, isCreated, err := store.Update(ctx, kubeconfigID, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.False(t, isCreated)
+		assert.True(t, apierrors.IsConflict(err), "stale UID precondition must yield 409 Conflict, got %v", err)
+		assert.False(t, apierrors.IsInternalError(err), "expected not InternalError, got %v", err)
+	})
+}
+
+func TestMapBackingError(t *testing.T) {
+	t.Parallel()
+
+	gr := gvr.GroupResource()
+
+	assert.Nil(t, mapBackingError(nil, "kc-1"))
+
+	conflict := apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "cc-x", errors.New("rv stale"))
+	got := mapBackingError(conflict, "kc-1")
+	require.True(t, apierrors.IsConflict(got))
+	statusErr, ok := got.(apierrors.APIStatus)
+	require.True(t, ok)
+	details := statusErr.Status().Details
+	require.NotNil(t, details)
+	assert.Equal(t, gr.Group, details.Group)
+	assert.Equal(t, gr.Resource, details.Kind)
+	assert.Equal(t, "kc-1", details.Name)
+
+	nf := apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "cc-x")
+	assert.True(t, apierrors.IsNotFound(mapBackingError(nf, "kc-1")))
+
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "cc-x", errors.New("denied"))
+	assert.True(t, apierrors.IsForbidden(mapBackingError(forbidden, "kc-1")))
+
+	other := errors.New("boom")
+	assert.True(t, apierrors.IsInternalError(mapBackingError(other, "kc-1")))
+
+	alreadyExists := apierrors.NewAlreadyExists(schema.GroupResource{Resource: "configmaps"}, "cc-x")
+	assert.True(t, apierrors.IsAlreadyExists(mapBackingError(alreadyExists, "kc-1")))
+
+	invalid := apierrors.NewInvalid(schema.GroupKind{Group: "configmaps"}, "cc-x", nil)
+	assert.True(t, apierrors.IsInvalid(mapBackingError(invalid, "kc-1")))
+
+	badRequest := apierrors.NewBadRequest("configmap is misconfigured")
+	assert.True(t, apierrors.IsBadRequest(mapBackingError(badRequest, "kc-1")))
+
+	tooManyRequests := apierrors.NewTooManyRequests("configmap throttled", 42)
+	assert.True(t, apierrors.IsTooManyRequests(mapBackingError(tooManyRequests, "kc-1")))
+
+	serviceUnavailable := apierrors.NewServiceUnavailable("configmap store down")
+	assert.True(t, apierrors.IsServiceUnavailable(mapBackingError(serviceUnavailable, "kc-1")))
+
+	for _, in := range []error{conflict, nf, forbidden, other, alreadyExists, invalid, badRequest, tooManyRequests, serviceUnavailable} {
+		assert.NotContains(t, mapBackingError(in, "kc-1").Error(), "configmap")
+	}
+
+	// R3-F2: 429 RetryAfterSeconds must be preserved in the mapped error.
+	tooManyRequestsWithRetry := apierrors.NewTooManyRequests("configmap throttled", 15)
+	gotTMR := mapBackingError(tooManyRequestsWithRetry, "kc-1")
+	require.True(t, apierrors.IsTooManyRequests(gotTMR), "must remain TooManyRequests")
+	tooManyStatus, ok := gotTMR.(apierrors.APIStatus)
+	require.True(t, ok)
+	require.NotNil(t, tooManyStatus.Status().Details)
+	assert.Equal(t, int32(15), tooManyStatus.Status().Details.RetryAfterSeconds, "RetryAfterSeconds must be preserved")
+
+	// R3-F3: Forbidden with causes must propagate those causes while remaining Forbidden
+	// and not leaking the backing resource's identity in the top-level message.
+	forbiddenWithCause := apierrors.NewForbidden(
+		schema.GroupResource{Resource: "configmaps"},
+		"cc-x",
+		errors.New("quota exceeded"),
+	)
+	forbiddenWithCause.ErrStatus.Details = &metav1.StatusDetails{
+		Causes: []metav1.StatusCause{
+			{Type: metav1.CauseTypeFieldValueInvalid, Message: "cpu quota exceeded", Field: "spec.cpu"},
+		},
+	}
+	gotForbidden := mapBackingError(forbiddenWithCause, "kc-1")
+	require.True(t, apierrors.IsForbidden(gotForbidden), "must remain Forbidden")
+	forbiddenStatus, ok := gotForbidden.(apierrors.APIStatus)
+	require.True(t, ok)
+	assert.NotContains(t, forbiddenStatus.Status().Message, "configmap", "top-level message must not leak backing identity")
+	forbiddenDetails := forbiddenStatus.Status().Details
+	require.NotNil(t, forbiddenDetails)
+	require.NotEmpty(t, forbiddenDetails.Causes, "field-level causes must be preserved")
+	assert.Equal(t, "spec.cpu", forbiddenDetails.Causes[0].Field)
+
+	// F4: Invalid backing error with field-level causes must propagate non-empty
+	// Details.Causes and the error must be re-scoped to the Kubeconfig GroupKind.
+	invalidWithCause := apierrors.NewInvalid(
+		schema.GroupKind{Group: "core", Kind: "ConfigMap"},
+		"cc-x",
+		field.ErrorList{
+			{Type: field.ErrorTypeInvalid, Field: "data.foo", Detail: "must be a number"},
+		},
+	)
+	gotInvalid := mapBackingError(invalidWithCause, "kc-1")
+	require.True(t, apierrors.IsInvalid(gotInvalid), "re-mapped error must still be Invalid")
+	invalidStatus, ok := gotInvalid.(apierrors.APIStatus)
+	require.True(t, ok)
+	invalidDetails := invalidStatus.Status().Details
+	require.NotNil(t, invalidDetails)
+	assert.Equal(t, gvr.Group, invalidDetails.Group, "GroupKind must be re-scoped to kubeconfigs")
+	assert.Equal(t, Kind, invalidDetails.Kind, "Kind must be Kubeconfig")
+	assert.Equal(t, "kc-1", invalidDetails.Name)
+	require.NotEmpty(t, invalidDetails.Causes, "field-level causes must be preserved")
+	assert.Equal(t, "data.foo", invalidDetails.Causes[0].Field)
+
+	// R4-F2: wrapped status errors must be classified and have their details extracted
+	// the same as unwrapped ones; the Is* predicates see through wrapping, so statusDetails
+	// must too.
+	wrappedForbidden := fmt.Errorf("wrapped: %w", forbiddenWithCause)
+	gotWrappedForbidden := mapBackingError(wrappedForbidden, "kc-1")
+	require.True(t, apierrors.IsForbidden(gotWrappedForbidden), "wrapped Forbidden must classify as Forbidden")
+	wrappedForbiddenStatus, ok := gotWrappedForbidden.(apierrors.APIStatus)
+	require.True(t, ok)
+	assert.NotContains(t, wrappedForbiddenStatus.Status().Message, "configmap", "top-level message must not leak backing identity")
+	wrappedForbiddenDetails := wrappedForbiddenStatus.Status().Details
+	require.NotNil(t, wrappedForbiddenDetails)
+	require.NotEmpty(t, wrappedForbiddenDetails.Causes, "causes must survive wrapping")
+	assert.Equal(t, "spec.cpu", wrappedForbiddenDetails.Causes[0].Field)
 }
 
 func TestStoreDelete(t *testing.T) {
@@ -2751,6 +3147,141 @@ func TestStoreDelete(t *testing.T) {
 		assert.True(t, deleteValidationCalled)
 		assert.Len(t, deletedTokens, 2)
 	})
+	t.Run("token delete failure leaves configmap intact and is retryable", func(t *testing.T) {
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["kubeconfig-a","kubeconfig-b"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		// Delete must be called exactly once — on the retry, after the token store recovers.
+		// If the first (failing) call incorrectly reaches the ConfigMap delete, gomock panics
+		// with "called more times than expected".
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(nil).Times(1)
+
+		tokensFailing := true
+		recovering := &fakeTokenStore{deleteFunc: func(name string, _ *metav1.DeleteOptions) error {
+			if tokensFailing {
+				return apierrors.NewInternalError(errors.New("etcd down"))
+			}
+			return nil
+		}}
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      recovering,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.Error(t, err)
+
+		tokensFailing = false
+		_, _, err = store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	})
+	t.Run("stale UID precondition has zero side effects", func(t *testing.T) {
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["kubeconfig-a","kubeconfig-b"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, gomock.Any(), gomock.Any()).Times(0)
+
+		var tokenDeleteCalled bool
+		ts := &fakeTokenStore{deleteFunc: func(name string, _ *metav1.DeleteOptions) error {
+			tokenDeleteCalled = true
+			return nil
+		}}
+		staleUID := uuid.NewUUID()
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      ts,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &staleUID},
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err))
+		assert.False(t, tokenDeleteCalled)
+	})
+	t.Run("configmap delete failure after token deletion is retryable", func(t *testing.T) {
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["kubeconfig-a","kubeconfig-b"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		var cmDeleteCount int
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).DoAndReturn(
+			func(_, _ string, _ *metav1.DeleteOptions) error {
+				cmDeleteCount++
+				if cmDeleteCount == 1 {
+					return apierrors.NewInternalError(errors.New("transient"))
+				}
+				return nil
+			}).Times(2)
+
+		v3TokenClient := fake.NewMockNonNamespacedClientInterface[*v3.Token, *v3.TokenList](ctrl)
+		v3TokenClient.EXPECT().Delete(gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "tokens"}, "")).
+			AnyTimes()
+
+		var tokenDeleteCount int
+		ts := &fakeTokenStore{deleteFunc: func(name string, _ *metav1.DeleteOptions) error {
+			tokenDeleteCount++
+			if tokenDeleteCount > 2 {
+				// Second call: tokens were already deleted on the first attempt.
+				return apierrors.NewNotFound(schema.GroupResource{Resource: "tokens"}, name)
+			}
+			return nil
+		}}
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      ts,
+			v3Tokens:        v3TokenClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.Error(t, err)
+
+		_, _, err = store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, 4, tokenDeleteCount)
+	})
+	t.Run("configmap conflict after token deletion reports already-revoked tokens", func(t *testing.T) {
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["kubeconfig-tok-conflict-1"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(
+			apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, cm.Name, errors.New("rv stale")),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err), "must be Conflict after tokens were deleted, got %v", err)
+		assert.Contains(t, err.Error(), "the object has been modified", "error must include the standard optimistic-lock message")
+		assert.Contains(t, err.Error(), "already revoked", "error must mention that tokens are already revoked")
+	})
 	t.Run("user can't delete other user's kubeconfig", func(t *testing.T) {
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
@@ -2778,6 +3309,41 @@ func TestStoreDelete(t *testing.T) {
 		assert.Equal(t, gvr.Group, statusErr.Status().Details.Group)
 		assert.Equal(t, ext.KubeconfigResourceName, statusErr.Status().Details.Kind)
 		assert.Equal(t, kubeconfigID, statusErr.Status().Details.Name)
+	})
+	t.Run("dry-run delete forwards DryRun to backing deletes", func(t *testing.T) {
+		tokenID := "kubeconfig-dry-abc"
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["` + tokenID + `"]`
+
+		var tokenDryRun []string
+		extTokenStore := &fakeTokenStore{deleteFunc: func(name string, o *metav1.DeleteOptions) error {
+			tokenDryRun = o.DryRun
+			return nil
+		}}
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).Return(cm, nil).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).DoAndReturn(
+			func(_, _ string, o *metav1.DeleteOptions) error {
+				assert.Equal(t, []string{metav1.DryRunAll}, o.DryRun)
+				return nil
+			}).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      extTokenStore,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+
+		_, _, err := store.Delete(ctx, kubeconfigID, nil, &metav1.DeleteOptions{
+			DryRun: []string{metav1.DryRunAll},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{metav1.DryRunAll}, tokenDryRun, "token store must receive DryRun")
 	})
 }
 
@@ -2908,6 +3474,145 @@ func TestStoreDeleteCollection(t *testing.T) {
 		assert.Equal(t, deleteValidationCalledTimes, 1)
 		assert.Len(t, deletedTokens, 2)
 	})
+
+	t.Run("skips concurrently deleted item", func(t *testing.T) {
+		kubeconfigID2 := "kubeconfig-abc12"
+
+		deleteOptions := &metav1.DeleteOptions{}
+		listOptions := &metainternalversion.ListOptions{}
+
+		cm1 := configMap.DeepCopy()
+		cm2 := configMap.DeepCopy()
+		cm2.Name = kubeconfigID2
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().List(namespace, gomock.Any()).Return(&corev1.ConfigMapList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+			Items:    []corev1.ConfigMap{*cm1, *cm2},
+		}, nil).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, kubeconfigID),
+		).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID2, gomock.Any()).Return(nil).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+
+		obj, err := store.DeleteCollection(ctx, nil, deleteOptions, listOptions)
+		require.NoError(t, err)
+		require.IsType(t, &ext.KubeconfigList{}, obj)
+		list := obj.(*ext.KubeconfigList)
+		require.Len(t, list.Items, 1)
+		assert.Equal(t, kubeconfigID2, list.Items[0].Name)
+	})
+
+	t.Run("surfaces genuine error unchanged", func(t *testing.T) {
+		deleteOptions := &metav1.DeleteOptions{}
+		listOptions := &metainternalversion.ListOptions{}
+
+		cm1 := configMap.DeepCopy()
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().List(namespace, gomock.Any()).Return(&corev1.ConfigMapList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "3"},
+			Items:    []corev1.ConfigMap{*cm1},
+		}, nil).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(
+			apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, kubeconfigID, errors.New("rv stale")),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+
+		_, err := store.DeleteCollection(ctx, nil, deleteOptions, listOptions)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err), "expected Conflict, got %v", err)
+		assert.False(t, apierrors.IsInternalError(err), "expected not InternalError, got %v", err)
+	})
+	t.Run("deleteValidation returning NotFound aborts collection", func(t *testing.T) {
+		// A deleteValidation that returns a NotFound-classified error must abort
+		// the whole collection. Prior to the F1 fix, DeleteCollection passed
+		// deleteValidation to s.delete, which passed through APIStatus errors —
+		// meaning a NotFound from the validator was indistinguishable from the
+		// concurrent-delete race and was silently skipped.
+		validationErr := apierrors.NewNotFound(gvr.GroupResource(), kubeconfigID)
+		deleteValidation := func(ctx context.Context, obj runtime.Object) error {
+			return validationErr
+		}
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().List(namespace, gomock.Any()).Return(&corev1.ConfigMapList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "4"},
+			Items:    []corev1.ConfigMap{*configMap.DeepCopy()},
+		}, nil).Times(1)
+		// s.delete must NOT be called; configMapClient.Delete must not be called.
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+
+		_, err := store.DeleteCollection(ctx, deleteValidation, &metav1.DeleteOptions{}, &metainternalversion.ListOptions{})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err), "deleteValidation NotFound must propagate, got %v", err)
+	})
+	t.Run("dry-run delete-collection forwards DryRun to backing deletes", func(t *testing.T) {
+		tokenID := "kubeconfig-dry-xyz"
+		cmWithToken := configMap.DeepCopy()
+		cmWithToken.Data[StatusTokensField] = `["` + tokenID + `"]`
+
+		var tokenDryRun []string
+		extTokenStore := &fakeTokenStore{deleteFunc: func(name string, o *metav1.DeleteOptions) error {
+			tokenDryRun = o.DryRun
+			return nil
+		}}
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().List(namespace, gomock.Any()).Return(&corev1.ConfigMapList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "5"},
+			Items:    []corev1.ConfigMap{*cmWithToken},
+		}, nil).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).DoAndReturn(
+			func(_, _ string, o *metav1.DeleteOptions) error {
+				assert.Equal(t, []string{metav1.DryRunAll}, o.DryRun)
+				return nil
+			}).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      extTokenStore,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+
+		_, err := store.DeleteCollection(ctx, nil, &metav1.DeleteOptions{
+			DryRun: []string{metav1.DryRunAll},
+		}, &metainternalversion.ListOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{metav1.DryRunAll}, tokenDryRun, "token store must receive DryRun")
+	})
 }
 
 func TestPrintKubeconfig(t *testing.T) {
@@ -2971,6 +3676,100 @@ func TestPrintKubeconfig(t *testing.T) {
 		require.Len(t, row.Cells, 8)
 		assert.Equal(t, unknownValue, row.Cells[3].(string))
 		assert.Equal(t, unknownValue, row.Cells[4].(string))
+	})
+}
+
+// fixedStringSelector is a labels.Selector whose String() returns a fixed raw string.
+// Used to inject an unparseable selector into toListOptions via ConvertListOptions.
+type fixedStringSelector string
+
+func (s fixedStringSelector) Matches(labels.Labels) bool                { return false }
+func (s fixedStringSelector) Empty() bool                               { return false }
+func (s fixedStringSelector) String() string                            { return string(s) }
+func (s fixedStringSelector) Add(...labels.Requirement) labels.Selector { return s }
+func (s fixedStringSelector) Requirements() (labels.Requirements, bool) { return nil, true }
+func (s fixedStringSelector) DeepCopySelector() labels.Selector         { return s }
+func (s fixedStringSelector) RequiresExactMatch(string) (string, bool)  { return "", false }
+
+func TestToListOptions(t *testing.T) {
+	t.Parallel()
+
+	user := &k8suser.DefaultInfo{Name: "u-abc123"}
+
+	parseSel := func(t *testing.T, s string) labels.Selector {
+		t.Helper()
+		sel, err := labels.Parse(s)
+		require.NoError(t, err)
+		return sel
+	}
+
+	// reqMap parses selStr and returns requirements indexed by key.
+	reqMap := func(t *testing.T, selStr string) map[string]labels.Requirement {
+		t.Helper()
+		sel, err := labels.Parse(selStr)
+		require.NoError(t, err)
+		reqs, selectable := sel.Requirements()
+		require.True(t, selectable)
+		m := make(map[string]labels.Requirement, len(reqs))
+		for _, r := range reqs {
+			m[r.Key()] = r
+		}
+		return m
+	}
+
+	t.Run("set-based selector preserved and requirements injected for non-admin", func(t *testing.T) {
+		opts := &metainternalversion.ListOptions{LabelSelector: parseSel(t, "env in (a,b)")}
+
+		result, err := toListOptions(opts, user, false)
+		require.NoError(t, err)
+
+		reqs := reqMap(t, result.LabelSelector)
+		assert.Contains(t, reqs, "env", "env requirement missing")
+		assert.Contains(t, reqs, KindLabel, "KindLabel requirement missing")
+		if assert.Contains(t, reqs, UserIDLabel, "UserIDLabel requirement missing") {
+			r := reqs[UserIDLabel]
+			assert.Equal(t, selection.Equals, r.Operator(), "UserIDLabel operator must be Equals")
+			vals := r.Values()
+			assert.True(t, vals.Has(user.Name), "UserIDLabel value must be the user's own name")
+		}
+	})
+
+	t.Run("set-based selector preserved for admin without UserIDLabel", func(t *testing.T) {
+		opts := &metainternalversion.ListOptions{LabelSelector: parseSel(t, "env in (a,b)")}
+
+		result, err := toListOptions(opts, user, true)
+		require.NoError(t, err)
+
+		reqs := reqMap(t, result.LabelSelector)
+		assert.Contains(t, reqs, "env", "env requirement missing")
+		assert.Contains(t, reqs, KindLabel, "KindLabel requirement missing")
+		assert.NotContains(t, reqs, UserIDLabel, "UserIDLabel must not be injected for admin")
+	})
+
+	t.Run("inequality selector preserved", func(t *testing.T) {
+		opts := &metainternalversion.ListOptions{LabelSelector: parseSel(t, "env!=prod")}
+
+		result, err := toListOptions(opts, user, false)
+		require.NoError(t, err)
+
+		reqs := reqMap(t, result.LabelSelector)
+		assert.Contains(t, reqs, "env", "env requirement missing")
+		assert.Contains(t, reqs, KindLabel, "KindLabel requirement missing")
+		if assert.Contains(t, reqs, UserIDLabel, "UserIDLabel requirement missing") {
+			r := reqs[UserIDLabel]
+			assert.Equal(t, selection.Equals, r.Operator(), "UserIDLabel operator must be Equals")
+			vals := r.Values()
+			assert.True(t, vals.Has(user.Name), "UserIDLabel value must be the user's own name")
+		}
+	})
+
+	t.Run("malformed selector returns 400 BadRequest", func(t *testing.T) {
+		opts := &metainternalversion.ListOptions{LabelSelector: fixedStringSelector("!!invalid!!")}
+
+		result, err := toListOptions(opts, user, false)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsBadRequest(err), "expected 400 BadRequest, got: %v", err)
+		assert.Nil(t, result)
 	})
 }
 

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -1200,6 +1200,31 @@ func TestStoreCreate(t *testing.T) {
 		assert.True(t, apierrors.IsForbidden(err))
 		assert.Contains(t, err.Error(), "\"non-existent\" not found")
 	})
+	t.Run("default TTL fetch error returns structured error", func(t *testing.T) {
+		store := &Store{
+			authorizer: commonAuthorizer,
+			userCache:  userCache,
+			tokenStore: tokenStore,
+			tokenMgr:   tokenManager,
+			getDefaultTTL: func() (*int64, error) {
+				return nil, fmt.Errorf("setting unavailable")
+			},
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+
+		obj, err := store.Create(ctx, &ext.Kubeconfig{}, nil, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		var apiStatus apierrors.APIStatus
+		assert.True(t, errors.As(err, &apiStatus), "expected apierrors.APIStatus, got %T: %v", err, err)
+		assert.True(t, apierrors.IsInternalError(err))
+	})
 	t.Run("negative ttl", func(t *testing.T) {
 		store := &Store{
 			authorizer:    commonAuthorizer,
@@ -1560,7 +1585,7 @@ func TestStoreCreate(t *testing.T) {
 		assert.Contains(t, config.Contexts, defaultClusterName)
 		assert.Contains(t, config.AuthInfos, defaultClusterName)
 	})
-	t.Run("one-shot status value", func(t *testing.T) {
+	t.Run("status value returned only in the create response", func(t *testing.T) {
 		tokenManager := &fakeTokenManager{}
 		var capturedCM *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
@@ -2358,6 +2383,40 @@ func TestStoreWatch(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "2", k.ResourceVersion)
 		assert.Empty(t, k.Annotations)
+
+		// Bookmark with internal annotation must not leak cattle.io/uid;
+		// only k8s.io/initial-events-end is allowed through.
+		configMapWatcher.add(watch.Event{
+			Type: watch.Bookmark,
+			Object: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "3",
+					Annotations: map[string]string{
+						"k8s.io/initial-events-end": "true",
+						UIDAnnotation:               "some-uid",
+					},
+				},
+			},
+		})
+		event = <-watcher.ResultChan()
+		require.Equal(t, watch.Bookmark, event.Type)
+		k, ok = event.Object.(*ext.Kubeconfig)
+		require.True(t, ok)
+		assert.Equal(t, "3", k.ResourceVersion)
+		assert.Equal(t, "true", k.Annotations["k8s.io/initial-events-end"])
+		assert.NotContains(t, k.Annotations, UIDAnnotation)
+
+		// Unknown future event type must pass through with a non-nil object.
+		futureConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "future-cm"},
+		}
+		configMapWatcher.add(watch.Event{
+			Type:   watch.EventType("FUTURE"),
+			Object: futureConfigMap,
+		})
+		event = <-watcher.ResultChan()
+		require.Equal(t, watch.EventType("FUTURE"), event.Type)
+		require.NotNil(t, event.Object)
 	})
 
 	t.Run("user watches kubeconfigs", func(t *testing.T) {
@@ -2922,6 +2981,75 @@ func TestStoreUpdate(t *testing.T) {
 		assert.False(t, isCreated)
 		assert.True(t, apierrors.IsConflict(err), "stale UID precondition must yield 409 Conflict, got %v", err)
 		assert.False(t, apierrors.IsInternalError(err), "expected not InternalError, got %v", err)
+	})
+	t.Run("double update yields exactly one Updated condition", func(t *testing.T) {
+		current := oldConfigMap.DeepCopy()
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).DoAndReturn(
+			func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+				return current.DeepCopy(), nil
+			}).Times(2)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(
+			func(configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+				updated := configMap.DeepCopy()
+				current = updated
+				return updated, nil
+			}).Times(2)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: adminID,
+		})
+
+		kc, err := store.fromConfigMap(oldConfigMap)
+		require.NoError(t, err)
+
+		up1 := kc.DeepCopy()
+		up1.Spec.Description = "first"
+		obj1, _, err := store.Update(ctx, kubeconfigID, &fakeUpdatedObjectInfo{obj: up1}, nil, nil, false, &metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		kc2, ok := obj1.(*ext.Kubeconfig)
+		require.True(t, ok)
+
+		var ts1 metav1.Time
+		for _, c := range kc2.Status.Conditions {
+			if c.Type == UpdatedCond {
+				ts1 = c.LastTransitionTime
+				break
+			}
+		}
+		require.False(t, ts1.IsZero(), "Updated condition must have a non-zero timestamp after first update")
+
+		// metav1.Time serializes at second precision through the ConfigMap JSON
+		// round-trip, so we must cross a second boundary to observe advancement.
+		time.Sleep(1100 * time.Millisecond)
+
+		up2 := kc2.DeepCopy()
+		up2.Spec.Description = "second"
+		obj2, _, err := store.Update(ctx, kubeconfigID, &fakeUpdatedObjectInfo{obj: up2}, nil, nil, false, &metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		final, ok := obj2.(*ext.Kubeconfig)
+		require.True(t, ok)
+
+		var updatedCount int
+		var ts2 metav1.Time
+		for _, c := range final.Status.Conditions {
+			if c.Type == UpdatedCond {
+				updatedCount++
+				ts2 = c.LastTransitionTime
+			}
+		}
+		assert.Equal(t, 1, updatedCount, "expected exactly one Updated condition, got %d", updatedCount)
+		assert.True(t, ts2.After(ts1.Time), "Updated condition LastTransitionTime must advance on each update (ts1=%v ts2=%v)", ts1, ts2)
 	})
 }
 

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -277,7 +277,7 @@ func schema_pkg_apis_extcattleio_v1_Kubeconfig(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Kubeconfig allows creating v1.Config kubeconfig files for interacting with Rancher and clusters managed by Rancher.",
+				Description: "Kubeconfig allows creating v1.Config kubeconfig files for interacting with Rancher and clusters managed by Rancher.\n\nName generation: the server always assigns a name with the \"kubeconfig-\" prefix. Any metadata.name or metadata.generateName supplied by the client is silently ignored — it is not rejected, but it has no effect.\n\nToken requirement: Create must be called by a Rancher user authenticated with a Rancher token — a UI session token or a user-created API token both work; the derived kubeconfig tokens are minted against the authenticating token. Requests authenticated by other means (for example, a service account) return Forbidden (403).\n\nValue availability: status.value is populated only in the Create response. It is empty on all subsequent Get or List reads. Clients must capture the value from the Create response; it cannot be retrieved again.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -466,12 +466,17 @@ func schema_pkg_apis_extcattleio_v1_KubeconfigStatus(ref common.ReferenceCallbac
 					},
 					"summary": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Summary of the Kubeconfig status. Can be \"Complete\" or \"Error\".",
+							Description: "Summary of the Kubeconfig status. Can be \"Pending\", \"Complete\", or \"Error\".",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"tokens": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Tokens is a list of Kubeconfig tokens.",
 							Type:        []string{"array"},


### PR DESCRIPTION
## Issue: #56315 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The ext.Kubeconfig store deviated from standard Kubernetes API behavior in ways that break generic kubectl-style clients:

- Backing-store errors were rewrapped as 500s on create and update: a stale-resourceVersion conflict never surfaced as 409, throttling lost its retry-after hint, and error messages named the backing ConfigMap.
- A dry-run update reported success without evaluating the resourceVersion or the caller's UID precondition, so a preview did not predict the real outcome.
- Delete removed the ConfigMap before its tokens and stopped at the first token-deletion error. The token list lived only in the ConfigMap, so the remaining tokens stayed valid with no record and no retry path.
- Collection deletes rewrapped per-item errors as 500s and aborted when an item was deleted concurrently.
- Set-based, inequality, and existence label selectors failed with a 500.
- The watch fan-out sent on a channel while holding a lock its teardown needed, deadlocking once a slow consumer's buffer filled. Bookmark events leaked an internal bookkeeping annotation.
- Every update appended another Updated condition, growing status.conditions without bound.
- The godoc/OpenAPI did not document server-generated names, the Rancher-token requirement for Create, or that the generated kubeconfig value is available only in the Create response; the cluster list serialized as null when empty.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Backing errors are rebuilt with their original classification (404/409/403/422/429/503), scoped to the Kubeconfig resource: structured causes and the  retry-after delay survive, the backing ConfigMap is never named, and discarded causes are logged at warn/error level.
- Update and dry-run update enforce the resourceVersion and UID/resourceVersion preconditions before any write, with the checks shared between update and delete.
- Delete enforces preconditions before any destructive step, removes tokens before the ConfigMap, and stays retryable after a partial failure; if the final ConfigMap delete conflicts after tokens were revoked, the returned conflict says so.
- Collection deletes run the caller's delete validation per item, surface per-item errors with their original classification, and skip only items removed by a concurrent delete.
- Label selectors are parsed with full selector syntax; malformed input returns 400; owner scoping is applied as ANDed requirements.
- The watcher escapes a blocked send through a done channel closed before teardown takes the lock. Bookmark events are rebuilt from an allowlist carrying only the resourceVersion and the initial-events-end marker.
- The Updated condition is upserted (one per type) and its timestamp advances on every update.
- The godoc and regenerated OpenAPI document the name generation, the token requirement (any Rancher token, not only a UI session token), and the Create-response-only value; the cluster list is omitted when empty and the token list is marked atomic.

Guard tests cover dry-run zero-write on single and collection deletes, the write-once kubeconfig value, stale-resourceVersion and precondition conflicts, watcher teardown under backpressure, and the admin check: authorizing the resource literally named `*` is deliberate — a kubeconfigs-scoped grant, which every default Rancher user holds, must never be treated as admin.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests