### PR TITLE
Remove annotation logic from GR and GRBs

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -3,7 +3,6 @@ package globalroles
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -30,7 +29,8 @@ import (
 )
 
 const (
-	globalRoleLabel       = "authz.management.cattle.io/globalrole"
+	globalRoleLabel = "authz.management.cattle.io/globalrole"
+	// crNameAnnotation is used to store the name of the ClusterRole created for a GlobalRole. It is only for informational purposes and is not used for reconciliation.
 	crNameAnnotation      = "authz.management.cattle.io/cr-name"
 	initialSyncAnnotation = "authz.management.cattle.io/initial-sync"
 	clusterRoleKind       = "ClusterRole"
@@ -45,8 +45,7 @@ const (
 	InheritedNamespacedRuleRoleExists = "InheritedNamespacedRuleRoleExists"
 	NamespaceNotAvailable             = "NamespaceNotAvailable"
 	FailedToGetNamespace              = "GetNamespaceFailed"
-	FailedToCreateClusterRole         = "CreateClusterRoleFailed"
-	FailedToUpdateClusterRole         = "UpdateClusterRoleFailed"
+	FailedToReconcileClusterRole      = "ReconcileClusterRoleFailed"
 	FailedToGetCluster                = "GetClusterFailed"
 )
 
@@ -58,7 +57,6 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 	return &globalRoleLifecycle{
 		clusters:                management.Wrangler.Mgmt.Cluster(),
 		clusterManager:          clusterManager,
-		crLister:                management.Wrangler.RBAC.ClusterRole().Cache(),
 		crClient:                management.Wrangler.RBAC.ClusterRole(),
 		nsCache:                 management.Wrangler.Core.Namespace().Cache(),
 		rLister:                 management.Wrangler.RBAC.Role().Cache(),
@@ -74,7 +72,6 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 type globalRoleLifecycle struct {
 	clusters                mgmtv3.ClusterClient
 	clusterManager          *clustermanager.Manager
-	crLister                wrbacv1.ClusterRoleCache
 	crClient                wrbacv1.ClusterRoleClient
 	nsCache                 wcorev1.NamespaceCache
 	rLister                 wrbacv1.RoleCache
@@ -107,7 +104,7 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 		gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj, &localConditions),
 		gr.updateStatus(obj, localConditions),
 	)
-	return nil, returnError
+	return obj, returnError
 }
 
 func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (runtime.Object, error) {
@@ -139,39 +136,18 @@ func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (runtime.Object, error
 }
 
 func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, localConditions *[]metav1.Condition) error {
-	crName := getCRName(globalRole)
+	crName := getCRName(globalRole.Name)
+	// Set the name of the cluster role in an annotation on the globalrole for informational purposes. This is not used for reconciliation.
+	if globalRole.Annotations == nil {
+		globalRole.Annotations = map[string]string{}
+	}
+	globalRole.Annotations[crNameAnnotation] = crName
+
 	condition := metav1.Condition{
 		Type: ClusterRoleExists,
 	}
 
-	clusterRole, _ := gr.crLister.Get(crName)
-	if clusterRole != nil {
-		updated := false
-		clusterRole = clusterRole.DeepCopy()
-		if !reflect.DeepEqual(globalRole.Rules, clusterRole.Rules) {
-			clusterRole.Rules = globalRole.Rules
-			logrus.Infof("[%v] Updating clusterRole %v. GlobalRole rules have changed. Have: %+v. Want: %+v", grController, clusterRole.Name, clusterRole.Rules, globalRole.Rules)
-			updated = true
-		}
-		// Ensure existing ClusterRoles have the correct grOwnerLabel pointing to the owning GlobalRole.
-		if grName := clusterRole.Labels[grOwnerLabel]; grName != globalRole.Name {
-			clusterRole.Labels[grOwnerLabel] = globalRole.Name
-			logrus.Infof("[%v] Updating clusterRole %s owner from %s to %s.", grController, clusterRole.Name, grName, globalRole.Name)
-			updated = true
-		}
-
-		if updated {
-			if _, err := gr.crClient.Update(clusterRole); err != nil {
-				gr.status.AddCondition(localConditions, condition, FailedToUpdateClusterRole, err)
-				return fmt.Errorf("couldn't update ClusterRole %v: %w", clusterRole.Name, err)
-			}
-		}
-		gr.status.AddCondition(localConditions, condition, ClusterRoleExists, nil)
-		return nil
-	}
-
-	logrus.Infof("[%s] Creating clusterRole %s for corresponding GlobalRole", grController, crName)
-	_, err := gr.crClient.Create(&rbacv1.ClusterRole{
+	desiredClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crName,
 			OwnerReferences: []metav1.OwnerReference{
@@ -188,18 +164,49 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, lo
 			},
 		},
 		Rules: globalRole.Rules,
+	}
+
+	clusterRoles, err := gr.crClient.List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", grOwnerLabel, globalRole.Name),
 	})
 	if err != nil {
-		gr.status.AddCondition(localConditions, condition, FailedToCreateClusterRole, err)
+		err = fmt.Errorf("couldn't list ClusterRoles for globalRole %v: %w", globalRole.Name, err)
+		gr.status.AddCondition(localConditions, condition, FailedToReconcileClusterRole, err)
 		return err
 	}
