### PR TITLE
Prevent globalrole reconcile loop 

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -406,8 +406,9 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 		},
 		Subjects: []rbacv1.Subject{rbac.GetGRBSubject(globalRoleBinding)},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName(globalRoleBinding.GlobalRoleName),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName(globalRoleBinding.GlobalRoleName),
+			Kind:     clusterRoleKind,
 		},
 	}
 

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -443,8 +443,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName("test-gr"),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName("test-gr"),
+			Kind:     clusterRoleKind,
 		},
 	}
 
@@ -472,8 +473,9 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: getCRName("test-gr"),
-			Kind: clusterRoleKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     getCRName("test-gr"),
+			Kind:     clusterRoleKind,
 		},
 	}
 


### PR DESCRIPTION
## Issue: Caused by my change here https://github.com/rancher/rancher/pull/56593
 
## Problem
The change I made set the RoleRef of the clusterrolebinding without an APIGroup. Then the `DeepEqual` at line 446 would fail because the clusterrolebinding has the APIGroup set everywhere else in the file. So when it failed, it would delete and recreate the CRB. 
 
## Solution
Make sure the APIGroup is set
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_