### PR TITLE
[v2.14] Globalrole annotation cleanup 

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -12,12 +12,14 @@ import (
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/wrangler/pkg/name"
 	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	wrbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	wrangler "github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -26,8 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var (
-	globalRoleLabel       = "authz.management.cattle.io/globalrole"
+const (
+	globalRoleLabel = "authz.management.cattle.io/globalrole"
+	// crNameAnnotation is used to store the name of the ClusterRole created for a GlobalRole. It is only for informational purposes and is not used for reconciliation.
 	crNameAnnotation      = "authz.management.cattle.io/cr-name"
 	initialSyncAnnotation = "authz.management.cattle.io/initial-sync"
 	clusterRoleKind       = "ClusterRole"
@@ -39,16 +42,20 @@ const (
 
 // Condition reason types
 const (
-	ClusterRoleExists         = "ClusterRoleExists"
-	NamespacedRuleRoleExists  = "NamespacedRuleRoleExists"
-	NamespaceNotFound         = "NamespaceNotFound"
-	NamespaceTerminating      = "NamespaceTerminating"
-	FailedToGetRole           = "GetRoleFailed"
-	FailedToCreateRole        = "CreateRoleFailed"
-	FailedToUpdateRole        = "UpdateRoleFailed"
-	FailedToGetNamespace      = "GetNamespaceFailed"
-	FailedToCreateClusterRole = "CreateClusterRoleFailed"
-	FailedToUpdateClusterRole = "UpdateClusterRoleFailed"
+	ClusterRoleExists                 = "ClusterRoleExists"
+	FailedToCreateClusterRole         = "CreateClusterRoleFailed"
+	FailedToCreateRole                = "CreateRoleFailed"
+	FailedToGetCluster                = "GetClusterFailed"
+	FailedToGetNamespace              = "GetNamespaceFailed"
+	FailedToGetRole                   = "GetRoleFailed"
+	FailedToReconcileClusterRole      = "ReconcileClusterRoleFailed"
+	FailedToUpdateClusterRole         = "UpdateClusterRoleFailed"
+	FailedToUpdateRole                = "UpdateRoleFailed"
+	InheritedNamespacedRuleRoleExists = "InheritedNamespacedRuleRoleExists"
+	NamespacedRuleRoleExists          = "NamespacedRuleRoleExists"
+	NamespaceNotAvailable             = "NamespaceNotAvailable"
+	NamespaceNotFound                 = "NamespaceNotFound"
+	NamespaceTerminating              = "NamespaceTerminating"
 )
 
 type fleetPermissionsRoleHandler interface {
@@ -59,7 +66,6 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 	return &globalRoleLifecycle{
 		clusters:                management.Wrangler.Mgmt.Cluster(),
 		clusterManager:          clusterManager,
-		crLister:                management.Wrangler.RBAC.ClusterRole().Cache(),
 		crClient:                management.Wrangler.RBAC.ClusterRole(),
 		nsCache:                 management.Wrangler.Core.Namespace().Cache(),
 		rLister:                 management.Wrangler.RBAC.Role().Cache(),
@@ -73,7 +79,6 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 type globalRoleLifecycle struct {
 	clusters                mgmtv3.ClusterClient
 	clusterManager          *clustermanager.Manager
-	crLister                wrbacv1.ClusterRoleCache
 	crClient                wrbacv1.ClusterRoleClient
 	nsCache                 wcorev1.NamespaceCache
 	rLister                 wrbacv1.RoleCache
@@ -115,7 +120,7 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 		gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj),
 		gr.setGRAsCompleted(obj),
 	)
-	return nil, returnError
+	return obj, returnError
 }
 
 func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (runtime.Object, error) {
@@ -146,39 +151,18 @@ func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (runtime.Object, error
 }
 
 func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) error {
-	crName := getCRName(globalRole)
+	crName := getCRName(globalRole.Name)
+	// Set the name of the cluster role in an annotation on the globalrole for informational purposes. This is not used for reconciliation.
+	if globalRole.Annotations == nil {
+		globalRole.Annotations = map[string]string{}
+	}
+	globalRole.Annotations[crNameAnnotation] = crName
+
 	condition := metav1.Condition{
 		Type: ClusterRoleExists,
 	}
 
-	clusterRole, _ := gr.crLister.Get(crName)
-	if clusterRole != nil {
-		updated := false
-		clusterRole = clusterRole.DeepCopy()
-		if !reflect.DeepEqual(globalRole.Rules, clusterRole.Rules) {
-			clusterRole.Rules = globalRole.Rules
-			logrus.Infof("[%v] Updating clusterRole %v. GlobalRole rules have changed. Have: %+v. Want: %+v", grController, clusterRole.Name, clusterRole.Rules, globalRole.Rules)
-			updated = true
-		}
-		// Ensure existing ClusterRoles have the correct grOwnerLabel pointing to the owning GlobalRole.
-		if grName := clusterRole.Labels[grOwnerLabel]; grName != globalRole.Name {
-			clusterRole.Labels[grOwnerLabel] = globalRole.Name
-			logrus.Infof("[%v] Updating clusterRole %s owner from %s to %s.", grController, clusterRole.Name, grName, globalRole.Name)
-			updated = true
-		}
-
-		if updated {
-			if _, err := gr.crClient.Update(clusterRole); err != nil {
-				addCondition(globalRole, condition, FailedToUpdateClusterRole, crName, err)
-				return fmt.Errorf("couldn't update ClusterRole %v: %w", clusterRole.Name, err)
-			}
-		}
-		addCondition(globalRole, condition, ClusterRoleExists, crName, nil)
-		return nil
-	}
-
-	logrus.Infof("[%v] Creating clusterRole %v for corresponding GlobalRole", grController, crName)
-	_, err := gr.crClient.Create(&rbacv1.ClusterRole{
+	desiredClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crName,
 			OwnerReferences: []metav1.OwnerReference{
@@ -195,18 +179,49 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) er
 			},
 		},
 		Rules: globalRole.Rules,
+	}
+
+	clusterRoles, err := gr.crClient.List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", grOwnerLabel, globalRole.Name),
 	})
 	if err != nil {
-		addCondition(globalRole, condition, FailedToCreateClusterRole, crName, err)
+		err = fmt.Errorf("couldn't list ClusterRoles for globalRole %v: %w", globalRole.Name, err)
+		addCondition(globalRole, condition, FailedToReconcileClusterRole, crName, err)
 		return err
 	}
-	// Add an annotation to the globalrole indicating the name we used for future updates
-	if globalRole.Annotations == nil {
-		globalRole.Annotations = map[string]string{}
+
+	// Delete any ClusterRoles that were created for this GlobalRole but have the wrong name.
+	for _, clusterRole := range clusterRoles.Items {
+		if clusterRole.Name != crName {
+			if err := rbac.DeleteResource(clusterRole.Name, gr.crClient); err != nil {
+				err = fmt.Errorf("couldn't delete ClusterRole %v for globalRole %v: %w", clusterRole.Name, globalRole.Name, err)
+				addCondition(globalRole, condition, FailedToReconcileClusterRole, crName, err)
+				return err
+			}
+		}
 	}
-	globalRole.Annotations[crNameAnnotation] = crName
+
+	if err := rbac.CreateOrUpdateResource(desiredClusterRole, gr.crClient, areGlobalRoleClusterRolesSame); err != nil {
+		addCondition(globalRole, condition, FailedToReconcileClusterRole, crName, err)
+		return fmt.Errorf("couldn't reconcile ClusterRole %v: %w", crName, err)
+	}
+
 	addCondition(globalRole, condition, ClusterRoleExists, crName, nil)
 	return nil
+}
+
+// areGlobalRoleClusterRolesSame returns true if the ClusterRole created for a GlobalRole matches the desired Rules, owner label, and owner reference.
+func areGlobalRoleClusterRolesSame(currentCR, desiredCR *rbacv1.ClusterRole) (bool, *rbacv1.ClusterRole) {
+	if !equality.Semantic.DeepEqual(currentCR.Rules, desiredCR.Rules) {
+		return false, desiredCR
+	}
+	if currentCR.Labels[grOwnerLabel] != desiredCR.Labels[grOwnerLabel] {
+		return false, desiredCR
+	}
+	if !equality.Semantic.DeepEqual(currentCR.OwnerReferences, desiredCR.OwnerReferences) {
+		return false, desiredCR
+	}
+	return true, desiredCR
 }
 
 // reconcileNamespacedRoles ensures that Roles exist in each namespace of NamespacedRules
@@ -384,15 +399,8 @@ func (gr *globalRoleLifecycle) setGRAsTerminating(globalRole *v3.GlobalRole) err
 	return err
 }
 
