### PR TITLE
Serve the /v1/logout endpoint when multi-cluster management is disabled

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -116,25 +116,63 @@ func newAPIManagement(ctx context.Context, scaledContext *config.ScaledContext, 
 			}
 		})
 
-		root := http.NewServeMux()
+		routes := authRoutes{
+			limit:    utils.APIBodyLimitingHandler(apiLimit),
+			saml:     saml,
+			v1Public: v1PublicAPI,
+			v3:       v3Handler,
+			logout:   logout,
+			next:     next,
+		}
+		if features.V3Public.Enabled() {
+			routes.v3Public = v3PublicAPI // Deprecated. Use /v1-public instead.
+		}
+		if features.SCIM.Enabled() {
+			routes.scim = scim.NewHandler(scaledContext)
+		}
+
+		root := newRootMux(routes)
 
 		p := handler.NewFromAuthConfigInterface(scaledContext.Management.AuthConfigs(""))
 		p.RegisterOIDCProviderHandlers(root)
 
-		limitingHandler := utils.APIBodyLimitingHandler(apiLimit)
-		root.Handle("/v1-saml/", limitingHandler(saml))
-		if features.V3Public.Enabled() {
-			root.Handle("/v3-public/", limitingHandler(v3PublicAPI)) // Deprecated. Use /v1-public instead.
-		}
-		root.Handle("/v1-public/", limitingHandler(v1PublicAPI))
-		if features.SCIM.Enabled() {
-			root.Handle(fmt.Sprint(scim.URLPrefix, "/"), limitingHandler(scim.NewHandler(scaledContext)))
-		}
-		root.Handle("/v3/", v3Handler)
-		root.Handle("/", next)
-
 		return root
 	}, nil
