### PR TITLE
[v2.14] prune stale pod IPs from the :443 serving cert too

### DIFF
--- a/pkg/tls/podips.go
+++ b/pkg/tls/podips.go
@@ -107,7 +107,9 @@ func (t *podIPTracker) filterExistingCN(cns ...string) []string {
 
 // newRancherPodIPFilter wires a podIPTracker to the upstream Rancher
 // server's pods (app=rancher in cattle-system) and returns its
-// FilterExistingCN closure.
-func newRancherPodIPFilter(ctx context.Context, pods corev1controllers.PodController) func(...string) []string {
-	return newPodIPTracker(ctx, namespace.System, "app=rancher", pods, "rancher-podip-tls-internal-filter")
+// FilterExistingCN closure. handlerName distinguishes each listener's
+// tracker instance (e.g. for metrics/logging) since this is called once per
+// listener (:443 and :444).
+func newRancherPodIPFilter(ctx context.Context, pods corev1controllers.PodController, handlerName string) func(...string) []string {
+	return newPodIPTracker(ctx, namespace.System, "app=rancher", pods, handlerName)
 }

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -68,7 +68,7 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 	}
 
 	if httpsPort != 0 {
-		opts, err = SetupListener(core.Core().V1().Secret(), acmeDomains, noCACerts)
+		opts, err = SetupListener(ctx, core.Core().V1().Secret(), core.Core().V1().Pod(), acmeDomains, noCACerts)
 		if err != nil {
 			return errors.Wrap(err, "failed to setup TLS listener")
 		}
@@ -142,7 +142,7 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 		serverOptions.TLSListenerConfig = dynamiclistener.Config{
 			SANs:           hostIPs,
 			MaxSANs:        30,
-			FilterCN:       newRancherPodIPFilter(ctx, core.Core().V1().Pod()),
+			FilterCN:       newRancherPodIPFilter(ctx, core.Core().V1().Pod(), "rancher-podip-tls-internal-filter"),
 			FilterExisting: true,
 		}
 	}
@@ -215,8 +215,8 @@ func migrateConfig(ctx context.Context, restConfig *rest.Config, opts *server.Li
 	}
 }
 