-func getCRName(globalRole *v3.GlobalRole) string {
-	if crName, ok := globalRole.Annotations[crNameAnnotation]; ok {
-		return crName
-	}
-	return generateCRName(globalRole.Name)
-}
-
-func generateCRName(name string) string {
-	return "cattle-globalrole-" + name
+func getCRName(grName string) string {
+	return name.SafeConcatName("cattle-globalrole", grName)
 }
 
 func addCondition(globalRole *v3.GlobalRole, condition metav1.Condition, reason, name string, err error) {

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -51,13 +51,22 @@ var (
 			readPodPolicyRule,
 		},
 	}
+	defaultGROwnerRefs = []metav1.OwnerReference{
+		{
+			APIVersion: defaultGR.TypeMeta.APIVersion,
+			Kind:       defaultGR.TypeMeta.Kind,
+			Name:       defaultGR.Name,
+			UID:        defaultGR.UID,
+		},
+	}
 	readConfigCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: getCRName(defaultGR.Name),
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
 				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
 			},
+			OwnerReferences: defaultGROwnerRefs,
 		},
 		Rules: []rbacv1.PolicyRule{
 			readConfigPolicyRule,
@@ -65,7 +74,32 @@ var (
 	}
 	readPodCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: getCRName(defaultGR.Name),
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrole": "true",
+				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
+			},
+			OwnerReferences: defaultGROwnerRefs,
+		},
+		Rules: []rbacv1.PolicyRule{
+			readPodPolicyRule,
+		},
+	}
+	missingLabelCR = rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getCRName(defaultGR.Name),
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrole": "true",
+			},
+			OwnerReferences: defaultGROwnerRefs,
+		},
+		Rules: []rbacv1.PolicyRule{
+			readPodPolicyRule,
+		},
+	}
+	missingOwnerRefCR = rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getCRName(defaultGR.Name),
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
 				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
