### PR TITLE
fix(capr/planner): restart workers when server-only flags affecting agents change

### DIFF
--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -45,6 +45,35 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// agentAffectingServerFlags lists flags that are server-only in KDM (appear in ServerArgs
+// but not AgentArgs) yet still affect agent behavior at runtime. Because filterConfigData
+// strips these from worker config files, the worker restart stamp never changes when they
+// are toggled — workers would not restart and would not pick up the change.
+//
+// Flags in this list are included in the worker restart stamp and drain hash so that
+// changing them causes affected workers to restart.
+//
+// NOTE: When a new server-only flag is found to affect agent behavior, add it here.
+var agentAffectingServerFlags = []string{
+	"disable-kube-proxy",
+}
+
+// agentAffectingServerConfig extracts the values of server-only flags from machineGlobalConfig
+// that are known to affect agent behavior.
+func agentAffectingServerConfig(controlPlane *rkev1.RKEControlPlane) map[string]interface{} {
+	result := map[string]interface{}{}
+	release := capr.GetKDMReleaseData(context.TODO(), controlPlane) // already used in filter.go
+	for k, field := range release.ServerArgs {
+		if !field.AgentRestart {
+			continue
+		}
+		if v, ok := controlPlane.Spec.MachineGlobalConfig.Data[k]; ok {
+			result[k] = v
+		}
+	}
+	return result
+}
+
 // addEtcd mutates the given config map with etcd-specific configuration elements, and adds S3-related arguments and files if renderS3 is true.
 func (p *Planner) addETCD(config map[string]interface{}, controlPlane *rkev1.RKEControlPlane, entry *planEntry, renderS3 bool) (result []plan.File, _ error) {
 	if !isEtcd(entry) || controlPlane.Spec.ETCD == nil {
@@ -374,7 +403,7 @@ func addOtherFiles(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, 
 	return nodePlan, nil
 }
 
-func restartStamp(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, image string) string {
+func restartStamp(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, image string, entry *planEntry) string {
 	restartStamp := sha256.New()
 	restartStamp.Write([]byte(strconv.Itoa(controlPlane.Spec.ProvisionGeneration)))
 	restartStamp.Write([]byte(image))
@@ -386,10 +415,15 @@ func restartStamp(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, i
 		restartStamp.Write([]byte(file.Content))
 	}
 	restartStamp.Write([]byte(strconv.FormatInt(controlPlane.Status.ConfigGeneration, 10)))
+	if isOnlyWorker(entry) {
+		if config, err := json.Marshal(agentAffectingServerConfig(controlPlane)); err == nil {
+			restartStamp.Write(config)
+		}
+	}
 	return hex.EncodeToString(restartStamp.Sum(nil))
 }
 
-func drainHash(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, image string) string {
+func drainHash(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, image string, entry *planEntry) string {
 	h := sha256.New()
 	h.Write([]byte(strconv.Itoa(controlPlane.Spec.ProvisionGeneration)))
 	h.Write([]byte(image))
@@ -405,6 +439,11 @@ func drainHash(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, imag
 		}
 	}
 	h.Write([]byte(strconv.FormatInt(controlPlane.Status.ConfigGeneration, 10)))
+	if isOnlyWorker(entry) {
+		if serverFlagBytes, err := json.Marshal(agentAffectingServerConfig(controlPlane)); err == nil {
+			h.Write(serverFlagBytes)
+		}
+	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/pkg/capr/planner/config_test.go
+++ b/pkg/capr/planner/config_test.go
@@ -10,11 +10,14 @@ import (
 	"strings"
 	"testing"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/data/management"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
 func TestPrimaryAddressFamily(t *testing.T) {
@@ -786,4 +789,112 @@ func buildExtractConfigGzipPayload(t *testing.T, payload []byte) string {
 	}
 
 	return base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func TestAgentAffectingServerConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]any
+		expected map[string]interface{}
+	}{
+		{
+			name:     "empty config",
+			config:   map[string]any{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "disable-kube-proxy present",
+			config:   map[string]any{"disable-kube-proxy": true, "cni": "cilium"},
+			expected: map[string]interface{}{"disable-kube-proxy": true},
+		},
+		{
+			name:     "only unrelated keys",
+			config:   map[string]any{"cni": "cilium", "tls-san": "example.com"},
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := &rkev1.RKEControlPlane{
+				Spec: rkev1.RKEControlPlaneSpec{
+					ClusterConfiguration: rkev1.ClusterConfiguration{
+						MachineGlobalConfig: rkev1.GenericMap{Data: tt.config},
+					},
+				},
+			}
+			result := agentAffectingServerConfig(cp)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRestartStampWorkerChangesWithDisableKubeProxy(t *testing.T) {
+	a := assert.New(t)
+
+	workerEntry := &planEntry{
+		Metadata: &plan.Metadata{
+			Labels: map[string]string{
+				capr.CattleOSLabel:        "linux",
+				capr.ControlPlaneRoleLabel: "false",
+				capr.EtcdRoleLabel:        "false",
+				capr.WorkerRoleLabel:      "true",
+			},
+		},
+		Machine: &capi.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					capr.ControlPlaneRoleLabel: "false",
+					capr.EtcdRoleLabel:        "false",
+					capr.WorkerRoleLabel:      "true",
+				},
+			},
+		},
+	}
+
+	cpEntry := &planEntry{
+		Metadata: &plan.Metadata{
+			Labels: map[string]string{
+				capr.CattleOSLabel:        "linux",
+				capr.ControlPlaneRoleLabel: "true",
+				capr.EtcdRoleLabel:        "true",
+				capr.WorkerRoleLabel:      "false",
+			},
+		},
+		Machine: &capi.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					capr.ControlPlaneRoleLabel: "true",
+					capr.EtcdRoleLabel:        "true",
+					capr.WorkerRoleLabel:      "false",
+				},
+			},
+		},
+	}
+
+	cpWithout := &rkev1.RKEControlPlane{
+		Spec: rkev1.RKEControlPlaneSpec{
+			ClusterConfiguration: rkev1.ClusterConfiguration{
+				MachineGlobalConfig: rkev1.GenericMap{Data: map[string]any{"cni": "cilium"}},
+			},
+		},
+	}
+	cpWith := &rkev1.RKEControlPlane{
+		Spec: rkev1.RKEControlPlaneSpec{
+			ClusterConfiguration: rkev1.ClusterConfiguration{
+				MachineGlobalConfig: rkev1.GenericMap{Data: map[string]any{"cni": "cilium", "disable-kube-proxy": true}},
+			},
+		},
+	}
+
+	nodePlan := plan.NodePlan{}
+	image := "test-image"
+
+	workerStampWithout := restartStamp(nodePlan, cpWithout, image, workerEntry)
+	workerStampWith := restartStamp(nodePlan, cpWith, image, workerEntry)
+	a.NotEqual(workerStampWithout, workerStampWith, "worker restart stamp should change when disable-kube-proxy is toggled")
+
+	cpStampWithout := restartStamp(nodePlan, cpWithout, image, cpEntry)
+	cpStampWith := restartStamp(nodePlan, cpWith, image, cpEntry)
+	a.Equal(cpStampWithout, cpStampWith, "control plane restart stamp should not be affected by agentAffectingServerFlags logic")
 }

--- a/pkg/capr/planner/instructions.go
+++ b/pkg/capr/planner/instructions.go
@@ -93,8 +93,8 @@ func (p *Planner) generateInstallInstruction(controlPlane *rkev1.RKEControlPlane
 func (p *Planner) addInstallInstructionWithRestartStamp(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, entry *planEntry) (plan.NodePlan, error) {
 	env := make([]string, 0, 2)
 	image := p.getInstallerImage(controlPlane)
-	stamp := restartStamp(nodePlan, controlPlane, image)
-	drainHash := drainHash(nodePlan, controlPlane, image)
+	stamp := restartStamp(nodePlan, controlPlane, image, entry)
+	drainHash := drainHash(nodePlan, controlPlane, image, entry)
 	switch entry.Metadata.Labels[capr.CattleOSLabel] {
 	case capr.WindowsMachineOS:
 		env = append(env,


### PR DESCRIPTION
## Issue: #55326

  ## Depends on
  - https://github.com/rancher/channelserver/pull/45 — adds `AgentRestart` to `schemas.Field` so the metadata is
  readable.
  - https://github.com/rancher/kontainer-driver-metadata/pull/2156 — sets `agentRestart: true` on the
  `disable-kube-proxy` serverArg.

  Both must merge (and the wrangler version be bumped here) before this behaves correctly.

  ## Problem

  When `disable-kube-proxy: true` is set in `machineGlobalConfig` on an RKE2 cluster, control
  plane nodes pick up the change but worker nodes do not. Workers continue running kube-proxy
  until manually restarted (`systemctl restart rke2-agent`).

  Root cause: `disable-kube-proxy` is a server-only flag. It is filtered out of worker config,
  so the worker node plan (and its restart stamp) never changes, and workers are never
  restarted.

  ## Solution

  Server-only flags that affect agent behavior are now included in the worker restart stamp
  and drain hash. When such a flag changes, workers receive a new stamp, restart, and re-poll
  the server for the updated value — without triggering restarts for unrelated server config
  edits.

  The set of these flags is **driven by the KDM `agentRestart` field** on each serverArg (read
  via `field.AgentRestart` in `pkg/capr/planner/config.go`), instead of a hardcoded list. New
  flags can be opted in from metadata without a Rancher code change. This is why the wrangler
  and KDM PRs above are required.

  ## Testing

  ## Engineering Testing
  ### Manual Testing

  1. Provision RKE2 downstream cluster with worker nodes.
  2. Set `disable-kube-proxy: true` in `machineGlobalConfig`.
  3. Verify worker nodes restart automatically and no longer run kube-proxy without manual
  intervention.
  4. Set an unrelated server-only flag (e.g. `etcd-snapshot-retention`) and verify workers do
  **not** restart.

  ### Automated Testing

  * Test types added/modified:
      * Unit

  `TestAgentAffectingServerConfig` verifies `agentAffectingServerConfig()` extracts only flags
  marked `agentRestart` in the KDM release data from `machineGlobalConfig`, ignoring
  unrelated keys.

  `TestRestartStampWorkerChangesWithDisableKubeProxy` verifies that toggling
  `disable-kube-proxy` produces a different restart stamp for a worker entry and an identical
  stamp for a control plane entry, confirming the fix is worker-scoped.

  ## QA Testing Considerations

  - Provision a cluster with multiple worker nodes. Toggle `disable-kube-proxy`. Verify all
  workers restart automatically and kube-proxy is no longer present after restart.
  - Upgrade scenario: ensure clusters that already have `disable-kube-proxy: true` do not
  trigger unexpected worker restarts on upgrade (stamp will change once on first reconcile
  after upgrade, then stabilize).
  - Verify clusters without `disable-kube-proxy` set are unaffected — worker stamps should not
  change.
  - Verify a flag **not** marked `agentRestart` in KDM does not restart workers, confirming
  the behavior is metadata-driven.
