### PR TITLE
[DO NOT MERGE] test: validate bare if: always() for integration-tests summary gate

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,7 +139,7 @@ jobs:
   # result is success only if every shard succeeded.
   test:
     needs: test-shard
-    if: ${{ always() }}
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Verify all integration shards passed


### PR DESCRIPTION
**DO NOT MERGE — testing only.**

Throwaway PR to validate that the bare form `if: always()` behaves identically to `if: ${{ always() }}` for the integration-tests summary gate (the `integration-tests / test` check that aggregates the shard matrix).

Built on top of #56263. The only functional change vs that branch is:

```diff
-    if: ${{ always() }}
+    if: always()
```

Purpose: confirm the summary gate still runs and reports on cancellation with the bare expression form.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>