### PR TITLE
[2.14] Create Plan CRD iff absent to avoid overwriting

### DIFF
--- a/pkg/crds/dashboard/crds.go
+++ b/pkg/crds/dashboard/crds.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	bootstrapFleet = map[string]interface{}{
+	bootstrapFleet = map[string]any{
 		"bundles.fleet.cattle.io":       fleetv1alpha1api.Bundle{},
 		"clusters.fleet.cattle.io":      fleetv1alpha1api.Cluster{},
 		"clustergroups.fleet.cattle.io": fleetv1alpha1api.ClusterGroup{},
@@ -42,18 +42,6 @@ func FeatureCRD() crd.CRD {
 
 func List(cfg *rest.Config) (_ []crd.CRD, err error) {
 	result := []crd.CRD{
-		// source: https://github.com/rancher/system-upgrade-controller/blob/v0.15.2/pkg/upgrade/plan/plan.go#L53-L70
-		newCRD(v1.Plan{}, func(c crd.CRD) crd.CRD {
-			c.GVK.Kind = "Plan"
-			c.GVK.Group = "upgrade.cattle.io"
-			c.GVK.Version = "v1"
-			return c.
-				WithStatus().
-				WithCategories("upgrade").
-				WithColumn("Image", ".spec.upgrade.image").
-				WithColumn("Channel", ".spec.channel").
-				WithColumn("Version", ".spec.version")
-		}),
 		newCRD(&uiv1.NavLink{}, func(c crd.CRD) crd.CRD {
 			c.Status = false
 			c.NonNamespace = true
@@ -121,6 +109,11 @@ func List(cfg *rest.Config) (_ []crd.CRD, err error) {
 		}),
 	}
 
+	result, err = planBootstrap(result, cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	if features.Fleet.Enabled() {
 		result = append(result, crd.CRD{
 			SchemaObject: v3.FleetWorkspace{},
@@ -184,6 +177,43 @@ func fleetBootstrap(crds []crd.CRD, cfg *rest.Config) ([]crd.CRD, error) {
 	return crds, nil
 }
 
+// planBootstrap creates plans.upgrade.cattle.io CRD only when it is absent so Rancher does not
+// overwrite an existing SUC-managed CRD schema.
+func planBootstrap(crds []crd.CRD, cfg *rest.Config) ([]crd.CRD, error) {
+	planCRD := newCRD(v1.Plan{}, func(c crd.CRD) crd.CRD {
+		c.GVK.Kind = "Plan"
+		c.GVK.Group = "upgrade.cattle.io"
+		c.GVK.Version = "v1"
+		return c.
+			WithStatus().
+			WithCategories("upgrade").
+			WithColumn("Image", ".spec.upgrade.image").
+			WithColumn("Channel", ".spec.channel").
+			WithColumn("Version", ".spec.version")
+	})
+
+	// Keep current test behavior when cfg is intentionally nil.
+	if cfg == nil {
+		return append(crds, planCRD), nil
+	}
+
+	f, err := apiextensions.NewFactoryFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = f.Apiextensions().V1().CustomResourceDefinition().Get("plans.upgrade.cattle.io", metav1.GetOptions{})
+	if err == nil {
+		// no need to create if the CRD exists
+		return crds, nil
+	}
+	if !apierror.IsNotFound(err) {
+		return nil, err
+	}
+
+	return append(crds, planCRD), nil
+}
+
 func Webhooks() []runtime.Object {
 	if features.ProvisioningV2.Enabled() {
 		return provisioningv2.Webhooks()
@@ -226,7 +256,7 @@ func Create(ctx context.Context, cfg *rest.Config) error {
 	return factory.BatchCreateCRDs(ctx, crds...).BatchWait()
 }
 
-func newCRD(obj interface{}, customize func(crd.CRD) crd.CRD) crd.CRD {
+func newCRD(obj any, customize func(crd.CRD) crd.CRD) crd.CRD {
 	crd := crd.CRD{
 		SchemaObject: obj,
 	}

--- a/pkg/crds/dashboard/crds_test.go
+++ b/pkg/crds/dashboard/crds_test.go
@@ -1,44 +1,250 @@
 package dashboard
 
 import (
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/rancher/rancher/pkg/crds"
 	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/wrangler/v3/pkg/crd"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 )
 
 func TestList(t *testing.T) {
-	// setting fleet to false so we can test with a nil cfg
-	features.Fleet.Set(false)
-
-	originalMigrated := crds.MigratedResources
-	defer func() {
-		crds.MigratedResources = originalMigrated
-	}()
-
-	crds.MigratedResources = nil
+	defer setupListTestState(false, false)()
 
 	result, err := List(nil)
 	require.NoError(t, err, "unexpected error while listing CRDs")
-	found := false
-	for _, crd := range result {
-		if crd.Name() == "clusters.management.cattle.io" {
-			found = true
-			break
-		}
-	}
-	require.Truef(t, found, "missing expected clusters CRD result=%v", result)
+	require.Truef(t, hasCRD(result, "clusters.management.cattle.io"), "missing expected clusters CRD result=%v", result)
 
 	// test that when the CRD is in the migrated list it does not get installed.
 	crds.MigratedResources = map[string]bool{"clusters.management.cattle.io": true}
 
 	result, err = List(nil)
 	require.NoError(t, err, "unexpected error while listing CRDs")
+	require.False(t, hasCRD(result, "clusters.management.cattle.io"), "unexpected clusters CRD result")
+}
 
-	for _, crd := range result {
-		if crd.Name() == "clusters.management.cattle.io" {
-			require.FailNow(t, "clusters.management.cattle.io", "unexpected clusters CRD result")
+func TestListSkipsPlanCRDWhenItAlreadyExists(t *testing.T) {
+	defer setupListTestState(false, false)()
+
+	server := newFakeCRDServer(withCRDExists(map[string]bool{
+		"plans.upgrade.cattle.io": true,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.NoError(t, err, "unexpected error while listing CRDs")
+	require.False(t, hasCRD(result, "plans.upgrade.cattle.io"), "unexpected plan CRD result when CRD already exists")
+}
+
+func TestListWithFleetEnabledIncludesFleetBootstrapCRDs(t *testing.T) {
+	defer setupListTestState(true, false)()
+
+	server := newFakeCRDServer(withCRDStatus(map[string]int{
+		"plans.upgrade.cattle.io": http.StatusOK,
+		// Fleet CRDs do not exist yet, so List should include bootstrap entries for them.
+		"bundles.fleet.cattle.io":       http.StatusNotFound,
+		"clusters.fleet.cattle.io":      http.StatusNotFound,
+		"clustergroups.fleet.cattle.io": http.StatusNotFound,
+		"helmops.fleet.cattle.io":       http.StatusNotFound,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+	requireCRDsPresent(t, result,
+		"fleetworkspaces.management.cattle.io",
+		"bundles.fleet.cattle.io",
+		"clusters.fleet.cattle.io",
+		"clustergroups.fleet.cattle.io",
+		"helmops.fleet.cattle.io",
+	)
+}
+
+func TestListWithFleetAndProvisioningV2IncludesManagedChartCRD(t *testing.T) {
+	defer setupListTestState(true, true)()
+
+	server := newFakeCRDServer(withCRDStatus(map[string]int{
+		"plans.upgrade.cattle.io":       http.StatusOK,
+		"bundles.fleet.cattle.io":       http.StatusOK,
+		"clusters.fleet.cattle.io":      http.StatusOK,
+		"clustergroups.fleet.cattle.io": http.StatusOK,
+		"helmops.fleet.cattle.io":       http.StatusOK,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+	requireCRDsPresent(t, result,
+		"managedcharts.management.cattle.io",
+		"fleetworkspaces.management.cattle.io",
+	)
+}
+
+func TestListReturnsErrorWhenPlanBootstrapFails(t *testing.T) {
+	defer setupListTestState(false, false)()
+
+	result, err := List(&rest.Config{Host: "invalid://bad"})
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestListReturnsErrorWhenFleetBootstrapFails(t *testing.T) {
+	defer setupListTestState(true, false)()
+
+	server := newFakeCRDServer(withCRDStatus(map[string]int{
+		"plans.upgrade.cattle.io": http.StatusOK,
+		"bundles.fleet.cattle.io": http.StatusInternalServerError,
+	}))
+	defer server.Close()
+
+	result, err := List(&rest.Config{Host: server.URL})
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestPlanBootstrap(t *testing.T) {
+	base := []crd.CRD{{GVK: schema.GroupVersionKind{Group: "test.cattle.io", Version: "v1", Kind: "Foo"}}}
+
+	t.Run("nil config appends plan crd", func(t *testing.T) {
+		result, err := planBootstrap(base, nil)
+		require.NoError(t, err)
+		require.True(t, hasCRD(result, "plans.upgrade.cattle.io"))
+	})
+
+	t.Run("existing plan crd does not append", func(t *testing.T) {
+		server := newFakeCRDServer(withCRDStatus(map[string]int{"plans.upgrade.cattle.io": http.StatusOK}))
+		defer server.Close()
+
+		result, err := planBootstrap(base, &rest.Config{Host: server.URL})
+		require.NoError(t, err)
+		require.False(t, hasCRD(result, "plans.upgrade.cattle.io"))
+		require.Equal(t, len(base), len(result))
+	})
+
+	t.Run("missing plan crd appends", func(t *testing.T) {
+		server := newFakeCRDServer(withCRDStatus(map[string]int{"plans.upgrade.cattle.io": http.StatusNotFound}))
+		defer server.Close()
+
+		result, err := planBootstrap(base, &rest.Config{Host: server.URL})
+		require.NoError(t, err)
+		require.True(t, hasCRD(result, "plans.upgrade.cattle.io"))
+	})
+
+	t.Run("api error returns error", func(t *testing.T) {
+		server := newFakeCRDServer(withCRDStatus(map[string]int{"plans.upgrade.cattle.io": http.StatusInternalServerError}))
+		defer server.Close()
+
+		result, err := planBootstrap(base, &rest.Config{Host: server.URL})
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}
+
+func newFakeCRDServer(options ...fakeCRDServerOption) *httptest.Server {
+	cfg := fakeCRDServerConfig{
+		statusByName: map[string]int{},
+	}
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/"
+		if len(r.URL.Path) >= len(prefix) && r.URL.Path[:len(prefix)] == prefix {
+			name := r.URL.Path[len(prefix):]
+			status, ok := cfg.statusByName[name]
+			if !ok {
+				status = http.StatusNotFound
+			}
+
+			switch status {
+			case http.StatusOK:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition","metadata":{"name":%q}}`, name)
+				return
+			case http.StatusNotFound:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = fmt.Fprintf(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"customresourcedefinitions.apiextensions.k8s.io %q not found","reason":"NotFound","details":{"name":%q,"group":"apiextensions.k8s.io","kind":"customresourcedefinitions"},"code":404}`, name, name)
+				return
+			default:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_, _ = fmt.Fprintf(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"server error","reason":"InternalError","code":%d}`, status)
+				return
+			}
 		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+type fakeCRDServerConfig struct {
+	statusByName map[string]int
+}
+
+type fakeCRDServerOption func(*fakeCRDServerConfig)
+
+func withCRDExists(existing map[string]bool) fakeCRDServerOption {
+	return func(cfg *fakeCRDServerConfig) {
+		for name, exists := range existing {
+			if exists {
+				cfg.statusByName[name] = http.StatusOK
+				continue
+			}
+			cfg.statusByName[name] = http.StatusNotFound
+		}
+	}
+}
+
+func withCRDStatus(statusByName map[string]int) fakeCRDServerOption {
+	return func(cfg *fakeCRDServerConfig) {
+		maps.Copy(cfg.statusByName, statusByName)
+	}
+}
+
+func hasCRD(crds []crd.CRD, name string) bool {
+	for _, c := range crds {
+		if c.Name() == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func requireCRDsPresent(t *testing.T, crds []crd.CRD, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		require.Truef(t, hasCRD(crds, name), "missing expected CRD %s", name)
+	}
+}
+
+func setFeatureForTest(feature *features.Feature, value bool) func() {
+	original := feature.Enabled()
+	feature.Set(value)
+
+	return func() {
+		feature.Set(original)
+	}
+}
+
+func setupListTestState(fleetEnabled, provisioningV2Enabled bool) func() {
+	restoreFleet := setFeatureForTest(features.Fleet, fleetEnabled)
+	restoreProvisioning := setFeatureForTest(features.ProvisioningV2, provisioningV2Enabled)
+	originalMigrated := crds.MigratedResources
+	crds.MigratedResources = nil
+
+	return func() {
+		crds.MigratedResources = originalMigrated
+		restoreProvisioning()
+		restoreFleet()
 	}
 }


### PR DESCRIPTION
Issue:
- https://github.com/rancher/rancher/issues/56400

Backport of 
- https://github.com/rancher/rancher/pull/56414 

Notes:

Drop the bumping of the `github.com/rancher/system-upgrade-controller/pkg/apis` in the go.mod file. Reasons:
1. The upstream Plan CRD has no changes except for the type of the `.spec.drain.timeout` field
2. The CRD will be updated by the SUC app anyway
3. It will introduce unexpected bumping of Go version and other k8s modules