### PR TITLE
Fix principal search for providers without a user lookup

### DIFF
--- a/pkg/auth/providers/cognito/cognito.go
+++ b/pkg/auth/providers/cognito/cognito.go
@@ -33,13 +33,14 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.
 	p := &CognitoProvider{
 		GenOIDCProvider: genericoidc.GenOIDCProvider{
 			OpenIDCProvider: baseoidc.OpenIDCProvider{
-				Name:        Name,
-				Type:        client.CognitoConfigType,
-				CTX:         ctx,
-				AuthConfigs: mgmtCtx.Management.AuthConfigs(""),
-				Secrets:     mgmtCtx.Wrangler.Core.Secret(),
-				UserMGR:     userMGR,
-				TokenMgr:    tokenMgr,
+				Name:         Name,
+				Type:         client.CognitoConfigType,
+				CTX:          ctx,
+				AuthConfigs:  mgmtCtx.Management.AuthConfigs(""),
+				Secrets:      mgmtCtx.Wrangler.Core.Secret(),
+				UserMGR:      userMGR,
+				TokenMgr:     tokenMgr,
+				UserSearcher: common.NewUserSearcher(mgmtCtx.Management.Users("").Controller().Lister()),
 			},
 		},
 	}

--- a/pkg/auth/providers/common/usersearch.go
+++ b/pkg/auth/providers/common/usersearch.go
@@ -1,0 +1,185 @@
+package common
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// UserLister lists v3.User resources, normally from an informer cache.
+type UserLister interface {
+	List(namespace string, selector labels.Selector) ([]*apiv3.User, error)
+}
+
+// UserSearcher resolves principals from the v3.User resources Rancher has
+// already created. Providers whose identity provider offers no user lookup use
+// it to return the real principals of users that have logged in or been
+// provisioned, rather than only a principal built from the search key.
+type UserSearcher struct {
+	users UserLister
+}
+
+// NewUserSearcher returns a UserSearcher backed by the given lister.
+func NewUserSearcher(users UserLister) *UserSearcher {
+	return &UserSearcher{users: users}
+}
+
+// SearchPrincipals returns the user principals owned by provider that belong to
+// users matching searchKey, ordered by principal ID. A user contributes a
+// principal only if it carries a principal ID for provider, so users known to
+// Rancher through some other provider are left out. A search key that is empty
+// or only whitespace matches nothing, to avoid returning every user.
+func (s *UserSearcher) SearchPrincipals(provider, searchKey string) ([]apiv3.Principal, error) {
+	queryKey := strings.ToLower(searchKey)
+	normalizedQueryKey := normalizeSearchKey(queryKey)
+
+	// A key that normalizes to nothing, because it is empty or only
+	// whitespace, is contained in every name and would return every user.
+	if normalizedQueryKey == "" {
+		return nil, nil
+	}
+
+	users, err := s.users.List("", labels.NewSelector())
+	if err != nil {
+		return nil, fmt.Errorf("listing users for search %q: %w", searchKey, err)
+	}
+
+	prefix := provider + "_" + UserPrincipalType + "://"
+
+	var principals []apiv3.Principal
+	for _, user := range users {
+		// Users of other providers cannot contribute a principal, so skip them
+		// before normalizing their display name to match it.
+		if !hasPrincipalWithPrefix(user, prefix) {
+			continue
+		}
+
+		if !userMatchesSearchKey(user, queryKey, normalizedQueryKey) {
+			continue
+		}
+
+		for _, principalID := range user.PrincipalIDs {
+			if !strings.HasPrefix(principalID, prefix) {
+				continue
+			}
+
+			principals = append(principals, apiv3.Principal{
+				ObjectMeta:    metav1.ObjectMeta{Name: principalID},
+				DisplayName:   user.DisplayName,
+				PrincipalType: UserPrincipalType,
+				Provider:      provider,
+			})
+		}
+	}
+
+	// The lister iterates the informer cache in no particular order, so sort to
+	// keep repeated searches in the same order.
+	slices.SortFunc(principals, func(a, b apiv3.Principal) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return principals, nil
+}
+
+// PrincipalsWithFallback returns the principals of provider's users matching
+// searchKey, followed by fallback unless one of them already has its ID.
+// Providers whose identity provider offers no user lookup call this with a
+// principal built from the search key, so an admin can still enter an external
+// ID by hand for an identity Rancher has not seen yet. A nil searcher yields
+// only the fallback.
+func PrincipalsWithFallback(searcher *UserSearcher, provider, searchKey string, fallback apiv3.Principal) ([]apiv3.Principal, error) {
+	var principals []apiv3.Principal
+
+	if searcher != nil {
+		known, err := searcher.SearchPrincipals(provider, searchKey)
+		if err != nil {
+			return nil, err
+		}
+		principals = known
+	}
+
+	if !ContainsPrincipal(principals, fallback.Name) {
+		principals = append(principals, fallback)
+	}
+
+	return principals, nil
+}
+
+func hasPrincipalWithPrefix(user *apiv3.User, prefix string) bool {
+	return slices.ContainsFunc(user.PrincipalIDs, func(id string) bool {
+		return strings.HasPrefix(id, prefix)
+	})
+}
+
+// ContainsPrincipal reports whether principals holds a principal with the given
+// resource name.
+func ContainsPrincipal(principals []apiv3.Principal, name string) bool {
+	return slices.ContainsFunc(principals, func(p apiv3.Principal) bool {
+		return p.Name == name
+	})
+}
+
+// UserMatchesSearchKey reports whether the user's resource name, login username
+// or display name matches searchKey. The search key is expected to be lower
+// case. Whitespace and diacritics are ignored so that a display name can be
+// found however it is typed.
+//
+// Callers that test many users against one search key should normalize the key
+// once with normalizeSearchKey and call userMatchesSearchKey instead.
+func UserMatchesSearchKey(user *apiv3.User, searchKey string) bool {
+	return userMatchesSearchKey(user, searchKey, normalizeSearchKey(searchKey))
+}
+
+// userMatchesSearchKey takes both the raw search key, matched against the user's
+// resource name, and its normalized form, matched against the login username and
+// display name.
+func userMatchesSearchKey(user *apiv3.User, searchKey, normalizedSearchKey string) bool {
+	// Every name contains the empty string, so a key that normalized to nothing
+	// is no search rather than a match on everything.
+	if normalizedSearchKey == "" {
+		return false
+	}
+
+	normalizedDisplayName := normalizeSearchKey(user.DisplayName)
+
+	return strings.HasPrefix(user.ObjectMeta.Name, searchKey) ||
+		strings.Contains(strings.ToLower(normalizeWhitespace(user.Username)), normalizedSearchKey) ||
+		strings.Contains(normalizedDisplayName, normalizedSearchKey)
+}
+
+func normalizeSearchKey(s string) string {
+	return strings.ToLower(normalizeWhitespace(SimplifyString(s)))
+}
+
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), "")
+}
+
+// SimplifyString transforms unicode characters in the string by replacing
+// the characters.
+//
+// The set of characters that is replaced (unicode.Mn) is here
+//
+//	https://www.compart.com/en/unicode/category/Mn
+func SimplifyString(s string) string {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	result, _, err := transform.String(t, s)
+
+	// This shouldn't really happen, as the rune transformer is very forgiving
+	// and bad things get changed to �
+	if err != nil {
+		logrus.Errorf("failed to simplify string %q: %s", s, err)
+		return s
+	}
+
+	return result
+}

