### PR TITLE
Create Plan CRD iff absent to avoid overwriting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/rancher/remotedialer-proxy v0.8.0-rc.5
 	github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6
 	github.com/rancher/steve v0.9.18
-	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8
+	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260803054930-c6c76ca75822
 	github.com/rancher/wrangler/v3 v3.7.1-rc.2
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.4
@@ -160,9 +160,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.2.2
-	k8s.io/api v0.36.2
+	k8s.io/api v0.36.3
 	k8s.io/apiextensions-apiserver v0.36.2
-	k8s.io/apimachinery v0.36.2
+	k8s.io/apimachinery v0.36.3
 	k8s.io/apiserver v0.36.2
 	k8s.io/cli-runtime v0.36.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -665,8 +665,8 @@ github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6 h1:b4Wo+0EqRiNUi+
 github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/steve v0.9.18 h1:d3q1iCSEO4EXhRhdpiZqHrZM3gHUisD64YZiW5VUw4g=
 github.com/rancher/steve v0.9.18/go.mod h1:uSzIkT7bxm1T66P2Gw+QfhoPtI1Db91jplQFx6BnobA=
-github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
-github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
+github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260803054930-c6c76ca75822 h1:PS5UzNmlTMeBhm0Df48pHjiy5MWkHzqHDr4On7kYpDc=
+github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260803054930-c6c76ca75822/go.mod h1:vMTQo88CdIoDMJCX9azje1ckE93d0B82TyMgFroWTcI=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.7.1-rc.2 h1:wnbPQE8/bw2GbLS3Ga71qY438CNgtb3w26FZYvy/9jw=

