### PR TITLE
[release/v2.15] fix: capi clusters day2ops control plane naming

### DIFF
--- a/pkg/operations/capi.go
+++ b/pkg/operations/capi.go
@@ -10,9 +10,7 @@ import (
 	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
-var (
-	errUnsupportedClusterType = fmt.Errorf("unsupported cluster type")
-)
+var errUnsupportedClusterType = fmt.Errorf("unsupported cluster type")
 
 func init() {
 	RegisterAdapter(capiv1beta2.GroupVersion.WithKind("Cluster"), func(clients *wrangler.CAPIContext, ustr *unstructured.Unstructured) (Adapter, error) {
@@ -36,7 +34,8 @@ func init() {
 // resolve the mgmt-side snapshot namespace independently of the CAPI Cluster's namespace.
 func capiClusterAdapter(clients *wrangler.CAPIContext, cluster *capiv1beta2.Cluster, mgmtClusterName string) (Adapter, error) {
 	if cluster.Spec.ControlPlaneRef.APIGroup == controlplanev1beta2.GroupVersion.Group && cluster.Spec.ControlPlaneRef.Kind == "RKE2ControlPlane" {
-		obj, err := clients.Dynamic.Get(controlplanev1beta2.GroupVersion.WithKind("RKE2ControlPlane"), cluster.Namespace, cluster.Name)
+		cpName := cluster.Spec.ControlPlaneRef.Name
+		obj, err := clients.Dynamic.Get(controlplanev1beta2.GroupVersion.WithKind("RKE2ControlPlane"), cluster.Namespace, cpName)
 		if err != nil {
 			return nil, err
 		}
@@ -46,12 +45,12 @@ func capiClusterAdapter(clients *wrangler.CAPIContext, cluster *capiv1beta2.Clus
 		// directly (mirrors how CAPRAdapter holds a typed *rkev1.RKEControlPlane).
 		cpUstr, ok := obj.(*unstructured.Unstructured)
 		if !ok {
-			return nil, fmt.Errorf("expected *unstructured.Unstructured for RKE2ControlPlane %s/%s, got %T", cluster.Namespace, cluster.Name, obj)
+			return nil, fmt.Errorf("expected *unstructured.Unstructured for RKE2ControlPlane %s/%s, got %T", cluster.Namespace, cpName, obj)
 		}
 
 		controlPlane := &controlplanev1beta2.RKE2ControlPlane{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(cpUstr.Object, controlPlane); err != nil {
-			return nil, fmt.Errorf("converting RKE2ControlPlane %s/%s from unstructured: %w", cluster.Namespace, cluster.Name, err)
+			return nil, fmt.Errorf("converting RKE2ControlPlane %s/%s from unstructured: %w", cluster.Namespace, cpName, err)
 		}
 
 		return &CAPRKE2Adapter{

--- a/pkg/operations/caprke2.go
+++ b/pkg/operations/caprke2.go
@@ -312,7 +312,7 @@ func (a *CAPRKE2Adapter) isSuitableLeader(s *corev1.Secret) (bool, error) {
 // back to the first sorted candidate.
 func (a *CAPRKE2Adapter) FindOrElectLeader(operation string, filter Filter) (*corev1.Secret, error) {
 	secrets := a.clients.Core.Secret()
-	candidates, err := plan.NewCollector(secrets, a.controlPlane, a.controlPlane.Namespace).
+	candidates, err := plan.NewCollector(secrets, a.cluster, a.cluster.Namespace).
 		WithFilter(plan.FilterFunc(filter)).
 		WithSorter(plan.DefaultSorter()).
 		Collect()
@@ -515,10 +515,11 @@ func (a *CAPRKE2Adapter) KubeconfigPath(_ *corev1.Secret) string {
 	return "/etc/rancher/rke2/rke2.yaml"
 }
 
-// PauseCluster toggles Spec.Paused on the CAPI Cluster that owns this RKE2ControlPlane. CAPI's
-// Cluster name matches the RKE2ControlPlane name by convention. Mirrors CAPRAdapter.PauseCluster.
+// PauseCluster toggles Spec.Paused on the CAPI Cluster that owns this RKE2ControlPlane.
+// Uses a.cluster since CAPI-native control plane objects do not necessarily have the
+// same name as the CAPI-native cluster object.
 func (a *CAPRKE2Adapter) PauseCluster(pause bool) error {
-	cluster, err := a.clients.CAPI.Cluster().Cache().Get(a.controlPlane.Namespace, a.controlPlane.Name)
+	cluster, err := a.clients.CAPI.Cluster().Cache().Get(a.cluster.Namespace, a.cluster.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

CAPI-native clusters do not necessarily share the same name with the corresponding control plane object.

In the case of Day2 Operations for imported clusters, if the downstream cluster is provisioned with CAPRKE2:
- `clusters.cluster.x-k8s.io`'s `metadata.name` is not necessarily equal to `controlplane.cluster.x-k8s.io`'s `metadata.name`.

The handler, after starting an operation, i.e. etcd snapshot, looks for a control plane with the same name as the cluster object, which doesn't exist, and the operation gets stuck.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

When looking for the control plane, use the control plane name specifically, from the cluster's specification.

The same name mismatch affects:
- `FindOrElectLeader` passes `a.controlPlane` to `plan.NewCollector`, which is later used as a cluster name.
- `PauseCluster` fetches the CAPI Cluster by `a.controlPlane.Name` instead of `a.cluster.Name`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_