--- a/pkg/auth/providers/common/usersearch_test.go
+++ b/pkg/auth/providers/common/usersearch_test.go
@@ -1,0 +1,259 @@
+package common_test
+
+import (
+	"errors"
+	"testing"
+
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestUserSearcherSearchPrincipals(t *testing.T) {
+	t.Parallel()
+
+	users := []*apiv3.User{
+		{
+			// OIDC user: no Username, opaque subject in the provider principal.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc1"},
+			DisplayName:  "Test UserOne",
+			PrincipalIDs: []string{"genericoidc_user://sub-0001", "local://u-oidc1"},
+		},
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc2"},
+			DisplayName:  "Test UserTwo",
+			PrincipalIDs: []string{"genericoidc_user://sub-0002", "local://u-oidc2"},
+		},
+		{
+			// SCIM-provisioned Okta user.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-okta1"},
+			DisplayName:  "testuser2@example.com",
+			PrincipalIDs: []string{"okta_user://abc-uuid-1", "local://u-okta1"},
+		},
+		{
+			// Purely local user, no external principal.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-local1"},
+			Username:     "svcadmin",
+			DisplayName:  "Service Admin",
+			PrincipalIDs: []string{"local://u-local1"},
+		},
+		{
+			// Hybrid user: local login plus an external principal.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-admin"},
+			Username:     "admin",
+			DisplayName:  "Default Admin",
+			PrincipalIDs: []string{"genericoidc_user://sub-0009", "local://u-admin"},
+		},
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-accent"},
+			DisplayName:  "Émile Dubois",
+			PrincipalIDs: []string{"genericoidc_user://sub-0003", "local://u-accent"},
+		},
+	}
+
+	searcher := common.NewUserSearcher(&fakes.UserListerMock{
+		ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+			return users, nil
+		},
+	})
+
+	tests := []struct {
+		name      string
+		provider  string
+		searchKey string
+		want      []apiv3.Principal
+	}{
+		{
+			name:      "matches display name of a provider user",
+			provider:  "genericoidc",
+			searchKey: "testu",
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: "user",
+					Provider:      "genericoidc",
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0002"},
+					DisplayName:   "Test UserTwo",
+					PrincipalType: "user",
+					Provider:      "genericoidc",
+				},
+			},
+		},
+		{
+			name:      "match is case insensitive and ignores whitespace",
+			provider:  "genericoidc",
+			searchKey: "test user",
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: "user",
+					Provider:      "genericoidc",
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0002"},
+					DisplayName:   "Test UserTwo",
+					PrincipalType: "user",
+					Provider:      "genericoidc",
+				},
+			},
+		},
+		{
+			name:      "match ignores diacritics",
+			provider:  "genericoidc",
+			searchKey: "emile",
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0003"},
+					DisplayName:   "Émile Dubois",
+					PrincipalType: "user",
+					Provider:      "genericoidc",
+				},
+			},
+		},
+		{
+			name:      "hybrid user is returned under the external provider",
+			provider:  "genericoidc",
+			searchKey: "Default Admin",
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0009"},
+					DisplayName:   "Default Admin",
+					PrincipalType: "user",
+					Provider:      "genericoidc",
+				},
+			},
+		},
+		{
+			name:      "matches the local login username of a hybrid user",
+			provider:  "genericoidc",
+			searchKey: "admin",
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0009"},
+					DisplayName:   "Default Admin",
+					PrincipalType: "user",
+					Provider:      "genericoidc",
+				},
+			},
+		},
+		{
+			name:      "only principals owned by the requested provider are returned",
+			provider:  "okta",
+			searchKey: "testuser2",
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "okta_user://abc-uuid-1"},
+					DisplayName:   "testuser2@example.com",
+					PrincipalType: "user",
+					Provider:      "okta",
+				},
+			},
+		},
+		{
+			name:      "user without a principal for the provider is skipped",
+			provider:  "genericoidc",
+			searchKey: "svcadmin",
+			want:      nil,
+		},
+		{
+			name:      "no match returns nothing",
+			provider:  "genericoidc",
+			searchKey: "nobody",
+			want:      nil,
+		},
+		{
+			name:      "empty search key returns nothing",
+			provider:  "genericoidc",
+			searchKey: "",
+			want:      nil,
+		},
+		{
+			name:      "whitespace search key returns nothing",
+			provider:  "genericoidc",
+			searchKey: "   ",
+			want:      nil,
+		},
+		{
+			name:      "long whitespace search key returns nothing",
+			provider:  "genericoidc",
+			searchKey: "          ",
+			want:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := searcher.SearchPrincipals(test.provider, test.searchKey)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestUserSearcherSearchPrincipalsOrder(t *testing.T) {
+	t.Parallel()
+
+	// The informer cache iterates in no particular order, so the lister can
+	// hand back matching users in any order.
+	users := []*apiv3.User{
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc3"},
+			DisplayName:  "Test UserThree",
+			PrincipalIDs: []string{"genericoidc_user://sub-0003"},
+		},
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc1"},
+			DisplayName:  "Test UserOne",
+			PrincipalIDs: []string{"genericoidc_user://sub-0001"},
+		},
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc2"},
+			DisplayName:  "Test UserTwo",
+			PrincipalIDs: []string{"genericoidc_user://sub-0002"},
+		},
+	}
+
+	searcher := common.NewUserSearcher(&fakes.UserListerMock{
+		ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+			return users, nil
+		},
+	})
+
+	got, err := searcher.SearchPrincipals("genericoidc", "testu")
+	require.NoError(t, err)
+
+	var ids []string
+	for _, principal := range got {
+		ids = append(ids, principal.Name)
+	}
+
+	assert.Equal(t, []string{
+		"genericoidc_user://sub-0001",
+		"genericoidc_user://sub-0002",
+		"genericoidc_user://sub-0003",
+	}, ids)
+}
+
+func TestUserSearcherSearchPrincipalsListError(t *testing.T) {
+	t.Parallel()
+
+	searcher := common.NewUserSearcher(&fakes.UserListerMock{
+		ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+			return nil, errors.New("cache is not synced")
+		},
+	})
+
+	got, err := searcher.SearchPrincipals("genericoidc", "testu")
+	require.ErrorContains(t, err, `listing users for search "testu": cache is not synced`)
+	assert.Nil(t, got)
+}

