### PR TITLE
[v2.13] Globalrole annotation cleanup

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -12,11 +12,14 @@ import (
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/wrangler/pkg/name"
 	wcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	wrbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
 	wrangler "github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -25,8 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var (
-	globalRoleLabel       = "authz.management.cattle.io/globalrole"
+const (
+	globalRoleLabel = "authz.management.cattle.io/globalrole"
+	// crNameAnnotation is used to store the name of the ClusterRole created for a GlobalRole. It is only for informational purposes and is not used for reconciliation.
 	crNameAnnotation      = "authz.management.cattle.io/cr-name"
 	initialSyncAnnotation = "authz.management.cattle.io/initial-sync"
 	clusterRoleKind       = "ClusterRole"
@@ -45,17 +49,20 @@ const (
 
 // Condition reason types
 const (
-	ClusterRoleExists         = "ClusterRoleExists"
-	NamespacedRuleRoleExists  = "NamespacedRuleRoleExists"
-	CatalogRoleExists         = "CatalogRoleExists"
-	NamespaceNotFound         = "NamespaceNotFound"
-	NamespaceTerminating      = "NamespaceTerminating"
-	FailedToGetRole           = "GetRoleFailed"
-	FailedToCreateRole        = "CreateRoleFailed"
-	FailedToUpdateRole        = "UpdateRoleFailed"
-	FailedToGetNamespace      = "GetNamespaceFailed"
-	FailedToCreateClusterRole = "CreateClusterRoleFailed"
-	FailedToUpdateClusterRole = "UpdateClusterRoleFailed"
+	ClusterRoleExists                 = "ClusterRoleExists"
+	FailedToCreateClusterRole         = "CreateClusterRoleFailed"
+	FailedToCreateRole                = "CreateRoleFailed"
+	FailedToGetCluster                = "GetClusterFailed"
+	FailedToGetNamespace              = "GetNamespaceFailed"
+	FailedToGetRole                   = "GetRoleFailed"
+	FailedToReconcileClusterRole      = "ReconcileClusterRoleFailed"
+	FailedToUpdateClusterRole         = "UpdateClusterRoleFailed"
+	FailedToUpdateRole                = "UpdateRoleFailed"
+	InheritedNamespacedRuleRoleExists = "InheritedNamespacedRuleRoleExists"
+	NamespacedRuleRoleExists          = "NamespacedRuleRoleExists"
+	NamespaceNotAvailable             = "NamespaceNotAvailable"
+	NamespaceNotFound                 = "NamespaceNotFound"
+	NamespaceTerminating              = "NamespaceTerminating"
 )
 
 type fleetPermissionsRoleHandler interface {
@@ -66,8 +73,7 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 	return &globalRoleLifecycle{
 		clusters:                management.Wrangler.Mgmt.Cluster(),
 		clusterManager:          clusterManager,
-		crLister:                management.RBAC.ClusterRoles("").Controller().Lister(),
-		crClient:                management.RBAC.ClusterRoles(""),
+		crClient:                management.Wrangler.RBAC.ClusterRole(),
 		nsCache:                 management.Wrangler.Core.Namespace().Cache(),
 		rLister:                 management.RBAC.Roles("").Controller().Lister(),
 		rClient:                 management.RBAC.Roles(""),
@@ -80,8 +86,7 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 type globalRoleLifecycle struct {
 	clusters                mgmtconv3.ClusterClient
 	clusterManager          *clustermanager.Manager
-	crLister                rbacv1.ClusterRoleLister
-	crClient                rbacv1.ClusterRoleInterface
+	crClient                wrbacv1.ClusterRoleClient
 	nsCache                 wcorev1.NamespaceCache
 	rLister                 rbacv1.RoleLister
 	rClient                 rbacv1.RoleInterface
@@ -122,7 +127,7 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 		gr.fleetPermissionsHandler.reconcileFleetWorkspacePermissions(obj),
 		gr.setGRAsCompleted(obj),
 	)
-	return nil, returnError
+	return obj, returnError
 }
 
 func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (runtime.Object, error) {
@@ -153,39 +158,18 @@ func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (runtime.Object, error
 }
 
 func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) error {
-	crName := getCRName(globalRole)
+	crName := getCRName(globalRole.Name)
+	// Set the name of the cluster role in an annotation on the globalrole for informational purposes. This is not used for reconciliation.
+	if globalRole.Annotations == nil {
+		globalRole.Annotations = map[string]string{}
+	}
+	globalRole.Annotations[crNameAnnotation] = crName
+
 	condition := metav1.Condition{
 		Type: ClusterRoleExists,
 	}
 
-	clusterRole, _ := gr.crLister.Get("", crName)
-	if clusterRole != nil {
-		updated := false
-		clusterRole = clusterRole.DeepCopy()
-		if !reflect.DeepEqual(globalRole.Rules, clusterRole.Rules) {
-			clusterRole.Rules = globalRole.Rules
-			logrus.Infof("[%v] Updating clusterRole %v. GlobalRole rules have changed. Have: %+v. Want: %+v", grController, clusterRole.Name, clusterRole.Rules, globalRole.Rules)
-			updated = true
-		}
-		// Ensure existing ClusterRoles have the correct grOwnerLabel pointing to the owning GlobalRole.
-		if grName := clusterRole.Labels[grOwnerLabel]; grName != globalRole.Name {
-			clusterRole.Labels[grOwnerLabel] = globalRole.Name
-			logrus.Infof("[%v] Updating clusterRole %s owner from %s to %s.", grController, clusterRole.Name, grName, globalRole.Name)
-			updated = true
-		}
-
-		if updated {
-			if _, err := gr.crClient.Update(clusterRole); err != nil {
-				addCondition(globalRole, condition, FailedToUpdateClusterRole, crName, err)
-				return fmt.Errorf("couldn't update ClusterRole %v: %w", clusterRole.Name, err)
-			}
-		}
-		addCondition(globalRole, condition, ClusterRoleExists, crName, nil)
-		return nil
-	}
-
-	logrus.Infof("[%v] Creating clusterRole %v for corresponding GlobalRole", grController, crName)
-	_, err := gr.crClient.Create(&v1.ClusterRole{
+	desiredClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crName,
 			OwnerReferences: []metav1.OwnerReference{
@@ -202,18 +186,49 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) er
 			},
 		},
 		Rules: globalRole.Rules,
+	}
+
+	clusterRoles, err := gr.crClient.List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", grOwnerLabel, globalRole.Name),
 	})
 	if err != nil {
-		addCondition(globalRole, condition, FailedToCreateClusterRole, crName, err)
+		err = fmt.Errorf("couldn't list ClusterRoles for globalRole %v: %w", globalRole.Name, err)
+		addCondition(globalRole, condition, FailedToReconcileClusterRole, crName, err)
 		return err
 	}
-	// Add an annotation to the globalrole indicating the name we used for future updates
-	if globalRole.Annotations == nil {
-		globalRole.Annotations = map[string]string{}
+
+	// Delete any ClusterRoles that were created for this GlobalRole but have the wrong name.
+	for _, clusterRole := range clusterRoles.Items {
+		if clusterRole.Name != crName {
+			if err := rbac.DeleteResource(clusterRole.Name, gr.crClient); err != nil {
+				err = fmt.Errorf("couldn't delete ClusterRole %v for globalRole %v: %w", clusterRole.Name, globalRole.Name, err)
+				addCondition(globalRole, condition, FailedToReconcileClusterRole, crName, err)
+				return err
+			}
+		}
 	}
-	globalRole.Annotations[crNameAnnotation] = crName
+
+	if err := rbac.CreateOrUpdateResource(desiredClusterRole, gr.crClient, areGlobalRoleClusterRolesSame); err != nil {
+		addCondition(globalRole, condition, FailedToReconcileClusterRole, crName, err)
+		return fmt.Errorf("couldn't reconcile ClusterRole %v: %w", crName, err)
+	}
+
 	addCondition(globalRole, condition, ClusterRoleExists, crName, nil)
 	return nil
+}
+
+// areGlobalRoleClusterRolesSame returns true if the ClusterRole created for a GlobalRole matches the desired Rules, owner label, and owner reference.
+func areGlobalRoleClusterRolesSame(currentCR, desiredCR *rbacv1.ClusterRole) (bool, *rbacv1.ClusterRole) {
+	if !equality.Semantic.DeepEqual(currentCR.Rules, desiredCR.Rules) {
+		return false, desiredCR
+	}
+	if currentCR.Labels[grOwnerLabel] != desiredCR.Labels[grOwnerLabel] {
+		return false, desiredCR
+	}
+	if !equality.Semantic.DeepEqual(currentCR.OwnerReferences, desiredCR.OwnerReferences) {
+		return false, desiredCR
+	}
+	return true, desiredCR
 }
 
 // reconcileNamespacedRoles ensures that Roles exist in each namespace of NamespacedRules
@@ -391,15 +406,8 @@ func (gr *globalRoleLifecycle) setGRAsTerminating(globalRole *v3.GlobalRole) err
 	return err
 }
 
-func getCRName(globalRole *v3.GlobalRole) string {
-	if crName, ok := globalRole.Annotations[crNameAnnotation]; ok {
-		return crName
-	}
-	return generateCRName(globalRole.Name)
-}
-
-func generateCRName(name string) string {
-	return "cattle-globalrole-" + name
+func getCRName(grName string) string {
+	return name.SafeConcatName("cattle-globalrole", grName)
 }
 
 func addCondition(globalRole *v3.GlobalRole, condition metav1.Condition, reason, name string, err error) {

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -58,13 +58,22 @@ var (
 			readPodPolicyRule,
 		},
 	}
+	defaultGROwnerRefs = []metav1.OwnerReference{
+		{
+			APIVersion: defaultGR.TypeMeta.APIVersion,
+			Kind:       defaultGR.TypeMeta.Kind,
+			Name:       defaultGR.Name,
+			UID:        defaultGR.UID,
+		},
+	}
 	readConfigCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: getCRName(defaultGR.Name),
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
 				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
 			},
+			OwnerReferences: defaultGROwnerRefs,
 		},
 		Rules: []rbacv1.PolicyRule{
 			readConfigPolicyRule,
@@ -72,7 +81,32 @@ var (
 	}
 	readPodCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: getCRName(defaultGR.Name),
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrole": "true",
+				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
+			},
+			OwnerReferences: defaultGROwnerRefs,
+		},
+		Rules: []rbacv1.PolicyRule{
+			readPodPolicyRule,
+		},
+	}
+	missingLabelCR = rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getCRName(defaultGR.Name),
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrole": "true",
+			},
+			OwnerReferences: defaultGROwnerRefs,
+		},
+		Rules: []rbacv1.PolicyRule{
+			readPodPolicyRule,
+		},
+	}
+	missingOwnerRefCR = rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getCRName(defaultGR.Name),
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
 				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
