### PR TITLE
Add tests for endpoint registration

### DIFF
--- a/pkg/api/steve/additionalapi.go
+++ b/pkg/api/steve/additionalapi.go
@@ -22,19 +22,16 @@ import (
 
 func AdditionalAPIsPreMCM(config *wrangler.Context) func(http.Handler) http.Handler {
 	if features.RKE2.Enabled() {
-		connectHandler := configserver.New(config)
-		mux := http.NewServeMux()
-		mux.Handle(configserver.ConnectAgent, connectHandler)
-		mux.Handle(configserver.ConnectConfigYamlPath, connectHandler)
-		mux.Handle(configserver.ConnectClusterInfo, connectHandler)
-		mux.Handle(installer.SystemAgentInstallPath, installer.Handler)
-		mux.Handle(installer.WindowsRke2InstallPath, installer.Handler)
 		var nextHandler http.Handler
-		mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if nextHandler != nil {
-				nextHandler.ServeHTTP(w, r)
-			}
-		}))
+		mux := NewPreMCMMux(PreMCMRoutes{
+			ConfigServer: configserver.New(config),
+			Installer:    installer.Handler,
+			Next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if nextHandler != nil {
+					nextHandler.ServeHTTP(w, r)
+				}
+			}),
+		})
 		return func(next http.Handler) http.Handler {
 			nextHandler = next
 			return mux
@@ -44,6 +41,25 @@ func AdditionalAPIsPreMCM(config *wrangler.Context) func(http.Handler) http.Hand
 	return func(next http.Handler) http.Handler {
 		return next
 	}
+}
+
+// PreMCMRoutes are the handlers served ahead of the multi-cluster management
+// mux. All fields are required.
+type PreMCMRoutes struct {
+	ConfigServer http.Handler
+	Installer    http.Handler
+	Next         http.Handler
+}
+
+func NewPreMCMMux(routes PreMCMRoutes) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle(configserver.ConnectAgent, routes.ConfigServer)
+	mux.Handle(configserver.ConnectConfigYamlPath, routes.ConfigServer)
+	mux.Handle(configserver.ConnectClusterInfo, routes.ConfigServer)
+	mux.Handle(installer.SystemAgentInstallPath, routes.Installer)
+	mux.Handle(installer.WindowsRke2InstallPath, routes.Installer)
+	mux.Handle("/", routes.Next)
+	return mux
 }
 
 func AdditionalAPIs(ctx context.Context, config *wrangler.Context, steve *steve.Server) (func(http.Handler) http.Handler, error) {
@@ -60,14 +76,20 @@ func AdditionalAPIs(ctx context.Context, config *wrangler.Context, steve *steve.
 		return nil, err
 	}
 
-	mux := http.NewServeMux()
-	if features.UIExtension.Enabled() {
-		catalog.RegisterUIPluginHandlers(mux)
+	var nextHandler http.Handler
+	routes := AdditionalAPIRoutes{
+		Github: githubHandler,
+		Tunnel: Tunnel(config),
+		Next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if nextHandler != nil {
+				nextHandler.ServeHTTP(w, r)
+			}
+		}),
 	}
-	mux.Handle("/v1/github/{path...}", githubHandler)
-	mux.Handle("/v3/connect", Tunnel(config))
 
-	health.Register(mux)
+	if features.UIExtension.Enabled() {
+		routes.RegisterUIPlugins = catalog.RegisterUIPluginHandlers
+	}
 
 	if features.OIDCProvider.Enabled() {
 		p, err := provider.NewProvider(ctx, exttokenstore.NewSystemFromWrangler(config),
@@ -79,19 +101,45 @@ func AdditionalAPIs(ctx context.Context, config *wrangler.Context, steve *steve.
 		if err != nil {
 			return nil, err
 		}
-		p.RegisterOIDCProviderHandles(mux)
+		routes.RegisterOIDC = p.RegisterOIDCProviderHandles
 	}
 
-	var nextHandler http.Handler
-	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if nextHandler != nil {
-			nextHandler.ServeHTTP(w, r)
-		}
-	}))
+	mux := NewAdditionalAPIMux(routes)
+
 	return func(next http.Handler) http.Handler {
 		nextHandler = clusterAPI(next)
 		return mux
 	}, nil
+}
+
+// AdditionalAPIRoutes are the handlers served by the extras mux. Github, Tunnel
+// and Next are required. RegisterUIPlugins and RegisterOIDC are feature gated:
+// when nil, their paths fall through to Next.
+type AdditionalAPIRoutes struct {
+	Github http.Handler
+	Tunnel http.Handler
+	Next   http.Handler
+
+	RegisterUIPlugins func(*http.ServeMux)
+	RegisterOIDC      func(*http.ServeMux)
+}
+
+func NewAdditionalAPIMux(routes AdditionalAPIRoutes) *http.ServeMux {
+	mux := http.NewServeMux()
+	if routes.RegisterUIPlugins != nil {
+		routes.RegisterUIPlugins(mux)
+	}
+	mux.Handle("/v1/github/{path...}", routes.Github)
+	mux.Handle("/v3/connect", routes.Tunnel)
+
+	health.Register(mux)
+
+	if routes.RegisterOIDC != nil {
+		routes.RegisterOIDC(mux)
+	}
+
+	mux.Handle("/", routes.Next)
+	return mux
 }
 
 func Tunnel(config *wrangler.Context) http.Handler {

--- a/pkg/api/steve/additionalapi_test.go
+++ b/pkg/api/steve/additionalapi_test.go
@@ -1,0 +1,192 @@
+package steve
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/capr/configserver"
+	"github.com/rancher/rancher/pkg/capr/installer"
+	"github.com/rancher/rancher/pkg/features"
+	"github.com/stretchr/testify/assert"
+)
+
+// markerHandler returns a handler that writes its own name, so a test can tell
+// which registration answered a request.
+func markerHandler(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(name))
+	})
+}
+
+func serve(t *testing.T, h http.Handler, method, path string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	return rec.Body.String()
+}
+
+func TestNewPreMCMMux(t *testing.T) {
+	t.Parallel()
+
+	mux := NewPreMCMMux(PreMCMRoutes{
+		ConfigServer: markerHandler("configServer"),
+		Installer:    markerHandler("installer"),
+		Next:         markerHandler("next"),
+	})
+
+	tests := []struct {
+		method string
+		path   string
+		want   string
+	}{
+		{http.MethodGet, configserver.ConnectAgent, "configServer"},
+		{http.MethodPost, configserver.ConnectAgent, "configServer"},
+		{http.MethodGet, configserver.ConnectConfigYamlPath, "configServer"},
+		{http.MethodGet, configserver.ConnectClusterInfo, "configServer"},
+		{http.MethodGet, installer.SystemAgentInstallPath, "installer"},
+		{http.MethodGet, installer.WindowsRke2InstallPath, "installer"},
+
+		// The config server paths are exact matches, so anything below them
+		// falls through rather than being served here.
+		{http.MethodGet, configserver.ConnectAgent + "/extra", "next"},
+		{http.MethodGet, "/v3/connect", "next"},
+		{http.MethodGet, "/v1/github/foo", "next"},
+		{http.MethodGet, "/", "next"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, serve(t, mux, test.method, test.path))
+		})
+	}
+}
+
+// TestAdditionalAPIsPreMCMRKE2Disabled asserts that with RKE2 off the returned
+// middleware is bare identity: traffic reaches next unchanged. That is a
+// different claim from "the routes are absent" - no mux is built at all.
+func TestAdditionalAPIsPreMCMRKE2Disabled(t *testing.T) {
+	features.RKE2.Set(false)
+	t.Cleanup(features.RKE2.Unset)
+
+	next := markerHandler("next")
+	h := AdditionalAPIsPreMCM(nil)(next)
+
+	assert.Equal(t, "next", serve(t, h, http.MethodGet, configserver.ConnectAgent))
+	assert.Equal(t, "next", serve(t, h, http.MethodGet, installer.SystemAgentInstallPath))
+}
+
+func TestNewAdditionalAPIMux(t *testing.T) {
+	t.Parallel()
+
+	mux := NewAdditionalAPIMux(AdditionalAPIRoutes{
+		Github: markerHandler("github"),
+		Tunnel: markerHandler("tunnel"),
+		Next:   markerHandler("next"),
+	})
+
+	tests := []struct {
+		method string
+		path   string
+		want   string
+	}{
+		{http.MethodGet, "/v1/github/foo", "github"},
+		{http.MethodGet, "/v1/github/foo/bar/baz", "github"},
+		{http.MethodPost, "/v1/github/foo", "github"},
+		{http.MethodGet, "/v3/connect", "tunnel"},
+
+		// Registered by health.Register, which is unconditional.
+		{http.MethodGet, "/healthz", "ok"},
+		{http.MethodGet, "/ping", "pong"},
+
+		// /v3/connect is an exact match, so the config server paths registered
+		// by the pre-MCM mux fall through here.
+		{http.MethodGet, configserver.ConnectAgent, "next"},
+		{http.MethodGet, "/v3/", "next"},
+		{http.MethodGet, "/", "next"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, serve(t, mux, test.method, test.path))
+		})
+	}
+
+	// The {path...} wildcard makes the mux redirect the bare prefix to the
+	// trailing slash form rather than passing it along.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/github", nil))
+	assert.Equal(t, http.StatusTemporaryRedirect, rec.Code)
+	assert.Equal(t, "/v1/github/", rec.Header().Get("Location"))
+}
+
+func TestNewAdditionalAPIMuxOptionalRoutes(t *testing.T) {
+	t.Parallel()
+
+	registerUIPlugins := func(mux *http.ServeMux) {
+		mux.Handle("/v1/uiplugins", markerHandler("uiplugins"))
+		mux.Handle("/v1/uiplugins/{name}/{version}/{rest...}", markerHandler("uiplugins"))
+	}
+	registerOIDC := func(mux *http.ServeMux) {
+		mux.Handle("/oidc/token", markerHandler("oidc"))
+		mux.Handle("/oidc/authorize", markerHandler("oidc"))
+	}
+
+	tests := []struct {
+		name              string
+		registerUIPlugins func(*http.ServeMux)
+		registerOIDC      func(*http.ServeMux)
+		wantUIPlugins     string
+		wantOIDC          string
+	}{
+		{
+			name:          "both disabled",
+			wantUIPlugins: "next",
+			wantOIDC:      "next",
+		},
+		{
+			name:              "ui extension enabled",
+			registerUIPlugins: registerUIPlugins,
+			wantUIPlugins:     "uiplugins",
+			wantOIDC:          "next",
+		},
+		{
+			name:          "oidc provider enabled",
+			registerOIDC:  registerOIDC,
+			wantUIPlugins: "next",
+			wantOIDC:      "oidc",
+		},
+		{
+			name:              "both enabled",
+			registerUIPlugins: registerUIPlugins,
+			registerOIDC:      registerOIDC,
+			wantUIPlugins:     "uiplugins",
+			wantOIDC:          "oidc",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			mux := NewAdditionalAPIMux(AdditionalAPIRoutes{
+				Github:            markerHandler("github"),
+				Tunnel:            markerHandler("tunnel"),
+				Next:              markerHandler("next"),
+				RegisterUIPlugins: test.registerUIPlugins,
+				RegisterOIDC:      test.registerOIDC,
+			})
+
+			assert.Equal(t, test.wantUIPlugins, serve(t, mux, http.MethodGet, "/v1/uiplugins"))
+			assert.Equal(t, test.wantUIPlugins, serve(t, mux, http.MethodGet, "/v1/uiplugins/name/1.0.0/plugin.js"))
+			assert.Equal(t, test.wantOIDC, serve(t, mux, http.MethodGet, "/oidc/token"))
+			assert.Equal(t, test.wantOIDC, serve(t, mux, http.MethodGet, "/oidc/authorize"))
+
+			// The gates do not move the routes that are always registered.
+			assert.Equal(t, "github", serve(t, mux, http.MethodGet, "/v1/github/foo"))
+			assert.Equal(t, "tunnel", serve(t, mux, http.MethodGet, "/v3/connect"))
+		})
+	}
+}