--- a/pkg/auth/providers/genericoidc/genericoidc_provider.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider.go
@@ -31,13 +31,14 @@ const (
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager) common.AuthProvider {
 	p := &GenOIDCProvider{
 		baseoidc.OpenIDCProvider{
-			Name:        Name,
-			Type:        client.GenericOIDCConfigType,
-			CTX:         ctx,
-			AuthConfigs: mgmtCtx.Management.AuthConfigs(""),
-			Secrets:     mgmtCtx.Wrangler.Core.Secret(),
-			UserMGR:     userMGR,
-			TokenMgr:    tokenMGR,
+			Name:         Name,
+			Type:         client.GenericOIDCConfigType,
+			CTX:          ctx,
+			AuthConfigs:  mgmtCtx.Management.AuthConfigs(""),
+			Secrets:      mgmtCtx.Wrangler.Core.Secret(),
+			UserMGR:      userMGR,
+			TokenMgr:     tokenMGR,
+			UserSearcher: common.NewUserSearcher(mgmtCtx.Management.Users("").Controller().Lister()),
 		},
 	}
 	p.GetConfig = p.GetOIDCConfig
@@ -49,22 +50,30 @@ func (g *GenOIDCProvider) GetName() string {
 	return Name
 }
 
-// SearchPrincipals will return a principal of the requested principalType with a displayName
-// that matches the searchValue.  If principalType is empty, both a user principal and a group principal will
-// be returned.  This is done because OIDC does not have a proper lookup mechanism.  In order
-// to provide some degree of functionality that allows manual entry for users/groups, this is the compromise.
+// SearchPrincipals will return the users Rancher already knows about whose
+// display name or username matches the searchValue, followed by a principal of
+// the requested principalType holding the searchValue itself.
+// If principalType is empty, both a user principal and a group principal will
+// be returned.  This is done because OIDC does not have a proper lookup
+// mechanism, so that last principal lets an admin enter a subject or group ID by
+// hand for an identity Rancher has not seen yet.
 func (g *GenOIDCProvider) SearchPrincipals(searchValue, principalType string, _ accessor.TokenAccessor) ([]apiv3.Principal, error) {
 	var principals []apiv3.Principal
 
 	if principalType != GroupType {
-		p := apiv3.Principal{
+		fromSearchValue := apiv3.Principal{
 			ObjectMeta:    metav1.ObjectMeta{Name: g.Name + "_" + UserType + "://" + searchValue},
 			DisplayName:   searchValue,
 			LoginName:     searchValue,
 			PrincipalType: UserType,
 			Provider:      g.Name,
 		}
-		principals = append(principals, p)
+
+		users, err := common.PrincipalsWithFallback(g.UserSearcher, g.Name, searchValue, fromSearchValue)
+		if err != nil {
+			return nil, err
+		}
+		principals = append(principals, users...)
 	}
 
 	if principalType != UserType {

--- a/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
+++ b/pkg/auth/providers/genericoidc/genericoidc_provider_test.go
@@ -1,16 +1,20 @@
 package genericoidc
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/oidc"
 	baseoidc "github.com/rancher/rancher/pkg/auth/providers/oidc"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestGenOIDCProvider_GetPrincipal(t *testing.T) {
@@ -372,4 +376,157 @@ func TestGenOIDCProvider_TransformToAuthProvider(t *testing.T) {
 			assert.Equal(t, test.expected, result)
 		})
 	}
+}
+
+func TestGenOIDCProviderSearchPrincipalsResolvesKnownUsers(t *testing.T) {
+	t.Parallel()
+
+	users := []*apiv3.User{
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc1"},
+			DisplayName:  "Test UserOne",
+			PrincipalIDs: []string{"genericoidc_user://sub-0001", "local://u-oidc1"},
+		},
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-okta1"},
+			DisplayName:  "Test UserFromOkta",
+			PrincipalIDs: []string{"okta_user://abc-uuid-1", "local://u-okta1"},
+		},
+	}
+
+	g := &GenOIDCProvider{
+		oidc.OpenIDCProvider{
+			Name: Name,
+			Type: client.GenericOIDCConfigType,
+			UserSearcher: common.NewUserSearcher(&fakes.UserListerMock{
+				ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+					return users, nil
+				},
+			}),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		searchValue   string
+		principalType string
+		expected      []apiv3.Principal
+	}{
+		{
+			name:          "known user is returned with its real subject",
+			searchValue:   "testu",
+			principalType: UserType,
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+			},
+		},
+		{
+			name:        "known user is returned alongside the group principal",
+			searchValue: "testu",
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_group://testu"},
+					DisplayName:   "testu",
+					PrincipalType: GroupType,
+					Provider:      Name,
+				},
+			},
+		},
+		{
+			name:          "searching the subject returns a single principal",
+			searchValue:   "sub-0001",
+			principalType: UserType,
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://sub-0001"},
+					DisplayName:   "sub-0001",
+					LoginName:     "sub-0001",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+			},
+		},
+		{
+			name:          "users of another provider are not returned",
+			searchValue:   "UserFromOkta",
+			principalType: UserType,
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_user://UserFromOkta"},
+					DisplayName:   "UserFromOkta",
+					LoginName:     "UserFromOkta",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+			},
+		},
+		{
+			name:          "group search does not resolve users",
+			searchValue:   "testu",
+			principalType: GroupType,
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "genericoidc_group://testu"},
+					DisplayName:   "testu",
+					PrincipalType: GroupType,
+					Provider:      Name,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := g.SearchPrincipals(test.searchValue, test.principalType, &apiv3.Token{})
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestGenOIDCProviderSearchPrincipalsUserSearchError(t *testing.T) {
+	t.Parallel()
+
+	g := &GenOIDCProvider{
+		oidc.OpenIDCProvider{
+			Name: Name,
+			Type: client.GenericOIDCConfigType,
+			UserSearcher: common.NewUserSearcher(&fakes.UserListerMock{
+				ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+					return nil, errors.New("cache is not synced")
+				},
+			}),
+		},
+	}
+
+	got, err := g.SearchPrincipals("testu", UserType, &apiv3.Token{})
+	assert.ErrorContains(t, err, "cache is not synced")
+	assert.Nil(t, got)
 }

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"unicode"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/apiserver/pkg/apierror"
@@ -21,9 +20,6 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/text/runes"
-	"golang.org/x/text/transform"
-	"golang.org/x/text/unicode/norm"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -50,16 +46,33 @@ type Provider struct {
 }
 
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, _ user.Manager) common.AuthProvider {
-	informer := mgmtCtx.Management.Users("").Controller().Informer()
-	indexers := map[string]cache.IndexFunc{userNameIndex: userNameIndexer, userSearchIndex: userSearchIndexer}
-	_ = informer.AddIndexers(indexers)
+	return NewProvider(
+		mgmtCtx.Management.Users("").Controller().Informer(),
+		mgmtCtx.Management.Users("").Controller().Lister(),
+		pbkdf2.New(mgmtCtx.Wrangler.Core.Secret().Cache(), mgmtCtx.Wrangler.Core.Secret()),
+	)
+}
 
