### PR TITLE
Remove the auth feature flag

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -34,24 +34,6 @@ type Server struct {
 	scaledContext *config.ScaledContext
 }
 
-func NewAlwaysAdmin() (*Server, error) {
-	return &Server{
-		Authenticator: steveauth.ToMiddleware(steveauth.AuthenticatorFunc(steveauth.AlwaysAdmin)),
-		Management: func(next http.Handler) http.Handler {
-			return next
-		},
-	}, nil
-}
-
-func NewHeaderAuth() (*Server, error) {
-	return &Server{
-		Authenticator: steveauth.ToMiddleware(steveauth.AuthenticatorFunc(steveauth.Impersonation)),
-		Management: func(next http.Handler) http.Handler {
-			return next
-		},
-	}, nil
-}
-
 func NewServer(ctx context.Context, wContext *wrangler.Context, scaledContext *config.ScaledContext, authenticator requests.Authenticator) (*Server, error) {
 	authManagement, err := newAPIManagement(ctx, scaledContext, authenticator)
 	if err != nil {
@@ -174,20 +156,16 @@ func (s *Server) Start(ctx context.Context, leader bool) error {
 
 func SetXAPICattleAuthHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if features.Auth.Enabled() {
-			user, ok := request.UserFrom(req.Context())
-			if ok {
-				ok = false
-				for _, group := range user.GetGroups() {
-					if group == "system:authenticated" {
-						ok = true
-					}
+		user, ok := request.UserFrom(req.Context())
+		if ok {
+			ok = false
+			for _, group := range user.GetGroups() {
+				if group == "system:authenticated" {
+					ok = true
 				}
 			}
-			rw.Header().Set("X-API-Cattle-Auth", fmt.Sprint(ok))
-		} else {
-			rw.Header().Set("X-API-Cattle-Auth", "none")
 		}
+		rw.Header().Set("X-API-Cattle-Auth", fmt.Sprint(ok))
 		next.ServeHTTP(rw, req)
 	})
 }

--- a/pkg/crds/crds_test.go
+++ b/pkg/crds/crds_test.go
@@ -190,6 +190,17 @@ func TestEnusure_metadata(t *testing.T) {
 	require.Equal(t, fleet.ReleaseNamespace, fleetObj.Annotations["meta.helm.sh/release-namespace"], "%s CRD missing expected annotation", bootstrapFleetCRD)
 }
 
+func TestRequiredCRDsIncludesAuthCRDs(t *testing.T) {
+	defer features.MCM.Unset()
+
+	for _, mcm := range []bool{true, false} {
+		t.Run(fmt.Sprintf("mcm=%v", mcm), func(t *testing.T) {
+			features.MCM.Set(mcm)
+			require.Subset(t, RequiredCRDs(), AuthCRDs(), "auth CRDs must be required regardless of MCM")
+		})
+	}
+}
+
 func setupFakeClient() *FakeClient {
 	fakeClient := &FakeClient{
 		client: fakeclientset.NewSimpleClientset(staticCRD).ApiextensionsV1().(*fake.FakeApiextensionsV1),

--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -24,9 +24,7 @@ func RequiredCRDs() []string {
 	if features.MCM.Enabled() {
 		requiredCRDS = append(requiredCRDS, MCMCRDs()...)
 	}
-	if features.Auth.Enabled() {
-		requiredCRDS = append(requiredCRDS, AuthCRDs()...)
-	}
+	requiredCRDS = append(requiredCRDS, AuthCRDs()...)
 	if features.UIExtension.Enabled() {
 		requiredCRDS = append(requiredCRDS, UIPluginsCRD()...)
 	}

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -56,12 +56,6 @@ var (
 		true,
 		false,
 		true)
-	Auth = newFeature(
-		"auth",
-		"Enable authentication",
-		true,
-		false,
-		false)
 	ManagedSystemUpgradeController = newFeature(
 		"managed-system-upgrade-controller",
 		"Enable the installation of the system-upgrade-controller app as a managed system chart",
@@ -288,6 +282,13 @@ func InitializeFeatures(featuresClient managementv3.FeatureClient, featureArgs s
 	err = featuresClient.Delete("ui-sql-cache", &metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		logrus.Errorf("unable to delete ui-sql-cache feature: %v", err)
+	}
+
+	// auth feature flag was removed in 2.16, authentication is always enabled.
+	// We need to delete it for users upgrading from 2.15.
+	err = featuresClient.Delete("auth", &metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		logrus.Errorf("unable to delete auth feature: %v", err)
 	}
 
 	// creates any features in map that do not exist, updates features with new default value

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -59,6 +59,7 @@ func TestInitializeFeatures(t *testing.T) {
 				mock := fake.NewMockNonNamespacedControllerInterface[*v3.Feature, *v3.FeatureList](gomock.NewController(t))
 				mock.EXPECT().Delete("external-rules", &metav1.DeleteOptions{})
 				mock.EXPECT().Delete("ui-sql-cache", &metav1.DeleteOptions{})
+				mock.EXPECT().Delete("auth", &metav1.DeleteOptions{})
 
 				return mock
 			},
@@ -69,6 +70,7 @@ func TestInitializeFeatures(t *testing.T) {
 				mock := fake.NewMockNonNamespacedControllerInterface[*v3.Feature, *v3.FeatureList](gomock.NewController(t))
 				mock.EXPECT().Delete("external-rules", &metav1.DeleteOptions{})
 				mock.EXPECT().Delete("ui-sql-cache", &metav1.DeleteOptions{})
+				mock.EXPECT().Delete("auth", &metav1.DeleteOptions{})
 				mock.EXPECT().Get("locked-feature", gomock.Any()).Return(nil, fmt.Errorf("not found"))
 				mock.EXPECT().Create(gomock.Any()).DoAndReturn(func(feature *v3.Feature) (*v3.Feature, error) {
 					assert.Equal(t, "locked-feature", feature.Name)
@@ -96,6 +98,7 @@ func TestInitializeFeatures(t *testing.T) {
 				mock := fake.NewMockNonNamespacedControllerInterface[*v3.Feature, *v3.FeatureList](gomock.NewController(t))
 				mock.EXPECT().Delete("external-rules", &metav1.DeleteOptions{})
 				mock.EXPECT().Delete("ui-sql-cache", &metav1.DeleteOptions{})
+				mock.EXPECT().Delete("auth", &metav1.DeleteOptions{})
 				mock.EXPECT().Get("unlocked-feature", gomock.Any()).Return(nil, fmt.Errorf("not found"))
 				mock.EXPECT().Create(gomock.Any()).DoAndReturn(func(feature *v3.Feature) (*v3.Feature, error) {
 					assert.Equal(t, "unlocked-feature", feature.Name)
@@ -122,6 +125,7 @@ func TestInitializeFeatures(t *testing.T) {
 				mock := fake.NewMockNonNamespacedControllerInterface[*v3.Feature, *v3.FeatureList](gomock.NewController(t))
 				mock.EXPECT().Delete("external-rules", &metav1.DeleteOptions{})
 				mock.EXPECT().Delete("ui-sql-cache", &metav1.DeleteOptions{})
+				mock.EXPECT().Delete("auth", &metav1.DeleteOptions{})
 
 				existingFeature := &v3.Feature{
 					ObjectMeta: metav1.ObjectMeta{
@@ -163,6 +167,7 @@ func TestInitializeFeatures(t *testing.T) {
 				mock := fake.NewMockNonNamespacedControllerInterface[*v3.Feature, *v3.FeatureList](gomock.NewController(t))
 				mock.EXPECT().Delete("external-rules", &metav1.DeleteOptions{})
 				mock.EXPECT().Delete("ui-sql-cache", &metav1.DeleteOptions{})
+				mock.EXPECT().Delete("auth", &metav1.DeleteOptions{})
 
 				existingFeature := &v3.Feature{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -237,35 +237,28 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		}
 	}
 
-	if features.Auth.Enabled() {
-		sc, err := config.NewScaledContext(*restConfig, nil)
-		if err != nil {
-			return nil, err
-		}
+	sc, err := config.NewScaledContext(*restConfig, nil)
+	if err != nil {
+		return nil, err
+	}
 
-		sc.Wrangler = wranglerContext
+	sc.Wrangler = wranglerContext
 
-		sc.UserManager, err = common.NewUserManagerNoBindings(wranglerContext)
-		if err != nil {
-			return nil, err
-		}
+	sc.UserManager, err = common.NewUserManagerNoBindings(wranglerContext)
+	if err != nil {
+		return nil, err
+	}
 
-		sc.ClientGetter, err = normanStoreProxy.NewClientGetterFromConfig(*restConfig)
-		if err != nil {
-			return nil, err
-		}
+	sc.ClientGetter, err = normanStoreProxy.NewClientGetterFromConfig(*restConfig)
+	if err != nil {
+		return nil, err
+	}
 
-		tokenAuthenticator := requests.NewAuthenticator(ctx, clusterrouter.GetClusterID, sc)
+	tokenAuthenticator := requests.NewAuthenticator(ctx, clusterrouter.GetClusterID, sc)
 
-		authServer, err = auth.NewServer(ctx, wranglerContext, sc, tokenAuthenticator)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		authServer, err = auth.NewAlwaysAdmin()
-		if err != nil {
-			return nil, err
-		}
+	authServer, err = auth.NewServer(ctx, wranglerContext, sc, tokenAuthenticator)
+	if err != nil {
+		return nil, err
 	}
 
 	if !features.Turtles.Enabled() {


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Running with the auth feature flag off is not an officially supported configuration. The flag gated three things: 
 - whether the auth server was built or replaced by a passthrough that treated every request as admin,
 - whether the auth CRDs were installed,
 - and whether the `X-API-Cattle-Auth` header reported true or false instead of none.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Authentication is now always enabled. The feature definition is gone, the auth CRDs are always required, and the header reports true or false. The leftover Feature resource is deleted on startup for users upgrading from 2.15.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests
