### PR TITLE
Wrap flaky tests with retrys

### DIFF
--- a/tests/v2/integration/rbac/features_test.go
+++ b/tests/v2/integration/rbac/features_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/pkg/clientbase"
@@ -44,9 +45,13 @@ func (p *RTBTestSuite) TestCanListFeatures() {
 	userClient, err := client.AsUser(user)
 	p.Require().NoError(err)
 
-	// Standard user should be able to list features.
-	userFeatures, err := userClient.Management.Feature.List(nil)
-	p.Require().NoError(err)
+	// Standard user should be able to list features once the "user" role's RBAC permissions propagate.
+	var userFeatures *management.FeatureCollection
+	p.Require().Eventually(func() bool {
+		var err error
+		userFeatures, err = userClient.Management.Feature.List(nil)
+		return err == nil && len(userFeatures.Data) > 0
+	}, 30*time.Second, time.Second, "timed out waiting for user to see features")
 	p.Require().NotEmpty(userFeatures.Data)
 
 	// Admin should be able to list features.

--- a/tests/v2/integration/rbac/global_roles_test.go
+++ b/tests/v2/integration/rbac/global_roles_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -39,9 +40,12 @@ func (p *RTBTestSuite) TestUserVsUserBaseGlobalRoleVisibility() {
 	p.Require().NoError(err)
 	p.Require().Len(user1Users.Data, 1, "user should only see themselves")
 
-	// user1 can see all roleTemplates.
-	user1RTs, err := user1Client.Management.RoleTemplate.List(nil)
-	p.Require().NoError(err)
+	// user1 can see all roleTemplates once the "user" role's RBAC permissions propagate.
+	var user1RTs *management.RoleTemplateCollection
+	p.Require().Eventually(func() bool {
+		user1RTs, err = user1Client.Management.RoleTemplate.List(nil)
+		return err == nil && len(user1RTs.Data) > 0
+	}, 30*time.Second, time.Second, "timed out waiting for user to see roleTemplates")
 	p.Require().NotEmpty(user1RTs.Data, "user should be able to see all roleTemplates")
 
 	// user2 (user-base role) should only see themselves.
@@ -66,24 +70,28 @@ func (p *RTBTestSuite) TestKontainerDriverVisibilityByGlobalRole() {
 	}
 
 	// Standard "user" role can see kontainer drivers.
-	kds, err := createUserWithRole("user").Management.KontainerDriver.List(nil)
-	p.Require().NoError(err)
-	p.Require().Len(kds.Data, 3)
+	p.assertKontainerDriverCount(createUserWithRole("user"), 3)
 
 	// "clusters-create" role can see kontainer drivers.
-	kds, err = createUserWithRole("clusters-create").Management.KontainerDriver.List(nil)
-	p.Require().NoError(err)
-	p.Require().Len(kds.Data, 3)
+	p.assertKontainerDriverCount(createUserWithRole("clusters-create"), 3)
 
 	// "kontainerdrivers-manage" role can see kontainer drivers.
-	kds, err = createUserWithRole("kontainerdrivers-manage").Management.KontainerDriver.List(nil)
-	p.Require().NoError(err)
-	p.Require().Len(kds.Data, 3)
+	p.assertKontainerDriverCount(createUserWithRole("kontainerdrivers-manage"), 3)
 
 	// "settings-manage" role cannot see kontainer drivers.
-	kds, err = createUserWithRole("settings-manage").Management.KontainerDriver.List(nil)
-	p.Require().NoError(err)
-	p.Require().Empty(kds.Data)
+	p.assertKontainerDriverCount(createUserWithRole("settings-manage"), 0)
+}
+
+// assertKontainerDriverCount polls until the client's visible kontainer driver count matches expected,
+// since GlobalRoleBinding permissions are reconciled asynchronously by RBAC controllers.
+func (p *RTBTestSuite) assertKontainerDriverCount(c *rancher.Client, expected int) {
+	var kds *management.KontainerDriverCollection
+	p.Require().Eventually(func() bool {
+		var err error
+		kds, err = c.Management.KontainerDriver.List(nil)
+		return err == nil && len(kds.Data) == expected
+	}, 30*time.Second, time.Second, "timed out waiting for kontainer driver visibility to reach %d item(s)", expected)
+	p.Require().Len(kds.Data, expected)
 }
 
 // TestBuiltinGlobalRoleOnlyNewUserDefaultEditable tests that admins can only edit


### PR DESCRIPTION
There are a handful of tests that create a user, assign a role and immediately check for permissions. The global role binding takes a moment to reconcile and create the required RBAC, so these ended up being flaky depending on how fast the RBAC was created.