### PR TITLE
Extended resource quota validation

### DIFF
--- a/pkg/api/norman/customization/project/project_store.go
+++ b/pkg/api/norman/customization/project/project_store.go
@@ -167,14 +167,18 @@ func (s *projectStore) validateResourceQuota(apiContext *types.APIContext, data 
 
 func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v32.ResourceQuotaLimit,
 	projectQuotaLimit *v32.ResourceQuotaLimit, id string) error {
-	// check that namespace default quota is within project quota
-	isFit, exceeded, err := resourcequota.IsQuotaFit(nsQuotaLimit, []*v32.ResourceQuotaLimit{}, projectQuotaLimit)
+	// check that namespace default quota is within project quota and no negative requests occurred
+	isFit, exceeded, negatives, err := resourcequota.IsQuotaFit(nsQuotaLimit, []*v32.ResourceQuotaLimit{}, projectQuotaLimit)
 	if err != nil {
 		return err
 	}
 	if !isFit {
-		return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, namespaceQuotaField, fmt.Sprintf("exceeds %s on fields: %s",
-			quotaField, utils.FormatResourceList(exceeded)))
+		if negatives != nil {
+			return httperror.NewFieldAPIError(httperror.MinLimitExceeded, namespaceQuotaField,
+				fmt.Sprintf("has negative inputs on fields: %s", utils.FormatResourceList(negatives)))
+		}
+		return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, namespaceQuotaField,
+			fmt.Sprintf("exceeds limits on fields: %s", utils.FormatResourceList(exceeded)))
 	}
 
 	if id == "" {
@@ -230,13 +234,17 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 	if err != nil {
 		return err
 	}
-	isFit, exceeded, err = resourcequota.IsQuotaFit(usedQuotaLimit, []*v32.ResourceQuotaLimit{}, projectQuotaLimit)
+	isFit, exceeded, negatives, err = resourcequota.IsQuotaFit(usedQuotaLimit, []*v32.ResourceQuotaLimit{}, projectQuotaLimit)
 	if err != nil {
 		return err
 	}
 	if !isFit {
-		return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, quotaField, fmt.Sprintf("is below the used limit on fields: %s",
-			utils.FormatResourceList(exceeded)))
+		if negatives != nil {
+			return httperror.NewFieldAPIError(httperror.MinLimitExceeded, quotaField,
+				fmt.Sprintf("has negative inputs on fields: %s", utils.FormatResourceList(negatives)))
+		}
+		return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, quotaField,
+			fmt.Sprintf("is below the used limit on fields: %s", utils.FormatResourceList(exceeded)))
 	}
 
 	if len(limitToAdd) == 0 && len(limitToRemove) == 0 {
@@ -265,17 +273,19 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 		nsLimits = append(nsLimits, converted)
 	}
 
-	isFit, exceeded, err = resourcequota.IsQuotaFit(&v32.ResourceQuotaLimit{}, nsLimits, projectQuotaLimit)
-	if err != nil {
+	isFit, exceeded, negatives, err = resourcequota.IsQuotaFit(&v32.ResourceQuotaLimit{}, nsLimits, projectQuotaLimit)
+	if err != nil || isFit {
 		return err
 	}
-	if !isFit {
-		return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, namespaceQuotaField,
-			fmt.Sprintf("exceeds project limit on fields %s when applied to all namespaces in a project",
-				utils.FormatResourceList(exceeded)))
-	}
 
