### PR TITLE
[v2.15] Update SCC Operator to v0.5.1-rc.2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,5 +5,5 @@ turtlesVersion: 110.0.0+up0.27.0
 cspAdapterMinVersion: 110.0.0+up10.0.0
 defaultShellVersion: rancher/shell:v0.8.1
 fleetVersion: 110.0.1+up0.16.1-beta.2
-defaultSccOperatorImage: rancher/scc-operator:v0.5.1-rc.1
+defaultSccOperatorImage: rancher/scc-operator:v0.5.1-rc.2
 chartAuditLogImage: rancher/mirrored-bci-micro:16.0-15.11

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,7 +5,7 @@ package buildconfig
 const (
 	ChartAuditLogImage       = "rancher/mirrored-bci-micro:16.0-15.11"
 	CspAdapterMinVersion     = "110.0.0+up10.0.0"
-	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.1-rc.1"
+	DefaultSccOperatorImage  = "rancher/scc-operator:v0.5.1-rc.2"
 	DefaultShellVersion      = "rancher/shell:v0.8.1"
 	FleetVersion             = "110.0.1+up0.16.1-beta.2"
 	RemoteDialerProxyVersion = "110.0.0+up0.8.0"


### PR DESCRIPTION
## Summary
Update SCC Operator image to [`v0.5.1-rc.2`](https://github.com/rancher/scc-operator/releases/tag/v0.5.1-rc.2)

## Changes
- Updated `defaultSccOperatorImage` in `build.yaml`
- Ran `go generate ./pkg/...` to update generated files