--- a/pkg/api/steve/projects/projects.go
+++ b/pkg/api/steve/projects/projects.go
@@ -82,25 +82,28 @@ func (s *projectServer) newAPIHandler() http.Handler {
 }
 
 func (s *projectServer) middleware() func(http.Handler) http.Handler {
-	server := s.newAPIHandler()
-	server = prefix(server)
+	server := prefix(s.newAPIHandler())
 
 	return func(next http.Handler) http.Handler {
-		router := http.NewServeMux()
-		router.HandleFunc("/v1/management.cattle.io.clusters/{namespace}", func(w http.ResponseWriter, r *http.Request) {
-			link := r.URL.Query().Get("link")
-			if link == "projects" || link == "project" {
-				server.ServeHTTP(w, r)
-			} else {
-				next.ServeHTTP(w, r)
-			}
-		})
-		router.Handle("/v1/management.cattle.io.clusters/{namespace}/{type}", server)
-		router.Handle("/v1/management.cattle.io.clusters/{namespace}/{type}/{name}", server)
-		router.Handle("/v1/management.cattle.io.clusters/{clusterID}/{type}/{namespace}/{name}", server)
-		router.Handle("/", next)
-		return router
+		return NewProjectsMux(server, next)
 	}
+}
+
+func NewProjectsMux(server, next http.Handler) *http.ServeMux {
+	router := http.NewServeMux()
+	router.HandleFunc("/v1/management.cattle.io.clusters/{namespace}", func(w http.ResponseWriter, r *http.Request) {
+		link := r.URL.Query().Get("link")
+		if link == "projects" || link == "project" {
+			server.ServeHTTP(w, r)
+		} else {
+			next.ServeHTTP(w, r)
+		}
+	})
+	router.Handle("/v1/management.cattle.io.clusters/{namespace}/{type}", server)
+	router.Handle("/v1/management.cattle.io.clusters/{namespace}/{type}/{name}", server)
+	router.Handle("/v1/management.cattle.io.clusters/{clusterID}/{type}/{namespace}/{name}", server)
+	router.Handle("/", next)
+	return router
 }
 
 func prefix(next http.Handler) http.Handler {

--- a/pkg/api/steve/projects/projects_test.go
+++ b/pkg/api/steve/projects/projects_test.go
@@ -1,0 +1,116 @@
+package projects
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// markerHandler returns a handler that writes its own name, so a test can tell
+// which registration answered a request.
+func markerHandler(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(name))
+	})
+}
+
+func serve(t *testing.T, h http.Handler, method, path string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	return rec.Body.String()
+}
+
+func TestNewProjectsMux(t *testing.T) {
+	t.Parallel()
+
+	mux := NewProjectsMux(markerHandler("server"), markerHandler("next"))
+
+	tests := []struct {
+		method string
+		path   string
+		want   string
+	}{
+		// The cluster path is shared with the rest of the chain: only the
+		// project links belong to the projects server.
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde?link=projects", "server"},
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde?link=project", "server"},
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde?link=schemas", "next"},
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde?link=subscribe", "next"},
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde", "next"},
+		{http.MethodPost, "/v1/management.cattle.io.clusters/c-abcde?link=projects", "server"},
+
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde/project", "server"},
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde/project/p-abcde", "server"},
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde/project/ns/p-abcde", "server"},
+		{http.MethodPut, "/v1/management.cattle.io.clusters/c-abcde/project/p-abcde", "server"},
+
+		{http.MethodGet, "/v1/management.cattle.io.clusters", "next"},
+		{http.MethodGet, "/v1/management.cattle.io.clusters/c-abcde/project/ns/p-abcde/extra", "next"},
+		{http.MethodGet, "/v1/pods", "next"},
+		{http.MethodGet, "/v3/clusters", "next"},
+		{http.MethodGet, "/", "next"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, serve(t, mux, test.method, test.path))
+		})
+	}
+}
+
+func TestPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		clusterID  string
+		namespace  string
+		wantPrefix string
+	}{
+		{
+			name:       "cluster id wins",
+			clusterID:  "c-abcde",
+			namespace:  "ns",
+			wantPrefix: "/v1/management.cattle.io.clusters/c-abcde",
+		},
+		{
+			name:       "cluster id only",
+			clusterID:  "c-abcde",
+			wantPrefix: "/v1/management.cattle.io.clusters/c-abcde",
+		},
+		{
+			name:       "namespace only",
+			namespace:  "c-fghij",
+			wantPrefix: "/v1/management.cattle.io.clusters/c-fghij",
+		},
+		{
+			name: "neither set",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got string
+			h := prefix(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.PathValue("prefix")
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/v1/management.cattle.io.clusters/x", nil)
+			if test.clusterID != "" {
+				req.SetPathValue("clusterID", test.clusterID)
+			}
+			if test.namespace != "" {
+				req.SetPathValue("namespace", test.namespace)
+			}
+
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			assert.Equal(t, test.wantPrefix, got)
+		})
+	}
+}

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -98,22 +98,22 @@ func newAPIManagement(ctx context.Context, scaledContext *config.ScaledContext, 
 			}
 		})
 