-	l := &Provider{
+// NewProvider returns a Provider backed by informer's user cache. It registers
+// the indexers the provider's lookups need, so it has to be called before the
+// informer starts.
+//
+// A registration failure is ignored on purpose. Configure runs more than once
+// per startup, since providers.Configure is called from both the principals
+// handler and the RTB store, and AddIndexers reports a conflict for names
+// already registered on the shared informer, so the second call always fails
+// with nothing wrong.
+func NewProvider(informer cache.SharedIndexInformer, userLister v3.UserLister, pwdVerifier PasswordVerifier) *Provider {
+	_ = informer.AddIndexers(cache.Indexers{
+		userNameIndex:   userNameIndexer,
+		userSearchIndex: userSearchIndexer,
+	})
+
+	return &Provider{
+		userLister:  userLister,
 		userIndexer: informer.GetIndexer(),
-		userLister:  mgmtCtx.Management.Users("").Controller().Lister(),
-		pwdVerifier: pbkdf2.New(mgmtCtx.Wrangler.Core.Secret().Cache(), mgmtCtx.Wrangler.Core.Secret()),
+		pwdVerifier: pwdVerifier,
 	}
-	return l
 }
 
 func (l *Provider) LogoutAll(w http.ResponseWriter, r *http.Request, token accessor.TokenAccessor) error {
@@ -174,22 +187,18 @@ func (l *Provider) RefetchGroupPrincipals(principalID string, secret string) ([]
 	return []apiv3.Principal{}, nil
 }
 
+// SearchPrincipals returns a local principal for every user matching searchKey
+// that can log in locally. Only user principals are returned; the local provider
+// does not own any groups.
+//
+// Results are not deduplicated against the principals other providers returned
+// for the same search. Every user here can log in locally, and a binding on an
+// external principal grants nothing when the user logs in locally, so the local
+// principal is never redundant. Users that cannot log in locally are left out by
+// isLocalUser instead.
 func (l *Provider) SearchPrincipals(searchKey, principalType string, token accessor.TokenAccessor) ([]apiv3.Principal, error) {
-	return l.SearchPrincipalsDedupe(searchKey, principalType, token, nil)
-}
-
-// SearchPrincipalsDedupe performs principal search, and deduplicates the
-// results against the supplied list (that should have come from other non-local
-// auth providers) to avoid duplicate search results. Only user principals are
-// returned; the local provider does not own any groups.
-func (l *Provider) SearchPrincipalsDedupe(searchKey, principalType string, token accessor.TokenAccessor, principalsFromOtherProviders []apiv3.Principal) ([]apiv3.Principal, error) {
 	if principalType == "group" {
 		return nil, nil
-	}
-
-	fromOtherProviders := map[string]bool{}
-	for _, p := range principalsFromOtherProviders {
-		fromOtherProviders[p.Name] = true
 	}
 
 	queryKey := strings.ToLower(searchKey)
@@ -208,16 +217,11 @@ func (l *Provider) SearchPrincipalsDedupe(searchKey, principalType string, token
 	}
 
 	var principals []apiv3.Principal
-User:
 	for _, user := range matched {
 		if !isLocalUser(user) {
 			continue
 		}
-		for _, p := range user.PrincipalIDs {
-			if fromOtherProviders[p] {
-				continue User
-			}
-		}
+
 		principalID := getLocalPrincipalID(user)
 		principals = append(principals, l.toPrincipal("user", user.DisplayName, user.Username, principalID, token))
 	}
@@ -270,7 +274,7 @@ func (l *Provider) listAllUsers(searchKey string) ([]*apiv3.User, error) {
 
 	var matched []*apiv3.User
 	for _, user := range allUsers {
-		if !userMatchesSearchKey(user, searchKey) {
+		if !common.UserMatchesSearchKey(user, searchKey) {
 			continue
 		}
 		matched = append(matched, user)
@@ -338,7 +342,7 @@ func userSearchIndexer(obj any) ([]string, error) {
 func indexField(field string, maxIndex int) []string {
 	var fieldIndexes []string
 	for i := 2; i <= maxIndex; i++ {
-		simplified := []rune(simplifyString(field))
+		simplified := []rune(common.SimplifyString(field))
 
 		// This calculates the string to be indexed after it has been
 		// simplified because it may now be shorter than it was when maxIndex
@@ -384,37 +388,4 @@ func (l *Provider) IsDisabledProvider() (bool, error) {
 // CleanupResources deletes resources associated with the local auth provider.
 func (l *Provider) CleanupResources(*apiv3.AuthConfig) error {
 	return nil
-}
-
-func userMatchesSearchKey(user *apiv3.User, searchKey string) bool {
-	normalizedDisplayName := strings.ToLower(normalizeWhitespace(simplifyString(user.DisplayName)))
-	normalizedSearchKey := strings.ToLower(normalizeWhitespace(simplifyString(searchKey)))
-
-	return (strings.HasPrefix(user.ObjectMeta.Name, searchKey) ||
-		strings.Contains(strings.ToLower(normalizeWhitespace(user.Username)), normalizedSearchKey) ||
-		strings.Contains(normalizedDisplayName, normalizedSearchKey))
-}
-
-func normalizeWhitespace(s string) string {
-	return strings.Join(strings.Fields(s), "")
-}
-
-// simplifyString transforms unicode characters in the string by replacing
-// the characters.
-//
-// The set of characters that is replaced (unicode.Mn) is here
-//
-//	https://www.compart.com/en/unicode/category/Mn
-func simplifyString(s string) string {
-	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-	result, _, err := transform.String(t, s)
-
-	// This shouldn't really happen, as the rune transformer is very forgiving
-	// and bad things get changed to �
-	if err != nil {
-		logrus.Errorf("failed to simplify string %q: %s", s, err)
-		return s
-	}
-
-	return result
 }

--- a/pkg/auth/providers/local/local_auth_provider_test.go
+++ b/pkg/auth/providers/local/local_auth_provider_test.go
@@ -349,3 +349,73 @@ func (f fakeUserLister) List(namespace string, selector labels.Selector) ([]*v3.
 func (f fakeUserLister) Get(namespace, name string) (*v3.User, error) {
 	return nil, nil
 }
+
+func TestProviderSearchPrincipalHybridUser(t *testing.T) {
+	t.Parallel()
+
+	testUsers := []*v3.User{
+		{
+			// Hybrid user: keeps a local login after an external provider was
+			// enabled, so a binding on its local:// principal still grants
+			// access when it logs in locally. It has to stay findable under
+			// local even though the external provider returns a principal for
+			// the same person.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-admin"},
+			Username:     "admin",
+			DisplayName:  "Default Admin",
+			PrincipalIDs: []string{"genericoidc_user://sub-0009", "local://u-admin"},
+		},
+		{
+			// External user with no local login. Must not surface as local.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc1"},
+			DisplayName:  "Admin Assistant",
+			PrincipalIDs: []string{"genericoidc_user://sub-0001", "local://u-oidc1"},
+		},
+	}
+
+	provider := Provider{
+		userLister:  fakeUserLister{users: testUsers},
+		userIndexer: newTestUserIndexer(testUsers...),
+	}
+
+	got, err := provider.SearchPrincipals("admin", "", nil)
+	require.NoError(t, err)
+
+	var ids []string
+	for _, principal := range got {
+		ids = append(ids, principal.Name)
+	}
+
+	require.Equal(t, []string{"local://u-admin"}, ids)
+}
+
+func TestProviderSearchPrincipalWhitespaceSearchKey(t *testing.T) {
+	t.Parallel()
+
+	testUsers := []*v3.User{
+		{
+			ObjectMeta:  metav1.ObjectMeta{Name: "u-12345"},
+			Username:    "test",
+			DisplayName: "Test User",
+		},
+		{
+			ObjectMeta:  metav1.ObjectMeta{Name: "u-23456"},
+			Username:    "other",
+			DisplayName: "Other User",
+		},
+	}
+
+	provider := Provider{
+		userLister:  fakeUserLister{users: testUsers},
+		userIndexer: newTestUserIndexer(testUsers...),
+	}
+
+	// A key of only whitespace normalizes to nothing, which every user would
+	// otherwise contain. Keys longer than searchIndexDefaultLen take the
+	// full-scan path, where that would return every user.
+	for _, searchKey := range []string{"", " ", "   ", "          "} {
+		got, err := provider.SearchPrincipals(searchKey, "", nil)
+		require.NoError(t, err)
+		require.Empty(t, got, "search key %q", searchKey)
+	}
+}

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -54,14 +54,15 @@ type tokenManager interface {
 }
 
 type OpenIDCProvider struct {
-	Name        string
-	Type        string
-	CTX         context.Context
-	AuthConfigs v3.AuthConfigInterface
-	Secrets     wcorev1.SecretController
-	UserMGR     user.Manager
-	TokenMgr    tokenManager
-	GetConfig   func() (*apiv3.OIDCConfig, error)
+	Name         string
+	Type         string
+	CTX          context.Context
+	AuthConfigs  v3.AuthConfigInterface
+	Secrets      wcorev1.SecretController
+	UserMGR      user.Manager
+	TokenMgr     tokenManager
+	UserSearcher *common.UserSearcher
+	GetConfig    func() (*apiv3.OIDCConfig, error)
 }
 
 type ClaimInfo struct {
@@ -199,13 +200,14 @@ func coerceToStringSlice(v any) []string {
 
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, TokenMgr *tokens.Manager) common.AuthProvider {
 	p := &OpenIDCProvider{
-		Name:        Name,
-		Type:        client.OIDCConfigType,
-		CTX:         ctx,
-		AuthConfigs: mgmtCtx.Management.AuthConfigs(""),
-		Secrets:     mgmtCtx.Wrangler.Core.Secret(),
-		UserMGR:     userMGR,
-		TokenMgr:    TokenMgr,
+		Name:         Name,
+		Type:         client.OIDCConfigType,
+		CTX:          ctx,
+		AuthConfigs:  mgmtCtx.Management.AuthConfigs(""),
+		Secrets:      mgmtCtx.Wrangler.Core.Secret(),
+		UserMGR:      userMGR,
+		TokenMgr:     TokenMgr,
+		UserSearcher: common.NewUserSearcher(mgmtCtx.Management.Users("").Controller().Lister()),
 	}
 
 	p.GetConfig = p.GetOIDCConfig
@@ -270,14 +272,18 @@ func (o *OpenIDCProvider) LoginUser(w http.ResponseWriter, req *http.Request, oa
 	return userPrincipal, groupPrincipals, string(oauthToken), userClaimInfo, err
 }
 
+// SearchPrincipals returns the users Rancher already knows about that match
+// searchValue, followed by a principal of the requested type holding searchValue
+// itself. OIDC has no lookup mechanism, so that last principal lets an admin
+// enter a subject or group ID by hand for an identity Rancher has not seen yet.
+// An OIDC subject is an ID chosen by the identity provider, so on its own it
+// only helps someone who already knows that ID.
 func (o *OpenIDCProvider) SearchPrincipals(searchValue, principalType string, token accessor.TokenAccessor) ([]apiv3.Principal, error) {
-	var principals []apiv3.Principal
-
 	if principalType == "" {
 		principalType = UserType
 	}
 
-	p := apiv3.Principal{
+	fromSearchValue := apiv3.Principal{
 		ObjectMeta:    metav1.ObjectMeta{Name: o.Name + "_" + principalType + "://" + searchValue},
 		DisplayName:   searchValue,
 		LoginName:     searchValue,
@@ -285,8 +291,11 @@ func (o *OpenIDCProvider) SearchPrincipals(searchValue, principalType string, to
 		Provider:      o.Name,
 	}
 
-	principals = append(principals, p)
-	return principals, nil
+	if principalType != UserType {
+		return []apiv3.Principal{fromSearchValue}, nil
+	}
+
+	return common.PrincipalsWithFallback(o.UserSearcher, o.Name, searchValue, fromSearchValue)
 }
 
 func (o *OpenIDCProvider) GetPrincipal(principalID string, token accessor.TokenAccessor) (apiv3.Principal, error) {

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -20,11 +20,15 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/mocks"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/oauth2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestValidateACR(t *testing.T) {
@@ -1725,4 +1729,128 @@ func TestCookieSecurityAttributes(t *testing.T) {
 			assert.Equal(t, http.SameSiteLaxMode, got.SameSite, "SameSite must be Lax")
 		})
 	}
+}
+
+func TestSearchPrincipals(t *testing.T) {
+	t.Parallel()
+
+	users := []*apiv3.User{
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc1"},
+			DisplayName:  "Test UserOne",
+			PrincipalIDs: []string{"oidc_user://sub-0001", "local://u-oidc1"},
+		},
+	}
+
+	provider := &OpenIDCProvider{
+		Name: Name,
+		UserSearcher: common.NewUserSearcher(&fakes.UserListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+				return users, nil
+			},
+		}),
+	}
+
+	tests := []struct {
+		name          string
+		searchValue   string
+		principalType string
+		expected      []apiv3.Principal
+	}{
+		{
+			name:          "known user is returned before the principal built from the search value",
+			searchValue:   "testu",
+			principalType: UserType,
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "oidc_user://sub-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "oidc_user://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+			},
+		},
+		{
+			name:        "an empty principal type searches for users",
+			searchValue: "testu",
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "oidc_user://sub-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "oidc_user://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+			},
+		},
+		{
+			name:          "searching the subject returns a single principal",
+			searchValue:   "sub-0001",
+			principalType: UserType,
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "oidc_user://sub-0001"},
+					DisplayName:   "sub-0001",
+					LoginName:     "sub-0001",
+					PrincipalType: UserType,
+					Provider:      Name,
+				},
+			},
+		},
+		{
+			name:          "group search does not resolve users",
+			searchValue:   "testu",
+			principalType: GroupType,
+			expected: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "oidc_group://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: GroupType,
+					Provider:      Name,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := provider.SearchPrincipals(test.searchValue, test.principalType, &apiv3.Token{})
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestSearchPrincipalsWithoutUserSearcher(t *testing.T) {
+	t.Parallel()
+
+	provider := &OpenIDCProvider{Name: Name}
+
+	result, err := provider.SearchPrincipals("testu", UserType, &apiv3.Token{})
+	require.NoError(t, err)
+	assert.Equal(t, []apiv3.Principal{
+		{
+			ObjectMeta:    metav1.ObjectMeta{Name: "oidc_user://testu"},
+			DisplayName:   "testu",
+			LoginName:     "testu",
+			PrincipalType: UserType,
+			Provider:      Name,
+		},
+	}, result)
 }

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -180,7 +180,9 @@ func GetPrincipal(principalID string, myToken accessor.TokenAccessor) (apiv3.Pri
 	return principal, err
 }
 
-// SearchPrincipals searches for principals by name using the token's auth provider, appending deduplicated local results.
+// SearchPrincipals searches for principals by name using the token's auth
+// provider, appending the local results so that users who can log in locally
+// remain findable under any provider.
 func SearchPrincipals(name, principalType string, myToken accessor.TokenAccessor) ([]apiv3.Principal, error) {
 	ap := myToken.GetAuthProvider()
 	if ap == "" {
@@ -199,14 +201,12 @@ func SearchPrincipals(name, principalType string, myToken accessor.TokenAccessor
 	if err != nil {
 		return principals, err
 	}
-	if ap != local.Name {
-		if lpDedupe, _ := lp.(*local.Provider); lpDedupe != nil {
-			localPrincipals, err := lpDedupe.SearchPrincipalsDedupe(name, principalType, myToken, principals)
-			if err != nil {
-				return principals, err
-			}
-			principals = append(principals, localPrincipals...)
+	if ap != local.Name && lp != nil {
+		localPrincipals, err := lp.SearchPrincipals(name, principalType, myToken)
+		if err != nil {
+			return principals, err
 		}
+		principals = append(principals, localPrincipals...)
 	}
 	return principals, err
 }

--- a/pkg/auth/providers/providers_test.go
+++ b/pkg/auth/providers/providers_test.go
@@ -4,15 +4,22 @@ import (
 	"fmt"
 	"testing"
 
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/genericoidc"
 	"github.com/rancher/rancher/pkg/auth/providers/github"
 	"github.com/rancher/rancher/pkg/auth/providers/githubapp"
 	"github.com/rancher/rancher/pkg/auth/providers/local"
 	"github.com/rancher/rancher/pkg/auth/providers/mocks"
+	"github.com/rancher/rancher/pkg/auth/providers/oidc"
 	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestIsSAMLProvider(t *testing.T) {
@@ -219,4 +226,64 @@ func TestIsLocalHiddenReflectsProviderStateChange(t *testing.T) {
 
 	assert.True(t, IsLocalHidden(), "local should be hidden while external provider is active")
 	assert.False(t, IsLocalHidden(), "local should reappear after external provider is disabled")
+}
+
+func TestSearchPrincipalsHybridUser(t *testing.T) {
+	users := []*apiv3.User{
+		{
+			// Hybrid user: kept a local login after OIDC was enabled. Both
+			// principals have to reach the caller, since a binding on the OIDC
+			// one grants nothing when they log in locally, and the other way
+			// round.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-admin"},
+			Username:     "admin",
+			DisplayName:  "Default Admin",
+			PrincipalIDs: []string{"genericoidc_user://sub-0009", "local://u-admin"},
+		},
+		{
+			// OIDC user with no local login. Findable under genericoidc, and
+			// must not surface as local. Issue rancher/rancher#54022.
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-oidc1"},
+			DisplayName:  "Admin Assistant",
+			PrincipalIDs: []string{"genericoidc_user://sub-0001", "local://u-oidc1"},
+		},
+	}
+
+	lister := &fakes.UserListerMock{
+		ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+			return users, nil
+		},
+	}
+
+	informer := cache.NewSharedIndexInformer(&cache.ListWatch{}, &apiv3.User{}, 0, cache.Indexers{})
+	for _, u := range users {
+		require.NoError(t, informer.GetIndexer().Add(u))
+	}
+
+	SetProviders(map[string]common.AuthProvider{
+		genericoidc.Name: &genericoidc.GenOIDCProvider{
+			OpenIDCProvider: oidc.OpenIDCProvider{
+				Name:         genericoidc.Name,
+				UserSearcher: common.NewUserSearcher(lister),
+			},
+		},
+		local.Name: local.NewProvider(informer, lister, nil),
+	})
+	defer SetProviders(nil)
+
+	got, err := SearchPrincipals("admin", "", &apiv3.Token{AuthProvider: genericoidc.Name})
+	require.NoError(t, err)
+
+	var ids []string
+	for _, principal := range got {
+		ids = append(ids, principal.Name)
+	}
+
+	assert.Equal(t, []string{
+		"genericoidc_user://sub-0001", // Admin Assistant, resolved from the user cache
+		"genericoidc_user://sub-0009", // hybrid user's real OIDC subject
+		"genericoidc_user://admin",    // built from the search key
+		"genericoidc_group://admin",   // same, for a group
+		"local://u-admin",             // hybrid user's local login
+	}, ids)
 }

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -49,6 +49,7 @@ type Provider struct {
 	groupType       string
 	clientState     ClientState
 	ldapProvider    common.AuthProvider
+	userSearcher    *common.UserSearcher
 	sloEnabled      bool
 	sloForced       bool
 
@@ -68,6 +69,7 @@ func Configure(mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *to
 		name:           name,
 		userType:       name + "_user",
 		groupType:      name + "_group",
+		userSearcher:   common.NewUserSearcher(mgmtCtx.Management.Users("").Controller().Lister()),
 		assertionCache: newAssertionCache(),
 	}
 	provider.getSamlConfig = provider.getSamlConfigFromUnstructured
@@ -371,9 +373,13 @@ func (s *Provider) UsesUserSecrets() bool      { return false }
 func (s *Provider) CanRefreshPrincipals() bool { return s.name == ShibbolethName }
 
 // SearchPrincipals searches for a principal by name using LDAP if configured.
-// Otherwise it returns a "fake" principal of a requested type with the name as the searchKey.
+// Otherwise it returns the users Rancher already knows about whose display name
+// or username matches the searchKey, followed by a principal of the requested
+// type holding the searchKey itself.
 // If the principalType is empty, both user and group principals are returned.
-// This is done because SAML, in the absence of LDAP, doesn't have a user/group lookup mechanism.
+// This is done because SAML, in the absence of LDAP, doesn't have a user/group
+// lookup mechanism, so that last principal lets an admin enter an external ID by
+// hand for an identity Rancher has not seen yet.
 func (s *Provider) SearchPrincipals(searchKey, principalType string, token accessor.TokenAccessor) ([]apiv3.Principal, error) {
 	if s.hasLdapGroupSearch() {
 		principals, err := s.ldapProvider.SearchPrincipals(searchKey, principalType, token)
@@ -386,13 +392,19 @@ func (s *Provider) SearchPrincipals(searchKey, principalType string, token acces
 	var principals []apiv3.Principal
 
 	if principalType != common.GroupPrincipalType {
-		principals = append(principals, apiv3.Principal{
+		fromSearchKey := apiv3.Principal{
 			ObjectMeta:    metav1.ObjectMeta{Name: s.userType + "://" + searchKey},
 			DisplayName:   searchKey,
 			LoginName:     searchKey,
 			PrincipalType: common.UserPrincipalType,
 			Provider:      s.name,
-		})
+		}
+
+		users, err := common.PrincipalsWithFallback(s.userSearcher, s.name, searchKey, fromSearchKey)
+		if err != nil {
+			return nil, err
+		}
+		principals = append(principals, users...)
 	}
 
 	if principalType != common.UserPrincipalType {

--- a/pkg/auth/providers/saml/saml_provider_test.go
+++ b/pkg/auth/providers/saml/saml_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,12 +21,14 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/ldap"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 )
@@ -489,4 +492,179 @@ func (p *mockLdapProvider) GetUserExtraAttributesFromToken(token accessor.TokenA
 
 func (p *mockLdapProvider) IsDisabledProvider() (bool, error) {
 	panic("IsDisabledProvider Unimplemented!")
+}
+
+func TestSearchPrincipalsResolvesKnownUsers(t *testing.T) {
+	t.Parallel()
+
+	users := []*apiv3.User{
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-ping1"},
+			DisplayName:  "Test UserOne",
+			PrincipalIDs: []string{"ping_user://uid-0001", "local://u-ping1"},
+		},
+		{
+			ObjectMeta:   metav1.ObjectMeta{Name: "u-okta1"},
+			DisplayName:  "Test UserFromOkta",
+			PrincipalIDs: []string{"okta_user://abc-uuid-1", "local://u-okta1"},
+		},
+	}
+
+	provider := &Provider{
+		name:      PingName,
+		userType:  PingName + "_user",
+		groupType: PingName + "_group",
+		userSearcher: common.NewUserSearcher(&fakes.UserListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+				return users, nil
+			},
+		}),
+	}
+
+	tests := []struct {
+		name          string
+		searchKey     string
+		principalType string
+		want          []apiv3.Principal
+	}{
+		{
+			name:          "known user is returned before the principal built from the search key",
+			searchKey:     "testu",
+			principalType: common.UserPrincipalType,
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_user://uid-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: common.UserPrincipalType,
+					Provider:      PingName,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_user://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: common.UserPrincipalType,
+					Provider:      PingName,
+				},
+			},
+		},
+		{
+			name:      "known user is returned alongside the group principal",
+			searchKey: "testu",
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_user://uid-0001"},
+					DisplayName:   "Test UserOne",
+					PrincipalType: common.UserPrincipalType,
+					Provider:      PingName,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_user://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: common.UserPrincipalType,
+					Provider:      PingName,
+				},
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_group://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: common.GroupPrincipalType,
+					Provider:      PingName,
+				},
+			},
+		},
+		{
+			name:          "users of another provider are not returned",
+			searchKey:     "UserFromOkta",
+			principalType: common.UserPrincipalType,
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_user://UserFromOkta"},
+					DisplayName:   "UserFromOkta",
+					LoginName:     "UserFromOkta",
+					PrincipalType: common.UserPrincipalType,
+					Provider:      PingName,
+				},
+			},
+		},
+		{
+			name:          "searching the external id returns a single principal",
+			searchKey:     "uid-0001",
+			principalType: common.UserPrincipalType,
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_user://uid-0001"},
+					DisplayName:   "uid-0001",
+					LoginName:     "uid-0001",
+					PrincipalType: common.UserPrincipalType,
+					Provider:      PingName,
+				},
+			},
+		},
+		{
+			name:          "group search does not resolve users",
+			searchKey:     "testu",
+			principalType: common.GroupPrincipalType,
+			want: []apiv3.Principal{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "ping_group://testu"},
+					DisplayName:   "testu",
+					LoginName:     "testu",
+					PrincipalType: common.GroupPrincipalType,
+					Provider:      PingName,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := provider.SearchPrincipals(test.searchKey, test.principalType, &apiv3.Token{})
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestSearchPrincipalsWithoutUserSearcher(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{
+		name:      PingName,
+		userType:  PingName + "_user",
+		groupType: PingName + "_group",
+	}
+
+	got, err := provider.SearchPrincipals("testu", common.UserPrincipalType, &apiv3.Token{})
+	require.NoError(t, err)
+	assert.Equal(t, []apiv3.Principal{
+		{
+			ObjectMeta:    metav1.ObjectMeta{Name: "ping_user://testu"},
+			DisplayName:   "testu",
+			LoginName:     "testu",
+			PrincipalType: common.UserPrincipalType,
+			Provider:      PingName,
+		},
+	}, got)
+}
+
+func TestSearchPrincipalsUserSearchError(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{
+		name:      PingName,
+		userType:  PingName + "_user",
+		groupType: PingName + "_group",
+		userSearcher: common.NewUserSearcher(&fakes.UserListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) ([]*apiv3.User, error) {
+				return nil, errors.New("cache is not synced")
+			},
+		}),
+	}
+
+	got, err := provider.SearchPrincipals("testu", common.UserPrincipalType, &apiv3.Token{})
+	require.ErrorContains(t, err, "cache is not synced")
+	assert.Nil(t, got)
 }


### PR DESCRIPTION
## Issue: #56362<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Local search used to return every matching v3.User as a local principal, including users of external providers. Member search then listed the same person twice, once under their provider and once as Local. Excluding external users from local search removed that duplicate. It also removed their only findable entry. Users of Generic OIDC, plain OIDC, Cognito, and SAML without LDAP have no login username and carry both an external principal and a local one. None of those providers can query their identity provider, and their own search returns only the search text wrapped as a principal, which matches no existing user. Those users cannot be granted project or cluster access.

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Those providers now also return the real principals of users Rancher has already seen, read from the user cache. The principal built from the search text is kept for identities that have not logged in yet. Keycloak is unchanged, since it queries the Keycloak admin API for real users. Local search continues to exclude external users, and its cross-provider deduplication is removed, since every user it returns can log in locally and its local principal is never redundant. A search key of only whitespace now matches nothing instead of every user.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests