### PR TITLE
[main] remove day2ops disable multinode provisioning test flaky check

### DIFF
--- a/tests/v2prov/tests/imported/day2ops_disable_reenable_multinode_test.go
+++ b/tests/v2prov/tests/imported/day2ops_disable_reenable_multinode_test.go
@@ -48,7 +48,7 @@ func Test_Imported_Operation_SetD_ImportedDisableMultiNode(t *testing.T) {
 	phase1Cluster := waitForClusterAnnotationValue(t, clients, fixture.mgmtCluster.Name, opsEnabledAnnotation, "true", importedIdentityWaitTimeout)
 	assert.Equal(t, "true", phase1Cluster.Annotations[opsEnabledAnnotation])
 
-	waitForDownstreamSystemAgentPlanUninstallMode(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, "false", importedIdentityWaitTimeout)
+	waitForDownstreamSystemAgentInstallPlan(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, importedIdentityWaitTimeout)
 
 	waitForSystemAgentActiveStateOnPods(t, clients, fixture.ns.Name, podNames, kubectlEnv, true, importedSystemAgentTransitionTimeout)
 	phase1SecretSet := waitForPodsConnectionInfoToMatchNodePlanIdentity(t, clients, fixture.mgmtCluster.Name, fixture.ns.Name, expectedNodeByPod, importedIdentityWaitTimeout)
@@ -65,7 +65,6 @@ func Test_Imported_Operation_SetD_ImportedDisableMultiNode(t *testing.T) {
 	if _, err := setClusterAnnotation(t, clients, fixture.mgmtCluster.Name, opsEnabledAnnotation, "false"); err != nil {
 		t.Fatal(err)
 	}
-	waitForDownstreamSystemAgentPlanUninstallMode(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, "true", importedIdentityWaitTimeout)
 	phase2Cluster := waitForImportedDay2OpsDisabled(t, clients, fixture.mgmtCluster.Name, importedDisableWaitTimeout)
 	assert.Equal(t, "false", phase2Cluster.Annotations[opsEnabledAnnotation])
 	assert.Empty(t, phase2Cluster.Annotations[importedCleaningStateAnnotation])
@@ -88,7 +87,7 @@ func Test_Imported_Operation_SetD_ImportedDisableMultiNode(t *testing.T) {
 	assert.Equal(t, "true", phase3Cluster.Annotations[opsEnabledAnnotation])
 	assert.NotEmpty(t, waitForAppliedSystemAgentHash(t, clients, fixture.mgmtCluster.Name, importedIdentityWaitTimeout))
 
-	waitForDownstreamSystemAgentPlanUninstallMode(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, "false", importedIdentityWaitTimeout)
+	waitForDownstreamSystemAgentInstallPlan(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, importedIdentityWaitTimeout)
 
 	waitForSystemAgentActiveStateOnPods(t, clients, fixture.ns.Name, podNames, kubectlEnv, true, importedSystemAgentTransitionTimeout)
 	phase3SecretSet := waitForPodsConnectionInfoToMatchNodePlanIdentity(t, clients, fixture.mgmtCluster.Name, fixture.ns.Name, expectedNodeByPod, importedIdentityWaitTimeout)

--- a/tests/v2prov/tests/imported/day2ops_disable_reenable_test.go
+++ b/tests/v2prov/tests/imported/day2ops_disable_reenable_test.go
@@ -94,7 +94,7 @@ func Test_Imported_Operation_SetD_ImportedDisableSingleNode(t *testing.T) {
 	assert.Len(t, phase1Identity.PlanTokenSecrets, 1)
 	assert.Len(t, phase1Identity.PlanRoles, 1)
 	assert.Len(t, phase1Identity.PlanRoleBindings, 1)
-	waitForDownstreamSystemAgentPlanUninstallMode(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, "false", importedIdentityWaitTimeout)
+	waitForDownstreamSystemAgentInstallPlan(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, importedIdentityWaitTimeout)
 	t.Logf("phase 1 identity: %s", summarizeImportedPlanIdentity(phase1Identity))
 
 	waitForSystemAgentActiveState(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, true, importedSystemAgentTransitionTimeout)
@@ -146,7 +146,7 @@ func Test_Imported_Operation_SetD_ImportedDisableSingleNode(t *testing.T) {
 	assert.Len(t, phase3Identity.PlanTokenSecrets, 1)
 	assert.Len(t, phase3Identity.PlanRoles, 1)
 	assert.Len(t, phase3Identity.PlanRoleBindings, 1)
-	waitForDownstreamSystemAgentPlanUninstallMode(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, "false", importedIdentityWaitTimeout)
+	waitForDownstreamSystemAgentInstallPlan(t, clients, fixture.ns.Name, fixture.pods[0].Name, kubectlEnv, importedIdentityWaitTimeout)
 	t.Logf("phase 3 identity: %s", summarizeImportedPlanIdentity(phase3Identity))
 
 	newMachinePlanSecretName := phase3Identity.MachinePlanSecrets[0].Name
@@ -206,10 +206,10 @@ func assertImportedDay2OpsFeatureEnabled(t *testing.T, clients *clients.Clients)
 	}
 }
 
-func waitForDownstreamSystemAgentPlanUninstallMode(
+func waitForDownstreamSystemAgentInstallPlan(
 	t *testing.T,
 	clients *clients.Clients,
-	namespace, podName, kubectlEnv, expectedUninstall string,
+	namespace, podName, kubectlEnv string,
 	timeout time.Duration,
 ) {
 	t.Helper()
@@ -248,14 +248,13 @@ func waitForDownstreamSystemAgentPlanUninstallMode(
 			lastUninstallValue = strings.TrimSpace(strings.TrimPrefix(line, "UNINSTALL="))
 		}
 
-		return lastUninstallCount == 1 && lastUninstallValue == expectedUninstall, nil
+		return lastUninstallCount == 1 && lastUninstallValue == "false", nil
 	})
 	if err != nil {
 		planState := dumpDownstreamSystemAgentPlanState(clients, namespace, podName, kubectlEnv)
 		t.Fatalf(
-			"timed out waiting for downstream plan %s UNINSTALL=%s exactly once on pod %s/%s: %v (lastUninstallCount=%d lastUninstallValue=%q lastErr=%v output=%q planState=%q)",
+			"timed out waiting for downstream install plan %s with UNINSTALL=false exactly once on pod %s/%s: %v (lastUninstallCount=%d lastUninstallValue=%q lastErr=%v output=%q planState=%q)",
 			systemAgentUpgraderPlanName,
-			expectedUninstall,
 			namespace,
 			podName,
 			err,


### PR DESCRIPTION
## Issue
#56407
## Problem

  The multi-node disable test waits to observe the downstream `system-agent-upgrader` Plan with `UNINSTALL=true`.

  This Plan is transient: after every targeted node completes the uninstall, the controller deletes it during cleanup. The test polls periodically and can miss the Plan between its creation and deletion, causing a timeout even though disable completed successfully.

  Observing this intermediate state is unnecessary because the test already waits for and validates the terminal disabled state.

  ## Solution

  Remove the transient `UNINSTALL=true` check and continue validating that:

  - Imported day-2 operations reach the disabled state.
  - Cleanup annotations and plan identity resources are removed.
  - System Agent becomes inactive on every node.

  Also refactor the remaining Plan helper to explicitly validate the install state (`UNINSTALL=false`) without a redundant expected-value parameter.