-		routes := authRoutes{
-			limit:    utils.APIBodyLimitingHandler(apiLimit),
-			saml:     saml,
-			v1Public: v1PublicAPI,
-			v3:       v3Handler,
-			logout:   logout,
-			next:     next,
+		routes := AuthRoutes{
+			Limit:    utils.APIBodyLimitingHandler(apiLimit),
+			SAML:     saml,
+			V1Public: v1PublicAPI,
+			V3:       v3Handler,
+			Logout:   logout,
+			Next:     next,
 		}
 		if features.V3Public.Enabled() {
-			routes.v3Public = v3PublicAPI // Deprecated. Use /v1-public instead.
+			routes.V3Public = v3PublicAPI // Deprecated. Use /v1-public instead.
 		}
 		if features.SCIM.Enabled() {
-			routes.scim = scim.NewHandler(scaledContext)
+			routes.SCIM = scim.NewHandler(scaledContext)
 		}
 
-		root := newRootMux(routes)
+		root := NewRootMux(routes)
 
 		p := handler.NewFromAuthConfigInterface(scaledContext.Management.AuthConfigs(""))
 		p.RegisterOIDCProviderHandlers(root)
@@ -122,37 +122,37 @@ func newAPIManagement(ctx context.Context, scaledContext *config.ScaledContext, 
 	}, nil
 }
 
