### PR TITLE
Fix provisioning test result publishing for nightly runs 

### DIFF
--- a/.github/actions/publish-provisioning-test-results/action.yml
+++ b/.github/actions/publish-provisioning-test-results/action.yml
@@ -70,7 +70,7 @@ runs:
 
     - name: Download the event file
       id: event_file
-      if: steps.xml_reports.outcome == 'success' && inputs.create-comment != 'off'
+      if: steps.xml_reports.outcome == 'success'
       continue-on-error: true
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:


### PR DESCRIPTION
The `rancher/publish-unit-test-result-action` action always requires an event file to determine if the event is coming from a fork or not. While `GITHUB_EVENT_PATH`  is a standard environment variable that the action can fall back to, we are explicitly passing `with.event_file` to a custom path, even if we do not download it. Since the provisioning tests [always upload the event file](https://github.com/rancher/rancher/blob/main/.github/workflows/provisioning-tests.yml#L139), it's simpler to just unconditionally download it in this workflow too. 