@@ -75,12 +109,14 @@ var (
 			readPodPolicyRule,
 		},
 	}
-	missingLabelCR = rbacv1.ClusterRole{
+	staleNamedCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: "stale-cluster-role-name",
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
+				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
 			},
+			OwnerReferences: defaultGROwnerRefs,
 		},
 		Rules: []rbacv1.PolicyRule{
 			readPodPolicyRule,
@@ -114,8 +150,8 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 	type controllers struct {
 		crController *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]
-		crCache      *fake.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]
 	}
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}, "clusterRole")
 	tests := []struct {
 		name             string
 		setupControllers func(controllers)
@@ -127,7 +163,8 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "no changes to clusterRole",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  false,
@@ -139,7 +176,8 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "clusterRole is updated",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -152,33 +190,36 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "update clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
 			condition: reducedCondition{
-				reason: FailedToUpdateClusterRole,
+				reason: FailedToReconcileClusterRole,
 				status: metav1.ConditionFalse,
 			},
 		},
 		{
 			name: "create clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(nil, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
 			condition: reducedCondition{
-				reason: FailedToCreateClusterRole,
+				reason: FailedToReconcileClusterRole,
 				status: metav1.ConditionFalse,
 			},
 		},
 		{
 			name: "clusterRole is created",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(nil, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -187,12 +228,13 @@ func TestReconcileGlobalRole(t *testing.T) {
 				reason: ClusterRoleExists,
 				status: metav1.ConditionTrue,
 			},
-			annotation: getCRName(&defaultGR),
+			annotation: getCRName(defaultGR.Name),
 		},
 		{
 			name: "missing grOwnerLabel in clusterRole triggers update",
 			setupControllers: func(c controllers) {
-				c.crCache.EXPECT().Get(gomock.Any()).Return(missingLabelCR.DeepCopy(), nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingLabelCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingLabelCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -202,6 +244,75 @@ func TestReconcileGlobalRole(t *testing.T) {
 				status: metav1.ConditionTrue,
 			},
 		},
+		{
+			name: "missing OwnerReference in clusterRole triggers update",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingOwnerRefCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingOwnerRefCR.DeepCopy(), nil)
+				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "stale-named ClusterRole is deleted and the correct one is created",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "stale-named ClusterRole already gone is not an error",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(notFoundErr)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "deleting a stale-named ClusterRole fails",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("error"))
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  true,
+			condition: reducedCondition{
+				reason: FailedToReconcileClusterRole,
+				status: metav1.ConditionFalse,
+			},
+		},
+		{
+			name: "listing ClusterRoles fails",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  true,
+			condition: reducedCondition{
+				reason: FailedToReconcileClusterRole,
+				status: metav1.ConditionFalse,
+			},
+		},
 	}
 
 	ctrl := gomock.NewController(t)
