### PR TITLE
56074 snapshot save token improvements

### DIFF
--- a/dev-scripts/dev-env
+++ b/dev-scripts/dev-env
@@ -24,7 +24,7 @@ set -eo pipefail
 cluster="${CAPRKE2_DEV_CLUSTER:-local-caprke2}"
 k3s_version="${K3S_VERSION:-v1.33.5-k3s1}"
 
-for bin in docker k3d kubectl; do
+for bin in docker k3d jq kubectl; do
   if ! command -v "$bin" >/dev/null 2>&1; then
     echo "error: '$bin' not found on PATH; install it and re-run." >&2
     exit 1
@@ -36,7 +36,7 @@ if ! docker network inspect kind >/dev/null 2>&1; then
   docker network create kind >/dev/null
 fi
 
-if k3d cluster list --output json 2>/dev/null | grep -q "\"name\": \"${cluster}\""; then
+if k3d cluster list --output json 2>/dev/null | jq "(map(select(.name == \"${cluster}\")) | first) // error (\"Cluster ${cluster} does not exist\")"; then
   echo "k3d cluster '${cluster}' already exists — reusing"
 else
   echo "Creating k3d cluster '${cluster}' on the 'kind' network with docker socket mounted"

--- a/dev-scripts/dev-env-cleanup
+++ b/dev-scripts/dev-env-cleanup
@@ -7,7 +7,14 @@ set -eo pipefail
 
 cluster="${CAPRKE2_DEV_CLUSTER:-local-caprke2}"
 
-if command -v k3d >/dev/null 2>&1 && k3d cluster list --output json 2>/dev/null | grep -q "\"name\": \"${cluster}\""; then
+for bin in docker jq k3d; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "error: '$bin' not found on PATH; install it and re-run." >&2
+    exit 1
+  fi
+done
+
+if k3d cluster list --output json 2>/dev/null | jq "(map(select(.name == \"${cluster}\")) | first) // error (\"Cluster ${cluster} does not exist\")"; then
   echo "Deleting k3d cluster '${cluster}'"
   k3d cluster delete "${cluster}"
 else

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -82,7 +82,8 @@ const (
 	AuthorizedObjectAnnotation                 = "rke.cattle.io/object-authorized-for-clusters"
 	DeleteMissingCustomMachinesAfterAnnotation = "rke.cattle.io/delete-missing-custom-machines-after"
 
-	SnapshotNameAnnotation = "etcdsnapshot.rke.io/snapshot-name"
+	SnapshotNameAnnotation      = "etcdsnapshot.rke.io/snapshot-name"
+	SnapshotTokenHashAnnotation = "rke.cattle.io/snapshot-token-hash"
 
 	JoinServerImplausible = "implausible"
 

--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -611,16 +611,6 @@ func generateRemoveTLSAndCredDirInstructions(controlPlane *rkev1.RKEControlPlane
 				},
 			},
 		},
-		{
-			CommonInstruction: planapi.CommonInstruction{
-				Name:    "remove-cred-directory",
-				Command: "rm",
-				Args: []string{
-					"-rf",
-					path.Join(capr.GetDistroDataDir(controlPlane), "server/cred"),
-				},
-			},
-		},
 	}
 }
 

--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -599,16 +599,16 @@ func (p *Planner) generateEtcdRestoreNodeCleanupFilesAndInstruction(controlPlane
 	}, instructions
 }
 
