### PR TITLE
[v2.15] prune stale pod IPs from the :443 serving cert too

### DIFF
--- a/pkg/tls/cnfilter.go
+++ b/pkg/tls/cnfilter.go
@@ -249,12 +249,15 @@ func (t *serviceIPTracker) allowCN(cns ...string) []string {
 // or allowlist accepts it. CNs rejected by primary are re-offered to
 // allowlist rather than dropped outright, so an admin-approved Service IP is
 // never pruned just because it isn't a live rancher pod IP.
+//
+// primary's rejected set is determined by set membership against its own
+// output, not by comparing lengths -- primary may transform its input
+// (e.g. collapse it down to a single hostname) rather than merely filtering
+// a subset of it, so an equal-length result does not imply nothing was
+// rejected.
 func unionFilterCN(primary, allowlist func(...string) []string) func(...string) []string {
 	return func(cns ...string) []string {
 		kept := primary(cns...)
-		if len(kept) == len(cns) {
-			return kept
-		}
 		keptSet := make(map[string]struct{}, len(kept))
 		for _, cn := range kept {
 			keptSet[cn] = struct{}{}
@@ -274,9 +277,11 @@ func unionFilterCN(primary, allowlist func(...string) []string) func(...string) 
 
 // newRancherPodIPFilter wires a podIPTracker to the upstream Rancher
 // server's pods (app=rancher in cattle-system) and returns its
-// FilterExistingCN closure.
-func newRancherPodIPFilter(ctx context.Context, pods corev1controllers.PodController) func(...string) []string {
-	return newPodIPTracker(ctx, namespace.System, "app=rancher", pods, "rancher-podip-tls-internal-filter")
+// FilterExistingCN closure. handlerName distinguishes each listener's
+// tracker instance (e.g. for metrics/logging) since this is called once per
+// listener (:443 and :444).
+func newRancherPodIPFilter(ctx context.Context, pods corev1controllers.PodController, handlerName string) func(...string) []string {
+	return newPodIPTracker(ctx, namespace.System, "app=rancher", pods, handlerName)
 }
 
 // newRancherInternalCNFilter builds the FilterCN used for the
@@ -286,7 +291,7 @@ func newRancherPodIPFilter(ctx context.Context, pods corev1controllers.PodContro
 // admin has explicitly named -- e.g. a LoadBalancer/VIP Service that isn't a
 // rancher pod IP -- are never rejected/pruned by the pod-IP filter.
 func newRancherInternalCNFilter(ctx context.Context, pods corev1controllers.PodController, services corev1controllers.ServiceController, allowedServices string) func(...string) []string {
-	podFilter := newRancherPodIPFilter(ctx, pods)
+	podFilter := newRancherPodIPFilter(ctx, pods, "rancher-podip-tls-internal-filter")
 	refs := parseAllowedServices(allowedServices)
 	svcFilter := newServiceIPTracker(ctx, refs, services, "rancher-service-allowlist-tls-internal-filter")
 	return unionFilterCN(podFilter, svcFilter)

--- a/pkg/tls/cnfilter_test.go
+++ b/pkg/tls/cnfilter_test.go
@@ -129,6 +129,44 @@ func TestUnionFilterCN(t *testing.T) {
 	}
 }
 
+// TestUnionFilterCN_TransformingPrimary is a regression test: unionFilterCN
+// must compute primary's rejected set by membership against its actual
+// output, not by comparing lengths. A primary that transforms its input
+// (e.g. collapses many CNs down to a single hostname, as serverURLFilterCN
+// does) can coincidentally return a result the same length as its input
+// without having "accepted everything" -- a length-based shortcut would
+// wrongly skip consulting allowlist in that case.
+func TestUnionFilterCN_TransformingPrimary(t *testing.T) {
+	t.Parallel()
+
+	// transformingPrimary always collapses its input down to a single fixed
+	// CN, regardless of what it was given -- simulating serverURLFilterCN's
+	// behavior of always returning the configured hostname.
+	transformingPrimary := func(cns ...string) []string {
+		return []string{"rancher.example.com"}
+	}
+	allowlist := func(cns ...string) []string {
+		var out []string
+		for _, cn := range cns {
+			if cn == "10.42.0.1" {
+				out = append(out, cn)
+			}
+		}
+		return out
+	}
+
+	union := unionFilterCN(transformingPrimary, allowlist)
+
+	// Single-CN input: primary's output happens to be the same length (1)
+	// as the input, but the input CN itself was rejected (it's not
+	// "rancher.example.com") and must still be checked against allowlist.
+	got := union("10.42.0.1")
+	expected := []string{"rancher.example.com", "10.42.0.1"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("union(10.42.0.1) = %v, want %v", got, expected)
+	}
+}
+
 // makeService builds a Service with the given ClusterIP, ExternalIPs, and
 // LoadBalancer ingress IPs for use in serviceIPTracker tests.
 func makeService(ns, name, clusterIP string, externalIPs []string, lbIPs ...string) *corev1.Service {

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -68,7 +68,7 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 	}
 
 	if httpsPort != 0 {
-		opts, err = SetupListener(core.Core().V1().Secret(), acmeDomains, noCACerts)
+		opts, err = SetupListener(ctx, core.Core().V1().Secret(), core.Core().V1().Pod(), acmeDomains, noCACerts)
 		if err != nil {
 			return errors.Wrap(err, "failed to setup TLS listener")
 		}
@@ -216,8 +216,8 @@ func migrateConfig(ctx context.Context, restConfig *rest.Config, opts *server.Li
 	}
 }
 
-func SetupListener(secrets corev1controllers.SecretController, acmeDomains []string, noCACerts bool) (*server.ListenOpts, error) {
-	caForAgent, noCACerts, opts, err := readConfig(secrets, acmeDomains, noCACerts)
+func SetupListener(ctx context.Context, secrets corev1controllers.SecretController, pods corev1controllers.PodController, acmeDomains []string, noCACerts bool) (*server.ListenOpts, error) {
+	caForAgent, noCACerts, opts, err := readConfig(ctx, secrets, pods, acmeDomains, noCACerts)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func SetupListener(secrets corev1controllers.SecretController, acmeDomains []str
 // - bool: The value of the noCACerts flag.
 // - *server.ListenOpts: The listener options for dynamiclistener.
 // - error: An error if the configuration is invalid.
-func readConfig(secrets corev1controllers.SecretController, acmeDomains []string, noCACerts bool) (string, bool, *server.ListenOpts, error) {
+func readConfig(ctx context.Context, secrets corev1controllers.SecretController, pods corev1controllers.PodController, acmeDomains []string, noCACerts bool) (string, bool, *server.ListenOpts, error) {
 	var (
 		ca  string
 		err error
@@ -294,7 +294,8 @@ func readConfig(secrets corev1controllers.SecretController, acmeDomains []string
 			TLSConfig:             tlsConfig,
 			ExpirationDaysCheck:   expiration,
 			SANs:                  sans,
-			FilterCN:              filterCN,
+			FilterCN:              newServingCertFilterCN(newRancherPodIPFilter(ctx, pods, "rancher-podip-serving-cert-filter")),
+			FilterExisting:        true,
 			CloseConnOnCertChange: true,
 		},
 	}
@@ -429,13 +430,9 @@ func collectNodeIPs(nodeController corev1controllers.NodeController) ([]string, 
 	return nodeIPs, nil
 }
 
-func filterCN(cns ...string) []string {
-	// In the embedded agent Rancher, reject all dynamic CN additions.
-	// The static Config.SANs (short-circuited by allowDefaultSANs) cover all
-	// legitimate access; anything dynamic is attacker-supplied SNI noise.
-	if features.MCMAgent.Enabled() {
-		return nil
-	}
+// serverURLFilterCN restricts dynamic CNs to the settings.ServerURL hostname
+// (or passes everything through pre-bootstrap / on a parse error).
+func serverURLFilterCN(cns ...string) []string {
 	serverURL := settings.ServerURL.Get()
 	if serverURL == "" {
 		return cns
@@ -450,6 +447,18 @@ func filterCN(cns ...string) []string {
 		return []string{host}
 	}
 	return cns
+}
+
+// newServingCertFilterCN builds the FilterCN closure for the :443 serving
+// cert: MCMAgent rejects all dynamic CNs outright; otherwise a CN is kept if
+// it matches the server-url hostname or is a live rancher pod IP.
+func newServingCertFilterCN(podIPFilter func(...string) []string) func(...string) []string {
+	return func(cns ...string) []string {
+		if features.MCMAgent.Enabled() {
+			return nil
+		}
+		return unionFilterCN(serverURLFilterCN, podIPFilter)(cns...)
+	}
 }
 
 func fileExists(path string) bool {

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -152,14 +152,70 @@ func TestEnsureInternalCertSANs(t *testing.T) {
 	}
 }
 
-// TestFilterCN covers all branches of filterCN, which gates dynamic CN
-// additions to the serving-cert (:443) listener.
-//
-// filterCN is the func(...string)[]string passed to dynamiclistener as
-// FilterCN.  allowDefaultSANs (inside dynamiclistener) already short-circuits
-// CNs that are in Config.SANs, so filterCN only ever receives the *unknown*
-// (dynamically presented) ones.
-func TestFilterCN(t *testing.T) {
+// TestServerURLFilterCN covers the hostname-only half of the filter (the
+// MCMAgent short-circuit and pod-IP union live in TestNewServingCertFilterCN).
+func TestServerURLFilterCN(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverURL string
+		input     []string
+		expected  []string
+	}{
+		{
+			name:      "empty serverURL — pass-through (pre-bootstrap)",
+			serverURL: "",
+			input:     []string{"anything.com", "10.0.0.5"},
+			expected:  []string{"anything.com", "10.0.0.5"},
+		},
+		{
+			name:      "serverURL set — only server hostname allowed",
+			serverURL: "https://rancher.example.com",
+			input:     []string{"other.example.com"},
+			expected:  []string{"rancher.example.com"},
+		},
+		{
+			name:      "serverURL with port — hostname without port returned",
+			serverURL: "https://rancher.example.com:8443",
+			input:     []string{"other.example.com"},
+			expected:  []string{"rancher.example.com"},
+		},
+		{
+			name:      "unparseable serverURL — pass-through",
+			serverURL: "://bad-url",
+			input:     []string{"other.example.com"},
+			expected:  []string{"other.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// serverURLFilterCN reads global state; do not run subtests in parallel.
+			_ = settings.ServerURL.Set(tt.serverURL)
+			t.Cleanup(func() { _ = settings.ServerURL.Set("") })
+
+			got := serverURLFilterCN(tt.input...)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("serverURLFilterCN(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestNewServingCertFilterCN covers the MCMAgent short-circuit and the
+// server-url/pod-IP union for the normal management-server case.
+func TestNewServingCertFilterCN(t *testing.T) {
+	// Stub pod-IP filter: only "10.42.0.1" is a "live" pod IP.
+	podIPFilter := func(cns ...string) []string {
+		var out []string
+		for _, cn := range cns {
+			if cn == "10.42.0.1" {
+				out = append(out, cn)
+			}
+		}
+		return out
+	}
+
 	tests := []struct {
 		name      string
 		mcmAgent  bool
@@ -168,45 +224,44 @@ func TestFilterCN(t *testing.T) {
 		expected  []string
 	}{
 		{
-			name:     "MCMAgent enabled — reject all dynamic CNs regardless of serverURL",
+			name:     "MCMAgent enabled — reject all dynamic CNs regardless of pod IPs",
 			mcmAgent: true,
-			input:    []string{"attacker.evil.com", "10.0.0.5"},
+			input:    []string{"other.example.com", "10.42.0.1"},
 			expected: nil,
 		},
 		{
 			name:     "MCMAgent enabled, empty serverURL — still returns nil",
 			mcmAgent: true,
-			serverURL: "",
-			input:    []string{"anything.com"},
+			input:    []string{"10.42.0.1"},
 			expected: nil,
 		},
 		{
-			name:     "MCMAgent disabled, empty serverURL — pass-through (pre-bootstrap)",
-			mcmAgent: false,
-			serverURL: "",
-			input:    []string{"anything.com", "10.0.0.5"},
-			expected: []string{"anything.com", "10.0.0.5"},
-		},
-		{
-			name:      "MCMAgent disabled, serverURL set — only server hostname allowed",
+			name:      "server mode: hostname CN kept via serverURLFilterCN",
 			mcmAgent:  false,
 			serverURL: "https://rancher.example.com",
-			input:     []string{"attacker.evil.com"},
+			input:     []string{"other.example.com"},
 			expected:  []string{"rancher.example.com"},
 		},
 		{
-			name:      "MCMAgent disabled, serverURL with port — hostname without port returned",
+			name:      "server mode: live pod IP kept via podIPFilter even though it's not the hostname",
 			mcmAgent:  false,
-			serverURL: "https://rancher.example.com:8443",
-			input:     []string{"attacker.evil.com"},
+			serverURL: "https://rancher.example.com",
+			input:     []string{"10.42.0.1"},
+			expected:  []string{"rancher.example.com", "10.42.0.1"},
+		},
+		{
+			name:      "server mode: stale/unknown pod IP rejected, hostname still present",
+			mcmAgent:  false,
+			serverURL: "https://rancher.example.com",
+			input:     []string{"10.42.0.99"},
 			expected:  []string{"rancher.example.com"},
 		},
 		{
-			name:      "MCMAgent disabled, unparseable serverURL — pass-through",
+			name:      "server mode: hostname and live pod IP both kept in the same call",
 			mcmAgent:  false,
-			serverURL: "://bad-url",
-			input:     []string{"attacker.evil.com"},
-			expected:  []string{"attacker.evil.com"},
+			serverURL: "https://rancher.example.com",
+			input:     []string{"other.example.com", "10.42.0.1"},
+			expected:  []string{"rancher.example.com", "10.42.0.1"},
 		},
 	}
 
@@ -220,9 +275,9 @@ func TestFilterCN(t *testing.T) {
 			_ = settings.ServerURL.Set(tt.serverURL)
 			t.Cleanup(func() { _ = settings.ServerURL.Set("") })
 
-			got := filterCN(tt.input...)
+			got := newServingCertFilterCN(podIPFilter)(tt.input...)
 			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("filterCN(%v) = %v, want %v", tt.input, got, tt.expected)
+				t.Errorf("newServingCertFilterCN(...)(%v) = %v, want %v", tt.input, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher/issues/53502

Backport of #56477 (`prune-serving-cert-pod-ips` on `main`) to `release/v2.15`.

`tls-rancher-internal` (`:444`) already prunes stale pod IPs from its CN annotations via `FilterExisting` + a live pod-IP tracker. The main serving cert on `:443` (`tls-rancher` / `serving-cert` secret) had no equivalent: its `FilterCN` only ever restricted dynamic CNs to the configured server-url hostname (or rejected everything outright in the embedded-agent/MCMAgent case), with no `FilterExisting` and no pod-IP awareness at all.

**Not a clean cherry-pick.** `release/v2.15`'s `pkg/tls/podips.go` was already renamed to `cnfilter.go` and had gained the `tls-internal-cn-allowed-services` admin Service-allowlist feature (`newRancherInternalCNFilter`/`serviceIPTracker`/`unionFilterCN`) ahead of `main` at the time of this backport. The fix is manually ported onto that file shape rather than replayed verbatim.

## Changes

- Added the same pod-IP pruning to the `:443` listener for the normal management-server case: a CN is now accepted if it matches the server-url hostname OR is a live `app=rancher` pod IP, with `FilterExisting` turned on so stale pod IPs get swept off the cert the same way they already are for `tls-rancher-internal`.
- The embedded agent (`MCMAgent`) case is unchanged: it continues to reject all dynamic CN additions outright, regardless of pod IPs.
- Refactored `filterCN` into `serverURLFilterCN` (hostname-only) + `newServingCertFilterCN` (wires the MCMAgent short-circuit + hostname filter + pod-IP filter together for `:443`), matching the shape used on `main`.
- `newRancherPodIPFilter` now takes an explicit `handlerName` parameter (rather than a hardcoded one), since it's called once per listener (`:443` and `:444`) and each call needs its own distinguishable tracker instance for metrics/logging.

## Additional fix found only on this branch

This branch's pre-existing `unionFilterCN` used a `len(kept) == len(cns)` shortcut to decide whether `primary` rejected anything. That's only valid when `primary` returns a *subset* of its input -- `serverURLFilterCN` instead *transforms* its input (always returns the single configured hostname), so a coincidental length match (e.g. one CN in, one hostname out) skipped the real rejected-CN computation and silently dropped the pod-IP fallback. Fixed `unionFilterCN` to compute the rejected set via membership against `primary`'s actual output, and added a regression test (`TestUnionFilterCN_TransformingPrimary`) covering a transforming primary. This bug does not exist on `main`, since `main`'s `serverURLFilterCN`/`unionFilterCN` pairing was written together from scratch there.

## Verification

Verified live in a k3d dev cluster built from this branch: with `settings.ServerURL` set, an unknown IP sent as TLS SNI was rejected outright (no write). Across three consecutive `rancher` deployment restarts, each old pod IP was pruned from the `serving-cert` secret's annotations by the next restart's write, while the hostname CN and current pod IP stayed present -- the CN count stayed bounded (5) rather than growing across restarts.

`go build ./pkg/tls/...`, `go vet ./pkg/tls/...`, and `go test ./pkg/tls/...` all pass.