@@ -209,7 +320,6 @@ func TestReconcileGlobalRole(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			controllers := controllers{
 				crController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl),
-				crCache:      fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl),
 			}
 			if test.setupControllers != nil {
 				test.setupControllers(controllers)
@@ -217,7 +327,6 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 			grLifecycle := globalRoleLifecycle{
 				crClient: controllers.crController,
-				crLister: controllers.crCache,
 			}
 			err := grLifecycle.reconcileGlobalRole(test.globalRole)
 

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -3,6 +3,7 @@ package globalroles
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -56,9 +57,10 @@ var (
 )
 
 const (
+	// crbNameAnnotation records the name of the ClusterRoleBinding created for a GlobalRoleBinding, for
+	// reference purposes. It is not read back for reconciliation.
 	crbNameAnnotation             = "authz.management.cattle.io/crb-name"
 	crtbGrbOwnerIndex             = "authz.management.cattle.io/crtb-owner"
-	crbNamePrefix                 = "cattle-globalrolebinding-"
 	localClusterName              = "local"
 	grbOwnerLabel                 = "authz.management.cattle.io/grb-owner"
 	fleetWorkspacePermissionLabel = "authz.management.cattle.io/fleet-workspace-permissions"
@@ -369,58 +371,16 @@ func (l *globalRoleBindingLifecycle) findMissingRTs(wantRTs []string, cluster *v
 func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBinding *v3.GlobalRoleBinding, localConditions *[]metav1.Condition) error {
 	condition := metav1.Condition{Type: globalRoleBindingReconciled}
 
-	crbName, ok := globalRoleBinding.Annotations[crbNameAnnotation]
-	if !ok {
-		crbName = crbNamePrefix + globalRoleBinding.Name
+	crbName := getCRBName(globalRoleBinding.Name)
+	if globalRoleBinding.Annotations == nil {
+		globalRoleBinding.Annotations = map[string]string{}
 	}
+	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
 
-	subject := rbac.GetGRBSubject(globalRoleBinding)
+	grLabels := map[string]string{grbOwnerLabel: globalRoleBinding.Name}
+	maps.Copy(grLabels, globalRoleBindingLabel)
 
-	crb, _ := l.crbLister.Get(crbName)
-	if crb != nil {
-		subjects := []rbacv1.Subject{subject}
-		updateSubject := !reflect.DeepEqual(subjects, crb.Subjects)
-
-		updateRoleRef := false
-		var roleRef rbacv1.RoleRef
-		gr, _ := l.grLister.Get(globalRoleBinding.GlobalRoleName)
-		if gr != nil {
-			crNameFromGR := getCRName(gr)
-			if crNameFromGR != crb.RoleRef.Name {
-				updateRoleRef = true
-				roleRef = rbacv1.RoleRef{
-					Name: crNameFromGR,
-					Kind: clusterRoleKind,
-				}
-			}
-		}
-		if updateSubject || updateRoleRef {
-			crb = crb.DeepCopy()
-			if updateRoleRef {
-				crb.RoleRef = roleRef
-			}
-			crb.Subjects = subjects
-			logrus.Infof("[%v] Updating clusterRoleBinding %v for globalRoleBinding %v user %v", grbController, crb.Name, globalRoleBinding.Name, globalRoleBinding.UserName)
-			if _, err := l.crbClient.Update(crb); err != nil {
-				l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
-				return fmt.Errorf("couldn't update ClusterRoleBinding %v: %w", crb.Name, err)
-			}
-		}
-
-		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
-		return nil
-	}
-
-	logrus.Infof("Creating new GlobalRoleBinding for GlobalRoleBinding %v", globalRoleBinding.Name)
-	gr, _ := l.grLister.Get(globalRoleBinding.GlobalRoleName)
-	var crName string
-	if gr != nil {
-		crName = getCRName(gr)
-	} else {
-		crName = generateCRName(globalRoleBinding.GlobalRoleName)
-	}
-	logrus.Infof("[%v] Creating clusterRoleBinding for globalRoleBinding %v for user %v with role %v", grbController, globalRoleBinding.Name, globalRoleBinding.UserName, crName)
-	_, err := l.crbClient.Create(&rbacv1.ClusterRoleBinding{
+	desiredCRB := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crbName,
 			OwnerReferences: []metav1.OwnerReference{
@@ -431,26 +391,77 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 					UID:        globalRoleBinding.UID,
 				},
 			},
-			Labels: globalRoleBindingLabel,
+			Labels: grLabels,
 		},
-		Subjects: []rbacv1.Subject{subject},
+		Subjects: []rbacv1.Subject{rbac.GetGRBSubject(globalRoleBinding)},
 		RoleRef: rbacv1.RoleRef{
-			Name: crName,
+			Name: getCRName(globalRoleBinding.GlobalRoleName),
 			Kind: clusterRoleKind,
 		},
-	})
+	}
+
+	clusterRoleBindings, err := l.crbLister.List(labels.SelectorFromSet(map[string]string{grbOwnerLabel: globalRoleBinding.Name}))
 	if err != nil {
-		l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+		err = fmt.Errorf("couldn't list ClusterRoleBindings for globalRoleBinding %v: %w", globalRoleBinding.Name, err)
+		l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
 		return err
 	}
-	// Add an annotation to the globalrole indicating the name we used for future updates
-	if globalRoleBinding.Annotations == nil {
-		globalRoleBinding.Annotations = map[string]string{}
+
+	// Delete any ClusterRoleBindings that were created for this GlobalRoleBinding but have the wrong name.
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		if clusterRoleBinding.Name != crbName {
+			if err := rbac.DeleteResource(clusterRoleBinding.Name, l.crbClient); err != nil {
+				err = fmt.Errorf("couldn't delete ClusterRoleBinding %v for globalRoleBinding %v: %w", clusterRoleBinding.Name, globalRoleBinding.Name, err)
+				l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+				return err
+			}
+		}
 	}
-	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
+
+	crb, _ := l.crbLister.Get(crbName)
+	if crb == nil {
+		logrus.Infof("[%v] Creating clusterRoleBinding for globalRoleBinding %v for user %v with role %v", grbController, globalRoleBinding.Name, globalRoleBinding.UserName, desiredCRB.RoleRef.Name)
+		if _, err := l.crbClient.Create(desiredCRB); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+			return err
+		}
+		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
+		return nil
+	}
+
+	// RoleRef is immutable on an existing ClusterRoleBinding, so a RoleRef change can only be applied by
+	// deleting and recreating it rather than updating it in place.
+	if !reflect.DeepEqual(crb.RoleRef, desiredCRB.RoleRef) {
+		logrus.Infof("[%v] Recreating clusterRoleBinding %v for globalRoleBinding %v with role %v", grbController, crb.Name, globalRoleBinding.Name, desiredCRB.RoleRef.Name)
+		if err := l.crbClient.Delete(crb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't delete ClusterRoleBinding %v: %w", crb.Name, err)
+		}
+		if _, err := l.crbClient.Create(desiredCRB); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't create ClusterRoleBinding %v: %w", desiredCRB.Name, err)
+		}
+		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
+		return nil
+	}
+
+	if !reflect.DeepEqual(crb.Subjects, desiredCRB.Subjects) {
+		crb = crb.DeepCopy()
+		crb.Subjects = desiredCRB.Subjects
+		logrus.Infof("[%v] Updating clusterRoleBinding %v for globalRoleBinding %v user %v", grbController, crb.Name, globalRoleBinding.Name, globalRoleBinding.UserName)
+		if _, err := l.crbClient.Update(crb); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't update ClusterRoleBinding %v: %w", crb.Name, err)
+		}
+	}
 
 	l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
 	return nil