-	// Add an annotation to the globalrole indicating the name we used for future updates
-	if globalRole.Annotations == nil {
-		globalRole.Annotations = map[string]string{}
+
+	// Delete any ClusterRoles that were created for this GlobalRole but have the wrong name.
+	for _, clusterRole := range clusterRoles.Items {
+		if clusterRole.Name != crName {
+			if err := rbac.DeleteResource(clusterRole.Name, gr.crClient); err != nil {
+				err = fmt.Errorf("couldn't delete ClusterRole %v for globalRole %v: %w", clusterRole.Name, globalRole.Name, err)
+				gr.status.AddCondition(localConditions, condition, FailedToReconcileClusterRole, err)
+				return err
+			}
+		}
 	}
-	globalRole.Annotations[crNameAnnotation] = crName
+
+	if err := rbac.CreateOrUpdateResource(desiredClusterRole, gr.crClient, areGlobalRoleClusterRolesSame); err != nil {
+		gr.status.AddCondition(localConditions, condition, FailedToReconcileClusterRole, err)
+		return fmt.Errorf("couldn't reconcile ClusterRole %v: %w", crName, err)
+	}
+
 	gr.status.AddCondition(localConditions, condition, ClusterRoleExists, nil)
 	return nil
+}
+
+// areGlobalRoleClusterRolesSame returns true if the ClusterRole created for a GlobalRole matches the desired Rules, owner label, and owner reference.
+func areGlobalRoleClusterRolesSame(currentCR, desiredCR *rbacv1.ClusterRole) bool {
+	if !equality.Semantic.DeepEqual(currentCR.Rules, desiredCR.Rules) {
+		return false
+	}
+	if currentCR.Labels[grOwnerLabel] != desiredCR.Labels[grOwnerLabel] {
+		return false
+	}
+	if !equality.Semantic.DeepEqual(currentCR.OwnerReferences, desiredCR.OwnerReferences) {
+		return false
+	}
+	return true
 }
 
 // reconcileNamespacedRoles ensures that Roles exist in each namespace of NamespacedRules
@@ -481,15 +488,8 @@ func (gr *globalRoleLifecycle) updateStatus(globalRole *v3.GlobalRole, localCond
 	})
 }
 
-func getCRName(globalRole *v3.GlobalRole) string {
-	if crName, ok := globalRole.Annotations[crNameAnnotation]; ok {
-		return crName
-	}
-	return generateCRName(globalRole.Name)
-}
-
-func generateCRName(name string) string {
-	return "cattle-globalrole-" + name
+func getCRName(grName string) string {
+	return name.SafeConcatName("cattle-globalrole", grName)
 }
 
 // validateNamespace checks if a namespace exists and is not terminating

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -52,13 +52,22 @@ var (
 			readPodPolicyRule,
 		},
 	}
+	defaultGROwnerRefs = []metav1.OwnerReference{
+		{
+			APIVersion: defaultGR.TypeMeta.APIVersion,
+			Kind:       defaultGR.TypeMeta.Kind,
+			Name:       defaultGR.Name,
+			UID:        defaultGR.UID,
+		},
+	}
 	readConfigCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: getCRName(defaultGR.Name),
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
 				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
 			},
+			OwnerReferences: defaultGROwnerRefs,
 		},
 		Rules: []rbacv1.PolicyRule{
 			readConfigPolicyRule,
@@ -66,7 +75,32 @@ var (
 	}
 	readPodCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: getCRName(defaultGR.Name),
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrole": "true",
+				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
+			},
+			OwnerReferences: defaultGROwnerRefs,
+		},
+		Rules: []rbacv1.PolicyRule{
+			readPodPolicyRule,
+		},
+	}
+	missingLabelCR = rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getCRName(defaultGR.Name),
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrole": "true",
+			},
+			OwnerReferences: defaultGROwnerRefs,
+		},
+		Rules: []rbacv1.PolicyRule{
+			readPodPolicyRule,
+		},
+	}
+	missingOwnerRefCR = rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getCRName(defaultGR.Name),
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
 				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
@@ -76,12 +110,14 @@ var (
 			readPodPolicyRule,
 		},
 	}
-	missingLabelCR = rbacv1.ClusterRole{
+	staleNamedCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: "stale-cluster-role-name",
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
+				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
 			},
+			OwnerReferences: defaultGROwnerRefs,
 		},
 		Rules: []rbacv1.PolicyRule{
 			readPodPolicyRule,
@@ -115,8 +151,8 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 	type controllers struct {
 		crController *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]
-		crCache      *fake.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]
 	}
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}, "clusterRole")
 	tests := []struct {
 		name             string
 		setupControllers func(controllers)
@@ -128,7 +164,8 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "no changes to clusterRole",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  false,
@@ -140,7 +177,8 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "clusterRole is updated",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -153,33 +191,36 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "update clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
 			condition: reducedCondition{
-				reason: FailedToUpdateClusterRole,
+				reason: FailedToReconcileClusterRole,
 				status: metav1.ConditionFalse,
 			},
 		},
 		{
 			name: "create clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(nil, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
 			condition: reducedCondition{
-				reason: FailedToCreateClusterRole,
+				reason: FailedToReconcileClusterRole,
 				status: metav1.ConditionFalse,
 			},
 		},
 		{
 			name: "clusterRole is created",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(nil, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -188,12 +229,13 @@ func TestReconcileGlobalRole(t *testing.T) {
 				reason: ClusterRoleExists,
 				status: metav1.ConditionTrue,
 			},
-			annotation: getCRName(&defaultGR),
+			annotation: getCRName(defaultGR.Name),
 		},
 		{
 			name: "missing grOwnerLabel in clusterRole triggers update",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(missingLabelCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingLabelCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingLabelCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -203,6 +245,75 @@ func TestReconcileGlobalRole(t *testing.T) {
 				status: metav1.ConditionTrue,
 			},
 		},
+		{
+			name: "missing OwnerReference in clusterRole triggers update",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingOwnerRefCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingOwnerRefCR.DeepCopy(), nil)
+				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "stale-named ClusterRole is deleted and the correct one is created",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "stale-named ClusterRole already gone is not an error",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(notFoundErr)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "deleting a stale-named ClusterRole fails",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("error"))
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  true,
+			condition: reducedCondition{
+				reason: FailedToReconcileClusterRole,
+				status: metav1.ConditionFalse,
+			},
+		},
+		{
+			name: "listing ClusterRoles fails",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  true,
+			condition: reducedCondition{
+				reason: FailedToReconcileClusterRole,
+				status: metav1.ConditionFalse,
+			},
+		},
 	}
 
 	ctrl := gomock.NewController(t)
