### PR TITLE
[main] Remove carriage returns from agent environment variables before updating clusterregistration token status

### DIFF
--- a/pkg/controllers/dashboard/clusterregistrationtoken/agentvars.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/agentvars.go
@@ -21,16 +21,17 @@ func AgentEnvVars(cluster *v3.Cluster, envType EnvType) string {
 		return ""
 	}
 	for _, envVar := range cluster.Spec.AgentEnvVars {
-		if envVar.Value == "" {
+		value := strings.TrimRight(envVar.Value, "\r\n")
+		if value == "" {
 			continue
 		}
 		switch envType {
 		case Docker:
-			agentEnvVars = append(agentEnvVars, fmt.Sprintf("-e \"%s=%s\"", envVar.Name, envVar.Value))
+			agentEnvVars = append(agentEnvVars, fmt.Sprintf("-e \"%s=%s\"", envVar.Name, value))
 		case PowerShell:
-			agentEnvVars = append(agentEnvVars, fmt.Sprintf("$env:%s=\"%s\";", envVar.Name, envVar.Value))
+			agentEnvVars = append(agentEnvVars, fmt.Sprintf("$env:%s=\"%s\";", envVar.Name, value))
 		default:
-			agentEnvVars = append(agentEnvVars, fmt.Sprintf("%s=\"%s\"", envVar.Name, envVar.Value))
+			agentEnvVars = append(agentEnvVars, fmt.Sprintf("%s=\"%s\"", envVar.Name, value))
 		}
 	}
 	return strings.Join(agentEnvVars, " ")

--- a/pkg/controllers/dashboard/clusterregistrationtoken/agentvars_test.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/agentvars_test.go
@@ -25,6 +25,38 @@ func TestAgentEnvVars(t *testing.T) {
 			},
 		},
 	}
+	cWithLineBreakSuffixes := &v3.Cluster{
+		Spec: v3.ClusterSpec{
+			ClusterSpecBase: v3.ClusterSpecBase{
+				AgentEnvVars: []corev1.EnvVar{
+					{
+						Name:  "HTTPS_PROXY",
+						Value: "https://0.0.0.0\n",
+					},
+					{
+						Name:  "HTTP_PROXY",
+						Value: "http://0.0.0.0\r\n",
+					},
+				},
+			},
+		},
+	}
+	cWithOnlyLineBreaks := &v3.Cluster{
+		Spec: v3.ClusterSpec{
+			ClusterSpecBase: v3.ClusterSpecBase{
+				AgentEnvVars: []corev1.EnvVar{
+					{
+						Name:  "ONLY_BREAKS",
+						Value: "\r\n",
+					},
+					{
+						Name:  "HTTP_PROXY",
+						Value: "http://0.0.0.0",
+					},
+				},
+			},
+		},
+	}
 	tests := []struct {
 		name     string
 		cluster  *v3.Cluster
@@ -60,6 +92,30 @@ func TestAgentEnvVars(t *testing.T) {
 			cluster:  c,
 			envType:  PowerShell,
 			expected: "$env:HTTPS_PROXY=\"https://0.0.0.0\"; $env:HTTP_PROXY=\"http://0.0.0.0\";",
+		},
+		{
+			name:     "Envvars should strip trailing line break suffixes for Linux",
+			cluster:  cWithLineBreakSuffixes,
+			envType:  Linux,
+			expected: "HTTPS_PROXY=\"https://0.0.0.0\" HTTP_PROXY=\"http://0.0.0.0\"",
+		},
+		{
+			name:     "Envvars should strip trailing line break suffixes for Docker",
+			cluster:  cWithLineBreakSuffixes,
+			envType:  Docker,
+			expected: "-e \"HTTPS_PROXY=https://0.0.0.0\" -e \"HTTP_PROXY=http://0.0.0.0\"",
+		},
+		{
+			name:     "Envvars should strip trailing line break suffixes for PowerShell",
+			cluster:  cWithLineBreakSuffixes,
+			envType:  PowerShell,
+			expected: "$env:HTTPS_PROXY=\"https://0.0.0.0\"; $env:HTTP_PROXY=\"http://0.0.0.0\";",
+		},
+		{
+			name:     "Envvars with only line breaks should be skipped",
+			cluster:  cWithOnlyLineBreaks,
+			envType:  Linux,
+			expected: "HTTP_PROXY=\"http://0.0.0.0\"",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/50213
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_