### PR TITLE
[2.14] Allow updatecli to detect RC tags for wins and system-agent

### DIFF
--- a/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
+++ b/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
@@ -70,7 +70,7 @@ sources:
       token: '{{ requiredEnv .scm.token }}'
       versionfilter:
         kind: semver
-        pattern: '~{{ source "wins-current-version" }}'
+        pattern: '~{{ source "wins-current-version" }}-0'
 
   system-agent-release:
     name: 'Get latest upstream System Agent version'
@@ -88,7 +88,7 @@ sources:
       token: '{{ requiredEnv .scm.token }}'
       versionfilter:
         kind: semver
-        pattern: '~{{ source "system-agent-current-version" }}'
+        pattern: '~{{ source "system-agent-current-version" }}-0'
 
   wins-checksum:
     name: 'Get sha256 for wins.exe from {{ source "wins-release" }}'


### PR DESCRIPTION
Issue: 
- https://github.com/rancher/rancher/issues/55769

The workflow-generated  PR https://github.com/rancher/rancher/pull/56373 does not detect the new wins tag v0.14.1-rc.1

This PR adds the `-0` suffix appended to the current version, which acts as a prerelease floor in semver, which means the constraint now includes prerelease tags like v0.14.1-rc.1 within the same `~v0.14.x` minor range.

From https://github.com/Masterminds/semver README:
> SemVer's comparisons using constraints without a pre-release comparator will skip pre-release versions. For example, >=1.2.3 will skip pre-releases when looking at a list of releases while >=1.2.3-0 will evaluate and find pre-releases.
 