### PR TITLE
Upload integration test failure logs as artifacts

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -133,6 +133,15 @@ jobs:
           INTEGRATION_TEST_PACKAGES: ${{ matrix.packages }}
           INTEGRATION_TEST_RUN: ${{ matrix.run }}
         run: sudo --preserve-env GOBIN=$(which go) ./scripts/gha/tests
+      - name: Upload Rancher + K3s logs if tests failed
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "Rancher + K3s logs (${{ matrix.shard }})"
+          path: |
+            /tmp/rancher.log
+            /tmp/k3s.log
+          retention-days: 7
   # Aggregates the shard matrix into the single stable check
   # "integration-tests / test" that branch protection requires, so the shard
   # matrix can change without editing repo-level required-check settings. Its

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -135,12 +135,14 @@ jobs:
         run: sudo --preserve-env GOBIN=$(which go) ./scripts/gha/tests
       - name: Upload Rancher + K3s logs if tests failed
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "Rancher + K3s logs (${{ matrix.shard }})"
           path: |
             /tmp/rancher.log
             /tmp/k3s.log
+          if-no-files-found: ignore
           retention-days: 7
   # Aggregates the shard matrix into the single stable check
   # "integration-tests / test" that branch protection requires, so the shard

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -79,23 +79,11 @@ curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYS
 
 dump_rancher_logs()
 {
-  echo Dumping Rancher + K3s Container Logs
-  echo -e "-----RANCHER-LOG-DUMP-START-----"
+  echo "Dumping Rancher + K3s container logs to /tmp/rancher.log and /tmp/k3s.log"
   docker logs rancher-server &> /tmp/rancher.log
-  if [ -s /tmp/rancher.log ]; then
-    cat /tmp/rancher.log | gzip | base64 -w 0
-  else
-    echo "------EMPTY------"
-  fi
-  echo -e "\n-----RANCHER-LOG-DUMP-END-----"
   docker cp rancher-server:/var/lib/rancher/k3s.log /tmp/k3s.log
-  echo -e "-----K3S-LOG-DUMP-START-----"
-  if [ -s /tmp/k3s.log ]; then
-    cat /tmp/k3s.log | gzip | base64 -w 0
-  else
-    echo "------EMPTY------"
-  fi
-  echo -e "\n-----K3S-LOG-DUMP-END-----"
+  # Written while running under sudo; make readable so the CI workflow can upload them as an artifact.
+  chmod 644 /tmp/rancher.log /tmp/k3s.log 2>/dev/null || true
 }
 
 export -f dump_rancher_logs

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -80,8 +80,10 @@ curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYS
 dump_rancher_logs()
 {
   echo "Dumping Rancher + K3s container logs to /tmp/rancher.log and /tmp/k3s.log"
-  docker logs rancher-server &> /tmp/rancher.log
-  docker cp rancher-server:/var/lib/rancher/k3s.log /tmp/k3s.log
+  # Best-effort: this runs under `set -e`, so don't let a missing container/log
+  # abort the caller or leave the workflow's artifact upload step empty-handed.
+  docker logs rancher-server &> /tmp/rancher.log || echo "failed to fetch rancher-server logs" >> /tmp/rancher.log
+  docker cp rancher-server:/var/lib/rancher/k3s.log /tmp/k3s.log || echo "failed to fetch k3s.log from rancher-server" > /tmp/k3s.log
   # Written while running under sudo; make readable so the CI workflow can upload them as an artifact.
   chmod 644 /tmp/rancher.log /tmp/k3s.log 2>/dev/null || true
 }


### PR DESCRIPTION
## Problem
Currently, when an integration/provisioning test fails, it dumps the rancher and k3s logs in the workflow, which leads to thousands upon thousands of lines of encoded logs cluttering the output.
 
## Solution
Instead of just dumping the logs, this uploads them as artifacts when the test fails instead. That way you still have them available to you to download, but you don't need to scroll past them or copy and paste them from the UI. As a bonus, they don't need to be base64 encoded because github just zips them anyway and we're no longer restricted by the logstream
 
## Other things
I currently have it set to 7 days of retention. That feels appropriate to me, but I'm open to changing it.