@@ -210,7 +321,6 @@ func TestReconcileGlobalRole(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			controllers := controllers{
 				crController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl),
-				crCache:      fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl),
 			}
 			if test.setupControllers != nil {
 				test.setupControllers(controllers)
@@ -218,7 +328,6 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 			grLifecycle := globalRoleLifecycle{
 				crClient: controllers.crController,
-				crLister: controllers.crCache,
 				status:   status.NewStatus(),
 			}
 			localConditions := []metav1.Condition{}
@@ -657,7 +766,7 @@ func TestUpdateStatus(t *testing.T) {
 		{
 			name: "condition false - error summary",
 			localConditions: []metav1.Condition{
-				{Type: ClusterRoleExists, Status: metav1.ConditionFalse, Reason: FailedToCreateClusterRole},
+				{Type: ClusterRoleExists, Status: metav1.ConditionFalse, Reason: FailedToReconcileClusterRole},
 			},
 			grFromCluster: &v3.GlobalRole{},
 			wantSummary:   status.SummaryError,

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -3,6 +3,7 @@ package globalroles
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -58,9 +59,10 @@ var (
 )
 
 const (
+	// crbNameAnnotation records the name of the ClusterRoleBinding created for a GlobalRoleBinding, for
+	// reference purposes. It is not read back for reconciliation.
 	crbNameAnnotation             = "authz.management.cattle.io/crb-name"
 	crtbGrbOwnerIndex             = "authz.management.cattle.io/crtb-owner"
-	crbNamePrefix                 = "cattle-globalrolebinding-"
 	localClusterName              = "local"
 	grbOwnerLabel                 = "authz.management.cattle.io/grb-owner"
 	fleetWorkspacePermissionLabel = "authz.management.cattle.io/fleet-workspace-permissions"
@@ -380,58 +382,16 @@ func (l *globalRoleBindingLifecycle) findMissingRTs(wantRTs []string, cluster *v
 func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBinding *v3.GlobalRoleBinding, localConditions *[]metav1.Condition) error {
 	condition := metav1.Condition{Type: globalRoleBindingReconciled}
 
-	crbName, ok := globalRoleBinding.Annotations[crbNameAnnotation]
-	if !ok {
-		crbName = crbNamePrefix + globalRoleBinding.Name
+	crbName := getCRBName(globalRoleBinding.Name)
+	if globalRoleBinding.Annotations == nil {
+		globalRoleBinding.Annotations = map[string]string{}
 	}
+	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
 
-	subject := rbac.GetGRBSubject(globalRoleBinding)
+	grLabels := map[string]string{grbOwnerLabel: globalRoleBinding.Name}
+	maps.Copy(grLabels, globalRoleBindingLabel)
 
-	crb, _ := l.crbLister.Get(crbName)
-	if crb != nil {
-		subjects := []rbacv1.Subject{subject}
-		updateSubject := !reflect.DeepEqual(subjects, crb.Subjects)
-
-		updateRoleRef := false
-		var roleRef rbacv1.RoleRef
-		gr, _ := l.grLister.Get(globalRoleBinding.GlobalRoleName)
-		if gr != nil {
-			crNameFromGR := getCRName(gr)
-			if crNameFromGR != crb.RoleRef.Name {
-				updateRoleRef = true
-				roleRef = rbacv1.RoleRef{
-					Name: crNameFromGR,
-					Kind: clusterRoleKind,
-				}
-			}
-		}
-		if updateSubject || updateRoleRef {
-			crb = crb.DeepCopy()
-			if updateRoleRef {
-				crb.RoleRef = roleRef
-			}
-			crb.Subjects = subjects
-			logrus.Infof("[%v] Updating clusterRoleBinding %v for globalRoleBinding %v user %v", grbController, crb.Name, globalRoleBinding.Name, globalRoleBinding.UserName)
-			if _, err := l.crbClient.Update(crb); err != nil {
-				l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
-				return fmt.Errorf("couldn't update ClusterRoleBinding %v: %w", crb.Name, err)
-			}
-		}
-
-		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
-		return nil
-	}
-
-	logrus.Infof("Creating new GlobalRoleBinding for GlobalRoleBinding %v", globalRoleBinding.Name)
-	gr, _ := l.grLister.Get(globalRoleBinding.GlobalRoleName)
-	var crName string
-	if gr != nil {
-		crName = getCRName(gr)
-	} else {
-		crName = generateCRName(globalRoleBinding.GlobalRoleName)
-	}
-	logrus.Infof("[%v] Creating clusterRoleBinding for globalRoleBinding %v for user %v with role %v", grbController, globalRoleBinding.Name, globalRoleBinding.UserName, crName)
-	_, err := l.crbClient.Create(&rbacv1.ClusterRoleBinding{
+	desiredCRB := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crbName,
 			OwnerReferences: []metav1.OwnerReference{
@@ -442,26 +402,77 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 					UID:        globalRoleBinding.UID,
 				},
 			},
-			Labels: globalRoleBindingLabel,
+			Labels: grLabels,
 		},
-		Subjects: []rbacv1.Subject{subject},
+		Subjects: []rbacv1.Subject{rbac.GetGRBSubject(globalRoleBinding)},
 		RoleRef: rbacv1.RoleRef{
-			Name: crName,
+			Name: getCRName(globalRoleBinding.GlobalRoleName),
 			Kind: clusterRoleKind,
 		},
-	})
+	}
+
+	clusterRoleBindings, err := l.crbLister.List(labels.SelectorFromSet(map[string]string{grbOwnerLabel: globalRoleBinding.Name}))
 	if err != nil {
-		l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+		err = fmt.Errorf("couldn't list ClusterRoleBindings for globalRoleBinding %v: %w", globalRoleBinding.Name, err)
+		l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
 		return err
 	}
-	// Add an annotation to the globalrole indicating the name we used for future updates
-	if globalRoleBinding.Annotations == nil {
-		globalRoleBinding.Annotations = map[string]string{}
+
+	// Delete any ClusterRoleBindings that were created for this GlobalRoleBinding but have the wrong name.
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		if clusterRoleBinding.Name != crbName {
+			if err := rbac.DeleteResource(clusterRoleBinding.Name, l.crbClient); err != nil {
+				err = fmt.Errorf("couldn't delete ClusterRoleBinding %v for globalRoleBinding %v: %w", clusterRoleBinding.Name, globalRoleBinding.Name, err)
+				l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+				return err
+			}
+		}
 	}
-	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
+
+	crb, _ := l.crbLister.Get(crbName)
+	if crb == nil {
+		logrus.Infof("[%v] Creating clusterRoleBinding for globalRoleBinding %v for user %v with role %v", grbController, globalRoleBinding.Name, globalRoleBinding.UserName, desiredCRB.RoleRef.Name)
+		if _, err := l.crbClient.Create(desiredCRB); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+			return err
+		}
+		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
+		return nil
+	}
+
+	// RoleRef is immutable on an existing ClusterRoleBinding, so a RoleRef change can only be applied by
+	// deleting and recreating it rather than updating it in place.
+	if !reflect.DeepEqual(crb.RoleRef, desiredCRB.RoleRef) {
+		logrus.Infof("[%v] Recreating clusterRoleBinding %v for globalRoleBinding %v with role %v", grbController, crb.Name, globalRoleBinding.Name, desiredCRB.RoleRef.Name)
+		if err := l.crbClient.Delete(crb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't delete ClusterRoleBinding %v: %w", crb.Name, err)
+		}
+		if _, err := l.crbClient.Create(desiredCRB); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't create ClusterRoleBinding %v: %w", desiredCRB.Name, err)
+		}
+		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
+		return nil
+	}
+
+	if !reflect.DeepEqual(crb.Subjects, desiredCRB.Subjects) {
+		crb = crb.DeepCopy()
+		crb.Subjects = desiredCRB.Subjects
+		logrus.Infof("[%v] Updating clusterRoleBinding %v for globalRoleBinding %v user %v", grbController, crb.Name, globalRoleBinding.Name, globalRoleBinding.UserName)
+		if _, err := l.crbClient.Update(crb); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't update ClusterRoleBinding %v: %w", crb.Name, err)
+		}
+	}
 
 	l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
 	return nil
