### PR TITLE
doc: remove retired goreportcard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Rancher
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/rancher/rancher.svg)](https://store.docker.com/community/images/rancher/rancher)
-[![Go Report Card](https://goreportcard.com/badge/github.com/rancher/rancher)](https://goreportcard.com/report/github.com/rancher/rancher)
 
 Rancher is an open source container management platform built for organizations that deploy containers in production. Rancher makes it easy to run Kubernetes everywhere, meet IT requirements, and empower DevOps teams.
 


### PR DESCRIPTION
## Problem
The goreportcard project was retired in Jul 1, 2026. 
The badge now shows "[go report | retired]"
<img width="342" height="177" alt="image" src="https://github.com/user-attachments/assets/28b43fa9-99f0-48f6-acab-6809d52fc2be" />

More details about the sunsetting on the archived goreportcard repo:
https://github.com/gojp/goreportcard

 
## Solution
Remove it from the README.md
 
## Testing
N/A