@@ -82,12 +116,14 @@ var (
 			readPodPolicyRule,
 		},
 	}
-	missingLabelCR = rbacv1.ClusterRole{
+	staleNamedCR = rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "clusterRole",
+			Name: "stale-cluster-role-name",
 			Labels: map[string]string{
 				"authz.management.cattle.io/globalrole": "true",
+				"authz.management.cattle.io/gr-owner":   defaultGR.Name,
 			},
+			OwnerReferences: defaultGROwnerRefs,
 		},
 		Rules: []rbacv1.PolicyRule{
 			readPodPolicyRule,
@@ -166,21 +202,25 @@ type grTestState struct {
 func TestReconcileGlobalRole(t *testing.T) {
 	t.Parallel()
 
+	type controllers struct {
+		crController *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]
+	}
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}, "clusterRole")
 	tests := []struct {
-		name            string
-		stateSetup      func(grTestState)
-		stateAssertions func(grTestStateChanges)
-		globalRole      *v3.GlobalRole
-		wantError       bool
-		condition       reducedCondition
-		annotation      string
+		name             string
+		stateSetup       func(grTestState)
+		stateAssertions  func(grTestStateChanges)
+		setupControllers func(controllers)
+		globalRole       *v3.GlobalRole
+		wantError        bool
+		condition        reducedCondition
+		annotation       string
 	}{
 		{
 			name: "no changes to clusterRole",
-			stateSetup: func(state grTestState) {
-				state.crListerMock.GetFunc = func(_, _ string) (*normanv1.ClusterRole, error) {
-					return readPodCR.DeepCopy(), nil
-				}
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  false,
@@ -191,20 +231,10 @@ func TestReconcileGlobalRole(t *testing.T) {
 		},
 		{
 			name: "clusterRole is updated",
-			stateSetup: func(state grTestState) {
-				state.crListerMock.GetFunc = func(_, _ string) (*normanv1.ClusterRole, error) {
-					return readConfigCR.DeepCopy(), nil
-				}
-				state.crClientMock.UpdateFunc = func(cr *normanv1.ClusterRole) (*normanv1.ClusterRole, error) {
-					state.stateChanges.createdClusterRoles[cr.Name] = cr
-					return nil, nil
-				}
-			},
-			stateAssertions: func(gtsc grTestStateChanges) {
-				require.Len(gtsc.t, gtsc.createdClusterRoles, 1)
-				cr, ok := gtsc.createdClusterRoles["clusterRole"]
-				require.True(gtsc.t, ok)
-				require.Equal(gtsc.t, &readPodCR, cr)
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
+				c.crController.EXPECT().Update(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  false,
@@ -215,54 +245,38 @@ func TestReconcileGlobalRole(t *testing.T) {
 		},
 		{
 			name: "update clusterRole fails",
-			stateSetup: func(state grTestState) {
-				state.crListerMock.GetFunc = func(_, _ string) (*normanv1.ClusterRole, error) {
-					return readConfigCR.DeepCopy(), nil
-				}
-				state.crClientMock.UpdateFunc = func(cr *normanv1.ClusterRole) (*normanv1.ClusterRole, error) {
-					return nil, fmt.Errorf("error")
-				}
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
+				c.crController.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
 			condition: reducedCondition{
-				reason: FailedToUpdateClusterRole,
+				reason: FailedToReconcileClusterRole,
 				status: metav1.ConditionFalse,
 			},
 		},
 		{
 			name: "create clusterRole fails",
-			stateSetup: func(state grTestState) {
-				state.crListerMock.GetFunc = func(_, _ string) (*normanv1.ClusterRole, error) {
-					return nil, nil
-				}
-				state.crClientMock.CreateFunc = func(cr *normanv1.ClusterRole) (*normanv1.ClusterRole, error) {
-					return nil, fmt.Errorf("error")
-				}
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
 			condition: reducedCondition{
-				reason: FailedToCreateClusterRole,
+				reason: FailedToReconcileClusterRole,
 				status: metav1.ConditionFalse,
 			},
 		},
 		{
 			name: "clusterRole is created",
-			stateSetup: func(state grTestState) {
-				state.crListerMock.GetFunc = func(_, _ string) (*normanv1.ClusterRole, error) {
-					return nil, nil
-				}
-				state.crClientMock.CreateFunc = func(cr *normanv1.ClusterRole) (*normanv1.ClusterRole, error) {
-					state.stateChanges.createdClusterRoles[cr.Name] = cr
-					return nil, nil
-				}
-			},
-			stateAssertions: func(gtsc grTestStateChanges) {
-				require.Len(gtsc.t, gtsc.createdClusterRoles, 1)
-				cr, ok := gtsc.createdClusterRoles[getCRName(&defaultGR)]
-				require.True(gtsc.t, ok)
-				require.Equal(gtsc.t, readPodCR.Rules, cr.Rules)
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  false,
@@ -270,35 +284,89 @@ func TestReconcileGlobalRole(t *testing.T) {
 				reason: ClusterRoleExists,
 				status: metav1.ConditionTrue,
 			},
-			annotation: getCRName(&defaultGR),
+			annotation: getCRName(defaultGR.Name),
 		},
 		{
 			name: "missing grOwnerLabel in clusterRole triggers update",
-			stateSetup: func(state grTestState) {
-				state.crListerMock.GetFunc = func(_, _ string) (*normanv1.ClusterRole, error) {
-					return missingLabelCR.DeepCopy(), nil
-				}
-				state.crClientMock.UpdateFunc = func(cr *normanv1.ClusterRole) (*normanv1.ClusterRole, error) {
-					state.stateChanges.createdClusterRoles[cr.Name] = cr
-					return nil, nil
-				}
-			},
-			stateAssertions: func(gtsc grTestStateChanges) {
-				require.Len(gtsc.t, gtsc.createdClusterRoles, 1)
-				cr, ok := gtsc.createdClusterRoles["clusterRole"]
-				require.True(gtsc.t, ok)
-				require.Equal(gtsc.t, &readPodCR, cr)
-
-				// Validate that label had expected owner value set
-				val, exists := cr.Labels[grOwnerLabel]
-				require.True(gtsc.t, exists)
-				require.Equal(gtsc.t, defaultGR.Name, val)
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingLabelCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingLabelCR.DeepCopy(), nil)
+				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  false,
 			condition: reducedCondition{
 				reason: ClusterRoleExists,
 				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "missing OwnerReference in clusterRole triggers update",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingOwnerRefCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingOwnerRefCR.DeepCopy(), nil)
+				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "stale-named ClusterRole is deleted and the correct one is created",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(nil)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "stale-named ClusterRole already gone is not an error",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(notFoundErr)
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
+				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "deleting a stale-named ClusterRole fails",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("error"))
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  true,
+			condition: reducedCondition{
+				reason: FailedToReconcileClusterRole,
+				status: metav1.ConditionFalse,
+			},
+		},
+		{
+			name: "listing ClusterRoles fails",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  true,
+			condition: reducedCondition{
+				reason: FailedToReconcileClusterRole,
+				status: metav1.ConditionFalse,
 			},
 		},
 	}
@@ -306,24 +374,22 @@ func TestReconcileGlobalRole(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			grLifecycle := globalRoleLifecycle{}
-			state := setupTest(t)
-			if test.stateSetup != nil {
-				test.stateSetup(state)
+			ctrl := gomock.NewController(t)
+			controllers := controllers{
+				crController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl),
 			}
-			grLifecycle.crLister = state.crListerMock
-			grLifecycle.crClient = state.crClientMock
-
+			if test.setupControllers != nil {
+				test.setupControllers(controllers)
+			}
+			grLifecycle := globalRoleLifecycle{
+				crClient: controllers.crController,
+			}
 			err := grLifecycle.reconcileGlobalRole(test.globalRole)
 
 			if test.wantError {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-			}
-			if test.stateAssertions != nil {
-				test.stateAssertions(*state.stateChanges)
 			}
 			if test.annotation != "" {
 				require.Equal(t, test.annotation, test.globalRole.Annotations[crNameAnnotation])
@@ -1283,12 +1349,6 @@ func TestSetGRAsInProgress(t *testing.T) {
 			oldGR:        &v3.GlobalRole{},
 			updateReturn: nil,
 			wantError:    false,
-		},
-		{
-			name:         "update gr fails",
-			oldGR:        &v3.GlobalRole{},
-			updateReturn: fmt.Errorf("error"),
-			wantError:    true,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -3,6 +3,7 @@ package globalroles
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -62,9 +63,10 @@ var (
 )
 
 const (
+	// crbNameAnnotation records the name of the ClusterRoleBinding created for a GlobalRoleBinding, for
+	// reference purposes. It is not read back for reconciliation.
 	crbNameAnnotation             = "authz.management.cattle.io/crb-name"
 	crtbGrbOwnerIndex             = "authz.management.cattle.io/crtb-owner"
-	crbNamePrefix                 = "cattle-globalrolebinding-"
 	localClusterName              = "local"
 	grbOwnerLabel                 = "authz.management.cattle.io/grb-owner"
 	fleetWorkspacePermissionLabel = "authz.management.cattle.io/fleet-workspace-permissions"
@@ -385,58 +387,16 @@ func (l *globalRoleBindingLifecycle) findMissingRTs(wantRTs []string, cluster *v
 func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBinding *v3.GlobalRoleBinding, localConditions *[]metav1.Condition) error {
 	condition := metav1.Condition{Type: globalRoleBindingReconciled}
 
-	crbName, ok := globalRoleBinding.Annotations[crbNameAnnotation]
-	if !ok {
-		crbName = crbNamePrefix + globalRoleBinding.Name
+	crbName := getCRBName(globalRoleBinding.Name)
+	if globalRoleBinding.Annotations == nil {
+		globalRoleBinding.Annotations = map[string]string{}
 	}
+	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
 
-	subject := rbac.GetGRBSubject(globalRoleBinding)
+	grLabels := map[string]string{grbOwnerLabel: globalRoleBinding.Name}
+	maps.Copy(grLabels, globalRoleBindingLabel)
 
-	crb, _ := l.crbLister.Get("", crbName)
-	if crb != nil {
-		subjects := []v1.Subject{subject}
-		updateSubject := !reflect.DeepEqual(subjects, crb.Subjects)
-
-		updateRoleRef := false
-		var roleRef v1.RoleRef
-		gr, _ := l.grLister.Get("", globalRoleBinding.GlobalRoleName)
-		if gr != nil {
-			crNameFromGR := getCRName(gr)
-			if crNameFromGR != crb.RoleRef.Name {
-				updateRoleRef = true
-				roleRef = v1.RoleRef{
-					Name: crNameFromGR,
-					Kind: clusterRoleKind,
-				}
-			}
-		}
-		if updateSubject || updateRoleRef {
-			crb = crb.DeepCopy()
-			if updateRoleRef {
-				crb.RoleRef = roleRef
-			}
-			crb.Subjects = subjects
-			logrus.Infof("[%v] Updating clusterRoleBinding %v for globalRoleBinding %v user %v", grbController, crb.Name, globalRoleBinding.Name, globalRoleBinding.UserName)
-			if _, err := l.crbClient.Update(crb); err != nil {
-				l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
-				return fmt.Errorf("couldn't update ClusterRoleBinding %v: %w", crb.Name, err)
-			}
-		}
-
-		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
-		return nil
-	}
-
-	logrus.Infof("Creating new GlobalRoleBinding for GlobalRoleBinding %v", globalRoleBinding.Name)
-	gr, _ := l.grLister.Get("", globalRoleBinding.GlobalRoleName)
-	var crName string
-	if gr != nil {
-		crName = getCRName(gr)
-	} else {
-		crName = generateCRName(globalRoleBinding.GlobalRoleName)
-	}
-	logrus.Infof("[%v] Creating clusterRoleBinding for globalRoleBinding %v for user %v with role %v", grbController, globalRoleBinding.Name, globalRoleBinding.UserName, crName)
-	_, err := l.crbClient.Create(&v1.ClusterRoleBinding{
+	desiredCRB := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crbName,
 			OwnerReferences: []metav1.OwnerReference{
@@ -447,26 +407,77 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 					UID:        globalRoleBinding.UID,
 				},
 			},
-			Labels: globalRoleBindingLabel,
+			Labels: grLabels,
 		},
-		Subjects: []v1.Subject{subject},
+		Subjects: []v1.Subject{rbac.GetGRBSubject(globalRoleBinding)},
 		RoleRef: v1.RoleRef{
-			Name: crName,
+			Name: getCRName(globalRoleBinding.GlobalRoleName),
 			Kind: clusterRoleKind,
 		},
-	})
+	}
+
+	clusterRoleBindings, err := l.crbLister.List("", labels.SelectorFromSet(map[string]string{grbOwnerLabel: globalRoleBinding.Name}))
 	if err != nil {
-		l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+		err = fmt.Errorf("couldn't list ClusterRoleBindings for globalRoleBinding %v: %w", globalRoleBinding.Name, err)
+		l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
 		return err
 	}
-	// Add an annotation to the globalrole indicating the name we used for future updates
-	if globalRoleBinding.Annotations == nil {
-		globalRoleBinding.Annotations = map[string]string{}
+
+	// Delete any ClusterRoleBindings that were created for this GlobalRoleBinding but have the wrong name.
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		if clusterRoleBinding.Name != crbName {
+			if err := l.crbClient.Delete(clusterRoleBinding.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				err = fmt.Errorf("couldn't delete ClusterRoleBinding %v for globalRoleBinding %v: %w", clusterRoleBinding.Name, globalRoleBinding.Name, err)
+				l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+				return err
+			}
+		}
 	}
-	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
+
+	crb, _ := l.crbLister.Get("", crbName)
+	if crb == nil {
+		logrus.Infof("[%v] Creating clusterRoleBinding for globalRoleBinding %v for user %v with role %v", grbController, globalRoleBinding.Name, globalRoleBinding.UserName, desiredCRB.RoleRef.Name)
+		if _, err := l.crbClient.Create(desiredCRB); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+			return err
+		}
+		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
+		return nil
+	}
+
+	// RoleRef is immutable on an existing ClusterRoleBinding, so a RoleRef change can only be applied by
+	// deleting and recreating it rather than updating it in place.
+	if !reflect.DeepEqual(crb.RoleRef, desiredCRB.RoleRef) {
+		logrus.Infof("[%v] Recreating clusterRoleBinding %v for globalRoleBinding %v with role %v", grbController, crb.Name, globalRoleBinding.Name, desiredCRB.RoleRef.Name)
+		if err := l.crbClient.Delete(crb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't delete ClusterRoleBinding %v: %w", crb.Name, err)
+		}
+		if _, err := l.crbClient.Create(desiredCRB); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToCreateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't create ClusterRoleBinding %v: %w", desiredCRB.Name, err)
+		}
+		l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
+		return nil
+	}
+
+	if !reflect.DeepEqual(crb.Subjects, desiredCRB.Subjects) {
+		crb = crb.DeepCopy()
+		crb.Subjects = desiredCRB.Subjects
+		logrus.Infof("[%v] Updating clusterRoleBinding %v for globalRoleBinding %v user %v", grbController, crb.Name, globalRoleBinding.Name, globalRoleBinding.UserName)
+		if _, err := l.crbClient.Update(crb); err != nil {
+			l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
+			return fmt.Errorf("couldn't update ClusterRoleBinding %v: %w", crb.Name, err)
+		}
+	}
 
 	l.status.AddCondition(localConditions, condition, globalRoleBindingReconciled, nil)
 	return nil
+}
+
+// getCRBName returns the name of the ClusterRoleBinding backing a GlobalRoleBinding with the given name.
+func getCRBName(grbName string) string {
+	return wrangler.SafeConcatName("cattle-globalrolebinding", grbName)
 }
 
 // reconcileNamespacedRoleBindings ensures that RoleBindings exist for each namespace listed in NamespacedRules

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -411,8 +411,9 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 		},
 		Subjects: []v1.Subject{rbac.GetGRBSubject(globalRoleBinding)},
 		RoleRef: v1.RoleRef{
-			Name: getCRName(globalRoleBinding.GlobalRoleName),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName(globalRoleBinding.GlobalRoleName),
+			Kind:     clusterRoleKind,
 		},
 	}
 

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -293,7 +293,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, bindingName, crb.Name)
 				require.Len(stateChanges.t, crb.OwnerReferences, 1)
 				require.Equal(stateChanges.t, grbOwnerRef, crb.OwnerReferences[0])
-				require.Equal(stateChanges.t, rbacv1.RoleRef{Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
+				require.Equal(stateChanges.t, rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
 				require.Equal(stateChanges.t, rbacv1.Subject{Name: userName, Kind: "User", APIGroup: rbacv1.GroupName}, crb.Subjects[0])
 				require.Equal(stateChanges.t, "true", crb.Labels["authz.management.cattle.io/globalrolebinding"])
 
@@ -338,8 +338,9 @@ func TestCreateUpdate(t *testing.T) {
 							Name: "cattle-globalrolebinding-test-grb",
 						},
 						RoleRef: rbacv1.RoleRef{
-							Name: getCRName(gr.Name),
-							Kind: clusterRoleKind,
+							APIGroup: rbacv1.GroupName,
+							Name:     getCRName(gr.Name),
+							Kind:     clusterRoleKind,
 						},
 					}, nil
 				}
@@ -431,7 +432,7 @@ func TestCreateUpdate(t *testing.T) {
 				bindingName := "cattle-globalrolebinding-" + grb.Name
 				roleName := "cattle-globalrole-" + gr.Name
 				require.Equal(stateChanges.t, bindingName, crb.Name)
-				require.Equal(stateChanges.t, rbacv1.RoleRef{Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
+				require.Equal(stateChanges.t, rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
 				require.Equal(stateChanges.t, rbacv1.Subject{Name: userName, Kind: "User", APIGroup: rbacv1.GroupName}, crb.Subjects[0])
 
 				// fleet workspace assertions
@@ -551,7 +552,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, "GlobalRoleBinding", ownerRef.Kind)
 				require.Equal(stateChanges.t, "test-grb", ownerRef.Name)
 				require.Equal(stateChanges.t, types.UID("1234"), ownerRef.UID)
-				require.Equal(stateChanges.t, rbacv1.RoleRef{Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
+				require.Equal(stateChanges.t, rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
 				require.Equal(stateChanges.t, rbacv1.Subject{Name: userName, Kind: "User", APIGroup: rbacv1.GroupName}, crb.Subjects[0])
 				require.Equal(stateChanges.t, "true", crb.Labels["authz.management.cattle.io/globalrolebinding"])
 
@@ -683,7 +684,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, bindingName, crb.Name)
 				require.Len(stateChanges.t, crb.OwnerReferences, 1)
 				require.Equal(stateChanges.t, grbOwnerRef, crb.OwnerReferences[0])
-				require.Equal(stateChanges.t, rbacv1.RoleRef{Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
+				require.Equal(stateChanges.t, rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
 				require.Equal(stateChanges.t, rbacv1.Subject{Name: userName, Kind: "User", APIGroup: rbacv1.GroupName}, crb.Subjects[0])
 				require.Equal(stateChanges.t, "true", crb.Labels["authz.management.cattle.io/globalrolebinding"])
 
@@ -799,7 +800,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, bindingName, crb.Name)
 				require.Len(stateChanges.t, crb.OwnerReferences, 1)
 				require.Equal(stateChanges.t, grbOwnerRef, crb.OwnerReferences[0])
-				require.Equal(stateChanges.t, rbacv1.RoleRef{Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
+				require.Equal(stateChanges.t, rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
 				require.Equal(stateChanges.t, rbacv1.Subject{Name: userName, Kind: "User", APIGroup: rbacv1.GroupName}, crb.Subjects[0])
 				require.Equal(stateChanges.t, "true", crb.Labels["authz.management.cattle.io/globalrolebinding"])
 				// fleet workspace assertions
@@ -929,7 +930,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, bindingName, crb.Name)
 				require.Len(stateChanges.t, crb.OwnerReferences, 1)
 				require.Equal(stateChanges.t, grbOwnerRef, crb.OwnerReferences[0])
-				require.Equal(stateChanges.t, rbacv1.RoleRef{Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
+				require.Equal(stateChanges.t, rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Name: roleName, Kind: "ClusterRole"}, crb.RoleRef)
 				require.Equal(stateChanges.t, rbacv1.Subject{Name: userName, Kind: "User", APIGroup: rbacv1.GroupName}, crb.Subjects[0])
 				require.Equal(stateChanges.t, "true", crb.Labels["authz.management.cattle.io/globalrolebinding"])
 

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -2097,8 +2097,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName("test-gr"),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName("test-gr"),
+			Kind:     clusterRoleKind,
 		},
 	}
 
@@ -2126,8 +2127,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName("test-gr"),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName("test-gr"),
+			Kind:     clusterRoleKind,
 		},
 	}
 

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -337,6 +337,10 @@ func TestCreateUpdate(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "cattle-globalrolebinding-test-grb",
 						},
+						RoleRef: rbacv1.RoleRef{
+							Name: getCRName(gr.Name),
+							Kind: clusterRoleKind,
+						},
 					}, nil
 				}
 				state.crbClientMock.UpdateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
@@ -434,7 +438,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, true, stateChanges.fwhCalled)
 			},
 			inputBinding: grb.DeepCopy(),
-			wantBinding:  addUserPrincipalName(&grb, testPrincipal),
+			wantBinding:  addUserPrincipalName(addAnnotation(&grb), testPrincipal),
 			wantError:    false,
 		},
 		{
@@ -687,7 +691,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, true, stateChanges.fwhCalled)
 			},
 			inputBinding: grb.DeepCopy(),
-			wantBinding:  addUserPrincipalName(&grb, testPrincipal),
+			wantBinding:  addUserPrincipalName(addAnnotation(&grb), testPrincipal),
 			wantError:    true,
 		},
 		{
@@ -802,7 +806,7 @@ func TestCreateUpdate(t *testing.T) {
 				require.Equal(stateChanges.t, true, stateChanges.fwhCalled)
 			},
 			inputBinding: grb.DeepCopy(),
-			wantBinding:  addUserPrincipalName(&grb, testPrincipal),
+			wantBinding:  addUserPrincipalName(addAnnotation(&grb), testPrincipal),
 			wantError:    true,
 		},
 		{
@@ -1276,7 +1280,11 @@ func TestCreateUpdate(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				crtbCacheMock := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
 				grListerMock := fakes.GlobalRoleListerMock{}
-				crbListerMock := rbacFakes.ClusterRoleBindingListerMock{}
+				crbListerMock := rbacFakes.ClusterRoleBindingListerMock{
+					ListFunc: func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+						return nil, nil
+					},
+				}
 				clusterCacheMock := fake.NewMockNonNamespacedCacheInterface[*v3.Cluster](ctrl)
 				crtbClientMock := fakes.ClusterRoleTemplateBindingInterfaceMock{}
 				crbClientMock := rbacFakes.ClusterRoleBindingInterfaceMock{}
@@ -2043,6 +2051,430 @@ func TestReconcileClusterPermissions(t *testing.T) {
 			}
 			if test.stateAssertions != nil {
 				test.stateAssertions(*state.stateChanges)
+			}
+		})
+	}
+
+}
+
+func TestReconcileGlobalRoleBinding(t *testing.T) {
+	t.Parallel()
+
+	testGRB := v3.GlobalRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-grb",
+			UID:  "1234",
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "management.cattle.io/v3",
+			Kind:       "GlobalRoleBinding",
+		},
+		GlobalRoleName: "test-gr",
+		UserName:       "test-user",
+	}
+
+	expectedCRB := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getCRBName("test-grb"),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "GlobalRoleBinding",
+					Name:       "test-grb",
+					UID:        "1234",
+				},
+			},
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrolebinding": "true",
+				grbOwnerLabel: "test-grb",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     "test-user",
+				APIGroup: rbacv1.GroupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: getCRName("test-gr"),
+			Kind: clusterRoleKind,
+		},
+	}
+
+	staleNamedCRB := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stale-cluster-role-binding-name",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "GlobalRoleBinding",
+					Name:       "test-grb",
+					UID:        "1234",
+				},
+			},
+			Labels: map[string]string{
+				"authz.management.cattle.io/globalrolebinding": "true",
+				grbOwnerLabel: "test-grb",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     "test-user",
+				APIGroup: rbacv1.GroupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: getCRName("test-gr"),
+			Kind: clusterRoleKind,
+		},
+	}
+
+	type controllers struct {
+		crbLister *rbacFakes.ClusterRoleBindingListerMock
+		crbClient *rbacFakes.ClusterRoleBindingInterfaceMock
+	}
+
+	tests := []struct {
+		name             string
+		setupControllers func(t *testing.T, c controllers)
+		inputObject      *v3.GlobalRoleBinding
+		wantError        bool
+		wantAnnotation   string
+	}{
+		{
+			name: "create new clusterRoleBinding",
+			setupControllers: func(t *testing.T, c controllers) {
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					require.Equal(t, expectedCRB.DeepCopy(), crb)
+					return &expectedCRB, nil
+				}
+			},
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "clusterRoleBinding creation fails",
+			setupControllers: func(t *testing.T, c controllers) {
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, fmt.Errorf("server unavailable")
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "clusterRoleBinding already exists no update needed",
+			setupControllers: func(t *testing.T, c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{existingCRB}, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return existingCRB, nil
+				}
+			},
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "update clusterRoleBinding subject",
+			setupControllers: func(t *testing.T, c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.Subjects = []rbacv1.Subject{
+					{
+						Kind:     "User",
+						Name:     "old-user",
+						APIGroup: rbacv1.GroupName,
+					},
+				}
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{existingCRB}, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return existingCRB, nil
+				}
+				updatedCRB := expectedCRB.DeepCopy()
+				c.crbClient.UpdateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					require.Equal(t, updatedCRB, crb)
+					return updatedCRB, nil
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   false,
+		},
+		{
+			name: "update clusterRoleBinding roleRef",
+			setupControllers: func(t *testing.T, c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{existingCRB}, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return existingCRB, nil
+				}
+				c.crbClient.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
+					require.Equal(t, existingCRB.Name, name)
+					return nil
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					require.Equal(t, expectedCRB.DeepCopy(), crb)
+					return expectedCRB.DeepCopy(), nil
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   false,
+		},
+		{
+			name: "update clusterRoleBinding subject and roleRef",
+			setupControllers: func(t *testing.T, c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.Subjects = []rbacv1.Subject{
+					{
+						Kind:     "User",
+						Name:     "old-user",
+						APIGroup: rbacv1.GroupName,
+					},
+				}
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{existingCRB}, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return existingCRB, nil
+				}
+				c.crbClient.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
+					require.Equal(t, existingCRB.Name, name)
+					return nil
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					require.Equal(t, expectedCRB.DeepCopy(), crb)
+					return expectedCRB.DeepCopy(), nil
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   false,
+		},
+		{
+			name: "roleRef change: delete fails",
+			setupControllers: func(t *testing.T, c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{existingCRB}, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return existingCRB, nil
+				}
+				c.crbClient.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
+					return fmt.Errorf("server unavailable")
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "roleRef change: recreate fails",
+			setupControllers: func(t *testing.T, c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.RoleRef = rbacv1.RoleRef{
+					Name: "old-role",
+					Kind: clusterRoleKind,
+				}
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{existingCRB}, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return existingCRB, nil
+				}
+				c.crbClient.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
+					return nil
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, fmt.Errorf("server unavailable")
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "update clusterRoleBinding fails",
+			setupControllers: func(t *testing.T, c controllers) {
+				existingCRB := expectedCRB.DeepCopy()
+				existingCRB.Subjects = []rbacv1.Subject{
+					{
+						Kind:     "User",
+						Name:     "old-user",
+						APIGroup: rbacv1.GroupName,
+					},
+				}
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{existingCRB}, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return existingCRB, nil
+				}
+				c.crbClient.UpdateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, fmt.Errorf("server unavailable")
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "stale-named ClusterRoleBinding is deleted and the correct one is created",
+			setupControllers: func(t *testing.T, c controllers) {
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil
+				}
+				c.crbClient.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
+					require.Equal(t, staleNamedCRB.Name, name)
+					return nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					return expectedCRB.DeepCopy(), nil
+				}
+			},
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "stale-named ClusterRoleBinding already gone is not an error",
+			setupControllers: func(t *testing.T, c controllers) {
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil
+				}
+				c.crbClient.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"}, staleNamedCRB.Name)
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					return expectedCRB.DeepCopy(), nil
+				}
+			},
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
+			name: "deleting a stale-named ClusterRoleBinding fails",
+			setupControllers: func(t *testing.T, c controllers) {
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return []*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil
+				}
+				c.crbClient.DeleteFunc = func(name string, options *metav1.DeleteOptions) error {
+					return fmt.Errorf("server unavailable")
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "listing ClusterRoleBindings fails",
+			setupControllers: func(t *testing.T, c controllers) {
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return nil, fmt.Errorf("server unavailable")
+				}
+			},
+			inputObject: testGRB.DeepCopy(),
+			wantError:   true,
+		},
+		{
+			name: "group principal binding",
+			setupControllers: func(t *testing.T, c controllers) {
+				c.crbLister.ListFunc = func(namespace string, selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				c.crbLister.GetFunc = func(namespace, name string) (*rbacv1.ClusterRoleBinding, error) {
+					return nil, nil
+				}
+				groupCRB := expectedCRB.DeepCopy()
+				groupCRB.Subjects = []rbacv1.Subject{
+					{
+						Kind:     "Group",
+						Name:     "test-group",
+						APIGroup: rbacv1.GroupName,
+					},
+				}
+				c.crbClient.CreateFunc = func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+					require.Equal(t, groupCRB, crb)
+					return groupCRB, nil
+				}
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "GlobalRoleBinding",
+				},
+				GlobalRoleName:     "test-gr",
+				GroupPrincipalName: "test-group",
+			},
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			controllers := controllers{
+				crbLister: &rbacFakes.ClusterRoleBindingListerMock{},
+				crbClient: &rbacFakes.ClusterRoleBindingInterfaceMock{},
+			}
+			if test.setupControllers != nil {
+				test.setupControllers(t, controllers)
+			}
+
+			grbLifecycle := globalRoleBindingLifecycle{
+				crbLister: controllers.crbLister,
+				crbClient: controllers.crbClient,
+				status:    status.NewStatus(),
+			}
+			var conditions []metav1.Condition
+			resErr := grbLifecycle.reconcileGlobalRoleBinding(test.inputObject, &conditions)
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+
+			if test.wantAnnotation != "" {
+				require.Equal(t, test.wantAnnotation, test.inputObject.Annotations[crbNameAnnotation])
 			}
 		})
 	}