+}
+
+// getCRBName returns the name of the ClusterRoleBinding backing a GlobalRoleBinding with the given name.
+func getCRBName(grbName string) string {
+	return wrangler.SafeConcatName("cattle-globalrolebinding", grbName)
 }
 
 // reconcileNamespacedRoleBindings ensures that RoleBindings exist for each namespace listed in NamespacedRules

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -406,35 +406,6 @@ func TestReconcileClusterPermissions(t *testing.T) {
 func TestReconcileGlobalRoleBinding(t *testing.T) {
 	t.Parallel()
 
-	testGR := v3.GlobalRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gr",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{"get", "list", "watch"},
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-			},
-		},
-	}
-
-	testGRWithAnnotation := v3.GlobalRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gr",
-			Annotations: map[string]string{
-				crNameAnnotation: "custom-cr-name",
-			},
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{"get", "list", "watch"},
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-			},
-		},
-	}
-
 	testGRB := v3.GlobalRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-grb",
@@ -448,25 +419,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		UserName:       "test-user",
 	}
 
-	testGRBWithAnnotation := v3.GlobalRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-grb",
-			UID:  "1234",
-			Annotations: map[string]string{
-				crbNameAnnotation: "custom-crb-name",
-			},
-		},
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "management.cattle.io/v3",
-			Kind:       "GlobalRoleBinding",
-		},
-		GlobalRoleName: "test-gr",
-		UserName:       "test-user",
-	}
-
 	expectedCRB := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: crbNamePrefix + "test-grb",
