### PR TITLE
Nightly Provisioning tests

### DIFF
--- a/.github/actions/publish-provisioning-test-results/action.yml
+++ b/.github/actions/publish-provisioning-test-results/action.yml
@@ -1,0 +1,94 @@
+name: Publish Provisioning Test Results
+description: > 
+  Generates a github action run summary and an optional PR comment using the 
+  output artifacts of the provisioning test suite. This action expects the 
+  caller to convert the test artifacts to an XML format compatible with junit-report,
+  and to export its event file as an artifact. The 'rancher/publish-unit-test-result-action'
+  will translate the XML artifacts into a Run summary, and uses the event file to find the PR 
+  it should comment on. As this action must perform privileged actions (PR comments),
+  it must not be directly invoked by callers which assume non-origin contexts 
+  (e.g. PRs from forks, see publish-provisioning-test-results.yaml as an example).
+
+inputs:
+  commit:
+    description: Commit SHA the results belong to.
+    required: true
+  event-name:
+    description: Originating event name (e.g. pull_request, schedule).
+    required: true
+  create-comment:
+    description: >-
+      Controls when a comment is added on the PR with the test results. Only applicable for
+      pull_request events, ignored for schedule/dispatch events. Requires that
+      the event file be downloaded from the triggering workflow run and the run-id of 
+      the triggering workflow run be provided (run-id=<workflow_run.id>).
+      Allowed options are: 'off', 'always', 'changes', 'failures'. Defaults to 'always'.
+    required: false
+    default: "always"
+  run-id:
+    description: >-
+      The run ID to download artifacts from.
+    required: true
+    default: ""
+  check-name:
+    description: Name of the check run / summary section.
+    required: false
+    default: Provisioning Tests Results
+  test-results-path:
+    description: Directory to download reports into.
+    required: false
+    default: /tmp/test-results
+
+runs:
+  using: composite
+  steps:
+    - name: Install Python deps
+      shell: bash
+      run: |
+        zypper --non-interactive install python311 python311-pip python311-virtualenv which
+        # set python as the default python (essentially just a symlink)
+        update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+
+    - name: mkdir test-results
+      shell: bash
+      env:
+        TEST_RESULTS_PATH: ${{ inputs.test-results-path }}
+      run: mkdir -p "$TEST_RESULTS_PATH"
+
+    - name: Download XML test reports
+      id: xml_reports
+      # don't error the whole job if the artifact is not there
+      continue-on-error: true
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        run-id: ${{ inputs.run-id }}
+        # needed per https://github.com/orgs/community/discussions/106300#discussioncomment-8369881
+        github-token: ${{ github.token }}
+        merge-multiple: true
+        path: ${{ inputs.test-results-path }}
+        name: "XML Results"
+
+    - name: Download the event file
+      id: event_file
+      if: steps.xml_reports.outcome == 'success' && inputs.create-comment != 'off'
+      continue-on-error: true
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        run-id: ${{ inputs.run-id }}
+        github-token: ${{ github.token }}
+        merge-multiple: true
+        path: ${{ inputs.test-results-path }}
+        name: "Event File"
+
+    - name: Publish test results
+      if: >-
+        steps.xml_reports.outcome == 'success' && (steps.event_file.outcome == 'success' || steps.event_file.outcome == 'skipped')
+      uses: rancher/publish-unit-test-result-action/linux@2c5c7685c1698e015459f9a9bfa49f0888800df5
+      with:
+        check_name: ${{ inputs.check-name }}
+        comment_mode: ${{ inputs.create-comment }}
+        commit: ${{ inputs.commit }}
+        event_name: ${{ inputs.event-name }}
+        # Providing an event_file indicates to the action that a comment should be generated on the associated PR
+        event_file: "${{ inputs.test-results-path }}/event.json"
+        files: "${{ inputs.test-results-path }}/*.xml"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,8 +2,8 @@ name: Integration Tests
 on:
   workflow_call:
 env:
-  TAG: v2.14-${{ github.sha }}-head
-  GIT_TAG: v2.14-${{ github.sha }}-head
+  TAG: v2.15-${{ github.sha }}-head
+  GIT_TAG: v2.15-${{ github.sha }}-head
   HOST_ARCH: amd64
   ARCH: amd64
   GOLANG_VERSION: '1.26'