+}
+
+// getCRBName returns the name of the ClusterRoleBinding backing a GlobalRoleBinding with the given name.
+func getCRBName(grbName string) string {
+	return wrangler.SafeConcatName("cattle-globalrolebinding", grbName)
 }
 
 // reconcileNamespacedRoleBindings ensures that RoleBindings exist for each namespace listed in NamespacedRules

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -395,8 +395,9 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 		},
 		Subjects: []rbacv1.Subject{rbac.GetGRBSubject(globalRoleBinding)},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName(globalRoleBinding.GlobalRoleName),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName(globalRoleBinding.GlobalRoleName),
+			Kind:     clusterRoleKind,
 		},
 	}
 

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -408,35 +408,6 @@ func TestReconcileClusterPermissions(t *testing.T) {
 func TestReconcileGlobalRoleBinding(t *testing.T) {
 	t.Parallel()
 
-	testGR := v3.GlobalRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gr",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{"get", "list", "watch"},
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-			},
-		},
-	}
-
-	testGRWithAnnotation := v3.GlobalRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gr",
-			Annotations: map[string]string{
-				crNameAnnotation: "custom-cr-name",
-			},
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{"get", "list", "watch"},
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-			},
-		},
-	}
-
 	testGRB := v3.GlobalRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-grb",
