### PR TITLE
updatecli: update harvester checksums

### DIFF
--- a/updatecli/updatecli.d/update-harvester-docker-machine/update-harvester-docker-machine.yaml
+++ b/updatecli/updatecli.d/update-harvester-docker-machine/update-harvester-docker-machine.yaml
@@ -105,6 +105,28 @@ targets:
         keyword: "ENV"
         matcher: "DOCKER_MACHINE_HARVESTER_VERSION"
 
+  update-dockerfile-amd64-sha:
+    name: 'Update ENV DOCKER_MACHINE_HARVESTER_CHECKSUM_amd64 to {{ source "get-sha256-binary-amd64-next-version" }} in Dockerfile'
+    kind: dockerfile
+    scmid: 'default'
+    sourceid: 'get-sha256-binary-amd64-next-version'
+    spec:
+      file: 'package/Dockerfile'
+      instruction:
+        keyword: "ENV"
+        matcher: "DOCKER_MACHINE_HARVESTER_CHECKSUM_amd64"
+
+  update-dockerfile-arm64-sha:
+    name: 'Update ENV DOCKER_MACHINE_HARVESTER_CHECKSUM_arm64 to {{ source "get-sha256-binary-arm64-next-version" }} in Dockerfile'
+    kind: dockerfile
+    scmid: 'default'
+    sourceid: 'get-sha256-binary-arm64-next-version'
+    spec:
+      file: 'package/Dockerfile'
+      instruction:
+        keyword: "ENV"
+        matcher: "DOCKER_MACHINE_HARVESTER_CHECKSUM_arm64"
+
   update-machine-driver-version:
     name: 'Update Harvester Docker machine {{ source "harvester-docker-machine-release" }} in machine driver file'
     kind: file
@@ -138,7 +160,7 @@ targets:
   go-fmt:
     name: 'Run go fmt in machine driver file'
     dependson:
-      - 'update-machine-driver-version' 
+      - 'update-machine-driver-version'
       - 'update-machine-driver-amd64-sha'
       - 'update-machine-driver-arm64-sha'
     kind: shell


### PR DESCRIPTION
Make updatecli also update the harvester checksums in the Dockerfile when it updates the Harvester machine driver.

## Issue: N/A
 
## Problem

CI fails when updatecli updates the Harvester node driver.
 
## Solution

Update the checksums everywhere where they are needed.
 
## Testing

CI should pass

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_