-func SetupListener(secrets corev1controllers.SecretController, acmeDomains []string, noCACerts bool) (*server.ListenOpts, error) {
-	caForAgent, noCACerts, opts, err := readConfig(secrets, acmeDomains, noCACerts)
+func SetupListener(ctx context.Context, secrets corev1controllers.SecretController, pods corev1controllers.PodController, acmeDomains []string, noCACerts bool) (*server.ListenOpts, error) {
+	caForAgent, noCACerts, opts, err := readConfig(ctx, secrets, pods, acmeDomains, noCACerts)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func SetupListener(secrets corev1controllers.SecretController, acmeDomains []str
 // - bool: The value of the noCACerts flag.
 // - *server.ListenOpts: The listener options for dynamiclistener.
 // - error: An error if the configuration is invalid.
-func readConfig(secrets corev1controllers.SecretController, acmeDomains []string, noCACerts bool) (string, bool, *server.ListenOpts, error) {
+func readConfig(ctx context.Context, secrets corev1controllers.SecretController, pods corev1controllers.PodController, acmeDomains []string, noCACerts bool) (string, bool, *server.ListenOpts, error) {
 	var (
 		ca  string
 		err error
@@ -293,7 +293,8 @@ func readConfig(secrets corev1controllers.SecretController, acmeDomains []string
 			TLSConfig:             tlsConfig,
 			ExpirationDaysCheck:   expiration,
 			SANs:                  sans,
-			FilterCN:              filterCN,
+			FilterCN:              newServingCertFilterCN(newRancherPodIPFilter(ctx, pods, "rancher-podip-serving-cert-filter")),
+			FilterExisting:        true,
 			CloseConnOnCertChange: true,
 		},
 	}
@@ -428,13 +429,9 @@ func collectNodeIPs(nodeController corev1controllers.NodeController) ([]string, 
 	return nodeIPs, nil
 }
 
-func filterCN(cns ...string) []string {
-	// In the embedded agent Rancher, reject all dynamic CN additions.
-	// The static Config.SANs (short-circuited by allowDefaultSANs) cover all
-	// legitimate access; anything dynamic is attacker-supplied SNI noise.
-	if features.MCMAgent.Enabled() {
-		return nil
-	}
+// serverURLFilterCN restricts dynamic CNs to the settings.ServerURL hostname
+// (or passes everything through pre-bootstrap / on a parse error).
+func serverURLFilterCN(cns ...string) []string {
 	serverURL := settings.ServerURL.Get()
 	if serverURL == "" {
 		return cns
@@ -449,6 +446,40 @@ func filterCN(cns ...string) []string {
 		return []string{host}
 	}
 	return cns
+}
+
+// newServingCertFilterCN builds the FilterCN closure for the :443 serving
+// cert: MCMAgent rejects all dynamic CNs outright; otherwise a CN is kept if
+// it matches the server-url hostname or is a live rancher pod IP.
+func newServingCertFilterCN(podIPFilter func(...string) []string) func(...string) []string {
+	return func(cns ...string) []string {
+		if features.MCMAgent.Enabled() {
+			return nil
+		}
+		return unionFilterCN(serverURLFilterCN, podIPFilter)(cns...)
+	}
+}
+
+// unionFilterCN keeps primary's accepted CNs, giving anything it rejects a
+// second chance against allowlist.
+func unionFilterCN(primary, allowlist func(...string) []string) func(...string) []string {
+	return func(cns ...string) []string {
+		allowed := primary(cns...)
+		allowedSet := make(map[string]struct{}, len(allowed))
+		for _, cn := range allowed {
+			allowedSet[cn] = struct{}{}
+		}
+		var rejected []string
+		for _, cn := range cns {
+			if _, ok := allowedSet[cn]; !ok {
+				rejected = append(rejected, cn)
+			}
+		}
+		if len(rejected) == 0 {
+			return allowed
+		}
+		return append(allowed, allowlist(rejected...)...)
+	}
 }
 
 func fileExists(path string) bool {

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -152,14 +152,70 @@ func TestEnsureInternalCertSANs(t *testing.T) {
 	}
 }
 
-// TestFilterCN covers all branches of filterCN, which gates dynamic CN
-// additions to the serving-cert (:443) listener.
-//
-// filterCN is the func(...string)[]string passed to dynamiclistener as
-// FilterCN.  allowDefaultSANs (inside dynamiclistener) already short-circuits
-// CNs that are in Config.SANs, so filterCN only ever receives the *unknown*
-// (dynamically presented) ones.
-func TestFilterCN(t *testing.T) {
+// TestServerURLFilterCN covers the hostname-only half of the filter (the
+// MCMAgent short-circuit and pod-IP union live in TestNewServingCertFilterCN).
+func TestServerURLFilterCN(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverURL string
+		input     []string
+		expected  []string
+	}{
+		{
+			name:      "empty serverURL — pass-through (pre-bootstrap)",
+			serverURL: "",
+			input:     []string{"anything.com", "10.0.0.5"},
+			expected:  []string{"anything.com", "10.0.0.5"},
+		},
+		{
+			name:      "serverURL set — only server hostname allowed",
+			serverURL: "https://rancher.example.com",
+			input:     []string{"other.example.com"},
+			expected:  []string{"rancher.example.com"},
+		},
+		{
+			name:      "serverURL with port — hostname without port returned",
+			serverURL: "https://rancher.example.com:8443",
+			input:     []string{"other.example.com"},
+			expected:  []string{"rancher.example.com"},
+		},
+		{
+			name:      "unparseable serverURL — pass-through",
+			serverURL: "://bad-url",
+			input:     []string{"other.example.com"},
+			expected:  []string{"other.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// serverURLFilterCN reads global state; do not run subtests in parallel.
+			_ = settings.ServerURL.Set(tt.serverURL)
+			t.Cleanup(func() { _ = settings.ServerURL.Set("") })
+
+			got := serverURLFilterCN(tt.input...)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("serverURLFilterCN(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestNewServingCertFilterCN covers the MCMAgent short-circuit and the
+// server-url/pod-IP union for the normal management-server case.
+func TestNewServingCertFilterCN(t *testing.T) {
+	// Stub pod-IP filter: only "10.42.0.1" is a "live" pod IP.
+	podIPFilter := func(cns ...string) []string {
+		var out []string
+		for _, cn := range cns {
+			if cn == "10.42.0.1" {
+				out = append(out, cn)
+			}
+		}
+		return out
+	}
+
 	tests := []struct {
 		name      string
 		mcmAgent  bool
@@ -168,45 +224,44 @@ func TestFilterCN(t *testing.T) {
 		expected  []string
 	}{
 		{
-			name:     "MCMAgent enabled — reject all dynamic CNs regardless of serverURL",
+			name:     "MCMAgent enabled — reject all dynamic CNs regardless of pod IPs",
 			mcmAgent: true,
-			input:    []string{"attacker.evil.com", "10.0.0.5"},
+			input:    []string{"other.example.com", "10.42.0.1"},
 			expected: nil,
 		},
 		{
 			name:     "MCMAgent enabled, empty serverURL — still returns nil",
 			mcmAgent: true,
-			serverURL: "",
-			input:    []string{"anything.com"},
+			input:    []string{"10.42.0.1"},
 			expected: nil,
 		},
 		{
-			name:     "MCMAgent disabled, empty serverURL — pass-through (pre-bootstrap)",
-			mcmAgent: false,
-			serverURL: "",
-			input:    []string{"anything.com", "10.0.0.5"},
-			expected: []string{"anything.com", "10.0.0.5"},
-		},
-		{
-			name:      "MCMAgent disabled, serverURL set — only server hostname allowed",
+			name:      "server mode: hostname CN kept via serverURLFilterCN",
 			mcmAgent:  false,
 			serverURL: "https://rancher.example.com",
-			input:     []string{"attacker.evil.com"},
+			input:     []string{"other.example.com"},
 			expected:  []string{"rancher.example.com"},
 		},
 		{
-			name:      "MCMAgent disabled, serverURL with port — hostname without port returned",
+			name:      "server mode: live pod IP kept via podIPFilter even though it's not the hostname",
 			mcmAgent:  false,
-			serverURL: "https://rancher.example.com:8443",
-			input:     []string{"attacker.evil.com"},
+			serverURL: "https://rancher.example.com",
+			input:     []string{"10.42.0.1"},
+			expected:  []string{"rancher.example.com", "10.42.0.1"},
+		},
+		{
+			name:      "server mode: stale/unknown pod IP rejected, hostname still present",
+			mcmAgent:  false,
+			serverURL: "https://rancher.example.com",
+			input:     []string{"10.42.0.99"},
 			expected:  []string{"rancher.example.com"},
 		},
 		{
-			name:      "MCMAgent disabled, unparseable serverURL — pass-through",
+			name:      "server mode: hostname and live pod IP both kept in the same call",
 			mcmAgent:  false,
-			serverURL: "://bad-url",
-			input:     []string{"attacker.evil.com"},
-			expected:  []string{"attacker.evil.com"},
+			serverURL: "https://rancher.example.com",
+			input:     []string{"other.example.com", "10.42.0.1"},
+			expected:  []string{"rancher.example.com", "10.42.0.1"},
 		},
 	}
 
@@ -220,11 +275,58 @@ func TestFilterCN(t *testing.T) {
 			_ = settings.ServerURL.Set(tt.serverURL)
 			t.Cleanup(func() { _ = settings.ServerURL.Set("") })
 
-			got := filterCN(tt.input...)
+			got := newServingCertFilterCN(podIPFilter)(tt.input...)
 			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("filterCN(%v) = %v, want %v", tt.input, got, tt.expected)
+				t.Errorf("newServingCertFilterCN(...)(%v) = %v, want %v", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+// TestUnionFilterCN covers unionFilterCN directly: primary's accepted CNs
+// are always kept, and only what primary rejects gets a second chance
+// against allowlist.
+func TestUnionFilterCN(t *testing.T) {
+	primary := func(cns ...string) []string {
+		var out []string
+		for _, cn := range cns {
+			if cn == "primary-ok" {
+				out = append(out, cn)
+			}
+		}
+		return out
+	}
+	allowlist := func(cns ...string) []string {
+		var out []string
+		for _, cn := range cns {
+			if cn == "allowlist-ok" {
+				out = append(out, cn)
+			}
+		}
+		return out
+	}
+
+	union := unionFilterCN(primary, allowlist)
+
+	got := union("primary-ok", "allowlist-ok", "neither")
+	expected := []string{"primary-ok", "allowlist-ok"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("unionFilterCN(...)(...) = %v, want %v", got, expected)
+	}
+
+	// When primary accepts everything, allowlist must never be consulted.
+	calledAllowlist := false
+	noisyAllowlist := func(cns ...string) []string {
+		calledAllowlist = true
+		return cns
+	}
+	acceptAll := func(cns ...string) []string { return cns }
+	got = unionFilterCN(acceptAll, noisyAllowlist)("a", "b")
+	if calledAllowlist {
+		t.Errorf("allowlist must not be called when primary already accepted every CN")
+	}
+	if !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Errorf("unionFilterCN(acceptAll, ...)(...) = %v, want [a b]", got)
 	}
 }
 


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher/issues/56551

Backport of #56477 (`prune-serving-cert-pod-ips` on `main`) to `release/v2.14`.

`tls-rancher-internal` (`:444`) already prunes stale pod IPs from its CN annotations via `FilterExisting` + a live pod-IP tracker. The main serving cert on `:443` (`tls-rancher` / `serving-cert` secret) had no equivalent: its `FilterCN` only ever restricted dynamic CNs to the configured server-url hostname (or rejected everything outright in the embedded-agent/MCMAgent case), with no `FilterExisting` and no pod-IP awareness at all.

**Clean cherry-pick.** `release/v2.14`'s `pkg/tls/tls.go` and `pkg/tls/podips.go` are byte-identical to `main`'s pre-fix versions (confirmed by diff before attempting this), so the original fix commit applied via a plain `git cherry-pick` with no conflicts and no manual adaptation needed. Unlike the `release/v2.15` backport (#56495), `release/v2.14` doesn't yet have the `tls-internal-cn-allowed-services` Service-allowlist feature, so the `unionFilterCN` length-comparison bug found on `release/v2.15` doesn't exist here either -- this branch's `unionFilterCN` is the same one written fresh as part of this fix.

## Changes

- Added pod-IP pruning to the `:443` listener for the normal management-server case: a CN is accepted if it matches the server-url hostname OR is a live `app=rancher` pod IP, with `FilterExisting` turned on so stale pod IPs get swept off the cert the same way they already are for `tls-rancher-internal`.
- The embedded agent (`MCMAgent`) case is unchanged: it continues to reject all dynamic CN additions outright, regardless of pod IPs.
- Refactored `filterCN` into `serverURLFilterCN` (hostname-only) + `newServingCertFilterCN` (wires the MCMAgent short-circuit + hostname filter + pod-IP filter together for `:443`), plus a small `unionFilterCN` combinator.
- `newRancherPodIPFilter` now takes an explicit `handlerName` parameter (rather than a hardcoded one), since it's called once per listener (`:443` and `:444`) and each call needs its own distinguishable tracker instance for metrics/logging.

## Verification

Verified live in a k3d dev cluster built from this branch: with `settings.ServerURL` set, an unknown IP sent as TLS SNI was rejected outright (no write). Across two consecutive `rancher` deployment restarts, the original pod IP was pruned from the `serving-cert` secret's annotations, while the hostname CN stayed present -- CN count stayed bounded (5) rather than growing across restarts.

`go build ./pkg/tls/...`, `go vet ./pkg/tls/...`, and `go test ./pkg/tls/...` all pass.
