### PR TITLE
[2.15] Allow updatecli to detect RC tags for wins and system-agent 

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -27,7 +27,7 @@ jobs:
   updatecli:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/release/v2.15'
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
+++ b/updatecli/updatecli.d/update-wins-system-agent/update-wins-system-agent.yaml
@@ -70,7 +70,7 @@ sources:
       token: '{{ requiredEnv .scm.token }}'
       versionfilter:
         kind: semver
-        pattern: '~{{ source "wins-current-version" }}'
+        pattern: '~{{ source "wins-current-version" }}-0'
 
   system-agent-release:
     name: 'Get latest upstream System Agent version'
@@ -88,7 +88,7 @@ sources:
       token: '{{ requiredEnv .scm.token }}'
       versionfilter:
         kind: semver
-        pattern: '~{{ source "system-agent-current-version" }}'
+        pattern: '~{{ source "system-agent-current-version" }}-0'
 
   wins-checksum:
     name: 'Get sha256 for wins.exe from {{ source "wins-release" }}'


### PR DESCRIPTION
Issue: 
- https://github.com/rancher/rancher/issues/55769

Backport of 
- https://github.com/rancher/rancher/pull/56374


Also fix the target branch in .github/workflows/updatecli.yml