@@ -450,25 +421,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		UserName:       "test-user",
 	}
 
-	testGRBWithAnnotation := v3.GlobalRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-grb",
-			UID:  "1234",
-			Annotations: map[string]string{
-				crbNameAnnotation: "custom-crb-name",
-			},
-		},
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "management.cattle.io/v3",
-			Kind:       "GlobalRoleBinding",
-		},
-		GlobalRoleName: "test-gr",
-		UserName:       "test-user",
-	}
-
 	expectedCRB := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: crbNamePrefix + "test-grb",
+			Name: getCRBName("test-grb"),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "management.cattle.io/v3",
@@ -477,7 +432,10 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					UID:        "1234",
 				},
 			},
-			Labels: globalRoleBindingLabel,
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrolebinding": "true",
+				grbOwnerLabel: "test-grb",
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -487,7 +445,36 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: generateCRName("test-gr"),
+			Name: getCRName("test-gr"),
+			Kind: clusterRoleKind,
+		},
+	}
+
+	staleNamedCRB := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stale-cluster-role-binding-name",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "GlobalRoleBinding",
+					Name:       "test-grb",
+					UID:        "1234",
+				},
+			},
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrolebinding": "true",
+				grbOwnerLabel: "test-grb",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     "test-user",
+				APIGroup: rbacv1.GroupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: getCRName("test-gr"),
 			Kind: clusterRoleKind,
 		},
 	}
@@ -495,7 +482,6 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 	type controllers struct {
 		crbCache      *fake.MockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding]
 		crbController *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList]
-		grCache       *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
 	}
 
 	tests := []struct {
@@ -508,45 +494,19 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "create new clusterRoleBinding",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(&expectedCRB, nil)
 			},
 			inputObject:    testGRB.DeepCopy(),
 			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
-		},
-		{
-			name: "create new clusterRoleBinding with custom annotation",
-			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get("custom-crb-name").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
-				customCRB := expectedCRB.DeepCopy()
-				customCRB.Name = "custom-crb-name"
-				c.crbController.EXPECT().Create(customCRB).Return(customCRB, nil)
-			},
-			inputObject:    testGRBWithAnnotation.DeepCopy(),
-			wantError:      false,
-			wantAnnotation: "custom-crb-name",
-		},
-		{
-			name: "create new clusterRoleBinding uses CR name from GlobalRole annotation",
-			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGRWithAnnotation.DeepCopy(), nil)
-				crbWithCustomCR := expectedCRB.DeepCopy()
-				crbWithCustomCR.RoleRef.Name = "custom-cr-name"
-				c.crbController.EXPECT().Create(crbWithCustomCR).Return(crbWithCustomCR, nil)
-			},
-			inputObject:    testGRB.DeepCopy(),
-			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
+			wantAnnotation: getCRBName("test-grb"),
 		},
 		{
 			name: "clusterRoleBinding creation fails",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(nil, fmt.Errorf("server unavailable"))
 			},
 			inputObject: testGRB.DeepCopy(),
@@ -556,11 +516,12 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			name: "clusterRoleBinding already exists no update needed",
 			setupControllers: func(c controllers) {
 				existingCRB := expectedCRB.DeepCopy()
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 			},
-			inputObject: testGRB.DeepCopy(),
-			wantError:   false,
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
 		},
 		{
 			name: "update clusterRoleBinding subject",
@@ -573,8 +534,8 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 						APIGroup: rbacv1.GroupName,
 					},
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				updatedCRB := expectedCRB.DeepCopy()
 				c.crbController.EXPECT().Update(updatedCRB).Return(updatedCRB, nil)
 			},
@@ -589,10 +550,10 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
-				updatedCRB := expectedCRB.DeepCopy()
-				c.crbController.EXPECT().Update(updatedCRB).Return(updatedCRB, nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
 			},
 			inputObject: testGRB.DeepCopy(),
 			wantError:   false,
