### PR TITLE
Enable security automerge overrides

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -70,6 +70,11 @@
     },
     {
       "description": "Automerge security updates",
+      "matchDepTypes": [
+        "!devDependencies",
+        "!dev-dependencies",
+        "!test"
+      ],
       "matchJsonata": [
         "$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"
       ],
@@ -77,6 +82,7 @@
         "patch",
         "minor"
       ],
+      "enabled": true,
       "automerge": true
     }
   ]


### PR DESCRIPTION
Re-enable eligible security updates after release presets disable them, while excluding test dependencies.

Should prevent prs like [this](https://github.com/rancher/rancher/pull/56705), where Automerge was disabled even though it should qualify.