### PR TITLE
[v2.14] Serve the /v1/logout endpoint when multi-cluster management is disabled

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -136,7 +136,17 @@ func newPrivateAPI(ctx context.Context, scaledContext *config.ScaledContext, aut
 	root.PathPrefix("/v3/user").Handler(otherAPIs)
 	root.PathPrefix("/v3/schema").Handler(otherAPIs)
 	root.PathPrefix("/v3/subscribe").Handler(otherAPIs)
+	// The multi-cluster management router serves this route too, but it only
+	// runs when MCM is enabled. Registering it here keeps logout working when
+	// MCM is disabled, as in standalone Harvester.
+	root.NewRoute().MatcherFunc(onlyPost).Path("/v1/logout").Handler(logout)
 	return root, nil
+}
+
+// onlyPost will match only POST but will not return a 405 like route.Methods
+// and instead just not match, so other methods fall through to the next handler.
+func onlyPost(req *http.Request, m *mux.RouteMatch) bool {
+	return req.Method == http.MethodPost
 }
 
 func (s *Server) OnLeader(ctx context.Context) error {

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -151,6 +151,8 @@ func router(ctx context.Context, localClusterEnabled bool, scaledContext *config
 	authed.PathPrefix("/v3/identit").Handler(tokenAPI)
 	authed.PathPrefix("/v3/token").Handler(tokenAPI)
 	authed.PathPrefix("/v3").Handler(managementAPI)
+	// The auth server registers this route too, and serves it when MCM is
+	// disabled. Keep the two in sync.
 	authed.Methods(http.MethodPost).Path("/v1/logout").Handler(logout)
 
 	// Metrics authenticated route


### PR DESCRIPTION
## Issue #56592

This is a minimal backport of #56579.

Because of the structural changes in v2.15+ we don't want to bring the whole diff for the original PR's commit.