@@ -612,13 +573,44 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
-				updatedCRB := expectedCRB.DeepCopy()
-				c.crbController.EXPECT().Update(updatedCRB).Return(updatedCRB, nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
 			},
 			inputObject: testGRB.DeepCopy(),
 			wantError:   false,
+		},
+		{
+			name: "roleRef change: delete fails",
+			setupControllers: func(c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "roleRef change: recreate fails",
+			setupControllers: func(c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
+				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
 		},
 		{
 			name: "update clusterRoleBinding fails",
@@ -631,8 +623,8 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 						APIGroup: rbacv1.GroupName,
 					},
 				}
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(existingCRB, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				updatedCRB := expectedCRB.DeepCopy()
 				c.crbController.EXPECT().Update(updatedCRB).Return(nil, fmt.Errorf("server unavailable"))
 			},
@@ -640,24 +632,51 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			wantError:   true,
 		},
 		{
-			name: "globalRole not found uses generated name",
+			name: "stale-named ClusterRoleBinding is deleted and the correct one is created",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(nil, apierrors.NewNotFound(schema.GroupResource{
-					Group:    "management.cattle.io",
-					Resource: "GlobalRole",
-				}, "test-gr"))
-				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(&expectedCRB, nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
 			},
 			inputObject:    testGRB.DeepCopy(),
 			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "stale-named ClusterRoleBinding already gone is not an error",
+			setupControllers: func(c controllers) {
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"}, staleNamedCRB.Name))
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
+				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
+			},
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "deleting a stale-named ClusterRoleBinding fails",
+			setupControllers: func(c controllers) {
+				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "listing ClusterRoleBindings fails",
+			setupControllers: func(c controllers) {
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
 		},
 		{
 			name: "group principal binding",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().Get(crbNamePrefix+"test-grb").Return(nil, nil)
-				c.grCache.EXPECT().Get("test-gr").Return(testGR.DeepCopy(), nil)
+				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				groupCRB := expectedCRB.DeepCopy()
 				groupCRB.Subjects = []rbacv1.Subject{
 					{
@@ -681,7 +700,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 				GroupPrincipalName: "test-group",
 			},
 			wantError:      false,
-			wantAnnotation: crbNamePrefix + "test-grb",
+			wantAnnotation: getCRBName("test-grb"),
 		},
 	}
 
@@ -691,7 +710,6 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			controllers := controllers{
 				crbCache:      fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl),
 				crbController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl),
-				grCache:       fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRole](ctrl),
 			}
 			if test.setupControllers != nil {
 				test.setupControllers(controllers)
@@ -700,7 +718,6 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			grbLifecycle := globalRoleBindingLifecycle{
 				crbLister: controllers.crbCache,
 				crbClient: controllers.crbController,
-				grLister:  controllers.grCache,
 				status:    status.NewStatus(),
 			}
 			var conditions []metav1.Condition
@@ -1296,8 +1313,10 @@ func Test_globalRoleBindingLifecycle_Create(t *testing.T) {
 		crtbClient := fake.NewMockClientInterface[*v3.ClusterRoleTemplateBinding, *v3.ClusterRoleTemplateBindingList](ctrl)
 		crtbClient.EXPECT().Create(gomock.Any()).Return(&v3.ClusterRoleTemplateBinding{}, nil)
 
-		// reconcileGlobalRoleBinding: Check if a ClusterRoleBinding already exists for this GRB
+		// reconcileGlobalRoleBinding: List existing ClusterRoleBindings owned by this GRB, then check if the
+		// correctly-named one already exists
 		crbLister := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
+		crbLister.EXPECT().List(gomock.Any()).Return(nil, nil)
 		crbLister.EXPECT().Get(gomock.Any()).Return(nil, apierrors.NewNotFound(rbacv1.Resource("clusterrolebinding"), "test"))
 
 		// reconcileGlobalRoleBinding: Create a ClusterRoleBinding to bind the user to the GlobalRole's ClusterRole
@@ -1395,6 +1414,6 @@ func Test_globalRoleBindingLifecycle_Create(t *testing.T) {
 		resultGRB, ok := result.(*v3.GlobalRoleBinding)
 		require.True(t, ok)
 		require.Equal(t, testPrincipal, resultGRB.UserPrincipalName, "user principal should be set by reconcileSubject")
-		require.Equal(t, crbNamePrefix+testGRBName, resultGRB.Annotations[crbNameAnnotation], "CRB annotation should be set by reconcileGlobalRoleBinding")
+		require.Equal(t, getCRBName(testGRBName), resultGRB.Annotations[crbNameAnnotation], "CRB annotation should be set by reconcileGlobalRoleBinding")
 	})
 }

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -445,8 +445,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName("test-gr"),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName("test-gr"),
+			Kind:     clusterRoleKind,
 		},
 	}
 
