### PR TITLE
Fix upgrade issue with stale cluster tokens

### DIFF
--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -36,7 +36,7 @@ const (
 type handler struct {
 	clusterRegistrationTokenCache      v32.ClusterRegistrationTokenCache
 	clusterRegistrationTokenController v32.ClusterRegistrationTokenController
-	clusters                           v32.ClusterCache
+	clustersCache                      v32.ClusterCache
 	secrets                            corecontrollers.SecretClient
 	secretCache                        corecontrollers.SecretCache
 	roles                              rbaccontrollers.RoleClient
@@ -48,7 +48,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 	h := &handler{
 		clusterRegistrationTokenController: clients.Mgmt.ClusterRegistrationToken(),
 		clusterRegistrationTokenCache:      clients.Mgmt.ClusterRegistrationToken().Cache(),
-		clusters:                           clients.Mgmt.Cluster().Cache(),
+		clustersCache:                      clients.Mgmt.Cluster().Cache(),
 		secrets:                            clients.Core.Secret(),
 		secretCache:                        clients.Core.Secret().Cache(),
 		roles:                              clients.RBAC.Role(),

--- a/pkg/controllers/dashboard/clusterregistrationtoken/status.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/status.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rancher/norman/types/convert"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/capr/installer"
-	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemtemplate"
@@ -33,12 +32,17 @@ func (h *handler) assignStatus(crt *v32.ClusterRegistrationToken) (v32.ClusterRe
 	clusterID := convert.ToString(crt.Spec.ClusterName)
 	crtStatus := crt.Status.DeepCopy()
 
-	return AssignCommands(crtStatus, clusterID, h.clusters)
+	cluster, err := h.clustersCache.Get(clusterID)
+	if err != nil {
+		return *crtStatus, err
+	}
+
+	return AssignCommands(crtStatus, cluster)
 }
 
 // AssignCommands populates the command fields in a CRT status using the "{token}" placeholder.
 // Substitution of the placeholder with the real token happens at the API layer.
-func AssignCommands(crtStatus *v32.ClusterRegistrationTokenStatus, clusterID string, clusters mgmtcontrollers.ClusterCache) (v32.ClusterRegistrationTokenStatus, error) {
+func AssignCommands(crtStatus *v32.ClusterRegistrationTokenStatus, cluster *v32.Cluster) (v32.ClusterRegistrationTokenStatus, error) {
 	checksum := systemtemplate.CAChecksum()
 	ca := ""
 	caWindows := ""
@@ -47,7 +51,7 @@ func AssignCommands(crtStatus *v32.ClusterRegistrationTokenStatus, clusterID str
 		caWindows = " -CaChecksum " + checksum
 	}
 
-	url, err := getURL(tokenPlaceholder, clusterID)
+	url, err := getURL(tokenPlaceholder, cluster.Name)
 	if err != nil {
 		return *crtStatus, err
 	}
@@ -61,11 +65,6 @@ func AssignCommands(crtStatus *v32.ClusterRegistrationTokenStatus, clusterID str
 	crtStatus.ManifestURL = url
 
 	rootURL, err := getRootURL()
-	if err != nil {
-		return *crtStatus, err
-	}
-
-	cluster, err := clusters.Get(clusterID)
 	if err != nil {
 		return *crtStatus, err
 	}

--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -110,7 +110,7 @@ func Register(ctx context.Context, clients *wrangler.Context, embedded bool, reg
 }
 
 // RegisterPostMigration registers controllers that should only start after boot-time
-// migrations (see pkg/rancher/migrations.go) have completed. This avoids redundant and conflicting work on startup.
+// migrations (see pkg/rancher/migrations.go) have completed. This avoids redundant or conflicting work on startup.
 func RegisterPostMigration(ctx context.Context, clients *wrangler.Context) {
 	if features.ProvisioningV2.Enabled() || features.MCM.Enabled() {
 		clusterregistrationtoken.Register(ctx, clients)

--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -66,10 +66,6 @@ func Register(ctx context.Context, clients *wrangler.Context, embedded bool, reg
 		}
 	}
 
-	if features.ProvisioningV2.Enabled() || features.MCM.Enabled() {
-		clusterregistrationtoken.Register(ctx, clients)
-	}
-
 	if features.ProvisioningV2.Enabled() {
 		kubeconfigManager := kubeconfig.New(clients)
 		provisioningv2.EarlyRegister(ctx, clients, kubeconfigManager)
@@ -111,4 +107,12 @@ func Register(ctx context.Context, clients *wrangler.Context, embedded bool, reg
 	}
 
 	return nil
+}
+
+// RegisterPostMigration registers controllers that should only start after boot-time
+// migrations (see pkg/rancher/migrations.go) have completed. This avoids redundant and conflicting work on startup.
+func RegisterPostMigration(ctx context.Context, clients *wrangler.Context) {
+	if features.ProvisioningV2.Enabled() || features.MCM.Enabled() {
+		clusterregistrationtoken.Register(ctx, clients)
+	}
 }

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -866,9 +866,12 @@ func migrateCRTTokensToSecretsFunc(w *wrangler.Context) error {
 		}
 	}
 
-	logrus.Infof("Successfully migrated cluster registration tokens to secrets")
 	cm.Data[crtTokensToSecretsMigratedKey] = "true"
-	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
+	if err := createOrUpdateConfigMap(w.Core.ConfigMap(), cm); err != nil {
+		return err
+	}
+	logrus.Infof("Successfully migrated cluster registration tokens to secrets")
+	return nil
 }
 
 // migrateExistingRKE2ClustersPrimeAnnotation sets the provisioning.cattle.io/rke2-prime-enabled=false
@@ -998,10 +1001,6 @@ func migrateSingleCRT(w *wrangler.Context, crt *v32.ClusterRegistrationToken) er
 		return fmt.Errorf("failed to create token secret: %w", createErr)
 	}
 
-	crtCopy := crt.DeepCopy()
-	crtCopy.Status.Token = ""
-	crtCopy.Status.TokenSecretName = secretName
-
 	if apierrors.IsAlreadyExists(createErr) {
 		existing, err := w.Core.Secret().Get(crt.Namespace, secretName, metav1.GetOptions{})
 		if err != nil {
@@ -1017,26 +1016,33 @@ func migrateSingleCRT(w *wrangler.Context, crt *v32.ClusterRegistrationToken) er
 		return fmt.Errorf("failed to get cluster: %w", err)
 	}
 
-	if cluster != nil {
-		newStatus, err := clusterregistrationtoken.AssignCommands(&crtCopy.Status, cluster)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := w.Mgmt.ClusterRegistrationToken().Get(crt.Namespace, crt.Name, metav1.GetOptions{})
 		if err != nil {
-			logrus.Warnf("Failed to regenerate commands for CRT %s/%s: %v",
-				crt.Namespace, crt.Name, err)
-		} else {
-			crtCopy.Status = newStatus
+			return err
 		}
-	}
 
-	if expiresAt != "" {
-		crtCopy.Status.ExpiresAt = expiresAt
-	}
+		crtCopy := latest.DeepCopy()
+		crtCopy.Status.Token = ""
+		crtCopy.Status.TokenSecretName = secretName
 
-	_, err = w.Mgmt.ClusterRegistrationToken().Update(crtCopy)
-	if err != nil {
-		return fmt.Errorf("failed to update CRT status: %w", err)
-	}
+		if cluster != nil {
+			newStatus, err := clusterregistrationtoken.AssignCommands(&crtCopy.Status, cluster)
+			if err != nil {
+				logrus.Warnf("Failed to regenerate commands for CRT %s/%s: %v",
+					crt.Namespace, crt.Name, err)
+			} else {
+				crtCopy.Status = newStatus
+			}
+		}
 
-	return nil
+		if expiresAt != "" {
+			crtCopy.Status.ExpiresAt = expiresAt
+		}
+
+		_, err = w.Mgmt.ClusterRegistrationToken().Update(crtCopy)
+		return err
+	})
 }
 
 func computeMigrationJitter(ttl time.Duration) time.Duration {

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -866,6 +866,7 @@ func migrateCRTTokensToSecretsFunc(w *wrangler.Context) error {
 		}
 	}
 
+	logrus.Infof("Successfully migrated cluster registration tokens to secrets")
 	cm.Data[crtTokensToSecretsMigratedKey] = "true"
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
 }
@@ -1017,7 +1018,7 @@ func migrateSingleCRT(w *wrangler.Context, crt *v32.ClusterRegistrationToken) er
 	}
 
 	if cluster != nil {
-		newStatus, err := clusterregistrationtoken.AssignCommands(&crtCopy.Status, crt.Spec.ClusterName, w.Mgmt.Cluster().Cache())
+		newStatus, err := clusterregistrationtoken.AssignCommands(&crtCopy.Status, cluster)
 		if err != nil {
 			logrus.Warnf("Failed to regenerate commands for CRT %s/%s: %v",
 				crt.Namespace, crt.Name, err)
@@ -1030,13 +1031,11 @@ func migrateSingleCRT(w *wrangler.Context, crt *v32.ClusterRegistrationToken) er
 		crtCopy.Status.ExpiresAt = expiresAt
 	}
 
-	_, err = w.Mgmt.ClusterRegistrationToken().UpdateStatus(crtCopy)
+	_, err = w.Mgmt.ClusterRegistrationToken().Update(crtCopy)
 	if err != nil {
 		return fmt.Errorf("failed to update CRT status: %w", err)
 	}
 
-	logrus.Infof("Successfully migrated CRT %s/%s token to secret %s",
-		crt.Namespace, crt.Name, secretName)
 	return nil
 }
 

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -501,7 +501,12 @@ func (r *Rancher) Start(ctx context.Context) error {
 			return errors.New("dashboard.Register() failed: " + err.Error())
 		}
 
-		return runMigrations(r.Wrangler)
+		if err := runMigrations(r.Wrangler); err != nil {
+			return err
+		}
+
+		dashboard.RegisterPostMigration(ctx, r.Wrangler)
+		return nil
 	})
 
 	r.Wrangler.OnLeaderOrDie("rancher-start::DefferedCAPIRegistration", func(ctx context.Context) error {

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -505,7 +505,12 @@ func (r *Rancher) Start(ctx context.Context) error {
 			return err
 		}
 
-		dashboard.RegisterPostMigration(ctx, r.Wrangler)
+		if err := r.Wrangler.StartFactoryWithTransaction(ctx, func(ctx context.Context) error {
+			dashboard.RegisterPostMigration(ctx, r.Wrangler)
+			return nil
+		}); err != nil {
+			return errors.New("dashboard.RegisterPostMigration() failed: " + err.Error())
+		}
 		return nil
 	})
 


### PR DESCRIPTION
**Problem:** 
- CRT migration was always failing because it incorrectly used `UpdateStatus()`, but this error was previously masked because CRT handler was registered before migration - causing the main reconcile loop to fire at the same time. Noticed this now because the reconcile loop couldn't succeed for stale tokens at `AssignCommands` with a deleted cluster. Fixed by switching to `Update()` and deferring controller registration until after migrations finish.

- Migration fetched the cluster from the API confirming cluster existed but it wasn't passed to `AssignCommands()`. If the cluster informer hadn't synced yet, `AssignCommands()` fell back to the lister and errored out - flooding the logs with handler errors and migration warnings but basically a no-op. Fixed by passing the fetched cluster directly into the function. 

Issue: https://github.com/rancher/rancher/issues/56487 