-	return nil
+	if negatives != nil {
+		return httperror.NewFieldAPIError(httperror.MinLimitExceeded, namespaceQuotaField,
+			fmt.Sprintf("has negative inputs on fields %s when applied to all namespaces in a project",
+				utils.FormatResourceList(negatives)))
+	}
+	return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, namespaceQuotaField,
+		fmt.Sprintf("exceeds project limit on fields %s when applied to all namespaces in a project",
+			utils.FormatResourceList(exceeded)))
 }
 
 func (s *projectStore) getNamespacesCount(apiContext *types.APIContext, project mgmtclient.Project) (int, error) {

--- a/pkg/api/norman/customization/project/project_store.go
+++ b/pkg/api/norman/customization/project/project_store.go
@@ -175,6 +175,12 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 		return err
 	}
 	if !isFit {
+		if negatives != nil && exceeded != nil {
+			message := fmt.Sprintf("is negative on fields: %s; exceeds projectLimit on fields: %s",
+				utils.FormatResourceList(negatives),
+				utils.FormatResourceList(exceeded))
+			return httperror.NewFieldAPIError(httperror.InvalidState, namespaceQuotaField, message)
+		}
 		if negatives != nil {
 			return httperror.NewFieldAPIError(httperror.MinLimitExceeded, namespaceQuotaField,
 				fmt.Sprintf("is negative on fields: %s", utils.FormatResourceList(negatives)))
@@ -241,6 +247,12 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 		return err
 	}
 	if !isFit {
+		if negatives != nil && exceeded != nil {
+			message := fmt.Sprintf("is negative on fields: %s; exceeds projectLimit on fields: %s",
+				utils.FormatResourceList(negatives),
+				utils.FormatResourceList(exceeded))
+			return httperror.NewFieldAPIError(httperror.InvalidState, quotaField, message)
+		}
 		if negatives != nil {
 			return httperror.NewFieldAPIError(httperror.MinLimitExceeded, quotaField,
 				fmt.Sprintf("is negative on fields: %s", utils.FormatResourceList(negatives)))
@@ -280,6 +292,12 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 		return err
 	}
 
+	if negatives != nil && exceeded != nil {
+		message := fmt.Sprintf("is negative on fields: %s; exceeds projectLimit on fields: %s",
+			utils.FormatResourceList(negatives),
+			utils.FormatResourceList(exceeded))
+		return httperror.NewFieldAPIError(httperror.InvalidState, namespaceQuotaField, message)
+	}
 	if negatives != nil {
 		return httperror.NewFieldAPIError(httperror.MinLimitExceeded, namespaceQuotaField,
 			fmt.Sprintf("is negative on fields %s when applied to all namespaces in a project",

--- a/pkg/api/norman/customization/project/project_store.go
+++ b/pkg/api/norman/customization/project/project_store.go
@@ -154,12 +154,14 @@ func (s *projectStore) validateResourceQuota(apiContext *types.APIContext, data 
 		return err
 	}
 	if len(nsQuotaLimitMap) != len(projectQuotaLimitMap) {
-		return httperror.NewFieldAPIError(httperror.MissingRequired, namespaceQuotaField, fmt.Sprintf("does not have all fields defined on a %s", quotaField))
+		return httperror.NewFieldAPIError(httperror.MissingRequired, namespaceQuotaField,
+			fmt.Sprintf("does not have all fields defined on a %s", quotaField))
 	}
 
 	for k := range projectQuotaLimitMap {
 		if _, ok := nsQuotaLimitMap[k]; !ok {
-			return httperror.NewFieldAPIError(httperror.MissingRequired, namespaceQuotaField, fmt.Sprintf("misses %s defined on a %s", k, quotaField))
+			return httperror.NewFieldAPIError(httperror.MissingRequired, namespaceQuotaField,
+				fmt.Sprintf("misses %s defined on a %s", k, quotaField))
 		}
 	}
 	return s.isQuotaFit(apiContext, nsQuotaLimit, projectQuotaLimit, id)
@@ -175,7 +177,7 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 	if !isFit {
 		if negatives != nil {
 			return httperror.NewFieldAPIError(httperror.MinLimitExceeded, namespaceQuotaField,
-				fmt.Sprintf("has negative inputs on fields: %s", utils.FormatResourceList(negatives)))
+				fmt.Sprintf("is negative on fields: %s", utils.FormatResourceList(negatives)))
 		}
 		return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, namespaceQuotaField,
 			fmt.Sprintf("exceeds limits on fields: %s", utils.FormatResourceList(exceeded)))
@@ -241,7 +243,7 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 	if !isFit {
 		if negatives != nil {
 			return httperror.NewFieldAPIError(httperror.MinLimitExceeded, quotaField,
-				fmt.Sprintf("has negative inputs on fields: %s", utils.FormatResourceList(negatives)))
+				fmt.Sprintf("is negative on fields: %s", utils.FormatResourceList(negatives)))
 		}
 		return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, quotaField,
 			fmt.Sprintf("is below the used limit on fields: %s", utils.FormatResourceList(exceeded)))
@@ -280,7 +282,7 @@ func (s *projectStore) isQuotaFit(apiContext *types.APIContext, nsQuotaLimit *v3
 
 	if negatives != nil {
 		return httperror.NewFieldAPIError(httperror.MinLimitExceeded, namespaceQuotaField,
-			fmt.Sprintf("has negative inputs on fields %s when applied to all namespaces in a project",
+			fmt.Sprintf("is negative on fields %s when applied to all namespaces in a project",
 				utils.FormatResourceList(negatives)))
 	}
 	return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, namespaceQuotaField,

--- a/pkg/api/norman/store/namespace/store.go
+++ b/pkg/api/norman/store/namespace/store.go
@@ -161,12 +161,18 @@ func (p *Store) validateResourceQuota(apiContext *types.APIContext, schema *type
 		data[containerResourceLimitField] = project.ContainerDefaultResourceLimit
 	}
 
-	isFit, exceeded, err := resourcequota.IsQuotaFit(nsQuotaLimit, nsLimits, projectQuotaLimit)
+	isFit, exceeded, negatives, err := resourcequota.IsQuotaFit(nsQuotaLimit, nsLimits, projectQuotaLimit)
 	if err != nil || isFit {
 		return err
 	}
 
-	return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, quotaField, fmt.Sprintf("exceeds projectLimit on fields: %s", utils.FormatResourceList(exceeded)))
+	if len(negatives) > 0 {
+		return httperror.NewFieldAPIError(httperror.MinLimitExceeded, quotaField,
+			fmt.Sprintf("negative inputs on fields: %s", utils.FormatResourceList(negatives)))
+	}
+
+	return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, quotaField,
+		fmt.Sprintf("exceeds projectLimit on fields: %s", utils.FormatResourceList(exceeded)))
 }
 
 func limitToLimit(from *mgmtclient.ResourceQuotaLimit) (*v32.ResourceQuotaLimit, error) {

--- a/pkg/api/norman/store/namespace/store.go
+++ b/pkg/api/norman/store/namespace/store.go
@@ -166,6 +166,13 @@ func (p *Store) validateResourceQuota(apiContext *types.APIContext, schema *type
 		return err
 	}
 
+	if len(negatives) > 0 && len(exceeded) > 0 {
+		message := fmt.Sprintf("negative on fields: %s; exceeds projectLimit on fields: %s",
+			utils.FormatResourceList(negatives),
+			utils.FormatResourceList(exceeded))
+		httperror.NewFieldAPIError(httperror.InvalidState, quotaField, message)
+	}
+
 	if len(negatives) > 0 {
 		return httperror.NewFieldAPIError(httperror.MinLimitExceeded, quotaField,
 			fmt.Sprintf("negative on fields: %s", utils.FormatResourceList(negatives)))

--- a/pkg/api/norman/store/namespace/store.go
+++ b/pkg/api/norman/store/namespace/store.go
@@ -168,7 +168,7 @@ func (p *Store) validateResourceQuota(apiContext *types.APIContext, schema *type
 
 	if len(negatives) > 0 {
 		return httperror.NewFieldAPIError(httperror.MinLimitExceeded, quotaField,
-			fmt.Sprintf("negative inputs on fields: %s", utils.FormatResourceList(negatives)))
+			fmt.Sprintf("negative on fields: %s", utils.FormatResourceList(negatives)))
 	}
 
 	return httperror.NewFieldAPIError(httperror.MaxLimitExceeded, quotaField,

--- a/pkg/api/norman/store/namespace/store.go
+++ b/pkg/api/norman/store/namespace/store.go
@@ -170,7 +170,7 @@ func (p *Store) validateResourceQuota(apiContext *types.APIContext, schema *type
 		message := fmt.Sprintf("negative on fields: %s; exceeds projectLimit on fields: %s",
 			utils.FormatResourceList(negatives),
 			utils.FormatResourceList(exceeded))
-		httperror.NewFieldAPIError(httperror.InvalidState, quotaField, message)
+		return httperror.NewFieldAPIError(httperror.InvalidState, quotaField, message)
 	}
 
 	if len(negatives) > 0 {

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_calculate_used.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_calculate_used.go
@@ -150,6 +150,14 @@ func (c *calculateLimitController) calculateProjectResourceQuota(projectID strin
 		if ns.DeletionTimestamp != nil {
 			continue
 		}
+		// Beware: Contrary to `getNamespacesLimits` this function
+		// rejects namespaces which are not validated as true. While
+		// doing so may cause us to overestimate the amount of resources
+		// available `IsQuotaFit` computes exact limits and will reject
+		// inadvertent oversubscriptions. To compute exact limits here
+		// we will have to know if a specific positive quantity is the
+		// very value causing an oversubscription or not. We cannot
+		// decide that.
 		set, err := namespaceutil.IsNamespaceConditionSet(ns, ResourceQuotaValidatedCondition, true)
 		if err != nil {
 			return err

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -166,13 +166,17 @@ func (c *SyncController) CreateResourceQuota(ns *corev1.Namespace) (*corev1.Name
 	var operationErr error
 	switch operation {
 	case "create":
-		isFit, updated, exceeded, err := c.validateAndSetNamespaceQuota(ns, &v32.NamespaceResourceQuota{Limit: *requestedQuotaLimit})
+		isFit, updated, exceeded, negatives, err := c.validateAndSetNamespaceQuota(ns, &v32.NamespaceResourceQuota{Limit: *requestedQuotaLimit})
 		if err != nil {
 			return updated, err
 		}
 		if !isFit {
-			// Create a quota with zeros only for overused resources.
+			// Create a quota with zeros only for bad resources (overused, negative inputs)
 			limit, err := zeroOutResourceQuotaLimit(requestedQuotaLimit, exceeded)
+			if err != nil {
+				return updated, err
+			}
+			limit, err = zeroOutResourceQuotaLimit(limit, negatives)
 			if err != nil {
 				return updated, err
 			}
@@ -184,7 +188,7 @@ func (c *SyncController) CreateResourceQuota(ns *corev1.Namespace) (*corev1.Name
 		}
 		operationErr = c.createResourceQuota(ns, newQuotaSpec)
 	case "update":
-		isFit, upd, _, err := c.validateAndSetNamespaceQuota(ns, &v32.NamespaceResourceQuota{Limit: *requestedQuotaLimit})
+		isFit, upd, _, _, err := c.validateAndSetNamespaceQuota(ns, &v32.NamespaceResourceQuota{Limit: *requestedQuotaLimit})
 		if err != nil {
 			return upd, err
 		}
@@ -379,19 +383,19 @@ func (c *SyncController) createDefaultLimitRange(ns *corev1.Namespace, spec *cor
 	return err
 }
 
-func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quotaToUpdate *v32.NamespaceResourceQuota) (bool, *corev1.Namespace, corev1.ResourceList, error) {
+func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quotaToUpdate *v32.NamespaceResourceQuota) (bool, *corev1.Namespace, corev1.ResourceList, corev1.ResourceList, error) {
 	if ns == nil || ns.DeletionTimestamp != nil {
-		return true, ns, nil, nil
+		return true, ns, nil, nil, nil
 	}
 
 	// get project limit
 	projectLimit, projectID, err := getProjectResourceQuotaLimit(ns, c.ProjectCache)
 	if err != nil {
-		return false, ns, nil, err
+		return false, ns, nil, nil, err
 	}
 
 	if projectLimit == nil {
-		return true, ns, nil, err
+		return true, ns, nil, nil, err
 	}
 
 	updatedNs := ns.DeepCopy()
@@ -401,14 +405,14 @@ func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quot
 		}
 		b, err := json.Marshal(quotaToUpdate)
 		if err != nil {
-			return false, ns, nil, err
+			return false, ns, nil, nil, err
 		}
 		updatedNs.Annotations[resourceQuotaAnnotation] = string(b)
 		// avoid updates if nothing would change
 		if !reflect.DeepEqual(updatedNs, ns) {
 			updatedNs, err = c.Namespaces.Update(updatedNs)
 			if err != nil {
-				return false, updatedNs, nil, err
+				return false, updatedNs, nil, nil, err
 			}
 		}
 	}
@@ -421,21 +425,30 @@ func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quot
 	// Get other namespaces' limits.
 	nsLimits, err := c.getNamespacesLimits(ns, projectID)
 	if err != nil {
-		return false, updatedNs, nil, err
+		return false, updatedNs, nil, nil, err
 	}
-	isFit, exceeded, err := validate.IsQuotaFit(&quotaToUpdate.Limit, nsLimits, projectLimit)
+	// Put everything together and check that things fit
+	isFit, exceeded, negatives, err := validate.IsQuotaFit(&quotaToUpdate.Limit, nsLimits, projectLimit)
 	if err != nil {
-		return false, updatedNs, nil, err
+		return false, updatedNs, nil, nil, err
 	}
 
 	var msg string
-	if !isFit && exceeded != nil {
-		msg = fmt.Sprintf("Resource quota [%v] exceeds project limit", utils.FormatResourceList(exceeded))
+	if !isFit && (exceeded != nil || negatives != nil) {
+		if exceeded != nil {
+			msg = fmt.Sprintf("Oversubscribed resource quota [%v]", utils.FormatResourceList(exceeded))
+		}
+		if negatives != nil {
+			if msg != "" {
+				msg = msg + "; "
+			}
+			msg = msg + fmt.Sprintf("Resource quota [%v] are based on negative inputs", utils.FormatResourceList(negatives))
+		}
 	}
 
 	validated, err := c.setValidated(updatedNs, isFit, msg)
 
-	return isFit, validated, exceeded, err
+	return isFit, validated, exceeded, negatives, err
 }
 
 func (c *SyncController) getNamespacesLimits(ns *v1.Namespace, projectID string) ([]*v32.ResourceQuotaLimit, error) {
@@ -450,6 +463,13 @@ func (c *SyncController) getNamespacesLimits(ns *v1.Namespace, projectID string)
 		if other.Name == ns.Name {
 			continue
 		}
+		// Beware: namespaces which are not validated are accepted here,
+		// contrary to `calculateProjectResourceQuota`.  Because while
+		// they may contain bogus resource quantities on some keys
+		// (oversubscribed, negative) other keys may be good. And
+		// excluding these good keys will cause the caller to generate
+		// an incorrect sum of used resources for these keys, opening
+		// the referenced resources up to oversubscription.
 		nsLimit, err := getNamespaceResourceQuotaLimit(other)
 		if err != nil {
 			return nil, err
@@ -571,16 +591,15 @@ func completeLimit(nsLimit *v32.ContainerResourceLimit, projectLimit *v32.Contai
 	return resultingLimit, err
 }
 
-// zeroOutResourceQuotaLimit takes a resource quota limit and a list of
-// resources exceeding the quota, and returns a new quota limit with exceeded
-// resources zeroed out.
-func zeroOutResourceQuotaLimit(limit *v32.ResourceQuotaLimit, exceeded corev1.ResourceList) (*v32.ResourceQuotaLimit, error) {
+// zeroOutResourceQuotaLimit takes a resource quota limit and a list of bad
+// resources, and returns a new quota limit with the bad resources zeroed out.
+func zeroOutResourceQuotaLimit(limit *v32.ResourceQuotaLimit, badResources corev1.ResourceList) (*v32.ResourceQuotaLimit, error) {
 	zeroed, err := convertProjectResourceLimitToResourceList(limit)
 	if err != nil {
 		return nil, err
 	}
 
-	for k := range exceeded {
+	for k := range badResources {
 		zeroed[k] = zeroQuantity
 	}
 

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -166,13 +166,13 @@ func (c *SyncController) CreateResourceQuota(ns *corev1.Namespace) (*corev1.Name
 	var operationErr error
 	switch operation {
 	case "create":
-		isFit, updated, exceeded, err := c.validateAndSetNamespaceQuota(ns, &v32.NamespaceResourceQuota{Limit: *requestedQuotaLimit})
+		isFit, updated, badResources, err := c.validateAndSetNamespaceQuota(ns, &v32.NamespaceResourceQuota{Limit: *requestedQuotaLimit})
 		if err != nil {
 			return updated, err
 		}
 		if !isFit {
 			// Create a quota with zeros only for overused resources.
-			limit, err := zeroOutResourceQuotaLimit(requestedQuotaLimit, exceeded)
+			limit, err := zeroOutResourceQuotaLimit(requestedQuotaLimit, badResources)
 			if err != nil {
 				return updated, err
 			}
@@ -423,19 +423,20 @@ func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quot
 	if err != nil {
 		return false, updatedNs, nil, err
 	}
-	isFit, exceeded, err := validate.IsQuotaFit(&quotaToUpdate.Limit, nsLimits, projectLimit)
+	isFit, badResources, err := validate.IsQuotaFit(&quotaToUpdate.Limit, nsLimits, projectLimit)
 	if err != nil {
 		return false, updatedNs, nil, err
 	}
 
 	var msg string
-	if !isFit && exceeded != nil {
-		msg = fmt.Sprintf("Resource quota [%v] exceeds project limit", utils.FormatResourceList(exceeded))
+	if !isFit && badResources != nil {
+		msg = fmt.Sprintf("Resource quota [%v] exceeds project limit, or is based on negative values",
+			utils.FormatResourceList(badResources))
 	}
 
 	validated, err := c.setValidated(updatedNs, isFit, msg)
 
-	return isFit, validated, exceeded, err
+	return isFit, validated, badResources, err
 }
 
 func (c *SyncController) getNamespacesLimits(ns *v1.Namespace, projectID string) ([]*v32.ResourceQuotaLimit, error) {
@@ -450,7 +451,7 @@ func (c *SyncController) getNamespacesLimits(ns *v1.Namespace, projectID string)
 		if other.Name == ns.Name {
 			continue
 		}
-		// Skip namespaces with invalid quotas
+		// Skip namespaces that are not validated (ResourceQuotaValidatedCondition != True)
 		set, err := namespaceutil.IsNamespaceConditionSet(other, ResourceQuotaValidatedCondition, true)
 		if err != nil {
 			return nil, err
@@ -579,16 +580,15 @@ func completeLimit(nsLimit *v32.ContainerResourceLimit, projectLimit *v32.Contai
 	return resultingLimit, err
 }
 
-// zeroOutResourceQuotaLimit takes a resource quota limit and a list of
-// resources exceeding the quota, and returns a new quota limit with exceeded
-// resources zeroed out.
-func zeroOutResourceQuotaLimit(limit *v32.ResourceQuotaLimit, exceeded corev1.ResourceList) (*v32.ResourceQuotaLimit, error) {
+// zeroOutResourceQuotaLimit takes a resource quota limit and a list of bad
+// resources, and returns a new quota limit with the bad resources zeroed out.
+func zeroOutResourceQuotaLimit(limit *v32.ResourceQuotaLimit, badResources corev1.ResourceList) (*v32.ResourceQuotaLimit, error) {
 	zeroed, err := convertProjectResourceLimitToResourceList(limit)
 	if err != nil {
 		return nil, err
 	}
 
-	for k := range exceeded {
+	for k := range badResources {
 		zeroed[k] = zeroQuantity
 	}
 

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -442,7 +442,7 @@ func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quot
 			if msg != "" {
 				msg = msg + "; "
 			}
-			msg = msg + fmt.Sprintf("Resource quota [%v] are based on negative inputs", utils.FormatResourceList(negatives))
+			msg = msg + fmt.Sprintf("Negative resource quota [%v]", utils.FormatResourceList(negatives))
 		}
 	}
 

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -393,9 +393,8 @@ func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quot
 	if err != nil {
 		return false, ns, nil, nil, err
 	}
-
 	if projectLimit == nil {
-		return true, ns, nil, nil, err
+		return true, ns, nil, nil, nil
 	}
 
 	updatedNs := ns.DeepCopy()

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -171,7 +171,7 @@ func (c *SyncController) CreateResourceQuota(ns *corev1.Namespace) (*corev1.Name
 			return updated, err
 		}
 		if !isFit {
-			// Create a quota with zeros only for overused resources.
+			// Create a quota with zeros only for bad resources (overused, negative inputs)
 			limit, err := zeroOutResourceQuotaLimit(requestedQuotaLimit, badResources)
 			if err != nil {
 				return updated, err

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -450,6 +450,14 @@ func (c *SyncController) getNamespacesLimits(ns *v1.Namespace, projectID string)
 		if other.Name == ns.Name {
 			continue
 		}
+		// Skip namespaces with invalid quotas
+		set, err := namespaceutil.IsNamespaceConditionSet(other, ResourceQuotaValidatedCondition, true)
+		if err != nil {
+			return nil, err
+		}
+		if !set {
+			continue
+		}
 		nsLimit, err := getNamespaceResourceQuotaLimit(other)
 		if err != nil {
 			return nil, err

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync_test.go
@@ -4,14 +4,17 @@ import (
 	"go.uber.org/mock/gomock"
 	"reflect"
 	"testing"
+	"time"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientcache "k8s.io/client-go/tools/cache"
 )
 
 func TestSetLimitRangeAnnotation(t *testing.T) {
@@ -570,4 +573,55 @@ func TestZeroOutResourceQuotaLimit(t *testing.T) {
 			},
 		}, out)
 	})
+}
+
+func TestGetNamespacesLimitsSkipsUnvalidatedNamespaces(t *testing.T) {
+	indexer := clientcache.NewIndexer(clientcache.MetaNamespaceKeyFunc, clientcache.Indexers{
+		nsByProjectIndex: nsByProjectID,
+	})
+
+	current := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "current",
+			Annotations: map[string]string{
+				projectIDAnnotation: "local:p-abcde",
+			},
+		},
+	}
+
+	assert.NoError(t, namespaceutil.SetNamespaceCondition(current, time.Second, ResourceQuotaValidatedCondition, true, ""))
+
+	validPeer := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-peer",
+			Annotations: map[string]string{
+				projectIDAnnotation:     "local:p-abcde",
+				resourceQuotaAnnotation: `{"limit":{"limitsMemory":"1000Mi"}}`,
+			},
+		},
+	}
+
+	assert.NoError(t, namespaceutil.SetNamespaceCondition(validPeer, time.Second, ResourceQuotaValidatedCondition, true, ""))
+
+	invalidPeer := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "invalid-peer",
+			Annotations: map[string]string{
+				projectIDAnnotation:     "local:p-abcde",
+				resourceQuotaAnnotation: `{"limit":{"limitsMemory":"-8000Mi"}}`,
+			},
+		},
+	}
+
+	assert.NoError(t, namespaceutil.SetNamespaceCondition(invalidPeer, time.Second, ResourceQuotaValidatedCondition, false, "invalid"))
+	assert.NoError(t, indexer.Add(current))
+	assert.NoError(t, indexer.Add(validPeer))
+	assert.NoError(t, indexer.Add(invalidPeer))
+
+	controller := &SyncController{NsIndexer: indexer}
+	limits, err := controller.getNamespacesLimits(current, "local:p-abcde")
+
+	assert.NoError(t, err)
+	assert.Len(t, limits, 1)
+	assert.Equal(t, "1000Mi", limits[0].LimitsMemory)
 }

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -41,35 +41,67 @@ func GetProjectLock(projectID string) *sync.Mutex {
 	return mu
 }
 
-func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLimit, projectLimit *v32.ResourceQuotaLimit) (bool, api.ResourceList, error) {
+// IsQuotaFit puts the various limits (of the namespace itself, and its
+// siblings) together and checks if they still fit into the project. It reports
+// the names of all found bad resources. A resource is flagged as bad either
+// because its sum goes beyond the project limit, or because it had bogus
+// (negative values) among the summed inputs.
+func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLimit, projectLimit *v32.ResourceQuotaLimit) (bool, api.ResourceList, api.ResourceList, error) {
 	nssResourceList := api.ResourceList{}
 	nsResourceList, err := ConvertLimitToResourceList(nsLimit)
 	if err != nil {
-		return false, nil, fmt.Errorf("checking quota fit: %w", err)
+		return false, nil, nil, fmt.Errorf("checking quota fit: %w", err)
 	}
+	negativeResources := quota.IsNegative(nsResourceList)
 	nssResourceList = quota.Add(nssResourceList, nsResourceList)
 
 	for _, nsLimit := range nsLimits {
 		nsResourceList, err := ConvertLimitToResourceList(nsLimit)
 		if err != nil {
-			return false, nil, fmt.Errorf("checking namespace limits: %w", err)
+			return false, nil, nil, fmt.Errorf("checking namespace limits: %w", err)
 		}
+		negativeResources = append(negativeResources, quota.IsNegative(nsResourceList)...)
 		nssResourceList = quota.Add(nssResourceList, nsResourceList)
 	}
 
 	projectResourceList, err := ConvertLimitToResourceList(projectLimit)
 	if err != nil {
-		return false, nil, fmt.Errorf("checking project limits: %w", err)
+		return false, nil, nil, fmt.Errorf("checking project limits: %w", err)
 	}
 
+	// Start the set of bad resources with the oversubscribed resources ...
 	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
-	// Include resources with negative values among exceeded resources.
-	exceeded = append(exceeded, quota.IsNegative(nsResourceList)...)
-	if len(exceeded) == 0 {
-		return true, nil, nil
+
+	// Include resources with negative inputs among the bad resources, their sums are bogus.
+	badResources := append(exceeded, negativeResources...)
+	badResources = uniqueResourceNames(badResources)
+	if len(badResources) == 0 {
+		return true, nil, nil, nil
 	}
-	failedHard := quota.Mask(nssResourceList, exceeded)
-	return false, failedHard, nil
+	failedExceeded := quota.Mask(nssResourceList, exceeded)
+	failedNegative := quota.Mask(nssResourceList, negativeResources)
+
+	if len(failedExceeded) == 0 {
+		failedExceeded = nil
+	}
+	if len(failedNegative) == 0 {
+		failedNegative = nil
+	}
+
+	return false, failedExceeded, failedNegative, nil
+}
+
+func uniqueResourceNames(resources []api.ResourceName) []api.ResourceName {
+	seen := map[api.ResourceName]struct{}{}
+	unique := make([]api.ResourceName, 0, len(resources))
+	for _, resource := range resources {
+		if _, ok := seen[resource]; ok {
+			continue
+		}
+		seen[resource] = struct{}{}
+		unique = append(unique, resource)
+	}
+	return unique
 }
 
 func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList, error) {

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -47,6 +47,7 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 	if err != nil {
 		return false, nil, fmt.Errorf("checking quota fit: %w", err)
 	}
+	negativeResources := quota.IsNegative(nsResourceList)
 	nssResourceList = quota.Add(nssResourceList, nsResourceList)
 
 	for _, nsLimit := range nsLimits {
@@ -54,6 +55,7 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 		if err != nil {
 			return false, nil, fmt.Errorf("checking namespace limits: %w", err)
 		}
+		negativeResources = append(negativeResources, quota.IsNegative(nsResourceList)...)
 		nssResourceList = quota.Add(nssResourceList, nsResourceList)
 	}
 
@@ -64,12 +66,26 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 
 	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
 	// Include resources with negative values among exceeded resources.
-	exceeded = append(exceeded, quota.IsNegative(nsResourceList)...)
+	exceeded = append(exceeded, negativeResources...)
+	exceeded = uniqueResourceNames(exceeded)
 	if len(exceeded) == 0 {
 		return true, nil, nil
 	}
 	failedHard := quota.Mask(nssResourceList, exceeded)
 	return false, failedHard, nil
+}
+
+func uniqueResourceNames(resources []api.ResourceName) []api.ResourceName {
+	seen := map[api.ResourceName]struct{}{}
+	unique := make([]api.ResourceName, 0, len(resources))
+	for _, resource := range resources {
+		if _, ok := seen[resource]; ok {
+			continue
+		}
+		seen[resource] = struct{}{}
+		unique = append(unique, resource)
+	}
+	return unique
 }
 
 func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList, error) {

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -16,6 +16,7 @@ import (
 const ExtendedKey = "extended"
 
 var (
+	zeroQuantity            = resource.MustParse("0")
 	projectLockCache        = cache.NewLRUExpireCache(1000)
 	resourceQuotaConversion = map[string]string{
 		"replicationControllers": "replicationcontrollers",
@@ -43,47 +44,50 @@ func GetProjectLock(projectID string) *sync.Mutex {
 
 // IsQuotaFit puts the various limits (of the namespace itself, and its
 // siblings) together and checks if they still fit into the project. It reports
-// the names of all found bad resources. A resource is flagged as bad either
-// because its sum goes beyond the project limit, or because it had bogus
-// (negative values) among the summed inputs.
+// the names of all bad resources. A resource is flagged as bad either because
+// its sum goes beyond the project limit (oversubscription), or because it is
+// negative.  Negative values in the data taken from the sibling namespaces are
+// treated as zero, as these are blocked anyway.
 func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLimit, projectLimit *v32.ResourceQuotaLimit) (bool, api.ResourceList, api.ResourceList, error) {
 	nssResourceList := api.ResourceList{}
 	nsResourceList, err := ConvertLimitToResourceList(nsLimit)
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("checking quota fit: %w", err)
 	}
-	negativeResources := quota.IsNegative(nsResourceList)
-	nssResourceList = quota.Add(nssResourceList, nsResourceList)
+	negatives := quota.IsNegative(nsResourceList)
+	nssResourceList = quota.Add(nssResourceList, ZeroOutResourceList(nsResourceList, negatives))
 
+	// Detect over-subscription
 	for _, nsLimit := range nsLimits {
 		nsResourceList, err := ConvertLimitToResourceList(nsLimit)
 		if err != nil {
 			return false, nil, nil, fmt.Errorf("checking namespace limits: %w", err)
 		}
-		negativeResources = append(negativeResources, quota.IsNegative(nsResourceList)...)
-		nssResourceList = quota.Add(nssResourceList, nsResourceList)
+		// zero any negative limits coming from the sibling namespace
+		nssResourceList = quota.Add(nssResourceList, ZeroOutResourceList(nsResourceList, quota.IsNegative(nsResourceList)))
 	}
-
 	projectResourceList, err := ConvertLimitToResourceList(projectLimit)
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("checking project limits: %w", err)
 	}
-
-	// Start the set of bad resources with the oversubscribed resources ...
 	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
 
-	// Include resources with negative inputs among the bad resources, their sums are bogus.
-	badResources := append(exceeded, negativeResources...)
+	// Compute full set of bad resources for current namespace, this is the
+	// union of exceeded and negatives.
+	badResources := append(exceeded, negatives...)
 	badResources = uniqueResourceNames(badResources)
+
 	if len(badResources) == 0 {
 		return true, nil, nil, nil
 	}
-	failedExceeded := quota.Mask(nssResourceList, exceeded)
-	failedNegative := quota.Mask(nssResourceList, negativeResources)
 
+	// We have problems. Fail the fit, and report the affected resources
+	failedExceeded := quota.Mask(nssResourceList, exceeded)
 	if len(failedExceeded) == 0 {
 		failedExceeded = nil
 	}
+
+	failedNegative := quota.Mask(nssResourceList, negatives)
 	if len(failedNegative) == 0 {
 		failedNegative = nil
 	}
@@ -145,4 +149,22 @@ func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList
 		toReturn[resourceName] = resourceQuantity
 	}
 	return toReturn, nil
+}
+
+// ZeroOutResourceList takes a resource list and a list of bad resources, and
+// returns a new list with the bad resources set to zero.
+func ZeroOutResourceList(limit api.ResourceList, badResources []api.ResourceName) api.ResourceList {
+	// fast path, nothing zero out
+	if len(badResources) == 0 {
+		return limit
+	}
+	// copy input, then zero the bad parts
+	zeroed := api.ResourceList{}
+	for k, v := range limit {
+		zeroed[k] = v
+	}
+	for _, k := range badResources {
+		zeroed[k] = zeroQuantity
+	}
+	return zeroed
 }

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -137,15 +137,16 @@ func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList
 // ZeroOutResourceList takes a resource list and a list of bad resources, and
 // returns a new list with the bad resources set to zero.
 func ZeroOutResourceList(limit api.ResourceList, badResources []api.ResourceName) api.ResourceList {
-	// fast path, nothing to zero out
-	if len(badResources) == 0 {
-		return limit
-	}
-	// copy input, then zero the bad parts
+	// copy input (we promised a new list)
 	zeroed := api.ResourceList{}
 	for k, v := range limit {
 		zeroed[k] = v
 	}
+	// fast path, nothing to zero out
+	if len(badResources) == 0 {
+		return zeroed
+	}
+	// zero the bad parts
 	for _, k := range badResources {
 		zeroed[k] = zeroQuantity
 	}

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -89,7 +89,7 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 		failedExceeded = nil
 	}
 
-	failedNegative := quota.Mask(nssResourceList, negatives)
+	failedNegative := quota.Mask(nsResourceList, negatives)
 	if len(failedNegative) == 0 {
 		failedNegative = nil
 	}

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -72,14 +72,8 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 	}
 	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
 
-	// Compute the full set of bad resources for the current namespace as
-	// the union of exceeded and negatives.
-	badResources := []api.ResourceName{}
-	badResources = append(badResources, exceeded...)
-	badResources = append(badResources, negatives...)
-	badResources = uniqueResourceNames(badResources)
-
-	if len(badResources) == 0 {
+	// Without issues abort early
+	if len(exceeded) == 0 && len(negatives) == 0 {
 		return true, nil, nil, nil
 	}
 
@@ -95,19 +89,6 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 	}
 
 	return false, failedExceeded, failedNegative, nil
-}
-
-func uniqueResourceNames(resources []api.ResourceName) []api.ResourceName {
-	seen := map[api.ResourceName]struct{}{}
-	unique := make([]api.ResourceName, 0, len(resources))
-	for _, resource := range resources {
-		if _, ok := seen[resource]; ok {
-			continue
-		}
-		seen[resource] = struct{}{}
-		unique = append(unique, resource)
-	}
-	return unique
 }
 
 func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList, error) {

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -72,9 +72,11 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 	}
 	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
 
-	// Compute full set of bad resources for current namespace, this is the
-	// union of exceeded and negatives.
-	badResources := append(exceeded, negatives...)
+	// Compute the full set of bad resources for the current namespace as
+	// the union of exceeded and negatives.
+	badResources := []api.ResourceName{}
+	badResources = append(badResources, exceeded...)
+	badResources = append(badResources, negatives...)
 	badResources = uniqueResourceNames(badResources)
 
 	if len(badResources) == 0 {

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -64,14 +64,14 @@ func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLi
 		return false, nil, fmt.Errorf("checking project limits: %w", err)
 	}
 
-	_, exceeded := quota.LessThanOrEqual(nssResourceList, projectResourceList)
-	// Include resources with negative values among exceeded resources.
-	exceeded = append(exceeded, negativeResources...)
-	exceeded = uniqueResourceNames(exceeded)
-	if len(exceeded) == 0 {
+	_, badResources := quota.LessThanOrEqual(nssResourceList, projectResourceList)
+	// Include resources with negative values among the bad resources.
+	badResources = append(badResources, negativeResources...)
+	badResources = uniqueResourceNames(badResources)
+	if len(badResources) == 0 {
 		return true, nil, nil
 	}
-	failedHard := quota.Mask(nssResourceList, exceeded)
+	failedHard := quota.Mask(nssResourceList, badResources)
 	return false, failedHard, nil
 }
 

--- a/pkg/resourcequota/quota_validate.go
+++ b/pkg/resourcequota/quota_validate.go
@@ -44,10 +44,10 @@ func GetProjectLock(projectID string) *sync.Mutex {
 
 // IsQuotaFit puts the various limits (of the namespace itself, and its
 // siblings) together and checks if they still fit into the project. It reports
-// the names of all bad resources. A resource is flagged as bad either because
-// its sum goes beyond the project limit (oversubscription), or because it is
-// negative.  Negative values in the data taken from the sibling namespaces are
-// treated as zero, as these are blocked anyway.
+// the names of all bad resources, separate by reason. A resource is flagged as
+// bad either because its sum goes beyond the project limit (oversubscription),
+// or because the resource is negative. Negative values in the data taken from
+// the sibling namespaces are treated as zero, as these are blocked anyway.
 func IsQuotaFit(nsLimit *v32.ResourceQuotaLimit, nsLimits []*v32.ResourceQuotaLimit, projectLimit *v32.ResourceQuotaLimit) (bool, api.ResourceList, api.ResourceList, error) {
 	nssResourceList := api.ResourceList{}
 	nsResourceList, err := ConvertLimitToResourceList(nsLimit)
@@ -137,7 +137,7 @@ func ConvertLimitToResourceList(limit *v32.ResourceQuotaLimit) (api.ResourceList
 // ZeroOutResourceList takes a resource list and a list of bad resources, and
 // returns a new list with the bad resources set to zero.
 func ZeroOutResourceList(limit api.ResourceList, badResources []api.ResourceName) api.ResourceList {
-	// fast path, nothing zero out
+	// fast path, nothing to zero out
 	if len(badResources) == 0 {
 		return limit
 	}

--- a/pkg/resourcequota/quota_validate_test.go
+++ b/pkg/resourcequota/quota_validate_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestIsQuotaFitRejectsNegativePeerLimit(t *testing.T) {
 	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
-	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "8000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
 	peerNegativeLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-8000Mi"}
 
 	fit, failedHard, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{

--- a/pkg/resourcequota/quota_validate_test.go
+++ b/pkg/resourcequota/quota_validate_test.go
@@ -1,6 +1,7 @@
 package resourcequota
 
 import (
+	"fmt"
 	"maps"
 	"slices"
 	"testing"
@@ -192,6 +193,10 @@ func TestIsQuotaFit(t *testing.T) {
 
 	failedResource := []api.ResourceName{api.ResourceLimitsMemory}
 
+	badLimit := &v32.ResourceQuotaLimit{LimitsMemory: "not a proper quantity"}
+	parseError := fmt.Errorf("quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'")
+	limitError := fmt.Errorf("parsing quantity %q: %w", "limitsMemory", parseError)
+
 	testcases := map[string]struct {
 		wantErr      error
 		wantExceeds  []api.ResourceName
@@ -200,6 +205,16 @@ func TestIsQuotaFit(t *testing.T) {
 		current      *v32.ResourceQuotaLimit
 		peer         *v32.ResourceQuotaLimit
 	}{
+		"current bad, peer ok, error": {
+			current: badLimit,
+			peer:    peerLimitOk,
+			wantErr: fmt.Errorf("checking quota fit: %w", limitError),
+		},
+		"current ok, peer bad, error": {
+			current: currentLimitOk,
+			peer:    badLimit,
+			wantErr: fmt.Errorf("checking namespace limits: %w", limitError),
+		},
 		"negative for current, ok peer, fail": {
 			wantNegative: failedResource,
 			current:      currentLimitNegative,

--- a/pkg/resourcequota/quota_validate_test.go
+++ b/pkg/resourcequota/quota_validate_test.go
@@ -248,7 +248,8 @@ func TestIsQuotaFit(t *testing.T) {
 
 			assert.Equal(t, spec.wantFit, fit)
 			if spec.wantErr != nil {
-				assert.Error(t, spec.wantErr, err)
+				assert.Error(t, err)
+				assert.Equal(t, spec.wantErr, err)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/resourcequota/quota_validate_test.go
+++ b/pkg/resourcequota/quota_validate_test.go
@@ -1,0 +1,41 @@
+package resourcequota
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	api "k8s.io/api/core/v1"
+)
+
+func TestIsQuotaFitRejectsNegativePeerLimit(t *testing.T) {
+	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "8000Mi"}
+	peerNegativeLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-8000Mi"}
+
+	fit, failedHard, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
+		peerNegativeLimit,
+	}, projectLimit)
+	assert.NoError(t, err)
+	assert.False(t, fit)
+	assert.NotNil(t, failedHard)
+	assert.Len(t, failedHard, 1)
+	assert.Equal(t, []api.ResourceName{
+		api.ResourceLimitsMemory,
+	}, slices.Sorted(maps.Keys(failedHard)))
+}
+
+func TestIsQuotaFitAllowsPositivePeerLimitWithinProjectLimit(t *testing.T) {
+	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
+	peerLimit := &v32.ResourceQuotaLimit{LimitsMemory: "1000Mi"}
+
+	fit, failedHard, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
+		peerLimit,
+	}, projectLimit)
+	assert.NoError(t, err)
+	assert.True(t, fit)
+	assert.Nil(t, failedHard)
+}

--- a/pkg/resourcequota/quota_validate_test.go
+++ b/pkg/resourcequota/quota_validate_test.go
@@ -8,90 +8,262 @@ import (
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
 	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestIsQuotaFitRejectsNegativePeerLimit(t *testing.T) {
-	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
-	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
-	peerNegativeLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-8000Mi"}
+func TestZeroOutResourceList(t *testing.T) {
+	t.Run("ZeroOutResourceList, zero all", func(t *testing.T) {
+		out := ZeroOutResourceList(
+			api.ResourceList{
+				"configmaps":             resource.MustParse("1"),
+				"ephemeral-storage":      resource.MustParse("1"),
+				"limits.cpu":             resource.MustParse("1"),
+				"limits.memory":          resource.MustParse("1"),
+				"persistentvolumeclaims": resource.MustParse("1"),
+				"pods":                   resource.MustParse("1"),
+				"replicationcontrollers": resource.MustParse("1"),
+				"requests.cpu":           resource.MustParse("1"),
+				"requests.memory":        resource.MustParse("1"),
+				"requests.storage":       resource.MustParse("1"),
+				"secrets":                resource.MustParse("1"),
+				"services":               resource.MustParse("1"),
+				"services.loadbalancers": resource.MustParse("1"),
+				"services.nodeports":     resource.MustParse("1"),
+			},
+			[]api.ResourceName{
+				"configmaps",
+				"ephemeral-storage",
+				"limits.cpu",
+				"limits.memory",
+				"persistentvolumeclaims",
+				"pods",
+				"replicationcontrollers",
+				"requests.cpu",
+				"requests.memory",
+				"requests.storage",
+				"secrets",
+				"services",
+				"services.loadbalancers",
+				"services.nodeports",
+			})
+		assert.Equal(t, api.ResourceList{
+			"configmaps":             resource.MustParse("0"),
+			"ephemeral-storage":      resource.MustParse("0"),
+			"limits.cpu":             resource.MustParse("0"),
+			"limits.memory":          resource.MustParse("0"),
+			"persistentvolumeclaims": resource.MustParse("0"),
+			"pods":                   resource.MustParse("0"),
+			"replicationcontrollers": resource.MustParse("0"),
+			"requests.cpu":           resource.MustParse("0"),
+			"requests.memory":        resource.MustParse("0"),
+			"requests.storage":       resource.MustParse("0"),
+			"secrets":                resource.MustParse("0"),
+			"services":               resource.MustParse("0"),
+			"services.loadbalancers": resource.MustParse("0"),
+			"services.nodeports":     resource.MustParse("0"),
+		}, out)
+	})
 
-	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
-		peerNegativeLimit,
-	}, projectLimit)
-	assert.NoError(t, err)
-	assert.False(t, fit)
-	assert.Nil(t, exceeded)
-	assert.NotNil(t, negatives)
-	assert.Len(t, negatives, 1)
-	assert.Equal(t, []api.ResourceName{
-		api.ResourceLimitsMemory,
-	}, slices.Sorted(maps.Keys(negatives)))
+	t.Run("ZeroOutResourceList, zero none", func(t *testing.T) {
+		out := ZeroOutResourceList(
+			api.ResourceList{
+				"configmaps":             resource.MustParse("1"),
+				"ephemeral-storage":      resource.MustParse("11"),
+				"limits.cpu":             resource.MustParse("2"),
+				"limits.memory":          resource.MustParse("4"),
+				"persistentvolumeclaims": resource.MustParse("17"),
+				"pods":                   resource.MustParse("41"),
+				"replicationcontrollers": resource.MustParse("71"),
+				"requests.cpu":           resource.MustParse("81"),
+				"requests.memory":        resource.MustParse("9"),
+				"requests.storage":       resource.MustParse("5"),
+				"secrets":                resource.MustParse("10"),
+				"services":               resource.MustParse("122"),
+				"services.loadbalancers": resource.MustParse("6"),
+				"services.nodeports":     resource.MustParse("101"),
+			},
+			[]api.ResourceName{})
+		assert.Equal(t, api.ResourceList{
+			"configmaps":             resource.MustParse("1"),
+			"ephemeral-storage":      resource.MustParse("11"),
+			"limits.cpu":             resource.MustParse("2"),
+			"limits.memory":          resource.MustParse("4"),
+			"persistentvolumeclaims": resource.MustParse("17"),
+			"pods":                   resource.MustParse("41"),
+			"replicationcontrollers": resource.MustParse("71"),
+			"requests.cpu":           resource.MustParse("81"),
+			"requests.memory":        resource.MustParse("9"),
+			"requests.storage":       resource.MustParse("5"),
+			"secrets":                resource.MustParse("10"),
+			"services":               resource.MustParse("122"),
+			"services.loadbalancers": resource.MustParse("6"),
+			"services.nodeports":     resource.MustParse("101"),
+		}, out)
+	})
+
+	t.Run("ZeroOutResourceList, zero none, nil", func(t *testing.T) {
+		out := ZeroOutResourceList(
+			api.ResourceList{
+				"configmaps":             resource.MustParse("1"),
+				"ephemeral-storage":      resource.MustParse("11"),
+				"limits.cpu":             resource.MustParse("2"),
+				"limits.memory":          resource.MustParse("4"),
+				"persistentvolumeclaims": resource.MustParse("17"),
+				"pods":                   resource.MustParse("41"),
+				"replicationcontrollers": resource.MustParse("71"),
+				"requests.cpu":           resource.MustParse("81"),
+				"requests.memory":        resource.MustParse("9"),
+				"requests.storage":       resource.MustParse("5"),
+				"secrets":                resource.MustParse("10"),
+				"services":               resource.MustParse("122"),
+				"services.loadbalancers": resource.MustParse("6"),
+				"services.nodeports":     resource.MustParse("101"),
+			}, nil)
+		assert.Equal(t, api.ResourceList{
+			"configmaps":             resource.MustParse("1"),
+			"ephemeral-storage":      resource.MustParse("11"),
+			"limits.cpu":             resource.MustParse("2"),
+			"limits.memory":          resource.MustParse("4"),
+			"persistentvolumeclaims": resource.MustParse("17"),
+			"pods":                   resource.MustParse("41"),
+			"replicationcontrollers": resource.MustParse("71"),
+			"requests.cpu":           resource.MustParse("81"),
+			"requests.memory":        resource.MustParse("9"),
+			"requests.storage":       resource.MustParse("5"),
+			"secrets":                resource.MustParse("10"),
+			"services":               resource.MustParse("122"),
+			"services.loadbalancers": resource.MustParse("6"),
+			"services.nodeports":     resource.MustParse("101"),
+		}, out)
+	})
+
+	t.Run("ZeroOutResourceList, zero in part", func(t *testing.T) {
+		out := ZeroOutResourceList(
+			api.ResourceList{
+				"configmaps":             resource.MustParse("1"),
+				"ephemeral-storage":      resource.MustParse("11"),
+				"limits.cpu":             resource.MustParse("2"),
+				"limits.memory":          resource.MustParse("4"),
+				"persistentvolumeclaims": resource.MustParse("17"),
+				"pods":                   resource.MustParse("41"),
+				"replicationcontrollers": resource.MustParse("71"),
+				"requests.cpu":           resource.MustParse("81"),
+				"requests.memory":        resource.MustParse("9"),
+				"requests.storage":       resource.MustParse("5"),
+				"secrets":                resource.MustParse("10"),
+				"services":               resource.MustParse("122"),
+				"services.loadbalancers": resource.MustParse("6"),
+				"services.nodeports":     resource.MustParse("101"),
+			},
+			[]api.ResourceName{
+				"ephemeral-storage",
+				"requests.cpu",
+				"secrets",
+			})
+		assert.Equal(t, api.ResourceList{
+			"configmaps":             resource.MustParse("1"),
+			"ephemeral-storage":      resource.MustParse("0"),
+			"limits.cpu":             resource.MustParse("2"),
+			"limits.memory":          resource.MustParse("4"),
+			"persistentvolumeclaims": resource.MustParse("17"),
+			"pods":                   resource.MustParse("41"),
+			"replicationcontrollers": resource.MustParse("71"),
+			"requests.cpu":           resource.MustParse("0"),
+			"requests.memory":        resource.MustParse("9"),
+			"requests.storage":       resource.MustParse("5"),
+			"secrets":                resource.MustParse("0"),
+			"services":               resource.MustParse("122"),
+			"services.loadbalancers": resource.MustParse("6"),
+			"services.nodeports":     resource.MustParse("101"),
+		}, out)
+	})
 }
 
-func TestIsQuotaFitRejectsCompensatingNegativePeerLimit(t *testing.T) {
+func TestIsQuotaFit(t *testing.T) {
 	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
-	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
-	peerNegativeLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-2000Mi"}
 
-	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
-		peerNegativeLimit,
-	}, projectLimit)
-	assert.NoError(t, err)
-	assert.False(t, fit)
-	assert.Nil(t, exceeded)
-	assert.NotNil(t, negatives)
-	assert.Len(t, negatives, 1)
-	assert.Equal(t, []api.ResourceName{
-		api.ResourceLimitsMemory,
-	}, slices.Sorted(maps.Keys(negatives)))
-}
+	currentLimitOk := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
+	currentLimitExceed := &v32.ResourceQuotaLimit{LimitsMemory: "6000Mi"}
+	currentLimitNegative := &v32.ResourceQuotaLimit{LimitsMemory: "-2000Mi"}
 
-func TestIsQuotaFitRejectsOversubscription(t *testing.T) {
-	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
-	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
-	peerLimit := &v32.ResourceQuotaLimit{LimitsMemory: "8000Mi"}
+	peerLimitOk := &v32.ResourceQuotaLimit{LimitsMemory: "1000Mi"}
+	peerLimitExceed := &v32.ResourceQuotaLimit{LimitsMemory: "3000Mi"}
+	peerLimitNegative := &v32.ResourceQuotaLimit{LimitsMemory: "-8000Mi"}
 
-	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
-		peerLimit,
-	}, projectLimit)
-	assert.NoError(t, err)
-	assert.False(t, fit)
-	assert.Nil(t, negatives)
-	assert.NotNil(t, exceeded)
-	assert.Len(t, exceeded, 1)
-	assert.Equal(t, []api.ResourceName{
-		api.ResourceLimitsMemory,
-	}, slices.Sorted(maps.Keys(exceeded)))
-}
+	failedResource := []api.ResourceName{api.ResourceLimitsMemory}
 
-func TestIsQuotaFitAllowsPositivePeerLimitWithinProjectLimit(t *testing.T) {
-	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
-	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
-	peerLimit := &v32.ResourceQuotaLimit{LimitsMemory: "1000Mi"}
+	testcases := map[string]struct {
+		wantErr      error
+		wantExceeds  []api.ResourceName
+		wantNegative []api.ResourceName
+		wantFit      bool
+		current      *v32.ResourceQuotaLimit
+		peer         *v32.ResourceQuotaLimit
+	}{
+		"negative for current, ok peer, fail": {
+			wantNegative: failedResource,
+			current:      currentLimitNegative,
+			peer:         peerLimitOk,
+		},
+		"negative for current, negative peer, fail": {
+			wantNegative: failedResource,
+			current:      currentLimitNegative,
+			peer:         peerLimitNegative,
+		},
+		"ok current, negative peer is ignored, ok": {
+			wantFit: true,
+			current: currentLimitOk,
+			peer:    peerLimitNegative,
+		},
+		"ok current, exceeds through peer, fail": {
+			wantExceeds: failedResource,
+			current:     currentLimitOk,
+			peer:        peerLimitExceed,
+		},
+		"ok current, ok peer, ok": {
+			wantFit: true,
+			current: currentLimitOk,
+			peer:    peerLimitOk,
+		},
+		"exceeds through current, ok peer, fail": {
+			wantExceeds: failedResource,
+			current:     currentLimitExceed,
+			peer:        peerLimitOk,
+		},
+		"exceeds through current, negative peer does not compensate, fail": {
+			wantExceeds: failedResource,
+			current:     currentLimitExceed,
+			peer:        peerLimitNegative,
+		},
+		"exceeds through current and peer, fail": {
+			wantExceeds: failedResource,
+			current:     currentLimitExceed,
+			peer:        peerLimitExceed,
+		},
+	}
+	for name, spec := range testcases {
+		t.Run(name, func(t *testing.T) {
+			fit, exceeded, negatives, err := IsQuotaFit(spec.current,
+				[]*v32.ResourceQuotaLimit{spec.peer}, projectLimit)
 
-	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
-		peerLimit,
-	}, projectLimit)
-	assert.NoError(t, err)
-	assert.True(t, fit)
-	assert.Nil(t, exceeded)
-	assert.Nil(t, negatives)
-}
-
-func TestIsQuotaFitRejectsNegativeOwnLimitWithinProjectLimit(t *testing.T) {
-	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
-	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-2000Mi"}
-	peerLimit := &v32.ResourceQuotaLimit{LimitsMemory: "1000Mi"}
-
-	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
-		peerLimit,
-	}, projectLimit)
-	assert.NoError(t, err)
-	assert.False(t, fit)
-	assert.Nil(t, exceeded)
-	assert.NotNil(t, negatives)
-	assert.Len(t, negatives, 1)
-	assert.Equal(t, []api.ResourceName{
-		api.ResourceLimitsMemory,
-	}, slices.Sorted(maps.Keys(negatives)))
+			assert.Equal(t, spec.wantFit, fit)
+			if spec.wantErr != nil {
+				assert.Error(t, spec.wantErr, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if spec.wantExceeds != nil {
+				assert.NotNil(t, exceeded)
+				assert.Equal(t, spec.wantExceeds, slices.Sorted(maps.Keys(exceeded)))
+			} else {
+				assert.Nil(t, exceeded)
+			}
+			if spec.wantNegative != nil {
+				assert.NotNil(t, negatives)
+				assert.Equal(t, spec.wantNegative, slices.Sorted(maps.Keys(negatives)))
+			} else {
+				assert.Nil(t, negatives)
+			}
+		})
+	}
 }

--- a/pkg/resourcequota/quota_validate_test.go
+++ b/pkg/resourcequota/quota_validate_test.go
@@ -1,0 +1,97 @@
+package resourcequota
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	api "k8s.io/api/core/v1"
+)
+
+func TestIsQuotaFitRejectsNegativePeerLimit(t *testing.T) {
+	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
+	peerNegativeLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-8000Mi"}
+
+	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
+		peerNegativeLimit,
+	}, projectLimit)
+	assert.NoError(t, err)
+	assert.False(t, fit)
+	assert.Nil(t, exceeded)
+	assert.NotNil(t, negatives)
+	assert.Len(t, negatives, 1)
+	assert.Equal(t, []api.ResourceName{
+		api.ResourceLimitsMemory,
+	}, slices.Sorted(maps.Keys(negatives)))
+}
+
+func TestIsQuotaFitRejectsCompensatingNegativePeerLimit(t *testing.T) {
+	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
+	peerNegativeLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-2000Mi"}
+
+	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
+		peerNegativeLimit,
+	}, projectLimit)
+	assert.NoError(t, err)
+	assert.False(t, fit)
+	assert.Nil(t, exceeded)
+	assert.NotNil(t, negatives)
+	assert.Len(t, negatives, 1)
+	assert.Equal(t, []api.ResourceName{
+		api.ResourceLimitsMemory,
+	}, slices.Sorted(maps.Keys(negatives)))
+}
+
+func TestIsQuotaFitRejectsOversubscription(t *testing.T) {
+	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
+	peerLimit := &v32.ResourceQuotaLimit{LimitsMemory: "8000Mi"}
+
+	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
+		peerLimit,
+	}, projectLimit)
+	assert.NoError(t, err)
+	assert.False(t, fit)
+	assert.Nil(t, negatives)
+	assert.NotNil(t, exceeded)
+	assert.Len(t, exceeded, 1)
+	assert.Equal(t, []api.ResourceName{
+		api.ResourceLimitsMemory,
+	}, slices.Sorted(maps.Keys(exceeded)))
+}
+
+func TestIsQuotaFitAllowsPositivePeerLimitWithinProjectLimit(t *testing.T) {
+	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "2000Mi"}
+	peerLimit := &v32.ResourceQuotaLimit{LimitsMemory: "1000Mi"}
+
+	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
+		peerLimit,
+	}, projectLimit)
+	assert.NoError(t, err)
+	assert.True(t, fit)
+	assert.Nil(t, exceeded)
+	assert.Nil(t, negatives)
+}
+
+func TestIsQuotaFitRejectsNegativeOwnLimitWithinProjectLimit(t *testing.T) {
+	projectLimit := &v32.ResourceQuotaLimit{LimitsMemory: "4000Mi"}
+	currentLimit := &v32.ResourceQuotaLimit{LimitsMemory: "-2000Mi"}
+	peerLimit := &v32.ResourceQuotaLimit{LimitsMemory: "1000Mi"}
+
+	fit, exceeded, negatives, err := IsQuotaFit(currentLimit, []*v32.ResourceQuotaLimit{
+		peerLimit,
+	}, projectLimit)
+	assert.NoError(t, err)
+	assert.False(t, fit)
+	assert.Nil(t, exceeded)
+	assert.NotNil(t, negatives)
+	assert.Len(t, negatives, 1)
+	assert.Equal(t, []api.ResourceName{
+		api.ResourceLimitsMemory,
+	}, slices.Sorted(maps.Keys(negatives)))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#56497 
 
## Problem

Rancher enforces per-project resource caps by checking each namespace's requested limits against the project limit, summing the sibling namespaces' limits.

The core function, `IsQuotaFit`, rejects negative limit values only for the current namespace; it never checks the summed peers or the peer limits. The peer limits are read from all namespaces. Invalid quotas are not excluded.
 
## Solution

The management is modified to reject negative quantities in all relevant namespaces, not just itself.

Rejection of entire namespaces was rejected, as that may reject good quota information from namespaces which are a mix of bad and good resources.

This fix is was created with copilot, with modifications in the unit tests
 
## Testing

Additional unit tests.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_