### PR TITLE
add MACHINE_RELEASE_TAG to the allowed env vars for the update-machine job

### DIFF
--- a/updatecli/updatecli.d/update-machine/update-machine.yaml
+++ b/updatecli/updatecli.d/update-machine/update-machine.yaml
@@ -46,6 +46,9 @@ sources:
     name: 'Get requested or latest upstream Rancher Machine version'
     kind: shell
     spec:
+      environments:
+        # pass through the var we need in order to make it available in the shell snippet below
+        - name: 'MACHINE_RELEASE_TAG'
       command: |
         if [ -n "${MACHINE_RELEASE_TAG}" ]; then
           if ! git check-ref-format --allow-onelevel "refs/tags/${MACHINE_RELEASE_TAG}"; then


### PR DESCRIPTION
## Summary                                                                                                                                                                                   
                                                                                                                                                                                             
- Pass `MACHINE_RELEASE_TAG` through to the Updatecli machine release source.                                                                                                                
                                                                                                                                                                                             
## Problem                                                                                                                                                                                   
                                                                                                                                                                                             
The GitHub Actions workflow correctly exports `MACHINE_RELEASE_TAG`, but Updatecli shell resources use an environment allow-list [rather than inheriting the full process environment](https://www.updatecli.io/docs/plugins/resource/shell/#_environments).        
                                                                                                                                                                                             
Because `MACHINE_RELEASE_TAG` was not included in that list, the shell source received it as unset and fell back to selecting the latest matching release. As a result, manually requesting  
`v0.15.0-rancher146-rc.1` selected `v0.15.0-rancher145` instead.                                                                                                                             
                                                                                                                                                                                             
## Solution                                                                                                                                                                                  
                                                                                                                                                                                             
Add `MACHINE_RELEASE_TAG` to the `machine-release` shell source environment configuration so the requested tag is available to the source command.                                
                                                                                                                                                                                             