--- a/.github/workflows/nightly-provisioning-tests.yml
+++ b/.github/workflows/nightly-provisioning-tests.yml
@@ -1,0 +1,122 @@
+name: Nightly Provisioning Tests
+on:
+  schedule:
+    # Runs every weekday at 05:00 UTC
+    # (1 AM EST, 10PM PST, 7AM CEST)
+    - cron: '0 5 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: none
+
+env:
+  ARCH: amd64
+  TAG: v2.15-${{ github.sha }}-head
+  GIT_TAG: v2.15-${{ github.sha }}-head
+  HEAD_TAG: "head"
+  COMMIT: ${{ github.sha }}
+  REPOSITORY_OWNER: ${{ github.repository_owner }}
+  IMAGE: ${{ github.repository_owner }}/rancher
+  IMAGE_AGENT: ${{ github.repository_owner }}/rancher-agent
+  IMAGE_INSTALLER: ${{ github.repository_owner }}/system-agent-installer-rancher
+jobs:
+  build-server:
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [x64, arm64]
+    runs-on: runs-on,runner=4cpu-${{ matrix.os }}-${{ matrix.arch }},image=ubuntu22-full-${{ matrix.arch }},run-id=${{ github.run_id }}
+    env:
+      ARCH: ${{ matrix.arch }}
+      OS: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: setup and build
+        uses: ./.github/actions/build-images/server
+  build-agent:
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [x64, arm64]
+    runs-on: runs-on,runner=4cpu-${{ matrix.os }}-${{ matrix.arch }},image=ubuntu22-full-${{ matrix.arch }},run-id=${{ github.run_id }}
+    env:
+      ARCH: ${{ matrix.arch }}
+      OS: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: setup and build
+        uses: ./.github/actions/build-images/agent
+  build-installer:
+    runs-on: runs-on,runner=4cpu-linux-x64,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Verify installer Dockerfile build
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          file: ./package/Dockerfile.installer
+          build-args: |
+            BUILDARCH=amd64
+            VERSION=0.0.0
+          platforms: linux/amd64
+          load: false
+          push: false
+          cache-from: type=gha,scope=pr-build-installer
+          cache-to: type=gha,mode=min,scope=pr-build-installer
+  integration-tests:
+    permissions:
+      contents: read
+    needs: [build-server, build-agent]
+    uses: ./.github/workflows/integration-tests.yml
+  provisioning-tests:
+    permissions:
+      contents: read
+    needs: [build-server, build-agent]
+    uses: ./.github/workflows/provisioning-tests.yml
+
+  # Publish provisioning results into this run's job summary (and a check run).
+  # The nightly is schedule/dispatch only, so it runs in this workflows context with the
+  # permissions granted here, no workflow_run indirection needed.
+  # use `if always()` so results publish even when tests fail. failed jobs
+  # which are retried regenerates the summary for that _attempt_.
+  publish-results:
+    if: always()
+    needs: [provisioning-tests]
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
+    container: registry.suse.com/bci/bci-base:15.7
+    permissions:
+      contents: read
+      checks: write
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Publish Test Results
+        uses: ./.github/actions/publish-provisioning-test-results
+        with:
+          commit: ${{ github.sha }}
+          event-name: ${{ github.event_name }}
+          create-comment: 'off'
+          run-id: ${{ github.run_id }}
+

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           for file in $(ls /tmp/test-results/report-*.txt); do
              echo "Processing $file..."
-             go run github.com/jstemmer/go-junit-report/v2@latest < $file > $(sed 's/txt/xml/g' <<<$file)
+             go run github.com/jstemmer/go-junit-report/v2@14d61e6e75e3f3c74551d757ad936e8e88014464 < $file > $(sed 's/txt/xml/g' <<<$file)
           done
       - name: Upload XML Test Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/publish-provisioning-test-results.yaml
+++ b/.github/workflows/publish-provisioning-test-results.yaml
@@ -17,49 +17,17 @@ jobs:
       checks: write
       pull-requests: write
       actions: read
+      contents: read
     steps:
-      - name: Install Python Deps
-        run: |
-          # install python
-          zypper --non-interactive install python311 python311-pip python311-virtualenv which
-
-          # set python as the default python (essentially just a symlink)
-          update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
-
-      - name: mkdir test-results
-        run: mkdir -p /tmp/test-results
-
-      - name: Download All XML Test Reports
-        id: xml_reports
-        # don't error the entire job if the artifact is not there
-        continue-on-error: true
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          run-id: ${{ github.event.workflow_run.id }}
-          # needed per https://github.com/orgs/community/discussions/106300#discussioncomment-8369881
-          github-token: ${{ github.token }}
-          merge-multiple: true
-          path: /tmp/test-results/
-          name: "XML Results"
-
-      - name: Download the Event File
-        id: event_file
-        continue-on-error: true
-        if: steps.xml_reports.outcome == 'success'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
-          merge-multiple: true
-          path: /tmp/test-results/
-          name: "Event File"
+          persist-credentials: false
 
       - name: Publish Test Results
