### PR TITLE
tls: tighten CN filtering on tls-rancher-internal to reject non-IP CNs + add default SANs

### DIFF
--- a/pkg/tls/podips.go
+++ b/pkg/tls/podips.go
@@ -13,8 +13,12 @@ import (
 
 // podIPTracker watches pods matching the given label selector in a single
 // namespace and maintains a snapshot of their current pod IPs. The snapshot
-// is consumed by filterExistingCN to prune stale IP CNs from the
-// dynamiclistener-managed cert without disturbing other (hostname) CNs.
+// is consumed by filterExistingCN to keep only live pod IPs on the
+// dynamiclistener-managed cert. Non-IP CNs (hostnames) are never permitted
+// here: the static default SANs (localhost, cluster IP, node IPs, etc.) are
+// already allowed upstream via dynamiclistener's allowDefaultSANs wrapper
+// before this filter ever runs, so anything reaching filterExistingCN is, by
+// definition, not one of the intended SANs.
 type podIPTracker struct {
 	// ips holds *map[string]struct{}. nil before the first list completes:
 	// in that pre-sync state filterExistingCN keeps everything (so we never
@@ -28,9 +32,9 @@ type podIPTracker struct {
 
 // newPodIPTracker registers an OnChange handler that updates the IP set on
 // every relevant pod event. The tracker function it returns is safe to use
-// as a dynamiclistener.Config.FilterExistingCN: non-IP CNs (hostnames) pass
-// through unchanged, IP CNs are kept only if they match a currently-running
-// pod IP.
+// as a dynamiclistener.Config.FilterExistingCN: only CNs that are live pod
+// IPs pass through. Non-IP CNs (hostnames) are always rejected — see
+// filterExistingCN and the podIPTracker doc comment for why.
 func newPodIPTracker(ctx context.Context, ns, labelSelector string, pods corev1controllers.PodController, handlerName string) func(...string) []string {
 	t := &podIPTracker{
 		namespace:     ns,
@@ -69,19 +73,29 @@ func (t *podIPTracker) onChange(_ string, pod *corev1.Pod) (*corev1.Pod, error) 
 
 func (t *podIPTracker) filterExistingCN(cns ...string) []string {
 	v := t.ips.Load()
-	// Pre-sync: keep everything to avoid pruning legitimate CNs before we
-	// know what the live pod set looks like.
+	// Pre-sync: keep IP CNs unconditionally to avoid pruning legitimate
+	// ones before we know what the live pod set looks like. Hostnames are
+	// still rejected even pre-sync — that decision never depends on the
+	// pod-IP snapshot, only on dynamiclistener's own allowDefaultSANs
+	// short-circuit having already accepted the legitimate ones upstream.
 	if v == nil {
-		return cns
+		out := make([]string, 0, len(cns))
+		for _, cn := range cns {
+			if net.ParseIP(cn) != nil {
+				out = append(out, cn)
+			}
+		}
+		return out
 	}
 	ips := *v.(*map[string]struct{})
 	out := make([]string, 0, len(cns))
 	for _, cn := range cns {
-		// Only prune IP CNs we can positively classify as stale.
-		// Hostnames and any other non-IP CNs pass through — we don't have
-		// enough information here to decide whether they're stale.
+		// Reject any non-IP CN outright. Hostnames beyond the static
+		// default SANs (already handled upstream, before this filter is
+		// ever consulted) have no legitimate path onto this cert — a
+		// client that can reach the listener and control TLS SNI or the
+		// HTTP Host header must never be able to add arbitrary hostnames.
 		if net.ParseIP(cn) == nil {
-			out = append(out, cn)
 			continue
 		}
 		if _, ok := ips[cn]; ok {

--- a/pkg/tls/podips_test.go
+++ b/pkg/tls/podips_test.go
@@ -1,0 +1,272 @@
+package tls
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makePod(ns, name, ip string, deleted bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Status:     corev1.PodStatus{PodIP: ip},
+	}
+	if deleted {
+		now := metav1.Now()
+		pod.DeletionTimestamp = &now
+	}
+	return pod
+}
+
+func TestPodIPTracker_FilterExistingCN_PreSync(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pods := fake.NewMockControllerInterface[*corev1.Pod, *corev1.PodList](ctrl)
+	pods.EXPECT().
+		OnChange(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes()
+	// List must never be called before the first pod event fires.
+
+	filter := newPodIPTracker(context.Background(), namespace.System, "app=rancher", pods, "test-podip-filter-presync")
+
+	// Pre-sync: keep IP CNs since we don't yet know the live pod set and
+	// must not prematurely prune a legitimate one. Hostnames are always
+	// rejected, pre-sync or not.
+	got := filter("10.42.0.1", "rancher.cattle-system", "192.168.10.131")
+	expected := []string{"10.42.0.1", "192.168.10.131"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("pre-sync filter(...) = %v, want %v", got, expected)
+	}
+}
+
+func TestPodIPTracker_OnChange_AndFilter(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pods := fake.NewMockControllerInterface[*corev1.Pod, *corev1.PodList](ctrl)
+
+	list := &corev1.PodList{
+		Items: []corev1.Pod{
+			*makePod(namespace.System, "rancher-1", "10.42.0.1", false),
+			*makePod(namespace.System, "rancher-2", "10.42.0.2", false),
+			*makePod(namespace.System, "rancher-3", "10.42.0.3", true), // being deleted, excluded
+			*makePod(namespace.System, "rancher-4", "", false),         // no IP yet, excluded
+		},
+	}
+	pods.EXPECT().
+		List(namespace.System, gomock.Any()).
+		Return(list, nil).
+		AnyTimes()
+
+	// Capture the real OnChange handler newPodIPTracker registers, so the
+	// test exercises the actual public entrypoint end-to-end rather than
+	// calling podIPTracker's unexported methods directly.
+	var handler func(string, *corev1.Pod) (*corev1.Pod, error)
+	pods.EXPECT().
+		OnChange(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, _ string, h func(string, *corev1.Pod) (*corev1.Pod, error)) {
+			handler = h
+		}).
+		Times(1)
+
+	filter := newPodIPTracker(context.Background(), namespace.System, "app=rancher", pods, "test-podip-filter")
+
+	// Simulate the informer delivering the first pod event, which triggers
+	// a List() and populates the snapshot.
+	if _, err := handler("rancher-1", &list.Items[0]); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "live pod IPs kept",
+			input:    []string{"10.42.0.1", "10.42.0.2"},
+			expected: []string{"10.42.0.1", "10.42.0.2"},
+		},
+		{
+			name:     "stale/unknown IP pruned",
+			input:    []string{"10.42.0.99"},
+			expected: []string{},
+		},
+		{
+			name:     "deleted pod's IP pruned even though it was in the list response",
+			input:    []string{"10.42.0.3"},
+			expected: []string{},
+		},
+		{
+			name:     "hostnames always rejected regardless of pod set",
+			input:    []string{"rancher.cattle-system", "some.other.host"},
+			expected: []string{},
+		},
+		{
+			name:     "mixed live IP, stale IP, and hostname",
+			input:    []string{"10.42.0.1", "10.42.0.99", "rancher.cattle-system"},
+			expected: []string{"10.42.0.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := filter(tt.input...)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("filter(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPodIPTracker_OnChange_SkipsOtherNamespaces(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pods := fake.NewMockControllerInterface[*corev1.Pod, *corev1.PodList](ctrl)
+	// List must never be called for an event on a pod outside our namespace.
+
+	tracker := &podIPTracker{namespace: namespace.System, labelSelector: "app=rancher", pods: pods}
+	otherNsPod := makePod("some-other-namespace", "unrelated", "10.99.0.1", false)
+	if _, err := tracker.onChange("unrelated", otherNsPod); err != nil {
+		t.Fatalf("onChange returned error: %v", err)
+	}
+
+	// Snapshot was never populated (still pre-sync / nil), so IP CNs still
+	// pass through -- confirms List() was correctly skipped.
+	got := tracker.filterExistingCN("10.99.0.1")
+	if !reflect.DeepEqual(got, []string{"10.99.0.1"}) {
+		t.Errorf("expected pass-through pre-sync behavior, got %v", got)
+	}
+}
+
+func TestPodIPTracker_OnChange_DeleteEventRelists(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pods := fake.NewMockControllerInterface[*corev1.Pod, *corev1.PodList](ctrl)
+	list := &corev1.PodList{
+		Items: []corev1.Pod{
+			*makePod(namespace.System, "rancher-1", "10.42.0.1", false),
+		},
+	}
+	pods.EXPECT().
+		List(namespace.System, gomock.Any()).
+		Return(list, nil).
+		Times(1)
+
+	tracker := &podIPTracker{namespace: namespace.System, labelSelector: "app=rancher", pods: pods}
+
+	// Delete events arrive with a nil pod; onChange must still re-list to
+	// pick up the pod's removal from the live set.
+	if _, err := tracker.onChange("rancher-2", nil); err != nil {
+		t.Fatalf("onChange returned error: %v", err)
+	}
+
+	got := tracker.filterExistingCN("10.42.0.1", "10.42.0.2")
+	if !reflect.DeepEqual(got, []string{"10.42.0.1"}) {
+		t.Errorf("filterExistingCN(...) = %v, want [10.42.0.1]", got)
+	}
+}
+
+func TestPodIPTracker_OnChange_ListError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pods := fake.NewMockControllerInterface[*corev1.Pod, *corev1.PodList](ctrl)
+	pods.EXPECT().
+		List(namespace.System, gomock.Any()).
+		Return(nil, apierrors.NewInternalError(errors.New("boom"))).
+		Times(1)
+
+	tracker := &podIPTracker{namespace: namespace.System, labelSelector: "app=rancher", pods: pods}
+	pod := makePod(namespace.System, "rancher-1", "10.42.0.1", false)
+	if _, err := tracker.onChange("rancher-1", pod); err == nil {
+		t.Fatal("expected error from onChange when List fails")
+	}
+
+	// Snapshot remains nil (pre-sync) since the list failed, so IP CNs
+	// still pass through rather than being incorrectly pruned.
+	got := tracker.filterExistingCN("10.42.0.1")
+	if !reflect.DeepEqual(got, []string{"10.42.0.1"}) {
+		t.Errorf("expected pass-through after failed List, got %v", got)
+	}
+}
+
+// TestPodIPTracker_RejectsArbitraryHostnameInjection is a regression test
+// for the CN-filtering behavior: a client that can reach the
+// tls-rancher-internal listener and control TLS SNI or the HTTP Host header
+// must never be able to get an arbitrary hostname added to the cert, no
+// matter how many distinct hostnames are attempted or what the live pod-IP
+// snapshot contains. Only the static default SANs (already applied upstream
+// by dynamiclistener's allowDefaultSANs, before this filter is ever
+// consulted) and live pod IPs may appear on the cert.
+func TestPodIPTracker_RejectsArbitraryHostnameInjection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pods := fake.NewMockControllerInterface[*corev1.Pod, *corev1.PodList](ctrl)
+	list := &corev1.PodList{
+		Items: []corev1.Pod{
+			*makePod(namespace.System, "rancher-1", "10.42.0.13", false),
+		},
+	}
+	pods.EXPECT().
+		List(namespace.System, gomock.Any()).
+		Return(list, nil).
+		AnyTimes()
+	pods.EXPECT().
+		OnChange(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes()
+
+	// Populate the snapshot the way the real onChange handler would.
+	tracker := &podIPTracker{namespace: namespace.System, labelSelector: "app=rancher", pods: pods}
+	if _, err := tracker.onChange("rancher-1", &list.Items[0]); err != nil {
+		t.Fatalf("onChange returned error: %v", err)
+	}
+	filter := tracker.filterExistingCN
+
+	// Simulate a client sending many distinct fake SNI hostnames, as would
+	// happen via repeated TLS ClientHello / HTTP Host header requests
+	// against the pod's live IP.
+	extraHostnames := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		extraHostnames = append(extraHostnames, fmt.Sprintf("san-test-extra-%d.example", i))
+	}
+
+	got := filter(extraHostnames...)
+	if len(got) != 0 {
+		t.Errorf("expected all %d extra hostnames to be rejected, but %d got through: %v", len(extraHostnames), len(got), got)
+	}
+
+	// A legitimate live pod IP must still be kept alongside the rejected
+	// hostnames in the same call.
+	mixed := append([]string{"10.42.0.13"}, extraHostnames...)
+	got = filter(mixed...)
+	if !reflect.DeepEqual(got, []string{"10.42.0.13"}) {
+		t.Errorf("filter(pod IP + extra hostnames) = %v, want only the live pod IP kept", got)
+	}
+}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -124,6 +124,15 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 		return err
 	}
 
+	// Always include localhost and the in-cluster DNS name for the
+	// rancher-internal Service as default SANs, alongside the dynamic
+	// pod/cluster IPs below. These are admin-controlled Config.SANs
+	// (short-circuited by dynamiclistener's allowDefaultSANs before
+	// FilterCN ever runs), so they're always present regardless of what
+	// the pod-IP/Service-allowlist filter would otherwise decide -- and
+	// unlike those IPs, they don't change across restarts.
+	hostIPs = append(hostIPs, "localhost", apiservice.RancherInternalServiceName+"."+namespace.System+".svc")
+
 	if clusterIP != "" {
 		hostIPs = append(hostIPs, clusterIP)
 	}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -124,14 +124,16 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 		return err
 	}
 
-	// Always include localhost and the in-cluster DNS name for the
-	// rancher-internal Service as default SANs, alongside the dynamic
-	// pod/cluster IPs below. These are admin-controlled Config.SANs
-	// (short-circuited by dynamiclistener's allowDefaultSANs before
-	// FilterCN ever runs), so they're always present regardless of what
-	// the pod-IP/Service-allowlist filter would otherwise decide -- and
-	// unlike those IPs, they don't change across restarts.
-	hostIPs = append(hostIPs, "localhost", apiservice.RancherInternalServiceName+"."+namespace.System+".svc")
+	// Always include localhost, 127.0.0.1, and the in-cluster DNS names
+	// (short and FQDN forms) for the rancher-internal Service as default
+	// SANs, alongside the dynamic pod/cluster IPs below. These are
+	// admin-controlled Config.SANs (short-circuited by dynamiclistener's
+	// allowDefaultSANs before FilterCN ever runs), so they're always
+	// present regardless of what the pod-IP/Service-allowlist filter
+	// would otherwise decide -- and unlike those IPs, they don't change
+	// across restarts.
+	internalSvcName := apiservice.RancherInternalServiceName + "." + namespace.System + ".svc"
+	hostIPs = append(hostIPs, "localhost", "127.0.0.1", internalSvcName, internalSvcName+".cluster.local")
 
 	if clusterIP != "" {
 		hostIPs = append(hostIPs, clusterIP)


### PR DESCRIPTION
## Summary

Forward port of #56308 and #56313 from `release/v2.15` to `main`. Both were merged into `release/v2.15` but hadn't landed on `main` yet.

- Reject non-IP CNs on the tls-rancher-internal (:444) listener's dynamic CN filter, keeping only live pod IPs. Static default SANs (localhost, cluster IP, node IPs, etc.) continue to be handled separately upstream and are unaffected.
- Add `localhost`, `127.0.0.1`, and the in-cluster DNS names (short + FQDN) for the rancher-internal Service as default SANs on that listener, matching what the main :443 listener already includes.

## Notes

`main`'s `pkg/tls` package predates the Service-allowlist feature that was added on `release/v2.15` (`pkg/tls/cnfilter.go`, PR #56238), so the two source PRs didn't cherry-pick cleanly for the first change:

- The two SAN-default commits (#56313) cherry-picked cleanly onto `pkg/tls/tls.go`.
- The CN-filtering tightening (#56308) touched `pkg/tls/cnfilter.go`, which doesn't exist on `main` (the equivalent logic lives in `pkg/tls/podips.go` without the Service-allowlist wrapper). That change was manually ported onto `podIPTracker`/`filterExistingCN` in `podips.go`, along with a new `podips_test.go` covering the same cases as the release branch's test file (adapted to drop allowlist-specific tests that don't apply here).

## Testing

- `go build ./pkg/tls/... ./pkg/...` passes.
- `go test ./pkg/tls/... -v` passes, including the new pod-IP-tracker tests and the hostname-injection regression test.