--- a/tests/controllers/globalroles/globalrole_test.go
+++ b/tests/controllers/globalroles/globalrole_test.go
@@ -166,11 +166,11 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 	}{
 		// NOTE: These test can be run in parallel only if the global role names are unique
 		{
-			name: "create primary cluster role given cr-name",
+			name: "ignore cr-name label and use global role name for cluster role",
 			globalRole: v3.GlobalRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						crNameLabel: "cr-name",
+						crNameLabel: "cr-label",
 					},
 					Name: "cr-name-gr",
 				},
@@ -178,7 +178,7 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 			},
 			clusterRole: rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cr-name",
+					Name: "cattle-globalrole-cr-name-gr",
 				},
 				Rules: []rbacv1.PolicyRule{getPodRule},
 			},
@@ -239,7 +239,6 @@ func (s *GlobalRoleTestSuite) TestCreateGlobalRole() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.Run(test.name, func() {
 			t := s.T()
 			t.Parallel()

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -401,17 +401,24 @@ def test_user_role_permissions(admin_mc, user_factory, remove_resource):
     assert len(users1.data) == 1, "user should only see themselves"
 
     # user1 can see all roleTemplates
-    role_templates = user1.client.list_role_template()
-    assert len(role_templates.data) > 0, ("user should be able to see all " +
-                                          "roleTemplates")
+    def user1_can_see_role_templates():
+        return len(user1.client.list_role_template().data) > 0
+
+    wait_for(user1_can_see_role_templates,
+             fail_handler=lambda: ("user should be able to see all " +
+                                   "roleTemplates"))
 
     # user2 should only see themselves in the user list
     users2 = user2.client.list_user()
     assert len(users2.data) == 1, "user should only see themselves"
+
     # user2 should not see any role templates
-    role_templates = user2.client.list_role_template()
-    assert len(role_templates.data) == 0, ("user2 does not have permission " +
-                                           "to view roleTemplates")
+    def user2_cannot_see_role_templates():
+        return len(user2.client.list_role_template().data) == 0
+
+    wait_for(user2_cannot_see_role_templates,
+             fail_handler=lambda: ("user2 does not have permission " +
+                                   "to view roleTemplates"))
 
 
 def test_impersonation_passthrough(admin_mc, admin_cc, user_mc, user_factory,
@@ -575,18 +582,41 @@ def ns_count(client, count):
 
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
-    kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 3
+    client = user_factory().client
 
-    kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 3
+    def can_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 3
 
-    kds = user_factory('kontainerdrivers-manage').client. \
-        list_kontainer_driver()
-    assert len(kds) == 3
+    wait_for(can_see_kontainer_drivers,
+             fail_handler=lambda: "user should be able to see kontainer "
+                                  "drivers")
 
-    kds = user_factory('settings-manage').client.list_kontainer_driver()
-    assert len(kds) == 0
+    client = user_factory('clusters-create').client
+
+    def clusters_create_can_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 3
+
+    wait_for(clusters_create_can_see_kontainer_drivers,
+             fail_handler=lambda: "clusters-create user should be able to "
+                                  "see kontainer drivers")
+
+    client = user_factory('kontainerdrivers-manage').client
+
+    def kontainerdrivers_manage_can_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 3
+
+    wait_for(kontainerdrivers_manage_can_see_kontainer_drivers,
+             fail_handler=lambda: "kontainerdrivers-manage user should be "
+                                  "able to see kontainer drivers")
+
+    client = user_factory('settings-manage').client
+
+    def settings_manage_cannot_see_kontainer_drivers():
+        return len(client.list_kontainer_driver()) == 0
+
+    wait_for(settings_manage_cannot_see_kontainer_drivers,
+             fail_handler=lambda: "settings-manage user should not see "
+                                  "kontainer drivers")
 
 
 def test_readonly_cannot_edit_secret(admin_mc, user_mc, admin_pc,


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/56593

Some changes because of the old status handling of globalroles and the old norman controllers. 