-func generateRemoveTLSAndCredDirInstructions(controlPlane *rkev1.RKEControlPlane) []plan.OneTimeInstruction {
-	return []plan.OneTimeInstruction{
-		{
-			CommonInstruction: planapi.CommonInstruction{
-				Name:    "remove-tls-directory",
-				Command: "rm",
-				Args: []string{
-					"-rf",
-					path.Join(capr.GetDistroDataDir(controlPlane), "server/tls"),
-				},
+// generateRemoveTLSDirInstruction returns an instruction for removing the server/tls directory within the distro's
+// data directory.
+func generateRemoveTLSDirInstruction(controlPlane *rkev1.RKEControlPlane) plan.OneTimeInstruction {
+	return plan.OneTimeInstruction{
+		CommonInstruction: planapi.CommonInstruction{
+			Name:    "remove-tls-directory",
+			Command: "rm",
+			Args: []string{
+				"-rf",
+				path.Join(capr.GetDistroDataDir(controlPlane), "server/tls"),
 			},
 		},
 	}
@@ -682,7 +682,7 @@ func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane,
 			stopPlan.Instructions = append(stopPlan.Instructions, generateCreateEtcdTombstoneInstruction(controlPlane))
 		}
 		if roleOr(isEtcd, isControlPlane)(server) {
-			stopPlan.Instructions = append(stopPlan.Instructions, generateRemoveTLSAndCredDirInstructions(controlPlane)...)
+			stopPlan.Instructions = append(stopPlan.Instructions, generateRemoveTLSDirInstruction(controlPlane))
 		}
 		if !p.equalities.DeepEqual(server.Plan.Plan, stopPlan) {
 			if err := p.store.UpdatePlan(server, stopPlan, joinedServer, 0, 0); err != nil {

--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
@@ -419,6 +419,10 @@ func getRestoreModesAnnotation(downstream *k3s.ETCDSnapshotFile, cluster *unstru
 	return strings.Join(availableModes, ",")
 }
 
+// getSnapshotHash returns the value of the "etcd.rke2.cattle.io/snapshot-token-hash" or
+// "etcd.k3s.cattle.io/snapshot-token-hash" annotation on the downstream snapshot object for RKE2 and K3s respectively.
+// Ideally this function should check one or the other depending on the detected distro, but for now it checks both as
+// this would ideally be supported via the operations.Adapter interface, which is currently disabled for v2prov.
 func getSnapshotHash(downstream *k3s.ETCDSnapshotFile) string {
 	if downstream == nil || downstream.Annotations == nil {
 		return ""

--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
@@ -419,6 +419,18 @@ func getRestoreModesAnnotation(downstream *k3s.ETCDSnapshotFile, cluster *unstru
 	return strings.Join(availableModes, ",")
 }
 
+func getSnapshotHash(downstream *k3s.ETCDSnapshotFile) string {
+	if downstream == nil || downstream.Annotations == nil {
+		return ""
+	}
+
+	if hash := downstream.Annotations["etcd.rke2.cattle.io/snapshot-token-hash"]; hash != "" {
+		return hash
+	}
+
+	return downstream.Annotations["etcd.k3s.cattle.io/snapshot-token-hash"]
+}
+
 // populateUpstreamSnapshotFromDownstream sets the labels, annotations, spec and status fields which are governed by the
 // downstream snapshot. Also sets the relevant owner references (machine for local, capi cluster for s3), and
 // namespace/name if the snapshot is being created.
@@ -460,6 +472,11 @@ func (h *handler) populateUpstreamSnapshotFromDownstream(
 	upstream.Annotations[StorageAnnotationKey] = string(storage)
 	upstream.Annotations[SnapshotFileNameAnnotationKey] = downstream.Spec.SnapshotName
 	upstream.Annotations[capr.SnapshotNameAnnotation] = downstream.Name
+
+	hash := getSnapshotHash(downstream)
+	if hash != "" {
+		upstream.Annotations[capr.SnapshotTokenHashAnnotation] = hash
+	}
 
 	upstream.Spec.ClusterName = clusterName
 	upstream.SnapshotFile = rkev1.ETCDSnapshotFile{

--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate_test.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate_test.go
@@ -3,6 +3,7 @@ package snapshotbackpopulate
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"regexp"
 	"strings"
 	"testing"
@@ -303,8 +304,9 @@ func TestOnUpstreamChange(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			h := tt.handlerFunc(ctrl)
 			snapshotCopy := tt.snapshot.DeepCopy()
@@ -323,6 +325,8 @@ func TestOnUpstreamChange(t *testing.T) {
 }
 
 func TestOnDownstreamChange(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	etcdSnapshotCache := fake.NewMockCacheInterface[*rkev1.ETCDSnapshot](ctrl)
 	etcdSnapshotController := fake.NewMockControllerInterface[*rkev1.ETCDSnapshot, *rkev1.ETCDSnapshotList](ctrl)
@@ -551,6 +555,8 @@ func TestOnDownstreamChange(t *testing.T) {
 }
 
 func TestOnDownstreamChange_RestoreModeAnnotationIsSetCorrectly(t *testing.T) {
+	t.Parallel()
+
 	compressSpec := func(t *testing.T, spec *provv1.ClusterSpec) string {
 		payload, err := snapshotutil.CompressInterface(spec)
 		require.NoError(t, err)
@@ -784,8 +790,9 @@ func TestGetCluster(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			h := handler{
 				clusterRef: tt.clusterRef,
 				dynamic:    &dynamicClientFake{obj: tt.dynamicObj, err: tt.dynamicErr},
@@ -871,8 +878,9 @@ func TestGetSnapshotsFromSnapshotFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			cache := fake.NewMockCacheInterface[*rkev1.ETCDSnapshot](ctrl)
 			tt.cacheFunc(cache)
@@ -894,6 +902,8 @@ func TestGetSnapshotsFromSnapshotFile(t *testing.T) {
 }
 
 func TestGetLogPrefix(t *testing.T) {
+	t.Parallel()
+
 	cluster := newProvisioningClusterUnstructured("test-namespace", "test-cluster")
 	expected := fmt.Sprintf("[snapshotbackpopulate] %s/test-namespace/test-cluster:",
 		schema.FromAPIVersionAndKind("provisioning.cattle.io/v1", "Cluster").String())
@@ -911,9 +921,7 @@ func TestMachineLifecycleLabelsToObjectReference(t *testing.T) {
 
 	drop := func(key string) map[string]string {
 		l := make(map[string]string, len(allLabels))
-		for k, v := range allLabels {
-			l[k] = v
-		}
+		maps.Copy(l, allLabels)
 		delete(l, key)
 		return l
 	}
@@ -981,14 +989,16 @@ func TestMachineLifecycleLabelsToObjectReference(t *testing.T) {
 
 	mapper := testRESTMapper()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			obj := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "test-node",
 					Labels: tt.labels,
 				},
 			}
+
 			ref, err := planv1alpha1.MachineLifecycleLabelsToObjectReference(obj, tt.contextNamespace, mapper)
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -1002,6 +1012,8 @@ func TestMachineLifecycleLabelsToObjectReference(t *testing.T) {
 }
 
 func TestGenerateSafeSnapshotName(t *testing.T) {
+	t.Parallel()
+
 	callTime := time.Unix(1_700_000_000, 0)
 
 	newSpec := func(name, node, loc string, s3 bool) k3s.ETCDSnapshotSpec {
@@ -1048,8 +1060,9 @@ func TestGenerateSafeSnapshotName(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := generateSafeSnapshotName(tc.spec, callTime)
 			require.Equal(t, strings.ToLower(got), got)
 			require.True(t, strings.HasPrefix(got, tc.wantPrefix), got)
@@ -1065,6 +1078,8 @@ func TestGenerateSafeSnapshotName(t *testing.T) {
 	}
 
 	t.Run("Digest changes when location changes", func(t *testing.T) {
+		t.Parallel()
+
 		a := newSpec("ok", "cp-0", "s3://bucket/prefix/A", true)
 		b := newSpec("ok", "cp-0", "s3://bucket/prefix/B", true)
 
@@ -1075,4 +1090,100 @@ func TestGenerateSafeSnapshotName(t *testing.T) {
 		require.True(t, strings.HasPrefix(gb, "s3-ok-"))
 		require.NotEqual(t, ga, gb, "digest suffix must differ when location differs")
 	})
+}
+
+func TestGetSnapshotHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		snapshot *k3s.ETCDSnapshotFile
+		want     string
+	}{
+		{
+			name:     "nil snapshot",
+			snapshot: nil,
+			want:     "",
+		},
+		{
+			name: "empty snapshot",
+			snapshot: &k3s.ETCDSnapshotFile{
+				Spec: k3s.ETCDSnapshotSpec{},
+			},
+			want: "",
+		},
+		{
+			name: "empty annotations",
+			snapshot: &k3s.ETCDSnapshotFile{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "empty rke2",
+			snapshot: &k3s.ETCDSnapshotFile{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"etcd.rke2.cattle.io/snapshot-token-hash": "",
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "empty k3s",
+			snapshot: &k3s.ETCDSnapshotFile{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"etcd.k3s.cattle.io/snapshot-token-hash": "",
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "unrelated",
+			snapshot: &k3s.ETCDSnapshotFile{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"etcd.testing.cattle.io/snapshot-token-hash": "abc123",
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "rke2",
+			snapshot: &k3s.ETCDSnapshotFile{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"etcd.rke2.cattle.io/snapshot-token-hash": "abc123",
+					},
+				},
+			},
+			want: "abc123",
+		},
+		{
+			name: "k3s",
+			snapshot: &k3s.ETCDSnapshotFile{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"etcd.k3s.cattle.io/snapshot-token-hash": "abc123",
+					},
+				},
+			},
+			want: "abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := getSnapshotHash(tt.snapshot)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/controllers/operations/encryptionkeyrotation/controller.go
+++ b/pkg/controllers/operations/encryptionkeyrotation/controller.go
@@ -484,7 +484,7 @@ func (h *handler) reconcileRotate(s *scope, status opv1alpha1.EncryptionKeyRotat
 		return status, err
 	}
 
-	env := operationEnv(s.op, status.Step)
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 	runtime := s.adapter.RuntimeCommand()
 
 	nodePlan := &plan.Plan{
@@ -495,7 +495,6 @@ func (h *handler) reconcileRotate(s *scope, status opv1alpha1.EncryptionKeyRotat
 					Name:    rotateKeysInstructionName,
 					Command: "/bin/sh",
 					Args:    []string{"-c", rotateKeysScript(runtime)},
-					Env:     env,
 				},
 				SaveOutput: true,
 			},
@@ -506,7 +505,6 @@ func (h *handler) reconcileRotate(s *scope, status opv1alpha1.EncryptionKeyRotat
 					Name:    waitForStatusInstructionName,
 					Command: "/bin/sh",
 					Args:    []string{"-c", waitForStatusScript(runtime)},
-					Env:     env,
 				},
 			},
 			// 3. One-time status snapshot captured when the plan is applied; provides an
@@ -516,7 +514,6 @@ func (h *handler) reconcileRotate(s *scope, status opv1alpha1.EncryptionKeyRotat
 					Name:    statusPeriodicName,
 					Command: runtime,
 					Args:    []string{"secrets-encrypt", "status"},
-					Env:     env,
 				},
 				SaveOutput: true,
 			},
@@ -528,7 +525,6 @@ func (h *handler) reconcileRotate(s *scope, status opv1alpha1.EncryptionKeyRotat
 					Name:    statusPeriodicName,
 					Command: runtime,
 					Args:    []string{"secrets-encrypt", "status"},
-					Env:     env,
 				},
 				PeriodSeconds: 5,
 			},
@@ -539,7 +535,7 @@ func (h *handler) reconcileRotate(s *scope, status opv1alpha1.EncryptionKeyRotat
 	// Use finite failure threshold so a plan that can't execute
 	// is marked Failed rather than retried forever. The wrapper always exits 0, so a
 	// real apply failure here means the wrapper itself couldn't run.
-	planStatus, err := h.store.AssignPlan(leader, nodePlan, 1, 1)
+	planStatus, err := h.store.AssignPlan(leader, ops.WithOperationEnv(nodePlan, opEnv), 1, 1)
 	if err != nil {
 		return status, err
 	}
@@ -662,7 +658,7 @@ func (h *handler) reconcileRestart(s *scope, status opv1alpha1.EncryptionKeyRota
 		return status, nil
 	}
 
-	env := operationEnv(s.op, status.Step)
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 	serverUnit := s.adapter.ServerUnit()
 	runtime := s.adapter.RuntimeCommand()
 
@@ -673,7 +669,7 @@ func (h *handler) reconcileRestart(s *scope, status opv1alpha1.EncryptionKeyRota
 	// reencrypt_finished while hashes still differ across servers.
 	for i, secret := range secrets {
 		requireHashMatch := i == len(secrets)-1
-		status, done, err := h.reconcileRestartNode(s, status, secret, env, serverUnit, runtime, requireHashMatch)
+		status, done, err := h.reconcileRestartNode(s, status, secret, opEnv, serverUnit, runtime, requireHashMatch)
 		if err != nil {
 			return status, err
 		}
@@ -702,7 +698,7 @@ func (h *handler) reconcileRestartNode(
 	s *scope,
 	status opv1alpha1.EncryptionKeyRotationStatus,
 	secret *corev1.Secret,
-	env []string,
+	opEnv []string,
 	serverUnit string,
 	runtime string,
 	requireHashMatch bool,
@@ -718,7 +714,6 @@ func (h *handler) reconcileRestartNode(
 				Name:    "restart",
 				Command: "systemctl",
 				Args:    []string{"restart", serverUnit},
-				Env:     env,
 			},
 		},
 		{
@@ -726,7 +721,6 @@ func (h *handler) reconcileRestartNode(
 				Name:    "wait-for-systemctl-status",
 				Command: "/bin/sh",
 				Args:    []string{"-c", waitForSystemctlStatusScript(serverUnit)},
-				Env:     env,
 			},
 		},
 	}
@@ -742,7 +736,6 @@ func (h *handler) reconcileRestartNode(
 					Name:    waitForStatusInstructionName,
 					Command: "/bin/sh",
 					Args:    []string{"-c", waitForStatusScript(runtime)},
-					Env:     env,
 				},
 			},
 			plan.OneTimeInstruction{
@@ -750,7 +743,6 @@ func (h *handler) reconcileRestartNode(
 					Name:    statusPeriodicName,
 					Command: runtime,
 					Args:    []string{"secrets-encrypt", "status"},
-					Env:     env,
 				},
 				SaveOutput: true,
 			},
@@ -761,14 +753,13 @@ func (h *handler) reconcileRestartNode(
 					Name:    statusPeriodicName,
 					Command: runtime,
 					Args:    []string{"secrets-encrypt", "status"},
-					Env:     env,
 				},
 				PeriodSeconds: 5,
 			},
 		}
 	}
 
-	planStatus, err := h.store.AssignPlan(secret, nodePlan, 5, 5)
+	planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 5, 5)
 	if err != nil {
 		return status, false, err
 	}
@@ -1039,16 +1030,6 @@ func (h *handler) reclaimStaleBeaconOwnerIfNeeded(s *scope) error {
 	s.beacon = updated
 
 	return nil
-}
-
-// operationEnv returns env vars that tie plan content to the operation UID and
-// current step. This keeps rotate and restart plans byte-distinct so
-// system-agent reruns them instead of reusing stale applied output.
-func operationEnv(op *opv1alpha1.EncryptionKeyRotation, step opv1alpha1.EncryptionKeyRotationStep) []string {
-	return []string{
-		fmt.Sprintf("ENCRYPTION_KEY_ROTATION_OPERATION_UID=%s", op.UID),
-		fmt.Sprintf("ENCRYPTION_KEY_ROTATION_STEP=%s", step),
-	}
 }
 
 // errRotateKeysOutputNotYet is returned by readRotateKeysResult when the rotate-keys output

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -79,8 +79,21 @@ const (
 	// persisted on disk, so it can be compared against the hash the distro stamped on the snapshot.
 	// The single format argument is the distro data directory, where the token file is persisted.
 	//
+	// It has to reproduce in a shell what the distro's do which respects colons as part of the password, treating
+	// everything after "server:" as the password.
+	//
+	// So two anchored, non-greedy substitutions recover the password: the first drops the `K10<CA-hash>::` prefix, the
+	// second drops the `server:` username. `[^:]*` cannot cross a colon, which is what makes them non-greedy; a greedy
+	// `.*:` would strip through the *last* colon. This also respects passwords ending in a colon.
+	//
+	// Whitespace is only trimmed at the edges, matching the bytes.TrimSpace the distro applies when it
+	// reads the same file; deleting all whitespace would corrupt a password that contains a space.
+	//
+	// The missing/empty guards are not incidental. Every element of the derivation is a pipeline, so without them a
+	// missing token file leaves the shell exiting 0 having printed sha256 of the empty string which is a valid hash.
+	//
 	// Exported so e2e tests can derive the same value the check derives.
-	TokenHashCommandFormat = `f=%[1]s/server/token; tr -d '[:space:]' < "$f" | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`
+	TokenHashCommandFormat = `f=%[1]s/server/token; [ -s "$f" ] || { echo "server token file $f not found or empty" >&2; exit 1; }; p=$(head -n 1 "$f" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^K10[^:]*:://' -e 's/^[^:]*://'); [ -n "$p" ] || { echo "no server token password found in $f" >&2; exit 1; }; printf '%%s' "$p" | sha256sum | cut -c1-12`
 
 	// idempotencyKey is the top-level key used to scope idempotency tracking for this controller.
 	// It is also used by the cleanup instruction issued during shutdown to clear prior tracking.

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -72,6 +72,18 @@ const (
 	// reconciliation.
 	RestartClusterStepHookLabelPrefix = "restart-cluster.step.hook.operation.cattle.io/"
 
+	// TokenHashCommandFormat is the shell command the Preflight step runs on every etcd node to hash
+	// the server token persisted on disk, so it can be compared against the hash the distro stamped
+	// on the snapshot. The single format argument is the distro data directory.
+	//
+	// The distro persists the token under its data directory, but the layout differs between versions
+	// (and between server and agent nodes), so the file is resolved rather than assumed — a missing
+	// file exits non-zero, and because plans are assigned with a failure threshold of -1 that would
+	// stall the operation rather than fail it.
+	//
+	// Exported so tests can derive the same value the check derives.
+	TokenHashCommandFormat = `f=%[1]s/server/token; [ -f "$f" ] || f=%[1]s/token; tr -d '[:space:]' < "$f" | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`
+
 	// idempotencyKey is the top-level key used to scope idempotency tracking for this controller.
 	// It is also used by the cleanup instruction issued during shutdown to clear prior tracking.
 	idempotencyKey = "etcd-restore"
@@ -644,9 +656,7 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 						Command: "/bin/sh",
 						Args: []string{
 							"-c",
-							fmt.Sprintf(`tr -d '[:space:]' < %s/token | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`,
-								s.adapter.DistroDataDirectory(secret),
-							),
+							fmt.Sprintf(TokenHashCommandFormat, s.adapter.DistroDataDirectory(secret)),
 						},
 					},
 				},
@@ -673,6 +683,8 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 			return status, nil
 		}
 
+		// The token hash can only be validated once the node has applied the plan and reported its
+		// output, so a waiting node is skipped entirely until a later reconcile.
 		if planStatus.Waiting() {
 			logrus.Debugf("[etcdsnapshotrestore] %s/%s: waiting for preflight check for %s/%s", s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
 
@@ -680,6 +692,8 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 			if concurrency <= 0 {
 				break
 			}
+
+			continue
 		}
 
 		if snapshot != nil {
@@ -687,6 +701,9 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 			if err != nil {
 				logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: could not read preflight check output for %s/%s",
 					s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
+
+				status.SetPhase(opv1alpha1.OperationPhaseFailed)
+
 				opv1alpha1.FailedCondition.True(&status)
 				opv1alpha1.FailedCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
 				opv1alpha1.FailedCondition.Message(&status, fmt.Sprintf("could not read preflight check output for %s/%s", secret.Namespace, secret.Name))
@@ -694,19 +711,19 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 				return status, nil
 			}
 			if hash, ok := snapshot.Annotations[capr.SnapshotTokenHashAnnotation]; ok && hash != "" {
-				if b, ok := output["preflight"]; ok && string(b) != hash {
+				// The instruction pipes through cut, so the saved output carries a trailing newline
+				// which the annotation does not.
+				if b, ok := output["preflight"]; ok && strings.TrimSpace(string(b)) != hash {
 					logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: preflight check output for %s/%s does not match snapshot token hash",
 						s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
+
+					status.SetPhase(opv1alpha1.OperationPhaseFailed)
+
 					opv1alpha1.FailedCondition.True(&status)
 					opv1alpha1.FailedCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
 					opv1alpha1.FailedCondition.Message(&status, fmt.Sprintf("preflight check output for %s/%s does not match snapshot token hash", secret.Namespace, secret.Name))
 
 					return status, nil
-				}
-
-				concurrency--
-				if concurrency <= 0 {
-					break
 				}
 			} else {
 				logrus.Warnf("[etcdsnapshotrestore] %s/%s: could not find snapshot token hash for %s/%s, preflight check output will not be validated",

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -625,19 +625,27 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 	concurrency := len(secrets)
 	results := make([]plan.PlanStatus, 0, concurrency)
 
+	snapshotName := s.op.Spec.Args.Name
+	snapshot, err := h.etcdsnapshots.Get(s.adapter.EtcdSnapshotNamespace(), snapshotName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		logrus.Debugf("[etcdsnapshotrestore] %s/%s: could not find associated etcdsnapshot.rke.cattle.io %s/%s, assuming snapshot file", s.op.Namespace, s.op.Name, s.adapter.EtcdSnapshotNamespace(), snapshotName)
+		snapshot = nil
+	} else if err != nil {
+		return status, err
+	}
+
 	for _, secret := range secrets {
 		nodePlan := &plan.Plan{
 			OneTimeInstructions: []plan.OneTimeInstruction{
 				{
+					SaveOutput: true,
 					CommonInstruction: plan.CommonInstruction{
 						Name:    "preflight",
 						Command: "/bin/sh",
 						Args: []string{
 							"-c",
-
-							fmt.Sprintf(`grep -rE -q '^[[:space:]]*[\x27\x22 ]?token[\x27\x22 ]?[[:space:]]*:[[:space:]]*[\x27\x22 ]*[^[:space:]\x27\x22]+' %s %s/ 2>/dev/null || (exit 1)`,
-								s.adapter.ConfigFile(secret),
-								s.adapter.ConfigDirectory(secret),
+							fmt.Sprintf(`tr -d '[:space:]' < %s/token | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`,
+								s.adapter.DistroDataDirectory(secret),
 							),
 						},
 					},
@@ -671,6 +679,38 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 			concurrency--
 			if concurrency <= 0 {
 				break
+			}
+		}
+
+		if snapshot != nil {
+			output, err := plan.ReadAppliedOutput(secret)
+			if err != nil {
+				logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: could not read preflight check output for %s/%s",
+					s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
+				opv1alpha1.FailedCondition.True(&status)
+				opv1alpha1.FailedCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
+				opv1alpha1.FailedCondition.Message(&status, fmt.Sprintf("could not read preflight check output for %s/%s", secret.Namespace, secret.Name))
+
+				return status, nil
+			}
+			if hash, ok := snapshot.Annotations[capr.SnapshotTokenHashAnnotation]; ok && hash != "" {
+				if b, ok := output["preflight"]; ok && string(b) != hash {
+					logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: preflight check output for %s/%s does not match snapshot token hash",
+						s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
+					opv1alpha1.FailedCondition.True(&status)
+					opv1alpha1.FailedCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
+					opv1alpha1.FailedCondition.Message(&status, fmt.Sprintf("preflight check output for %s/%s does not match snapshot token hash", secret.Namespace, secret.Name))
+
+					return status, nil
+				}
+
+				concurrency--
+				if concurrency <= 0 {
+					break
+				}
+			} else {
+				logrus.Warnf("[etcdsnapshotrestore] %s/%s: could not find snapshot token hash for %s/%s, preflight check output will not be validated",
+					s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
 			}
 		}
 	}
@@ -854,7 +894,7 @@ func (h *handler) reconcileRestore(s *scope, status opv1alpha1.ETCDSnapshotResto
 		return status, err
 	} else if snapshot != nil && snapshot.SnapshotFile.S3 == nil {
 		// Prefer the snapshot's stamped MachineLifecycleNameLabel (used by CAPRKE2 where the
-		// owner ref is a mgmt v3 Node but plan secrets are labelled with the CAPI Machine's
+		// owner ref is a mgmt v3 Node but plan secrets are labeled with the CAPI Machine's
 		// name). Fall back to OwnerReferences[0].Name for v2prov/imported paths that predate the
 		// label.
 		machineName := snapshot.Labels[planv1alpha1.MachineLifecycleNameLabel]

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -79,8 +79,8 @@ const (
 	// persisted on disk, so it can be compared against the hash the distro stamped on the snapshot.
 	// The single format argument is the distro data directory, where the token file is persisted.
 	//
-	// Exported so tests can derive the same value the check derives.
-	TokenHashCommandFormat = `f=%[1]s/token; tr -d '[:space:]' < "$f" | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`
+	// Exported so e2e tests can derive the same value the check derives.
+	TokenHashCommandFormat = `f=%[1]s/server/token; tr -d '[:space:]' < "$f" | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`
 
 	// idempotencyKey is the top-level key used to scope idempotency tracking for this controller.
 	// It is also used by the cleanup instruction issued during shutdown to clear prior tracking.
@@ -90,10 +90,11 @@ const (
 	// helper scripts the controller writes to nodes during the restore.
 	etcdRestoreBinSubdir = "etcd-restore/bin"
 
+	// waitForPodListScriptName is the name of the script file containing the instruction to list pods in all namespaces.
 	waitForPodListScriptName = "wait_for_pod_list.sh"
 
-	nodeCleanupScriptName = "clean_up_nodes.sh"
-
+	// waitForPodListScript is the bash script for listing pods in all namespaces.
+	// Although the script itself accepts a template to execute, it is only used for listing pods.
 	waitForPodListScript = `#!/bin/sh
 
 i=0
@@ -108,6 +109,11 @@ done
 exit 1
 `
 
+	// nodeCleanupScriptName is the name of the script file containing the instruction to clean up nodes no longer
+	// present after restoring.
+	nodeCleanupScriptName = "clean_up_nodes.sh"
+
+	// nodeCleanupScript is the bash script for cleaning up nodes no longer present after restoring.
 	nodeCleanupScript = `#!/bin/sh
 
 if [ -z "$KUBECTL" ]; then
@@ -162,8 +168,7 @@ rm "$NODENAMESFILE"
 
 type handler struct {
 	etcdsnapshotrestores operationcontrollers.ETCDSnapshotRestoreController
-
-	etcdsnapshots rkecontrollers.ETCDSnapshotController
+	etcdsnapshots        rkecontrollers.ETCDSnapshotController
 
 	beacons     plancontrollers.BeaconClient
 	beaconCache plancontrollers.BeaconCache
@@ -171,11 +176,11 @@ type handler struct {
 	secrets     corecontrollers.SecretClient
 	secretCache corecontrollers.SecretCache
 
-	store *plan.Store
-
 	dynamic *dynamic.Controller
 
 	clients *wrangler.CAPIContext
+
+	store *plan.Store
 }
 
 func Register(ctx context.Context, clients *wrangler.CAPIContext) {
@@ -187,8 +192,8 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 		secrets:              clients.Core.Secret(),
 		secretCache:          clients.Core.Secret().Cache(),
 		dynamic:              clients.Dynamic,
-		store:                plan.NewStore(clients.Core.Secret()),
 		clients:              clients,
+		store:                plan.NewStore(clients.Core.Secret()),
 	}
 
 	operationcontrollers.RegisterETCDSnapshotRestoreStatusHandler(ctx, clients.Operation.ETCDSnapshotRestore(), "", "etcd-snapshot-restore-handler", h.OnChange)
@@ -1409,7 +1414,6 @@ func buildPreflightPlan(s *scope, secret *corev1.Secret) *plan.Plan {
 			{
 				SaveOutput: true,
 				CommonInstruction: plan.CommonInstruction{
-					// The name is the key the output is read back under; see reconcilePreflight.
 					Name:    preflightInstructionName,
 					Command: "/bin/sh",
 					Args: []string{

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -72,6 +72,10 @@ const (
 	// reconciliation.
 	RestartClusterStepHookLabelPrefix = "restart-cluster.step.hook.operation.cattle.io/"
 
+	// preflightInstructionName is the name of the Preflight step's instruction, and therefore the key
+	// its output is saved under on the machine-plan secret.
+	preflightInstructionName = "preflight"
+
 	// TokenHashCommandFormat is the shell command the Preflight step runs on every etcd node to hash
 	// the server token persisted on disk, so it can be compared against the hash the distro stamped
 	// on the snapshot. The single format argument is the distro data directory.
@@ -646,24 +650,13 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 		return status, err
 	}
 
-	for _, secret := range secrets {
-		nodePlan := &plan.Plan{
-			OneTimeInstructions: []plan.OneTimeInstruction{
-				{
-					SaveOutput: true,
-					CommonInstruction: plan.CommonInstruction{
-						Name:    "preflight",
-						Command: "/bin/sh",
-						Args: []string{
-							"-c",
-							fmt.Sprintf(TokenHashCommandFormat, s.adapter.DistroDataDirectory(secret)),
-						},
-					},
-				},
-			},
-		}
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 
-		planStatus, err := h.store.AssignPlan(secret, nodePlan, 1, -1)
+	for _, secret := range secrets {
+		// A finite failure threshold, unlike the other steps: the check only reads a file, so there is
+		// nothing to gain from retrying it, and without one a check which cannot run at all would
+		// leave the operation in progress indefinitely instead of reaching the cancellation below.
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(buildPreflightPlan(s, secret), opEnv), 1, 1)
 		if err != nil {
 			return status, err
 		}
@@ -713,7 +706,7 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 			if hash, ok := snapshot.Annotations[capr.SnapshotTokenHashAnnotation]; ok && hash != "" {
 				// The instruction pipes through cut, so the saved output carries a trailing newline
 				// which the annotation does not.
-				if b, ok := output["preflight"]; ok && strings.TrimSpace(string(b)) != hash {
+				if b, ok := output[preflightInstructionName]; ok && strings.TrimSpace(string(b)) != hash {
 					logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: preflight check output for %s/%s does not match snapshot token hash",
 						s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
 
@@ -781,57 +774,10 @@ func (h *handler) reconcileShutdown(s *scope, status opv1alpha1.ETCDSnapshotRest
 	concurrency := len(secrets)
 	results := make([]plan.PlanStatus, 0, concurrency)
 
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
+
 	for _, secret := range secrets {
-		provisioningDir := s.adapter.ProvisioningDataDirectory(secret)
-		// Clear any prior idempotency tracking under the restore key before starting; subsequent
-		// reconciles see the cleanup already applied and skip it.
-		instructions := []plan.OneTimeInstruction{
-			ops.GenerateIdempotencyCleanupInstruction(provisioningDir, idempotencyKey),
-			{
-				CommonInstruction: plan.CommonInstruction{
-					Name:    "shutdown",
-					Command: "/bin/sh",
-					Env: []string{
-						fmt.Sprintf("%s_DATA_DIR=%s", strings.ToUpper(s.adapter.RuntimeCommand()), s.adapter.DistroDataDirectory(secret)),
-					},
-					Args: []string{
-						"-c",
-						fmt.Sprintf("if [ -z $(command -v %[1]s) ] && [ -z $(command -v %[2]s) ]; then echo %[1]s does not appear to be installed; exit 0; else %[2]s; fi",
-							s.adapter.RuntimeCommand(),
-							s.adapter.RuntimeCommand()+"-killall.sh"),
-					},
-				},
-			},
-		}
-
-		if secret.Labels[capr.EtcdRoleLabel] == "true" {
-			instructions = append(instructions, plan.OneTimeInstruction{
-				CommonInstruction: plan.CommonInstruction{
-					Name:    "create-etcd-tombstone",
-					Command: "touch",
-					Args:    []string{path.Join(s.adapter.DistroDataDirectory(secret), "server/db/etcd/tombstone")},
-				},
-			})
-		}
-
-		if secret.Labels[capr.EtcdRoleLabel] == "true" || secret.Labels[capr.ControlPlaneRoleLabel] == "true" {
-			instructions = append(instructions,
-				plan.OneTimeInstruction{
-					CommonInstruction: plan.CommonInstruction{
-						Name:    "remove-tls-directory",
-						Command: "rm",
-						Args:    []string{"-rf", path.Join(s.adapter.DistroDataDirectory(secret), "server/tls")},
-					},
-				},
-			)
-		}
-
-		nodePlan := &plan.Plan{
-			Files:               []plan.File{ops.IdempotentScriptFile(provisioningDir)},
-			OneTimeInstructions: instructions,
-		}
-
-		planStatus, err := h.store.AssignPlan(secret, nodePlan, 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(buildShutdownPlan(s, secret), opEnv), 1, -1)
 		if err != nil {
 			return status, err
 		}
@@ -963,6 +909,7 @@ func (h *handler) reconcileRestore(s *scope, status opv1alpha1.ETCDSnapshotResto
 
 	provisioningDir := s.adapter.ProvisioningDataDirectory(secret)
 	value := s.idempotencyValue()
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 
 	args := []string{
 		"server",
@@ -1007,7 +954,7 @@ func (h *handler) reconcileRestore(s *scope, status opv1alpha1.ETCDSnapshotResto
 		},
 	}
 
-	planStatus, err := h.store.AssignPlan(secret, nodePlan, 1, -1)
+	planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
 	if err != nil {
 		return status, err
 	}
@@ -1137,6 +1084,7 @@ func (h *handler) reconcilePostRestorePodCleanup(s *scope, status opv1alpha1.ETC
 
 	provisioningDir := s.adapter.ProvisioningDataDirectory(etcdSecret)
 	value := s.idempotencyValue()
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 	waitScriptPath := etcdRestoreScriptPath(s, etcdSecret, waitForPodListScriptName)
 
 	instructions := []plan.OneTimeInstruction{
@@ -1206,7 +1154,7 @@ func (h *handler) reconcilePostRestorePodCleanup(s *scope, status opv1alpha1.ETC
 			},
 		}
 
-		planStatus, err := h.store.AssignPlan(etcdSecret, etcdNodePlan, 1, -1)
+		planStatus, err := h.store.AssignPlan(etcdSecret, ops.WithOperationEnv(etcdNodePlan, opEnv), 1, -1)
 		if err != nil {
 			return status, err
 		}
@@ -1240,7 +1188,7 @@ func (h *handler) reconcilePostRestorePodCleanup(s *scope, status opv1alpha1.ETC
 		})
 	}
 
-	planStatus, err := h.store.AssignPlan(controlPlaneSecret, nodePlan, 1, -1)
+	planStatus, err := h.store.AssignPlan(controlPlaneSecret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
 	if err != nil {
 		return status, err
 	}
@@ -1310,6 +1258,7 @@ func (h *handler) reconcileRestartCluster(s *scope, status opv1alpha1.ETCDSnapsh
 	// The two restart phases must use distinct values; otherwise the second phase would skip the
 	// restart as already-reconciled.
 	value := s.idempotencyValue()
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 	if nextStep != "" {
 		value = value + "/initial"
 	} else {
@@ -1396,7 +1345,7 @@ func (h *handler) reconcileRestartCluster(s *scope, status opv1alpha1.ETCDSnapsh
 			}
 		}
 
-		planStatus, err := h.store.AssignPlan(secret, nodePlan, 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
 		if err != nil {
 			return status, err
 		}
@@ -1450,6 +1399,87 @@ func (h *handler) reconcileRestartCluster(s *scope, status opv1alpha1.ETCDSnapsh
 	opv1alpha1.SucceededCondition.Message(&status, "Operation completed successfully")
 
 	return status, nil
+}
+
+// buildPreflightPlan assembles the plan which hashes the server token the node currently has on
+// disk, so the Preflight step can compare it against the hash stamped on the snapshot being restored.
+//
+// The instruction is deliberately not wrapped with ops.ConvertToIdempotentInstruction like the
+// instructions of every other step: the idempotent script gates on the agent's attempt number and, on
+// an attempt it considers already reconciled, prints a message instead of running the command. With
+// SaveOutput that message would land in the applied output in place of the hash. A check must run on
+// every attempt, so it relies on the operation environment for plan uniqueness instead.
+func buildPreflightPlan(s *scope, secret *corev1.Secret) *plan.Plan {
+	return &plan.Plan{
+		OneTimeInstructions: []plan.OneTimeInstruction{
+			{
+				SaveOutput: true,
+				CommonInstruction: plan.CommonInstruction{
+					// The name is the key the output is read back under; see reconcilePreflight.
+					Name:    preflightInstructionName,
+					Command: "/bin/sh",
+					Args: []string{
+						"-c",
+						fmt.Sprintf(TokenHashCommandFormat, s.adapter.DistroDataDirectory(secret)),
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildShutdownPlan assembles the plan which stops the distro on a node ahead of the restore: it
+// clears any idempotency tracking left by a previous attempt, runs the distro's killall script, and
+// on etcd and control-plane nodes lays down the etcd tombstone and removes the TLS directory.
+func buildShutdownPlan(s *scope, secret *corev1.Secret) *plan.Plan {
+	provisioningDir := s.adapter.ProvisioningDataDirectory(secret)
+	// Clear any prior idempotency tracking under the restore key before starting; subsequent
+	// reconciles see the cleanup already applied and skip it.
+	instructions := []plan.OneTimeInstruction{
+		ops.GenerateIdempotencyCleanupInstruction(provisioningDir, idempotencyKey),
+		{
+			CommonInstruction: plan.CommonInstruction{
+				Name:    "shutdown",
+				Command: "/bin/sh",
+				Env: []string{
+					fmt.Sprintf("%s_DATA_DIR=%s", strings.ToUpper(s.adapter.RuntimeCommand()), s.adapter.DistroDataDirectory(secret)),
+				},
+				Args: []string{
+					"-c",
+					fmt.Sprintf("if [ -z $(command -v %[1]s) ] && [ -z $(command -v %[2]s) ]; then echo %[1]s does not appear to be installed; exit 0; else %[2]s; fi",
+						s.adapter.RuntimeCommand(),
+						s.adapter.RuntimeCommand()+"-killall.sh"),
+				},
+			},
+		},
+	}
+
+	if secret.Labels[capr.EtcdRoleLabel] == "true" {
+		instructions = append(instructions, plan.OneTimeInstruction{
+			CommonInstruction: plan.CommonInstruction{
+				Name:    "create-etcd-tombstone",
+				Command: "touch",
+				Args:    []string{path.Join(s.adapter.DistroDataDirectory(secret), "server/db/etcd/tombstone")},
+			},
+		})
+	}
+
+	if secret.Labels[capr.EtcdRoleLabel] == "true" || secret.Labels[capr.ControlPlaneRoleLabel] == "true" {
+		instructions = append(instructions,
+			plan.OneTimeInstruction{
+				CommonInstruction: plan.CommonInstruction{
+					Name:    "remove-tls-directory",
+					Command: "rm",
+					Args:    []string{"-rf", path.Join(s.adapter.DistroDataDirectory(secret), "server/tls")},
+				},
+			},
+		)
+	}
+
+	return &plan.Plan{
+		Files:               []plan.File{ops.IdempotentScriptFile(provisioningDir)},
+		OneTimeInstructions: instructions,
+	}
 }
 
 // buildPostRestoreNodeCleanupPlan assembles the plan that runs the node-cleanup script on the init
@@ -1567,7 +1597,9 @@ func (h *handler) reconcilePostRestoreNodeCleanup(s *scope, status opv1alpha1.ET
 		return status, nil
 	}
 
-	planStatus, err := h.store.AssignPlan(initSecret, nodePlan, 1, -1)
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
+
+	planStatus, err := h.store.AssignPlan(initSecret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
 	if err != nil {
 		return status, err
 	}

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -766,13 +766,6 @@ func (h *handler) reconcileShutdown(s *scope, status opv1alpha1.ETCDSnapshotRest
 						Args:    []string{"-rf", path.Join(s.adapter.DistroDataDirectory(secret), "server/tls")},
 					},
 				},
-				plan.OneTimeInstruction{
-					CommonInstruction: plan.CommonInstruction{
-						Name:    "remove-cred-directory",
-						Command: "rm",
-						Args:    []string{"-rf", path.Join(s.adapter.DistroDataDirectory(secret), "server/cred")},
-					},
-				},
 			)
 		}
 

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -67,26 +67,20 @@ const (
 	// correspond to a machine in the cluster.
 	PostRestoreNodeCleanupStepHookLabelPrefix = "post-restore-node-cleanup.step.hook.operation.cattle.io/"
 
-	// RestartClusterStepHookLabelPrefix gates the final restart pass, after node cleanup. This
-	// removes the temporary server-URL override and lets each node return to its normal
-	// reconciliation.
+	// RestartClusterStepHookLabelPrefix gates the final restart pass, after node cleanup. This removes the temporary
+	// server-URL override and lets each node return to its normal reconciliation.
 	RestartClusterStepHookLabelPrefix = "restart-cluster.step.hook.operation.cattle.io/"
 
-	// preflightInstructionName is the name of the Preflight step's instruction, and therefore the key
-	// its output is saved under on the machine-plan secret.
+	// preflightInstructionName is the name of the Preflight step's instruction, and therefore the key its output is
+	// saved under on the machine-plan secret.
 	preflightInstructionName = "preflight"
 
-	// TokenHashCommandFormat is the shell command the Preflight step runs on every etcd node to hash
-	// the server token persisted on disk, so it can be compared against the hash the distro stamped
-	// on the snapshot. The single format argument is the distro data directory.
-	//
-	// The distro persists the token under its data directory, but the layout differs between versions
-	// (and between server and agent nodes), so the file is resolved rather than assumed — a missing
-	// file exits non-zero, and because plans are assigned with a failure threshold of -1 that would
-	// stall the operation rather than fail it.
+	// TokenHashCommandFormat is the shell command the Preflight step runs on every etcd node to hash the server token
+	// persisted on disk, so it can be compared against the hash the distro stamped on the snapshot.
+	// The single format argument is the distro data directory, where the token file is persisted.
 	//
 	// Exported so tests can derive the same value the check derives.
-	TokenHashCommandFormat = `f=%[1]s/server/token; [ -f "$f" ] || f=%[1]s/token; tr -d '[:space:]' < "$f" | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`
+	TokenHashCommandFormat = `f=%[1]s/token; tr -d '[:space:]' < "$f" | sed 's/.*://' | tr -d '\n' | sha256sum | cut -c1-12`
 
 	// idempotencyKey is the top-level key used to scope idempotency tracking for this controller.
 	// It is also used by the cleanup instruction issued during shutdown to clear prior tracking.
@@ -608,7 +602,7 @@ func (h *handler) handleInProgress(s *scope, status opv1alpha1.ETCDSnapshotResto
 }
 
 func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRestoreStatus) (opv1alpha1.ETCDSnapshotRestoreStatus, error) {
-	logrus.Debugf("[etcdsnapshotrestore] %s/%s: handling shutdown", s.op.Namespace, s.op.Name)
+	logrus.Debugf("[etcdsnapshotrestore] %s/%s: handling preflight", s.op.Namespace, s.op.Name)
 
 	delegated, err := h.handleHook(s, PreflightStepHookLabelPrefix)
 	if err != nil {
@@ -652,44 +646,48 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 
 	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 
-	for _, secret := range secrets {
-		// A finite failure threshold, unlike the other steps: the check only reads a file, so there is
-		// nothing to gain from retrying it, and without one a check which cannot run at all would
-		// leave the operation in progress indefinitely instead of reaching the cancellation below.
-		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(buildPreflightPlan(s, secret), opEnv), 1, 1)
-		if err != nil {
-			return status, err
-		}
+	hash := ""
+	if snapshot != nil && snapshot.Annotations != nil && snapshot.Annotations[capr.SnapshotTokenHashAnnotation] != "" {
+		hash = snapshot.Annotations[capr.SnapshotTokenHashAnnotation]
+	}
 
-		results = append(results, *planStatus)
-
-		if planStatus.Failure() {
-			logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: preflight check failed for %s/%s",
-				s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
-
-			status.SetPhase(opv1alpha1.OperationPhaseCanceled)
-
-			opv1alpha1.CanceledCondition.True(&status)
-			opv1alpha1.CanceledCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
-			opv1alpha1.CanceledCondition.Message(&status, fmt.Sprintf("could not find server token for %s/%s", secret.Namespace, secret.Name))
-
-			return status, nil
-		}
-
-		// The token hash can only be validated once the node has applied the plan and reported its
-		// output, so a waiting node is skipped entirely until a later reconcile.
-		if planStatus.Waiting() {
-			logrus.Debugf("[etcdsnapshotrestore] %s/%s: waiting for preflight check for %s/%s", s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
-
-			concurrency--
-			if concurrency <= 0 {
-				break
+	if hash == "" {
+		logrus.Warnf("[etcdsnapshotrestore] %s/%s: could not find snapshot token hash in snapshot %s/%s, skipping preflight step", s.op.Namespace, s.op.Name, s.adapter.EtcdSnapshotNamespace(), snapshotName)
+	} else {
+		for _, secret := range secrets {
+			planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(buildPreflightPlan(s, secret), opEnv), 1, 1)
+			if err != nil {
+				return status, err
 			}
 
-			continue
-		}
+			results = append(results, *planStatus)
 
-		if snapshot != nil {
+			if planStatus.Failure() {
+				logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: preflight check failed for %s/%s",
+					s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
+
+				status.SetPhase(opv1alpha1.OperationPhaseCanceled)
+
+				opv1alpha1.CanceledCondition.True(&status)
+				opv1alpha1.CanceledCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
+				opv1alpha1.CanceledCondition.Message(&status, fmt.Sprintf("could not find server token for %s/%s", secret.Namespace, secret.Name))
+
+				return status, nil
+			}
+
+			// The token hash can only be validated once the node has applied the plan and reported its
+			// output, so a waiting node is skipped entirely until a later reconcile.
+			if planStatus.Waiting() {
+				logrus.Debugf("[etcdsnapshotrestore] %s/%s: waiting for preflight check for %s/%s", s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
+
+				concurrency--
+				if concurrency <= 0 {
+					break
+				}
+
+				continue
+			}
+
 			output, err := plan.ReadAppliedOutput(secret)
 			if err != nil {
 				logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: could not read preflight check output for %s/%s",
@@ -703,24 +701,20 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotRes
 
 				return status, nil
 			}
-			if hash, ok := snapshot.Annotations[capr.SnapshotTokenHashAnnotation]; ok && hash != "" {
-				// The instruction pipes through cut, so the saved output carries a trailing newline
-				// which the annotation does not.
-				if b, ok := output[preflightInstructionName]; ok && strings.TrimSpace(string(b)) != hash {
-					logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: preflight check output for %s/%s does not match snapshot token hash",
-						s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
 
-					status.SetPhase(opv1alpha1.OperationPhaseFailed)
-
-					opv1alpha1.FailedCondition.True(&status)
-					opv1alpha1.FailedCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
-					opv1alpha1.FailedCondition.Message(&status, fmt.Sprintf("preflight check output for %s/%s does not match snapshot token hash", secret.Namespace, secret.Name))
-
-					return status, nil
-				}
-			} else {
-				logrus.Warnf("[etcdsnapshotrestore] %s/%s: could not find snapshot token hash for %s/%s, preflight check output will not be validated",
+			// The instruction pipes through cut, so the saved output carries a trailing newline which the annotation
+			// does not.
+			if b, ok := output[preflightInstructionName]; ok && strings.TrimSpace(string(b)) != hash {
+				logrus.Errorf("[etcdsnapshotrestore] %s/%s: marking operation as failed: preflight check output for %s/%s does not match snapshot token hash",
 					s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
+
+				status.SetPhase(opv1alpha1.OperationPhaseFailed)
+
+				opv1alpha1.FailedCondition.True(&status)
+				opv1alpha1.FailedCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
+				opv1alpha1.FailedCondition.Message(&status, fmt.Sprintf("preflight check output for %s/%s does not match snapshot token hash", secret.Namespace, secret.Name))
+
+				return status, nil
 			}
 		}
 	}
@@ -777,7 +771,7 @@ func (h *handler) reconcileShutdown(s *scope, status opv1alpha1.ETCDSnapshotRest
 	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 
 	for _, secret := range secrets {
-		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(buildShutdownPlan(s, secret), opEnv), 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(buildShutdownPlan(s, secret), opEnv), 1, 1)
 		if err != nil {
 			return status, err
 		}
@@ -954,7 +948,7 @@ func (h *handler) reconcileRestore(s *scope, status opv1alpha1.ETCDSnapshotResto
 		},
 	}
 
-	planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
+	planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, 1)
 	if err != nil {
 		return status, err
 	}
@@ -1154,7 +1148,7 @@ func (h *handler) reconcilePostRestorePodCleanup(s *scope, status opv1alpha1.ETC
 			},
 		}
 
-		planStatus, err := h.store.AssignPlan(etcdSecret, ops.WithOperationEnv(etcdNodePlan, opEnv), 1, -1)
+		planStatus, err := h.store.AssignPlan(etcdSecret, ops.WithOperationEnv(etcdNodePlan, opEnv), 1, 1)
 		if err != nil {
 			return status, err
 		}
@@ -1188,7 +1182,7 @@ func (h *handler) reconcilePostRestorePodCleanup(s *scope, status opv1alpha1.ETC
 		})
 	}
 
-	planStatus, err := h.store.AssignPlan(controlPlaneSecret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
+	planStatus, err := h.store.AssignPlan(controlPlaneSecret, ops.WithOperationEnv(nodePlan, opEnv), 1, 1)
 	if err != nil {
 		return status, err
 	}
@@ -1345,7 +1339,7 @@ func (h *handler) reconcileRestartCluster(s *scope, status opv1alpha1.ETCDSnapsh
 			}
 		}
 
-		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, 1)
 		if err != nil {
 			return status, err
 		}
@@ -1599,7 +1593,7 @@ func (h *handler) reconcilePostRestoreNodeCleanup(s *scope, status opv1alpha1.ET
 
 	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
 
-	planStatus, err := h.store.AssignPlan(initSecret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
+	planStatus, err := h.store.AssignPlan(initSecret, ops.WithOperationEnv(nodePlan, opEnv), 1, 1)
 	if err != nil {
 		return status, err
 	}

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
@@ -2,6 +2,7 @@ package etcdsnapshotrestore
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
@@ -262,5 +263,156 @@ func TestIdempotencyValueStable(t *testing.T) {
 	s := newTestScope(defaultAdapter(), "abc-123")
 	if got := s.idempotencyValue(); got != "abc-123" {
 		t.Errorf("idempotencyValue = %q, want %q", got, "abc-123")
+	}
+}
+
+func TestBuildPreflightPlan(t *testing.T) {
+	t.Parallel()
+
+	s := newTestScope(defaultAdapter(), "restore-uid")
+	secret := makePlanSecret("init", "node-init", map[string]string{
+		capr.EtcdRoleLabel: "true",
+		capr.InitNodeLabel: "true",
+	})
+
+	plan := buildPreflightPlan(s, secret)
+
+	if len(plan.OneTimeInstructions) != 1 {
+		t.Fatalf("expected 1 instruction, got %d", len(plan.OneTimeInstructions))
+	}
+	instr := plan.OneTimeInstructions[0]
+	// The name is the key reconcilePreflight reads the token hash back under.
+	if instr.Name != preflightInstructionName {
+		t.Errorf("instruction Name = %q, want %q", instr.Name, preflightInstructionName)
+	}
+	if !instr.SaveOutput {
+		t.Error("SaveOutput must be set; the step compares the instruction's output against the snapshot")
+	}
+
+	// The check must resolve the token file rather than assume one layout, because an instruction that
+	// exits non-zero cannot be distinguished from a token mismatch by the caller.
+	joined := strings.Join(instr.Args, " ")
+	for _, want := range []string{
+		path.Join(s.adapter.DistroDataDirectory(secret), "server/token"),
+		path.Join(s.adapter.DistroDataDirectory(secret), "token"),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("instruction args do not reference %q: %v", want, instr.Args)
+		}
+	}
+
+	// Wrapping the check in the idempotent script would print a message in place of the hash on an
+	// attempt it considers already reconciled.
+	if len(instr.Args) > 1 && instr.Args[1] == ops.IdempotentActionScriptPath(s.adapter.ProvisioningDataDirectory(secret)) {
+		t.Error("the preflight check must not be idempotent-wrapped; it has to run on every attempt")
+	}
+}
+
+func TestBuildShutdownPlan(t *testing.T) {
+	t.Parallel()
+
+	s := newTestScope(defaultAdapter(), "restore-uid")
+	adapter := defaultAdapter()
+
+	t.Run("etcd and control plane node", func(t *testing.T) {
+		secret := makePlanSecret("init", "node-init", map[string]string{
+			capr.EtcdRoleLabel:         "true",
+			capr.ControlPlaneRoleLabel: "true",
+		})
+
+		plan := buildShutdownPlan(s, secret)
+
+		var names []string
+		for _, instr := range plan.OneTimeInstructions {
+			names = append(names, instr.Name)
+		}
+		want := []string{"remove idempotency tracking", "shutdown", "create-etcd-tombstone", "remove-tls-directory"}
+		if strings.Join(names, ",") != strings.Join(want, ",") {
+			t.Errorf("instructions = %v, want %v", names, want)
+		}
+
+		// The killall script reads the data directory out of the environment.
+		wantEnv := fmt.Sprintf("%s_DATA_DIR=%s", strings.ToUpper(adapter.RuntimeCommand()), adapter.DistroDataDirectory(secret))
+		var found bool
+		for _, e := range plan.OneTimeInstructions[1].Env {
+			if e == wantEnv {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("shutdown instruction env = %v, want it to contain %q", plan.OneTimeInstructions[1].Env, wantEnv)
+		}
+
+		if len(plan.Files) != 1 || plan.Files[0].Path != ops.IdempotentActionScriptPath(adapter.ProvisioningDataDirectory(secret)) {
+			t.Errorf("expected the idempotent script file, got %v", plan.Files)
+		}
+	})
+
+	t.Run("worker node", func(t *testing.T) {
+		secret := makePlanSecret("worker-1", "node-worker-1", map[string]string{
+			capr.WorkerRoleLabel: "true",
+		})
+
+		plan := buildShutdownPlan(s, secret)
+
+		// No etcd data or TLS material to clear on a worker.
+		if len(plan.OneTimeInstructions) != 2 {
+			t.Fatalf("expected 2 instructions, got %d", len(plan.OneTimeInstructions))
+		}
+		for _, instr := range plan.OneTimeInstructions {
+			if instr.Name == "create-etcd-tombstone" || instr.Name == "remove-tls-directory" {
+				t.Errorf("unexpected instruction %q for a worker node", instr.Name)
+			}
+		}
+	})
+}
+
+// TestAssignedPlansAreOperationScoped covers the property every plan this controller assigns depends
+// on: the system-agent only re-runs a plan whose serialized content changed, and AssignPlan only
+// writes a plan whose bytes differ from the one already on the secret. Two operations doing the same
+// work must therefore serialize differently, or the second is reported as already applied — its
+// instructions never run and its output is the first operation's. Reconciles of one operation must
+// serialize identically, or the plan would churn and re-trigger its instructions.
+func TestAssignedPlansAreOperationScoped(t *testing.T) {
+	t.Parallel()
+
+	secret := makePlanSecret("init", "node-init", map[string]string{
+		capr.EtcdRoleLabel:         "true",
+		capr.ControlPlaneRoleLabel: "true",
+	})
+
+	builders := map[string]struct {
+		build func(*scope) *planapi.Plan
+		step  opv1alpha1.ETCDSnapshotRestoreStep
+	}{
+		"preflight": {
+			build: func(s *scope) *planapi.Plan { return buildPreflightPlan(s, secret) },
+			step:  opv1alpha1.ETCDSnapshotRestoreStepPreflight,
+		},
+		"shutdown": {
+			build: func(s *scope) *planapi.Plan { return buildShutdownPlan(s, secret) },
+			step:  opv1alpha1.ETCDSnapshotRestoreStepShutdown,
+		},
+	}
+
+	for name, b := range builders {
+		t.Run(name, func(t *testing.T) {
+			marshal := func(uid types.UID) string {
+				s := newTestScope(defaultAdapter(), uid)
+				p := ops.WithOperationEnv(b.build(s), ops.OperationEnv(ControllerOwnerKey, s.op, b.step))
+				data, err := json.Marshal(p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return string(data)
+			}
+
+			if marshal("restore-uid-1") == marshal("restore-uid-2") {
+				t.Error("plans for two operations serialize identically, so the second would be reported as already applied")
+			}
+			if marshal("restore-uid-1") != marshal("restore-uid-1") {
+				t.Error("plans for one operation must serialize identically across reconciles")
+			}
+		})
 	}
 }

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
@@ -289,18 +289,6 @@ func TestBuildPreflightPlan(t *testing.T) {
 		t.Error("SaveOutput must be set; the step compares the instruction's output against the snapshot")
 	}
 
-	// The check must resolve the token file rather than assume one layout, because an instruction that
-	// exits non-zero cannot be distinguished from a token mismatch by the caller.
-	joined := strings.Join(instr.Args, " ")
-	for _, want := range []string{
-		path.Join(s.adapter.DistroDataDirectory(secret), "server/token"),
-		path.Join(s.adapter.DistroDataDirectory(secret), "token"),
-	} {
-		if !strings.Contains(joined, want) {
-			t.Errorf("instruction args do not reference %q: %v", want, instr.Args)
-		}
-	}
-
 	// Wrapping the check in the idempotent script would print a message in place of the hash on an
 	// attempt it considers already reconciled.
 	if len(instr.Args) > 1 && instr.Args[1] == ops.IdempotentActionScriptPath(s.adapter.ProvisioningDataDirectory(secret)) {

--- a/pkg/controllers/operations/etcdsnapshotrestore/tokenhash_test.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/tokenhash_test.go
@@ -1,0 +1,259 @@
+package etcdsnapshotrestore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// distroTokenHash mirrors k3s's util.ShortHash(password, 12): the first 12 characters of the
+// hex-encoded sha256 of the token password. This is the value the distro stamps on every snapshot
+// (util.GetTokenHash), and therefore the value TokenHashCommandFormat has to reproduce in shell.
+// Reimplemented rather than imported — pulling in the k3s module (and the kubeadm bootstrap-token
+// parser it depends on) is what TokenHashCommandFormat exists to avoid.
+func distroTokenHash(password string) string {
+	sum := sha256.Sum256([]byte(password))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// writeTokenFile lays down a token file at <dir>/server/token with the given contents and returns
+// dir, ready to be passed to TokenHashCommandFormat as the distro data directory.
+func writeTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	// The command interpolates the data directory into an unquoted shell assignment, so a path with
+	// a space in it would not survive. Production data directories never have one, but t.TempDir
+	// derives its path from the test name, so guard rather than debug a mangled command later.
+	if strings.ContainsAny(dir, " \t\n'\"$") {
+		t.Fatalf("temp dir %q contains characters the command cannot carry; rename the test case", dir)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "server"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "server", "token"), []byte(contents), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// runTokenHashCommand runs TokenHashCommandFormat under /bin/sh exactly as buildPreflightPlan does,
+// returning trimmed stdout, combined stderr and the error (non-nil on a non-zero exit).
+func runTokenHashCommand(t *testing.T, dataDir string) (string, string, error) {
+	t.Helper()
+
+	var stdout, stderr strings.Builder
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf(TokenHashCommandFormat, dataDir))
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
+}
+
+// requireShellTools skips the test when the utilities the command shells out to are unavailable, so
+// the package still tests on a machine without a POSIX userland.
+func requireShellTools(t *testing.T) {
+	t.Helper()
+	for _, bin := range []string{"/bin/sh"} {
+		if _, err := os.Stat(bin); err != nil {
+			t.Skipf("%s is not available: %v", bin, err)
+		}
+	}
+	for _, bin := range []string{"head", "sed", "sha256sum", "cut"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s is not on PATH: %v", bin, err)
+		}
+	}
+}
+
+// caHash stands in for the sha256-of-server-CA that clientaccess.FormatTokenBytes prepends. Only its
+// shape matters to the command (64 hex characters containing no colon), not its value.
+const caHash = "b2c3f6b8b8bd0d2a3e5f4c07e1c7f9a4d3b6e8c1a9f2d4b7c0e3a6f9b2d5c8e1"
+
+// canonicalTokenFile renders the token file exactly as k3s writes it: FormatTokenBytes supplies the
+// `K10<CA-hash>::` prefix, deps.readTokens supplies the `server:` username, and handlers.WriteToken
+// appends the trailing newline.
+func canonicalTokenFile(password string) string {
+	return fmt.Sprintf("K10%s::server:%s\n", caHash, password)
+}
+
+// TestTokenHashCommandMatchesDistroHash is the unit-level counterpart to the imported e2e test
+// Test_Imported_Operation_SetE_ImportedETCDSnapshotRestoreColonToken: it pins the Preflight check's
+// shell derivation against the hash the distro stamps, for passwords that make the two diverge.
+//
+// The colon cases are the point. clientaccess.parseToken splits the username from the password with
+// strings.SplitN(token, ":", 2), so a password keeps every colon after the first one — meaning any
+// greedy strip in the shell (`sed 's/.*://'`) hashes only the trailing segment, and hashes the empty
+// string for a password ending in a colon.
+func TestTokenHashCommandMatchesDistroHash(t *testing.T) {
+	t.Parallel()
+	requireShellTools(t)
+
+	for _, tt := range []struct {
+		name     string
+		password string
+	}{
+		{
+			name:     "no colon",
+			password: "3f8a1c9e5b2d7f04a6c8e1b3d5f7092a",
+		},
+		{
+			name:     "single colon",
+			password: "left:right",
+		},
+		{
+			name:     "several colons",
+			password: "a:b:c:d",
+		},
+		{
+			name:     "leading colon",
+			password: ":leading",
+		},
+		{
+			// The greedy form hashed the empty string here, which is the worst case: sha256 of ""
+			// is a perfectly well-formed hash, so the mismatch looked like a rotated token.
+			name:     "trailing colon",
+			password: "trailing:colon:",
+		},
+		{
+			name:     "internal space",
+			password: "pass with spaces",
+		},
+		{
+			// A password that itself looks like a full K10 token must survive intact: the prefix
+			// strip is anchored and applied once, and the username strip runs after it.
+			name:     "password resembling a K10 token",
+			password: "K10deadbeef::nested:secret",
+		},
+		{
+			name:     "password resembling a bootstrap token",
+			password: "abcdef.0123456789abcdef",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := writeTokenFile(t, canonicalTokenFile(tt.password))
+			got, stderr, err := runTokenHashCommand(t, dir)
+			if err != nil {
+				t.Fatalf("command failed: %v\nstderr: %s", err, stderr)
+			}
+			if want := distroTokenHash(tt.password); got != want {
+				t.Errorf("hash of password %q = %q, want %q (the value the distro stamps on the snapshot)", tt.password, got, want)
+			}
+		})
+	}
+}
+
+// TestTokenHashCommandTolerantOfFileShape holds the derivation steady across the incidental
+// variation in how the token file can land on disk. The password is fixed, so any difference in the
+// output is the command reacting to the file's shape rather than to its credentials.
+func TestTokenHashCommandTolerantOfFileShape(t *testing.T) {
+	t.Parallel()
+	requireShellTools(t)
+
+	const password = "some:pass"
+
+	for _, tt := range []struct {
+		name     string
+		contents string
+	}{
+		{
+			name:     "canonical",
+			contents: canonicalTokenFile(password),
+		},
+		{
+			name:     "no trailing newline",
+			contents: fmt.Sprintf("K10%s::server:%s", caHash, password),
+		},
+		{
+			// bytes.TrimSpace on the distro side tolerates surrounding whitespace, so this must too —
+			// and must trim only the edges, leaving any space inside the password alone.
+			name:     "surrounding whitespace",
+			contents: fmt.Sprintf("  K10%s::server:%s  \n", caHash, password),
+		},
+		{
+			// parseToken accepts an empty CA hash (it only rejects a hash of the wrong non-zero
+			// length), which is the form a bare token normalises to.
+			name:     "empty CA hash",
+			contents: fmt.Sprintf("K10::server:%s\n", password),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := writeTokenFile(t, tt.contents)
+			got, stderr, err := runTokenHashCommand(t, dir)
+			if err != nil {
+				t.Fatalf("command failed: %v\nstderr: %s", err, stderr)
+			}
+			if want := distroTokenHash(password); got != want {
+				t.Errorf("hash = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestTokenHashCommandFailsLoudlyWithoutAToken covers the reason the command guards its input at
+// all. Every step of the derivation is a pipeline, whose exit status is the last element's, so an
+// unreadable token file otherwise leaves the shell exiting 0 having printed sha256 of the empty
+// string. That is a well-formed hash, so Preflight would compare it against the snapshot's and
+// report a token mismatch — sending whoever reads the failure after a token rotation that never
+// happened. A non-zero exit with no hash on stdout is what lets the step say what actually went
+// wrong.
+func TestTokenHashCommandFailsLoudlyWithoutAToken(t *testing.T) {
+	t.Parallel()
+	requireShellTools(t)
+
+	emptyStringHash := distroTokenHash("")
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+
+		// A data directory with no server/token in it at all.
+		dir := t.TempDir()
+		got, stderr, err := runTokenHashCommand(t, dir)
+		if err == nil {
+			t.Errorf("command succeeded with no token file, output %q; it must exit non-zero", got)
+		}
+		if got == emptyStringHash {
+			t.Errorf("command printed sha256 of the empty string (%q), which preflight would read as a token mismatch", got)
+		}
+		if stderr == "" {
+			t.Error("command wrote nothing to stderr; the failure needs to say the token file was unreadable")
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		t.Parallel()
+
+		dir := writeTokenFile(t, "")
+		got, _, err := runTokenHashCommand(t, dir)
+		if err == nil {
+			t.Errorf("command succeeded on an empty token file, output %q; it must exit non-zero", got)
+		}
+		if got == emptyStringHash {
+			t.Errorf("command printed sha256 of the empty string (%q), which preflight would read as a token mismatch", got)
+		}
+	})
+
+	t.Run("prefix but no password", func(t *testing.T) {
+		t.Parallel()
+
+		// parseToken rejects this too: SplitN(":", 2) yields an empty password, and it requires a
+		// non-empty one.
+		dir := writeTokenFile(t, fmt.Sprintf("K10%s::server:\n", caHash))
+		got, _, err := runTokenHashCommand(t, dir)
+		if err == nil {
+			t.Errorf("command succeeded on a token file with no password, output %q; it must exit non-zero", got)
+		}
+		if got == emptyStringHash {
+			t.Errorf("command printed sha256 of the empty string (%q), which preflight would read as a token mismatch", got)
+		}
+	})
+}

--- a/pkg/controllers/operations/etcdsnapshotsave/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller.go
@@ -552,6 +552,8 @@ func (h *handler) reconcileSave(s *scope, status opv1alpha1.ETCDSnapshotSaveStat
 	concurrency := len(secrets)
 	results := make([]plan.PlanStatus, 0, concurrency)
 
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
+
 	for _, secret := range secrets {
 		probes, err := s.adapter.RenderProbes(secret, true)
 		if err != nil {
@@ -580,7 +582,7 @@ func (h *handler) reconcileSave(s *scope, status opv1alpha1.ETCDSnapshotSaveStat
 			Probes: probes,
 		}
 
-		planStatus, err := h.store.AssignPlan(secret, nodePlan, 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
 		if err != nil {
 			return status, err
 		}
@@ -665,6 +667,8 @@ func (h *handler) reconcileRestart(s *scope, status opv1alpha1.ETCDSnapshotSaveS
 	concurrency := 1
 	results := make([]plan.PlanStatus, 0, concurrency)
 
+	opEnv := ops.OperationEnv(ControllerOwnerKey, s.op, status.Step)
+
 	for _, secret := range secrets {
 		probes, err := s.adapter.RenderProbes(secret, true)
 		if err != nil {
@@ -687,7 +691,7 @@ func (h *handler) reconcileRestart(s *scope, status opv1alpha1.ETCDSnapshotSaveS
 			Probes: probes,
 		}
 
-		planStatus, err := h.store.AssignPlan(secret, nodePlan, 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
 		if err != nil {
 			return status, err
 		}

--- a/pkg/controllers/operations/etcdsnapshotsave/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller.go
@@ -481,7 +481,7 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotSav
 		return status, nil
 	}
 
-	secrets, err := plan.NewCollector(h.secrets, s.clusterObj, s.namespace).
+	_, err = plan.NewCollector(h.secrets, s.clusterObj, s.namespace).
 		WithSorter(plan.DefaultSorter()).
 		WithFilter(ops.IsEtcd).
 		WithValidator(plan.AtLeast(1, "")).
@@ -496,67 +496,6 @@ func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotSav
 		opv1alpha1.CanceledCondition.True(&status)
 		opv1alpha1.CanceledCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
 		opv1alpha1.CanceledCondition.Message(&status, fmt.Sprintf("encountered terminal error collecting machine-plan secrets: %v", err))
-		return status, nil
-	}
-
-	concurrency := len(secrets)
-	results := make([]plan.PlanStatus, 0, concurrency)
-
-	for _, secret := range secrets {
-		nodePlan := &plan.Plan{
-			OneTimeInstructions: []plan.OneTimeInstruction{
-				{
-					CommonInstruction: plan.CommonInstruction{
-						Name:    "preflight",
-						Command: "/bin/sh",
-						Args: []string{
-							"-c",
-							fmt.Sprintf(`grep -rE -q '^[[:space:]]*[\x27\x22 ]?token[\x27\x22 ]?[[:space:]]*:[[:space:]]*[\x27\x22 ]*[^[:space:]\x27\x22]+' %s %s/ 2>/dev/null || (exit 1)`,
-								s.adapter.ConfigFile(secret),
-								s.adapter.ConfigDirectory(secret),
-							),
-						},
-					},
-				},
-			},
-		}
-
-		planStatus, err := h.store.AssignPlan(secret, nodePlan, 1, -1)
-		if err != nil {
-			return status, err
-		}
-
-		results = append(results, *planStatus)
-
-		if planStatus.Failure() {
-			logrus.Errorf("[etcdsnapshotsave] %s/%s: marking operation as failed: preflight check failed for %s/%s",
-				s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
-
-			status.SetPhase(opv1alpha1.OperationPhaseCanceled)
-
-			opv1alpha1.CanceledCondition.True(&status)
-			opv1alpha1.CanceledCondition.Reason(&status, opv1alpha1.PreflightCheckFailedReason)
-			opv1alpha1.CanceledCondition.Message(&status, fmt.Sprintf("could not find server token for %s/%s", secret.Namespace, secret.Name))
-
-			return status, nil
-		}
-
-		if planStatus.Waiting() {
-			logrus.Debugf("[etcdsnapshotsave] %s/%s: waiting for preflight check for %s/%s", s.op.Namespace, s.op.Name, secret.Namespace, secret.Name)
-
-			concurrency--
-			if concurrency <= 0 {
-				break
-			}
-		}
-	}
-
-	if concurrency < len(secrets) {
-		msg := plan.Message(results)
-		opv1alpha1.InProgressCondition.True(&status)
-		opv1alpha1.InProgressCondition.Reason(&status, opv1alpha1.WaitingForPlanAppliedReason)
-		opv1alpha1.InProgressCondition.Message(&status, fmt.Sprintf("Waiting in step %s: %s", status.Step, msg))
-
 		return status, nil
 	}
 

--- a/pkg/controllers/operations/etcdsnapshotsave/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller.go
@@ -464,10 +464,8 @@ func (h *handler) handleInProgress(s *scope, status opv1alpha1.ETCDSnapshotSaveS
 	return status, nil
 }
 
-// reconcilePreflight is responsible for determining if an etcd snapshot taken on this node may be restored.
-// It will grep for the `token` key in both the config file and directory (e.g., /etc/rancher/rke2/config.yaml &
-// /etc/rancher/rke2/config.yaml.d).
-// It will validate both json and yaml formatted config files.
+// reconcilePreflight does not currently run any plans, but exists to ensure that the cluster has a sufficient amount of
+// etcd nodes to run the operation on.
 func (h *handler) reconcilePreflight(s *scope, status opv1alpha1.ETCDSnapshotSaveStatus) (opv1alpha1.ETCDSnapshotSaveStatus, error) {
 	logrus.Debugf("[etcdsnapshotsave] %s/%s: handling preflight", s.op.Namespace, s.op.Name)
 
@@ -582,7 +580,7 @@ func (h *handler) reconcileSave(s *scope, status opv1alpha1.ETCDSnapshotSaveStat
 			Probes: probes,
 		}
 
-		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, 1)
 		if err != nil {
 			return status, err
 		}
@@ -691,7 +689,7 @@ func (h *handler) reconcileRestart(s *scope, status opv1alpha1.ETCDSnapshotSaveS
 			Probes: probes,
 		}
 
-		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, -1)
+		planStatus, err := h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, opEnv), 1, 1)
 		if err != nil {
 			return status, err
 		}

--- a/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
@@ -274,8 +274,6 @@ func (f *fakeBeaconClient) UpdateStatus(b *planv1alpha1.Beacon) (*planv1alpha1.B
 	return b, nil
 }
 
-// --- updateStatus ---------------------------------------------------------------------------
-
 func TestUpdateStatusPaused(t *testing.T) {
 	t.Parallel()
 
@@ -337,6 +335,8 @@ func TestUpdateStatusByPhase(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			op := newOp()
 			status := updateStatus(op, opv1alpha1.ETCDSnapshotSaveStatus{
 				OperationStatus: opv1alpha1.OperationStatus{Phase: tc.phase},
@@ -345,8 +345,6 @@ func TestUpdateStatusByPhase(t *testing.T) {
 		})
 	}
 }
-
-// --- handlePending --------------------------------------------------------------------------
 
 func TestHandlePending_NilBeacon(t *testing.T) {
 	t.Parallel()
@@ -418,8 +416,6 @@ func TestHandlePending_WaitForRegisterErrorBubbles(t *testing.T) {
 	assert.ErrorIs(t, err, sentinel)
 }
 
-// --- handleInProgress -----------------------------------------------------------------------
-
 func TestHandleInProgress_BeaconLost(t *testing.T) {
 	t.Parallel()
 
@@ -446,8 +442,6 @@ func TestHandleInProgress_UnknownStep(t *testing.T) {
 	assert.Equal(t, opv1alpha1.OperationPhaseFailed, got.Phase)
 	assert.Equal(t, opv1alpha1.UnknownStepReason, opv1alpha1.FailedCondition.GetReason(&got))
 }
-
-// --- handleFailed / handleSucceeded --------------------------------------------------------
 
 func TestHandleFailed_HoldingBeaconReleases(t *testing.T) {
 	t.Parallel()
@@ -515,8 +509,6 @@ func TestHandleSucceeded_HoldingBeaconEnqueuesCluster(t *testing.T) {
 		assert.Equal(t, "provisioning.cattle.io/v1, Kind=Cluster/fleet-default/test", dyn.enqueued[0])
 	}
 }
-
-// --- reconcileSave --------------------------------------------------------------------------
 
 // expectedSaveInstruction builds the snapshot save instruction the controller will dispatch given
 // an op spec and stubAdapter, so tests can predict the exact plan bytes the agent will see.
@@ -658,8 +650,6 @@ func TestReconcileSave_AppliesSnapshotArgs(t *testing.T) {
 	}
 }
 
-// --- reconcileRestart -----------------------------------------------------------------------
-
 func TestReconcileRestart_MarksSucceededWhenApplied(t *testing.T) {
 	t.Parallel()
 
@@ -771,6 +761,8 @@ func TestAssignedPlansAreOperationScoped(t *testing.T) {
 		"restart": func(op *opv1alpha1.ETCDSnapshotSave) *planapi.Plan { return expectedRestartPlan(op, adapter) },
 	} {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			marshal := func(uid types.UID) string {
 				data, err := json.Marshal(build(opWithUID(uid)))
 				assert.NoError(t, err)

--- a/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
@@ -534,15 +534,18 @@ func expectedSaveInstruction(op *opv1alpha1.ETCDSnapshotSave, runtime string) pl
 	}
 }
 
+// Both plans are scoped to the operation and step they belong to, exactly as the controller assigns
+// them: without that the plan bytes of two operations would be identical, and the second would be
+// reported as already applied instead of being executed.
 func expectedSavePlan(op *opv1alpha1.ETCDSnapshotSave, adapter *stubAdapter) *planapi.Plan {
-	return &planapi.Plan{
+	return ops.WithOperationEnv(&planapi.Plan{
 		OneTimeInstructions: []planapi.OneTimeInstruction{expectedSaveInstruction(op, adapter.runtimeCommand)},
 		Probes:              adapter.probes,
-	}
+	}, ops.OperationEnv(ControllerOwnerKey, op, opv1alpha1.ETCDSnapshotSaveStepSave))
 }
 
-func expectedRestartPlan(adapter *stubAdapter) *planapi.Plan {
-	return &planapi.Plan{
+func expectedRestartPlan(op *opv1alpha1.ETCDSnapshotSave, adapter *stubAdapter) *planapi.Plan {
+	return ops.WithOperationEnv(&planapi.Plan{
 		OneTimeInstructions: []planapi.OneTimeInstruction{
 			{CommonInstruction: planapi.CommonInstruction{
 				Name:    "restart",
@@ -551,7 +554,7 @@ func expectedRestartPlan(adapter *stubAdapter) *planapi.Plan {
 			}},
 		},
 		Probes: adapter.probes,
-	}
+	}, ops.OperationEnv(ControllerOwnerKey, op, opv1alpha1.ETCDSnapshotSaveStepRestart))
 }
 
 func TestReconcileSave_NoSecrets(t *testing.T) {
@@ -563,7 +566,7 @@ func TestReconcileSave_NoSecrets(t *testing.T) {
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	status, err := h.reconcileSave(newScope(newOp(), nil, defaultAdapter()), opv1alpha1.ETCDSnapshotSaveStatus{})
+	status, err := h.reconcileSave(newScope(newOp(), nil, defaultAdapter()), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepSave})
 	// The Collector validator surfaces the empty-set condition as an error; the outer status
 	// handler will requeue (and the op stays in its current phase until the situation resolves).
 	assert.NoError(t, err, "terminal errors should not trigger reenqueue")
@@ -583,7 +586,7 @@ func TestReconcileSave_WaitsForPlanApply(t *testing.T) {
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	got, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	got, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepSave})
 	assert.NoError(t, err)
 	// Plan was just delivered to the agent — controller must report InProgress and let the next
 	// reconcile poll feedback.
@@ -604,7 +607,7 @@ func TestReconcileSave_TransitionsToRestartWhenApplied(t *testing.T) {
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	got, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	got, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepSave})
 	assert.NoError(t, err)
 	assert.Empty(t, string(got.Phase), "phase must not change on a clean transition")
 	assert.Equal(t, opv1alpha1.ETCDSnapshotSaveStepRestart, got.Step)
@@ -623,7 +626,7 @@ func TestReconcileSave_PlanFailureMarksFailed(t *testing.T) {
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	got, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	got, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepSave})
 	assert.NoError(t, err)
 	assert.Equal(t, opv1alpha1.OperationPhaseFailed, got.Phase)
 	assert.Equal(t, opv1alpha1.PlanFailedReason, opv1alpha1.FailedCondition.GetReason(&got))
@@ -646,7 +649,7 @@ func TestReconcileSave_AppliesSnapshotArgs(t *testing.T) {
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	_, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	_, err := h.reconcileSave(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepSave})
 	assert.NoError(t, err)
 
 	wantArgs := []string{"etcd-snapshot", "save", "--name", "my-snap"}
@@ -664,13 +667,13 @@ func TestReconcileRestart_MarksSucceededWhenApplied(t *testing.T) {
 	op := newOp()
 	adapter := defaultAdapter()
 
-	secret := withAppliedPlan(newPlanSecret("etcd-1"), expectedRestartPlan(adapter))
+	secret := withAppliedPlan(newPlanSecret("etcd-1"), expectedRestartPlan(op, adapter))
 	h := &handler{
 		secrets: newSecretClient(t, ctrl, secret),
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepRestart})
 	assert.NoError(t, err)
 	assert.Equal(t, opv1alpha1.OperationPhaseSucceeded, got.Phase)
 	assert.Equal(t, opv1alpha1.FinishedReason, opv1alpha1.SucceededCondition.GetReason(&got))
@@ -689,7 +692,7 @@ func TestReconcileRestart_WaitsForPlanApply(t *testing.T) {
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepRestart})
 	assert.NoError(t, err)
 	assert.Empty(t, string(got.Phase), "phase must not advance to Succeeded while restart is pending")
 	assert.Equal(t, opv1alpha1.WaitingForPlanAppliedReason, opv1alpha1.InProgressCondition.GetReason(&got))
@@ -702,13 +705,13 @@ func TestReconcileRestart_PlanFailureMarksFailed(t *testing.T) {
 	op := newOp()
 	adapter := defaultAdapter()
 
-	secret := withFailedPlan(newPlanSecret("etcd-1"), expectedRestartPlan(adapter))
+	secret := withFailedPlan(newPlanSecret("etcd-1"), expectedRestartPlan(op, adapter))
 	h := &handler{
 		secrets: newSecretClient(t, ctrl, secret),
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepRestart})
 	assert.NoError(t, err)
 	assert.Equal(t, opv1alpha1.OperationPhaseFailed, got.Phase)
 	assert.Equal(t, opv1alpha1.PlanFailedReason, opv1alpha1.FailedCondition.GetReason(&got))
@@ -721,7 +724,7 @@ func TestReconcileRestart_FiltersToEtcdSecrets(t *testing.T) {
 	op := newOp()
 	adapter := defaultAdapter()
 
-	etcd := withAppliedPlan(newPlanSecret("etcd-1"), expectedRestartPlan(adapter))
+	etcd := withAppliedPlan(newPlanSecret("etcd-1"), expectedRestartPlan(op, adapter))
 	worker := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "worker-1",
@@ -740,9 +743,44 @@ func TestReconcileRestart_FiltersToEtcdSecrets(t *testing.T) {
 	}
 	h.store = planapi.NewStore(h.secrets)
 
-	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{})
+	got, err := h.reconcileRestart(newScope(op, nil, adapter), opv1alpha1.ETCDSnapshotSaveStatus{Step: opv1alpha1.ETCDSnapshotSaveStepRestart})
 	assert.NoError(t, err)
 	// Worker secret must be ignored — only etcd nodes receive the restart plan; success would
 	// not be reached if the worker were included (its plan is not in "applied" state).
 	assert.Equal(t, opv1alpha1.OperationPhaseSucceeded, got.Phase, "non-etcd secrets must not be in the iteration")
+}
+
+// TestAssignedPlansAreOperationScoped covers the property the assigned plans depend on: AssignPlan
+// only writes a plan whose bytes differ from the one already on the secret, and the system-agent only
+// re-runs a plan whose content changed. Two saves of the same shape must therefore serialize
+// differently, otherwise a save retried after a failed one would be reported as already applied and
+// succeed without ever taking a snapshot.
+func TestAssignedPlansAreOperationScoped(t *testing.T) {
+	t.Parallel()
+
+	adapter := defaultAdapter()
+
+	opWithUID := func(uid types.UID) *opv1alpha1.ETCDSnapshotSave {
+		op := newOp()
+		op.UID = uid
+		return op
+	}
+
+	for name, build := range map[string]func(*opv1alpha1.ETCDSnapshotSave) *planapi.Plan{
+		"save":    func(op *opv1alpha1.ETCDSnapshotSave) *planapi.Plan { return expectedSavePlan(op, adapter) },
+		"restart": func(op *opv1alpha1.ETCDSnapshotSave) *planapi.Plan { return expectedRestartPlan(op, adapter) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			marshal := func(uid types.UID) string {
+				data, err := json.Marshal(build(opWithUID(uid)))
+				assert.NoError(t, err)
+				return string(data)
+			}
+
+			assert.NotEqual(t, marshal("save-uid-1"), marshal("save-uid-2"),
+				"plans for two operations must not serialize identically, or the second is reported as already applied")
+			assert.Equal(t, marshal("save-uid-1"), marshal("save-uid-1"),
+				"plans for one operation must serialize identically across reconciles")
+		})
+	}
 }

--- a/pkg/operations/env.go
+++ b/pkg/operations/env.go
@@ -1,0 +1,50 @@
+package operations
+
+import (
+	"fmt"
+	"strings"
+
+	planapi "github.com/rancher/rancher/pkg/plan"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// OperationEnv returns environment variables which tie plan content to a specific operation and step.
+//
+// The system-agent only re-executes a plan when its serialized content changes, and AssignPlan only
+// writes a plan when its bytes differ from the one already on the machine-plan secret. Without
+// something operation-specific in the plan, a second operation which computes a byte-identical plan
+// is reported as already applied on its first reconcile: its instructions never run again, and any
+// saved output still belongs to the previous operation. Including these variables makes each
+// operation's plans distinct, so every operation gets its own execution and its own output.
+//
+// controllerName is the controller's owner key (e.g. "etcd-snapshot-restore"), normalized to
+// SCREAMING_SNAKE_CASE for the variable prefix. The variables themselves are inert on the node.
+func OperationEnv[S ~string](controllerName string, op metav1.Object, step S) []string {
+	prefix := strings.ToUpper(strings.ReplaceAll(controllerName, "-", "_"))
+	return []string{
+		fmt.Sprintf("%s_OPERATION_UID=%s", prefix, op.GetUID()),
+		fmt.Sprintf("%s_STEP=%s", prefix, step),
+	}
+}
+
+// WithOperationEnv appends env to every one-time and periodic instruction in p, and returns p so it
+// can wrap a plan where it is assigned:
+//
+//	h.store.AssignPlan(secret, ops.WithOperationEnv(nodePlan, env), 1, 1)
+//
+// Applying the operation environment at the point of assignment rather than while each instruction is
+// built keeps the guarantee — every assigned plan is scoped to its operation — in one place, and
+// leaves plan builders free to be tested on their own terms. Returns nil for a nil plan so callers
+// which build a plan conditionally can pass it through unchecked.
+func WithOperationEnv(p *planapi.Plan, env []string) *planapi.Plan {
+	if p == nil || len(env) == 0 {
+		return p
+	}
+	for i := range p.OneTimeInstructions {
+		p.OneTimeInstructions[i].Env = append(p.OneTimeInstructions[i].Env, env...)
+	}
+	for i := range p.PeriodicInstructions {
+		p.PeriodicInstructions[i].Env = append(p.PeriodicInstructions[i].Env, env...)
+	}
+	return p
+}

--- a/pkg/operations/env_test.go
+++ b/pkg/operations/env_test.go
@@ -1,0 +1,132 @@
+package operations
+
+import (
+	"encoding/json"
+	"testing"
+
+	planapi "github.com/rancher/rancher/pkg/plan"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type testStep string
+
+func testOperation(uid types.UID) metav1.Object {
+	return &metav1.ObjectMeta{Name: "op", Namespace: "fleet-default", UID: uid}
+}
+
+func TestOperationEnv(t *testing.T) {
+	t.Parallel()
+
+	got := OperationEnv("etcd-snapshot-restore", testOperation("abc-123"), testStep("Preflight"))
+	want := []string{
+		"ETCD_SNAPSHOT_RESTORE_OPERATION_UID=abc-123",
+		"ETCD_SNAPSHOT_RESTORE_STEP=Preflight",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("OperationEnv = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("OperationEnv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOperationEnvIsStableForTheSameOperationAndStep(t *testing.T) {
+	t.Parallel()
+
+	// Reconciles of a single operation must produce identical plan content, otherwise the plan would
+	// change every reconcile and re-trigger its instructions.
+	first := OperationEnv("etcd-snapshot-save", testOperation("abc-123"), testStep("Save"))
+	second := OperationEnv("etcd-snapshot-save", testOperation("abc-123"), testStep("Save"))
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("OperationEnv is not stable: %v then %v", first, second)
+		}
+	}
+}
+
+func TestOperationEnvDiffersPerOperationAndStep(t *testing.T) {
+	t.Parallel()
+
+	base := OperationEnv("etcd-snapshot-restore", testOperation("abc-123"), testStep("Preflight"))
+
+	otherOp := OperationEnv("etcd-snapshot-restore", testOperation("def-456"), testStep("Preflight"))
+	if base[0] == otherOp[0] {
+		t.Errorf("a different operation must produce a different UID variable, both are %q", base[0])
+	}
+
+	otherStep := OperationEnv("etcd-snapshot-restore", testOperation("abc-123"), testStep("Shutdown"))
+	if base[1] == otherStep[1] {
+		t.Errorf("a different step must produce a different step variable, both are %q", base[1])
+	}
+}
+
+func TestWithOperationEnv(t *testing.T) {
+	t.Parallel()
+
+	env := OperationEnv("encryption-key-rotation", testOperation("abc-123"), testStep("Rotate"))
+
+	p := &planapi.Plan{
+		OneTimeInstructions: []planapi.OneTimeInstruction{
+			{CommonInstruction: planapi.CommonInstruction{Name: "no-env"}},
+			{CommonInstruction: planapi.CommonInstruction{Name: "existing-env", Env: []string{"RKE2_DATA_DIR=/var/lib/rancher/rke2"}}},
+		},
+		PeriodicInstructions: []planapi.PeriodicInstruction{
+			{CommonInstruction: planapi.CommonInstruction{Name: "periodic"}},
+		},
+	}
+
+	if got := WithOperationEnv(p, env); got != p {
+		t.Error("WithOperationEnv should return the plan it was given so it can wrap an AssignPlan argument")
+	}
+
+	// Every instruction which can carry environment must be scoped, and pre-existing entries must
+	// survive — the shutdown instruction relies on its data-directory variable.
+	if got := p.OneTimeInstructions[0].Env; len(got) != 2 || got[0] != env[0] || got[1] != env[1] {
+		t.Errorf("instruction without env = %v, want %v", got, env)
+	}
+	if got := p.OneTimeInstructions[1].Env; len(got) != 3 || got[0] != "RKE2_DATA_DIR=/var/lib/rancher/rke2" || got[1] != env[0] {
+		t.Errorf("instruction with existing env = %v, want its own entry followed by %v", got, env)
+	}
+	if got := p.PeriodicInstructions[0].Env; len(got) != 2 || got[0] != env[0] {
+		t.Errorf("periodic instruction env = %v, want %v", got, env)
+	}
+}
+
+func TestWithOperationEnvChangesPlanBytes(t *testing.T) {
+	t.Parallel()
+
+	// This is the property the whole helper exists for: two operations running the same work must
+	// serialize differently, so AssignPlan writes a new plan and the node runs it again.
+	newPlan := func() *planapi.Plan {
+		return &planapi.Plan{
+			OneTimeInstructions: []planapi.OneTimeInstruction{
+				{CommonInstruction: planapi.CommonInstruction{Name: "preflight", Command: "/bin/sh"}},
+			},
+		}
+	}
+
+	first, err := json.Marshal(WithOperationEnv(newPlan(), OperationEnv("etcd-snapshot-restore", testOperation("abc-123"), testStep("Preflight"))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := json.Marshal(WithOperationEnv(newPlan(), OperationEnv("etcd-snapshot-restore", testOperation("def-456"), testStep("Preflight"))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) == string(second) {
+		t.Fatalf("plans for two operations serialize identically, so the second would be reported as already applied: %s", first)
+	}
+}
+
+func TestWithOperationEnvNilPlan(t *testing.T) {
+	t.Parallel()
+
+	// Callers which build a plan conditionally (a builder may skip and return nil) pass it through
+	// unchecked.
+	if got := WithOperationEnv(nil, []string{"A=b"}); got != nil {
+		t.Errorf("WithOperationEnv(nil) = %v, want nil", got)
+	}
+}

--- a/tests/v2prov/tests/imported/etcdsnapshotrestore.go
+++ b/tests/v2prov/tests/imported/etcdsnapshotrestore.go
@@ -105,6 +105,16 @@ func WithRestoreLabels(labels map[string]string) SnapshotRestoreOption {
 	}
 }
 
+// WithRestoreTTL overrides the default TTL. The operation CR is garbage collected TTL seconds after
+// it reaches a terminal phase, so tests which assert against a terminal operation (rather than just
+// waiting for it) need a longer window than the default to avoid racing that deletion. A negative
+// TTL disables expiry entirely.
+func WithRestoreTTL(seconds int64) SnapshotRestoreOption {
+	return func(op *opv1alpha1.ETCDSnapshotRestore) {
+		op.Spec.TTL = seconds
+	}
+}
+
 // buildSnapshotRestoreOp assembles the ETCDSnapshotRestore object with the standard defaults so the
 // Create/Run/Hook helpers don't duplicate the literal.
 func buildSnapshotRestoreOp(namespace, snapshotName string, clusterRef corev1.ObjectReference, opts ...SnapshotRestoreOption) *opv1alpha1.ETCDSnapshotRestore {
@@ -265,6 +275,41 @@ func AdvancePastSnapshotRestoreHook(
 	if _, err := plan.PopDelegate(beacon, delegateName, clients.Plan.Beacon()); err != nil {
 		t.Fatalf("pop delegate %q from beacon %s/%s: %v", delegateName, beaconNS, beaconName, err)
 	}
+}
+
+// WaitForSnapshotRestoreFailed polls until the op reaches the Failed phase and returns it, for tests
+// which assert that a restore is refused. Fails fast if the operation instead succeeds.
+//
+// Canceled is reported separately from Failed on purpose: the preflight step cancels (rather than
+// fails) the operation when the check instruction itself could not run — e.g. the server token file
+// was not found where the controller looked for it — which is a different defect from the check
+// running and rejecting the snapshot.
+func WaitForSnapshotRestoreFailed(t *testing.T, clients *clients.Clients, op *opv1alpha1.ETCDSnapshotRestore) *opv1alpha1.ETCDSnapshotRestore {
+	t.Helper()
+
+	var latestOp *opv1alpha1.ETCDSnapshotRestore
+	err := utilwait.PollUntilContextTimeout(clients.Ctx, 5*time.Second, 10*time.Minute, true, func(_ context.Context) (bool, error) {
+		got, err := clients.Operation.ETCDSnapshotRestore().Get(op.Namespace, op.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		switch got.Status.Phase {
+		case opv1alpha1.OperationPhaseSucceeded:
+			return false, fmt.Errorf("operation %s/%s reached Succeeded but should have failed", got.Namespace, got.Name)
+		case opv1alpha1.OperationPhaseCanceled:
+			return false, fmt.Errorf("operation %s/%s was canceled at step %q (%s: %s) but should have failed",
+				got.Namespace, got.Name, got.Status.Step,
+				opv1alpha1.CanceledCondition.GetReason(got), opv1alpha1.CanceledCondition.GetMessage(got))
+		case opv1alpha1.OperationPhaseFailed:
+			latestOp = got
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		handleError(t, clients, op.Spec.ClusterRef.Name, err)
+	}
+	return latestOp
 }
 
 // WaitForSnapshotRestoreSucceeded polls until the op reaches Succeeded with no delegate left on

--- a/tests/v2prov/tests/imported/etcdsnapshotrestoretokencolon_test.go
+++ b/tests/v2prov/tests/imported/etcdsnapshotrestoretokencolon_test.go
@@ -1,0 +1,134 @@
+package imported
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/controllers/operations/etcdsnapshotrestore"
+	"github.com/rancher/rancher/tests/v2prov/clients"
+	"github.com/rancher/rancher/tests/v2prov/cluster"
+	"github.com/rancher/wrangler/v3/pkg/randomtoken"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortServerTokenHash mirrors k3s's util.ShortHash(password, 12): the first 12 characters of the
+// hex-encoded sha256 of the token *password*, which is the value the distro stamps on every
+// snapshot. Reimplemented here (rather than imported) so the test asserts against the documented
+// distro behaviour without pulling the k3s module into the test binary.
+func shortServerTokenHash(password string) string {
+	sum := sha256.Sum256([]byte(password))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// rawServerTokenFile returns the verbatim contents of the token file the restore preflight check
+// reads. k3s writes it as `K10<sha256-of-server-CA>::server:<password>` (see
+// clientaccess.FormatTokenBytes), so it is the only place a test can see how much of the file is
+// prefix and how much is the password the distro actually hashes.
+func (s *serverTokenFixture) rawServerTokenFile(t *testing.T) string {
+	t.Helper()
+
+	path := fmt.Sprintf("%s/server/token", s.dataDir)
+	out, err := s.exec(t, fmt.Sprintf("cat %s", path))
+	if err != nil {
+		t.Fatalf("reading %s failed: %v\noutput: %s", path, err, out)
+	}
+	return strings.TrimSpace(out)
+}
+
+// Test_Imported_Operation_SetE_ImportedETCDSnapshotRestoreColonToken verifies that a snapshot taken
+// under a server token whose password contains a colon can be restored, i.e. that the restore
+// Preflight step derives the same token hash the distro stamped on the snapshot.
+//
+// The token file on disk is written by k3s as:
+//
+//	K10<sha256-of-server-CA>::server:<password>
+//
+// and the hash stamped on a snapshot is sha256(<password>)[:12] — where <password> is everything
+// after the *first* colon of the credential portion, because clientaccess.parseToken splits
+// username from password with strings.SplitN(token, ":", 2). A password containing a colon
+// therefore keeps its colons in the hashed value.
+//
+// The controller's Preflight check has to reproduce that in shell without the k3s/kubeadm parsers
+// (see etcdsnapshotrestore.TokenHashCommandFormat), which is exactly where the two can diverge:
+// stripping the prefix greedily (up to the last colon) yields only the trailing segment of such a
+// password.
+//
+// Unlike Test_Imported_Operation_SetE_ImportedETCDSnapshotRestoreTokenRotation, the token is *not*
+// changed between the save and the restore — it is rotated once to a colon-bearing value before
+// anything is snapshotted and then left alone. So the snapshot is always legitimately restorable,
+// and any Preflight rejection here is a defect in the hash derivation rather than a genuine token
+// mismatch.
+func Test_Imported_Operation_SetE_ImportedETCDSnapshotRestoreColonToken(t *testing.T) {
+	cs, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	fx := setUpImportedCluster(t, cs, "test-restore-colon-token", []cluster.ImportedNodePool{
+		{ControlPlane: true, ETCD: true, Worker: true, Quantity: 1},
+	})
+
+	token := newServerTokenFixture(cs, fx)
+
+	// The cluster is brought up with a colon-free hex token (see cluster.generateImportedToken), so
+	// rotate to a colon-bearing one first. Two random halves joined by a colon: neither half can be
+	// mistaken for a kubeadm bootstrap token (those require a `.`), so the distro parses this as
+	// username-less basic auth and the whole string is the password.
+	left, err := randomtoken.Generate()
+	require.NoError(t, err)
+	right, err := randomtoken.Generate()
+	require.NoError(t, err)
+	colonToken := left + ":" + right
+
+	token.rotate(t, token.configuredToken(t), colonToken)
+	t.Logf("rotated the server token to a colon-bearing value; token file on disk is %q", token.rawServerTokenFile(t))
+
+	// Payload whose presence after the restore proves etcd was actually rolled back.
+	cm := newConfigMapProof()
+	cm.create(t, fx)
+
+	snapshotsValidAfter := time.Now().Add(-30 * time.Second)
+	saveOp := RunETCDSnapshotSaveOperationTest(t, cs, fx.ns.Name, fx.clusterRef)
+	t.Logf("snapshot save operation %s/%s completed", saveOp.Namespace, saveOp.Name)
+	waitForSnapshots(t, cs, fx.mgmtCluster.Name, fx.mgmtCluster.Name, snapshotsValidAfter, 1)
+	snapshot := waitForBackpopulatedSnapshot(t, cs, fx.mgmtCluster.Name, fx.mgmtCluster.Name, "imported-init-0", snapshotsValidAfter)
+
+	// Without a stamped hash Preflight has nothing to compare against and skips validation, which
+	// would make the rest of this test silently vacuous.
+	stampedHash := snapshot.Annotations[capr.SnapshotTokenHashAnnotation]
+	if stampedHash == "" {
+		t.Fatalf("snapshot %s carries no %s annotation, so the restore preflight check cannot validate the token: annotations=%v",
+			snapshot.Name, capr.SnapshotTokenHashAnnotation, snapshot.Annotations)
+	}
+
+	// Pin down what the distro hashed: the full password, colon included. If this fails the premise
+	// of the test (and of the Preflight check) is wrong, not the shell command.
+	assert.Equal(t, shortServerTokenHash(colonToken), stampedHash,
+		"the distro should stamp the snapshot with sha256 of the whole password, colons included")
+
+	// The check the controller actually runs on the node. Reported before the restore is attempted
+	// so a mismatch is visible as a hash comparison rather than only as a Preflight failure ~minutes
+	// later.
+	nodeHash := token.tokenHash(t)
+	t.Logf("token hashes: snapshot=%s, sha256(password)[:12]=%s, %q=%s",
+		stampedHash, shortServerTokenHash(colonToken),
+		fmt.Sprintf(etcdsnapshotrestore.TokenHashCommandFormat, token.dataDir), nodeHash)
+	assert.Equal(t, stampedHash, nodeHash,
+		"the preflight token hash command must derive the same hash the distro stamped for a password containing a colon")
+
+	// Delete the ConfigMap so the post-restore assertion is meaningful rather than trivially true.
+	cm.delete(t, fx)
+
+	// The token has not changed since the snapshot was taken, so this restore must succeed.
+	restoreOp := RunETCDSnapshotRestoreOperationTest(t, cs, fx.ns.Name, snapshot.Name, fx.clusterRef)
+	t.Logf("snapshot restore operation %s/%s completed", restoreOp.Namespace, restoreOp.Name)
+
+	cm.assertRestored(t, fx)
+}

--- a/tests/v2prov/tests/imported/etcdsnapshotrestoretokenrotation_test.go
+++ b/tests/v2prov/tests/imported/etcdsnapshotrestoretokenrotation_test.go
@@ -1,0 +1,230 @@
+package imported
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	opv1alpha1 "github.com/rancher/rancher/pkg/apis/operation.cattle.io/v1alpha1"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/controllers/operations/etcdsnapshotrestore"
+	"github.com/rancher/rancher/tests/v2prov/clients"
+	"github.com/rancher/rancher/tests/v2prov/cluster"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
+	"github.com/rancher/wrangler/v3/pkg/randomtoken"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serverTokenFixture drives the server token of an imported cluster's init node: reading the token
+// the node was brought up with, hashing the token the node currently has on disk, and rotating to a
+// different one. The distro-specific paths and unit name are resolved once from the k8s version
+// under test so the individual operations read as the story rather than as string formatting.
+type serverTokenFixture struct {
+	cs *clients.Clients
+	fx *importedClusterFixture
+
+	// runtimeCommand is the distro CLI (`rke2` / `k3s`), which is also the subcommand host for
+	// `token rotate`.
+	runtimeCommand string
+	// serverUnit is the systemd unit that must be restarted for a new token to take effect.
+	serverUnit string
+	// dataDir is where the distro persists the token it is running with. Imported clusters always
+	// use the runtime default (see ImportedAdapter.DistroDataDirectory).
+	dataDir string
+	// configFile is the config drop-in that cluster.NewImportedClusterPods wrote the token into. It
+	// is the node's source of truth on restart, so a rotation has to update it.
+	configFile string
+}
+
+func newServerTokenFixture(cs *clients.Clients, fx *importedClusterFixture) *serverTokenFixture {
+	distro := capr.GetRuntime(defaults.SomeK8sVersion)
+	return &serverTokenFixture{
+		cs:             cs,
+		fx:             fx,
+		runtimeCommand: capr.GetRuntimeCommand(defaults.SomeK8sVersion),
+		serverUnit:     capr.GetRuntimeServerUnit(defaults.SomeK8sVersion),
+		dataDir:        fmt.Sprintf("/var/lib/rancher/%s", distro),
+		configFile:     fmt.Sprintf("/etc/rancher/%s/config.yaml.d/50-test.yaml", distro),
+	}
+}
+
+// exec runs a shell command on the init node. The init node is the only etcd member in the
+// single-node topology this test uses, so it is also the only node the restore preflight checks.
+func (s *serverTokenFixture) exec(t *testing.T, cmd string) (string, error) {
+	t.Helper()
+	return cluster.ExecOnPod(s.cs, s.fx.ns.Name, s.fx.pods[0].Name, "sh", "-c", cmd)
+}
+
+// configuredToken reads the token the node was brought up with out of its config drop-in. The token
+// is generated inside cluster.NewImportedClusterPods and is not surfaced on the fixture, and
+// rotating requires knowing the current value.
+func (s *serverTokenFixture) configuredToken(t *testing.T) string {
+	t.Helper()
+
+	out, err := s.exec(t, fmt.Sprintf("sed -n 's/^token: //p' %s", s.configFile))
+	if err != nil {
+		t.Fatalf("reading the configured server token from %s failed: %v\noutput: %s", s.configFile, err, out)
+	}
+	token := strings.TrimSpace(out)
+	if token == "" {
+		t.Fatalf("no token found in %s", s.configFile)
+	}
+	return token
+}
+
+// tokenHash computes the hash of the token the node currently has on disk, using the very command
+// the restore preflight check runs, so the test's notion of the current hash cannot drift from the
+// controller's.
+func (s *serverTokenFixture) tokenHash(t *testing.T) string {
+	t.Helper()
+
+	out, err := s.exec(t, fmt.Sprintf(etcdsnapshotrestore.TokenHashCommandFormat, s.dataDir))
+	if err != nil {
+		// The preflight instruction would fail the same way, and because its plan is assigned with a
+		// failure threshold of -1 the operation would stall instead of failing — so surface this as
+		// the token file not being where the check looks for it, rather than letting the test hang.
+		t.Fatalf("hashing the on-disk server token under %s failed, so the restore preflight check cannot read it either: %v\noutput: %s",
+			s.dataDir, err, out)
+	}
+	return strings.TrimSpace(out)
+}
+
+// rotate rotates the server token from currentToken to newToken and returns once the cluster is
+// serving again with the new token in place.
+func (s *serverTokenFixture) rotate(t *testing.T, currentToken, newToken string) {
+	t.Helper()
+
+	// `token rotate` re-encrypts the datastore's bootstrap data under the new token. The node keeps
+	// running with the old one until it restarts with the new value in its config, which is also
+	// when the token it persists on disk — the value the restore preflight check hashes — changes.
+	if out, err := s.exec(t, fmt.Sprintf("%s token rotate --token %s --new-token %s", s.runtimeCommand, currentToken, newToken)); err != nil {
+		t.Fatalf("rotating the server token failed: %v\noutput: %s", err, out)
+	}
+
+	if out, err := s.exec(t, fmt.Sprintf("sed -i 's|^token: .*|token: %s|' %s", newToken, s.configFile)); err != nil {
+		t.Fatalf("updating the token in %s failed: %v\noutput: %s", s.configFile, err, out)
+	}
+
+	if out, err := s.exec(t, fmt.Sprintf("systemctl restart %s", s.serverUnit)); err != nil {
+		diag, _ := s.exec(t, fmt.Sprintf("journalctl -u %s --no-pager -n 40 2>/dev/null || true", s.serverUnit))
+		t.Fatalf("restarting %s after the token rotation failed: %v\noutput: %s\njournal:\n%s", s.serverUnit, err, out, diag)
+	}
+
+	s.waitForAPI(t)
+}
+
+// waitForAPI polls the downstream API server until it serves again. A restart of the server unit
+// takes the API down for a while, and every subsequent step (snapshot back-population, the restore
+// itself) depends on it being back.
+func (s *serverTokenFixture) waitForAPI(t *testing.T) {
+	t.Helper()
+
+	for i := 0; i < 60; i++ {
+		out, err := s.fx.execKubectl(t, "kubectl get nodes")
+		if err == nil {
+			return
+		}
+		if i == 59 {
+			t.Fatalf("timed out waiting for the %s API server to serve after restarting %s: %v\noutput: %s",
+				s.runtimeCommand, s.serverUnit, err, out)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// Test_Imported_Operation_SetE_ImportedETCDSnapshotRestoreTokenRotation verifies that an
+// ETCDSnapshotRestore refuses a snapshot that was taken under a different server token, and that the
+// same snapshot restores successfully once the original token is back in place.
+//
+// A snapshot's bootstrap data is encrypted with the server token that was current when it was taken,
+// so restoring it into a cluster whose token has since been rotated leaves a cluster that cannot
+// start. The restore's Preflight step guards against that: the distro stamps a hash of the token on
+// each snapshot, snapshotbackpopulate mirrors it onto the upstream ETCDSnapshot as
+// rke.cattle.io/snapshot-token-hash, and Preflight hashes the token each etcd node currently has on
+// disk and compares the two.
+//
+// The test takes a snapshot, rotates the server token (re-encrypting the live cluster's bootstrap
+// data and restarting the node with the new token), and asserts the restore fails at Preflight with
+// the token-hash mismatch. It then rotates back to the original token — the documented way to make
+// a pre-rotation snapshot restorable again — and asserts a fresh restore of that same snapshot
+// succeeds and rolls etcd back, proving the guard rejected the restore on the token rather than on
+// anything else about the snapshot.
+//
+// Note that the restore is created against the ETCDSnapshot CR name, not the snapshot file name: the
+// controller resolves either, but only a CR lookup can read the stamped hash, so restoring by file
+// name skips the check entirely.
+func Test_Imported_Operation_SetE_ImportedETCDSnapshotRestoreTokenRotation(t *testing.T) {
+	cs, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	fx := setUpImportedCluster(t, cs, "test-restore-token-rotation", []cluster.ImportedNodePool{
+		{ControlPlane: true, ETCD: true, Worker: true, Quantity: 1},
+	})
+
+	token := newServerTokenFixture(cs, fx)
+	originalToken := token.configuredToken(t)
+
+	// Payload whose presence after the restore proves etcd was actually rolled back.
+	cm := newConfigMapProof()
+	cm.create(t, fx)
+
+	// Take the snapshot that the rest of the test restores from. It is stamped with a hash of the
+	// token the cluster currently runs with.
+	snapshotsValidAfter := time.Now().Add(-30 * time.Second)
+	saveOp := RunETCDSnapshotSaveOperationTest(t, cs, fx.ns.Name, fx.clusterRef)
+	t.Logf("snapshot save operation %s/%s completed", saveOp.Namespace, saveOp.Name)
+	waitForSnapshots(t, cs, fx.mgmtCluster.Name, fx.mgmtCluster.Name, snapshotsValidAfter, 1)
+	snapshot := waitForBackpopulatedSnapshot(t, cs, fx.mgmtCluster.Name, fx.mgmtCluster.Name, "imported-init-0", snapshotsValidAfter)
+
+	// Without a stamped hash the preflight check has nothing to compare against and skips validation,
+	// which would make the rest of this test silently vacuous.
+	stampedHash := snapshot.Annotations[capr.SnapshotTokenHashAnnotation]
+	if stampedHash == "" {
+		t.Fatalf("snapshot %s carries no %s annotation, so the restore preflight check cannot validate the token: annotations=%v",
+			snapshot.Name, capr.SnapshotTokenHashAnnotation, snapshot.Annotations)
+	}
+	assert.Equal(t, token.tokenHash(t), stampedHash, "the snapshot should be stamped with the hash of the token the cluster was running with")
+
+	// Delete the ConfigMap so the post-restore assertion is meaningful rather than trivially true.
+	cm.delete(t, fx)
+
+	rotatedToken, err := randomtoken.Generate()
+	require.NoError(t, err)
+
+	token.rotate(t, originalToken, rotatedToken)
+	rotatedHash := token.tokenHash(t)
+	if rotatedHash == stampedHash {
+		t.Fatalf("the node still hashes to %s after rotating its token, so the preflight check cannot detect the rotation", rotatedHash)
+	}
+	t.Logf("rotated the server token: node hash %s, snapshot hash %s", rotatedHash, stampedHash)
+
+	// The restore must be refused. A longer TTL than the default keeps the operation around while its
+	// terminal state is asserted, instead of racing garbage collection.
+	refused := CreateETCDSnapshotRestoreOp(t, cs, fx.ns.Name, snapshot.Name, fx.clusterRef, WithRestoreTTL(600))
+	refused = WaitForSnapshotRestoreFailed(t, cs, refused)
+
+	assert.Equal(t, opv1alpha1.OperationPhaseFailed, refused.Status.Phase)
+	assert.Equal(t, opv1alpha1.ETCDSnapshotRestoreStepPreflight, refused.Status.Step,
+		"the restore should be refused before it shuts anything down")
+	assert.Equal(t, opv1alpha1.PreflightCheckFailedReason, opv1alpha1.FailedCondition.GetReason(refused))
+	assert.Contains(t, opv1alpha1.FailedCondition.GetMessage(refused), "does not match snapshot token hash")
+
+	// Rotating back restores the bootstrap data the snapshot's token can decrypt, which is what makes
+	// a pre-rotation snapshot restorable again.
+	token.rotate(t, rotatedToken, originalToken)
+	assert.Equal(t, stampedHash, token.tokenHash(t), "rotating back should return the node to the token the snapshot was taken with")
+
+	// The same snapshot, by the same CR name, now passes the check and restores. This leg also covers
+	// plan reuse across operations: the refused restore left its preflight plan on the machine-plan
+	// secret, so unless this operation's plan is distinct from it the node is never asked to hash its
+	// token again and this restore is refused on the previous operation's output.
+	restoreOp := RunETCDSnapshotRestoreOperationTest(t, cs, fx.ns.Name, snapshot.Name, fx.clusterRef)
+	t.Logf("snapshot restore operation %s/%s completed", restoreOp.Namespace, restoreOp.Name)
+
+	cm.assertRestored(t, fx)
+}


### PR DESCRIPTION
## Issues: <!-- link the issue or issues this PR resolves here --> #56074, #56076
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->


- Operations not failing as intended, rather getting stuck when encountering a failure
- Token checks in etcd snapshot save  & restore operations too restrictive.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Made operations fail as desired
- Relaxed token checks, added validation for comparing snapshot token hash with current hash.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Added unit & v2prov tests

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
I would test that etcd restores are blocked when the server token is rotated, and that it will be allowed once the token is reset. 