+}
+
+// authRoutes are the handlers served by the auth server's root mux. All
+// handlers are required except v3Public and scim, which are feature gated:
+// when nil, their paths fall through to next.
+type authRoutes struct {
+	limit    func(http.Handler) http.Handler
+	saml     http.Handler
+	v3Public http.Handler
+	v1Public http.Handler
+	scim     http.Handler
+	v3       http.Handler
+	logout   http.Handler
+	next     http.Handler
+}
+
+func newRootMux(routes authRoutes) *http.ServeMux {
+	root := http.NewServeMux()
+
+	root.Handle("/v1-saml/", routes.limit(routes.saml))
+	if routes.v3Public != nil {
+		root.Handle("/v3-public/", routes.limit(routes.v3Public)) // Deprecated. Use /v1-public instead.
+	}
+	root.Handle("/v1-public/", routes.limit(routes.v1Public))
+	if routes.scim != nil {
+		root.Handle(fmt.Sprint(scim.URLPrefix, "/"), routes.limit(routes.scim))
+	}
+	// The multi-cluster management router serves this route too, but it only
+	// runs when MCM is enabled. Registering it here keeps logout working when
+	// MCM is disabled, as in standalone Harvester.
+	root.Handle("POST /v1/logout", routes.limit(requests.NewAuthenticatedFilter(routes.logout)))
+	root.Handle("/v3/", routes.v3)
+	root.Handle("/", routes.next)
+
+	return root
 }
 
 func (s *Server) OnLeader(ctx context.Context) error {

--- a/pkg/auth/server_test.go
+++ b/pkg/auth/server_test.go
@@ -1,0 +1,162 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// markerHandler writes its name so tests can tell which route was picked.
+func markerHandler(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(name))
+	})
+}
+
+func testRoutes() authRoutes {
+	return authRoutes{
+		limit:    func(next http.Handler) http.Handler { return next },
+		saml:     markerHandler("saml"),
+		v1Public: markerHandler("v1Public"),
+		v3:       markerHandler("v3"),
+		logout:   markerHandler("logout"),
+		next:     markerHandler("next"),
+	}
+}
+
+func TestNewRootMux(t *testing.T) {
+	t.Parallel()
+
+	authenticated := &user.DefaultInfo{Name: "u-abcde", Groups: []string{"system:authenticated"}}
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		user     user.Info
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "logout is served when MCM is disabled",
+			method:   http.MethodPost,
+			path:     "/v1/logout",
+			user:     authenticated,
+			wantCode: http.StatusOK,
+			wantBody: "logout",
+		},
+		{
+			name:     "logout all is served when MCM is disabled",
+			method:   http.MethodPost,
+			path:     "/v1/logout?all",
+			user:     authenticated,
+			wantCode: http.StatusOK,
+			wantBody: "logout",
+		},
+		{
+			name:     "logout requires authentication",
+			method:   http.MethodPost,
+			path:     "/v1/logout",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "logout rejects a failed authentication",
+			method:   http.MethodPost,
+			path:     "/v1/logout",
+			user:     &user.DefaultInfo{Name: "system:cattle:error"},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "a non POST logout falls through",
+			method:   http.MethodGet,
+			path:     "/v1/logout",
+			user:     authenticated,
+			wantCode: http.StatusOK,
+			wantBody: "next",
+		},
+		{
+			name:     "other v1 paths fall through",
+			method:   http.MethodPost,
+			path:     "/v1/management.cattle.io.settings",
+			user:     authenticated,
+			wantCode: http.StatusOK,
+			wantBody: "next",
+		},
+		{
+			name:     "v3 is served",
+			method:   http.MethodGet,
+			path:     "/v3/tokens",
+			user:     authenticated,
+			wantCode: http.StatusOK,
+			wantBody: "v3",
+		},
+		{
+			name:     "v1 public is served",
+			method:   http.MethodGet,
+			path:     "/v1-public/authProviders",
+			wantCode: http.StatusOK,
+			wantBody: "v1Public",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(test.method, test.path, nil)
+			if test.user != nil {
+				req = req.WithContext(request.WithUser(req.Context(), test.user))
+			}
+
+			rec := httptest.NewRecorder()
+			newRootMux(testRoutes()).ServeHTTP(rec, req)
+
+			require.Equal(t, test.wantCode, rec.Code)
+			if test.wantBody != "" {
+				assert.Equal(t, test.wantBody, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestNewRootMuxOptionalRoutes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("v3 public and scim fall through when not configured", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newRootMux(testRoutes())
+
+		for _, path := range []string{"/v3-public/authProviders", "/v1-scim/v2/Users"} {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			assert.Equal(t, "next", rec.Body.String(), "path %s", path)
+		}
+	})
+
+	t.Run("v3 public and scim are served when configured", func(t *testing.T) {
+		t.Parallel()
+
+		routes := testRoutes()
+		routes.v3Public = markerHandler("v3Public")
+		routes.scim = markerHandler("scim")
+		mux := newRootMux(routes)
+
+		for path, want := range map[string]string{
+			"/v3-public/authProviders": "v3Public",
+			"/v1-scim/v2/Users":        "scim",
+		} {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			assert.Equal(t, want, rec.Body.String(), "path %s", path)
+		}
+	})
+}

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -197,6 +197,8 @@ func router(ctx context.Context, localClusterEnabled bool, scaledContext *config
 			managementAPI.ServeHTTP(w, r)
 		}
 	})))
+	// The auth server registers this route too, and serves it when MCM is
+	// disabled. Keep the two in sync.
 	authed.Handle("POST /v1/logout", authedMW(logout))
 	saAuthed.Handle("/", authed)
 	authed.Handle("/", metricsAuthed)


### PR DESCRIPTION
## Issue: #56580 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The /v1/logout route was only registered by the multi-cluster management router. With multi-cluster management disabled, as in standalone Harvester, that router never runs and logout requests fall through to Steve, which returns 404.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The route is now also registered on the auth server, which runs in both modes. It requires an authenticated request and is subject to the auth API body limit. The multi-cluster management router runs earlier in the handler chain, so its behavior is unchanged.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests