### PR TITLE
Updates for CRT Role Bindings

### DIFF
--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken.go
@@ -526,6 +526,9 @@ func (h *handler) ensureCRTTokenReaderRole(namespace string) error {
 	for _, crt := range crts {
 		secretNames = append(secretNames, SecretName(crt.Name))
 	}
+	// Sort so the desired Rules are deterministic and the DeepEqual doesn't
+	// trigger an unnecessary Update when the list is unchanged.
+	slices.Sort(secretNames)
 
 	// If no CRT Secrets exist, delete the Role if it exists
 	if len(secretNames) == 0 {

--- a/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken_test.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/clusterregistrationtoken_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -270,4 +271,56 @@ func TestHandleTTL_DisabledFeatureHonorsExistingGracePeriod(t *testing.T) {
 	require.NotNil(t, updated(), "expired grace period must be cleaned up from the Secret even when the feature is disabled")
 	require.Empty(t, updated().Data[gracePeriodExpiresAtDataKey])
 	require.Empty(t, updated().Data[expiresAtDataKey], "feature disabled: no new expiry should be assigned")
+}
+
+// TestEnsureCRTTokenReaderRole_StableOrderingAvoidsSpuriousUpdate ensures that when the
+// same set of CRTs is listed in a different order than what's stored on the Role (which
+// can happen because informer cache List() order isn't guaranteed stable across calls),
+// the Role is not needlessly Updated, since that bumps its ResourceVersion and invalidates
+// every bound subject's cached AccessSet in steve.
+func TestEnsureCRTTokenReaderRole_StableOrderingAvoidsSpuriousUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	namespace := "c-test"
+
+	nsCache := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+	nsCache.EXPECT().Get(namespace).Return(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}, nil)
+
+	// Existing Role already has the secret names sorted.
+	existingRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: crtTokenReaderRole},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				ResourceNames: []string{SecretName("crt-a"), SecretName("crt-b"), SecretName("crt-c")},
+				Verbs:         []string{"get"},
+			},
+		},
+	}
+	roleCache := fake.NewMockCacheInterface[*rbacv1.Role](ctrl)
+	roleCache.EXPECT().Get(namespace, crtTokenReaderRole).Return(existingRole, nil)
+
+	roleClient := fake.NewMockControllerInterface[*rbacv1.Role, *rbacv1.RoleList](ctrl)
+	roleClient.EXPECT().Update(gomock.Any()).Times(0) // must NOT be called
+
+	// CRT cache returns the same set of CRTs but in a different (unsorted) order than
+	// how they were originally stored on the Role - simulating non-deterministic
+	// informer indexer iteration order.
+	crtCache := fake.NewMockCacheInterface[*v3.ClusterRegistrationToken](ctrl)
+	crtCache.EXPECT().List(namespace, gomock.Any()).Return([]*v3.ClusterRegistrationToken{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "crt-c"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "crt-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "crt-b"}},
+	}, nil)
+
+	h := &handler{
+		namespaceCache:                nsCache,
+		roleCache:                     roleCache,
+		roles:                         roleClient,
+		clusterRegistrationTokenCache: crtCache,
+	}
+
+	require.NoError(t, h.ensureCRTTokenReaderRole(namespace))
 }

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -20,7 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/util/retry"
+	rbacauth "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 )
 
 const (
@@ -255,21 +257,24 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 		return err
 	}
 
-	// Check if RoleTemplate grants CRT access, and if so, grant access to CRT token secrets
-	grantsCRT, err := c.mgr.checkIfRoleTemplateGrantsCRTAccess(binding.RoleTemplateName)
+	// Check if RoleTemplate grants CRT access, and if so, grant access to CRT token secrets -
+	// unless the RoleTemplate already grants unrestricted secret access, which makes a
+	// separate crt-token-reader RoleBinding redundant.
+	grantsCRT, hasUnrestrictedSecretAccess, err := c.mgr.checkIfRoleTemplateGrantsCRTAccess(binding.RoleTemplateName)
 	if err != nil {
 		c.s.AddCondition(localConditions, condition, failedToCheckReferencedRole, err)
 		return err
 	}
 
-	if grantsCRT {
+	if grantsCRT && !hasUnrestrictedSecretAccess {
 		if err := c.ensureCRTTokenReaderRoleBinding(binding, subject); err != nil {
 			c.s.AddCondition(localConditions, condition, failedToGrantManagementPlanePrivileges, err)
 			return err
 		}
 	} else {
-		// Role doesn't grant CRT access - ensure RoleBinding is removed if it exists
-		// (handles case where RoleTemplate was updated to remove CRT permissions)
+		// Role doesn't grant CRT access, or already grants unrestricted secret access that
+		// covers it - ensure RoleBinding is removed if it exists (handles the case where the
+		// RoleTemplate was updated to remove CRT permissions, or gained unrestricted secret access).
 		// Unlike the CRTB deletion path, the CRTB is still alive here so owner reference GC
 		// will not clean this up - we must return the error to trigger a re-enqueue.
 		if err := c.removeCRTTokenReaderRoleBinding(binding, subject); err != nil {
@@ -322,13 +327,13 @@ func (c *crtbLifecycle) removeMGMTClusterScopedPrivilegesInProjectNamespace(bind
 	return nil
 }
 
-// grantsCRTAccessFromRoleTemplate checks if a RoleTemplate grants read/create access
-// to clusterregistrationtokens. Handles both External and non-External RoleTemplates.
-func grantsCRTAccessFromRoleTemplate(rt *v3.RoleTemplate, crLister typesrbacv1.ClusterRoleLister) bool {
-	readOrCreateVerbs := map[string]bool{
-		"get": true, "list": true, "watch": true, "create": true, "*": true,
-	}
+var crtReadOrCreateVerbs = []string{"get", "list", "watch", "create"}
 
+// grantsCRTAccessFromRoleTemplate reports whether a RoleTemplate grants access to
+// clusterregistrationtokens, and whether it separately grants unrestricted secret
+// access (making a dedicated crt-token-reader RoleBinding redundant). Uses the same
+// rule-matching semantics as the Kubernetes RBAC authorizer (via rbacauth.RulesAllow).
+func grantsCRTAccessFromRoleTemplate(rt *v3.RoleTemplate, crLister typesrbacv1.ClusterRoleLister) (grantsCRT bool, hasUnrestrictedSecretAccess bool) {
 	var rules []v1.PolicyRule
 	if rt.External {
 		if rt.ExternalRules != nil {
@@ -336,7 +341,7 @@ func grantsCRTAccessFromRoleTemplate(rt *v3.RoleTemplate, crLister typesrbacv1.C
 		} else {
 			externalRole, err := crLister.Get("", rt.Name)
 			if err != nil || externalRole == nil {
-				return false
+				return false, false
 			}
 			rules = externalRole.Rules
 		}
@@ -344,43 +349,27 @@ func grantsCRTAccessFromRoleTemplate(rt *v3.RoleTemplate, crLister typesrbacv1.C
 		rules = rt.Rules
 	}
 
-	for _, rule := range rules {
-		hasCRTResource := false
-		hasManagementAPI := false
-		hasReadOrCreate := false
-
-		for _, resource := range rule.Resources {
-			if resource == "clusterregistrationtokens" || resource == "*" {
-				hasCRTResource = true
-				break
-			}
-		}
-		if !hasCRTResource {
-			continue
-		}
-
-		for _, apiGroup := range rule.APIGroups {
-			if apiGroup == "management.cattle.io" || apiGroup == "*" {
-				hasManagementAPI = true
-				break
-			}
-		}
-		if !hasManagementAPI {
-			continue
-		}
-
-		for _, verb := range rule.Verbs {
-			if readOrCreateVerbs[verb] {
-				hasReadOrCreate = true
-				break
-			}
-		}
-
-		if hasReadOrCreate {
-			return true
+	for _, verb := range crtReadOrCreateVerbs {
+		if rbacauth.RulesAllow(authorizer.AttributesRecord{
+			Verb:            verb,
+			APIGroup:        "management.cattle.io",
+			Resource:        "clusterregistrationtokens",
+			ResourceRequest: true,
+		}, rules...) {
+			grantsCRT = true
+			break
 		}
 	}
-	return false
+
+	// Name left empty: only matches rules with no ResourceNames restriction, i.e. unrestricted access.
+	hasUnrestrictedSecretAccess = rbacauth.RulesAllow(authorizer.AttributesRecord{
+		Verb:            "get",
+		APIGroup:        "",
+		Resource:        "secrets",
+		ResourceRequest: true,
+	}, rules...)
+
+	return grantsCRT, hasUnrestrictedSecretAccess
 }
 
 // ensureCRTTokenReaderRoleBinding ensures RoleBinding to crt-token-reader exists

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -68,7 +68,20 @@ const (
 	failedToDeleteMGMTClusterScopedPrivilegesInProjectNamespace      = "FailedToDeleteMGMTClusterScopedPrivilegesInProjectNamespace"
 	failedToDeleteAuthV2Permissions                                  = "FailedToDeleteAuthV2Permissions"
 	failedToRevokeManagementPlanePrivileges                          = "FailedToRevokeManagementPlanePrivileges"
+	crtTokenReaderRoleName                                           = "crt-token-reader"
 )
+
+var crtTokenReaderRoleRef = v1.RoleRef{
+	Kind:     "Role",
+	Name:     crtTokenReaderRoleName,
+	APIGroup: "rbac.authorization.k8s.io",
+}
+
+// crtTokenReaderRoleBindingName returns the deterministic name of the reserved crt-token-reader
+// RoleBinding for the given namespace and subject.
+func crtTokenReaderRoleBindingName(namespace string, subject v1.Subject) string {
+	return pkgrbac.NameForRoleBinding(namespace, crtTokenReaderRoleRef, subject)
+}
 
 var clusterManagementPlaneResources = map[string]string{
 	"clusterscans":                "management.cattle.io",
@@ -374,8 +387,7 @@ func grantsCRTAccessFromRoleTemplate(rt *v3.RoleTemplate, crLister typesrbacv1.C
 
 // ensureCRTTokenReaderRoleBinding ensures RoleBinding to crt-token-reader exists
 func (c *crtbLifecycle) ensureCRTTokenReaderRoleBinding(binding *v3.ClusterRoleTemplateBinding, subject v1.Subject) error {
-	roleRef := v1.RoleRef{Kind: "Role", Name: "crt-token-reader", APIGroup: "rbac.authorization.k8s.io"}
-	rbName := pkgrbac.NameForRoleBinding(binding.Namespace, roleRef, subject)
+	rbName := crtTokenReaderRoleBindingName(binding.Namespace, subject)
 
 	// Check if already exists
 	existing, err := c.rbLister.Get(binding.Namespace, rbName)
@@ -383,14 +395,14 @@ func (c *crtbLifecycle) ensureCRTTokenReaderRoleBinding(binding *v3.ClusterRoleT
 		// Already exists - verify it's correct
 		if len(existing.Subjects) == 1 &&
 			existing.Subjects[0] == subject &&
-			existing.RoleRef.Name == "crt-token-reader" {
+			existing.RoleRef.Name == crtTokenReaderRoleName {
 			return nil
 		}
 
 		// Exists but incorrect - update
 		updated := existing.DeepCopy()
 		updated.Subjects = []v1.Subject{subject}
-		updated.RoleRef = roleRef
+		updated.RoleRef = crtTokenReaderRoleRef
 		_, err = c.rbClient.Update(updated)
 		return err
 	}
@@ -414,7 +426,7 @@ func (c *crtbLifecycle) ensureCRTTokenReaderRoleBinding(binding *v3.ClusterRoleT
 			},
 		},
 		Subjects: []v1.Subject{subject},
-		RoleRef:  roleRef,
+		RoleRef:  crtTokenReaderRoleRef,
 	}
 
 	_, err = c.rbClient.Create(rb)
@@ -426,8 +438,7 @@ func (c *crtbLifecycle) ensureCRTTokenReaderRoleBinding(binding *v3.ClusterRoleT
 
 // removeCRTTokenReaderRoleBinding deletes the RoleBinding to crt-token-reader if it exists
 func (c *crtbLifecycle) removeCRTTokenReaderRoleBinding(binding *v3.ClusterRoleTemplateBinding, subject v1.Subject) error {
-	roleRef := v1.RoleRef{Kind: "Role", Name: "crt-token-reader", APIGroup: "rbac.authorization.k8s.io"}
-	rbName := pkgrbac.NameForRoleBinding(binding.Namespace, roleRef, subject)
+	rbName := crtTokenReaderRoleBindingName(binding.Namespace, subject)
 
 	err := c.rbClient.DeleteNamespaced(binding.Namespace, rbName, &metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/controllers/management/auth/crtb_handler_test.go
+++ b/pkg/controllers/management/auth/crtb_handler_test.go
@@ -223,7 +223,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(errDefault)
 				cts.managerMock.EXPECT().
 					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
-					Return(false, nil).
+					Return(false, false, nil).
 					AnyTimes()
 			},
 			wantError: true,
@@ -258,7 +258,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(nil)
 				cts.managerMock.EXPECT().
 					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
-					Return(false, nil)
+					Return(false, false, nil)
 				cts.projectListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Project, error) {
 					return nil, errDefault
 				}
@@ -295,7 +295,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(nil)
 				cts.managerMock.EXPECT().
 					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
-					Return(false, nil)
+					Return(false, false, nil)
 				cts.projectListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Project, error) {
 					p := defaultProject.DeepCopy()
 					return []*v3.Project{p}, nil
@@ -333,7 +333,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(nil)
 				cts.managerMock.EXPECT().
 					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
-					Return(false, nil)
+					Return(false, false, nil)
 				cts.managerMock.EXPECT().
 					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "test-project", gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
@@ -372,7 +372,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(nil)
 				cts.managerMock.EXPECT().
 					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
-					Return(false, nil)
+					Return(false, false, nil)
 				cts.managerMock.EXPECT().
 					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "test-project", gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
@@ -411,7 +411,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(nil)
 				cts.managerMock.EXPECT().
 					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
-					Return(false, nil)
+					Return(false, false, nil)
 				cts.managerMock.EXPECT().
 					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "c-ABC-p-XYZ", gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
@@ -450,7 +450,7 @@ func TestReconcileBindings(t *testing.T) {
 					Return(nil)
 				cts.managerMock.EXPECT().
 					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
-					Return(false, nil)
+					Return(false, false, nil)
 				// This should not be called
 				cts.managerMock.EXPECT().
 					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "deleting-project", gomock.Any(), gomock.Any(), gomock.Any()).
@@ -463,6 +463,49 @@ func TestReconcileBindings(t *testing.T) {
 					p := deletingProject.DeepCopy()
 					return []*v3.Project{p}, nil
 				}
+			},
+			crtb: defaultCRTB.DeepCopy(),
+			wantConditions: []v1.Condition{
+				{
+					Type:   bindingExists,
+					Status: v1.ConditionTrue,
+					Reason: bindingExists,
+					LastTransitionTime: v1.Time{
+						Time: mockTime,
+					},
+				},
+			},
+		},
+		{
+			name: "skip crt-token-reader rolebinding when role grants unrestricted secret access",
+			stateSetup: func(cts crtbTestState) {
+				cts.managerMock.EXPECT().
+					checkReferencedRoles("roleTemplate", "cluster", gomock.Any()).
+					Return(true, nil)
+				cts.managerMock.EXPECT().
+					ensureClusterMembershipBinding("clustername-clusterowner", gomock.Any(), gomock.Any(), true, gomock.Any()).
+					Return(nil)
+				cts.managerMock.EXPECT().
+					grantManagementPlanePrivileges("roleTemplate", gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+				cts.managerMock.EXPECT().
+					checkIfRoleTemplateGrantsCRTAccess("roleTemplate").
+					Return(true, true, nil)
+				cts.managerMock.EXPECT().
+					grantManagementClusterScopedPrivilegesInProjectNamespace("roleTemplate", "test-project", gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+				cts.clusterListerMock.GetFunc = func(namespace, name string) (*v3.Cluster, error) {
+					c := defaultCluster.DeepCopy()
+					return c, nil
+				}
+				cts.projectListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Project, error) {
+					p := defaultProject.DeepCopy()
+					return []*v3.Project{p}, nil
+				}
+				// ensureCRTTokenReaderRoleBinding must not be called since the RoleTemplate
+				// already grants unrestricted secret access; rbClient.Create is left unmocked
+				// (nil CreateFunc panics) so any unexpected Create call fails the test.
+				// removeCRTTokenReaderRoleBinding is expected instead, which only deletes.
 			},
 			crtb: defaultCRTB.DeepCopy(),
 			wantConditions: []v1.Condition{

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -453,12 +453,14 @@ func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resour
 	if err != nil {
 		return err
 	}
+	// The crt-token-reader RoleBinding is managed independently by
+	// ensureCRTTokenReaderRoleBinding/removeCRTTokenReaderRoleBinding (crtb_handler.go). Skip it here
+	// by its exact name so it isn't deleted as undesired on every sync. We can't match on
+	// RoleRef.Name, since that would also match any custom RoleTemplate named "crt-token-reader".
+	crtTokenReaderRBName := crtTokenReaderRoleBindingName(namespace, subject)
 	for _, c := range current {
 		rb := c.(*v1.RoleBinding)
-		// The crt-token-reader rolebinding is managed by ensureCRTTokenReaderRoleBinding/removeCRTTokenReaderRoleBinding
-		// (in crtb_handler.go) even though it shares an OwnerReference with this binding. Skip it here so this reconcile
-		// doesn't delete it as undesired on every sync.
-		if rb.RoleRef.Name == "crt-token-reader" {
+		if rb.Name == crtTokenReaderRBName {
 			continue
 		}
 		currentRBs[rb.Name] = rb

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -455,6 +455,12 @@ func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resour
 	}
 	for _, c := range current {
 		rb := c.(*v1.RoleBinding)
+		// The crt-token-reader rolebinding is managed by ensureCRTTokenReaderRoleBinding/removeCRTTokenReaderRoleBinding
+		// (in crtb_handler.go) even though it shares an OwnerReference with this binding. Skip it here so this reconcile
+		// doesn't delete it as undesired on every sync.
+		if rb.RoleRef.Name == "crt-token-reader" {
+			continue
+		}
 		currentRBs[rb.Name] = rb
 	}
 

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -105,7 +105,7 @@ type managerInterface interface {
 	grantManagementPlanePrivileges(string, map[string]string, v1.Subject, interface{}) error
 	grantManagementClusterScopedPrivilegesInProjectNamespace(string, string, map[string]string, v1.Subject, *v3.ClusterRoleTemplateBinding) error
 	grantManagementProjectScopedPrivilegesInClusterNamespace(string, string, map[string]string, v1.Subject, *v3.ProjectRoleTemplateBinding) error
-	checkIfRoleTemplateGrantsCRTAccess(string) (bool, error)
+	checkIfRoleTemplateGrantsCRTAccess(string) (bool, bool, error)
 }
 
 type manager struct {
@@ -624,19 +624,24 @@ func (m *manager) gatherAndDedupeRoles(roleTemplateName string) (map[string]*v3.
 }
 
 // checkIfRoleTemplateGrantsCRTAccess checks if a RoleTemplate or any of its referenced RoleTemplates
-// grant access to clusterregistrationtokens
-func (m *manager) checkIfRoleTemplateGrantsCRTAccess(roleTemplateName string) (bool, error) {
+// grant access to clusterregistrationtokens. It also reports whether the RoleTemplate (or any
+// referenced RoleTemplate) already grants unrestricted read access to secrets, which makes a
+// separate crt-token-reader RoleBinding redundant.
+func (m *manager) checkIfRoleTemplateGrantsCRTAccess(roleTemplateName string) (grantsCRT bool, hasUnrestrictedSecretAccess bool, err error) {
 	roles, err := m.gatherAndDedupeRoles(roleTemplateName)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	for _, role := range roles {
-		if grantsCRTAccessFromRoleTemplate(role, m.crLister) {
-			return true, nil
+		roleGrantsCRT, roleHasUnrestrictedSecretAccess := grantsCRTAccessFromRoleTemplate(role, m.crLister)
+		grantsCRT = grantsCRT || roleGrantsCRT
+		hasUnrestrictedSecretAccess = hasUnrestrictedSecretAccess || roleHasUnrestrictedSecretAccess
+		if grantsCRT && hasUnrestrictedSecretAccess {
+			break
 		}
 	}
-	return false, nil
+	return grantsCRT, hasUnrestrictedSecretAccess, nil
 }
 
 // reconcileDesiredMGMTPlaneRoleBindings ensures that the desired management plane role bindings

--- a/pkg/controllers/management/auth/manager_test.go
+++ b/pkg/controllers/management/auth/manager_test.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 )
 
 var roles = map[string]*v3.RoleTemplate{
@@ -870,6 +872,292 @@ func Test_gatherRoleTemplates(t *testing.T) {
 			} else {
 				assert.NoError(t, err, fmt.Sprintf("expected no error, got: %v", err))
 				assert.Equal(t, tt.want, got, "expected roles to be %v, got: %v", tt.want, got)
+			}
+		})
+	}
+}
+
+// TestGrantManagementPlanePrivilegesSkipsCRTTokenReaderRoleBinding verifies that the
+// crt-token-reader RoleBinding (managed independently in crtb_handler.go) is never deleted as
+// undesired here, while other stale RoleBindings still are.
+func TestGrantManagementPlanePrivilegesSkipsCRTTokenReaderRoleBinding(t *testing.T) {
+	const bindingUID = types.UID("test-uid")
+
+	binding := &v3.ClusterRoleTemplateBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "crtb1",
+			Namespace: "ns1",
+			UID:       bindingUID,
+		},
+		RoleTemplateName: "test-rt",
+	}
+	ownerRef := v1.OwnerReference{UID: bindingUID}
+	subject := rbacv1.Subject{Name: "test-user"}
+
+	crtTokenReaderRB := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            crtTokenReaderRoleBindingName("ns1", subject),
+			Namespace:       "ns1",
+			OwnerReferences: []v1.OwnerReference{ownerRef},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "Role", Name: "crt-token-reader"},
+	}
+	staleRB := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            "crtb1-old-role",
+			Namespace:       "ns1",
+			OwnerReferences: []v1.OwnerReference{ownerRef},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "Role", Name: "old-role"},
+	}
+
+	rbIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		rbByOwnerIndex: func(obj interface{}) ([]string, error) {
+			return rbByOwner(obj.(*rbacv1.RoleBinding))
+		},
+	})
+	require.NoError(t, rbIndexer.Add(crtTokenReaderRB))
+	require.NoError(t, rbIndexer.Add(staleRB))
+
+	var deletedNames []string
+	rbClientMock := &rbacFakes.RoleBindingInterfaceMock{
+		DeleteNamespacedFunc: func(namespace, name string, options *v1.DeleteOptions) error {
+			deletedNames = append(deletedNames, name)
+			return nil
+		},
+	}
+	nsListerMock := &normanFakes.NamespaceListerMock{
+		GetFunc: func(namespace, name string) (*corev1.Namespace, error) {
+			return &corev1.Namespace{Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}}, nil
+		},
+	}
+
+	m := &manager{
+		rtLister: &fakes.RoleTemplateListerMock{
+			GetFunc: func(namespace, name string) (*v3.RoleTemplate, error) {
+				return &v3.RoleTemplate{ObjectMeta: v1.ObjectMeta{Name: name}}, nil
+			},
+		},
+		rbIndexer:  rbIndexer,
+		rbClient:   rbClientMock,
+		nsLister:   nsListerMock,
+		controller: "test",
+	}
+
+	// No management-plane resources requested, so no new desired RoleBindings are computed here;
+	// this isolates the currentRBs filtering/deletion behavior under test.
+	err := m.grantManagementPlanePrivileges("test-rt", map[string]string{}, subject, binding)
+	require.NoError(t, err)
+
+	assert.NotContains(t, deletedNames, crtTokenReaderRB.Name, "crt-token-reader RoleBinding should not be deleted by grantManagementPlanePrivileges")
+	assert.Contains(t, deletedNames, staleRB.Name, "stale RoleBinding not owned by crt-token-reader should still be deleted")
+}
+
+// TestGrantManagementPlanePrivilegesCustomRoleTemplateNamedCRTTokenReader verifies that a custom
+// RoleTemplate literally named "crt-token-reader" is not mistaken for the real reserved
+// crt-token-reader binding (whose RoleBinding uses a hashed name, not the normal
+// "<binding>-<role>" name). Its RoleBinding must go through normal reconcile - deleted once
+// undesired (not permanently orphaned), and left alone while still desired (not churned/recreated
+// every sync).
+func TestGrantManagementPlanePrivilegesCustomRoleTemplateNamedCRTTokenReader(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []rbacv1.PolicyRule // rules on the colliding "crt-token-reader" RoleTemplate
+	}{
+		{
+			name:  "RoleTemplate no longer grants access - RoleBinding is deleted, not orphaned",
+			rules: nil,
+		},
+		{
+			name: "RoleTemplate still grants access - RoleBinding is left alone, not churned",
+			rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"management.cattle.io"}, Resources: []string{"clusterregistrationtokens"}, Verbs: []string{"get"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const bindingUID = types.UID("test-uid")
+
+			binding := &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "crtb1",
+					Namespace: "ns1",
+					UID:       bindingUID,
+				},
+				RoleTemplateName: "crt-token-reader",
+			}
+			ownerRef := v1.OwnerReference{UID: bindingUID}
+
+			// Named via the normal "<binding>-<role>" convention, not the hashed name used by the
+			// real reserved crt-token-reader binding.
+			collidingRB := &rbacv1.RoleBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "crtb1-crt-token-reader",
+					Namespace:       "ns1",
+					OwnerReferences: []v1.OwnerReference{ownerRef},
+				},
+				RoleRef: rbacv1.RoleRef{Kind: "Role", Name: "crt-token-reader"},
+			}
+
+			rbIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+				rbByOwnerIndex: func(obj interface{}) ([]string, error) {
+					return rbByOwner(obj.(*rbacv1.RoleBinding))
+				},
+			})
+			require.NoError(t, rbIndexer.Add(collidingRB))
+
+			var deletedNames, createdNames []string
+			rbClientMock := &rbacFakes.RoleBindingInterfaceMock{
+				DeleteNamespacedFunc: func(namespace, name string, options *v1.DeleteOptions) error {
+					deletedNames = append(deletedNames, name)
+					return nil
+				},
+				CreateFunc: func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					createdNames = append(createdNames, rb.Name)
+					return rb, nil
+				},
+			}
+			nsListerMock := &normanFakes.NamespaceListerMock{
+				GetFunc: func(namespace, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}}, nil
+				},
+			}
+
+			m := &manager{
+				rtLister: &fakes.RoleTemplateListerMock{
+					GetFunc: func(namespace, name string) (*v3.RoleTemplate, error) {
+						return &v3.RoleTemplate{ObjectMeta: v1.ObjectMeta{Name: name}, Rules: tt.rules}, nil
+					},
+				},
+				rLister: &rbacFakes.RoleListerMock{
+					GetFunc: func(namespace, name string) (*rbacv1.Role, error) {
+						return nil, errors.NewNotFound(schema.GroupResource{}, name)
+					},
+				},
+				rClient: &rbacFakes.RoleInterfaceMock{
+					CreateFunc: func(r *rbacv1.Role) (*rbacv1.Role, error) { return r, nil },
+				},
+				rbIndexer:  rbIndexer,
+				rbClient:   rbClientMock,
+				nsLister:   nsListerMock,
+				controller: "test",
+			}
+
+			err := m.grantManagementPlanePrivileges("crt-token-reader", map[string]string{"clusterregistrationtokens": "management.cattle.io"}, rbacv1.Subject{Name: "test-user"}, binding)
+			require.NoError(t, err)
+
+			if tt.rules == nil {
+				assert.Contains(t, deletedNames, collidingRB.Name, "RoleBinding for a custom RoleTemplate named crt-token-reader should be deleted once its RoleTemplate no longer grants access, not permanently orphaned")
+			} else {
+				assert.NotContains(t, deletedNames, collidingRB.Name, "RoleBinding for a custom RoleTemplate named crt-token-reader should not be deleted while its RoleTemplate still grants access")
+				assert.NotContains(t, createdNames, collidingRB.Name, "RoleBinding already exists and matches desired state, so it should not be recreated (churn)")
+			}
+		})
+	}
+}
+
+// TestGrantManagementPlanePrivilegesPRTBWithProjectRoleTemplateNamedCRTTokenReader is the PRTB
+// equivalent of the above: grantManagementPlanePrivileges is also called for PRTBs, using the
+// project's backing namespace. A project RoleTemplate named "crt-token-reader" must get the same
+// normal reconcile treatment there too - deleted once undesired, left alone (not churned) while
+// still desired.
+func TestGrantManagementPlanePrivilegesPRTBWithProjectRoleTemplateNamedCRTTokenReader(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []rbacv1.PolicyRule // rules on the colliding "crt-token-reader" RoleTemplate
+	}{
+		{
+			name:  "RoleTemplate no longer grants access - RoleBinding is deleted, not orphaned",
+			rules: nil,
+		},
+		{
+			name: "RoleTemplate still grants access - RoleBinding is left alone, not churned",
+			rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"management.cattle.io"}, Resources: []string{"clusterregistrationtokens"}, Verbs: []string{"get"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const bindingUID = types.UID("test-uid")
+			const projectNamespace = "p-abc123"
+
+			binding := &v3.ProjectRoleTemplateBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "prtb1",
+					Namespace: projectNamespace,
+					UID:       bindingUID,
+				},
+				RoleTemplateName: "crt-token-reader",
+			}
+			ownerRef := v1.OwnerReference{UID: bindingUID}
+
+			// Named via the normal "<binding>-<role>" convention, not the hashed name used by the
+			// real reserved crt-token-reader binding (which is never created in project namespaces).
+			collidingRB := &rbacv1.RoleBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "prtb1-crt-token-reader",
+					Namespace:       projectNamespace,
+					OwnerReferences: []v1.OwnerReference{ownerRef},
+				},
+				RoleRef: rbacv1.RoleRef{Kind: "Role", Name: "crt-token-reader"},
+			}
+
+			rbIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+				rbByOwnerIndex: func(obj interface{}) ([]string, error) {
+					return rbByOwner(obj.(*rbacv1.RoleBinding))
+				},
+			})
+			require.NoError(t, rbIndexer.Add(collidingRB))
+
+			var deletedNames, createdNames []string
+			rbClientMock := &rbacFakes.RoleBindingInterfaceMock{
+				DeleteNamespacedFunc: func(namespace, name string, options *v1.DeleteOptions) error {
+					deletedNames = append(deletedNames, name)
+					return nil
+				},
+				CreateFunc: func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+					createdNames = append(createdNames, rb.Name)
+					return rb, nil
+				},
+			}
+			nsListerMock := &normanFakes.NamespaceListerMock{
+				GetFunc: func(namespace, name string) (*corev1.Namespace, error) {
+					return &corev1.Namespace{Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}}, nil
+				},
+			}
+
+			m := &manager{
+				rtLister: &fakes.RoleTemplateListerMock{
+					GetFunc: func(namespace, name string) (*v3.RoleTemplate, error) {
+						return &v3.RoleTemplate{ObjectMeta: v1.ObjectMeta{Name: name}, Rules: tt.rules}, nil
+					},
+				},
+				rLister: &rbacFakes.RoleListerMock{
+					GetFunc: func(namespace, name string) (*rbacv1.Role, error) {
+						return nil, errors.NewNotFound(schema.GroupResource{}, name)
+					},
+				},
+				rClient: &rbacFakes.RoleInterfaceMock{
+					CreateFunc: func(r *rbacv1.Role) (*rbacv1.Role, error) { return r, nil },
+				},
+				rbIndexer:  rbIndexer,
+				rbClient:   rbClientMock,
+				nsLister:   nsListerMock,
+				controller: "test",
+			}
+
+			err := m.grantManagementPlanePrivileges("crt-token-reader", map[string]string{"clusterregistrationtokens": "management.cattle.io"}, rbacv1.Subject{Name: "test-user"}, binding)
+			require.NoError(t, err)
+
+			if tt.rules == nil {
+				assert.Contains(t, deletedNames, collidingRB.Name, "RoleBinding for a project RoleTemplate named crt-token-reader should be deleted once its RoleTemplate no longer grants access, not permanently orphaned in the project's backing namespace")
+			} else {
+				assert.NotContains(t, deletedNames, collidingRB.Name, "RoleBinding for a project RoleTemplate named crt-token-reader should not be deleted while its RoleTemplate still grants access")
+				assert.NotContains(t, createdNames, collidingRB.Name, "RoleBinding already exists and matches desired state, so it should not be recreated (churn)")
 			}
 		})
 	}

--- a/pkg/controllers/management/auth/zz_manager_fakes.go
+++ b/pkg/controllers/management/auth/zz_manager_fakes.go
@@ -43,12 +43,13 @@ func (m *MockmanagerInterface) EXPECT() *MockmanagerInterfaceMockRecorder {
 }
 
 // checkIfRoleTemplateGrantsCRTAccess mocks base method.
-func (m *MockmanagerInterface) checkIfRoleTemplateGrantsCRTAccess(arg0 string) (bool, error) {
+func (m *MockmanagerInterface) checkIfRoleTemplateGrantsCRTAccess(arg0 string) (bool, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "checkIfRoleTemplateGrantsCRTAccess", arg0)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // checkIfRoleTemplateGrantsCRTAccess indicates an expected call of checkIfRoleTemplateGrantsCRTAccess.


### PR DESCRIPTION
**Problem:** 

1. `grantManagementPlanePrivileges`'s "desired vs current" RoleBinding calculation uses an OwnerReference-based lookup that has no awareness of the CRT RoleBinding, so it always treats it as stale and deletes it, then it's immediately recreated by the separate CRT access logic in the same reconcile. 

2. CRT rolebindings are also created for `*` or when the roletemplate grants unrestricted secret access. 

3. The list of CRT secret names isn't sorted, so List() 's nondeterministic ordering could cause unnecessary Updates even when nothing's changed, forcing Steve's `AccessFor` to rebuild the cached `AccessSet`. 

**Solution**

1. Exclude `crt-token-reader` rolebinding from mgmt-plane reconcile to stop delete/recreate churn. 
2. Skip redundant crt-token-reader RoleBinding when RoleTemplate already grants unrestricted secret access. 
3. Sort crt `secretNames` to keep the list of desired roles deterministic. 

Issue: https://github.com/rancher/rancher/issues/56654 