### PR TITLE
Enable Renovate automerging and allow more Renovate prs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
     "go.qase.io/client"
   ],
   "prHourlyLimit": 6,
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 20,
   "packageRules": [
     {
       "matchBaseBranches": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,6 +56,34 @@
       "extends": [
         "github>rancher/renovate-config//rancher-2.11#release"
       ]
+    },
+    {
+      "description": "Automerge patch and minor updates on main",
+      "matchBaseBranches": [
+        "main"
+      ],
+      "matchJsonata": [
+        "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge security updates on main",
+      "matchBaseBranches": [
+        "main"
+      ],
+      "matchJsonata": [
+        "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Enable patch, minor, and security automerge rules for Renovate locally, since they are disabled now globally in the renovate-config.

Allow more Renovate prs because most of them will be approved automatically.