+			Name: getCRBName("test-grb"),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "management.cattle.io/v3",
@@ -475,7 +430,10 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					UID:        "1234",
 				},
 			},
-			Labels: globalRoleBindingLabel,
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrolebinding": "true",
+				grbOwnerLabel: "test-grb",
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -485,7 +443,36 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: generateCRName("test-gr"),
+			Name: getCRName("test-gr"),
+			Kind: clusterRoleKind,
+		},
+	}
+
+	staleNamedCRB := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stale-cluster-role-binding-name",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "GlobalRoleBinding",
+					Name:       "test-grb",
+					UID:        "1234",
+				},
+			},
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrolebinding": "true",
+				grbOwnerLabel: "test-grb",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     "test-user",
+				APIGroup: rbacv1.GroupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: getCRName("test-gr"),
 			Kind: clusterRoleKind,
 		},
 	}
@@ -493,7 +480,6 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 	type controllers struct {
 		crbCache      *fake.MockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding]
 		crbController *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]
-		grCache       *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
 	}
 
 	tests := []struct {
@@ -506,45 +492,19 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "create new clusterRoleBinding",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(&expectedCRB, nil)
 			},
 			inputObject:    testGRB.DeepCopy(),
 			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
-		},
-		{
-			name: "create new clusterRoleBinding with custom annotation",
-			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get("custom-crb-name").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
-				customCRB := expectedCRB.DeepCopy()
-				customCRB.Name = "custom-crb-name"
-				c.crbController.EXPECT().Create(customCRB).Return(customCRB, nil)
-			},
-			inputObject:    testGRBWithAnnotation.DeepCopy(),
-			wantError:      false,
-			wantAnnotation: "custom-crb-name",
-		},
-		{
-			name: "create new clusterRoleBinding uses CR name from GlobalRole annotation",
-			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGRWithAnnotation.DeepCopy(), nil)
-				crbWithCustomCR := expectedCRB.DeepCopy()
-				crbWithCustomCR.RoleRef.Name = "custom-cr-name"
-				c.crbController.EXPECT().Create(crbWithCustomCR).Return(crbWithCustomCR, nil)
-			},
-			inputObject:    testGRB.DeepCopy(),
-			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
+			wantAnnotation: getCRBName("test-grb"),
 		},
 		{
 			name: "clusterRoleBinding creation fails",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(nil, fmt.Errorf("server unavailable"))
 			},
 			inputObject: testGRB.DeepCopy(),
@@ -554,11 +514,12 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			name: "clusterRoleBinding already exists no update needed",
 			setupControllers: func(c controllers) {
 				existingCRB := expectedCRB.DeepCopy()
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 			},
-			inputObject: testGRB.DeepCopy(),
-			wantError:   false,
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
 		},
 		{
 			name: "update clusterRoleBinding subject",
@@ -571,8 +532,8 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 						APIGroup: rbacv1.GroupName,
 					},
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				updatedCRB := expectedCRB.DeepCopy()
 				c.crbController.EXPECT().Update(updatedCRB).Return(updatedCRB, nil)
 			},
@@ -587,10 +548,10 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
-				updatedCRB := expectedCRB.DeepCopy()
-				c.crbController.EXPECT().Update(updatedCRB).Return(updatedCRB, nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
 			},
 			inputObject: testGRB.DeepCopy(),
 			wantError:   false,
@@ -610,13 +571,44 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
-				updatedCRB := expectedCRB.DeepCopy()
-				c.crbController.EXPECT().Update(updatedCRB).Return(updatedCRB, nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
 			},
 			inputObject: testGRB.DeepCopy(),
 			wantError:   false,
+		},
+		{
+			name: "roleRef change: delete fails",
+			setupControllers: func(c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "roleRef change: recreate fails",
+			setupControllers: func(c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
 		},
 		{
 			name: "update clusterRoleBinding fails",
@@ -629,8 +621,8 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 						APIGroup: rbacv1.GroupName,
 					},
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				updatedCRB := expectedCRB.DeepCopy()
 				c.crbController.EXPECT().Update(updatedCRB).Return(nil, fmt.Errorf("server unavailable"))
 			},
@@ -638,24 +630,51 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			wantError:   true,
 		},
 		{
-			name: "globalRole not found uses generated name",
+			name: "stale-named ClusterRoleBinding is deleted and the correct one is created",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(nil, apierrors.NewNotFound(schema.GroupResource{
-					Group:    "management.cattle.io",
-					Resource: "GlobalRole",
-				}, "test-gr"))
-				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(&expectedCRB, nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
 			},
 			inputObject:    testGRB.DeepCopy(),
 			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "stale-named ClusterRoleBinding already gone is not an error",
+			setupControllers: func(c controllers) {
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"}, staleNamedCRB.Name))
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
+			},
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "deleting a stale-named ClusterRoleBinding fails",
+			setupControllers: func(c controllers) {
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "listing ClusterRoleBindings fails",
+			setupControllers: func(c controllers) {
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
 		},
 		{
 			name: "group principal binding",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				groupCRB := expectedCRB.DeepCopy()
 				groupCRB.Subjects = []rbacv1.Subject{
 					{
@@ -679,7 +698,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 				GroupPrincipalName: "test-group",
 			},
 			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
+			wantAnnotation: getCRBName("test-grb"),
 		},
 	}
 
@@ -689,7 +708,6 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			controllers := controllers{
 				crbCache:      fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl),
 				crbController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl),
-				grCache:       fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRole](ctrl),
 			}
 			if test.setupControllers != nil {
 				test.setupControllers(controllers)
@@ -698,7 +716,6 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			grbLifecycle := globalRoleBindingLifecycle{
 				crbLister: controllers.crbCache,
 				crbClient: controllers.crbController,
-				grLister:  controllers.grCache,
 				status:    status.NewStatus(),
 			}
 			var conditions []metav1.Condition
@@ -1313,8 +1330,10 @@ func Test_globalRoleBindingLifecycle_Create(t *testing.T) {
 		crtbClient := fake.NewMockClientInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 		crtbClient.EXPECT().Create(gomock.Any()).Return(&v3.ClusterRoleTemplateBinding{}, nil)
 
-		// reconcileGlobalRoleBinding: Check if a ClusterRoleBinding already exists for this GRB
+		// reconcileGlobalRoleBinding: List existing ClusterRoleBindings owned by this GRB, then check if the
+		// correctly-named one already exists
 		crbLister := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+		crbLister.EXPECT().List(gomock.Any()).Return(nil, nil)
 		crbLister.EXPECT().Get(gomock.Any()).Return(nil, apierrors.NewNotFound(rbacv1.Resource("clusterrolebinding"), "test"))
 
 		// reconcileGlobalRoleBinding: Create a ClusterRoleBinding to bind the user to the GlobalRole's ClusterRole
@@ -1418,7 +1437,7 @@ func Test_globalRoleBindingLifecycle_Create(t *testing.T) {
 		resultGRB, ok := result.(*v3.GlobalRoleBinding)
 		require.True(t, ok)
 		require.Equal(t, testPrincipal, resultGRB.UserPrincipalName, "user principal should be set by reconcileSubject")
-		require.Equal(t, crbNamePrefix+testGRBName, resultGRB.Annotations[crbNameAnnotation], "CRB annotation should be set by reconcileGlobalRoleBinding")
+		require.Equal(t, getCRBName(testGRBName), resultGRB.Annotations[crbNameAnnotation], "CRB annotation should be set by reconcileGlobalRoleBinding")
 	})
 }
 

--- a/tests/controllers/globalroles/globalrole_test.go
+++ b/tests/controllers/globalroles/globalrole_test.go
@@ -179,11 +179,11 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 	}{
 		// NOTE: These test can be run in parallel only if the global role names are unique
 		{
-			name: "create primary cluster role given cr-name",
+			name: "ignore cr-name label and use global role name for cluster role",
 			globalRole: v3.GlobalRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						crNameLabel: "cr-name",
+						crNameLabel: "cr-label",
 					},
 					Name: "cr-name-gr",
 				},
@@ -191,7 +191,7 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 			},
 			clusterRole: rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cr-name",
+					Name: "cattle-globalrole-cr-name-gr",
 				},
 				Rules: []rbacv1.PolicyRule{getPodRule},
 			},
@@ -252,7 +252,6 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.Run(test.name, func() {
 			t := s.T()
 			t.Parallel()


### PR DESCRIPTION
## Problem
The `authz.management.cattle.io/cr-name` and `authz.management.cattle.io/crb-name` annotations for GlobalRoles and GlobalRoleBindings respectively are used to determine cluster role and cluster role binding names.
 
## Solution
Compute the names each time instead and use the annotations as purely informational.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_