@@ -474,8 +475,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName("test-gr"),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName("test-gr"),
+			Kind:     clusterRoleKind,
 		},
 	}
 

--- a/tests/controllers/globalroles/globalrole_test.go
+++ b/tests/controllers/globalroles/globalrole_test.go
@@ -167,11 +167,11 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 	}{
 		// NOTE: These test can be run in parallel only if the global role names are unique
 		{
-			name: "create primary cluster role given cr-name",
+			name: "ignore cr-name label and use global role name for cluster role",
 			globalRole: v3.GlobalRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						crNameLabel: "cr-name",
+						crNameLabel: "cr-label",
 					},
 					Name: "cr-name-gr",
 				},
@@ -179,7 +179,7 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 			},
 			clusterRole: rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cr-name",
+					Name: "cattle-globalrole-cr-name-gr",
 				},
 				Rules: []rbacv1.PolicyRule{getPodRule},
 			},
@@ -240,7 +240,6 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.Run(test.name, func() {
 			t := s.T()
 			t.Parallel()

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -400,17 +400,24 @@ def test_user_role_permissions(admin_mc, user_factory, remove_resource):
     assert len(users1.data) == 1, "user should only see themselves"
 
     # user1 can see all roleTemplates
-    role_templates = user1.client.list_role_template()
-    assert len(role_templates.data) > 0, ("user should be able to see all " +
-                                          "roleTemplates")
+    def user1_can_see_role_templates():
+        return len(user1.client.list_role_template().data) > 0
+
+    wait_for(user1_can_see_role_templates,
+             fail_handler=lambda: ("user should be able to see all " +
+                                   "roleTemplates"))
 
     # user2 should only see themselves in the user list
     users2 = user2.client.list_user()
     assert len(users2.data) == 1, "user should only see themselves"
+
     # user2 should not see any role templates
-    role_templates = user2.client.list_role_template()
-    assert len(role_templates.data) == 0, ("user2 does not have permission " +
-                                           "to view roleTemplates")
+    def user2_cannot_see_role_templates():
+        return len(user2.client.list_role_template().data) == 0
+
+    wait_for(user2_cannot_see_role_templates,
+             fail_handler=lambda: ("user2 does not have permission " +
+                                   "to view roleTemplates"))
 
 
 def test_impersonation_passthrough(admin_mc, admin_cc, user_mc, user_factory,
@@ -517,18 +524,41 @@ def test_impersonation_passthrough(admin_mc, admin_cc, user_mc, user_factory,
 
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
-    kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 3
+    client = user_factory().client
 
-    kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 3
+    def can_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 3
 
-    kds = user_factory('kontainerdrivers-manage').client. \
-        list_kontainer_driver()
-    assert len(kds) == 3
+    wait_for(can_see_kontainer_drivers,
+             fail_handler=lambda: "user should be able to see kontainer "
+                                  "drivers")
 
-    kds = user_factory('settings-manage').client.list_kontainer_driver()
-    assert len(kds) == 0
+    client = user_factory('clusters-create').client
+
+    def clusters_create_can_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 3
+
+    wait_for(clusters_create_can_see_kontainer_drivers,
+             fail_handler=lambda: "clusters-create user should be able to "
+                                  "see kontainer drivers")
+
+    client = user_factory('kontainerdrivers-manage').client
+
+    def kontainerdrivers_manage_can_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 3
+
+    wait_for(kontainerdrivers_manage_can_see_kontainer_drivers,
+             fail_handler=lambda: "kontainerdrivers-manage user should be "
+                                  "able to see kontainer drivers")
+
+    client = user_factory('settings-manage').client
+
+    def settings_manage_cannot_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 0
+
+    wait_for(settings_manage_cannot_see_kontainer_drivers,
+             fail_handler=lambda: "settings-manage user should not see "
+                                  "kontainer drivers")
 
 
 def test_readonly_cannot_edit_secret(admin_mc, user_mc, admin_pc,


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/56593

Required some changes because globalrole statuses were changed in 2.15, but core functionality is preserved.