--- a/pkg/crds/dashboard/crds.go
+++ b/pkg/crds/dashboard/crds.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	bootstrapFleet = map[string]interface{}{
+	bootstrapFleet = map[string]any{
 		"bundles.fleet.cattle.io":       fleetv1alpha1api.Bundle{},
 		"clusters.fleet.cattle.io":      fleetv1alpha1api.Cluster{},
 		"clustergroups.fleet.cattle.io": fleetv1alpha1api.ClusterGroup{},
@@ -42,18 +42,6 @@ func FeatureCRD() crd.CRD {
 
 func List(cfg *rest.Config) (_ []crd.CRD, err error) {
 	result := []crd.CRD{
-		// source: https://github.com/rancher/system-upgrade-controller/blob/v0.15.2/pkg/upgrade/plan/plan.go#L53-L70
-		newCRD(v1.Plan{}, func(c crd.CRD) crd.CRD {
-			c.GVK.Kind = "Plan"
-			c.GVK.Group = "upgrade.cattle.io"
-			c.GVK.Version = "v1"
-			return c.
-				WithStatus().
-				WithCategories("upgrade").
-				WithColumn("Image", ".spec.upgrade.image").
-				WithColumn("Channel", ".spec.channel").
-				WithColumn("Version", ".spec.version")
-		}),
 		newCRD(&uiv1.NavLink{}, func(c crd.CRD) crd.CRD {
 			c.Status = false
 			c.NonNamespace = true
@@ -121,6 +109,11 @@ func List(cfg *rest.Config) (_ []crd.CRD, err error) {
 		}),
 	}
 
+	result, err = planBootstrap(result, cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	if features.Fleet.Enabled() {
 		result = append(result, crd.CRD{
 			SchemaObject: v3.FleetWorkspace{},
@@ -184,6 +177,43 @@ func fleetBootstrap(crds []crd.CRD, cfg *rest.Config) ([]crd.CRD, error) {
 	return crds, nil
 }
 
+// planBootstrap creates plans.upgrade.cattle.io CRD only when it is absent so Rancher does not
+// overwrite an existing SUC-managed CRD schema.
+func planBootstrap(crds []crd.CRD, cfg *rest.Config) ([]crd.CRD, error) {
+	planCRD := newCRD(v1.Plan{}, func(c crd.CRD) crd.CRD {
+		c.GVK.Kind = "Plan"
+		c.GVK.Group = "upgrade.cattle.io"
+		c.GVK.Version = "v1"
+		return c.
+			WithStatus().
+			WithCategories("upgrade").
+			WithColumn("Image", ".spec.upgrade.image").
+			WithColumn("Channel", ".spec.channel").
+			WithColumn("Version", ".spec.version")
+	})
+
+	// Keep current test behavior when cfg is intentionally nil.
+	if cfg == nil {
+		return append(crds, planCRD), nil
+	}
+
+	f, err := apiextensions.NewFactoryFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = f.Apiextensions().V1().CustomResourceDefinition().Get("plans.upgrade.cattle.io", metav1.GetOptions{})
+	if err == nil {
+		// no need to create if the CRD exists
+		return crds, nil
+	}
+	if !apierror.IsNotFound(err) {
+		return nil, err
+	}
+
+	return append(crds, planCRD), nil
+}
+
 func Webhooks() []runtime.Object {
 	if features.ProvisioningV2.Enabled() {
 		return provisioningv2.Webhooks()
@@ -226,7 +256,7 @@ func Create(ctx context.Context, cfg *rest.Config) error {
 	return factory.BatchCreateCRDs(ctx, crds...).BatchWait()
 }
 
-func newCRD(obj interface{}, customize func(crd.CRD) crd.CRD) crd.CRD {
+func newCRD(obj any, customize func(crd.CRD) crd.CRD) crd.CRD {
 	crd := crd.CRD{
 		SchemaObject: obj,
 	}

--- a/pkg/crds/dashboard/crds_test.go
+++ b/pkg/crds/dashboard/crds_test.go
@@ -1,44 +1,250 @@
 package dashboard
 
 import (
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/rancher/rancher/pkg/crds"
 	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/wrangler/v3/pkg/crd"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 )
 
 func TestList(t *testing.T) {
-	// setting fleet to false so we can test with a nil cfg
-	features.Fleet.Set(false)
-
-	originalMigrated := crds.MigratedResources
-	defer func() {
-		crds.MigratedResources = originalMigrated
-	}()
-
-	crds.MigratedResources = nil
+	defer setupListTestState(false, false)()
 
 	result, err := List(nil)
 	require.NoError(t, err, "unexpected error while listing CRDs")
-	found := false
-	for _, crd := range result {
-		if crd.Name() == "clusters.management.cattle.io" {
-			found = true
-			break
-		}
-	}
-	require.Truef(t, found, "missing expected clusters CRD result=%v", result)
+	require.Truef(t, hasCRD(result, "clusters.management.cattle.io"), "missing expected clusters CRD result=%v", result)
 
 	// test that when the CRD is in the migrated list it does not get installed.
 	crds.MigratedResources = map[string]bool{"clusters.management.cattle.io": true}
 
 	result, err = List(nil)
 	require.NoError(t, err, "unexpected error while listing CRDs")
+	require.False(t, hasCRD(result, "clusters.management.cattle.io"), "unexpected clusters CRD result")
+}
 
-	for _, crd := range result {
-		if crd.Name() == "clusters.management.cattle.io" {
-			require.FailNow(t, "clusters.management.cattle.io", "unexpected clusters CRD result")
+func TestListSkipsPlanCRDWhenItAlreadyExists(t *testing.T) {
+	defer setupListTestState(false, false)()
+
+	server := newFakeCRDServer(withCRDExists(map[string]bool{
+		"plans.upgrade.cattle.io": true,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.NoError(t, err, "unexpected error while listing CRDs")
+	require.False(t, hasCRD(result, "plans.upgrade.cattle.io"), "unexpected plan CRD result when CRD already exists")
+}
+
+func TestListWithFleetEnabledIncludesFleetBootstrapCRDs(t *testing.T) {
+	defer setupListTestState(true, false)()
+
+	server := newFakeCRDServer(withCRDStatus(map[string]int{
+		"plans.upgrade.cattle.io": http.StatusOK,
+		// Fleet CRDs do not exist yet, so List should include bootstrap entries for them.
+		"bundles.fleet.cattle.io":       http.StatusNotFound,
+		"clusters.fleet.cattle.io":      http.StatusNotFound,
+		"clustergroups.fleet.cattle.io": http.StatusNotFound,
+		"helmops.fleet.cattle.io":       http.StatusNotFound,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+	requireCRDsPresent(t, result,
+		"fleetworkspaces.management.cattle.io",
+		"bundles.fleet.cattle.io",
+		"clusters.fleet.cattle.io",
+		"clustergroups.fleet.cattle.io",
+		"helmops.fleet.cattle.io",
+	)
+}
+
+func TestListWithFleetAndProvisioningV2IncludesManagedChartCRD(t *testing.T) {
+	defer setupListTestState(true, true)()
+
+	server := newFakeCRDServer(withCRDStatus(map[string]int{
+		"plans.upgrade.cattle.io":       http.StatusOK,
+		"bundles.fleet.cattle.io":       http.StatusOK,
+		"clusters.fleet.cattle.io":      http.StatusOK,
+		"clustergroups.fleet.cattle.io": http.StatusOK,
+		"helmops.fleet.cattle.io":       http.StatusOK,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+	requireCRDsPresent(t, result,
+		"managedcharts.management.cattle.io",
+		"fleetworkspaces.management.cattle.io",
+	)
+}
+
+func TestListReturnsErrorWhenPlanBootstrapFails(t *testing.T) {
+	defer setupListTestState(false, false)()
+
+	result, err := List(&rest.Config{Host: "invalid://bad"})
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestListReturnsErrorWhenFleetBootstrapFails(t *testing.T) {
+	defer setupListTestState(true, false)()
+
+	server := newFakeCRDServer(withCRDStatus(map[string]int{
+		"plans.upgrade.cattle.io": http.StatusOK,
+		"bundles.fleet.cattle.io": http.StatusInternalServerError,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestPlanBootstrap(t *testing.T) {
+	base := []crd.CRD{{GVK: schema.GroupVersionKind{Group: "test.cattle.io", Version: "v1", Kind: "Foo"}}}
+
+	t.Run("nil config appends plan crd", func(t *testing.T) {
+		result, err := planBootstrap(base, nil)
+		require.NoError(t, err)
+		require.True(t, hasCRD(result, "plans.upgrade.cattle.io"))
+	})
+
+	t.Run("existing plan crd does not append", func(t *testing.T) {
+		server := newFakeCRDServer(withCRDStatus(map[string]int{"plans.upgrade.cattle.io": http.StatusOK}))
+		defer server.Close()
+
+		result, err := planBootstrap(base, &rest.Config{Host: server.URL})
+		require.NoError(t, err)
+		require.False(t, hasCRD(result, "plans.upgrade.cattle.io"))
+		require.Equal(t, len(base), len(result))
+	})
+
+	t.Run("missing plan crd appends", func(t *testing.T) {
+		server := newFakeCRDServer(withCRDStatus(map[string]int{"plans.upgrade.cattle.io": http.StatusNotFound}))
+		defer server.Close()
+
+		result, err := planBootstrap(base, &rest.Config{Host: server.URL})
+		require.NoError(t, err)
+		require.True(t, hasCRD(result, "plans.upgrade.cattle.io"))
+	})
+
+	t.Run("api error returns error", func(t *testing.T) {
+		server := newFakeCRDServer(withCRDStatus(map[string]int{"plans.upgrade.cattle.io": http.StatusInternalServerError}))
+		defer server.Close()
+
+		result, err := planBootstrap(base, &rest.Config{Host: server.URL})
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}
+
+func newFakeCRDServer(options ...fakeCRDServerOption) *httptest.Server {
+	cfg := fakeCRDServerConfig{
+		statusByName: map[string]int{},
+	}
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/"
+		if len(r.URL.Path) >= len(prefix) && r.URL.Path[:len(prefix)] == prefix {
+			name := r.URL.Path[len(prefix):]
+			status, ok := cfg.statusByName[name]
+			if !ok {
+				status = http.StatusNotFound
+			}
+
+			switch status {
+			case http.StatusOK:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition","metadata":{"name":%q}}`, name)
+				return
+			case http.StatusNotFound:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = fmt.Fprintf(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"customresourcedefinitions.apiextensions.k8s.io %q not found","reason":"NotFound","details":{"name":%q,"group":"apiextensions.k8s.io","kind":"customresourcedefinitions"},"code":404}`, name, name)
+				return
+			default:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_, _ = fmt.Fprintf(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"server error","reason":"InternalError","code":%d}`, status)
+				return
+			}
 		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+type fakeCRDServerConfig struct {
+	statusByName map[string]int
+}
+
+type fakeCRDServerOption func(*fakeCRDServerConfig)
+
+func withCRDExists(existing map[string]bool) fakeCRDServerOption {
+	return func(cfg *fakeCRDServerConfig) {
+		for name, exists := range existing {
+			if exists {
+				cfg.statusByName[name] = http.StatusOK
+				continue
+			}
+			cfg.statusByName[name] = http.StatusNotFound
+		}
+	}
+}
+
+func withCRDStatus(statusByName map[string]int) fakeCRDServerOption {
+	return func(cfg *fakeCRDServerConfig) {
+		maps.Copy(cfg.statusByName, statusByName)
+	}
+}
+
+func hasCRD(crds []crd.CRD, name string) bool {
+	for _, c := range crds {
+		if c.Name() == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func requireCRDsPresent(t *testing.T, crds []crd.CRD, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		require.Truef(t, hasCRD(crds, name), "missing expected CRD %s", name)
+	}
+}
+
+func setFeatureForTest(feature *features.Feature, value bool) func() {
+	original := feature.Enabled()
+	feature.Set(value)
+
+	return func() {
+		feature.Set(original)
+	}
+}
+
+func setupListTestState(fleetEnabled, provisioningV2Enabled bool) func() {
+	restoreFleet := setFeatureForTest(features.Fleet, fleetEnabled)
+	restoreProvisioning := setFeatureForTest(features.ProvisioningV2, provisioningV2Enabled)
+	originalMigrated := crds.MigratedResources
+	crds.MigratedResources = nil
+
+	return func() {
+		crds.MigratedResources = originalMigrated
+		restoreProvisioning()
+		restoreFleet()
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/56369

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

 

Both Rancher and the SUC application create and update the same Plan CRD. 

Rancher relies on Wrangler's CRD generation mechanism to create the Plan CRD during startup. The Plan CRD is required for Rancher's cluster management functionality and must exist before Rancher can operate correctly.

Starting with v0.15.3, SUC migrated CRD generation to `controller-gen`.  See https://github.com/rancher/system-upgrade-controller/commit/99a03a0d61aa85294d313df06f1a1f4f1bf995fa
Starting with v0.16.3, SUC changed the type of `.spec.drain.timeout` from `*time.Duration` to `*intstr.IntOrString`, introducing a schema difference between the two CRDs.  See https://github.com/rancher/system-upgrade-controller/commit/a8d5a372d82cb65f54c08aea80a1855a4983e6a6
 

This discrepancy does not affect Rancher's own functionality because none of the Plan resources managed by Rancher currently set `spec.drain.timeout`. 

However, it does affect users who create and manage their own Plan resources and rely on the `drain.timeout` field, as the CRD schema exposed by Rancher may not match the one expected by newer SUC releases. Any Plan resource using a string timeout value (e.g. timeout: "5m") fails schema validation after any Rancher restart, until SUC is restarted to re-assert the correct schema.

Schema from SUC: 
```
                  timeout:
                    anyOf:
                    - type: integer
                    - type: string
                    description: |-
                      If a string, this is passed through directly to the `kubectl drain` command.
                      If an int, this represents the duration as a count of nanoseconds, and will be converted to a duration string when passed to the `kubectl drain` command.
                    x-kubernetes-int-or-string: true
```

Schema from Rancher:
```
                  timeout:
                    nullable: true
                    x-kubernetes-int-or-string: true
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Inspired by the existing `fleetBootstrap` implementation, this PR changes Rancher's behavior so that it creates the `plans.upgrade.cattle.io` CRD only if it does not already exist. This prevents Rancher from overwriting an existing CRD schema managed by the System Upgrade Controller (SUC), avoiding schema drift while still ensuring the CRD is available during Rancher startup.



## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The fix was tested locally in the following scenarios:

1. **Fresh Rancher installation**

   On a fresh Rancher installation, the `Plan` CRD does not exist, so Rancher creates it during startup. Later, Rancher installs the SUC application, which updates the existing `Plan` CRD. As a result, the final CRD schema matches the upstream SUC schema.

2. **Rancher upgrade**

   During a Rancher upgrade, the `Plan` CRD already exists in the local cluster. Rancher detects the existing CRD and skips creating it. Later, the bundled SUC application is upgraded to the newer version pinned in Rancher, which updates the existing `Plan` CRD (if there are changes). As a result, the final CRD schema again matches the upstream SUC schema.

 
### Automated Testing

none 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
Please refer to the issue for the steps to reproduce.

With this fix applied, the issue should no longer occur.



### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

The reported issue still exists. 

Existing / newly added automated tests that provide evidence there are no regressions:

n/a