-// authRoutes are the handlers served by the auth server's root mux. All
-// handlers are required except v3Public and scim, which are feature gated:
-// when nil, their paths fall through to next.
-type authRoutes struct {
-	limit    func(http.Handler) http.Handler
-	saml     http.Handler
-	v3Public http.Handler
-	v1Public http.Handler
-	scim     http.Handler
-	v3       http.Handler
-	logout   http.Handler
-	next     http.Handler
+// AuthRoutes are the handlers served by the auth server's root mux. All
+// handlers are required except V3Public and SCIM, which are feature gated:
+// when nil, their paths fall through to Next.
+type AuthRoutes struct {
+	Limit    func(http.Handler) http.Handler
+	SAML     http.Handler
+	V3Public http.Handler
+	V1Public http.Handler
+	SCIM     http.Handler
+	V3       http.Handler
+	Logout   http.Handler
+	Next     http.Handler
 }
 
-func newRootMux(routes authRoutes) *http.ServeMux {
+func NewRootMux(routes AuthRoutes) *http.ServeMux {
 	root := http.NewServeMux()
 
-	root.Handle("/v1-saml/", routes.limit(routes.saml))
-	if routes.v3Public != nil {
-		root.Handle("/v3-public/", routes.limit(routes.v3Public)) // Deprecated. Use /v1-public instead.
+	root.Handle("/v1-saml/", routes.Limit(routes.SAML))
+	if routes.V3Public != nil {
+		root.Handle("/v3-public/", routes.Limit(routes.V3Public)) // Deprecated. Use /v1-public instead.
 	}
-	root.Handle("/v1-public/", routes.limit(routes.v1Public))
-	if routes.scim != nil {
-		root.Handle(fmt.Sprint(scim.URLPrefix, "/"), routes.limit(routes.scim))
+	root.Handle("/v1-public/", routes.Limit(routes.V1Public))
+	if routes.SCIM != nil {
+		root.Handle(fmt.Sprint(scim.URLPrefix, "/"), routes.Limit(routes.SCIM))
 	}
 	// The multi-cluster management router serves this route too, but it only
 	// runs when MCM is enabled. Registering it here keeps logout working when
 	// MCM is disabled, as in standalone Harvester.
-	root.Handle("POST /v1/logout", routes.limit(requests.NewAuthenticatedFilter(routes.logout)))
-	root.Handle("/v3/", routes.v3)
-	root.Handle("/", routes.next)
+	root.Handle("POST /v1/logout", routes.Limit(requests.NewAuthenticatedFilter(routes.Logout)))
+	root.Handle("/v3/", routes.V3)
+	root.Handle("/", routes.Next)
 
 	return root
 }

--- a/pkg/auth/server_test.go
+++ b/pkg/auth/server_test.go
@@ -19,14 +19,14 @@ func markerHandler(name string) http.Handler {
 	})
 }
 
-func testRoutes() authRoutes {
-	return authRoutes{
-		limit:    func(next http.Handler) http.Handler { return next },
-		saml:     markerHandler("saml"),
-		v1Public: markerHandler("v1Public"),
-		v3:       markerHandler("v3"),
-		logout:   markerHandler("logout"),
-		next:     markerHandler("next"),
+func testRoutes() AuthRoutes {
+	return AuthRoutes{
+		Limit:    func(next http.Handler) http.Handler { return next },
+		SAML:     markerHandler("saml"),
+		V1Public: markerHandler("v1Public"),
+		V3:       markerHandler("v3"),
+		Logout:   markerHandler("logout"),
+		Next:     markerHandler("next"),
 	}
 }
 
@@ -115,7 +115,7 @@ func TestNewRootMux(t *testing.T) {
 			}
 
 			rec := httptest.NewRecorder()
-			newRootMux(testRoutes()).ServeHTTP(rec, req)
+			NewRootMux(testRoutes()).ServeHTTP(rec, req)
 
 			require.Equal(t, test.wantCode, rec.Code)
 			if test.wantBody != "" {
@@ -131,7 +131,7 @@ func TestNewRootMuxOptionalRoutes(t *testing.T) {
 	t.Run("v3 public and scim fall through when not configured", func(t *testing.T) {
 		t.Parallel()
 
-		mux := newRootMux(testRoutes())
+		mux := NewRootMux(testRoutes())
 
 		for _, path := range []string{"/v3-public/authProviders", "/v1-scim/v2/Users"} {
 			rec := httptest.NewRecorder()
@@ -145,9 +145,9 @@ func TestNewRootMuxOptionalRoutes(t *testing.T) {
 		t.Parallel()
 
 		routes := testRoutes()
-		routes.v3Public = markerHandler("v3Public")
-		routes.scim = markerHandler("scim")
-		mux := newRootMux(routes)
+		routes.V3Public = markerHandler("v3Public")
+		routes.SCIM = markerHandler("scim")
+		mux := NewRootMux(routes)
 
 		for path, want := range map[string]string{
 			"/v3-public/authProviders": "v3Public",

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -84,134 +84,209 @@ func router(ctx context.Context, localClusterEnabled bool, scaledContext *config
 	channelserver := channelserver.NewHandler(ctx)
 
 	supportConfigGenerator := supportconfigs.NewHandler(scaledContext)
-	// Unauthenticated routes
-	unauthed := http.NewServeMux()
 
 	publicLimit, err := settings.APIBodyLimit.GetQuantityAsInt64(1024 * 1024)
 	if err != nil {
 		return nil, fmt.Errorf("parsing the public API body limit: %w", err)
 	}
 	logrus.Infof("Configuring public API body limit to %v bytes", publicLimit)
-	limitingHandler := utils.APIBodyLimitingHandler(publicLimit)
 
 	handler := sar.NewSubjectAccessReview(
 		scaledContext.K8sClient.AuthorizationV1().SubjectAccessReviews())
 	impersonatingAuth := requests.NewImpersonatingAuth(scaledContext.Wrangler, handler)
 
 	saAuth := auth.ToMiddleware(requests.NewServiceAccountAuth(scaledContext, clustermanager.ToRESTConfig))
+	tokenReviewAuth := auth.ToMiddleware(requests.NewTokenReviewAuth(scaledContext.K8sClient.AuthenticationV1()))
 	accessControlHandler := rbac.NewAccessControlHandler()
 
-	// Setup middlewares for the service account authenticated routes.
-	saAuthedMW := func(h http.Handler) http.Handler {
-		h = requests.NewAuthenticatedFilter(h)
-		h = accessControlHandler(h)
-		h = saAuth.Chain(impersonatingAuth.ImpersonationMiddleware)(h)
-		return h
+	routes := MCMRoutes{
+		Limit: utils.APIBodyLimitingHandler(publicLimit),
+		// Setup middlewares for the service account authenticated routes.
+		SAAuthedMW: func(h http.Handler) http.Handler {
+			h = requests.NewAuthenticatedFilter(h)
+			h = accessControlHandler(h)
+			h = saAuth.Chain(impersonatingAuth.ImpersonationMiddleware)(h)
+			return h
+		},
+		// Setup middlewares for authenticated routes.
+		AuthedMW: func(h http.Handler) http.Handler {
+			h = requests.NewAuthenticatedFilter(h)
+			h = accessControlHandler(h)
+			h = impersonatingAuth.ImpersonationMiddleware(h)
+			return h
+		},
+		// Setup middlewares for the metrics route.
+		MetricsMW: func(h http.Handler) http.Handler {
+			h = metrics.NewMetricsHandler(scaledContext.K8sClient)(h)
+			h = requests.NewAuthenticatedFilter(h)
+			h = accessControlHandler(h)
+			h = tokenReviewAuth.Chain(impersonatingAuth.ImpersonationMiddleware)(h)
+			return h
+		},
+
+		K8sProxy:      k8sProxy,
+		ManagementAPI: managementAPI,
+		Connect:       connectHandler,
+		ClusterImport: http.HandlerFunc(clusterImport.ClusterImportHandler),
+		Version:       version.NewVersionHandler(),
+		ChannelServer: channelserver,
+		SAML:          saml.AuthHandler(),
+		V1Public:      v1PublicAPI,
+		Metrics:       promhttp.Handler(),
+		MetaAKS:       aks.NewAKSHandler(scaledContext),
+		MetaGKE:       gke.NewGKEHandler(scaledContext),
+		MetaAlibaba:   alibaba.NewAlibabaHandler(scaledContext),
+		MetaOCI:       oci.NewOCIHandler(scaledContext),
+		MetaVsphere:   vsphere.NewVsphereHandler(scaledContext),
+		MetaProxy:     metaProxy,
+		TokenReview:   &webhook.TokenReviewer{},
+		SupportConfig: &supportConfigGenerator,
+		TokenAPI:      tokenAPI,
+		Logout:        logout,
 	}
+	if features.V3Public.Enabled() {
+		routes.V3Public = v3PublicAPI
+	}
+	if features.SCIM.Enabled() {
+		routes.SCIM = scim.NewHandler(scaledContext)
+	}
+
+	// next is only known once the middleware is applied, which happens after
+	// the mux is built. Read it through a variable so the mux is built once.
+	var nextHandler http.Handler
+	routes.Next = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if nextHandler != nil {
+			nextHandler.ServeHTTP(w, r)
+		}
+	})
+
+	mux := NewMCMMux(routes)
+
+	return func(next http.Handler) http.Handler {
+		nextHandler = next
+		return mux
+	}, nil
+}
+
+// MCMRoutes are the handlers served by the multi-cluster management muxes. All
+// fields are required except V3Public and SCIM, which are feature gated: when
+// nil, their paths fall through to Next.
+type MCMRoutes struct {
+	Limit      func(http.Handler) http.Handler
+	SAAuthedMW func(http.Handler) http.Handler
+	AuthedMW   func(http.Handler) http.Handler
+	MetricsMW  func(http.Handler) http.Handler
+
+	K8sProxy      http.Handler
+	ManagementAPI http.Handler
+	Connect       http.Handler
+	ClusterImport http.Handler
+	Version       http.Handler
+	ChannelServer http.Handler
+	SAML          http.Handler
+	V3Public      http.Handler
+	V1Public      http.Handler
+	SCIM          http.Handler
+	Metrics       http.Handler
+	MetaAKS       http.Handler
+	MetaGKE       http.Handler
+	MetaAlibaba   http.Handler
+	MetaOCI       http.Handler
+	MetaVsphere   http.Handler
+	MetaProxy     http.Handler
+	TokenReview   http.Handler
+	SupportConfig http.Handler
+	TokenAPI      http.Handler
+	Logout        http.Handler
+	Next          http.Handler
+}
+
+// NewMCMMux builds the four interlinked muxes the multi-cluster management
+// server serves: unauthenticated routes fall through to the service account
+// authenticated ones, which fall through to the authenticated ones, which fall
+// through to the metrics one, which falls through to next.
+func NewMCMMux(routes MCMRoutes) http.Handler {
+	unauthed := http.NewServeMux()
 	saAuthed := http.NewServeMux()
-	saAuthed.Handle("/k8s/clusters/{clusterID}/", saAuthedMW(k8sProxy))
-	saAuthed.Handle("/k8s/proxy/{clusterID}/", saAuthedMW(k8sProxy))
+	authed := http.NewServeMux()
+	metricsAuthed := http.NewServeMux()
+
+	saAuthed.Handle("/k8s/clusters/{clusterID}/", routes.SAAuthedMW(routes.K8sProxy))
+	saAuthed.Handle("/k8s/proxy/{clusterID}/", routes.SAAuthedMW(routes.K8sProxy))
 
 	unauthed.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" && parse.MatchNotBrowser(r) {
-			managementAPI.ServeHTTP(w, r)
+			routes.ManagementAPI.ServeHTTP(w, r)
 			return
 		}
 		saAuthed.ServeHTTP(w, r)
 	}))
-	unauthed.Handle("/v3/connect", connectHandler)
-	unauthed.Handle("/v3/connect/register", connectHandler)
+	unauthed.Handle("/v3/connect", routes.Connect)
+	unauthed.Handle("/v3/connect/register", routes.Connect)
 	unauthed.HandleFunc("/v3/import/{filename}", func(w http.ResponseWriter, r *http.Request) {
 		filename := r.PathValue("filename")
 		// Match pattern: {token}_{clusterId}.yaml
 		if strings.Contains(filename, "_") && strings.HasSuffix(filename, ".yaml") {
-			clusterImport.ClusterImportHandler(w, r)
+			routes.ClusterImport.ServeHTTP(w, r)
 		} else {
 			http.NotFound(w, r)
 		}
 	})
-	unauthed.Handle("GET /v3/settings/cacerts", managementAPI)
-	unauthed.Handle("GET /v3/settings/first-login", managementAPI)
-	unauthed.Handle("GET /v3/settings/ui-banners", managementAPI)
-	unauthed.Handle("GET /v3/settings/ui-issues", managementAPI)
-	unauthed.Handle("GET /v3/settings/ui-pl", managementAPI)
-	unauthed.Handle("GET /v3/settings/ui-brand", managementAPI)
-	unauthed.Handle("GET /v3/settings/ui-default-landing", managementAPI)
-	unauthed.Handle("/rancherversion", version.NewVersionHandler())
-	unauthed.Handle("/v1-k3s-release/", channelserver)
-	unauthed.Handle("/v1-rke2-release/", channelserver)
-	unauthed.Handle("/v1-saml/", saml.AuthHandler())
-	if features.V3Public.Enabled() {
-		unauthed.Handle("/v3-public/", v3PublicAPI)
+	unauthed.Handle("GET /v3/settings/cacerts", routes.ManagementAPI)
+	unauthed.Handle("GET /v3/settings/first-login", routes.ManagementAPI)
+	unauthed.Handle("GET /v3/settings/ui-banners", routes.ManagementAPI)
+	unauthed.Handle("GET /v3/settings/ui-issues", routes.ManagementAPI)
+	unauthed.Handle("GET /v3/settings/ui-pl", routes.ManagementAPI)
+	unauthed.Handle("GET /v3/settings/ui-brand", routes.ManagementAPI)
+	unauthed.Handle("GET /v3/settings/ui-default-landing", routes.ManagementAPI)
+	unauthed.Handle("/rancherversion", routes.Version)
+	unauthed.Handle("/v1-k3s-release/", routes.ChannelServer)
+	unauthed.Handle("/v1-rke2-release/", routes.ChannelServer)
+	unauthed.Handle("/v1-saml/", routes.SAML)
+	if routes.V3Public != nil {
+		unauthed.Handle("/v3-public/", routes.V3Public)
 	}
-	unauthed.Handle("/v1-public/", v1PublicAPI)
-	if features.SCIM.Enabled() {
-		unauthed.Handle(fmt.Sprint(scim.URLPrefix, "/"), scim.NewHandler(scaledContext))
-	}
-
-	// Setup middlewares for the metrics route.
-	tokenReviewAuth := auth.ToMiddleware(requests.NewTokenReviewAuth(scaledContext.K8sClient.AuthenticationV1()))
-	metricsMW := func(h http.Handler) http.Handler {
-		h = metrics.NewMetricsHandler(scaledContext.K8sClient)(h)
-		h = requests.NewAuthenticatedFilter(h)
-		h = accessControlHandler(h)
-		h = tokenReviewAuth.Chain(impersonatingAuth.ImpersonationMiddleware)(h)
-		return h
-	}
-	metricsAuthed := http.NewServeMux()
-	metricsAuthed.Handle("/metrics", metricsMW(promhttp.Handler()))
-
-	// Setup middlewares for authenticated routes.
-	authedMW := func(h http.Handler) http.Handler {
-		h = requests.NewAuthenticatedFilter(h)
-		h = accessControlHandler(h)
-		h = impersonatingAuth.ImpersonationMiddleware(h)
-		return h
+	unauthed.Handle("/v1-public/", routes.V1Public)
+	if routes.SCIM != nil {
+		unauthed.Handle(fmt.Sprint(scim.URLPrefix, "/"), routes.SCIM)
 	}
 
-	authed := http.NewServeMux()
+	metricsAuthed.Handle("/metrics", routes.MetricsMW(routes.Metrics))
+
 	authed.Handle("/meta/{resource}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource := r.PathValue("resource")
 		var h http.Handler
 		if strings.HasPrefix(resource, "aks") {
-			h = authedMW(aks.NewAKSHandler(scaledContext))
+			h = routes.AuthedMW(routes.MetaAKS)
 		} else if strings.HasPrefix(resource, "gke") {
-			h = authedMW(gke.NewGKEHandler(scaledContext))
+			h = routes.AuthedMW(routes.MetaGKE)
 		} else if strings.HasPrefix(resource, "alibaba") {
-			h = authedMW(alibaba.NewAlibabaHandler(scaledContext))
+			h = routes.AuthedMW(routes.MetaAlibaba)
 		} else {
 			metricsAuthed.ServeHTTP(w, r)
 			return
 		}
 		h.ServeHTTP(w, r)
 	}))
-	authed.Handle("/meta/oci/{resource}", authedMW(oci.NewOCIHandler(scaledContext)))
-	authed.Handle("GET /meta/vsphere/{field}", authedMW(vsphere.NewVsphereHandler(scaledContext)))
-	authed.Handle("POST /v3/tokenreview", authedMW(&webhook.TokenReviewer{}))
-	authed.Handle(supportconfigs.Endpoint, authedMW(&supportConfigGenerator))
-	authed.Handle("/meta/proxy/", authedMW(metaProxy))
-	authed.Handle("/v3/", authedMW(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	authed.Handle("/meta/oci/{resource}", routes.AuthedMW(routes.MetaOCI))
+	authed.Handle("GET /meta/vsphere/{field}", routes.AuthedMW(routes.MetaVsphere))
+	authed.Handle("POST /v3/tokenreview", routes.AuthedMW(routes.TokenReview))
+	authed.Handle(supportconfigs.Endpoint, routes.AuthedMW(routes.SupportConfig))
+	authed.Handle("/meta/proxy/", routes.AuthedMW(routes.MetaProxy))
+	authed.Handle("/v3/", routes.AuthedMW(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/v3/identit") || strings.HasPrefix(r.URL.Path, "/v3/token") {
-			tokenAPI.ServeHTTP(w, r)
+			routes.TokenAPI.ServeHTTP(w, r)
 		} else {
-			managementAPI.ServeHTTP(w, r)
+			routes.ManagementAPI.ServeHTTP(w, r)
 		}
 	})))
 	// The auth server registers this route too, and serves it when MCM is
 	// disabled. Keep the two in sync.
-	authed.Handle("POST /v1/logout", authedMW(logout))
+	authed.Handle("POST /v1/logout", routes.AuthedMW(routes.Logout))
+
 	saAuthed.Handle("/", authed)
 	authed.Handle("/", metricsAuthed)
+	metricsAuthed.Handle("/", routes.Next)
 
-	var nextHandler http.Handler
-	metricsAuthed.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if nextHandler != nil {
-			nextHandler.ServeHTTP(w, r)
-		}
-	}))
-
-	return func(next http.Handler) http.Handler {
-		nextHandler = next
-		return limitingHandler(unauthed)
-	}, nil
+	return routes.Limit(unauthed)
 }

--- a/pkg/multiclustermanager/routes_test.go
+++ b/pkg/multiclustermanager/routes_test.go
@@ -1,0 +1,458 @@
+package multiclustermanager
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/api/steve/supportconfigs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// markerHandler writes its name so tests can tell which route was picked.
+func markerHandler(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(name))
+	})
+}
+
+// identityMW passes the handler through unchanged, so tests that care about
+// which route was picked are not affected by the middleware stacks.
+func identityMW(h http.Handler) http.Handler {
+	return h
+}
+
+func testMCMRoutes() MCMRoutes {
+	return MCMRoutes{
+		Limit:      identityMW,
+		SAAuthedMW: identityMW,
+		AuthedMW:   identityMW,
+		MetricsMW:  identityMW,
+
+		K8sProxy:      markerHandler("k8sProxy"),
+		ManagementAPI: markerHandler("managementAPI"),
+		Connect:       markerHandler("connect"),
+		ClusterImport: markerHandler("clusterImport"),
+		Version:       markerHandler("version"),
+		ChannelServer: markerHandler("channelServer"),
+		SAML:          markerHandler("saml"),
+		V1Public:      markerHandler("v1Public"),
+		Metrics:       markerHandler("metrics"),
+		MetaAKS:       markerHandler("metaAKS"),
+		MetaGKE:       markerHandler("metaGKE"),
+		MetaAlibaba:   markerHandler("metaAlibaba"),
+		MetaOCI:       markerHandler("metaOCI"),
+		MetaVsphere:   markerHandler("metaVsphere"),
+		MetaProxy:     markerHandler("metaProxy"),
+		TokenReview:   markerHandler("tokenReview"),
+		SupportConfig: markerHandler("supportConfig"),
+		TokenAPI:      markerHandler("tokenAPI"),
+		Logout:        markerHandler("logout"),
+		Next:          markerHandler("next"),
+	}
+}
+
+func TestNewMCMMux(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		header   map[string]string
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "the root path serves the management API to a non browser",
+			method:   http.MethodGet,
+			path:     "/",
+			header:   map[string]string{"User-Agent": "curl/8.7.1", "Accept": "*/*"},
+			wantBody: "managementAPI",
+		},
+		{
+			name:   "the root path falls through for a browser",
+			method: http.MethodGet,
+			path:   "/",
+			// A browser is a Mozilla user agent that accepts */*. Both halves
+			// are required, so this case sets both.
+			header:   map[string]string{"User-Agent": "Mozilla/5.0", "Accept": "*/*"},
+			wantBody: "next",
+		},
+		{
+			name:     "a request with no headers is not a browser",
+			method:   http.MethodGet,
+			path:     "/",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "cluster proxy is served",
+			method:   http.MethodGet,
+			path:     "/k8s/clusters/c-abcde/v1/pods",
+			wantBody: "k8sProxy",
+		},
+		{
+			name:     "k8s proxy is served",
+			method:   http.MethodGet,
+			path:     "/k8s/proxy/c-abcde/v1/pods",
+			wantBody: "k8sProxy",
+		},
+		{
+			name:     "connect is served",
+			method:   http.MethodGet,
+			path:     "/v3/connect",
+			wantBody: "connect",
+		},
+		{
+			name:     "connect register is served",
+			method:   http.MethodGet,
+			path:     "/v3/connect/register",
+			wantBody: "connect",
+		},
+		{
+			name:     "a well formed import filename is served",
+			method:   http.MethodGet,
+			path:     "/v3/import/sometoken_c-abcde.yaml",
+			wantBody: "clusterImport",
+		},
+		{
+			name:     "an import filename without a token is not found",
+			method:   http.MethodGet,
+			path:     "/v3/import/c-abcde.yaml",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "an import filename that is not yaml is not found",
+			method:   http.MethodGet,
+			path:     "/v3/import/sometoken_c-abcde.json",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "the cacerts setting is served unauthenticated",
+			method:   http.MethodGet,
+			path:     "/v3/settings/cacerts",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "the first-login setting is served unauthenticated",
+			method:   http.MethodGet,
+			path:     "/v3/settings/first-login",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "the ui-banners setting is served unauthenticated",
+			method:   http.MethodGet,
+			path:     "/v3/settings/ui-banners",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "the ui-issues setting is served unauthenticated",
+			method:   http.MethodGet,
+			path:     "/v3/settings/ui-issues",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "the ui-pl setting is served unauthenticated",
+			method:   http.MethodGet,
+			path:     "/v3/settings/ui-pl",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "the ui-brand setting is served unauthenticated",
+			method:   http.MethodGet,
+			path:     "/v3/settings/ui-brand",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "the ui-default-landing setting is served unauthenticated",
+			method:   http.MethodGet,
+			path:     "/v3/settings/ui-default-landing",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "a setting that is not on the unauthenticated list falls through to the authenticated table",
+			method:   http.MethodGet,
+			path:     "/v3/settings/server-url",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "posting to an unauthenticated setting falls through to the authenticated table",
+			method:   http.MethodPost,
+			path:     "/v3/settings/cacerts",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "the version is served",
+			method:   http.MethodGet,
+			path:     "/rancherversion",
+			wantBody: "version",
+		},
+		{
+			name:     "k3s releases are served",
+			method:   http.MethodGet,
+			path:     "/v1-k3s-release/channels",
+			wantBody: "channelServer",
+		},
+		{
+			name:     "rke2 releases are served",
+			method:   http.MethodGet,
+			path:     "/v1-rke2-release/channels",
+			wantBody: "channelServer",
+		},
+		{
+			name:     "saml is served",
+			method:   http.MethodGet,
+			path:     "/v1-saml/adfs/login",
+			wantBody: "saml",
+		},
+		{
+			name:     "v1 public is served",
+			method:   http.MethodGet,
+			path:     "/v1-public/authProviders",
+			wantBody: "v1Public",
+		},
+		{
+			name:     "the aks meta resource is served",
+			method:   http.MethodGet,
+			path:     "/meta/aksVirtualNetworks",
+			wantBody: "metaAKS",
+		},
+		{
+			name:     "the gke meta resource is served",
+			method:   http.MethodGet,
+			path:     "/meta/gkeNetworks",
+			wantBody: "metaGKE",
+		},
+		{
+			name:     "the alibaba meta resource is served",
+			method:   http.MethodGet,
+			path:     "/meta/alibabaInstanceTypes",
+			wantBody: "metaAlibaba",
+		},
+		{
+			name:     "an unknown meta resource falls through to the metrics table",
+			method:   http.MethodGet,
+			path:     "/meta/somethingelse",
+			wantBody: "next",
+		},
+		{
+			name:     "the oci meta resource is served",
+			method:   http.MethodGet,
+			path:     "/meta/oci/vcns",
+			wantBody: "metaOCI",
+		},
+		{
+			name:     "the vsphere meta field is served",
+			method:   http.MethodGet,
+			path:     "/meta/vsphere/datacenter",
+			wantBody: "metaVsphere",
+		},
+		{
+			name:     "a non GET vsphere meta field falls through",
+			method:   http.MethodPost,
+			path:     "/meta/vsphere/datacenter",
+			wantBody: "next",
+		},
+		{
+			name:     "the meta proxy is served",
+			method:   http.MethodGet,
+			path:     "/meta/proxy/example.com/path",
+			wantBody: "metaProxy",
+		},
+		{
+			name:     "token review is served",
+			method:   http.MethodPost,
+			path:     "/v3/tokenreview",
+			wantBody: "tokenReview",
+		},
+		{
+			// /v3/tokenreview shares the /v3/token prefix the token API claims,
+			// so a GET lands there rather than on the management API.
+			name:     "a non POST token review falls through to the token API",
+			method:   http.MethodGet,
+			path:     "/v3/tokenreview",
+			wantBody: "tokenAPI",
+		},
+		{
+			name:     "the support config endpoint is served",
+			method:   http.MethodGet,
+			path:     supportconfigs.Endpoint,
+			wantBody: "supportConfig",
+		},
+		{
+			name:     "tokens are served by the token API",
+			method:   http.MethodGet,
+			path:     "/v3/tokens",
+			wantBody: "tokenAPI",
+		},
+		{
+			name:     "identities are served by the token API",
+			method:   http.MethodGet,
+			path:     "/v3/identities",
+			wantBody: "tokenAPI",
+		},
+		{
+			name:     "other v3 paths are served by the management API",
+			method:   http.MethodGet,
+			path:     "/v3/clusters",
+			wantBody: "managementAPI",
+		},
+		{
+			name:     "logout is served",
+			method:   http.MethodPost,
+			path:     "/v1/logout",
+			wantBody: "logout",
+		},
+		{
+			name:     "a non POST logout falls through",
+			method:   http.MethodGet,
+			path:     "/v1/logout",
+			wantBody: "next",
+		},
+		{
+			name:     "metrics are served",
+			method:   http.MethodGet,
+			path:     "/metrics",
+			wantBody: "metrics",
+		},
+		{
+			name:     "an unclaimed path falls through",
+			method:   http.MethodGet,
+			path:     "/v1/management.cattle.io.settings",
+			wantBody: "next",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(test.method, test.path, nil)
+			for k, v := range test.header {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+			NewMCMMux(testMCMRoutes()).ServeHTTP(rec, req)
+
+			wantCode := test.wantCode
+			if wantCode == 0 {
+				wantCode = http.StatusOK
+			}
+			require.Equal(t, wantCode, rec.Code)
+			if test.wantBody != "" {
+				assert.Equal(t, test.wantBody, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestNewMCMMuxOptionalRoutes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("v3 public and scim fall through when not configured", func(t *testing.T) {
+		t.Parallel()
+
+		mux := NewMCMMux(testMCMRoutes())
+
+		for _, path := range []string{"/v3-public/authProviders", "/v1-scim/v2/Users"} {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			assert.Equal(t, "next", rec.Body.String(), "path %s", path)
+		}
+	})
+
+	t.Run("v3 public and scim are served when configured", func(t *testing.T) {
+		t.Parallel()
+
+		routes := testMCMRoutes()
+		routes.V3Public = markerHandler("v3Public")
+		routes.SCIM = markerHandler("scim")
+		mux := NewMCMMux(routes)
+
+		for path, want := range map[string]string{
+			"/v3-public/authProviders": "v3Public",
+			"/v1-scim/v2/Users":        "scim",
+		} {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			assert.Equal(t, want, rec.Body.String(), "path %s", path)
+		}
+	})
+}
+
+// TestNewMCMMuxMiddleware pins which middleware stack owns which route. Each
+// wrapper tags the response with its own name, so the body reads as the stack
+// that ran followed by the handler that answered.
+func TestNewMCMMuxMiddleware(t *testing.T) {
+	t.Parallel()
+
+	tagging := func(name string) func(http.Handler) http.Handler {
+		return func(h http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(name + ":"))
+				h.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	routes := testMCMRoutes()
+	routes.Limit = tagging("limit")
+	routes.SAAuthedMW = tagging("saAuthed")
+	routes.AuthedMW = tagging("authed")
+	routes.MetricsMW = tagging("metricsMW")
+	mux := NewMCMMux(routes)
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		wantBody string
+	}{
+		{
+			name:     "unauthenticated routes are limited only",
+			method:   http.MethodGet,
+			path:     "/rancherversion",
+			wantBody: "limit:version",
+		},
+		{
+			name:     "the service account table wraps the cluster proxy",
+			method:   http.MethodGet,
+			path:     "/k8s/clusters/c-abcde/v1/pods",
+			wantBody: "limit:saAuthed:k8sProxy",
+		},
+		{
+			name:     "the authenticated table wraps logout",
+			method:   http.MethodPost,
+			path:     "/v1/logout",
+			wantBody: "limit:authed:logout",
+		},
+		{
+			name:     "the metrics table wraps metrics",
+			method:   http.MethodGet,
+			path:     "/metrics",
+			wantBody: "limit:metricsMW:metrics",
+		},
+		{
+			name:     "the fallthrough is limited only",
+			method:   http.MethodGet,
+			path:     "/v1/management.cattle.io.settings",
+			wantBody: "limit:next",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(test.method, test.path, nil))
+
+			assert.Equal(t, test.wantBody, rec.Body.String())
+		})
+	}
+}

--- a/pkg/rancher/chain_test.go
+++ b/pkg/rancher/chain_test.go
@@ -1,0 +1,269 @@
+package rancher
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	responsewriter "github.com/rancher/apiserver/pkg/middleware"
+	steveapi "github.com/rancher/rancher/pkg/api/steve"
+	"github.com/rancher/rancher/pkg/api/steve/projects"
+	"github.com/rancher/rancher/pkg/api/steve/proxy"
+	"github.com/rancher/rancher/pkg/auth"
+	"github.com/rancher/rancher/pkg/auth/requests"
+	"github.com/rancher/rancher/pkg/multiclustermanager"
+	"github.com/rancher/rancher/pkg/websocket"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// markerHandler returns a handler that writes its own name, so a test can tell
+// which table in the chain answered a request.
+func markerHandler(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(name))
+	})
+}
+
+func identityMW(h http.Handler) http.Handler {
+	return h
+}
+
+// newTestMCM builds the real multi-cluster management table with marker
+// handlers. Its middlewares are identity: which table owns a path is what this
+// test covers, and the authentication wrappers are pinned by the table's own
+// test in pkg/multiclustermanager.
+func newTestMCM(next http.Handler) http.Handler {
+	return multiclustermanager.NewMCMMux(multiclustermanager.MCMRoutes{
+		Limit:      identityMW,
+		SAAuthedMW: identityMW,
+		AuthedMW:   identityMW,
+		MetricsMW:  identityMW,
+
+		K8sProxy:      markerHandler("mcm:k8sProxy"),
+		ManagementAPI: markerHandler("mcm:managementAPI"),
+		Connect:       markerHandler("mcm:connect"),
+		ClusterImport: markerHandler("mcm:clusterImport"),
+		Version:       markerHandler("mcm:version"),
+		ChannelServer: markerHandler("mcm:channelServer"),
+		SAML:          markerHandler("mcm:saml"),
+		V3Public:      markerHandler("mcm:v3Public"),
+		V1Public:      markerHandler("mcm:v1Public"),
+		SCIM:          markerHandler("mcm:scim"),
+		Metrics:       markerHandler("mcm:metrics"),
+		MetaAKS:       markerHandler("mcm:metaAKS"),
+		MetaGKE:       markerHandler("mcm:metaGKE"),
+		MetaAlibaba:   markerHandler("mcm:metaAlibaba"),
+		MetaOCI:       markerHandler("mcm:metaOCI"),
+		MetaVsphere:   markerHandler("mcm:metaVsphere"),
+		MetaProxy:     markerHandler("mcm:metaProxy"),
+		TokenReview:   markerHandler("mcm:tokenReview"),
+		SupportConfig: markerHandler("mcm:supportConfig"),
+		TokenAPI:      markerHandler("mcm:tokenAPI"),
+		Logout:        markerHandler("mcm:logout"),
+		Next:          next,
+	})
+}
+
+func newTestAuthServer(next http.Handler) http.Handler {
+	return auth.NewRootMux(auth.AuthRoutes{
+		Limit:    identityMW,
+		SAML:     markerHandler("auth:saml"),
+		V3Public: markerHandler("auth:v3Public"),
+		V1Public: markerHandler("auth:v1Public"),
+		SCIM:     markerHandler("auth:scim"),
+		V3:       authV3Handler(next),
+		Logout:   markerHandler("auth:logout"),
+		Next:     next,
+	})
+}
+
+// authV3Handler mirrors the dispatch newAPIManagement puts behind the auth
+// server's /v3/ route: a handful of prefixes go to the token API or the Norman
+// APIs and everything else carries on down the chain. It lives in
+// pkg/auth/server.go outside newRootMux, so the chain test has to model it -
+// treating /v3/ as one opaque handler would claim the auth server owns paths
+// like /v3/connect, which it hands off instead.
+func authV3Handler(next http.Handler) http.Handler {
+	tokenAPI := markerHandler("auth:tokenAPI")
+	normanAPI := markerHandler("auth:normanAPI")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasPrefix(path, "/v3/identit"), strings.HasPrefix(path, "/v3/token"):
+			tokenAPI.ServeHTTP(w, r)
+		case strings.HasPrefix(path, "/v3/authConfig"),
+			strings.HasPrefix(path, "/v3/principal"),
+			strings.HasPrefix(path, "/v3/user"),
+			strings.HasPrefix(path, "/v3/schema"),
+			strings.HasPrefix(path, "/v3/subscribe"):
+			normanAPI.ServeHTTP(w, r)
+		default:
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+func newTestPreMCM(next http.Handler) http.Handler {
+	return steveapi.NewPreMCMMux(steveapi.PreMCMRoutes{
+		ConfigServer: markerHandler("preMCM:configServer"),
+		Installer:    markerHandler("preMCM:installer"),
+		Next:         next,
+	})
+}
+
+// newTestAdditionalAPI builds the extras table over the projects table, the
+// same nesting AdditionalAPIs sets up with nextHandler = clusterAPI(next).
+func newTestAdditionalAPI(next http.Handler) http.Handler {
+	return steveapi.NewAdditionalAPIMux(steveapi.AdditionalAPIRoutes{
+		Github: markerHandler("extras:github"),
+		Tunnel: markerHandler("extras:tunnel"),
+		RegisterUIPlugins: func(mux *http.ServeMux) {
+			mux.Handle("/v1/uiplugins", markerHandler("extras:uiplugins"))
+		},
+		Next: projects.NewProjectsMux(markerHandler("projects:server"), next),
+	})
+}
+
+// newTestChain assembles the real chain. Cluster proxy and aggregation go in as
+// identity: the test covers ownership among the extracted tables and treats
+// those two as transparent.
+//
+// mcmEnabled false is modelled as identity in the mcm slot. That is what
+// production does with MCM off: wranglerContext.MultiClusterManager is a
+// *DeferredServer whatever the feature flag says, and its Middleware falls
+// straight through to next because Start never ran, so getMCM returns nil. The
+// noopMCM in pkg/wrangler is only the zero value and never reaches the request
+// path.
+func newTestChain(mcmEnabled bool) http.Handler {
+	mcm := identityMW
+	if mcmEnabled {
+		mcm = newTestMCM
+	}
+
+	return newHandlerChain(chainHandlers{
+		setAuthHeader:       auth.SetXAPICattleAuthHeader,
+		contentTypeOptions:  responsewriter.ContentTypeOptions,
+		noCache:             responsewriter.NoCache,
+		websocket:           websocket.NewWebsocketHandler,
+		rewriteLocalCluster: proxy.RewriteLocalCluster,
+		clusterProxy:        identityMW,
+		aggregation:         identityMW,
+		preMCM:              newTestPreMCM,
+		mcm:                 mcm,
+		authServer:          newTestAuthServer,
+		additionalAPI:       newTestAdditionalAPI,
+		requireAuthed:       requests.NewRequireAuthenticatedFilter("/v1/", "/v1/management.cattle.io.setting"),
+		steve:               markerHandler("steve"),
+	})
+}
+
+// TestHandlerChainOwnership pins which table answers each path, with MCM on and
+// off. Paths whose owner changes between the two modes are the ones a route
+// change can break in one mode only, which is what #56580 was.
+func TestHandlerChainOwnership(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method    string
+		path      string
+		wantMCMOn string
+		// wantMCMOff is the owner with MCM disabled. Equal to wantMCMOn for
+		// every path that is not registered twice.
+		wantMCMOff string
+		// authenticated sends the request with a user in its context, for the
+		// routes registered behind an authenticated filter.
+		authenticated bool
+	}{
+		// The pre-MCM table sits above everything and owns its paths in both
+		// modes.
+		{method: http.MethodGet, path: "/v3/connect/agent", wantMCMOn: "preMCM:configServer", wantMCMOff: "preMCM:configServer"},
+		{method: http.MethodGet, path: "/v3/connect/config-yaml", wantMCMOn: "preMCM:configServer", wantMCMOff: "preMCM:configServer"},
+		{method: http.MethodGet, path: "/system-agent-install.sh", wantMCMOn: "preMCM:installer", wantMCMOff: "preMCM:installer"},
+
+		// Registered in both the MCM table and the auth server. MCM wins when
+		// it is on. Branch B removes the MCM copies, which flips the left
+		// column to match the right one.
+		{method: http.MethodGet, path: "/v1-saml/login", wantMCMOn: "mcm:saml", wantMCMOff: "auth:saml"},
+		{method: http.MethodGet, path: "/v3-public/authProviders", wantMCMOn: "mcm:v3Public", wantMCMOff: "auth:v3Public"},
+		{method: http.MethodGet, path: "/v1-public/authProviders", wantMCMOn: "mcm:v1Public", wantMCMOff: "auth:v1Public"},
+		{method: http.MethodGet, path: "/v1-scim/v2/Users", wantMCMOn: "mcm:scim", wantMCMOff: "auth:scim"},
+		// The auth server registers logout behind an authenticated filter, so
+		// this case needs a user to reach the handler at all.
+		{method: http.MethodPost, path: "/v1/logout", wantMCMOn: "mcm:logout", wantMCMOff: "auth:logout", authenticated: true},
+
+		// Registered in both the MCM table and the extras table. The auth
+		// server's /v3/ route sits between them and hands this path on.
+		{method: http.MethodGet, path: "/v3/connect", wantMCMOn: "mcm:connect", wantMCMOff: "extras:tunnel"},
+
+		// Owned by MCM alone. With MCM off they fall through to the terminal
+		// handler, which is the shape #56580 had.
+		{method: http.MethodGet, path: "/v3/connect/register", wantMCMOn: "mcm:connect", wantMCMOff: "steve"},
+		{method: http.MethodGet, path: "/metrics", wantMCMOn: "mcm:metrics", wantMCMOff: "steve"},
+		{method: http.MethodGet, path: "/rancherversion", wantMCMOn: "mcm:version", wantMCMOff: "steve"},
+		{method: http.MethodGet, path: "/v1-k3s-release/channels", wantMCMOn: "mcm:channelServer", wantMCMOff: "steve"},
+		{method: http.MethodGet, path: "/meta/proxy/example.com", wantMCMOn: "mcm:metaProxy", wantMCMOff: "steve"},
+		{method: http.MethodGet, path: "/k8s/clusters/c-abcde/version", wantMCMOn: "mcm:k8sProxy", wantMCMOff: "steve"},
+
+		// /v3/ is not a duplicate: the two tables serve different endpoints
+		// behind the same prefix. The management API is MCM's alone, tokens are
+		// served in both modes, and the rest of /v3/ carries on down the chain
+		// when MCM is off.
+		{method: http.MethodGet, path: "/v3/clusters", wantMCMOn: "mcm:managementAPI", wantMCMOff: "steve"},
+		{method: http.MethodGet, path: "/v3/tokens", wantMCMOn: "mcm:tokenAPI", wantMCMOff: "auth:tokenAPI"},
+		{method: http.MethodGet, path: "/v3/users", wantMCMOn: "mcm:managementAPI", wantMCMOff: "auth:normanAPI"},
+
+		// The extras table sits below both, so its paths are unaffected by the
+		// mode.
+		{method: http.MethodGet, path: "/v1/github/repos", wantMCMOn: "extras:github", wantMCMOff: "extras:github"},
+		{method: http.MethodGet, path: "/v1/uiplugins", wantMCMOn: "extras:uiplugins", wantMCMOff: "extras:uiplugins"},
+		{method: http.MethodGet, path: "/healthz", wantMCMOn: "ok", wantMCMOff: "ok"},
+		{method: http.MethodGet, path: "/ping", wantMCMOn: "pong", wantMCMOff: "pong"},
+
+		// The projects table sits below the extras mux.
+		{method: http.MethodGet, path: "/v1/management.cattle.io.clusters/c-abcde?link=projects", wantMCMOn: "projects:server", wantMCMOff: "projects:server"},
+
+		// Anything no table claims reaches the terminal handler.
+		{method: http.MethodGet, path: "/dashboard/", wantMCMOn: "steve", wantMCMOff: "steve"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.wantMCMOn, serveChain(newTestChain(true), test.method, test.path, test.authenticated), "MCM enabled")
+			assert.Equal(t, test.wantMCMOff, serveChain(newTestChain(false), test.method, test.path, test.authenticated), "MCM disabled")
+		})
+	}
+}
+
+// TestHandlerChainRequireAuthenticated pins the filter at the bottom of the
+// chain: paths under /v1/ that no table claims need a login before they reach
+// the terminal handler, apart from the settings exception.
+func TestHandlerChainRequireAuthenticated(t *testing.T) {
+	t.Parallel()
+
+	chain := newTestChain(true)
+
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/pods", nil))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	assert.Equal(t, "steve", serveChain(chain, http.MethodGet, "/v1/pods", true))
+	assert.Equal(t, "steve", serveChain(chain, http.MethodGet, "/v1/management.cattle.io.setting", false))
+}
+
+func serveChain(h http.Handler, method, path string, authenticated bool) string {
+	req := httptest.NewRequest(method, path, nil)
+	if authenticated {
+		req = req.WithContext(request.WithUser(req.Context(),
+			&user.DefaultInfo{Name: "u-abcde", Groups: []string{"system:authenticated"}}))
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Body.String()
+}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -388,20 +388,21 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 	return &Rancher{
 		Auth: authServer.Authenticator.Chain(
 			auditLogMiddleware),
-		Handler: responsewriter.Chain{
-			auth.SetXAPICattleAuthHeader,
-			responsewriter.ContentTypeOptions,
-			responsewriter.NoCache,
-			websocket.NewWebsocketHandler,
-			proxy.RewriteLocalCluster,
-			clusterProxy,
-			aggregationMiddleware,
-			additionalAPIPreMCM,
-			wranglerContext.MultiClusterManager.Middleware,
-			authServer.Management,
-			additionalAPI,
-			requests.NewRequireAuthenticatedFilter("/v1/", "/v1/management.cattle.io.setting"),
-		}.Handler(steve),
+		Handler: newHandlerChain(chainHandlers{
+			setAuthHeader:       auth.SetXAPICattleAuthHeader,
+			contentTypeOptions:  responsewriter.ContentTypeOptions,
+			noCache:             responsewriter.NoCache,
+			websocket:           websocket.NewWebsocketHandler,
+			rewriteLocalCluster: proxy.RewriteLocalCluster,
+			clusterProxy:        clusterProxy,
+			aggregation:         aggregationMiddleware,
+			preMCM:              additionalAPIPreMCM,
+			mcm:                 wranglerContext.MultiClusterManager.Middleware,
+			authServer:          authServer.Management,
+			additionalAPI:       additionalAPI,
+			requireAuthed:       requests.NewRequireAuthenticatedFilter("/v1/", "/v1/management.cattle.io.setting"),
+			steve:               steve,
+		}),
 		Wrangler:                       wranglerContext,
 		Steve:                          steve,
 		auditLog:                       auditLogWriter,
@@ -411,6 +412,42 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		aggregationRegistrationTimeout: opts.AggregationRegistrationTimeout,
 		kubeAggregationReadyChan:       kubeAggregationReadyChan,
 	}, nil
+}
+
+// chainHandlers are the middlewares and the terminal handler making up the
+// server's request chain, in the order they are applied. Each middleware sees a
+// request before the ones below it and hands off what it does not serve itself.
+type chainHandlers struct {
+	setAuthHeader       func(http.Handler) http.Handler
+	contentTypeOptions  func(http.Handler) http.Handler
+	noCache             func(http.Handler) http.Handler
+	websocket           func(http.Handler) http.Handler
+	rewriteLocalCluster func(http.Handler) http.Handler
+	clusterProxy        func(http.Handler) http.Handler
+	aggregation         func(http.Handler) http.Handler
+	preMCM              func(http.Handler) http.Handler
+	mcm                 func(http.Handler) http.Handler
+	authServer          func(http.Handler) http.Handler
+	additionalAPI       func(http.Handler) http.Handler
+	requireAuthed       func(http.Handler) http.Handler
+	steve               http.Handler
+}
+
+func newHandlerChain(h chainHandlers) http.Handler {
+	return responsewriter.Chain{
+		h.setAuthHeader,
+		h.contentTypeOptions,
+		h.noCache,
+		h.websocket,
+		h.rewriteLocalCluster,
+		h.clusterProxy,
+		h.aggregation,
+		h.preMCM,
+		h.mcm,
+		h.authServer,
+		h.additionalAPI,
+		h.requireAuthed,
+	}.Handler(h.steve)
 }
 
 // settings aren't initialized yet so we need to use the regular client.


### PR DESCRIPTION
## Issue: TBD<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Requests pass through about a dozen chained muxes, each serving the paths it registers and falling through to the next. None were tested. An endpoint could be dropped, duplicated, or shadowed by an earlier mux with no signal until a user reported it, which is how the logout endpoint came to return 404 when multi-cluster management was disabled. Most of the muxes were also assembled inline inside middleware closures, out of reach of a test.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Each mux is now built by a constructor that takes a struct of handlers and returns the assembled router. Tests fill those structs with handlers that write their own name and assert which one answered a given method and path. Feature-gated endpoints are nil fields rather than feature lookups inside the constructor, so a gate can be tested without touching global feature state. The constructors and their route structs are exported so a test over the whole chain can assemble the real muxes and assert, for each path, which one serves it with multi-cluster management both enabled and disabled. Routing is unchanged.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests