### PR TITLE
Cloudcredential controller nil map panic

### DIFF
--- a/pkg/controllers/management/cloudcredential/controller.go
+++ b/pkg/controllers/management/cloudcredential/controller.go
@@ -149,6 +149,10 @@ func (c *Controller) syncHarvesterToken(key string, secret *v1.Secret) (*v1.Secr
 	}
 
 	secret = secret.DeepCopy()
+	// writing to a nil annotation map would cause a panic, so we need to ensure it exists first.
+	if secret.Annotations == nil {
+		secret.Annotations = make(map[string]string)
+	}
 	secret.Annotations[harvesterCloudCredentialTokenChecksumAnnotation] = checksum
 	secret, err = c.secretClient.Update(secret)
 	if err != nil {

--- a/pkg/controllers/management/cloudcredential/controller_test.go
+++ b/pkg/controllers/management/cloudcredential/controller_test.go
@@ -180,6 +180,44 @@ func TestSyncHarvesterToken(t *testing.T) {
 			},
 		},
 		{
+			name: "success with nil secret annotations",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "cattle-global-data",
+					Name:      "test",
+				},
+				Data: map[string][]byte{
+					"harvestercredentialConfig-kubeconfigContent": []byte("users:\n- user:\n    token: kubeconfig-u-test:abcdef"),
+				},
+			},
+			expected: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "cattle-global-data",
+					Name:      "test",
+					Annotations: map[string]string{
+						"management.cattle.io/harvester-token-checksum": "380a5176e6ba7262e104bfbcf4b2617b4125d0eedfa2df8d5c16f54ffbc46dd6",
+					},
+					Finalizers: []string{"management.cattle.io/harvester-token-cleanup"},
+				},
+				Data: map[string][]byte{
+					"harvestercredentialConfig-kubeconfigContent": []byte("users:\n- user:\n    token: kubeconfig-u-test:abcdef"),
+				},
+			},
+			token: &v3.Token{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kubeconfig-u-test",
+				},
+				Token:     "test-token",
+				TTLMillis: 1000,
+			},
+			before: func(tt *test) {
+				tt._tokens.EXPECT().Get("kubeconfig-u-test", metav1.GetOptions{}).Return(tt.token, nil).Times(1)
+				tt._secrets.EXPECT().Update(gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(obj *corev1.Secret) (*corev1.Secret, error) {
+					return obj, nil
+				}).Times(2)
+			},
+		},
+		{
 			name: "success",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56610
 
## Problem

Rancher tried to write to a harvester cloudcredential's secret without annotations, which caused Rancher to panic.

This is because reading a nil map is safe in go, but writing to a nil map can cause a panic. 
 
## Solution
We need to ensure the secret's annotation exists before we write to it.
 
## Testing

1. Have a harvester cloudcredential with a nil annotations map.
2. Run the cloudcredential controller and it will panic.

## Engineering Testing
### Manual Testing

No manual testing is done because I don't have a local development rancher environment. If necessary, I can build one.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_