-        if: steps.xml_reports.outcome == 'success' && steps.event_file.outcome == 'success'
-        uses: rancher/publish-unit-test-result-action/linux@2c5c7685c1698e015459f9a9bfa49f0888800df5
+        uses: ./.github/actions/publish-provisioning-test-results
         with:
-          check_name: Provisioning Tests Results
           commit: ${{ github.event.workflow_run.head_sha }}
-          event_name: ${{ github.event.workflow_run.event }}
-          event_file: /tmp/test-results/event.json
-          files: "/tmp/test-results/*.xml"
+          event-name: ${{ github.event.workflow_run.event }}
+          # download the fork's artifacts from the run that triggered this handler
+          run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,8 @@ permissions:
 
 env:
   ARCH: amd64
-  TAG: v2.14-${{ github.sha }}-head
-  GIT_TAG: v2.14-${{ github.sha }}-head
+  TAG: v2.15-${{ github.sha }}-head
+  GIT_TAG: v2.15-${{ github.sha }}-head
   HEAD_TAG: "head"
   COMMIT: ${{ github.sha }}
   REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/retry-failed-jobs.yml
+++ b/.github/workflows/retry-failed-jobs.yml
@@ -1,10 +1,11 @@
-name: Retry failed jobs once
+name: Retry failed jobs
 
 on:
   workflow_run: # zizmor: ignore[dangerous-triggers] -- only calls rerun-failed-jobs API, does not run untrusted code
     workflows:
       - "Build Pull Request"
       - "Push to release branches"
+      - "Nightly Provisioning Tests"
     types: [completed]
 
 permissions:
@@ -21,6 +22,26 @@ jobs:
       (github.event.workflow_run.event == 'pull_request' ||
        (github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_repository.full_name == github.repository))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/actions/runs/$RUN_ID/rerun-failed-jobs"
+
+  retry-nightly:
+    # We execute the nightly provisioning tests 3 times
+    # to avoid false alarms from flaky tests. This should
+    # be removed or shortened once the tests are more stable.
+    if: >-
+      github.event.workflow_run.name == 'Nightly Provisioning Tests' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'schedule' &&
+      github.event.workflow_run.run_attempt < 3
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed jobs


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55231
 
## Problem

This is the first part of a larger refactor regarding how and when Rancher CI runs the provisioning test suite. This PR introduces nightly tests which always trigger the full test v2prov test surface. As we adjust / reduce the number of tests that run on a per PR basis, this workflow ensures that we maintain coverage. 

## Solution

+ Adds a dedicated Nightly Provisioning Test workflow which runs at 5:00 UTC, every week day.
+ Migrates the existing `publish-provisioning-tests-results` action into a composite action.
   + The current workflow is only able to comment on PRs. Because it is indirectly called via `on.workflow_run`, it can't actually add a summary onto the GHA run summary view. 
    + This is a problem for the nightly tests, as there will be no associated PR. 
    + Using a composite action allows us to call it directly in the nightly workflow, which should allow for the summary to be placed on the correct run. 
+ Updates the `retry-failed-jobs.yml` workflow to restart the nightly provisioning tests up to two times (for three runs total) 
   + This is temporary measure that should be removed once the stability of the provisioning tests is improved
   + We may be able to improve the stability of the tests by doing similar investigation into runner right-sizing, and test sharding, similar to https://github.com/rancher/rancher/pull/56263. This is viewed as a next step, in addition to limiting the specific tests that run per PR. 

This change does not fully cover the alerting requirement, and a follow up PR will be raised to implement some alerting method (likely slack notifications) 
 
## Testing
As this action requires EIO runners it must be tested after it is merged. This PR does not impact existing CI workflows outside of the provisioning test reports, which are non-critical. There should be no negative impact on current PRs or workflows AFAIK. 

## Engineering Testing
### Manual Testing
I ran zizmor and actionlint 

### Automated Testing
n/a

## QA Testing Considerations
n/a
 
### Regressions Considerations
Translating the test publish step into a composite action is the only place where I can foresee a potential regression. 